### PR TITLE
daemon: add reusable temporal context formatter for future weekday/weekend grounding

### DIFF
--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -194,4 +194,32 @@ describe('DST-safe timezone behavior', () => {
     const result = buildTemporalContext({ nowMs: nearMidnight, timeZone: 'Asia/Tokyo' });
     expect(result).toContain('Today: 2026-02-19 (Thursday)');
   });
+
+  test('addDays is correct across DST spring-forward boundary', () => {
+    // 2026-03-08 is spring-forward day in America/New_York (clocks jump 2:00→3:00 AM).
+    // Use a timestamp at local 23:30 on Friday March 6 (04:30 UTC March 7).
+    const preDST = Date.UTC(2026, 2, 7, 4, 30, 0); // local: Fri Mar 6 23:30 EST
+    const result = buildTemporalContext({ nowMs: preDST, timeZone: 'America/New_York', horizonDays: 5 });
+    // Today should be Friday March 6
+    expect(result).toContain('Today: 2026-03-06 (Friday)');
+    // Horizon should have 5 consecutive days with no duplicates/skips
+    expect(result).toContain('2026-03-07 Saturday');
+    expect(result).toContain('2026-03-08 Sunday');
+    expect(result).toContain('2026-03-09 Monday');
+    expect(result).toContain('2026-03-10 Tuesday');
+    expect(result).toContain('2026-03-11 Wednesday');
+  });
+
+  test('addDays is correct across DST fall-back boundary', () => {
+    // 2026-11-01 is fall-back day in America/New_York (clocks jump 2:00→1:00 AM).
+    // Use a timestamp at local 00:30 on Sunday Nov 1 (04:30 UTC Nov 1).
+    const preFallback = Date.UTC(2026, 10, 1, 4, 30, 0); // local: Sun Nov 1 00:30 EDT
+    const result = buildTemporalContext({ nowMs: preFallback, timeZone: 'America/New_York', horizonDays: 3 });
+    // Today should be Sunday Nov 1
+    expect(result).toContain('Today: 2026-11-01 (Sunday)');
+    // Horizon should have 3 consecutive days
+    expect(result).toContain('2026-11-02 Monday');
+    expect(result).toContain('2026-11-03 Tuesday');
+    expect(result).toContain('2026-11-04 Wednesday');
+  });
 });

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect } from 'bun:test';
+import { buildTemporalContext } from '../daemon/date-context.js';
+
+// Fixed timestamps for deterministic assertions (all UTC midday to avoid DST edge cases).
+
+/** Wednesday 2026-02-18 12:00 UTC */
+const WED_FEB_18 = Date.UTC(2026, 1, 18, 12, 0, 0);
+
+/** Saturday 2026-02-21 12:00 UTC */
+const SAT_FEB_21 = Date.UTC(2026, 1, 21, 12, 0, 0);
+
+/** Sunday 2026-02-22 12:00 UTC */
+const SUN_FEB_22 = Date.UTC(2026, 1, 22, 12, 0, 0);
+
+/** Tuesday 2026-12-29 12:00 UTC — year boundary */
+const TUE_DEC_29 = Date.UTC(2026, 11, 29, 12, 0, 0);
+
+/** Friday 2026-02-27 12:00 UTC */
+const FRI_FEB_27 = Date.UTC(2026, 1, 27, 12, 0, 0);
+
+// ---------------------------------------------------------------------------
+// Basic structure
+// ---------------------------------------------------------------------------
+
+describe('buildTemporalContext', () => {
+  test('returns output wrapped in <temporal_context> tags', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toStartWith('<temporal_context>');
+    expect(result).toEndWith('</temporal_context>');
+  });
+
+  test('includes today date and weekday', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toContain('Today: 2026-02-18 (Wednesday)');
+  });
+
+  test('includes timezone', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'America/New_York' });
+    expect(result).toContain('Timezone: America/New_York');
+  });
+
+  test('includes week definitions', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toContain('work week = Monday–Friday');
+    expect(result).toContain('weekend = Saturday–Sunday');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weekday baseline — today is Wednesday
+// ---------------------------------------------------------------------------
+
+describe('weekday baseline (Wednesday)', () => {
+  test('next weekend is the upcoming Saturday-Sunday', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    // Wednesday Feb 18 → next Saturday is Feb 21, Sunday is Feb 22
+    expect(result).toContain('Next weekend: 2026-02-21 – 2026-02-22');
+  });
+
+  test('next work week is the following Monday-Friday', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    // Wednesday Feb 18 → next Monday is Feb 23, Friday is Feb 27
+    expect(result).toContain('Next work week: 2026-02-23 – 2026-02-27');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weekend baseline — today is Saturday
+// ---------------------------------------------------------------------------
+
+describe('weekend baseline (Saturday)', () => {
+  test('next weekend is the *following* Saturday-Sunday, not today', () => {
+    const result = buildTemporalContext({ nowMs: SAT_FEB_21, timeZone: 'UTC' });
+    // Saturday Feb 21 → next Saturday is Feb 28, Sunday is Mar 1
+    expect(result).toContain('Next weekend: 2026-02-28 – 2026-03-01');
+  });
+
+  test('next work week is the upcoming Monday-Friday', () => {
+    const result = buildTemporalContext({ nowMs: SAT_FEB_21, timeZone: 'UTC' });
+    // Saturday Feb 21 → next Monday is Feb 23, Friday is Feb 27
+    expect(result).toContain('Next work week: 2026-02-23 – 2026-02-27');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weekend baseline — today is Sunday
+// ---------------------------------------------------------------------------
+
+describe('weekend baseline (Sunday)', () => {
+  test('next weekend is the following Saturday-Sunday', () => {
+    const result = buildTemporalContext({ nowMs: SUN_FEB_22, timeZone: 'UTC' });
+    // Sunday Feb 22 → next Saturday is Feb 28, Sunday is Mar 1
+    expect(result).toContain('Next weekend: 2026-02-28 – 2026-03-01');
+  });
+
+  test('next work week is the upcoming Monday-Friday', () => {
+    const result = buildTemporalContext({ nowMs: SUN_FEB_22, timeZone: 'UTC' });
+    // Sunday Feb 22 → next Monday is Feb 23, Friday is Feb 27
+    expect(result).toContain('Next work week: 2026-02-23 – 2026-02-27');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Friday baseline
+// ---------------------------------------------------------------------------
+
+describe('Friday baseline', () => {
+  test('next weekend is tomorrow (Saturday) and Sunday', () => {
+    const result = buildTemporalContext({ nowMs: FRI_FEB_27, timeZone: 'UTC' });
+    // Friday Feb 27 → next Saturday is Feb 28, Sunday is Mar 1
+    expect(result).toContain('Next weekend: 2026-02-28 – 2026-03-01');
+  });
+
+  test('next work week is the following Monday-Friday', () => {
+    const result = buildTemporalContext({ nowMs: FRI_FEB_27, timeZone: 'UTC' });
+    // Friday Feb 27 → next Monday is Mar 2, Friday is Mar 6
+    expect(result).toContain('Next work week: 2026-03-02 – 2026-03-06');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Month / year boundary
+// ---------------------------------------------------------------------------
+
+describe('month/year boundary', () => {
+  test('handles year boundary correctly', () => {
+    const result = buildTemporalContext({ nowMs: TUE_DEC_29, timeZone: 'UTC' });
+    expect(result).toContain('Today: 2026-12-29 (Tuesday)');
+    // Tuesday Dec 29 → next Saturday is Jan 2 2027
+    expect(result).toContain('Next weekend: 2027-01-02 – 2027-01-03');
+    // Next Monday is Jan 4 2027 (skips current work week)
+    // Wait — Dec 29 is Tuesday, so next Monday = Jan 4? Let me think:
+    // Dec 29 Tue → Mon is (1-2+7)%7 = 6 days → Jan 4 Mon
+    expect(result).toContain('Next work week: 2027-01-04 – 2027-01-08');
+  });
+
+  test('horizon entries cross year boundary', () => {
+    const result = buildTemporalContext({ nowMs: TUE_DEC_29, timeZone: 'UTC', horizonDays: 5 });
+    expect(result).toContain('2026-12-30 Wednesday');
+    expect(result).toContain('2026-12-31 Thursday');
+    expect(result).toContain('2027-01-01 Friday');
+    expect(result).toContain('2027-01-02 Saturday');
+    expect(result).toContain('2027-01-03 Sunday');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output size caps
+// ---------------------------------------------------------------------------
+
+describe('output size caps', () => {
+  test('output is at most 1500 characters', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC', horizonDays: 14 });
+    expect(result.length).toBeLessThanOrEqual(1500);
+  });
+
+  test('horizon entries are capped at 14 even if more requested', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC', horizonDays: 30 });
+    const horizonMatches = result.match(/^\s+\d{4}-\d{2}-\d{2} \w+$/gm);
+    expect(horizonMatches).not.toBeNull();
+    expect(horizonMatches!.length).toBeLessThanOrEqual(14);
+  });
+
+  test('default horizon is 14 days', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    const horizonMatches = result.match(/^\s+\d{4}-\d{2}-\d{2} \w+$/gm);
+    expect(horizonMatches).not.toBeNull();
+    expect(horizonMatches!.length).toBe(14);
+  });
+
+  test('respects smaller horizonDays', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC', horizonDays: 3 });
+    const horizonMatches = result.match(/^\s+\d{4}-\d{2}-\d{2} \w+$/gm);
+    expect(horizonMatches).not.toBeNull();
+    expect(horizonMatches!.length).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DST-safe timezone behavior
+// ---------------------------------------------------------------------------
+
+describe('DST-safe timezone behavior', () => {
+  test('date labels are correct in US Eastern timezone', () => {
+    // Feb 18 12:00 UTC = Feb 18 07:00 EST (same calendar date)
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'America/New_York' });
+    expect(result).toContain('Today: 2026-02-18 (Wednesday)');
+  });
+
+  test('date labels are correct in timezone ahead of UTC', () => {
+    // Use a timestamp near midnight UTC so the local date differs
+    // Feb 18 23:00 UTC = Feb 19 08:00 JST
+    const nearMidnight = Date.UTC(2026, 1, 18, 23, 0, 0);
+    const result = buildTemporalContext({ nowMs: nearMidnight, timeZone: 'Asia/Tokyo' });
+    expect(result).toContain('Today: 2026-02-19 (Thursday)');
+  });
+});

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -222,4 +222,15 @@ describe('DST-safe timezone behavior', () => {
     expect(result).toContain('2026-11-03 Tuesday');
     expect(result).toContain('2026-11-04 Wednesday');
   });
+
+  test('dates are correct in far-east UTC+13 timezone (Pacific/Auckland NZDT)', () => {
+    // Feb 18 12:00 UTC = Feb 19 01:00 NZDT (UTC+13 during daylight saving)
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'Pacific/Auckland', horizonDays: 3 });
+    // In Auckland, Feb 18 12:00 UTC is already Feb 19 (Thursday)
+    expect(result).toContain('Today: 2026-02-19 (Thursday)');
+    // Horizon should show consecutive days without +1 shift
+    expect(result).toContain('2026-02-20 Friday');
+    expect(result).toContain('2026-02-21 Saturday');
+    expect(result).toContain('2026-02-22 Sunday');
+  });
 });

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -60,12 +60,20 @@ function formatLocalDate(date: Date, timeZone: string): string {
  */
 function addDays(date: Date, days: number, timeZone: string): Date {
   const parts = localDateParts(date, timeZone);
-  // Build a date string for the target local date at noon, then resolve via Intl.
-  const target = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days, 12, 0, 0));
-  // Verify the target resolves to the expected local date by checking the
-  // local date parts.  Date.UTC handles month/year overflow automatically
-  // (e.g. Jan 32 → Feb 1), so this is safe across boundaries.
-  return target;
+  // Use Date.UTC for calendar overflow (e.g. Jan 32 → Feb 1).
+  const ref = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
+  const tY = ref.getUTCFullYear();
+  const tM = ref.getUTCMonth() + 1;
+  const tD = ref.getUTCDate();
+  // Noon UTC covers UTC-12 through ~UTC+11.  For far-east timezones
+  // (UTC+12/+13/+14) noon UTC is already the next local day, so fall
+  // back to midnight UTC which resolves correctly there.
+  const noonUTC = new Date(Date.UTC(tY, tM - 1, tD, 12, 0, 0));
+  const r = localDateParts(noonUTC, timeZone);
+  if (r.year === tY && r.month === tM && r.day === tD) {
+    return noonUTC;
+  }
+  return new Date(Date.UTC(tY, tM - 1, tD, 0, 0, 0));
 }
 
 /**

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -53,12 +53,19 @@ function formatLocalDate(date: Date, timeZone: string): string {
 }
 
 /**
- * Advance a date by `days` calendar days (timezone-aware).
- * Uses noon UTC as anchor to avoid DST edge cases with day boundaries.
+ * Advance a date by `days` calendar days in the given timezone.
+ *
+ * Computes the local date, adds days to the day component, then anchors
+ * the result at noon local time to avoid DST-transition edge cases.
  */
-function addDays(date: Date, days: number): Date {
-  const result = new Date(date.getTime() + days * 86_400_000);
-  return result;
+function addDays(date: Date, days: number, timeZone: string): Date {
+  const parts = localDateParts(date, timeZone);
+  // Build a date string for the target local date at noon, then resolve via Intl.
+  const target = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days, 12, 0, 0));
+  // Verify the target resolves to the expected local date by checking the
+  // local date parts.  Date.UTC handles month/year overflow automatically
+  // (e.g. Jan 32 → Feb 1), so this is safe across boundaries.
+  return target;
 }
 
 /**
@@ -78,18 +85,18 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
 
   // ── Next weekend (Saturday-Sunday) ──
   const daysUntilSaturday = (6 - todayParts.weekday + 7) % 7 || 7;
-  const nextSaturday = addDays(now, daysUntilSaturday);
-  const nextSunday = addDays(now, daysUntilSaturday + 1);
+  const nextSaturday = addDays(now, daysUntilSaturday, timeZone);
+  const nextSunday = addDays(now, daysUntilSaturday + 1, timeZone);
 
   // ── Next work week (Monday-Friday) ──
   const daysUntilMonday = (1 - todayParts.weekday + 7) % 7 || 7;
-  const nextMonday = addDays(now, daysUntilMonday);
-  const nextFriday = addDays(now, daysUntilMonday + 4);
+  const nextMonday = addDays(now, daysUntilMonday, timeZone);
+  const nextFriday = addDays(now, daysUntilMonday + 4, timeZone);
 
   // ── Horizon list ──
   const horizonLines: string[] = [];
   for (let i = 1; i <= horizonDays; i++) {
-    const futureDate = addDays(now, i);
+    const futureDate = addDays(now, i, timeZone);
     const futureParts = localDateParts(futureDate, timeZone);
     const label = WEEKDAY_NAMES[futureParts.weekday];
     horizonLines.push(`  ${formatLocalDate(futureDate, timeZone)} ${label}`);

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -1,0 +1,121 @@
+/**
+ * Temporal context formatter for future weekday/weekend grounding.
+ *
+ * Produces a compact, deterministic payload describing the current date,
+ * upcoming weekend/work-week windows, and a short horizon of labelled
+ * future dates.  Intended for runtime injection into the model context.
+ */
+
+export interface TemporalContextOptions {
+  /** Override current time (epoch ms) for deterministic tests. */
+  nowMs?: number;
+  /** IANA timezone (e.g. "America/New_York"). Defaults to host timezone. */
+  timeZone?: string;
+  /** Number of future days to list (default 14, hard-capped at 14). */
+  horizonDays?: number;
+}
+
+const MAX_OUTPUT_CHARS = 1500;
+const MAX_HORIZON_ENTRIES = 14;
+
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const;
+
+/**
+ * Get the local date parts for a given instant in the specified timezone.
+ */
+function localDateParts(date: Date, timeZone: string): { year: number; month: number; day: number; weekday: number } {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  });
+  const parts = fmt.formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  // Weekday as 0-6 (Sun-Sat)
+  const weekdayShort = get('weekday');
+  const weekdayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  return {
+    year: parseInt(get('year'), 10),
+    month: parseInt(get('month'), 10),
+    day: parseInt(get('day'), 10),
+    weekday: weekdayMap[weekdayShort] ?? 0,
+  };
+}
+
+/**
+ * Format a Date as YYYY-MM-DD in the given timezone.
+ */
+function formatLocalDate(date: Date, timeZone: string): string {
+  const p = localDateParts(date, timeZone);
+  return `${p.year}-${String(p.month).padStart(2, '0')}-${String(p.day).padStart(2, '0')}`;
+}
+
+/**
+ * Advance a date by `days` calendar days (timezone-aware).
+ * Uses noon UTC as anchor to avoid DST edge cases with day boundaries.
+ */
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date.getTime() + days * 86_400_000);
+  return result;
+}
+
+/**
+ * Build a compact temporal context string for model injection.
+ *
+ * Output is hard-capped at {@link MAX_OUTPUT_CHARS} characters and
+ * {@link MAX_HORIZON_ENTRIES} horizon entries.
+ */
+export function buildTemporalContext(options: TemporalContextOptions = {}): string {
+  const now = new Date(options.nowMs ?? Date.now());
+  const timeZone = options.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const horizonDays = Math.min(options.horizonDays ?? MAX_HORIZON_ENTRIES, MAX_HORIZON_ENTRIES);
+
+  const todayParts = localDateParts(now, timeZone);
+  const todayStr = formatLocalDate(now, timeZone);
+  const todayWeekday = WEEKDAY_NAMES[todayParts.weekday];
+
+  // ── Next weekend (Saturday-Sunday) ──
+  const daysUntilSaturday = (6 - todayParts.weekday + 7) % 7 || 7;
+  const nextSaturday = addDays(now, daysUntilSaturday);
+  const nextSunday = addDays(now, daysUntilSaturday + 1);
+
+  // ── Next work week (Monday-Friday) ──
+  const daysUntilMonday = (1 - todayParts.weekday + 7) % 7 || 7;
+  const nextMonday = addDays(now, daysUntilMonday);
+  const nextFriday = addDays(now, daysUntilMonday + 4);
+
+  // ── Horizon list ──
+  const horizonLines: string[] = [];
+  for (let i = 1; i <= horizonDays; i++) {
+    const futureDate = addDays(now, i);
+    const futureParts = localDateParts(futureDate, timeZone);
+    const label = WEEKDAY_NAMES[futureParts.weekday];
+    horizonLines.push(`  ${formatLocalDate(futureDate, timeZone)} ${label}`);
+  }
+
+  const lines = [
+    `<temporal_context>`,
+    `Today: ${todayStr} (${todayWeekday})`,
+    `Timezone: ${timeZone}`,
+    ``,
+    `Week definitions: work week = Monday–Friday, weekend = Saturday–Sunday`,
+    ``,
+    `Next weekend: ${formatLocalDate(nextSaturday, timeZone)} – ${formatLocalDate(nextSunday, timeZone)}`,
+    `Next work week: ${formatLocalDate(nextMonday, timeZone)} – ${formatLocalDate(nextFriday, timeZone)}`,
+    ``,
+    `Upcoming dates:`,
+    ...horizonLines,
+    `</temporal_context>`,
+  ];
+
+  let output = lines.join('\n');
+
+  // Hard cap: truncate if somehow over budget (shouldn't happen with 14 entries).
+  if (output.length > MAX_OUTPUT_CHARS) {
+    output = output.slice(0, MAX_OUTPUT_CHARS - 25) + '\n</temporal_context>';
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Summary
- Add `buildTemporalContext()` utility that produces compact, deterministic temporal context with current date, timezone, upcoming weekend/work-week windows, and a 14-day horizon of labelled future dates
- Injectable `nowMs`, `timeZone`, and `horizonDays` options for deterministic testing
- Output hard-capped at 1500 chars and 14 horizon entries to prevent prompt bloat
- 20 unit tests covering weekday/weekend baselines, month/year boundaries, size caps, and DST-safe timezone behavior

Part of plan: correct-dates-2.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
