### PR TITLE
fix: log malformed IPC messages instead of silently dropping them

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -2,6 +2,9 @@
 export * from './ipc-contract.js';
 
 import type { ClientMessage, ServerMessage } from './ipc-contract.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('ipc-protocol');
 
 // === Serialization ===
 
@@ -43,8 +46,8 @@ export function createMessageParser(options?: { maxLineSize?: number }) {
             entry.rawByteLength = Buffer.byteLength(trimmed, 'utf8');
           }
           results.push(entry);
-        } catch {
-          // Skip malformed messages
+        } catch (err) {
+          log.warn({ lineLength: trimmed.length, err }, 'Skipping malformed IPC message');
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add warn-level logging to the IPC message parser's catch block in `ipc-protocol.ts`
- Logs the raw line length (not content, for security) and the parse error to aid protocol debugging
- Replaces the empty catch block that silently swallowed malformed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
