### PR TITLE
fix: skip thumbnail generation for lazy-loaded video attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -144,23 +144,7 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func generateThumbnail() async {
-        let base64: String
-        if !attachment.data.isEmpty {
-            base64 = attachment.data
-        } else if attachment.isLazyLoad,
-                  let port = daemonHttpPort,
-                  let attachmentId = attachment.id.isEmpty ? nil : attachment.id {
-            do {
-                base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-            } catch {
-                log.error("Failed to fetch attachment for thumbnail \(attachment.id): \(error.localizedDescription)")
-                return
-            }
-        } else {
-            return
-        }
-
-        guard let data = Data(base64Encoded: base64) else { return }
+        guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }
 
         let fileURL = safeTempURL()
         do {


### PR DESCRIPTION
Addresses feedback from PR #5280. Lazy-loaded video attachments no longer auto-download full video data just for thumbnail generation. Only generates thumbnails when the video data is already available (non-lazy-loaded). This preserves the lazy-load contract and prevents network/memory spikes when threads contain multiple videos.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
