### PR TITLE
fix: tighten context-too-large error pattern for max_tokens

### DIFF
--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -41,7 +41,8 @@ const CONTEXT_TOO_LARGE_PATTERNS = [
   /prompt.?is.?too.?long/i,
   /request too large/i,
   /too many.*input.*tokens/i,
-  /max_tokens/i,
+  /max_tokens.*exceeded/i,
+  /exceeded.*max_tokens/i,
 ];
 
 // Provider API error patterns (5xx, server error, etc.)


### PR DESCRIPTION
## Summary
- Replace overly broad `/max_tokens/i` regex with `/max_tokens.*exceeded/i` and `/exceeded.*max_tokens/i`
- Prevents misclassifying config errors (e.g. "invalid max_tokens parameter") as context-too-large failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
