### PR TITLE
fix: restore lazy-load thumbnail generation for videos

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -144,7 +144,23 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func generateThumbnail() async {
-        guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }
+        let base64: String
+        if !attachment.data.isEmpty {
+            base64 = attachment.data
+        } else if attachment.isLazyLoad,
+                  let port = daemonHttpPort,
+                  let attachmentId = attachment.id.isEmpty ? nil : attachment.id {
+            do {
+                base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
+            } catch {
+                log.error("Failed to fetch attachment for thumbnail: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+        } else {
+            return
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return }
 
         let fileURL = safeTempURL()
         do {


### PR DESCRIPTION
## Summary
- PR #5289 (automated review agent) reverted the lazy-load path in `generateThumbnail()`, breaking thumbnails for large video attachments that are lazy-loaded
- Re-applies the lazy-load fetch logic: when `attachment.data` is empty and `isLazyLoad` is true, fetch the video data via the daemon HTTP endpoint before generating the thumbnail
- Also uses `privacy: .public` on the error log so diagnostic info is visible in Console.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
