### PR TITLE
Remove assistantId from memory store APIs (PR 6 of 8)

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -103,7 +103,7 @@ describe('AssetMaterializeTool sandbox path enforcement', () => {
   beforeEach(resetTables);
 
   test('rejects path that escapes sandbox via ../', async () => {
-    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('test.png', 'image/png', 'AAAA');
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: '../../etc/evil.png' },
       dummyContext,
@@ -113,7 +113,7 @@ describe('AssetMaterializeTool sandbox path enforcement', () => {
   });
 
   test('rejects absolute path outside sandbox', async () => {
-    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('test.png', 'image/png', 'AAAA');
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: '/tmp/outside-sandbox/evil.png' },
       dummyContext,
@@ -123,7 +123,7 @@ describe('AssetMaterializeTool sandbox path enforcement', () => {
   });
 
   test('accepts relative path inside sandbox', async () => {
-    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('test.png', 'image/png', 'AAAA');
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: 'output.png' },
       dummyContext,
@@ -133,7 +133,7 @@ describe('AssetMaterializeTool sandbox path enforcement', () => {
   });
 
   test('accepts nested path inside sandbox with auto-created subdirs', async () => {
-    const stored = uploadAttachment('ast-1', 'test.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('test.png', 'image/png', 'AAAA');
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: 'subdir/deep/output.png' },
       dummyContext,
@@ -172,7 +172,7 @@ describe('AssetMaterializeTool materialization', () => {
     const originalContent = 'Hello, World!';
     const base64Content = Buffer.from(originalContent).toString('base64');
 
-    const stored = uploadAttachment('ast-1', 'hello.txt', 'text/plain', base64Content);
+    const stored = uploadAttachment('hello.txt', 'text/plain', base64Content);
 
     const destPath = 'materialized-hello.txt';
     const result = await assetMaterializeTool.execute(
@@ -194,7 +194,7 @@ describe('AssetMaterializeTool materialization', () => {
     const binaryBytes = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
     const base64Content = binaryBytes.toString('base64');
 
-    const stored = uploadAttachment('ast-1', 'tiny.png', 'image/png', base64Content);
+    const stored = uploadAttachment('tiny.png', 'image/png', base64Content);
 
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: 'images/tiny.png' },
@@ -209,7 +209,7 @@ describe('AssetMaterializeTool materialization', () => {
 
   test('result includes resolved path', async () => {
     const base64Content = Buffer.from('test').toString('base64');
-    const stored = uploadAttachment('ast-1', 'doc.txt', 'text/plain', base64Content);
+    const stored = uploadAttachment('doc.txt', 'text/plain', base64Content);
 
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: 'output/doc.txt' },
@@ -222,7 +222,7 @@ describe('AssetMaterializeTool materialization', () => {
 
   test('result includes filename, MIME type and size info', async () => {
     const base64Content = Buffer.from('some data here').toString('base64');
-    const stored = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', base64Content);
+    const stored = uploadAttachment('report.pdf', 'application/pdf', base64Content);
 
     const result = await assetMaterializeTool.execute(
       { attachment_id: stored.id, destination_path: 'report.pdf' },
@@ -307,7 +307,7 @@ describe('AssetMaterializeTool visibility policy', () => {
   test('materializing from a standard thread works from any context', async () => {
     const standardConv = createConversation({ title: 'standard-conv' });
     const base64Content = Buffer.from('standard content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'public.txt', 'text/plain', base64Content);
+    const attachment = uploadAttachment('public.txt', 'text/plain', base64Content);
     const msg = addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -330,7 +330,7 @@ describe('AssetMaterializeTool visibility policy', () => {
   test('materializing from a private thread works within the same private thread', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -352,7 +352,7 @@ describe('AssetMaterializeTool visibility policy', () => {
   test('materializing from a private thread is REJECTED from a different conversation', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -376,7 +376,7 @@ describe('AssetMaterializeTool visibility policy', () => {
   test('error message is user-actionable', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'confidential.pdf', 'application/pdf', base64Content);
+    const attachment = uploadAttachment('confidential.pdf', 'application/pdf', base64Content);
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -402,7 +402,7 @@ describe('AssetMaterializeTool visibility policy', () => {
   test('materializing from a different private thread is REJECTED', async () => {
     const privateConv1 = createConversation({ title: 'private-conv-1', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'secret.txt', 'text/plain', base64Content);
+    const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
     const msg = addMessage(privateConv1.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -426,7 +426,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const standardConv = createConversation({ title: 'standard-conv' });
     const base64Content = Buffer.from('shared content').toString('base64');
-    const attachment = uploadAttachment('ast-1', 'shared.txt', 'text/plain', base64Content);
+    const attachment = uploadAttachment('shared.txt', 'text/plain', base64Content);
 
     const msg1 = addMessage(privateConv.id, 'user', 'private message');
     const msg2 = addMessage(standardConv.id, 'user', 'standard message');

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -66,10 +66,10 @@ function seedAttachments() {
   // Force createdAt by uploading then manipulating the DB
   const db = getDb();
 
-  const png1 = uploadAttachment('ast-1', 'selfie.png', 'image/png', 'AAAA');
-  const jpg1 = uploadAttachment('ast-1', 'photo.jpg', 'image/jpeg', 'BBBB');
-  const pdf1 = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', 'CCCC');
-  const png2 = uploadAttachment('ast-1', 'screenshot.png', 'image/png', 'DDDD');
+  const png1 = uploadAttachment('selfie.png', 'image/png', 'AAAA');
+  const jpg1 = uploadAttachment('photo.jpg', 'image/jpeg', 'BBBB');
+  const pdf1 = uploadAttachment('report.pdf', 'application/pdf', 'CCCC');
+  const png2 = uploadAttachment('screenshot.png', 'image/png', 'DDDD');
 
   // Backdate some attachments for recency testing
   db.run(`UPDATE attachments SET created_at = ${oneDayAgo} WHERE id = '${jpg1.id}'`);
@@ -217,8 +217,8 @@ describe('searchAttachments with conversation_id', () => {
   beforeEach(resetTables);
 
   test('returns only attachments linked to the specified conversation', () => {
-    const png1 = uploadAttachment('ast-1', 'in-conv.png', 'image/png', 'AAAA');
-    const png2 = uploadAttachment('ast-1', 'other-conv.png', 'image/png', 'BBBB');
+    const png1 = uploadAttachment('in-conv.png', 'image/png', 'AAAA');
+    const png2 = uploadAttachment('other-conv.png', 'image/png', 'BBBB');
 
     const conv1 = createConversation();
     const conv2 = createConversation();
@@ -234,7 +234,7 @@ describe('searchAttachments with conversation_id', () => {
   });
 
   test('returns empty when conversation has no attachments', () => {
-    uploadAttachment('ast-1', 'orphan.png', 'image/png', 'AAAA');
+    uploadAttachment('orphan.png', 'image/png', 'AAAA');
     const conv = createConversation();
     addMessage(conv.id, 'user', 'No attachments here');
 
@@ -243,14 +243,14 @@ describe('searchAttachments with conversation_id', () => {
   });
 
   test('returns empty for nonexistent conversation_id', () => {
-    uploadAttachment('ast-1', 'file.png', 'image/png', 'AAAA');
+    uploadAttachment('file.png', 'image/png', 'AAAA');
     const results = searchAttachments({ conversation_id: 'conv-nonexistent' });
     expect(results.length).toBe(0);
   });
 
   test('combines conversation_id with mime_type filter', () => {
-    const png = uploadAttachment('ast-1', 'image.png', 'image/png', 'AAAA');
-    const pdf = uploadAttachment('ast-1', 'doc.pdf', 'application/pdf', 'BBBB');
+    const png = uploadAttachment('image.png', 'image/png', 'AAAA');
+    const pdf = uploadAttachment('doc.pdf', 'application/pdf', 'BBBB');
 
     const conv = createConversation();
     const msg = addMessage(conv.id, 'user', 'Both types');
@@ -264,8 +264,8 @@ describe('searchAttachments with conversation_id', () => {
   });
 
   test('combines conversation_id with filename filter', () => {
-    const a = uploadAttachment('ast-1', 'target.png', 'image/png', 'AAAA');
-    const b = uploadAttachment('ast-1', 'other.png', 'image/png', 'BBBB');
+    const a = uploadAttachment('target.png', 'image/png', 'AAAA');
+    const b = uploadAttachment('other.png', 'image/png', 'BBBB');
 
     const conv = createConversation();
     const msg = addMessage(conv.id, 'user', 'Both');
@@ -294,7 +294,7 @@ describe('AssetSearchTool.execute', () => {
   });
 
   test('returns formatted results for matching assets', async () => {
-    uploadAttachment('ast-1', 'selfie.png', 'image/png', 'AAAA');
+    uploadAttachment('selfie.png', 'image/png', 'AAAA');
     const result = await tool.execute({}, dummyContext);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('selfie.png');
@@ -320,14 +320,14 @@ describe('AssetSearchTool.execute', () => {
   });
 
   test('includes attachment ID in output', async () => {
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('chart.png', 'image/png', 'AAAA');
     const result = await tool.execute({}, dummyContext);
     expect(result.isError).toBe(false);
     expect(result.content).toContain(stored.id);
   });
 
   test('includes MIME type and kind in output', async () => {
-    uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');
+    uploadAttachment('chart.png', 'image/png', 'AAAA');
     const result = await tool.execute({}, dummyContext);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('image/png');
@@ -363,7 +363,7 @@ describe('AssetSearchTool visibility policy', () => {
 
   test('attachments from standard threads are visible from any context', async () => {
     const standardConv = createConversation({ title: 'standard-conv' });
-    const attachment = uploadAttachment('ast-1', 'public.png', 'image/png', 'AAAA');
+    const attachment = uploadAttachment('public.png', 'image/png', 'AAAA');
     const msg = addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -382,7 +382,7 @@ describe('AssetSearchTool visibility policy', () => {
 
   test('attachments from private threads are visible within the same private thread', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
-    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -400,7 +400,7 @@ describe('AssetSearchTool visibility policy', () => {
 
   test('attachments from private threads are NOT visible from a different conversation', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
-    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -419,7 +419,7 @@ describe('AssetSearchTool visibility policy', () => {
 
   test('attachments from private threads are NOT visible from standard threads', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
-    const attachment = uploadAttachment('ast-1', 'secret.png', 'image/png', 'AAAA');
+    const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
     const msg = addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
@@ -439,7 +439,7 @@ describe('AssetSearchTool visibility policy', () => {
   test('attachment linked to both private and standard threads is visible everywhere', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const standardConv = createConversation({ title: 'standard-conv' });
-    const attachment = uploadAttachment('ast-1', 'shared.png', 'image/png', 'AAAA');
+    const attachment = uploadAttachment('shared.png', 'image/png', 'AAAA');
 
     const msg1 = addMessage(privateConv.id, 'user', 'private message');
     const msg2 = addMessage(standardConv.id, 'user', 'standard message');
@@ -460,7 +460,7 @@ describe('AssetSearchTool visibility policy', () => {
   });
 
   test('orphan attachments (no message linkage) remain visible', async () => {
-    uploadAttachment('ast-1', 'orphan.png', 'image/png', 'AAAA');
+    uploadAttachment('orphan.png', 'image/png', 'AAAA');
 
     const conv = createConversation({ title: 'any-conv' });
     const context: ToolContext = {

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -42,7 +42,6 @@ import {
   getAttachmentById,
   linkAttachmentToMessage,
   getAttachmentsForMessage,
-  getAttachmentsForMessageUnscoped,
   deleteOrphanAttachments,
   validateAttachmentUpload,
   isValidBase64,
@@ -73,10 +72,9 @@ describe('uploadAttachment', () => {
   beforeEach(resetTables);
 
   test('stores attachment and returns metadata', () => {
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBORw0K');
+    const stored = uploadAttachment('chart.png', 'image/png', 'iVBORw0K');
 
     expect(stored.id).toBeDefined();
-    expect(stored.assistantId).toBe('ast-1');
     expect(stored.originalFilename).toBe('chart.png');
     expect(stored.mimeType).toBe('image/png');
     expect(stored.kind).toBe('image');
@@ -85,48 +83,42 @@ describe('uploadAttachment', () => {
   });
 
   test('classifies image MIME as image kind', () => {
-    const stored = uploadAttachment('ast-1', 'pic.jpg', 'image/jpeg', 'AAAA');
+    const stored = uploadAttachment('pic.jpg', 'image/jpeg', 'AAAA');
     expect(stored.kind).toBe('image');
   });
 
   test('classifies non-image MIME as document kind', () => {
-    const stored = uploadAttachment('ast-1', 'doc.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment('doc.pdf', 'application/pdf', 'JVBER');
     expect(stored.kind).toBe('document');
   });
 
   test('generates unique IDs for each upload', () => {
-    const a = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'AA==');
-    const b = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'QQ==');
+    const a = uploadAttachment('a.txt', 'text/plain', 'AA==');
+    const b = uploadAttachment('b.txt', 'text/plain', 'QQ==');
     expect(a.id).not.toBe(b.id);
   });
 
   test('computes sizeBytes from base64 correctly', () => {
     // "hello" = "aGVsbG8=" (8 chars, 1 pad → 5 bytes)
-    const stored = uploadAttachment('ast-1', 'hello.txt', 'text/plain', 'aGVsbG8=');
+    const stored = uploadAttachment('hello.txt', 'text/plain', 'aGVsbG8=');
     expect(stored.sizeBytes).toBe(5);
   });
 
-  test('deduplicates by content hash within the same assistant', () => {
-    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
-    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
+  test('deduplicates by content hash', () => {
+    const first = uploadAttachment('photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
+    const second = uploadAttachment('photo.png', 'image/png', 'iVBORw0KGgoAAAANSUh');
     expect(second.id).toBe(first.id);
   });
 
   test('deduplicates even when filenames differ', () => {
-    const first = uploadAttachment('ast-1', 'original.png', 'image/png', 'DUPECONTENT123');
-    const second = uploadAttachment('ast-1', 'renamed.png', 'image/png', 'DUPECONTENT123');
+    const first = uploadAttachment('original.png', 'image/png', 'DUPECONTENT123');
+    const second = uploadAttachment('renamed.png', 'image/png', 'DUPECONTENT123');
     expect(second.id).toBe(first.id);
   });
 
-  test('does not deduplicate across different assistants', () => {
-    const first = uploadAttachment('ast-1', 'file.txt', 'text/plain', 'CROSSASSISTANT');
-    const second = uploadAttachment('ast-2', 'file.txt', 'text/plain', 'CROSSASSISTANT');
-    expect(second.id).not.toBe(first.id);
-  });
-
   test('does not deduplicate different content', () => {
-    const first = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'CONTENTA');
-    const second = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'CONTENTB');
+    const first = uploadAttachment('a.txt', 'text/plain', 'CONTENTA');
+    const second = uploadAttachment('b.txt', 'text/plain', 'CONTENTB');
     expect(second.id).not.toBe(first.id);
   });
 
@@ -137,20 +129,20 @@ describe('uploadAttachment', () => {
     const oversizedData = 'A'.repeat(oversizedLength);
 
     expect(() =>
-      uploadAttachment('ast-1', 'huge.bin', 'application/octet-stream', oversizedData),
+      uploadAttachment('huge.bin', 'application/octet-stream', oversizedData),
     ).toThrow(AttachmentUploadError);
   });
 
   test('rejects invalid base64 data', () => {
     expect(() =>
-      uploadAttachment('ast-1', 'bad.txt', 'text/plain', '!!!not-base64!!!'),
+      uploadAttachment('bad.txt', 'text/plain', '!!!not-base64!!!'),
     ).toThrow(AttachmentUploadError);
   });
 
   test('accepts base64 with non-standard padding/length', () => {
     // Lenient on length — only character set is validated
     expect(() =>
-      uploadAttachment('ast-1', 'ok.txt', 'text/plain', 'AAA'),
+      uploadAttachment('ok.txt', 'text/plain', 'AAA'),
     ).not.toThrow();
   });
 
@@ -161,7 +153,7 @@ describe('uploadAttachment', () => {
     const exactData = 'A'.repeat(exactLength);
 
     expect(() =>
-      uploadAttachment('ast-1', 'exact.bin', 'application/octet-stream', exactData),
+      uploadAttachment('exact.bin', 'application/octet-stream', exactData),
     ).not.toThrow();
   });
 });
@@ -199,27 +191,17 @@ describe('deleteAttachment', () => {
   beforeEach(resetTables);
 
   test('deletes existing attachment and returns deleted', () => {
-    const stored = uploadAttachment('ast-1', 'file.txt', 'text/plain', 'dGVzdA==');
-    const result = deleteAttachment('ast-1', stored.id);
+    const stored = uploadAttachment('file.txt', 'text/plain', 'dGVzdA==');
+    const result = deleteAttachment(stored.id);
     expect(result).toBe('deleted');
 
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).toBeNull();
   });
 
   test('returns not_found for nonexistent attachment', () => {
-    const result = deleteAttachment('ast-1', 'nonexistent-id');
+    const result = deleteAttachment('nonexistent-id');
     expect(result).toBe('not_found');
-  });
-
-  test('returns not_found when assistantId does not match', () => {
-    const stored = uploadAttachment('ast-owner', 'file.txt', 'text/plain', 'dGVzdA==');
-    const result = deleteAttachment('ast-other', stored.id);
-    expect(result).toBe('not_found');
-
-    // Original still exists
-    const fetched = getAttachmentById('ast-owner', stored.id);
-    expect(fetched).not.toBeNull();
   });
 
   test('returns still_referenced when messages reference the attachment', () => {
@@ -228,35 +210,35 @@ describe('deleteAttachment', () => {
     const msg2 = addMessage(conv.id, 'user', 'Duplicate upload');
 
     // Dedup: both uploads return the same attachment row
-    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHAREDCONTENT1');
-    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'SHAREDCONTENT1');
+    const first = uploadAttachment('photo.png', 'image/png', 'SHAREDCONTENT1');
+    const second = uploadAttachment('photo.png', 'image/png', 'SHAREDCONTENT1');
     expect(second.id).toBe(first.id);
 
     linkAttachmentToMessage(msg1.id, first.id, 0);
     linkAttachmentToMessage(msg2.id, second.id, 0);
 
     // Delete should return still_referenced and NOT remove the attachment row
-    const result = deleteAttachment('ast-1', first.id);
+    const result = deleteAttachment(first.id);
     expect(result).toBe('still_referenced');
 
     // Attachment row still exists because messages reference it
-    const fetched = getAttachmentById('ast-1', first.id);
+    const fetched = getAttachmentById(first.id);
     expect(fetched).not.toBeNull();
 
     // Both messages still see the attachment
-    const linked1 = getAttachmentsForMessage(msg1.id, 'ast-1');
+    const linked1 = getAttachmentsForMessage(msg1.id);
     expect(linked1).toHaveLength(1);
-    const linked2 = getAttachmentsForMessage(msg2.id, 'ast-1');
+    const linked2 = getAttachmentsForMessage(msg2.id);
     expect(linked2).toHaveLength(1);
   });
 
   test('deletes attachment when no messages reference it', () => {
-    const stored = uploadAttachment('ast-1', 'lonely.txt', 'text/plain', 'UNREFERENCED');
+    const stored = uploadAttachment('lonely.txt', 'text/plain', 'UNREFERENCED');
     // No linkAttachmentToMessage call — zero references
-    const result = deleteAttachment('ast-1', stored.id);
+    const result = deleteAttachment(stored.id);
     expect(result).toBe('deleted');
 
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).toBeNull();
   });
 });
@@ -269,30 +251,24 @@ describe('getAttachmentsByIds', () => {
   beforeEach(resetTables);
 
   test('returns matching attachments with data', () => {
-    const a = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'AAAA');
-    const b = uploadAttachment('ast-1', 'b.txt', 'text/plain', 'BBBB');
+    const a = uploadAttachment('a.txt', 'text/plain', 'AAAA');
+    const b = uploadAttachment('b.txt', 'text/plain', 'BBBB');
 
-    const results = getAttachmentsByIds('ast-1', [a.id, b.id]);
+    const results = getAttachmentsByIds([a.id, b.id]);
     expect(results).toHaveLength(2);
     expect(results[0].dataBase64).toBe('AAAA');
     expect(results[1].dataBase64).toBe('BBBB');
   });
 
   test('returns empty array for empty IDs list', () => {
-    const results = getAttachmentsByIds('ast-1', []);
+    const results = getAttachmentsByIds([]);
     expect(results).toHaveLength(0);
   });
 
   test('skips IDs that do not exist', () => {
-    const a = uploadAttachment('ast-1', 'a.txt', 'text/plain', 'AAAA');
-    const results = getAttachmentsByIds('ast-1', [a.id, 'nonexistent']);
+    const a = uploadAttachment('a.txt', 'text/plain', 'AAAA');
+    const results = getAttachmentsByIds([a.id, 'nonexistent']);
     expect(results).toHaveLength(1);
-  });
-
-  test('enforces assistantId scoping', () => {
-    const a = uploadAttachment('ast-owner', 'a.txt', 'text/plain', 'AAAA');
-    const results = getAttachmentsByIds('ast-other', [a.id]);
-    expect(results).toHaveLength(0);
   });
 });
 
@@ -304,8 +280,8 @@ describe('getAttachmentById', () => {
   beforeEach(resetTables);
 
   test('returns attachment with data when found', () => {
-    const stored = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', 'JVBER');
-    const result = getAttachmentById('ast-1', stored.id);
+    const stored = uploadAttachment('report.pdf', 'application/pdf', 'JVBER');
+    const result = getAttachmentById(stored.id);
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(stored.id);
@@ -313,14 +289,8 @@ describe('getAttachmentById', () => {
     expect(result!.dataBase64).toBe('JVBER');
   });
 
-  test('returns null for wrong assistantId', () => {
-    const stored = uploadAttachment('ast-1', 'file.txt', 'text/plain', 'dGVzdA==');
-    const result = getAttachmentById('ast-other', stored.id);
-    expect(result).toBeNull();
-  });
-
   test('returns null for nonexistent ID', () => {
-    const result = getAttachmentById('ast-1', 'no-such-id');
+    const result = getAttachmentById('no-such-id');
     expect(result).toBeNull();
   });
 });
@@ -335,11 +305,11 @@ describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
   test('links attachment and retrieves it by message', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'Here is a chart');
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBORw0K');
+    const stored = uploadAttachment('chart.png', 'image/png', 'iVBORw0K');
 
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const linked = getAttachmentsForMessage(msg.id, 'ast-1');
+    const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(1);
     expect(linked[0].id).toBe(stored.id);
     expect(linked[0].originalFilename).toBe('chart.png');
@@ -349,14 +319,14 @@ describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
   test('returns attachments in position order', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'Multiple files');
-    const a = uploadAttachment('ast-1', 'first.txt', 'text/plain', 'AAAA');
-    const b = uploadAttachment('ast-1', 'second.txt', 'text/plain', 'BBBB');
+    const a = uploadAttachment('first.txt', 'text/plain', 'AAAA');
+    const b = uploadAttachment('second.txt', 'text/plain', 'BBBB');
 
     // Link in reverse order
     linkAttachmentToMessage(msg.id, b.id, 1);
     linkAttachmentToMessage(msg.id, a.id, 0);
 
-    const linked = getAttachmentsForMessage(msg.id, 'ast-1');
+    const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(2);
     expect(linked[0].originalFilename).toBe('first.txt');
     expect(linked[1].originalFilename).toBe('second.txt');
@@ -366,49 +336,7 @@ describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'No attachments');
 
-    const linked = getAttachmentsForMessage(msg.id, 'ast-1');
-    expect(linked).toHaveLength(0);
-  });
-
-  test('enforces assistantId scoping on retrieval', () => {
-    const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Scoped');
-    const stored = uploadAttachment('ast-owner', 'secret.txt', 'text/plain', 'c2VjcmV0');
-
-    linkAttachmentToMessage(msg.id, stored.id, 0);
-
-    const wrongScope = getAttachmentsForMessage(msg.id, 'ast-other');
-    expect(wrongScope).toHaveLength(0);
-
-    const rightScope = getAttachmentsForMessage(msg.id, 'ast-owner');
-    expect(rightScope).toHaveLength(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getAttachmentsForMessageUnscoped
-// ---------------------------------------------------------------------------
-
-describe('getAttachmentsForMessageUnscoped', () => {
-  beforeEach(resetTables);
-
-  test('returns attachments without assistant scoping', () => {
-    const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Desktop history');
-    const stored = uploadAttachment('ast-1', 'result.png', 'image/png', 'iVBORw0K');
-
-    linkAttachmentToMessage(msg.id, stored.id, 0);
-
-    const linked = getAttachmentsForMessageUnscoped(msg.id);
-    expect(linked).toHaveLength(1);
-    expect(linked[0].id).toBe(stored.id);
-  });
-
-  test('returns empty for message with no links', () => {
-    const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Nothing here');
-
-    const linked = getAttachmentsForMessageUnscoped(msg.id);
+    const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(0);
   });
 });
@@ -421,7 +349,7 @@ describe('deleteOrphanAttachments', () => {
   beforeEach(resetTables);
 
   test('removes candidate attachments with no message links', () => {
-    const stored = uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'ZGF0YQ==');
+    const stored = uploadAttachment('orphan.txt', 'text/plain', 'ZGF0YQ==');
 
     const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(1);
@@ -430,27 +358,27 @@ describe('deleteOrphanAttachments', () => {
   test('preserves attachments that are still linked', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'With attachment');
-    const stored = uploadAttachment('ast-1', 'linked.txt', 'text/plain', 'ZGF0YQ==');
+    const stored = uploadAttachment('linked.txt', 'text/plain', 'ZGF0YQ==');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(0);
 
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).not.toBeNull();
   });
 
   test('removes only orphans when mixed candidates provided', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'Mixed');
-    const linked = uploadAttachment('ast-1', 'linked.txt', 'text/plain', 'AAAA');
-    const orphan = uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'BBBB');
+    const linked = uploadAttachment('linked.txt', 'text/plain', 'AAAA');
+    const orphan = uploadAttachment('orphan.txt', 'text/plain', 'BBBB');
     linkAttachmentToMessage(msg.id, linked.id, 0);
 
     const removed = deleteOrphanAttachments([linked.id, orphan.id]);
     expect(removed).toBe(1);
 
-    const remaining = getAttachmentById('ast-1', linked.id);
+    const remaining = getAttachmentById(linked.id);
     expect(remaining).not.toBeNull();
   });
 
@@ -460,14 +388,14 @@ describe('deleteOrphanAttachments', () => {
   });
 
   test('does not delete attachments outside the candidate set', () => {
-    const unrelated = uploadAttachment('ast-1', 'unrelated.txt', 'text/plain', 'AAAA');
-    const candidate = uploadAttachment('ast-1', 'candidate.txt', 'text/plain', 'BBBB');
+    const unrelated = uploadAttachment('unrelated.txt', 'text/plain', 'AAAA');
+    const candidate = uploadAttachment('candidate.txt', 'text/plain', 'BBBB');
 
     const removed = deleteOrphanAttachments([candidate.id]);
     expect(removed).toBe(1);
 
     // The unrelated attachment should still exist
-    const fetched = getAttachmentById('ast-1', unrelated.id);
+    const fetched = getAttachmentById(unrelated.id);
     expect(fetched).not.toBeNull();
   });
 });

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -40,7 +40,6 @@ import {
   linkAttachmentToMessage,
   getAttachmentsForMessage,
   getAttachmentById,
-  getAttachmentsForMessageUnscoped,
 } from '../memory/attachments-store.js';
 
 // Initialize db once before all tests
@@ -236,11 +235,11 @@ describe('attachment orphan cleanup', () => {
     addMessage(conv.id, 'user', 'hello');
     const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
 
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    const stored = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     // Verify attachment is linked
-    expect(getAttachmentsForMessageUnscoped(assistantMsg.id)).toHaveLength(1);
+    expect(getAttachmentsForMessage(assistantMsg.id)).toHaveLength(1);
 
     // Delete the exchange — should also clean up orphaned attachments
     deleteLastExchange(conv.id);
@@ -257,7 +256,7 @@ describe('attachment orphan cleanup', () => {
     addMessage(conv.id, 'user', 'question');
     const msg2 = addMessage(conv.id, 'assistant', 'second');
 
-    const shared = uploadAttachment('ast-1', 'shared.png', 'image/png', 'AAAA');
+    const shared = uploadAttachment('shared.png', 'image/png', 'AAAA');
     linkAttachmentToMessage(msg1.id, shared.id, 0);
     linkAttachmentToMessage(msg2.id, shared.id, 0);
 
@@ -273,7 +272,7 @@ describe('attachment orphan cleanup', () => {
   test('clearAll removes all attachments', () => {
     const conv = createConversation('test');
     const msg = addMessage(conv.id, 'assistant', 'file');
-    const stored = uploadAttachment('ast-1', 'doc.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment('doc.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     clearAll();
@@ -291,11 +290,11 @@ describe('attachment orphan cleanup', () => {
     const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
 
     // An attachment linked to the assistant message (should be cleaned up)
-    const linked = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    const linked = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(assistantMsg.id, linked.id, 0);
 
     // A freshly uploaded attachment not linked to any message (should survive)
-    uploadAttachment('ast-1', 'pending.png', 'image/png', 'AAAA');
+    uploadAttachment('pending.png', 'image/png', 'AAAA');
 
     deleteLastExchange(conv.id);
 
@@ -440,7 +439,7 @@ describe('attachment reuse across thread lifecycles', () => {
   test('attachment uploaded in conversation A is retrievable by ID without any conversation reference', () => {
     const convA = createConversation('Thread A');
     const msgA = addMessage(convA.id, 'assistant', 'Here is a file');
-    const stored = uploadAttachment('ast-1', 'report.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment('report.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msgA.id, stored.id, 0);
 
     // Create a completely separate conversation
@@ -448,8 +447,7 @@ describe('attachment reuse across thread lifecycles', () => {
     addMessage(convB.id, 'user', 'hello');
 
     // The attachment is retrievable by ID regardless of which conversation is active.
-    // getAttachmentById only scopes by assistantId, not conversationId.
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).not.toBeNull();
     expect(fetched!.id).toBe(stored.id);
     expect(fetched!.originalFilename).toBe('report.pdf');
@@ -464,16 +462,16 @@ describe('attachment reuse across thread lifecycles', () => {
     const msgB = addMessage(convB.id, 'assistant', 'Reused file');
 
     // Upload once, link to both conversations
-    const stored = uploadAttachment('ast-1', 'shared.png', 'image/png', 'iVBORw0K');
+    const stored = uploadAttachment('shared.png', 'image/png', 'iVBORw0K');
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
 
     // Both messages see the attachment
-    const linkedA = getAttachmentsForMessage(msgA.id, 'ast-1');
+    const linkedA = getAttachmentsForMessage(msgA.id);
     expect(linkedA).toHaveLength(1);
     expect(linkedA[0].id).toBe(stored.id);
 
-    const linkedB = getAttachmentsForMessage(msgB.id, 'ast-1');
+    const linkedB = getAttachmentsForMessage(msgB.id);
     expect(linkedB).toHaveLength(1);
     expect(linkedB[0].id).toBe(stored.id);
   });
@@ -489,7 +487,7 @@ describe('attachment reuse across thread lifecycles', () => {
     addMessage(convB.id, 'user', 'Show me the chart');
     const msgB = addMessage(convB.id, 'assistant', 'Reused');
 
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'AAAA');
+    const stored = uploadAttachment('chart.png', 'image/png', 'AAAA');
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
 
@@ -497,11 +495,11 @@ describe('attachment reuse across thread lifecycles', () => {
     deleteLastExchange(convA.id);
 
     // Attachment survives because convB still references it
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).not.toBeNull();
 
     // convB's message still has the attachment linked
-    const linkedB = getAttachmentsForMessage(msgB.id, 'ast-1');
+    const linkedB = getAttachmentsForMessage(msgB.id);
     expect(linkedB).toHaveLength(1);
     expect(linkedB[0].id).toBe(stored.id);
   });
@@ -514,8 +512,8 @@ describe('attachment reuse across thread lifecycles', () => {
     addMessage(convB.id, 'user', 'upload in B');
 
     // Same content uploaded in two different conversation contexts
-    const first = uploadAttachment('ast-1', 'photo.png', 'image/png', 'DEDUPCROSS');
-    const second = uploadAttachment('ast-1', 'photo.png', 'image/png', 'DEDUPCROSS');
+    const first = uploadAttachment('photo.png', 'image/png', 'DEDUPCROSS');
+    const second = uploadAttachment('photo.png', 'image/png', 'DEDUPCROSS');
 
     // Dedup returns the same attachment row
     expect(second.id).toBe(first.id);
@@ -540,11 +538,11 @@ describe('no private-thread attachment visibility boundary', () => {
     expect(privateConv.threadType).toBe('private');
 
     const msg = addMessage(privateConv.id, 'assistant', 'Private content');
-    const stored = uploadAttachment('ast-1', 'secret.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment('secret.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     // Attachment is globally visible by ID — no thread-type filter exists
-    const fetched = getAttachmentById('ast-1', stored.id);
+    const fetched = getAttachmentById(stored.id);
     expect(fetched).not.toBeNull();
     expect(fetched!.originalFilename).toBe('secret.pdf');
   });
@@ -556,27 +554,26 @@ describe('no private-thread attachment visibility boundary', () => {
     const privateMsg = addMessage(privateConv.id, 'assistant', 'Private file');
     const standardMsg = addMessage(standardConv.id, 'assistant', 'Reusing private file');
 
-    const stored = uploadAttachment('ast-1', 'private-doc.png', 'image/png', 'PRIVDATA');
+    const stored = uploadAttachment('private-doc.png', 'image/png', 'PRIVDATA');
     linkAttachmentToMessage(privateMsg.id, stored.id, 0);
     linkAttachmentToMessage(standardMsg.id, stored.id, 0);
 
     // Both threads can see the attachment
-    const linkedPrivate = getAttachmentsForMessage(privateMsg.id, 'ast-1');
+    const linkedPrivate = getAttachmentsForMessage(privateMsg.id);
     expect(linkedPrivate).toHaveLength(1);
 
-    const linkedStandard = getAttachmentsForMessage(standardMsg.id, 'ast-1');
+    const linkedStandard = getAttachmentsForMessage(standardMsg.id);
     expect(linkedStandard).toHaveLength(1);
     expect(linkedStandard[0].id).toBe(stored.id);
   });
 
-  test('getAttachmentsForMessageUnscoped returns private thread attachments', () => {
+  test('getAttachmentsForMessage returns private thread attachments', () => {
     const privateConv = createConversation({ title: 'Private', threadType: 'private' });
     const msg = addMessage(privateConv.id, 'assistant', 'Private media');
-    const stored = uploadAttachment('ast-1', 'photo.jpg', 'image/jpeg', 'AAAA');
+    const stored = uploadAttachment('photo.jpg', 'image/jpeg', 'AAAA');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    // Unscoped retrieval has no thread-type filter
-    const linked = getAttachmentsForMessageUnscoped(msg.id);
+    const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(1);
     expect(linked[0].id).toBe(stored.id);
   });
@@ -586,8 +583,8 @@ describe('no private-thread attachment visibility boundary', () => {
     createConversation({ title: 'Standard', threadType: 'standard' });
 
     // Same content uploaded in private and standard contexts
-    const fromPrivate = uploadAttachment('ast-1', 'file.png', 'image/png', 'CROSSTHREAD');
-    const fromStandard = uploadAttachment('ast-1', 'file.png', 'image/png', 'CROSSTHREAD');
+    const fromPrivate = uploadAttachment('file.png', 'image/png', 'CROSSTHREAD');
+    const fromStandard = uploadAttachment('file.png', 'image/png', 'CROSSTHREAD');
 
     // Dedup returns the same row — no thread-type isolation
     expect(fromStandard.id).toBe(fromPrivate.id);
@@ -600,8 +597,8 @@ describe('no private-thread attachment visibility boundary', () => {
     const privateMsg = addMessage(privateConv.id, 'assistant', 'Private file');
     const standardMsg = addMessage(standardConv.id, 'assistant', 'Standard file');
 
-    const att1 = uploadAttachment('ast-1', 'private.png', 'image/png', 'PRIV');
-    const att2 = uploadAttachment('ast-1', 'standard.png', 'image/png', 'STD');
+    const att1 = uploadAttachment('private.png', 'image/png', 'PRIV');
+    const att2 = uploadAttachment('standard.png', 'image/png', 'STD');
     linkAttachmentToMessage(privateMsg.id, att1.id, 0);
     linkAttachmentToMessage(standardMsg.id, att2.id, 0);
 

--- a/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
@@ -31,7 +31,6 @@ const NOW = 1700000000000;
 /** A fake selfie image attachment with deterministic IDs. */
 export const FAKE_SELFIE_ATTACHMENT: StoredAttachment = {
   id: 'att-selfie-001',
-  assistantId: 'asst-test-001',
   originalFilename: 'selfie.png',
   mimeType: 'image/png',
   sizeBytes: Buffer.from(TINY_PNG_BASE64, 'base64').length,
@@ -43,7 +42,6 @@ export const FAKE_SELFIE_ATTACHMENT: StoredAttachment = {
 /** A fake document attachment. */
 export const FAKE_DOCUMENT_ATTACHMENT: StoredAttachment = {
   id: 'att-doc-001',
-  assistantId: 'asst-test-001',
   originalFilename: 'report.pdf',
   mimeType: 'application/pdf',
   sizeBytes: 4096,
@@ -55,7 +53,6 @@ export const FAKE_DOCUMENT_ATTACHMENT: StoredAttachment = {
 /** A fake JPEG photo attachment. */
 export const FAKE_PHOTO_ATTACHMENT: StoredAttachment = {
   id: 'att-photo-001',
-  assistantId: 'asst-test-001',
   originalFilename: 'photo.jpg',
   mimeType: 'image/jpeg',
   sizeBytes: Buffer.from(TINY_JPEG_BASE64, 'base64').length,

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -466,6 +466,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'work_item_cancel',
     id: 'wi-001',
   },
+  work_item_render: {
+    type: 'work_item_render',
+    id: 'wi-001',
+  },
   document_save: {
     type: 'document_save',
     surfaceId: 'doc-001',
@@ -1376,6 +1380,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'work_item_cancel_response',
     id: 'wi-001',
     success: true,
+  },
+  work_item_render_response: {
+    type: 'work_item_render_response',
+    id: 'wi-001',
+    success: true,
+    content: '# Rendered Work Item',
+    title: 'Process report',
   },
   work_item_status_changed: {
     type: 'work_item_status_changed',

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -211,7 +211,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
 
     // -- Step 2: Selfie uploaded in Thread A (standard) --
     threadA = createConversation({ title: 'Thread A — selfie upload' });
-    selfieAttachment = uploadAttachment('asst-story-01', 'selfie.png', 'image/png', TINY_PNG_BASE64);
+    selfieAttachment = uploadAttachment('selfie.png', 'image/png', TINY_PNG_BASE64);
     selfieId = selfieAttachment.id;
 
     const msgA = addMessage(threadA.id, 'user', 'Here is my selfie from yesterday');
@@ -358,7 +358,6 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
     // in the attachment store (same hash = returns existing row).
     const generatedImageBase64 = Buffer.from('generated-portrait-data-unique').toString('base64');
     const outputAttachment = uploadAttachment(
-      'asst-story-01',
       'generated-portrait.png',
       'image/png',
       generatedImageBase64,
@@ -473,7 +472,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
   test('selfie in private thread A is NOT discoverable via search from Thread B', async () => {
     // Upload selfie in a private thread
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
-    const selfie = uploadAttachment('asst-priv', 'private-selfie.png', 'image/png', TINY_PNG_BASE64);
+    const selfie = uploadAttachment('private-selfie.png', 'image/png', TINY_PNG_BASE64);
     const msg = addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
@@ -497,7 +496,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
   test('selfie in private thread A is NOT materializable from Thread B', async () => {
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
     const base64 = Buffer.from('private image data').toString('base64');
-    const selfie = uploadAttachment('asst-priv', 'private-selfie.png', 'image/png', base64);
+    const selfie = uploadAttachment('private-selfie.png', 'image/png', base64);
     const msg = addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
@@ -521,7 +520,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
 
   test('selfie in private thread IS accessible from the same private thread', async () => {
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
-    const selfie = uploadAttachment('asst-priv', 'private-selfie.png', 'image/png', TINY_PNG_BASE64);
+    const selfie = uploadAttachment('private-selfie.png', 'image/png', TINY_PNG_BASE64);
     const msg = addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
@@ -550,7 +549,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
 
   test('selfie in private thread A is NOT accessible from private thread B', async () => {
     const privateThreadA = createConversation({ title: 'Private thread A', threadType: 'private' });
-    const selfie = uploadAttachment('asst-priv', 'thread-a-selfie.png', 'image/png', TINY_PNG_BASE64);
+    const selfie = uploadAttachment('thread-a-selfie.png', 'image/png', TINY_PNG_BASE64);
     const msgA = addMessage(privateThreadA.id, 'user', 'Selfie in thread A');
     linkAttachmentToMessage(msgA.id, selfie.id, 0);
 

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -139,7 +139,7 @@ describe('run approval state executionTarget', () => {
 
   test('stores pending confirmation executionTarget when provided', () => {
     const conversation = createConversation('run test');
-    const run = createRun('assistant-1', conversation.id);
+    const run = createRun(conversation.id);
 
     setRunConfirmation(run.id, {
       toolName: 'host_file_read',
@@ -158,7 +158,7 @@ describe('run approval state executionTarget', () => {
 
   test('parses pending confirmations without executionTarget for legacy rows', () => {
     const conversation = createConversation('legacy run test');
-    const run = createRun('assistant-1', conversation.id);
+    const run = createRun(conversation.id);
 
     setRunConfirmation(run.id, {
       toolName: 'bash',

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -82,7 +82,7 @@ describe('Runtime attachment metadata', () => {
     const conversationKey = 'test-conv-1';
 
     // Set up conversation and messages using "self" as the assistantId
-    const mapping = getOrCreateConversation("self", conversationKey);
+    const mapping = getOrCreateConversation(conversationKey);
     conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
     const assistantMsg = conversationStore.addMessage(
       mapping.conversationId,
@@ -91,7 +91,7 @@ describe('Runtime attachment metadata', () => {
     );
 
     // Upload and link an attachment using "self" as the assistantId
-    const stored = uploadAttachment("self", 'chart.png', 'image/png', 'iVBOR');
+    const stored = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     const res = await fetch(
@@ -121,7 +121,7 @@ describe('Runtime attachment metadata', () => {
   test('GET /messages returns empty attachments when none linked', async () => {
     const conversationKey = 'test-conv-2';
 
-    const mapping = getOrCreateConversation("self", conversationKey);
+    const mapping = getOrCreateConversation(conversationKey);
     conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
     conversationStore.addMessage(
       mapping.conversationId,
@@ -142,7 +142,7 @@ describe('Runtime attachment metadata', () => {
   });
 
   test('GET /attachments/:id returns attachment with payload', async () => {
-    const stored = uploadAttachment("self", 'report.pdf', 'application/pdf', 'JVBER');
+    const stored = uploadAttachment('report.pdf', 'application/pdf', 'JVBER');
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,
@@ -162,7 +162,7 @@ describe('Runtime attachment metadata', () => {
   });
 
   test('GET /attachments/:id returns attachment stored under "self"', async () => {
-    const stored = uploadAttachment("self", 'shared.txt', 'text/plain', 'c2hhcmVk');
+    const stored = uploadAttachment('shared.txt', 'text/plain', 'c2hhcmVk');
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -29,7 +29,7 @@ import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import {
   uploadAttachment,
   linkAttachmentToMessage,
-  getAttachmentsForMessageUnscoped,
+  getAttachmentsForMessage,
 } from '../memory/attachments-store.js';
 import {
   createConversation,
@@ -370,7 +370,7 @@ describe('mergeToolResults', () => {
   });
 });
 
-describe('getAttachmentsForMessageUnscoped', () => {
+describe('getAttachmentsForMessage', () => {
   beforeEach(() => {
     const db = getDb();
     db.run('DELETE FROM message_attachments');
@@ -387,10 +387,10 @@ describe('getAttachmentsForMessageUnscoped', () => {
 
   test('returns attachments linked to a message', () => {
     const msgId = createMessage('assistant', 'Here is a chart');
-    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    const stored = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(msgId, stored.id, 0);
 
-    const result = getAttachmentsForMessageUnscoped(msgId);
+    const result = getAttachmentsForMessage(msgId);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(stored.id);
     expect(result[0].originalFilename).toBe('chart.png');
@@ -399,32 +399,32 @@ describe('getAttachmentsForMessageUnscoped', () => {
   });
 
   test('returns empty array when no attachments are linked', () => {
-    expect(getAttachmentsForMessageUnscoped('msg-nonexistent')).toEqual([]);
+    expect(getAttachmentsForMessage('msg-nonexistent')).toEqual([]);
   });
 
   test('returns multiple attachments in position order', () => {
     const msgId = createMessage('assistant', 'Two files');
-    const a1 = uploadAttachment('ast-1', 'first.txt', 'text/plain', 'AAAA');
-    const a2 = uploadAttachment('ast-1', 'second.txt', 'text/plain', 'BBBB');
+    const a1 = uploadAttachment('first.txt', 'text/plain', 'AAAA');
+    const a2 = uploadAttachment('second.txt', 'text/plain', 'BBBB');
 
     linkAttachmentToMessage(msgId, a2.id, 1);
     linkAttachmentToMessage(msgId, a1.id, 0);
 
-    const result = getAttachmentsForMessageUnscoped(msgId);
+    const result = getAttachmentsForMessage(msgId);
     expect(result).toHaveLength(2);
     expect(result[0].originalFilename).toBe('first.txt');
     expect(result[1].originalFilename).toBe('second.txt');
   });
 
-  test('works across different assistantIds', () => {
+  test('returns all attachments linked to a message', () => {
     const msgId = createMessage('assistant', 'Mixed');
-    const a1 = uploadAttachment('ast-A', 'a.png', 'image/png', 'AAAA');
-    const a2 = uploadAttachment('ast-B', 'b.png', 'image/png', 'BBBB');
+    const a1 = uploadAttachment('a.png', 'image/png', 'AAAA');
+    const a2 = uploadAttachment('b.png', 'image/png', 'BBBB');
 
     linkAttachmentToMessage(msgId, a1.id, 0);
     linkAttachmentToMessage(msgId, a2.id, 1);
 
-    const result = getAttachmentsForMessageUnscoped(msgId);
+    const result = getAttachmentsForMessage(msgId);
     expect(result).toHaveLength(2);
   });
 });

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,11 +1,8 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import type { ImageContent } from '../../../../providers/types.js';
-import { eq } from 'drizzle-orm';
 import { getConfig } from '../../../../config/loader.js';
 import { generateImage, mapGeminiError } from '../../../../media/gemini-image-service.js';
 import { getAttachmentsByIds } from '../../../../memory/attachments-store.js';
-import { getDb } from '../../../../memory/db.js';
-import { conversationKeys } from '../../../../memory/schema.js';
 import { isAttachmentVisible, type AttachmentContext } from '../../../../daemon/media-visibility-policy.js';
 import { getConversationThreadType } from '../../../../memory/conversation-store.js';
 import { getAttachmentSourceConversations } from '../../../../tools/assets/search.js';
@@ -27,17 +24,6 @@ function isAttachmentAccessible(attachmentId: string, currentContext: Attachment
   return sources.some(
     (s) => isAttachmentVisible({ conversationId: s.conversationId, isPrivate: true }, currentContext),
   );
-}
-
-/** Resolve the assistantId for the current conversation. */
-function getAssistantIdForConversation(conversationId: string): string | null {
-  const db = getDb();
-  const row = db
-    .select({ assistantId: conversationKeys.assistantId })
-    .from(conversationKeys)
-    .where(eq(conversationKeys.conversationId, conversationId))
-    .get();
-  return row?.assistantId ?? null;
 }
 
 export async function run(
@@ -64,15 +50,7 @@ export async function run(
   let sourceImages: Array<{ mimeType: string; dataBase64: string }> | undefined;
 
   if (attachmentIds && attachmentIds.length > 0) {
-    const assistantId = getAssistantIdForConversation(context.conversationId);
-    if (!assistantId) {
-      return {
-        content: 'Could not resolve assistant context for attachment lookup.',
-        isError: true,
-      };
-    }
-
-    const attachments = getAttachmentsByIds(assistantId, attachmentIds);
+    const attachments = getAttachmentsByIds(attachmentIds);
 
     // Build visibility context for the current conversation
     const threadType = getConversationThreadType(context.conversationId);

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
-import { getAttachmentsForMessageUnscoped, setAttachmentThumbnail } from '../../memory/attachments-store.js';
+import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
@@ -349,7 +349,7 @@ export function handleHistoryRequest(
   const historyMessages = merged.map((m) => {
     let attachments: UserMessageAttachment[] | undefined;
     if (m.role === 'assistant' && m.id) {
-      const linked = getAttachmentsForMessageUnscoped(m.id);
+      const linked = getAttachmentsForMessage(m.id);
       if (linked.length > 0) {
         // Skip embedding base64 data for large video attachments to keep the
         // history_response payload small. Only videos have a lazy-fetch path on

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1011,7 +1011,7 @@ export class DaemonServer {
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
+      ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
@@ -1084,7 +1084,7 @@ export class DaemonServer {
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
+      ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
@@ -1132,7 +1132,7 @@ export class DaemonServer {
       getOrCreateSession: (conversationId) =>
         this.getOrCreateSession(conversationId),
       resolveAttachments: (attachmentIds) =>
-        attachmentsStore.getAttachmentsByIds('self', attachmentIds).map((a) => ({
+        attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -707,7 +707,6 @@ export async function runAgentLoopImpl(
       ctx.workingDir,
       async (filePath) => approveHostAttachmentRead(filePath, ctx.workingDir, ctx.prompter, ctx.conversationId, ctx.hasNoClient),
       lastAssistantMessageId,
-      ctx.channelCapabilities != null ? 'self' : 'local-assistant',
     );
     const { assistantAttachments, emittedAttachments } = attachmentResult;
 

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -93,7 +93,6 @@ export async function resolveAssistantAttachments(
   workingDir: string,
   approveHostRead: ApproveHostRead,
   lastAssistantMessageId: string | undefined,
-  assistantScope: string,
 ): Promise<AttachmentResolutionResult> {
   let assistantAttachments: AssistantAttachmentDraft[] = [];
   const emittedAttachments: UserMessageAttachment[] = [];
@@ -143,7 +142,6 @@ export async function resolveAssistantAttachments(
       let stored;
       try {
         stored = uploadAttachment(
-          assistantScope,
           draft.filename,
           draft.mimeType,
           draft.dataBase64,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -333,6 +333,7 @@ export class Session {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);
   }
 
+
   drainQueue(reason: QueueDrainReason = 'loop_complete'): void {
     drainQueueImpl(this as ProcessSessionContext, reason);
   }

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -5,14 +5,13 @@
  * data. Provides upload, delete, and message-linkage operations.
  */
 
-import { eq, and } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { attachments, messageAttachments } from './schema.js';
 
 export interface StoredAttachment {
   id: string;
-  assistantId: string;
   originalFilename: string;
   mimeType: string;
   sizeBytes: number;
@@ -153,7 +152,6 @@ function computeContentHash(dataBase64: string): string {
 }
 
 export function uploadAttachment(
-  assistantId: string,
   filename: string,
   mimeType: string,
   dataBase64: string,
@@ -174,12 +172,11 @@ export function uploadAttachment(
   const db = getDb();
   const contentHash = computeContentHash(dataBase64);
 
-  // Dedup: if an attachment with the same content already exists for this
-  // assistant, return it instead of storing a duplicate.
+  // Dedup: if an attachment with the same content already exists, return it
+  // instead of storing a duplicate.
   const existing = db
     .select({
       id: attachments.id,
-      assistantId: attachments.assistantId,
       originalFilename: attachments.originalFilename,
       mimeType: attachments.mimeType,
       sizeBytes: attachments.sizeBytes,
@@ -188,12 +185,7 @@ export function uploadAttachment(
       createdAt: attachments.createdAt,
     })
     .from(attachments)
-    .where(
-      and(
-        eq(attachments.assistantId, assistantId),
-        eq(attachments.contentHash, contentHash),
-      ),
-    )
+    .where(eq(attachments.contentHash, contentHash))
     .get();
 
   if (existing) {
@@ -205,7 +197,7 @@ export function uploadAttachment(
 
   const record = {
     id: uuid(),
-    assistantId,
+    assistantId: 'self',
     originalFilename: filename,
     mimeType,
     sizeBytes,
@@ -219,7 +211,6 @@ export function uploadAttachment(
 
   return {
     id: record.id,
-    assistantId,
     originalFilename: filename,
     mimeType,
     sizeBytes,
@@ -242,17 +233,12 @@ export function setAttachmentThumbnail(attachmentId: string, thumbnailBase64: st
 
 export type DeleteAttachmentResult = 'deleted' | 'not_found' | 'still_referenced';
 
-export function deleteAttachment(assistantId: string, attachmentId: string): DeleteAttachmentResult {
+export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
   const db = getDb();
   const existing = db
     .select({ id: attachments.id })
     .from(attachments)
-    .where(
-      and(
-        eq(attachments.id, attachmentId),
-        eq(attachments.assistantId, assistantId),
-      ),
-    )
+    .where(eq(attachments.id, attachmentId))
     .get();
 
   if (!existing) return 'not_found';
@@ -277,7 +263,6 @@ export function deleteAttachment(assistantId: string, attachmentId: string): Del
 }
 
 export function getAttachmentsByIds(
-  assistantId: string,
   ids: string[],
 ): Array<StoredAttachment & { dataBase64: string }> {
   if (ids.length === 0) return [];
@@ -287,17 +272,11 @@ export function getAttachmentsByIds(
     const row = db
       .select()
       .from(attachments)
-      .where(
-        and(
-          eq(attachments.id, id),
-          eq(attachments.assistantId, assistantId),
-        ),
-      )
+      .where(eq(attachments.id, id))
       .get();
     if (row) {
       results.push({
         id: row.id,
-        assistantId: row.assistantId,
         originalFilename: row.originalFilename,
         mimeType: row.mimeType,
         sizeBytes: row.sizeBytes,
@@ -333,7 +312,6 @@ export function linkAttachmentToMessage(
  */
 export function getAttachmentsForMessage(
   messageId: string,
-  assistantId: string,
 ): Array<StoredAttachment & { dataBase64: string }> {
   const db = getDb();
   const links = db
@@ -346,7 +324,7 @@ export function getAttachmentsForMessage(
   if (links.length === 0) return [];
 
   const ids = links.map((l) => l.attachmentId).filter((id): id is string => id !== null);
-  return getAttachmentsByIds(assistantId, ids);
+  return getAttachmentsByIds(ids);
 }
 
 /**
@@ -357,7 +335,6 @@ export function getAttachmentsForMessage(
  */
 export function getAttachmentMetadataForMessage(
   messageId: string,
-  assistantId: string,
 ): StoredAttachment[] {
   const db = getDb();
   const links = db
@@ -375,7 +352,6 @@ export function getAttachmentMetadataForMessage(
     const row = db
       .select({
         id: attachments.id,
-        assistantId: attachments.assistantId,
         originalFilename: attachments.originalFilename,
         mimeType: attachments.mimeType,
         sizeBytes: attachments.sizeBytes,
@@ -384,12 +360,7 @@ export function getAttachmentMetadataForMessage(
         createdAt: attachments.createdAt,
       })
       .from(attachments)
-      .where(
-        and(
-          eq(attachments.id, link.attachmentId),
-          eq(attachments.assistantId, assistantId),
-        ),
-      )
+      .where(eq(attachments.id, link.attachmentId))
       .get();
     if (row) results.push(row);
   }
@@ -397,83 +368,13 @@ export function getAttachmentMetadataForMessage(
 }
 
 /**
- * Return all attachments linked to a message without assistant scoping.
- * Used by the desktop IPC history handler where tenant isolation is not needed.
- */
-export function getAttachmentsForMessageUnscoped(
-  messageId: string,
-): Array<StoredAttachment & { dataBase64: string }> {
-  const db = getDb();
-  const links = db
-    .select({ attachmentId: messageAttachments.attachmentId, position: messageAttachments.position })
-    .from(messageAttachments)
-    .where(eq(messageAttachments.messageId, messageId))
-    .orderBy(messageAttachments.position)
-    .all();
-
-  if (links.length === 0) return [];
-
-  const results: Array<StoredAttachment & { dataBase64: string }> = [];
-  for (const link of links) {
-    if (!link.attachmentId) continue;
-    const row = db
-      .select()
-      .from(attachments)
-      .where(eq(attachments.id, link.attachmentId))
-      .get();
-    if (row) {
-      results.push({
-        id: row.id,
-        assistantId: row.assistantId,
-        originalFilename: row.originalFilename,
-        mimeType: row.mimeType,
-        sizeBytes: row.sizeBytes,
-        kind: row.kind,
-        thumbnailBase64: row.thumbnailBase64,
-        dataBase64: row.dataBase64,
-        createdAt: row.createdAt,
-      });
-    }
-  }
-  return results;
-}
-
-/**
- * Retrieve a single attachment by ID, scoped to an assistant.
+ * Retrieve a single attachment by ID.
  */
 export function getAttachmentById(
-  assistantId: string,
   attachmentId: string,
 ): (StoredAttachment & { dataBase64: string }) | null {
-  const results = getAttachmentsByIds(assistantId, [attachmentId]);
+  const results = getAttachmentsByIds([attachmentId]);
   return results[0] ?? null;
-}
-
-/**
- * Retrieve a single attachment by ID without assistant scoping.
- * Used by the desktop HTTP endpoint where tenant isolation is not needed.
- */
-export function getAttachmentByIdUnscoped(
-  attachmentId: string,
-): (StoredAttachment & { dataBase64: string }) | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(attachments)
-    .where(eq(attachments.id, attachmentId))
-    .get();
-  if (!row) return null;
-  return {
-    id: row.id,
-    assistantId: row.assistantId,
-    originalFilename: row.originalFilename,
-    mimeType: row.mimeType,
-    sizeBytes: row.sizeBytes,
-    kind: row.kind,
-    thumbnailBase64: row.thumbnailBase64,
-    dataBase64: row.dataBase64,
-    createdAt: row.createdAt,
-  };
 }
 
 /**

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -11,7 +11,7 @@
  * and a replay endpoint allows manual recovery of dead-lettered ones.
  */
 
-import { eq, and, lte, isNotNull } from 'drizzle-orm';
+import { eq, and, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
@@ -35,10 +35,9 @@ export interface RecordInboundOptions {
 
 /**
  * Record an inbound channel event. Returns `duplicate: true` if this
- * exact (assistant, channel, chat, message) combination was already seen.
+ * exact (channel, chat, message) combination was already seen.
  */
 export function recordInbound(
-  assistantId: string,
   sourceChannel: string,
   externalChatId: string,
   externalMessageId: string,
@@ -54,7 +53,6 @@ export function recordInbound(
     .from(channelInboundEvents)
     .where(
       and(
-        eq(channelInboundEvents.assistantId, assistantId),
         eq(channelInboundEvents.sourceChannel, sourceChannel),
         eq(channelInboundEvents.externalChatId, externalChatId),
         eq(channelInboundEvents.externalMessageId, externalMessageId),
@@ -72,7 +70,7 @@ export function recordInbound(
   }
 
   const conversationKey = `${sourceChannel}:${externalChatId}`;
-  const mapping = getOrCreateConversation(assistantId, conversationKey);
+  const mapping = getOrCreateConversation(conversationKey);
   const now = Date.now();
   const eventId = uuid();
 
@@ -84,7 +82,7 @@ export function recordInbound(
     tx.insert(channelInboundEvents)
       .values({
         id: eventId,
-        assistantId,
+        assistantId: 'self',
         sourceChannel,
         externalChatId,
         externalMessageId,
@@ -122,7 +120,6 @@ export function linkMessage(eventId: string, messageId: string): void {
  * platform-level message identifier (e.g. Telegram message_id).
  */
 export function findMessageBySourceId(
-  assistantId: string,
   sourceChannel: string,
   externalChatId: string,
   sourceMessageId: string,
@@ -136,11 +133,9 @@ export function findMessageBySourceId(
     .from(channelInboundEvents)
     .where(
       and(
-        eq(channelInboundEvents.assistantId, assistantId),
         eq(channelInboundEvents.sourceChannel, sourceChannel),
         eq(channelInboundEvents.externalChatId, externalChatId),
         eq(channelInboundEvents.sourceMessageId, sourceMessageId),
-        isNotNull(channelInboundEvents.messageId),
       ),
     )
     .get();
@@ -153,7 +148,6 @@ export function findMessageBySourceId(
  * Acknowledge delivery of an outbound message for a channel event.
  */
 export function acknowledgeDelivery(
-  assistantId: string,
   sourceChannel: string,
   externalChatId: string,
   externalMessageId: string,
@@ -166,7 +160,6 @@ export function acknowledgeDelivery(
     .from(channelInboundEvents)
     .where(
       and(
-        eq(channelInboundEvents.assistantId, assistantId),
         eq(channelInboundEvents.sourceChannel, sourceChannel),
         eq(channelInboundEvents.externalChatId, externalChatId),
         eq(channelInboundEvents.externalMessageId, externalMessageId),
@@ -271,7 +264,6 @@ export function recordProcessingFailure(eventId: string, err: unknown): void {
 /** Fetch events eligible for automatic retry (failed + past their backoff). */
 export function getRetryableEvents(limit = 20): Array<{
   id: string;
-  assistantId: string;
   conversationId: string;
   processingAttempts: number;
   rawPayload: string | null;
@@ -281,7 +273,6 @@ export function getRetryableEvents(limit = 20): Array<{
   return db
     .select({
       id: channelInboundEvents.id,
-      assistantId: channelInboundEvents.assistantId,
       conversationId: channelInboundEvents.conversationId,
       processingAttempts: channelInboundEvents.processingAttempts,
       rawPayload: channelInboundEvents.rawPayload,
@@ -297,8 +288,8 @@ export function getRetryableEvents(limit = 20): Array<{
     .all();
 }
 
-/** Fetch dead-lettered events for an assistant. */
-export function getDeadLetterEvents(assistantId: string): Array<{
+/** Fetch dead-lettered events. */
+export function getDeadLetterEvents(): Array<{
   id: string;
   sourceChannel: string;
   externalChatId: string;
@@ -321,12 +312,7 @@ export function getDeadLetterEvents(assistantId: string): Array<{
       createdAt: channelInboundEvents.createdAt,
     })
     .from(channelInboundEvents)
-    .where(
-      and(
-        eq(channelInboundEvents.assistantId, assistantId),
-        eq(channelInboundEvents.processingStatus, 'dead_letter'),
-      ),
-    )
+    .where(eq(channelInboundEvents.processingStatus, 'dead_letter'))
     .all();
 }
 
@@ -334,7 +320,7 @@ export function getDeadLetterEvents(assistantId: string): Array<{
  * Reset dead-lettered events back to 'failed' so the sweep can retry
  * them. Resets attempt counter and sets an immediate retry_after.
  */
-export function replayDeadLetters(assistantId: string, eventIds: string[]): number {
+export function replayDeadLetters(eventIds: string[]): number {
   const db = getDb();
   const now = Date.now();
   let count = 0;
@@ -345,7 +331,6 @@ export function replayDeadLetters(assistantId: string, eventIds: string[]): numb
       .where(
         and(
           eq(channelInboundEvents.id, id),
-          eq(channelInboundEvents.assistantId, assistantId),
           eq(channelInboundEvents.processingStatus, 'dead_letter'),
         ),
       )

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -11,7 +11,7 @@
  * and a replay endpoint allows manual recovery of dead-lettered ones.
  */
 
-import { eq, and, lte } from 'drizzle-orm';
+import { eq, and, lte, isNotNull } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
@@ -136,6 +136,7 @@ export function findMessageBySourceId(
         eq(channelInboundEvents.sourceChannel, sourceChannel),
         eq(channelInboundEvents.externalChatId, externalChatId),
         eq(channelInboundEvents.sourceMessageId, sourceMessageId),
+        isNotNull(channelInboundEvents.messageId),
       ),
     )
     .get();

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -1,49 +1,42 @@
 /**
- * Maps (assistant_id, conversation_key) pairs to internal conversation IDs.
+ * Maps conversation keys to internal conversation IDs.
  *
  * The web UI identifies conversations by an opaque `conversationKey` (e.g.
  * a user ID, a channel thread ID).  This store resolves those keys to the
- * assistant's internal conversation IDs, creating new conversations on
+ * daemon's internal conversation IDs, creating new conversations on
  * first contact.
  */
 
-import { eq, and } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, conversationKeys } from './schema.js';
 
 export interface ConversationKeyMapping {
   id: string;
-  assistantId: string;
   conversationKey: string;
   conversationId: string;
   createdAt: number;
 }
 
 /**
- * Look up the conversation ID for a given (assistantId, conversationKey).
+ * Look up the conversation ID for a given conversationKey.
  * Returns `null` if no mapping exists yet.
  */
 export function getConversationByKey(
-  assistantId: string,
   conversationKey: string,
 ): ConversationKeyMapping | null {
   const db = getDb();
   const result = db
     .select()
     .from(conversationKeys)
-    .where(
-      and(
-        eq(conversationKeys.assistantId, assistantId),
-        eq(conversationKeys.conversationKey, conversationKey),
-      ),
-    )
+    .where(eq(conversationKeys.conversationKey, conversationKey))
     .get();
   return result ?? null;
 }
 
 /**
- * Delete the conversation-key mapping for a given (assistantId, conversationKey).
+ * Delete the conversation-key mapping for a given conversationKey.
  *
  * This is a soft reset: the old conversation data remains in the database,
  * but it is no longer reachable via this key.  The next message with the
@@ -51,29 +44,22 @@ export function getConversationByKey(
  *
  */
 export function deleteConversationKey(
-  assistantId: string,
   conversationKey: string,
 ): void {
   const db = getDb();
   db.delete(conversationKeys)
-    .where(
-      and(
-        eq(conversationKeys.assistantId, assistantId),
-        eq(conversationKeys.conversationKey, conversationKey),
-      ),
-    )
+    .where(eq(conversationKeys.conversationKey, conversationKey))
     .run();
 }
 
 /**
- * Get or create a conversation for the given (assistantId, conversationKey).
+ * Get or create a conversation for the given conversationKey.
  *
  * If a mapping already exists, returns the existing conversation ID.
  * Otherwise, creates a new conversation and mapping atomically within a
  * single transaction to prevent race conditions and orphaned rows.
  */
 export function getOrCreateConversation(
-  assistantId: string,
   conversationKey: string,
 ): { conversationId: string; created: boolean } {
   const db = getDb();
@@ -82,12 +68,7 @@ export function getOrCreateConversation(
     const existing = tx
       .select()
       .from(conversationKeys)
-      .where(
-        and(
-          eq(conversationKeys.assistantId, assistantId),
-          eq(conversationKeys.conversationKey, conversationKey),
-        ),
-      )
+      .where(eq(conversationKeys.conversationKey, conversationKey))
       .get();
 
     if (existing) {
@@ -115,7 +96,7 @@ export function getOrCreateConversation(
     tx.insert(conversationKeys)
       .values({
         id: uuid(),
-        assistantId,
+        assistantId: 'self',
         conversationKey,
         conversationId,
         createdAt: now,

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -85,7 +85,6 @@ function rowToRun(row: typeof messageRuns.$inferSelect): Run {
 // ---------------------------------------------------------------------------
 
 export function createRun(
-  assistantId: string,
   conversationId: string,
   messageId?: string,
 ): Run {
@@ -95,7 +94,7 @@ export function createRun(
 
   const row = {
     id,
-    assistantId,
+    assistantId: 'self',
     conversationId,
     messageId: messageId ?? null,
     status: 'running' as const,

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -56,7 +56,6 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
   let attachment: attachmentsStore.StoredAttachment;
   try {
     attachment = attachmentsStore.uploadAttachment(
-      "self",
       filename,
       mimeType,
       data,
@@ -98,7 +97,7 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
     );
   }
 
-  const result = attachmentsStore.deleteAttachment("self", attachmentId);
+  const result = attachmentsStore.deleteAttachment(attachmentId);
 
   if (result === 'not_found') {
     return Response.json(
@@ -118,7 +117,7 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
 }
 
 export function handleGetAttachment(attachmentId: string): Response {
-  const attachment = attachmentsStore.getAttachmentByIdUnscoped(attachmentId);
+  const attachment = attachmentsStore.getAttachmentById(attachmentId);
   if (!attachment) {
     return Response.json({ error: 'Attachment not found' }, { status: 404 });
   }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -34,7 +34,7 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
   }
 
   const conversationKey = `${sourceChannel}:${externalChatId}`;
-  deleteConversationKey("self", conversationKey);
+  deleteConversationKey(conversationKey);
 
   return Response.json({ ok: true });
 }
@@ -89,7 +89,7 @@ export async function handleChannelInbound(
   }
 
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -112,7 +112,6 @@ export async function handleChannelInbound(
   if (isEdit && sourceMessageId) {
     // Dedup the edit event itself (retried edited_message webhooks)
     const editResult = channelDeliveryStore.recordInbound(
-      "self",
       sourceChannel,
       externalChatId,
       externalMessageId,
@@ -136,7 +135,6 @@ export async function handleChannelInbound(
     let original: { messageId: string; conversationId: string } | null = null;
     for (let attempt = 0; attempt <= EDIT_LOOKUP_RETRIES; attempt++) {
       original = channelDeliveryStore.findMessageBySourceId(
-        "self",
         sourceChannel,
         externalChatId,
         sourceMessageId,
@@ -173,7 +171,6 @@ export async function handleChannelInbound(
 
   // ── New message path ──
   const result = channelDeliveryStore.recordInbound(
-    "self",
     sourceChannel,
     externalChatId,
     externalMessageId,
@@ -256,7 +253,7 @@ export async function handleChannelInbound(
         try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
         const rendered = renderHistoryContent(parsed);
 
-        const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id, "self");
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id);
         const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
           id: a.id,
           filename: a.originalFilename,
@@ -289,7 +286,7 @@ export async function handleChannelInbound(
 }
 
 export function handleListDeadLetters(): Response {
-  const events = channelDeliveryStore.getDeadLetterEvents("self");
+  const events = channelDeliveryStore.getDeadLetterEvents();
   return Response.json({ events });
 }
 
@@ -301,7 +298,7 @@ export async function handleReplayDeadLetters(req: Request): Promise<Response> {
     return Response.json({ error: 'eventIds array is required' }, { status: 400 });
   }
 
-  const replayed = channelDeliveryStore.replayDeadLetters("self", eventIds);
+  const replayed = channelDeliveryStore.replayDeadLetters(eventIds);
   return Response.json({ replayed });
 }
 
@@ -325,7 +322,6 @@ export async function handleChannelDeliveryAck(req: Request): Promise<Response> 
   }
 
   const acked = channelDeliveryStore.acknowledgeDelivery(
-    "self",
     sourceChannel,
     externalChatId,
     externalMessageId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -54,7 +54,7 @@ export function handleListMessages(
     );
   }
 
-  const mapping = getConversationByKey("self", conversationKey);
+  const mapping = getConversationByKey(conversationKey);
   if (!mapping) {
     return Response.json({ messages: [] });
   }
@@ -89,7 +89,7 @@ export function handleListMessages(
   const messages: RuntimeMessagePayload[] = merged.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.role === 'assistant' && m.id) {
-      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id, "self");
+      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
       if (linked.length > 0) {
         msgAttachments = linked.map((a) => ({
           id: a.id,
@@ -170,7 +170,7 @@ export async function handleSendMessage(
 
   // Validate that all attachment IDs resolve
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -181,7 +181,7 @@ export async function handleSendMessage(
     }
   }
 
-  const mapping = getOrCreateConversation("self", conversationKey);
+  const mapping = getOrCreateConversation(conversationKey);
 
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
@@ -247,7 +247,7 @@ export async function handleGetSuggestion(
     );
   }
 
-  const mapping = getConversationByKey("self", conversationKey);
+  const mapping = getConversationByKey(conversationKey);
   if (!mapping) {
     return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
   }

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -38,7 +38,7 @@ export async function handleCreateRun(
   }
 
   if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds("self", attachmentIds);
+    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
@@ -49,7 +49,7 @@ export async function handleCreateRun(
     }
   }
 
-  const mapping = getOrCreateConversation("self", conversationKey);
+  const mapping = getOrCreateConversation(conversationKey);
 
   try {
     const run = await runOrchestrator.startRun(

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -89,7 +89,7 @@ export class RunOrchestrator {
 
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content, attachments, requestId);
-    const run = runsStore.createRun('self', conversationId, messageId);
+    const run = runsStore.createRun(conversationId, messageId);
 
     // Runs are always HTTP-originated; set channel capabilities so the attachment
     // scope heuristic resolves to 'self' rather than 'local-assistant'.

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -214,7 +214,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_RESULTS);
     const stmt = raw.prepare(
-      `SELECT a.id, a.assistant_id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
+      `SELECT a.id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
        FROM attachments a
        WHERE ${whereParts.join(' AND ')}
        ORDER BY a.created_at DESC
@@ -223,7 +223,6 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
 
     const rows = stmt.all(...bindValues, limit) as Array<{
       id: string;
-      assistant_id: string;
       original_filename: string;
       mime_type: string;
       size_bytes: number;
@@ -234,7 +233,6 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
 
     return rows.map((r) => ({
       id: r.id,
-      assistantId: r.assistant_id,
       originalFilename: r.original_filename,
       mimeType: r.mime_type,
       sizeBytes: r.size_bytes,
@@ -251,7 +249,6 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
   const query = db
     .select({
       id: attachments.id,
-      assistantId: attachments.assistantId,
       originalFilename: attachments.originalFilename,
       mimeType: attachments.mimeType,
       sizeBytes: attachments.sizeBytes,


### PR DESCRIPTION
## Summary
- Remove `assistantId` parameter from all memory store APIs (conversation-key-store, attachments-store, channel-delivery-store, runs-store)
- Drop assistant-scoped WHERE clauses from all DB queries; write `'self'` to NOT NULL columns until schema migration in PR 7
- Fold `getAttachmentsForMessageUnscoped` / `getAttachmentByIdUnscoped` into the now-unscoped main functions; update all callers and tests

## Plan

# Remove `assistantId` From Daemon Runtime (Incremental PR Stack)

## Goal
Remove `assistantId` from assistant daemon HTTP routes and daemon internals by moving to a single implicit runtime identity ("self"), shipped as small, reviewable pull requests.

## Scope
- Runtime HTTP API currently uses `/v1/assistants/:assistantId/...`.
- Daemon/runtime internals thread `assistantId` through handlers, orchestration, stores, and DB schema.
- Downstream callers (gateway + adapters) currently construct assistant-scoped runtime URLs.

## Migration Rules
- Ship backward-compatible route support before removing old routes.
- Remove runtime path `assistantId` first, then remove daemon function parameters.
- Do DB schema changes only after code reads/writes no longer depend on assistant scoping.
- Keep each PR testable and independently mergeable.

## Incremental PRs

## PR 1: Add assistant-less runtime routes (compat mode, no breakage)
- Add new route family in `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/http-server.ts`:
  - `/v1/health`
  - `/v1/messages`
  - `/v1/attachments`
  - `/v1/attachments/:attachmentId`
  - `/v1/suggestion`
  - `/v1/runs`
  - `/v1/runs/:runId`
  - `/v1/runs/:runId/decision`
  - `/v1/runs/:runId/trust-rule`
  - `/v1/channels/conversation`
  - `/v1/channels/inbound`
  - `/v1/channels/delivery-ack`
  - `/v1/channels/dead-letters`
  - `/v1/channels/replay`
- Keep `/v1/assistants/:assistantId/...` temporarily; ignore the path `assistantId`.
- Add deprecation logs when old route shape is used.
- Tests:
  - Both route shapes pass for representative endpoints.
  - Behavior parity (same status/body) between old and new route shapes.

## PR 2: Move all first-party callers to assistant-less routes
- Update runtime clients to use `/v1/...` URLs:
  - `/Users/maddieabboud/projects/vellum-assistant/gateway/src/runtime/client.ts`
- Remove unnecessary URL-level `assistantId` parameter plumbing in caller APIs where possible.
- Keep compatibility for any temporary mixed usage during rollout.
- Tests:
  - Gateway runtime client integration tests pass with new URLs.

## PR 3: Remove `assistantId` from runtime route handler signatures
- Refactor handler signatures and call sites:
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/routes/conversation-routes.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/routes/attachment-routes.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/routes/channel-routes.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/routes/run-routes.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/http-types.ts`
- Preserve gateway edge contract: gateway input should still accept
  `/v1/assistants/:assistantId/...`.
- Add a gateway translation layer that:
  - extracts `assistantId` from inbound gateway path,
  - resolves the target assistant/runtime using that ID,
  - rewrites upstream daemon request path to assistant-less `/v1/...`.
- If `assistantId` cannot be resolved, return a deterministic client error
  (`404`/`422`) instead of proxying.
- Primary gateway files to update in this step:
  - `/Users/maddieabboud/projects/vellum-assistant/gateway/src/http/routes/runtime-proxy.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/gateway/src/config.ts` (if assistantId -> runtime mapping config is needed)
- Replace calls to assistant-scoped store APIs with temporary assistant-less wrappers (introduced in this PR if needed).
- Tests:
  - Runtime HTTP tests updated to no longer provide `assistantId` route context.
  - Run endpoints still enforce run existence/ownership semantics via run ID only.
  - Gateway proxy tests verify `/v1/assistants/:assistantId/...` is accepted and correctly forwarded to `/v1/...` for the resolved assistant target.

## PR 4: Remove `assistantId` from daemon runtime entrypoints + orchestrator
- Refactor signatures in:
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/daemon/server.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/daemon/lifecycle.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/runtime/run-orchestrator.ts`
- Stop passing/setting assistant identity per request for HTTP runtime flows.
- Keep IPC/desktop behavior unchanged except for removed unused identity plumbing.
- Tests:
  - Message processing and run orchestration integration tests pass with new signatures.
  - Channel retry sweep still replays correctly.

## PR 5: Remove assistant-scoped session/usage identity plumbing
- Refactor:
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/daemon/session.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/daemon/session-usage.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/llm-usage-store.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/usage/types.ts`
- Remove `setAssistantId` and `assistantId` usage tracking where it no longer adds information.
- Decide and apply one policy for historical usage records:
  - Keep nullable `assistant_id` as legacy field with null writes, or
  - Hardcode a single canonical value (for compatibility analytics).
- Tests:
  - Usage event persistence still works.
  - Session loops and attachment directive resolution still work.

## PR 6: Convert memory stores from assistant-scoped APIs to assistant-less APIs
- Refactor store contracts and call sites:
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/conversation-key-store.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/attachments-store.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/channel-delivery-store.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/runs-store.ts`
- Keep gateway assistant routing strictly at the gateway boundary; do not
  pass assistant identity into daemon store APIs.
- Update logic currently keyed by `(assistant_id, ...)` to key on remaining identifiers only.
- Add collision handling where uniqueness dimensions shrink (conversation keys, channel idempotency).
- Tests:
  - Attachment retrieval/deletion and dedup behavior preserved.
  - Channel idempotency still prevents duplicates.
  - Conversation key mapping and run retrieval still correct.

## PR 7: Schema migration to remove `assistant_id` columns and indexes
- Update schema + DB bootstrap/migration code:
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/schema.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/src/memory/db.ts`
  - `/Users/maddieabboud/projects/vellum-assistant/assistant/drizzle/*` (if maintained as source of truth)
- The daemon schema must not depend on gateway `assistantId`; gateway-level
  assistant routing should map to daemon instance/target before persistence.
- Tables affected:
  - `conversation_keys`
  - `attachments`
  - `channel_inbound_events`
  - `message_runs`
  - `llm_usage_events` (optional remove vs legacy nullable keep)
- Replace assistant-based unique indexes with new unique/index strategy.
- Add data migration path for existing DBs (table rebuild where SQLite requires it).
- Tests:
  - Migration from pre-change DB succeeds.
  - Post-migration runtime behavior matches pre-migration semantics.

## PR 8: Remove legacy route compatibility + finalize docs/tests
- Remove `/v1/assistants/:assistantId/...` support from runtime router.
- Keep gateway-facing `/v1/assistants/:assistantId/...` contract in
  gateway proxy/router and continue rewriting to daemon `/v1/...`.
- Remove remaining dead `assistantId` types/comments/tests:
  - runtime tests
  - attachment scoping tests
  - event hub tests if assistant filtering is removed
- Update docs:
  - `/Users/maddieabboud/projects/vellum-assistant/README.md`
  - `/Users/maddieabboud/projects/vellum-assistant/gateway/README.md`
  - `/Users/maddieabboud/projects/vellum-assistant/ARCHITECTURE.md` (route/data-flow changes)
- Final verification:
  - full test suite
  - manual smoke test through gateway -> daemon runtime path

## Merge Gate Per PR
- No cross-PR hidden dependencies.
- Tests updated in same PR for changed surface.
- Backward compatibility maintained until planned removal PR.
- Clear rollback path documented in PR description.

Part of plan: REMOVE-ASSISTANT-ID-INCREMENTAL.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
