### PR TITLE
fix: move OAuth2 client credentials from metadata to keychain

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -95,15 +95,19 @@ function findStoredOAuthField(service: string, fieldNames: string[]): string | u
     }
   }
 
-  // Fallback: check credential metadata on the access_token record, where
-  // oauth2_connect persists the client config after a successful flow.
+  // Legacy fallback: check credential metadata on the access_token record.
+  // Older OAuth2 flows stored client_id/client_secret only in metadata JSON.
+  // New flows persist them in the keychain (checked above) for defense in depth.
   const metadataKey = fieldNames.some((f) => f.includes('client_id'))
     ? 'oauth2ClientId' as const
     : 'oauth2ClientSecret' as const;
   for (const svc of servicesToCheck) {
     const meta = getCredentialMetadata(svc, 'access_token');
     const value = meta?.[metadataKey];
-    if (value) return value;
+    if (value) {
+      log.debug({ service: svc, field: metadataKey }, 'OAuth client credential resolved from metadata (legacy fallback)');
+      return value;
+    }
   }
 
   return undefined;
@@ -584,6 +588,12 @@ class CredentialStoreTool implements Tool {
             } catch {
               // Non-fatal
             }
+          }
+
+          // Persist client credentials in keychain for defense in depth
+          setSecureKey(`credential:${service}:client_id`, clientId);
+          if (clientSecret) {
+            setSecureKey(`credential:${service}:client_secret`, clientSecret);
           }
 
           upsertCredentialMetadata(service, 'access_token', {


### PR DESCRIPTION
## Summary

- After a successful OAuth2 flow, store `client_id` and `client_secret` in the keychain via `setSecureKey()` — the same secure path used for access/refresh tokens
- Retain the metadata JSON fallback in `findStoredOAuthField()` for pre-existing credentials (legacy path)
- Add debug logging when the legacy metadata fallback is used, to track migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
