### PR TITLE
fix: add debug logging to empty catch blocks

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -418,13 +418,13 @@ export class Session {
       if (result.delivery === 'transient_send') {
         const { credentialBroker } = await import('../tools/credentials/broker.js');
         credentialBroker.injectTransient(service, field, result.value);
-        try { upsertCredentialMetadata(service, field, {}); } catch {}
+        try { upsertCredentialMetadata(service, field, {}); } catch (e) { log.debug({ err: e, service, field }, 'Non-critical credential metadata upsert failed'); }
         log.info({ service, field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');
       } else {
         const key = `credential:${service}:${field}`;
         const stored = setSecureKey(key, result.value);
         if (stored) {
-          try { upsertCredentialMetadata(service, field, {}); } catch {}
+          try { upsertCredentialMetadata(service, field, {}); } catch (e) { log.debug({ err: e, service, field }, 'Non-critical credential metadata upsert failed'); }
           log.info({ service, field }, 'Ingress redirect: credential stored');
         } else {
           log.warn({ service, field }, 'Ingress redirect: secure storage write failed');

--- a/assistant/src/hooks/templates.ts
+++ b/assistant/src/hooks/templates.ts
@@ -45,7 +45,7 @@ export function installTemplates(): void {
       log.info({ hook: entry.name }, 'Installed hook template (disabled by default)');
     } catch (err) {
       // Clean up partially-copied directory so the next restart can retry
-      try { rmSync(targetDir, { recursive: true, force: true }); } catch {}
+      try { rmSync(targetDir, { recursive: true, force: true }); } catch (e) { log.debug({ err: e }, 'Cleanup of partial hook template directory failed'); }
       log.warn({ err, hook: entry.name }, 'Failed to install hook template');
     }
   }

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -3,6 +3,9 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { computeMemoryFingerprint } from './fingerprint.js';
 import * as schema from './schema.js';
 import { getDbPath, ensureDataDir, migrateToDataLayout, migrateToWorkspaceLayout } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('memory-db');
 
 let db: ReturnType<typeof drizzle<typeof schema>> | null = null;
 
@@ -337,8 +340,8 @@ export function initializeDb(): void {
     )
   `);
 
-  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN app_id TEXT`); } catch {}
-  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN project_slug TEXT`); } catch {}
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN app_id TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE published_pages ADD COLUMN app_id (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN project_slug TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE published_pages ADD COLUMN project_slug (likely already exists)'); }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS shared_app_links (
@@ -824,8 +827,8 @@ export function initializeDb(): void {
   `);
 
   // Work item permission preflight columns
-  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approved_tools TEXT`); } catch {}
-  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approval_status TEXT DEFAULT 'none'`); } catch {}
+  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approved_tools TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE work_items ADD COLUMN approved_tools (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approval_status TEXT DEFAULT 'none'`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE work_items ADD COLUMN approval_status (likely already exists)'); }
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_task_id ON work_items(task_id)`);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -433,7 +433,7 @@ class BrowserManager {
     if (this.browserCdpSession) {
       try {
         await this.browserCdpSession.detach();
-      } catch {}
+      } catch (e) { log.debug({ err: e }, 'CDP session detach failed during shutdown'); }
       this.browserCdpSession = null;
       this.browserWindowId = null;
     }
@@ -489,7 +489,7 @@ class BrowserManager {
       try {
         await cdp.send('Page.stopScreencast');
         await cdp.detach();
-      } catch {}
+      } catch (e) { log.debug({ err: e }, 'Screencast stop / CDP detach failed during cleanup'); }
       this.cdpSessions.delete(sessionId);
       this.screencastCallbacks.delete(sessionId);
     }

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -54,7 +54,7 @@ class DirectCDPClient {
               for (const h of handlers) h(msg.params ?? {});
             }
           }
-        } catch {}
+        } catch (e) { log.debug({ err: e }, 'Failed to parse CDP WebSocket message'); }
       };
     });
   }
@@ -195,7 +195,7 @@ export class NetworkRecorder {
     for (const client of this.pageClients) {
       try {
         await client.send('Network.disable');
-      } catch {}
+      } catch (e) { log.debug({ err: e }, 'Network.disable failed during cleanup'); }
       client.close();
     }
     this.pageClients = [];


### PR DESCRIPTION
## Summary
- Add `log.debug({ err }, '<context>')` to empty catch blocks in `assistant/src/` files so silently swallowed errors are diagnosable
- Covers hooks/templates.ts, memory/db.ts, daemon/session.ts, browser/network-recorder.ts, and browser/browser-manager.ts
- CLI instances (hatch.ts, retire.ts, aws.ts) left as-is since they use intentional best-effort patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
