### PR TITLE
fix: use correct conversationId for task run sessions

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -285,14 +285,19 @@ export async function handleWorkItemRunTask(
   broadcastWorkItemStatus(ctx, msg.id);
   ctx.broadcast({ type: 'tasks_changed' });
 
-  // Execute task asynchronously — create a session and wire processMessage
+  // Execute task asynchronously — lazily create a session inside the callback
+  // using the conversationId provided by runTask, so the session references
+  // the conversation that was actually inserted into the database.
   try {
-    const session = await ctx.getOrCreateSession(crypto.randomUUID());
+    let session: Awaited<ReturnType<typeof ctx.getOrCreateSession>> | null = null;
     // Pass pre-approved tools from the preflight flow if available
     const approvedTools: string[] | undefined = workItem.approvedTools ? JSON.parse(workItem.approvedTools) : undefined;
     const result = await runTask(
       { taskId: workItem.taskId, workingDir: process.cwd(), approvedTools },
-      async (_conversationId, message) => {
+      async (conversationId, message) => {
+        if (!session) {
+          session = await ctx.getOrCreateSession(conversationId);
+        }
         await session.processMessage(message, [], (event) => {
           ctx.broadcast(event);
         });


### PR DESCRIPTION
## Summary
- Fixed FOREIGN KEY constraint failure when running tasks from the task queue
- The session was being created with a random UUID that never existed in the conversations table, while runTask created its own conversation with a different UUID
- Now lazily creates the session inside the callback using the conversationId from runTask, ensuring the session references a valid conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
