### PR TITLE
fix: add timeout-specific error classification to session errors

### DIFF
--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -45,6 +45,13 @@ const CONTEXT_TOO_LARGE_PATTERNS = [
   /exceeded.*max_tokens/i,
 ];
 
+// Timeout patterns (provider-side timeouts distinct from network-level ETIMEDOUT)
+const TIMEOUT_PATTERNS = [
+  /\btimeout\b/i,
+  /deadline.?exceeded/i,
+  /request.?timed?.?out/i,
+];
+
 // Provider API error patterns (5xx, server error, etc.)
 const PROVIDER_API_PATTERNS = [
   /\b5\d{2}\b/,
@@ -206,6 +213,17 @@ function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debug
       return {
         code: 'PROVIDER_RATE_LIMIT',
         userMessage: 'The AI provider is rate limiting requests. Please wait a moment and try again.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Timeout errors (checked before network so generic "timeout" isn't caught by NETWORK_PATTERNS)
+  for (const pattern of TIMEOUT_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'PROVIDER_API',
+        userMessage: 'The request took too long. This is usually temporary — try again shortly.',
         retryable: true,
       };
     }


### PR DESCRIPTION
## Summary
- Add `TIMEOUT_PATTERNS` array to catch generic timeout errors ("timeout", "deadline exceeded", "request timed out")
- Check timeout patterns between rate limit and network error checks in `classifyByMessage` so they get classified as `PROVIDER_API` with a tailored message instead of falling through to `SESSION_PROCESSING_FAILED`
- Timeout message suggests waiting and retrying rather than checking connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
