### PR TITLE
M1: Conversation-thread consultation bridge

### DIFF
--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -1,0 +1,374 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+
+const testDir = mkdtempSync(join(tmpdir(), 'call-bridge-test-'));
+
+// ── Platform + logger mocks (must come before any source imports) ────
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Config mock ─────────────────────────────────────────────────────
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { anthropic: 'test-key' },
+    memory: { enabled: false },
+  }),
+}));
+
+// ── Anthropic SDK mock ──────────────────────────────────────────────
+
+function createMockStream(tokens: string[]) {
+  const emitter = new EventEmitter();
+  const fullText = tokens.join('');
+
+  const stream = {
+    on: (event: string, handler: (...args: unknown[]) => void) => {
+      emitter.on(event, handler);
+      return stream;
+    },
+    finalMessage: () => {
+      for (const token of tokens) {
+        emitter.emit('text', token);
+      }
+      return Promise.resolve({
+        content: [{ type: 'text', text: fullText }],
+      });
+    },
+  };
+
+  return stream;
+}
+
+let mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello']));
+
+mock.module('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      stream: (...args: unknown[]) => mockStreamFn(...args),
+    };
+  },
+}));
+
+// ── Import source modules after all mocks ───────────────────────────
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { conversations, messages } from '../memory/schema.js';
+import {
+  createCallSession,
+  getCallSession,
+  getPendingQuestion,
+  updateCallSession,
+  recordCallEvent,
+} from '../calls/call-store.js';
+import {
+  registerCallQuestionNotifier,
+  unregisterCallQuestionNotifier,
+  registerCallCompletionNotifier,
+  unregisterCallCompletionNotifier,
+  getCallOrchestrator,
+  fireCallQuestionNotifier,
+  fireCallCompletionNotifier,
+} from '../calls/call-state.js';
+import { CallOrchestrator } from '../calls/call-orchestrator.js';
+import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
+import * as conversationStore from '../memory/conversation-store.js';
+import type { RelayConnection } from '../calls/relay-server.js';
+
+initializeDb();
+
+afterAll(() => {
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ── Relay mock factory ──────────────────────────────────────────────
+
+interface MockRelay extends RelayConnection {
+  sentTokens: Array<{ token: string; last: boolean }>;
+  endCalled: boolean;
+}
+
+function createMockRelay(): MockRelay {
+  const state = {
+    sentTokens: [] as Array<{ token: string; last: boolean }>,
+    _endCalled: false,
+  };
+
+  return {
+    get sentTokens() { return state.sentTokens; },
+    get endCalled() { return state._endCalled; },
+    sendTextToken(token: string, last: boolean) {
+      state.sentTokens.push({ token, last });
+    },
+    endSession(_reason?: string) {
+      state._endCalled = true;
+    },
+  } as unknown as MockRelay;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+let ensuredConvIds = new Set<string>();
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+function getMessagesForConversation(conversationId: string) {
+  return conversationStore.getMessages(conversationId);
+}
+
+describe('call-bridge', () => {
+  beforeEach(() => {
+    resetTables();
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello']));
+  });
+
+  // ── tryHandlePendingCallAnswer ──────────────────────────────────
+
+  test('returns handled:false when no active call exists', async () => {
+    ensureConversation('conv-no-call');
+    const result = await tryHandlePendingCallAnswer('conv-no-call', 'some answer');
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('no_active_call');
+  });
+
+  test('returns handled:false when call exists but no pending question', async () => {
+    ensureConversation('conv-no-question');
+    createCallSession({
+      conversationId: 'conv-no-question',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    const result = await tryHandlePendingCallAnswer('conv-no-question', 'some answer');
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('no_pending_question');
+  });
+
+  test('returns handled:false when orchestrator is not found (call ended)', async () => {
+    ensureConversation('conv-ended');
+    const callSession = createCallSession({
+      conversationId: 'conv-ended',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // Mark the call as completed
+    updateCallSession(callSession.id, { status: 'completed', endedAt: Date.now() });
+
+    // Create a pending question without an orchestrator
+    const db = getDb();
+    const questionId = 'q-ended';
+    db.run(
+      'INSERT INTO call_pending_questions (id, callSessionId, questionText, status, askedAt) VALUES (?, ?, ?, ?, ?)',
+      questionId, callSession.id, 'What time?', 'pending', Date.now(),
+    );
+
+    const result = await tryHandlePendingCallAnswer('conv-ended', 'Too late');
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('orchestrator_not_found');
+
+    // Should have persisted a follow-up message about the call ending
+    const msgs = getMessagesForConversation('conv-ended');
+    const assistantMsgs = msgs.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length).toBe(1);
+    expect(assistantMsgs[0].content).toContain('call ended');
+  });
+
+  test('returns handled:false when orchestrator is not in waiting_on_user state', async () => {
+    ensureConversation('conv-not-waiting');
+    const callSession = createCallSession({
+      conversationId: 'conv-not-waiting',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Create orchestrator (state=idle by default)
+    const relay = createMockRelay();
+    const orchestrator = new CallOrchestrator(callSession.id, relay as unknown as RelayConnection, null);
+
+    // Create a pending question in the DB but orchestrator is idle, not waiting_on_user
+    const db = getDb();
+    db.run(
+      'INSERT INTO call_pending_questions (id, callSessionId, questionText, status, askedAt) VALUES (?, ?, ?, ?, ?)',
+      'q-not-waiting', callSession.id, 'What time?', 'pending', Date.now(),
+    );
+
+    const result = await tryHandlePendingCallAnswer('conv-not-waiting', 'answer');
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('orchestrator_not_waiting');
+
+    orchestrator.destroy();
+  });
+
+  test('routes answer to orchestrator when waiting and returns handled:true', async () => {
+    // Setup: trigger ASK_USER to put orchestrator in waiting_on_user state
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Hold on. [ASK_USER: Preferred date?]']),
+    );
+
+    ensureConversation('conv-bridge');
+    const callSession = createCallSession({
+      conversationId: 'conv-bridge',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const relay = createMockRelay();
+    const orchestrator = new CallOrchestrator(callSession.id, relay as unknown as RelayConnection, 'test task');
+
+    await orchestrator.handleCallerUtterance('I need a reservation');
+
+    // Verify the orchestrator is now waiting
+    expect(orchestrator.getState()).toBe('waiting_on_user');
+
+    // Now provide the answer — set up mock for the LLM call after answer
+    mockStreamFn.mockImplementation(() => createMockStream(['Great, booking for tomorrow.']));
+
+    const result = await tryHandlePendingCallAnswer('conv-bridge', 'Tomorrow at noon');
+    expect(result.handled).toBe(true);
+
+    // Wait for the fire-and-forget LLM call
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify the pending question was answered
+    const question = getPendingQuestion(callSession.id);
+    // After answering, there should be no pending question left
+    expect(question).toBeNull();
+
+    orchestrator.destroy();
+  });
+
+  // ── Call question notifier ──────────────────────────────────────
+
+  test('call question notifier persists assistant message and emits events', () => {
+    ensureConversation('conv-notifier-q');
+
+    const emittedEvents: Array<{ type: string; text?: string }> = [];
+    const sendToClient = (msg: { type: string; text?: string }) => {
+      emittedEvents.push(msg);
+    };
+
+    // Register notifier (as Session would)
+    registerCallQuestionNotifier('conv-notifier-q', (_callSessionId: string, question: string) => {
+      const questionText = `**Live call question**:\n\n${question}\n\n_Reply in this thread to answer._`;
+      conversationStore.addMessage(
+        'conv-notifier-q',
+        'assistant',
+        JSON.stringify([{ type: 'text', text: questionText }]),
+      );
+      sendToClient({ type: 'assistant_text_delta', text: questionText });
+      sendToClient({ type: 'message_complete' });
+    });
+
+    // Fire the notifier
+    fireCallQuestionNotifier('conv-notifier-q', 'call-session-1', 'What time works best?');
+
+    // Verify message was persisted
+    const msgs = getMessagesForConversation('conv-notifier-q');
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].role).toBe('assistant');
+    expect(msgs[0].content).toContain('What time works best?');
+
+    // Verify events were emitted
+    expect(emittedEvents.length).toBe(2);
+    expect(emittedEvents[0].type).toBe('assistant_text_delta');
+    expect(emittedEvents[0].text).toContain('What time works best?');
+    expect(emittedEvents[1].type).toBe('message_complete');
+
+    unregisterCallQuestionNotifier('conv-notifier-q');
+  });
+
+  // ── Call completion notifier ────────────────────────────────────
+
+  test('call completion notifier persists summary and emits events', () => {
+    ensureConversation('conv-notifier-c');
+
+    const emittedEvents: Array<{ type: string; text?: string }> = [];
+    const sendToClient = (msg: { type: string; text?: string }) => {
+      emittedEvents.push(msg);
+    };
+
+    // Create a call session so getCallSession works
+    const callSession = createCallSession({
+      conversationId: 'conv-notifier-c',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(callSession.id, { status: 'completed', startedAt: Date.now() - 30000, endedAt: Date.now() });
+    recordCallEvent(callSession.id, 'call_started', {});
+    recordCallEvent(callSession.id, 'call_ended', {});
+
+    registerCallCompletionNotifier('conv-notifier-c', (callSessionId: string) => {
+      const summaryText = `**Call completed**. Events recorded.`;
+      conversationStore.addMessage(
+        'conv-notifier-c',
+        'assistant',
+        JSON.stringify([{ type: 'text', text: summaryText }]),
+      );
+      sendToClient({ type: 'assistant_text_delta', text: summaryText });
+      sendToClient({ type: 'message_complete' });
+    });
+
+    fireCallCompletionNotifier('conv-notifier-c', callSession.id);
+
+    // Verify message persisted
+    const msgs = getMessagesForConversation('conv-notifier-c');
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].role).toBe('assistant');
+    expect(msgs[0].content).toContain('Call completed');
+
+    // Verify events emitted
+    expect(emittedEvents.length).toBe(2);
+    expect(emittedEvents[0].type).toBe('assistant_text_delta');
+    expect(emittedEvents[1].type).toBe('message_complete');
+
+    unregisterCallCompletionNotifier('conv-notifier-c');
+  });
+});

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { afterAll, describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -49,6 +49,10 @@ import { _setBackend } from '../security/secure-keys.js';
 import { loadConfig, invalidateConfigCache } from '../config/loader.js';
 import { AssistantConfigSchema } from '../config/schema.js';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
+
+afterAll(() => {
+  mock.restore();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import { afterAll, describe, expect, mock, test, beforeEach } from 'bun:test';
 import { rmSync, writeFileSync } from 'node:fs';
 import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent, CheckpointInfo, CheckpointDecision } from '../agent/loop.js';
@@ -8,8 +8,16 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 // Mocks — must precede the Session import so Bun applies them at load time.
 // ---------------------------------------------------------------------------
 
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of ['info', 'warn', 'error', 'debug', 'trace', 'fatal', 'silent', 'child']) {
+    stub[m] = m === 'child' ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
 mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeLoggerStub(),
 }));
 
 mock.module('../util/platform.js', () => ({
@@ -287,6 +295,10 @@ beforeEach(() => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 // ---------------------------------------------------------------------------
@@ -1472,41 +1484,45 @@ describe('Regression: cancel semantics and error channel split', () => {
 
     turnCommitHangForever = true;
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
+    try {
+      const events1: ServerMessage[] = [];
+      const events2: ServerMessage[] = [];
 
-    // Start first message (promise intentionally not awaited — we test queue drain behavior)
-    const _p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
-    await waitForPendingRun(1);
+      // Start first message (promise intentionally not awaited — we test queue drain behavior)
+      const _p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+      await waitForPendingRun(1);
 
-    // Enqueue a second message while the first is processing
-    session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+      // Enqueue a second message while the first is processing
+      session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
 
-    // Complete the first agent loop run
-    resolveRun(0);
+      // Complete the first agent loop run
+      resolveRun(0);
 
-    // The turn should still complete (timeout fires) and drain the queue
-    // even though commitTurnChanges never resolves.
-    // The default turnCommitMaxWaitMs is 4000ms in the config mock,
-    // but the mock config doesn't set it, so it defaults to 4000ms.
-    // We wait for the second run to be registered, which proves the
-    // turn completed and the queue drained despite the hanging commit.
-    await waitForPendingRun(2, 10_000);
+      // The turn should still complete (timeout fires) and drain the queue
+      // even though commitTurnChanges never resolves.
+      // The default turnCommitMaxWaitMs is 4000ms in the config mock,
+      // but the mock config doesn't set it, so it defaults to 4000ms.
+      // We wait for the second run to be registered, which proves the
+      // turn completed and the queue drained despite the hanging commit.
+      await waitForPendingRun(2, 10_000);
 
-    // First message should have completed
-    const completion1 = events1.find((e) => e.type === 'message_complete');
-    expect(completion1).toBeDefined();
+      // First message should have completed
+      const completion1 = events1.find((e) => e.type === 'message_complete');
+      expect(completion1).toBeDefined();
 
-    // Second message should have been dequeued
-    const dequeued = events2.find((e) => e.type === 'message_dequeued');
-    expect(dequeued).toBeDefined();
+      // Second message should have been dequeued
+      const dequeued = events2.find((e) => e.type === 'message_dequeued');
+      expect(dequeued).toBeDefined();
 
-    // The turn commit should have been called
-    expect(turnCommitCalls).toHaveLength(1);
+      // The turn commit should have been called
+      expect(turnCommitCalls).toHaveLength(1);
 
-    // Complete the second run so the test can clean up
-    turnCommitHangForever = false;
-    resolveRun(1);
-    await new Promise((r) => setTimeout(r, 50));
+      // Complete the second run so the test can clean up
+      turnCommitHangForever = false;
+      resolveRun(1);
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      turnCommitHangForever = false;
+    }
   }, 15_000);
 });

--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
+import { _resetEnrichmentService, getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
 import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('commitTurnChanges', () => {
@@ -16,10 +17,18 @@ describe('commitTurnChanges', () => {
     _resetGitServiceRegistry();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Shut down any in-flight enrichment work before removing the test directory
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  afterAll(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
   });
 
   test('turn with file edits creates a commit', async () => {

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -11,6 +11,7 @@ import {
   HeartbeatService,
   _resetHeartbeatState,
 } from '../workspace/heartbeat-service.js';
+import { _resetEnrichmentService, getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
 import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('HeartbeatService', () => {
@@ -31,10 +32,18 @@ describe('HeartbeatService', () => {
     services.set(testDir, service);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Shut down any in-flight enrichment work before removing the test directory
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  afterAll(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
   });
 
   describe('heartbeat check with age threshold', () => {

--- a/assistant/src/calls/call-bridge.ts
+++ b/assistant/src/calls/call-bridge.ts
@@ -1,0 +1,95 @@
+/**
+ * Call-answer bridge: auto-consumes user replies in-thread as answers
+ * to pending call questions, routing them to the live call orchestrator.
+ *
+ * When a call has a pending question and the user sends a normal message
+ * in the conversation thread, this bridge intercepts the message before
+ * the agent loop, forwards the answer to the orchestrator, and returns
+ * `{ handled: true }` so the caller can skip agent processing.
+ */
+
+import { getLogger } from '../util/logger.js';
+import {
+  getActiveCallSessionForConversation,
+  getPendingQuestion,
+  answerPendingQuestion,
+  recordCallEvent,
+  getCallSession,
+} from './call-store.js';
+import { getCallOrchestrator } from './call-state.js';
+import * as conversationStore from '../memory/conversation-store.js';
+
+const log = getLogger('call-bridge');
+
+export interface CallBridgeResult {
+  handled: boolean;
+  reason?: string;
+}
+
+/**
+ * Attempt to route a user message as an answer to a pending call question.
+ *
+ * @param conversationId - The conversation the message belongs to.
+ * @param userText - The user's message text.
+ * @param _userMessageId - The persisted message ID (reserved for future use).
+ * @returns `{ handled: true }` if the answer was consumed by the call system,
+ *          `{ handled: false, reason }` otherwise.
+ */
+export async function tryHandlePendingCallAnswer(
+  conversationId: string,
+  userText: string,
+  _userMessageId?: string,
+): Promise<CallBridgeResult> {
+  // 1. Find an active call for this conversation
+  const callSession = getActiveCallSessionForConversation(conversationId);
+  if (!callSession) {
+    return { handled: false, reason: 'no_active_call' };
+  }
+
+  // 2. Check for a pending question
+  const pendingQuestion = getPendingQuestion(callSession.id);
+  if (!pendingQuestion) {
+    return { handled: false, reason: 'no_pending_question' };
+  }
+
+  // 3. Check that the orchestrator is alive and waiting
+  const orchestrator = getCallOrchestrator(callSession.id);
+  if (!orchestrator) {
+    // The call may have ended between the question being asked and the
+    // user replying. Persist a follow-up message so the user knows.
+    const freshSession = getCallSession(callSession.id);
+    const ended = freshSession && (freshSession.status === 'completed' || freshSession.status === 'failed');
+    if (ended) {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{
+          type: 'text',
+          text: 'The call ended before your answer could be relayed to the caller.',
+        }]),
+      );
+    }
+    return { handled: false, reason: 'orchestrator_not_found' };
+  }
+
+  if (orchestrator.getState() !== 'waiting_on_user') {
+    return { handled: false, reason: 'orchestrator_not_waiting' };
+  }
+
+  // 4. Route the answer through the orchestrator
+  const accepted = await orchestrator.handleUserAnswer(userText);
+  if (!accepted) {
+    return { handled: false, reason: 'orchestrator_rejected' };
+  }
+
+  // 5. Persist the answered state
+  answerPendingQuestion(pendingQuestion.id, userText);
+  recordCallEvent(callSession.id, 'user_answered', { answer: userText });
+
+  log.info(
+    { conversationId, callSessionId: callSession.id, questionId: pendingQuestion.id },
+    'User reply routed as call answer via bridge',
+  );
+
+  return { handled: true };
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -36,6 +36,7 @@ import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { SessionEvictor } from './session-evictor.js';
 import { getSubagentManager } from '../subagent/index.js';
+import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
 
 const log = getLogger('server');
 
@@ -1006,6 +1007,23 @@ export class DaemonServer {
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content, attachments, requestId);
 
+    // Attempt the call-answer bridge before launching the agent loop.
+    // If the message is consumed as a call answer, skip the agent loop.
+    try {
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
+      if (bridgeResult.handled) {
+        // The message was consumed by the call system. Release the
+        // processing lock so the session can accept subsequent messages.
+        // runAgentLoop normally does this in its finally block, but we
+        // skipped it entirely.
+        resetSessionProcessingState(session);
+        log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
+        return { messageId };
+      }
+    } catch (err) {
+      log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
+    }
+
     // Fire-and-forget the agent loop. Errors are logged but do not
     // affect the HTTP response (the client polls GET /messages).
     session.runAgentLoop(content, messageId, () => {}).catch((err) => {
@@ -1054,7 +1072,23 @@ export class DaemonServer {
         }))
       : [];
 
-    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
+    // Persist user message first so we can check the call bridge
+    const requestId = crypto.randomUUID();
+    const messageId = session.persistUserMessage(content, attachments, requestId);
+
+    // Attempt the call-answer bridge before launching the agent loop.
+    try {
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
+      if (bridgeResult.handled) {
+        resetSessionProcessingState(session);
+        log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
+        return { messageId };
+      }
+    } catch (err) {
+      log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
+    }
+
+    await session.runAgentLoop(content, messageId, () => {});
 
     if (!messageId) {
       throw new Error('Failed to persist user message');
@@ -1080,4 +1114,19 @@ export class DaemonServer {
     });
   }
 
+}
+
+/**
+ * Reset the processing state set by `persistUserMessage` when the agent loop
+ * is intentionally skipped (e.g. call-answer bridge consumed the message).
+ */
+function resetSessionProcessingState(session: Session): void {
+  const s = session as unknown as {
+    processing: boolean;
+    abortController: AbortController | null;
+    currentRequestId: string | undefined;
+  };
+  s.processing = false;
+  s.abortController = null;
+  s.currentRequestId = undefined;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -28,6 +28,13 @@ import {
 } from '../tools/watch/watch-state.js';
 import type { WatchSession } from '../tools/watch/watch-state.js';
 import { lastCommentaryBySession, lastSummaryBySession } from './watch-handler.js';
+import {
+  registerCallQuestionNotifier,
+  unregisterCallQuestionNotifier,
+  registerCallCompletionNotifier,
+  unregisterCallCompletionNotifier,
+} from '../calls/call-state.js';
+import { getCallSession, getCallEvents } from '../calls/call-store.js';
 import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
 import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
@@ -259,6 +266,59 @@ export class Session {
       }
     });
 
+    // ── Call notifiers (same pattern as watch notifiers) ──
+    registerCallQuestionNotifier(conversationId, (callSessionId: string, question: string) => {
+      const callSession = getCallSession(callSessionId);
+      const callee = callSession?.toNumber ?? 'the caller';
+      const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Reply in this thread to answer._`;
+
+      // Persist as an assistant message so it appears in history
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: questionText }]),
+      );
+
+      // Emit to active clients in real-time
+      this.sendToClient({
+        type: 'assistant_text_delta',
+        text: questionText,
+        sessionId: conversationId,
+      });
+      this.sendToClient({
+        type: 'message_complete',
+        sessionId: conversationId,
+      });
+    });
+
+    registerCallCompletionNotifier(conversationId, (callSessionId: string) => {
+      const callSession = getCallSession(callSessionId);
+      const events = getCallEvents(callSessionId);
+      const duration = callSession?.endedAt && callSession?.startedAt
+        ? Math.round((callSession.endedAt - callSession.startedAt) / 1000)
+        : null;
+      const durationStr = duration !== null ? ` (${duration}s)` : '';
+      const summaryText = `**Call completed**${durationStr}. ${events.length} event(s) recorded.`;
+
+      // Persist as an assistant message
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: summaryText }]),
+      );
+
+      // Emit to active clients
+      this.sendToClient({
+        type: 'assistant_text_delta',
+        text: summaryText,
+        sessionId: conversationId,
+      });
+      this.sendToClient({
+        type: 'message_complete',
+        sessionId: conversationId,
+      });
+    });
+
     this.executor = new ToolExecutor(this.prompter);
     this.profiler = new ToolProfiler();
     registerToolMetricsLoggingListener(this.eventBus);
@@ -461,6 +521,8 @@ export class Session {
       unregisterWatchCommentaryNotifier(this.conversationId);
       unregisterWatchCompletionNotifier(this.conversationId);
       pruneWatchSessions(this.conversationId);
+      unregisterCallQuestionNotifier(this.conversationId);
+      unregisterCallCompletionNotifier(this.conversationId);
 
       // Clear queued messages and notify each caller with a session-scoped
       // cancel event so other sessions do not receive cross-thread errors.
@@ -477,6 +539,11 @@ export class Session {
       sessionId: this.conversationId,
     });
     this.abort();
+    // Unconditionally unregister call notifiers (abort() only cleans up
+    // when processing is true, but notifiers are registered in the
+    // constructor regardless of processing state).
+    unregisterCallQuestionNotifier(this.conversationId);
+    unregisterCallCompletionNotifier(this.conversationId);
     unregisterSessionSender(this.conversationId);
     resetSkillToolProjection(this.skillProjectionState);
     this.eventBus.dispose();


### PR DESCRIPTION
Part of #5296. Closes #5297.

## Changes
- Add `call-bridge.ts` helper to auto-consume user replies as call answers
- Wire call question/completion notifiers into Session (matching watch notifier pattern)
- Invoke bridge from both DaemonServer message entrypoints (processMessage + persistAndProcessMessage)
- Add comprehensive tests for notifier emission, auto-binding, rejection, and call-ended scenarios
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
