### PR TITLE
M2: Runtime call API and transition invariants

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -1,0 +1,410 @@
+/**
+ * HTTP-layer integration tests for the call API endpoints.
+ *
+ * Tests POST /v1/calls/start, GET /v1/calls/:id,
+ * POST /v1/calls/:id/cancel, and POST /v1/calls/:id/answer
+ * through RuntimeHttpServer.
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'call-routes-http-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+// Mock Twilio provider to avoid real API calls
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    static verifyWebhookSignature() { return true; }
+    async initiateCall() { return { callSid: 'CA_mock_sid_123' }; }
+    async endCall() { return; }
+  },
+}));
+
+// Mock Twilio config
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test_token',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+// Mock secure keys
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => null,
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import { RuntimeHttpServer } from '../runtime/http-server.js';
+import {
+  createCallSession,
+  updateCallSession,
+  createPendingQuestion,
+} from '../calls/call-store.js';
+import { registerCallOrchestrator, unregisterCallOrchestrator } from '../calls/call-state.js';
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_TOKEN = 'test-bearer-token-calls';
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
+let ensuredConvIds = new Set<string>();
+
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runtime call routes — HTTP layer', () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  async function startServer(): Promise<void> {
+    port = 19000 + Math.floor(Math.random() * 1000);
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
+    await server.start();
+  }
+
+  async function stopServer(): Promise<void> {
+    await server?.stop();
+  }
+
+  function callsUrl(path = ''): string {
+    return `http://127.0.0.1:${port}/v1/calls${path}`;
+  }
+
+  // ── POST /v1/calls/start ────────────────────────────────────────────
+
+  test('POST /v1/calls/start returns 201 with call session', async () => {
+    await startServer();
+    ensureConversation('conv-start-1');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-1',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+
+    const body = await res.json() as {
+      callSessionId: string;
+      callSid: string;
+      status: string;
+      toNumber: string;
+      fromNumber: string;
+    };
+
+    expect(body.callSessionId).toBeDefined();
+    expect(body.callSid).toBe('CA_mock_sid_123');
+    expect(body.status).toBe('initiated');
+    expect(body.toNumber).toBe('+15559998888');
+    expect(body.fromNumber).toBe('+15550001111');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start returns 400 when conversationId missing', async () => {
+    await startServer();
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('conversationId');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start returns 400 for invalid phone number', async () => {
+    await startServer();
+    ensureConversation('conv-start-2');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: 'not-a-number',
+        task: 'Book a table',
+        conversationId: 'conv-start-2',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('E.164');
+
+    await stopServer();
+  });
+
+  // ── GET /v1/calls/:id ───────────────────────────────────────────────
+
+  test('GET /v1/calls/:id returns call status', async () => {
+    await startServer();
+    ensureConversation('conv-get-1');
+
+    const session = createCallSession({
+      conversationId: 'conv-get-1',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+      task: 'Test task',
+    });
+
+    const res = await fetch(callsUrl(`/${session.id}`), {
+      headers: AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      callSessionId: string;
+      status: string;
+      toNumber: string;
+      fromNumber: string;
+      task: string;
+      pendingQuestion: null;
+    };
+
+    expect(body.callSessionId).toBe(session.id);
+    expect(body.status).toBe('initiated');
+    expect(body.toNumber).toBe('+15559998888');
+    expect(body.fromNumber).toBe('+15550001111');
+    expect(body.task).toBe('Test task');
+    expect(body.pendingQuestion).toBeNull();
+
+    await stopServer();
+  });
+
+  test('GET /v1/calls/:id returns 404 for unknown session', async () => {
+    await startServer();
+
+    const res = await fetch(callsUrl('/nonexistent-id'), {
+      headers: AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(404);
+
+    await stopServer();
+  });
+
+  // ── POST /v1/calls/:id/cancel ──────────────────────────────────────
+
+  test('POST /v1/calls/:id/cancel transitions to cancelled', async () => {
+    await startServer();
+    ensureConversation('conv-cancel-1');
+
+    const session = createCallSession({
+      conversationId: 'conv-cancel-1',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    const res = await fetch(callsUrl(`/${session.id}/cancel`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ reason: 'User requested' }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { callSessionId: string; status: string };
+    expect(body.callSessionId).toBe(session.id);
+    expect(body.status).toBe('cancelled');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/:id/cancel returns 409 for already-ended call', async () => {
+    await startServer();
+    ensureConversation('conv-cancel-2');
+
+    const session = createCallSession({
+      conversationId: 'conv-cancel-2',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    updateCallSession(session.id, { status: 'completed', endedAt: Date.now() });
+
+    const res = await fetch(callsUrl(`/${session.id}/cancel`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(409);
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/:id/cancel returns 404 for unknown session', async () => {
+    await startServer();
+
+    const res = await fetch(callsUrl('/nonexistent-id/cancel'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(404);
+
+    await stopServer();
+  });
+
+  // ── POST /v1/calls/:id/answer ──────────────────────────────────────
+
+  test('POST /v1/calls/:id/answer returns 404 when no pending question', async () => {
+    await startServer();
+    ensureConversation('conv-answer-1');
+
+    const session = createCallSession({
+      conversationId: 'conv-answer-1',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    const res = await fetch(callsUrl(`/${session.id}/answer`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ answer: 'Yes, please' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('pending question');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/:id/answer returns 400 when answer is empty', async () => {
+    await startServer();
+    ensureConversation('conv-answer-2');
+
+    const session = createCallSession({
+      conversationId: 'conv-answer-2',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    const res = await fetch(callsUrl(`/${session.id}/answer`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ answer: '' }),
+    });
+
+    expect(res.status).toBe(400);
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/:id/answer returns 409 when no orchestrator', async () => {
+    await startServer();
+    ensureConversation('conv-answer-3');
+
+    const session = createCallSession({
+      conversationId: 'conv-answer-3',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    // Create a pending question but no orchestrator
+    createPendingQuestion(session.id, 'What date do you prefer?');
+
+    const res = await fetch(callsUrl(`/${session.id}/answer`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ answer: 'Tomorrow' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('orchestrator');
+
+    await stopServer();
+  });
+});

--- a/assistant/src/__tests__/call-state-machine.test.ts
+++ b/assistant/src/__tests__/call-state-machine.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from 'bun:test';
+import { validateTransition, isTerminalState } from '../calls/call-state-machine.js';
+import type { CallStatus } from '../calls/types.js';
+
+describe('call-state-machine', () => {
+  // ── Valid transitions ───────────────────────────────────────────────
+
+  describe('valid transitions', () => {
+    const validCases: Array<[CallStatus, CallStatus]> = [
+      // From initiated
+      ['initiated', 'ringing'],
+      ['initiated', 'in_progress'],
+      ['initiated', 'completed'],
+      ['initiated', 'failed'],
+      ['initiated', 'cancelled'],
+
+      // From ringing
+      ['ringing', 'in_progress'],
+      ['ringing', 'completed'],
+      ['ringing', 'failed'],
+      ['ringing', 'cancelled'],
+
+      // From in_progress
+      ['in_progress', 'waiting_on_user'],
+      ['in_progress', 'completed'],
+      ['in_progress', 'failed'],
+      ['in_progress', 'cancelled'],
+
+      // From waiting_on_user
+      ['waiting_on_user', 'in_progress'],
+      ['waiting_on_user', 'completed'],
+      ['waiting_on_user', 'failed'],
+      ['waiting_on_user', 'cancelled'],
+    ];
+
+    for (const [from, to] of validCases) {
+      test(`${from} -> ${to} is valid`, () => {
+        const result = validateTransition(from, to);
+        expect(result.valid).toBe(true);
+        expect(result.reason).toBeUndefined();
+      });
+    }
+  });
+
+  // ── Same-state transitions (no-op, valid) ──────────────────────────
+
+  describe('same-state transitions', () => {
+    const allStatuses: CallStatus[] = [
+      'initiated', 'ringing', 'in_progress', 'waiting_on_user',
+      'completed', 'failed', 'cancelled',
+    ];
+
+    for (const status of allStatuses) {
+      test(`${status} -> ${status} is valid (no-op)`, () => {
+        const result = validateTransition(status, status);
+        expect(result.valid).toBe(true);
+      });
+    }
+  });
+
+  // ── Invalid transitions ─────────────────────────────────────────────
+
+  describe('invalid transitions', () => {
+    const invalidCases: Array<[CallStatus, CallStatus]> = [
+      // Cannot skip backwards
+      ['ringing', 'initiated'],
+      ['in_progress', 'initiated'],
+      ['in_progress', 'ringing'],
+      ['waiting_on_user', 'initiated'],
+      ['waiting_on_user', 'ringing'],
+
+      // Cannot go from initiated directly to waiting_on_user
+      ['initiated', 'waiting_on_user'],
+
+      // Cannot go from ringing to waiting_on_user
+      ['ringing', 'waiting_on_user'],
+    ];
+
+    for (const [from, to] of invalidCases) {
+      test(`${from} -> ${to} is invalid`, () => {
+        const result = validateTransition(from, to);
+        expect(result.valid).toBe(false);
+        expect(result.reason).toBeDefined();
+        expect(result.reason!.length).toBeGreaterThan(0);
+      });
+    }
+  });
+
+  // ── Terminal state immutability ─────────────────────────────────────
+
+  describe('terminal state immutability', () => {
+    const terminalStates: CallStatus[] = ['completed', 'failed', 'cancelled'];
+    const nonTerminalTargets: CallStatus[] = [
+      'initiated', 'ringing', 'in_progress', 'waiting_on_user',
+    ];
+
+    for (const terminal of terminalStates) {
+      for (const target of nonTerminalTargets) {
+        test(`${terminal} -> ${target} is rejected (terminal state)`, () => {
+          const result = validateTransition(terminal, target);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain('terminal');
+        });
+      }
+
+      // Also cannot go between terminal states
+      for (const otherTerminal of terminalStates) {
+        if (otherTerminal === terminal) continue;
+        test(`${terminal} -> ${otherTerminal} is rejected (terminal to terminal)`, () => {
+          const result = validateTransition(terminal, otherTerminal);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain('terminal');
+        });
+      }
+    }
+  });
+
+  // ── isTerminalState ─────────────────────────────────────────────────
+
+  describe('isTerminalState', () => {
+    test('completed is terminal', () => {
+      expect(isTerminalState('completed')).toBe(true);
+    });
+
+    test('failed is terminal', () => {
+      expect(isTerminalState('failed')).toBe(true);
+    });
+
+    test('cancelled is terminal', () => {
+      expect(isTerminalState('cancelled')).toBe(true);
+    });
+
+    test('initiated is not terminal', () => {
+      expect(isTerminalState('initiated')).toBe(false);
+    });
+
+    test('ringing is not terminal', () => {
+      expect(isTerminalState('ringing')).toBe(false);
+    });
+
+    test('in_progress is not terminal', () => {
+      expect(isTerminalState('in_progress')).toBe(false);
+    });
+
+    test('waiting_on_user is not terminal', () => {
+      expect(isTerminalState('waiting_on_user')).toBe(false);
+    });
+  });
+});

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -1,0 +1,260 @@
+/**
+ * Shared domain functions for call operations.
+ *
+ * Both the tool implementations and the HTTP route handlers delegate
+ * to these functions so business logic lives in one place.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { DENIED_NUMBERS } from './call-constants.js';
+import {
+  createCallSession,
+  getCallSession,
+  getActiveCallSessionForConversation,
+  updateCallSession,
+  getPendingQuestion,
+  answerPendingQuestion,
+} from './call-store.js';
+import { getCallOrchestrator, unregisterCallOrchestrator } from './call-state.js';
+import { activeRelayConnections } from './relay-server.js';
+import { TwilioConversationRelayProvider } from './twilio-provider.js';
+import { getTwilioConfig } from './twilio-config.js';
+import type { CallSession } from './types.js';
+
+const log = getLogger('call-domain');
+
+const E164_REGEX = /^\+\d+$/;
+
+// ── Result types ─────────────────────────────────────────────────────
+
+export interface StartCallResult {
+  ok: true;
+  session: CallSession;
+  callSid: string;
+}
+
+export interface CallError {
+  ok: false;
+  error: string;
+  status?: number;
+}
+
+export type StartCallInput = {
+  phoneNumber: string;
+  task: string;
+  context?: string;
+  conversationId: string;
+};
+
+export type CancelCallInput = {
+  callSessionId: string;
+  reason?: string;
+};
+
+export type AnswerCallInput = {
+  callSessionId: string;
+  answer: string;
+};
+
+// ── Domain operations ────────────────────────────────────────────────
+
+/**
+ * Initiate a new outbound call.
+ */
+export async function startCall(input: StartCallInput): Promise<StartCallResult | CallError> {
+  const { phoneNumber, task, context: callContext, conversationId } = input;
+
+  if (!phoneNumber || typeof phoneNumber !== 'string') {
+    return { ok: false, error: 'phone_number is required and must be a string', status: 400 };
+  }
+
+  if (!E164_REGEX.test(phoneNumber)) {
+    return {
+      ok: false,
+      error: 'phone_number must be in E.164 format (starts with + followed by digits, e.g. +14155551234)',
+      status: 400,
+    };
+  }
+
+  if (!task || typeof task !== 'string' || task.trim().length === 0) {
+    return { ok: false, error: 'task is required and must be a non-empty string', status: 400 };
+  }
+
+  if (DENIED_NUMBERS.has(phoneNumber)) {
+    return { ok: false, error: 'This phone number is not allowed to be called', status: 403 };
+  }
+
+  let sessionId: string | null = null;
+
+  try {
+    const config = getTwilioConfig();
+    const provider = new TwilioConversationRelayProvider();
+
+    const session = createCallSession({
+      conversationId,
+      provider: 'twilio',
+      fromNumber: config.phoneNumber,
+      toNumber: phoneNumber,
+      task: callContext ? `${task}\n\nContext: ${callContext}` : task,
+    });
+    sessionId = session.id;
+
+    log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
+
+    const baseUrl = config.webhookBaseUrl.replace(/\/$/, '');
+    const { callSid } = await provider.initiateCall({
+      from: config.phoneNumber,
+      to: phoneNumber,
+      webhookUrl: `${baseUrl}/v1/calls/twilio/voice-webhook?callSessionId=${session.id}`,
+      statusCallbackUrl: `${baseUrl}/v1/calls/twilio/status`,
+    });
+
+    updateCallSession(session.id, { providerCallSid: callSid });
+
+    log.info({ callSessionId: session.id, callSid }, 'Call initiated successfully');
+
+    return {
+      ok: true,
+      session: { ...session, providerCallSid: callSid },
+      callSid,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, phoneNumber }, 'Failed to initiate call');
+
+    if (sessionId) {
+      updateCallSession(sessionId, {
+        status: 'failed',
+        endedAt: Date.now(),
+        lastError: msg,
+      });
+    }
+
+    return { ok: false, error: `Error initiating call: ${msg}`, status: 500 };
+  }
+}
+
+/**
+ * Get the status of a call session. If no callSessionId is provided,
+ * looks up the active call for the given conversationId.
+ */
+export function getCallStatus(
+  callSessionId?: string,
+  conversationId?: string,
+): { ok: true; session: CallSession; pendingQuestion?: { id: string; questionText: string } } | CallError {
+  let session: CallSession | null = null;
+
+  if (callSessionId) {
+    session = getCallSession(callSessionId);
+    if (!session) {
+      return { ok: false, error: `No call session found with ID ${callSessionId}`, status: 404 };
+    }
+  } else if (conversationId) {
+    session = getActiveCallSessionForConversation(conversationId);
+    if (!session) {
+      return { ok: false, error: 'No active call found in the current conversation', status: 404 };
+    }
+  } else {
+    return { ok: false, error: 'Either callSessionId or conversationId is required', status: 400 };
+  }
+
+  log.info({ callSessionId: session.id, status: session.status }, 'Checking call status');
+
+  const pendingQuestion = getPendingQuestion(session.id);
+  return {
+    ok: true,
+    session,
+    pendingQuestion: pendingQuestion
+      ? { id: pendingQuestion.id, questionText: pendingQuestion.questionText }
+      : undefined,
+  };
+}
+
+/**
+ * Cancel an active call. Cleans up relay connections and orchestrators.
+ */
+export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; session: CallSession } | CallError> {
+  const { callSessionId, reason } = input;
+
+  const session = getCallSession(callSessionId);
+  if (!session) {
+    return { ok: false, error: `No call session found with ID ${callSessionId}`, status: 404 };
+  }
+
+  if (session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled') {
+    return { ok: false, error: `Call session ${callSessionId} has already ended with status: ${session.status}`, status: 409 };
+  }
+
+  log.info({ callSessionId, reason }, 'Cancelling call');
+
+  // Terminate the call via the provider API
+  if (session.providerCallSid) {
+    try {
+      const provider = new TwilioConversationRelayProvider();
+      await provider.endCall(session.providerCallSid);
+    } catch (endErr) {
+      log.warn({ err: endErr, callSessionId, callSid: session.providerCallSid }, 'Failed to terminate call via provider API — proceeding with cleanup');
+    }
+  }
+
+  // End the relay connection if active
+  const relayConnection = activeRelayConnections.get(callSessionId);
+  if (relayConnection) {
+    relayConnection.endSession(reason);
+    relayConnection.destroy();
+    activeRelayConnections.delete(callSessionId);
+  }
+
+  // Clean up orchestrator
+  const orchestrator = getCallOrchestrator(callSessionId);
+  if (orchestrator) {
+    orchestrator.destroy();
+    unregisterCallOrchestrator(callSessionId);
+  }
+
+  // Update session status
+  updateCallSession(callSessionId, {
+    status: 'cancelled',
+    endedAt: Date.now(),
+  });
+
+  log.info({ callSessionId }, 'Call cancelled successfully');
+
+  const updated = getCallSession(callSessionId);
+  return { ok: true, session: updated ?? { ...session, status: 'cancelled', endedAt: Date.now() } };
+}
+
+/**
+ * Answer a pending question for an active call.
+ */
+export async function answerCall(input: AnswerCallInput): Promise<{ ok: true; questionId: string } | CallError> {
+  const { callSessionId, answer } = input;
+
+  if (!answer || typeof answer !== 'string') {
+    return { ok: false, error: 'Missing answer', status: 400 };
+  }
+
+  const question = getPendingQuestion(callSessionId);
+  if (!question) {
+    return { ok: false, error: 'No pending question found', status: 404 };
+  }
+
+  const orchestrator = getCallOrchestrator(callSessionId);
+  if (!orchestrator) {
+    log.warn({ callSessionId }, 'answerCall: no active orchestrator for call session');
+    return { ok: false, error: 'No active orchestrator for this call', status: 409 };
+  }
+
+  const accepted = await orchestrator.handleUserAnswer(answer);
+  if (!accepted) {
+    log.warn(
+      { callSessionId },
+      'answerCall: orchestrator rejected the answer (not in waiting_on_user state)',
+    );
+    return { ok: false, error: 'Orchestrator is not waiting for an answer', status: 409 };
+  }
+
+  answerPendingQuestion(question.id, answer);
+
+  return { ok: true, questionId: question.id };
+}

--- a/assistant/src/calls/call-state-machine.ts
+++ b/assistant/src/calls/call-state-machine.ts
@@ -1,0 +1,68 @@
+/**
+ * Call state machine — defines allowed status transitions and validates
+ * all state changes in a single place.
+ *
+ * Terminal states (completed, failed, cancelled) are immutable: no further
+ * transitions are permitted once a call reaches one of these states.
+ */
+
+import type { CallStatus } from './types.js';
+
+// ── Transition table ─────────────────────────────────────────────────
+
+/**
+ * Maps each call status to the set of statuses it may transition to.
+ * Terminal states map to an empty set.
+ */
+const ALLOWED_TRANSITIONS: Record<CallStatus, Set<CallStatus>> = {
+  initiated: new Set<CallStatus>(['ringing', 'in_progress', 'completed', 'failed', 'cancelled']),
+  ringing: new Set<CallStatus>(['in_progress', 'completed', 'failed', 'cancelled']),
+  in_progress: new Set<CallStatus>(['waiting_on_user', 'completed', 'failed', 'cancelled']),
+  waiting_on_user: new Set<CallStatus>(['in_progress', 'completed', 'failed', 'cancelled']),
+  // Terminal states — no further transitions allowed
+  completed: new Set<CallStatus>(),
+  failed: new Set<CallStatus>(),
+  cancelled: new Set<CallStatus>(),
+};
+
+const TERMINAL_STATES: Set<CallStatus> = new Set(['completed', 'failed', 'cancelled']);
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export interface TransitionResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Check whether a transition from `current` to `next` is allowed.
+ */
+export function validateTransition(current: CallStatus, next: CallStatus): TransitionResult {
+  if (current === next) {
+    return { valid: true };
+  }
+
+  if (isTerminalState(current)) {
+    return {
+      valid: false,
+      reason: `Cannot transition from terminal state '${current}'`,
+    };
+  }
+
+  const allowed = ALLOWED_TRANSITIONS[current];
+  if (!allowed || !allowed.has(next)) {
+    return {
+      valid: false,
+      reason: `Invalid transition from '${current}' to '${next}'`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Returns true if the given status is a terminal (immutable) state.
+ */
+export function isTerminalState(status: CallStatus): boolean {
+  return TERMINAL_STATES.has(status);
+}

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -2,7 +2,8 @@ import { eq, and, notInArray, desc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
 import { callSessions, callEvents, callPendingQuestions } from '../memory/schema.js';
-import type { CallSession, CallEvent, CallPendingQuestion, CallEventType } from './types.js';
+import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
+import { validateTransition } from './call-state-machine.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('call-store');
@@ -105,7 +106,7 @@ export function getActiveCallSessionForConversation(conversationId: string): Cal
     .where(
       and(
         eq(callSessions.conversationId, conversationId),
-        notInArray(callSessions.status, ['completed', 'failed']),
+        notInArray(callSessions.status, ['completed', 'failed', 'cancelled']),
       ),
     )
     .orderBy(desc(callSessions.createdAt))
@@ -119,6 +120,19 @@ export function updateCallSession(
   updates: Partial<Pick<CallSession, 'status' | 'providerCallSid' | 'startedAt' | 'endedAt' | 'lastError'>>,
 ): void {
   const db = getDb();
+
+  // Validate status transition when a new status is provided
+  if (updates.status) {
+    const current = getCallSession(id);
+    if (current) {
+      const result = validateTransition(current.status, updates.status as CallStatus);
+      if (!result.valid) {
+        log.warn({ callSessionId: id, from: current.status, to: updates.status, reason: result.reason }, 'Invalid call status transition — skipping update');
+        return;
+      }
+    }
+  }
+
   db.update(callSessions)
     .set({ ...updates, updatedAt: Date.now() })
     .where(eq(callSessions.id, id))

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -13,11 +13,9 @@ import {
   updateCallSession,
   recordCallEvent,
   expirePendingQuestions,
-  getPendingQuestion,
-  answerPendingQuestion,
 } from './call-store.js';
 import type { CallStatus } from './types.js';
-import { getCallOrchestrator } from './call-state.js';
+import { answerCall } from './call-domain.js';
 
 const log = getLogger('twilio-routes');
 
@@ -200,37 +198,15 @@ export async function handleConnectAction(_req: Request): Promise<Response> {
  */
 export async function handleCallAnswer(req: Request, callSessionId: string): Promise<Response> {
   const body = await req.json() as { answer?: string };
-  if (!body.answer) {
-    return Response.json({ error: 'Missing answer' }, { status: 400 });
+
+  const result = await answerCall({
+    callSessionId,
+    answer: body.answer ?? '',
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status ?? 500 });
   }
 
-  const question = getPendingQuestion(callSessionId);
-  if (!question) {
-    return Response.json({ error: 'No pending question found' }, { status: 404 });
-  }
-
-  // Verify the orchestrator exists before attempting to route the answer.
-  const orchestrator = getCallOrchestrator(callSessionId);
-  if (!orchestrator) {
-    log.warn({ callSessionId }, 'handleCallAnswer: no active orchestrator for call session');
-    return Response.json({ error: 'No active orchestrator for this call' }, { status: 409 });
-  }
-
-  // Route answer to the orchestrator FIRST — it atomically checks whether it is
-  // in the `waiting_on_user` state and transitions to `processing`. Only persist
-  // the answer to the DB if the orchestrator actually accepted it, preventing a
-  // race where the consultation timer expires between our check and the persist.
-  const accepted = await orchestrator.handleUserAnswer(body.answer);
-  if (!accepted) {
-    log.warn(
-      { callSessionId },
-      'handleCallAnswer: orchestrator rejected the answer (not in waiting_on_user state)',
-    );
-    return Response.json({ error: 'Orchestrator is not waiting for an answer' }, { status: 409 });
-  }
-
-  // Mark question as answered — only after the orchestrator has accepted
-  answerPendingQuestion(question.id, body.answer);
-
-  return Response.json({ ok: true, questionId: question.id });
+  return Response.json({ ok: true, questionId: result.questionId });
 }

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -1,4 +1,4 @@
-export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed';
+export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed' | 'cancelled';
 export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'call_ended' | 'call_failed';
 export type PendingQuestionStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -48,6 +48,12 @@ import {
 } from './routes/app-routes.js';
 import { handleAddSecret } from './routes/secret-routes.js';
 import {
+  handleStartCall,
+  handleGetCallStatus,
+  handleCancelCall,
+  handleAnswerCall,
+} from './routes/call-routes.js';
+import {
   handleVoiceWebhook,
   handleStatusCallback,
   handleConnectAction,
@@ -527,6 +533,29 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/replay' && req.method === 'POST') {
         return await handleReplayDeadLetters(req);
+      }
+
+      // ── Call API routes ───────────────────────────────────────────
+      if (endpoint === 'calls/start' && req.method === 'POST') {
+        return await handleStartCall(req);
+      }
+
+      // Match calls/:callSessionId and calls/:callSessionId/cancel, calls/:callSessionId/answer
+      const callsMatch = endpoint.match(/^calls\/([^/]+?)(\/cancel|\/answer)?$/);
+      if (callsMatch) {
+        const callSessionId = callsMatch[1];
+        // Skip known sub-paths that are handled elsewhere (twilio, relay)
+        if (callSessionId !== 'twilio' && callSessionId !== 'relay' && callSessionId !== 'start') {
+          if (callsMatch[2] === '/cancel' && req.method === 'POST') {
+            return await handleCancelCall(req, callSessionId);
+          }
+          if (callsMatch[2] === '/answer' && req.method === 'POST') {
+            return await handleAnswerCall(req, callSessionId);
+          }
+          if (!callsMatch[2] && req.method === 'GET') {
+            return handleGetCallStatus(callSessionId);
+          }
+        }
       }
 
       return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -1,0 +1,125 @@
+/**
+ * Runtime HTTP route handlers for the call API.
+ *
+ * POST   /v1/calls/start              — initiate a new call
+ * GET    /v1/calls/:callSessionId      — get call status
+ * POST   /v1/calls/:callSessionId/cancel — cancel a call
+ * POST   /v1/calls/:callSessionId/answer — answer a pending question
+ */
+
+import { startCall, getCallStatus, cancelCall, answerCall } from '../../calls/call-domain.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('call-routes');
+
+/**
+ * POST /v1/calls/start
+ *
+ * Body: { phoneNumber: string; task: string; context?: string; conversationId: string }
+ */
+export async function handleStartCall(req: Request): Promise<Response> {
+  const body = await req.json() as {
+    phoneNumber?: string;
+    task?: string;
+    context?: string;
+    conversationId?: string;
+  };
+
+  if (!body.conversationId) {
+    return Response.json({ error: 'conversationId is required' }, { status: 400 });
+  }
+
+  const result = await startCall({
+    phoneNumber: body.phoneNumber ?? '',
+    task: body.task ?? '',
+    context: body.context,
+    conversationId: body.conversationId,
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+  }
+
+  return Response.json({
+    callSessionId: result.session.id,
+    callSid: result.callSid,
+    status: result.session.status,
+    toNumber: result.session.toNumber,
+    fromNumber: result.session.fromNumber,
+  }, { status: 201 });
+}
+
+/**
+ * GET /v1/calls/:callSessionId
+ */
+export function handleGetCallStatus(callSessionId: string): Response {
+  const result = getCallStatus(callSessionId);
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+  }
+
+  const { session } = result;
+  return Response.json({
+    callSessionId: session.id,
+    conversationId: session.conversationId,
+    status: session.status,
+    toNumber: session.toNumber,
+    fromNumber: session.fromNumber,
+    provider: session.provider,
+    providerCallSid: session.providerCallSid,
+    task: session.task,
+    startedAt: session.startedAt ? new Date(session.startedAt).toISOString() : null,
+    endedAt: session.endedAt ? new Date(session.endedAt).toISOString() : null,
+    lastError: session.lastError,
+    pendingQuestion: result.pendingQuestion ?? null,
+    createdAt: new Date(session.createdAt).toISOString(),
+    updatedAt: new Date(session.updatedAt).toISOString(),
+  });
+}
+
+/**
+ * POST /v1/calls/:callSessionId/cancel
+ *
+ * Body: { reason?: string }
+ */
+export async function handleCancelCall(req: Request, callSessionId: string): Promise<Response> {
+  let reason: string | undefined;
+  try {
+    const body = await req.json() as { reason?: string };
+    reason = body.reason;
+  } catch {
+    // Empty body is fine
+  }
+
+  const result = await cancelCall({ callSessionId, reason });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+  }
+
+  return Response.json({
+    callSessionId: result.session.id,
+    status: result.session.status,
+  });
+}
+
+/**
+ * POST /v1/calls/:callSessionId/answer
+ *
+ * Body: { answer: string }
+ */
+export async function handleAnswerCall(req: Request, callSessionId: string): Promise<Response> {
+  const body = await req.json() as { answer?: string };
+
+  const result = await answerCall({
+    callSessionId,
+    answer: body.answer ?? '',
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+  }
+
+  return Response.json({ ok: true, questionId: result.questionId });
+}

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -2,13 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { getCallSession, updateCallSession } from '../../calls/call-store.js';
-import { getCallOrchestrator, unregisterCallOrchestrator } from '../../calls/call-state.js';
-import { activeRelayConnections } from '../../calls/relay-server.js';
-import { TwilioConversationRelayProvider } from '../../calls/twilio-provider.js';
-import { getLogger } from '../../util/logger.js';
-
-const log = getLogger('call-end');
+import { cancelCall } from '../../calls/call-domain.js';
 
 const definition: ToolDefinition = {
   name: 'call_end',
@@ -47,70 +41,26 @@ class CallEndTool implements Tool {
 
     const reason = input.reason as string | undefined;
 
-    try {
-      const session = getCallSession(callSessionId);
-      if (!session) {
-        return { content: `Error: no call session found with ID ${callSessionId}`, isError: true };
+    const result = await cancelCall({ callSessionId, reason });
+
+    if (!result.ok) {
+      // If the call already ended, report it as a non-error for the tool
+      if (result.status === 409) {
+        return { content: result.error, isError: false };
       }
-
-      if (session.status === 'completed' || session.status === 'failed') {
-        return {
-          content: `Call session ${callSessionId} has already ended with status: ${session.status}`,
-          isError: false,
-        };
-      }
-
-      log.info({ callSessionId, reason }, 'Ending call');
-
-      // Terminate the call via the provider API so Twilio hangs up,
-      // even if the relay WebSocket is not connected.
-      if (session.providerCallSid) {
-        try {
-          const provider = new TwilioConversationRelayProvider();
-          await provider.endCall(session.providerCallSid);
-        } catch (endErr) {
-          log.warn({ err: endErr, callSessionId, callSid: session.providerCallSid }, 'Failed to terminate call via provider API — proceeding with cleanup');
-        }
-      }
-
-      // End the relay connection if active
-      const relayConnection = activeRelayConnections.get(callSessionId);
-      if (relayConnection) {
-        relayConnection.endSession(reason);
-        relayConnection.destroy();
-        activeRelayConnections.delete(callSessionId);
-      }
-
-      // Clean up orchestrator
-      const orchestrator = getCallOrchestrator(callSessionId);
-      if (orchestrator) {
-        orchestrator.destroy();
-        unregisterCallOrchestrator(callSessionId);
-      }
-
-      // Update session status
-      updateCallSession(callSessionId, {
-        status: 'completed',
-        endedAt: Date.now(),
-      });
-
-      log.info({ callSessionId }, 'Call ended successfully');
-
-      const lines = [
-        'Call ended successfully.',
-        `  Call Session ID: ${callSessionId}`,
-        `  Status: completed`,
-      ];
-      if (reason) {
-        lines.push(`  Reason: ${reason}`);
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ err, callSessionId }, 'Failed to end call');
-      return { content: `Error ending call: ${msg}`, isError: true };
+      return { content: `Error: ${result.error}`, isError: true };
     }
+
+    const lines = [
+      'Call ended successfully.',
+      `  Call Session ID: ${callSessionId}`,
+      `  Status: cancelled`,
+    ];
+    if (reason) {
+      lines.push(`  Reason: ${reason}`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
   }
 }
 

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -2,15 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { DENIED_NUMBERS } from '../../calls/call-constants.js';
-import { createCallSession, updateCallSession } from '../../calls/call-store.js';
-import { TwilioConversationRelayProvider } from '../../calls/twilio-provider.js';
-import { getTwilioConfig } from '../../calls/twilio-config.js';
-import { getLogger } from '../../util/logger.js';
-
-const log = getLogger('call-start');
-
-const E164_REGEX = /^\+\d+$/;
+import { startCall } from '../../calls/call-domain.js';
 
 const definition: ToolDefinition = {
   name: 'call_start',
@@ -47,87 +39,29 @@ class CallStartTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const phoneNumber = input.phone_number as string | undefined;
-    if (!phoneNumber || typeof phoneNumber !== 'string') {
-      return { content: 'Error: phone_number is required and must be a string', isError: true };
+    const result = await startCall({
+      phoneNumber: input.phone_number as string,
+      task: input.task as string,
+      context: input.context as string | undefined,
+      conversationId: context.conversationId,
+    });
+
+    if (!result.ok) {
+      return { content: `Error: ${result.error}`, isError: true };
     }
 
-    if (!E164_REGEX.test(phoneNumber)) {
-      return {
-        content: 'Error: phone_number must be in E.164 format (starts with + followed by digits, e.g. +14155551234)',
-        isError: true,
-      };
-    }
-
-    const task = input.task as string | undefined;
-    if (!task || typeof task !== 'string' || task.trim().length === 0) {
-      return { content: 'Error: task is required and must be a non-empty string', isError: true };
-    }
-
-    if (DENIED_NUMBERS.has(phoneNumber)) {
-      return { content: 'Error: this phone number is not allowed to be called', isError: true };
-    }
-
-    const callContext = input.context as string | undefined;
-
-    // Create session outside the try block so it's available in the catch block
-    // for marking as failed if the provider call fails.
-    let sessionId: string | null = null;
-
-    try {
-      const config = getTwilioConfig();
-      const provider = new TwilioConversationRelayProvider();
-
-      const session = createCallSession({
-        conversationId: context.conversationId,
-        provider: 'twilio',
-        fromNumber: config.phoneNumber,
-        toNumber: phoneNumber,
-        task: callContext ? `${task}\n\nContext: ${callContext}` : task,
-      });
-      sessionId = session.id;
-
-      log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
-
-      const baseUrl = config.webhookBaseUrl.replace(/\/$/, '');
-      const { callSid } = await provider.initiateCall({
-        from: config.phoneNumber,
-        to: phoneNumber,
-        webhookUrl: `${baseUrl}/v1/calls/twilio/voice-webhook?callSessionId=${session.id}`,
-        statusCallbackUrl: `${baseUrl}/v1/calls/twilio/status`,
-      });
-
-      updateCallSession(session.id, { providerCallSid: callSid });
-
-      log.info({ callSessionId: session.id, callSid }, 'Call initiated successfully');
-
-      return {
-        content: [
-          'Call initiated successfully.',
-          `  Call Session ID: ${session.id}`,
-          `  Call SID: ${callSid}`,
-          `  To: ${phoneNumber}`,
-          `  Status: initiated`,
-          '',
-          'The AI voice assistant is now placing the call. Use call_status to check progress.',
-        ].join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ err, phoneNumber }, 'Failed to initiate call');
-
-      // Mark the session as failed so it doesn't stay in 'initiated' state
-      if (sessionId) {
-        updateCallSession(sessionId, {
-          status: 'failed',
-          endedAt: Date.now(),
-          lastError: msg,
-        });
-      }
-
-      return { content: `Error initiating call: ${msg}`, isError: true };
-    }
+    return {
+      content: [
+        'Call initiated successfully.',
+        `  Call Session ID: ${result.session.id}`,
+        `  Call SID: ${result.callSid}`,
+        `  To: ${result.session.toNumber}`,
+        `  Status: initiated`,
+        '',
+        'The AI voice assistant is now placing the call. Use call_status to check progress.',
+      ].join('\n'),
+      isError: false,
+    };
   }
 }
 

--- a/assistant/src/tools/calls/call-status.ts
+++ b/assistant/src/tools/calls/call-status.ts
@@ -2,10 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { getCallSession, getActiveCallSessionForConversation, getPendingQuestion } from '../../calls/call-store.js';
-import { getLogger } from '../../util/logger.js';
-
-const log = getLogger('call-status');
+import { getCallStatus } from '../../calls/call-domain.js';
 
 const definition: ToolDefinition = {
   name: 'call_status',
@@ -35,62 +32,49 @@ class CallStatusTool implements Tool {
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const callSessionId = input.call_session_id as string | undefined;
 
-    try {
-      let session;
+    const result = getCallStatus(callSessionId, context.conversationId);
 
-      if (callSessionId) {
-        session = getCallSession(callSessionId);
-        if (!session) {
-          return { content: `Error: no call session found with ID ${callSessionId}`, isError: true };
-        }
-      } else {
-        session = getActiveCallSessionForConversation(context.conversationId);
-        if (!session) {
-          return { content: 'No active call found in the current conversation.', isError: false };
-        }
+    if (!result.ok) {
+      // When no active call is found and no specific ID was requested, it's not an error
+      if (!callSessionId && result.error === 'No active call found in the current conversation') {
+        return { content: result.error, isError: false };
       }
-
-      log.info({ callSessionId: session.id, status: session.status }, 'Checking call status');
-
-      const lines = [
-        `Call Session: ${session.id}`,
-        `  Status: ${session.status}`,
-        `  To: ${session.toNumber}`,
-        `  From: ${session.fromNumber}`,
-      ];
-
-      if (session.providerCallSid) {
-        lines.push(`  Call SID: ${session.providerCallSid}`);
-      }
-
-      if (session.task) {
-        lines.push(`  Task: ${session.task}`);
-      }
-
-      if (session.startedAt) {
-        const durationMs = (session.endedAt ?? Date.now()) - session.startedAt;
-        const durationSec = Math.round(durationMs / 1000);
-        lines.push(`  Duration: ${durationSec}s`);
-      }
-
-      if (session.lastError) {
-        lines.push(`  Last Error: ${session.lastError}`);
-      }
-
-      // Check for pending questions from the call
-      const pendingQuestion = getPendingQuestion(session.id);
-      if (pendingQuestion) {
-        lines.push('');
-        lines.push(`  Pending Question: ${pendingQuestion.questionText}`);
-        lines.push(`  Question ID: ${pendingQuestion.id}`);
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ err, callSessionId }, 'Failed to check call status');
-      return { content: `Error checking call status: ${msg}`, isError: true };
+      return { content: `Error: ${result.error}`, isError: true };
     }
+
+    const { session } = result;
+    const lines = [
+      `Call Session: ${session.id}`,
+      `  Status: ${session.status}`,
+      `  To: ${session.toNumber}`,
+      `  From: ${session.fromNumber}`,
+    ];
+
+    if (session.providerCallSid) {
+      lines.push(`  Call SID: ${session.providerCallSid}`);
+    }
+
+    if (session.task) {
+      lines.push(`  Task: ${session.task}`);
+    }
+
+    if (session.startedAt) {
+      const durationMs = (session.endedAt ?? Date.now()) - session.startedAt;
+      const durationSec = Math.round(durationMs / 1000);
+      lines.push(`  Duration: ${durationSec}s`);
+    }
+
+    if (session.lastError) {
+      lines.push(`  Last Error: ${session.lastError}`);
+    }
+
+    if (result.pendingQuestion) {
+      lines.push('');
+      lines.push(`  Pending Question: ${result.pendingQuestion.questionText}`);
+      lines.push(`  Question ID: ${result.pendingQuestion.id}`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
   }
 }
 

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -174,13 +174,14 @@ export class CommitEnrichmentService {
   private async executeJob(job: InternalJob): Promise<void> {
     job.attempts++;
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
       // Race the enrichment work against a timeout
       await Promise.race([
         this.doEnrichment(job),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Enrichment job timed out')), this.jobTimeoutMs),
-        ),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => reject(new Error('Enrichment job timed out')), this.jobTimeoutMs);
+        }),
       ]);
       this.succeededCount++;
       log.debug(
@@ -214,6 +215,10 @@ export class CommitEnrichmentService {
         { commitHash: job.commitHash, attempts: job.attempts, timedOut: isTimeout, err },
         isTimeout ? 'Enrichment job timed out after max retries' : 'Enrichment job failed after max retries',
       );
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 


### PR DESCRIPTION
Part of #5296. Closes #5298.

## Changes
- Add call-state-machine.ts with transition validation table
- Add runtime call routes (start, status, cancel, answer)
- Extract shared domain functions from tools for route reuse
- Add state machine unit tests and HTTP route tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
