### PR TITLE
fix: replace console.log with structured logging in daemon code

### DIFF
--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -3,40 +3,25 @@ import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } fr
 import type * as net from 'node:net';
 import type { Database } from 'bun:sqlite';
 import { getDb } from '../../memory/db.js';
+import { getLogger } from '../../util/logger.js';
 
-import { writeFileSync } from 'node:fs';
+const log = getLogger('documents');
 
 export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket, ctx: HandlerContext): void {
-  const logMsg = `[${new Date().toISOString()}] handleDocumentSave called: ${JSON.stringify({
+  log.info({
     surfaceId: msg.surfaceId,
     conversationId: msg.conversationId,
     title: msg.title,
     contentLength: msg.content.length,
     wordCount: msg.wordCount,
-  })}\n`;
+  }, 'Received save request');
 
   try {
-    writeFileSync('/tmp/document-save-debug.log', logMsg, { flag: 'a' });
-  } catch {
-    // Ignore logging errors
-  }
-
-  console.log('💾 [handleDocumentSave] Received save request:', {
-    surfaceId: msg.surfaceId,
-    conversationId: msg.conversationId,
-    title: msg.title,
-    contentLength: msg.content.length,
-    wordCount: msg.wordCount,
-  });
-
-  try {
-    writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] Getting db...\n`, { flag: 'a' });
     const db = getDb();
     // Get the raw SQLite client from Drizzle
     const sqlite = (db as unknown as { $client: Database }).$client;
     const now = Date.now();
 
-    writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] Running sqlite.run()...\n`, { flag: 'a' });
     // Upsert document (insert or update if exists)
     sqlite.run(
       `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
@@ -49,18 +34,15 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
       [msg.surfaceId, msg.conversationId, msg.title, msg.content, msg.wordCount, now, now]
     );
 
-    writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] db.run() completed, sending response...\n`, { flag: 'a' });
     ctx.send(socket, {
       type: 'document_save_response',
       surfaceId: msg.surfaceId,
       success: true,
     });
 
-    writeFileSync('/tmp/document-save-debug.log', `[${new Date().toISOString()}] Response sent successfully\n`, { flag: 'a' });
-
-    console.log(`[documents] Saved document: ${msg.surfaceId} - "${msg.title}"`);
+    log.info({ surfaceId: msg.surfaceId, title: msg.title }, 'Saved document');
   } catch (error) {
-    console.error('[documents] Save error:', error);
+    log.error({ err: error, surfaceId: msg.surfaceId }, 'Save error');
     ctx.send(socket, {
       type: 'document_save_response',
       surfaceId: msg.surfaceId,
@@ -101,7 +83,7 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         updatedAt: result.updated_at,
         success: true,
       });
-      console.log(`[documents] Loaded document: ${msg.surfaceId}`);
+      log.info({ surfaceId: msg.surfaceId }, 'Loaded document');
     } else {
       ctx.send(socket, {
         type: 'document_load_response',
@@ -115,10 +97,10 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
         success: false,
         error: 'Document not found',
       });
-      console.log(`[documents] Document not found: ${msg.surfaceId}`);
+      log.info({ surfaceId: msg.surfaceId }, 'Document not found');
     }
   } catch (error) {
-    console.error('[documents] Load error:', error);
+    log.error({ err: error, surfaceId: msg.surfaceId }, 'Load error');
     ctx.send(socket, {
       type: 'document_load_response',
       surfaceId: msg.surfaceId,
@@ -173,9 +155,9 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
       })),
     });
 
-    console.log(`[documents] Listed ${results.length} documents`);
+    log.info({ count: results.length }, 'Listed documents');
   } catch (error) {
-    console.error('[documents] List error:', error);
+    log.error({ err: error }, 'List error');
     ctx.send(socket, {
       type: 'document_list_response',
       documents: [],

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -1,14 +1,20 @@
 #!/usr/bin/env bun
 import * as Sentry from '@sentry/node';
 import { runDaemon } from './lifecycle.js';
+import { getLogger } from '../util/logger.js';
 
-// Use console.error instead of the structured logger here because
-// startDaemon() captures the child process's stderr to surface error
-// details to the parent process. The structured logger writes to a file
-// by default, so these messages would be lost from stderr.
 runDaemon().catch(async (err) => {
   Sentry.captureException(err);
   await Sentry.flush(2000);
+  // Try structured log first; fall back to console.error because
+  // startDaemon() captures the child process's stderr to surface error
+  // details to the parent process.
+  try {
+    const log = getLogger('daemon-main');
+    log.fatal({ err }, 'Failed to start daemon');
+  } catch {
+    // Logger may not be initialized yet
+  }
   console.error('Failed to start daemon:', err);
   console.error('Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/');
   process.exit(1);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -239,7 +239,6 @@ export async function handleChannelInbound(
     } catch (err) {
       // Secret ingress blocks are not retryable — let the top-level handler return 422
       if (err instanceof IngressBlockedError) throw err;
-      console.error(`[runtime-http] Processing failed`, err);
       log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       channelDeliveryStore.recordProcessingFailure(result.eventId, err);
     }


### PR DESCRIPTION
## Summary
- Replace all `console.log`/`console.error` calls in `documents.ts` with structured `getLogger('documents')` calls and remove leftover temp debug file logging (`writeFileSync` to `/tmp/document-save-debug.log`)
- Remove redundant `console.error` in `channel-routes.ts` that duplicated the adjacent `log.error` call
- Add structured logging with `console.error` fallback in `daemon/main.ts` for startup failures (logger may not be initialized yet)
- Leave `default-gallery.ts` `console.error` calls untouched — they run in browser-side JavaScript inside HTML template strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
