### PR TITLE
fix: revert task run finalStatus back to awaiting_review

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -304,7 +304,7 @@ export async function handleWorkItemRunTask(
       },
     );
 
-    const finalStatus: WorkItemStatus = result.status === 'completed' ? 'done' : 'failed';
+    const finalStatus: WorkItemStatus = result.status === 'completed' ? 'awaiting_review' : 'failed';
     updateWorkItem(msg.id, {
       status: finalStatus,
       lastRunId: result.taskRunId,


### PR DESCRIPTION
## Summary
- Reverted `finalStatus` in `handleWorkItemRunTask` from `'done'` back to `'awaiting_review'`
- PR #5293 incorrectly changed the post-run status — the intent was to remove the "Mark Reviewed" button, not the `awaiting_review` status itself
- Tasks should still land in `awaiting_review` after a successful run so users can review output before considering the task complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
