### PR TITLE
Namespace swarm branches and milestone labels for parallel safety

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -14,6 +14,12 @@ Extract these flags from `$ARGUMENTS` before treating the remainder as the featu
 
 Everything after stripping flags is the **feature description**.
 
+## Namespace
+
+Derive a short namespace slug from the feature description to avoid conflicts with parallel swarms. Take the first 3-4 meaningful words of the feature description, convert to kebab-case, and truncate to 20 characters max (e.g., "Add WebSocket transport for daemon IPC" → `ws-daemon-ipc`). This namespace is used for:
+- Prefixing milestone labels in TODO.md to distinguish tasks from different blitzes
+- Namespacing swarm branch names to avoid worktree collisions
+
 ## Repo-specific gotchas (include these in every agent prompt)
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
@@ -123,11 +129,11 @@ EOF
 ## Phase 3: Populate TODO.md
 
 1. Read `.private/TODO.md` (preserve existing items).
-2. Prepend milestone issues as TODO items at the top:
+2. Prepend milestone issues as TODO items at the top, prefixed with the namespace:
 
 ```
-- M1: <title> (#<issue-number>)
-- M2: <title> (#<issue-number>)
+- [<namespace>] M1: <title> (#<issue-number>)
+- [<namespace>] M2: <title> (#<issue-number>)
 ...
 ```
 
@@ -138,6 +144,7 @@ EOF
 Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
 
 - Pass the `--workers` count (or default: 12) as the first argument.
+- Pass `--namespace <namespace>` to use the derived namespace for branch naming.
 - **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items from Phase 5 — those are PR-based and have no associated milestone issue):
   1. Set the project board status to "Done" and close the issue:
 

--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -2,10 +2,11 @@ Run `/check-reviews` to triage pending PR reviews, then immediately `/swarm` to 
 
 Arguments (optional): $ARGUMENTS
 
-Parse positional arguments (these are passed through to `/swarm`):
+Parse positional arguments and flags (these are passed through to `/swarm`):
 
 - **First argument** (optional): number of parallel workers (default: 12).
 - **Second argument** (optional): maximum number of tasks to complete before shutting down.
+- **`--namespace NAME`** (optional): namespace for swarm branch naming (passed through to `/swarm`).
 
 ## Phase 1: Check reviews
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -17,6 +17,12 @@ Extract these flags from `$ARGUMENTS` before treating the remainder as the featu
 
 Everything after stripping flags is the **feature description**.
 
+## Namespace
+
+Derive a short namespace slug from the feature description to avoid conflicts with parallel swarms. Take the first 3-4 meaningful words of the feature description, convert to kebab-case, and truncate to 20 characters max (e.g., "Add WebSocket transport for daemon IPC" → `ws-daemon-ipc`). This namespace is used for:
+- Prefixing milestone labels in TODO.md to distinguish tasks from different blitzes
+- Namespacing swarm branch names to avoid worktree collisions
+
 ## Repo-specific gotchas (include these in every agent prompt)
 
 - **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
@@ -151,11 +157,11 @@ EOF
 ## Phase 3: Populate TODO.md
 
 1. Read `.private/TODO.md` (preserve existing items).
-2. Prepend milestone issues as TODO items at the top:
+2. Prepend milestone issues as TODO items at the top, prefixed with the namespace:
 
 ```
-- M1: <title> (#<issue-number>)
-- M2: <title> (#<issue-number>)
+- [<namespace>] M1: <title> (#<issue-number>)
+- [<namespace>] M2: <title> (#<issue-number>)
 ...
 ```
 
@@ -170,7 +176,7 @@ For each task being handed off:
 1. Create a worktree **from the feature branch** (not main):
 
 ```bash
-.claude/worktree create swarm/task-<counter> origin/<feature-branch-name>
+.claude/worktree create swarm/<namespace>/task-<counter> origin/<feature-branch-name>
 ```
 
 2. Create a `TaskCreate` entry for tracking.
@@ -222,7 +228,7 @@ For "Address the feedback on <PR URL>" tasks:
    - Append the PR link to .private/UNREVIEWED_PRS.md.
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
-5. Remove the worktree: `.claude/worktree remove swarm/task-<counter> --delete-branch`.
+5. Remove the worktree: `.claude/worktree remove swarm/<namespace>/task-<counter> --delete-branch`.
 6. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate.
 7. Remove the item from the in-flight list.
 8. Pull the latest **feature branch** (not main):

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -2,10 +2,11 @@ Work through .private/TODO.md using a pool of parallel agents. One task per agen
 
 Arguments (optional): $ARGUMENTS
 
-Parse positional arguments:
+Parse positional arguments and flags:
 
 - **First argument** (optional): number of parallel workers (default: 12). Example: `/swarm 5` runs 5 workers.
 - **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 8 10` runs 8 workers and stops after completing 10 tasks.
+- **`--namespace NAME`** (optional): a short identifier to namespace branch names and avoid conflicts with other parallel swarm runs. If not provided, generate a random 4-character hex string (e.g., `a3f2`) as the namespace.
 
 If no arguments are provided, default to 12 workers with no task limit (run until TODO.md is empty or the user says to stop).
 
@@ -19,7 +20,7 @@ If no arguments are provided, default to 12 workers with no task limit (run unti
 ## Phase 1: Setup
 
 1. Read .private/TODO.md. Keep an internal list of which items are currently in-flight.
-2. Parse the arguments: note the worker count (default: 12) and max-tasks limit (if provided). Track a **completed count** starting at 0.
+2. Parse the arguments: note the worker count (default: 12), max-tasks limit (if provided), and namespace (or generate a random 4-char hex default). Track a **completed count** starting at 0.
 3. Create a team with `TeamCreate` (team name: `swarm`).
 
 ## Phase 2: Pick the next task
@@ -40,7 +41,7 @@ These are tasks to read review comments on an already-merged PR, then create a N
 
 For each task being handed off:
 
-1. Create a worktree: `.claude/worktree create swarm/task-<counter>`.
+1. Create a worktree: `.claude/worktree create swarm/<namespace>/task-<counter>`.
 2. Create a `TaskCreate` entry for tracking.
 3. Spawn a `general-purpose` agent via the `Task` tool with `team_name: "swarm"`. The prompt must include:
 
@@ -102,7 +103,7 @@ For "Fix CI failures from merged PR <PR URL> (run: <run URL>)" tasks:
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
 5. Send the agent a shutdown request.
-6. Remove the worktree: `.claude/worktree remove swarm/task-<counter> --delete-branch`.
+6. Remove the worktree: `.claude/worktree remove swarm/<namespace>/task-<counter> --delete-branch`.
 7. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate — give enough detail that the user understands what happened without clicking the PR.
 8. Remove the item from the in-flight list.
 9. Pull the latest main branch to ensure the worktree is up to date.


### PR DESCRIPTION
## Summary
- Add `--namespace NAME` flag to `/swarm` (defaults to random 4-char hex) so branch names use `swarm/<namespace>/task-<counter>` instead of `swarm/task-<counter>`, preventing worktree collisions across parallel swarm runs
- `/blitz` and `/safe-blitz` derive a namespace slug from the feature description and prefix milestone TODO items as `[<namespace>] M1: ...` to disambiguate tasks from concurrent blitzes
- Thread namespace through `/check-reviews-and-swarm` passthrough to `/swarm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)