### PR TITLE
M5: Recovery and stale-session reconciliation

### DIFF
--- a/assistant/src/__tests__/call-recovery.test.ts
+++ b/assistant/src/__tests__/call-recovery.test.ts
@@ -1,0 +1,460 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'call-recovery-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import {
+  createCallSession,
+  updateCallSession,
+  getCallSession,
+  listRecoverableCalls,
+  createPendingQuestion,
+  getPendingQuestion,
+} from '../calls/call-store.js';
+import { reconcileCallsOnStartup, logDeadLetterEvent } from '../calls/call-recovery.js';
+import type { VoiceProvider } from '../calls/voice-provider.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+/** Ensure a conversation row exists for the given ID so FK constraints pass. */
+let ensuredConvIds = new Set<string>();
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+function createTestCallSession(opts: Parameters<typeof createCallSession>[0]) {
+  ensureConversation(opts.conversationId);
+  return createCallSession(opts);
+}
+
+/** Create a mock VoiceProvider that returns configurable statuses. */
+function createMockProvider(statusMap: Record<string, string> = {}): VoiceProvider {
+  return {
+    name: 'mock-twilio',
+    initiateCall: async () => ({ callSid: 'mock-sid' }),
+    endCall: async () => {},
+    getCallStatus: async (callSid: string) => {
+      const status = statusMap[callSid];
+      if (status === undefined) {
+        throw new Error(`Unknown call SID: ${callSid}`);
+      }
+      return status;
+    },
+  };
+}
+
+/** Silent logger for tests */
+const silentLog = new Proxy({} as Record<string, unknown>, {
+  get: () => () => {},
+}) as ReturnType<typeof import('../util/logger.js').getLogger>;
+
+describe('listRecoverableCalls', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('returns sessions in non-terminal states', () => {
+    const s1 = createTestCallSession({
+      conversationId: 'conv-r1',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // s1 is 'initiated' — should be recoverable
+
+    const s2 = createTestCallSession({
+      conversationId: 'conv-r2',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15553333333',
+    });
+    updateCallSession(s2.id, { status: 'in_progress' });
+    // s2 is 'in_progress' — should be recoverable
+
+    const s3 = createTestCallSession({
+      conversationId: 'conv-r3',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15554444444',
+    });
+    updateCallSession(s3.id, { status: 'ringing' });
+    // s3 is 'ringing' — should be recoverable
+
+    const results = listRecoverableCalls();
+    const ids = results.map(r => r.id);
+
+    expect(ids).toContain(s1.id);
+    expect(ids).toContain(s2.id);
+    expect(ids).toContain(s3.id);
+    expect(results).toHaveLength(3);
+  });
+
+  test('does not include terminal calls (completed, failed, cancelled)', () => {
+    const completed = createTestCallSession({
+      conversationId: 'conv-t1',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(completed.id, { status: 'completed' });
+
+    const failed = createTestCallSession({
+      conversationId: 'conv-t2',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15553333333',
+    });
+    updateCallSession(failed.id, { status: 'failed' });
+
+    const cancelled = createTestCallSession({
+      conversationId: 'conv-t3',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15554444444',
+    });
+    updateCallSession(cancelled.id, { status: 'cancelled' });
+
+    const results = listRecoverableCalls();
+    expect(results).toHaveLength(0);
+  });
+
+  test('returns empty array when no calls exist', () => {
+    const results = listRecoverableCalls();
+    expect(results).toHaveLength(0);
+  });
+
+  test('includes waiting_on_user status', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-w1',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, { status: 'in_progress' });
+    updateCallSession(session.id, { status: 'waiting_on_user' });
+
+    const results = listRecoverableCalls();
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(session.id);
+    expect(results[0].status).toBe('waiting_on_user');
+  });
+});
+
+describe('reconcileCallsOnStartup', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('does nothing when no recoverable calls exist', async () => {
+    const provider = createMockProvider();
+    await reconcileCallsOnStartup(provider, silentLog);
+    // Should complete without error
+  });
+
+  test('fails calls with no provider SID', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-nosid',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // No providerCallSid set — it's null by default
+
+    const provider = createMockProvider();
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.endedAt).not.toBeNull();
+    expect(updated!.lastError).toContain('Daemon restarted before call connected to provider');
+  });
+
+  test('transitions to completed when provider says call completed', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-comp',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_completed_123',
+      status: 'in_progress',
+    });
+
+    const provider = createMockProvider({ 'CA_completed_123': 'completed' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('completed');
+    expect(updated!.endedAt).not.toBeNull();
+  });
+
+  test('transitions to failed when provider says call failed', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-fail',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_failed_123',
+      status: 'ringing',
+    });
+
+    const provider = createMockProvider({ 'CA_failed_123': 'failed' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.endedAt).not.toBeNull();
+  });
+
+  test('leaves call active when provider says call is still in-progress', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-active',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_active_123',
+      status: 'in_progress',
+    });
+
+    const provider = createMockProvider({ 'CA_active_123': 'in-progress' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('in_progress');
+    expect(updated!.endedAt).toBeNull();
+  });
+
+  test('leaves call active when provider says call is ringing', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-ring',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_ringing_123',
+      status: 'ringing',
+    });
+
+    const provider = createMockProvider({ 'CA_ringing_123': 'ringing' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('ringing');
+    expect(updated!.endedAt).toBeNull();
+  });
+
+  test('expires pending questions when call transitions to terminal state', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-expire',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_expire_123',
+      status: 'in_progress',
+    });
+    updateCallSession(session.id, { status: 'waiting_on_user' });
+
+    // Create a pending question
+    createPendingQuestion(session.id, 'What is your name?');
+
+    // Verify the question is pending
+    const pendingBefore = getPendingQuestion(session.id);
+    expect(pendingBefore).not.toBeNull();
+    expect(pendingBefore!.status).toBe('pending');
+
+    const provider = createMockProvider({ 'CA_expire_123': 'completed' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    // Pending question should be expired
+    const pendingAfter = getPendingQuestion(session.id);
+    expect(pendingAfter).toBeNull();
+  });
+
+  test('does not expire pending questions when call stays active', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-keep',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_keep_123',
+      status: 'in_progress',
+    });
+    updateCallSession(session.id, { status: 'waiting_on_user' });
+
+    createPendingQuestion(session.id, 'Still waiting?');
+
+    const provider = createMockProvider({ 'CA_keep_123': 'in-progress' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    // The pending question should still be there
+    const pendingAfter = getPendingQuestion(session.id);
+    expect(pendingAfter).not.toBeNull();
+    expect(pendingAfter!.status).toBe('pending');
+  });
+
+  test('fails call when provider status fetch throws', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-err',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_error_123',
+      status: 'in_progress',
+    });
+
+    // Provider will throw for unknown SIDs
+    const provider = createMockProvider({});
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.lastError).toContain('Recovery: failed to fetch provider status');
+  });
+
+  test('fails call when provider returns unrecognised status', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-unk',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    updateCallSession(session.id, {
+      providerCallSid: 'CA_unknown_123',
+      status: 'in_progress',
+    });
+
+    const provider = createMockProvider({ 'CA_unknown_123': 'some-unknown-status' });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.lastError).toContain("unrecognised provider status 'some-unknown-status'");
+  });
+
+  test('handles mixed recoverable calls correctly', async () => {
+    // Call 1: no SID — should fail
+    const noSid = createTestCallSession({
+      conversationId: 'conv-mix1',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Call 2: provider says completed — should complete
+    const completed = createTestCallSession({
+      conversationId: 'conv-mix2',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15553333333',
+    });
+    updateCallSession(completed.id, {
+      providerCallSid: 'CA_mix_completed',
+      status: 'in_progress',
+    });
+
+    // Call 3: provider says still active — should stay
+    const active = createTestCallSession({
+      conversationId: 'conv-mix3',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15554444444',
+    });
+    updateCallSession(active.id, {
+      providerCallSid: 'CA_mix_active',
+      status: 'ringing',
+    });
+
+    const provider = createMockProvider({
+      'CA_mix_completed': 'completed',
+      'CA_mix_active': 'ringing',
+    });
+
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updatedNoSid = getCallSession(noSid.id);
+    expect(updatedNoSid!.status).toBe('failed');
+
+    const updatedCompleted = getCallSession(completed.id);
+    expect(updatedCompleted!.status).toBe('completed');
+
+    const updatedActive = getCallSession(active.id);
+    expect(updatedActive!.status).toBe('ringing');
+  });
+});
+
+describe('logDeadLetterEvent', () => {
+  test('does not throw when called with a payload', () => {
+    expect(() => {
+      logDeadLetterEvent('test reason', { foo: 'bar' }, silentLog);
+    }).not.toThrow();
+  });
+
+  test('does not throw when called with null payload', () => {
+    expect(() => {
+      logDeadLetterEvent('null payload', null, silentLog);
+    }).not.toThrow();
+  });
+});

--- a/assistant/src/calls/call-recovery.ts
+++ b/assistant/src/calls/call-recovery.ts
@@ -1,0 +1,169 @@
+/**
+ * Call recovery — reconciles in-flight calls on daemon restart.
+ *
+ * When the daemon restarts, any calls left in non-terminal states may be stale
+ * (the daemon crashed mid-call) or still active on the provider side. This
+ * module fetches the actual provider status and transitions each call
+ * accordingly.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { listRecoverableCalls, updateCallSession, expirePendingQuestions } from './call-store.js';
+import type { VoiceProvider } from './voice-provider.js';
+import type { CallStatus } from './types.js';
+
+type Logger = ReturnType<typeof getLogger>;
+
+const defaultLog = getLogger('call-recovery');
+
+/**
+ * Map a Twilio provider status string to our internal CallStatus.
+ * Returns the mapped status or null if the status is unrecognised.
+ */
+function mapProviderStatus(providerStatus: string): CallStatus | null {
+  switch (providerStatus) {
+    case 'queued':
+    case 'ringing':
+      return 'ringing';
+    case 'in-progress':
+      return 'in_progress';
+    case 'completed':
+      return 'completed';
+    case 'failed':
+    case 'busy':
+    case 'no-answer':
+    case 'canceled':
+      return 'failed';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Check whether a CallStatus is terminal (no further transitions allowed).
+ */
+function isTerminal(status: CallStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+/**
+ * Reconcile all non-terminal call sessions at daemon startup.
+ *
+ * For each recoverable call:
+ * - If it has a provider SID, fetch the current status from the provider
+ *   and transition the call to match.
+ * - If no provider SID exists (call never connected), fail it with an
+ *   explanatory error message.
+ * - If the call transitions to a terminal state, expire any pending questions.
+ */
+export async function reconcileCallsOnStartup(
+  provider: VoiceProvider,
+  log: Logger = defaultLog,
+): Promise<void> {
+  const recoverableCalls = listRecoverableCalls();
+
+  if (recoverableCalls.length === 0) {
+    log.info('No recoverable calls found at startup');
+    return;
+  }
+
+  log.info({ count: recoverableCalls.length }, 'Reconciling non-terminal calls at startup');
+
+  for (const session of recoverableCalls) {
+    try {
+      if (!session.providerCallSid) {
+        // Call never connected to provider — fail it cleanly
+        log.info(
+          { callSessionId: session.id, previousStatus: session.status },
+          'Failing call with no provider SID (never connected)',
+        );
+        updateCallSession(session.id, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: 'Daemon restarted before call connected to provider',
+        });
+        expirePendingQuestions(session.id);
+        continue;
+      }
+
+      // Fetch actual status from provider
+      let providerStatus: string;
+      try {
+        providerStatus = await provider.getCallStatus(session.providerCallSid);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          { callSessionId: session.id, callSid: session.providerCallSid, err },
+          'Failed to fetch provider status during recovery — failing call',
+        );
+        updateCallSession(session.id, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: `Recovery: failed to fetch provider status: ${msg}`,
+        });
+        expirePendingQuestions(session.id);
+        continue;
+      }
+
+      const mappedStatus = mapProviderStatus(providerStatus);
+
+      if (!mappedStatus) {
+        log.warn(
+          { callSessionId: session.id, providerStatus },
+          'Unrecognised provider status during recovery — failing call',
+        );
+        updateCallSession(session.id, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: `Recovery: unrecognised provider status '${providerStatus}'`,
+        });
+        expirePendingQuestions(session.id);
+        continue;
+      }
+
+      if (isTerminal(mappedStatus)) {
+        // Provider says the call has ended
+        log.info(
+          { callSessionId: session.id, providerStatus, mappedStatus },
+          'Provider reports call ended — transitioning to terminal state',
+        );
+        updateCallSession(session.id, {
+          status: mappedStatus,
+          endedAt: Date.now(),
+        });
+        expirePendingQuestions(session.id);
+      } else {
+        // Provider says call is still active — leave it for webhooks to handle
+        log.info(
+          { callSessionId: session.id, providerStatus, mappedStatus },
+          'Provider reports call still active — leaving for webhook handling',
+        );
+      }
+    } catch (err) {
+      log.error(
+        { callSessionId: session.id, err },
+        'Unexpected error during call recovery',
+      );
+    }
+  }
+
+  log.info('Call recovery reconciliation complete');
+}
+
+/**
+ * Log a dead-letter provider event — a provider callback payload that
+ * could not be processed (malformed, unknown format, etc.).
+ *
+ * Rather than silently dropping these events, we log the full payload
+ * so operators can investigate later.
+ */
+export function logDeadLetterEvent(
+  reason: string,
+  payload: unknown,
+  log: Logger = defaultLog,
+): void {
+  log.error(
+    { reason, payload },
+    'Dead-letter provider event: callback could not be processed',
+  );
+}

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -139,6 +139,25 @@ export function updateCallSession(
     .run();
 }
 
+// ── Recovery queries ─────────────────────────────────────────────────
+
+/**
+ * Returns all call sessions that are in a non-terminal state
+ * (i.e. not completed, failed, or cancelled). Used during daemon startup
+ * to reconcile in-flight calls.
+ */
+export function listRecoverableCalls(): CallSession[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(callSessions)
+    .where(
+      notInArray(callSessions.status, ['completed', 'failed', 'cancelled']),
+    )
+    .all();
+  return rows.map(parseCallSession);
+}
+
 // ── Call Events ──────────────────────────────────────────────────────
 
 export function recordCallEvent(

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -16,6 +16,7 @@ import {
 } from './call-store.js';
 import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
+import { logDeadLetterEvent } from './call-recovery.js';
 
 const log = getLogger('twilio-routes');
 
@@ -124,7 +125,8 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
   const callStatus = formBody.get('CallStatus');
 
   if (!callSid || !callStatus) {
-    log.warn({ callSid, callStatus }, 'Status callback missing CallSid or CallStatus');
+    const rawPayload = Object.fromEntries(formBody.entries());
+    logDeadLetterEvent('Status callback missing CallSid or CallStatus', rawPayload, log);
     return new Response(null, { status: 200 });
   }
 
@@ -138,7 +140,8 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
 
   const mappedStatus = mapTwilioStatus(callStatus);
   if (!mappedStatus) {
-    log.warn({ callSid, callStatus }, 'Status callback: unknown Twilio status');
+    const rawPayload = Object.fromEntries(formBody.entries());
+    logDeadLetterEvent(`Unknown Twilio status: ${callStatus}`, rawPayload, log);
     return new Response(null, { status: 200 });
   }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -45,6 +45,8 @@ import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
 import { HeartbeatService } from '../workspace/heartbeat-service.js';
 import { getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
+import { reconcileCallsOnStartup } from '../calls/call-recovery.js';
+import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 
 const log = getLogger('lifecycle');
 
@@ -290,6 +292,15 @@ export async function runDaemon(): Promise<void> {
       log.info({ workItemId: item.id, title: item.title }, 'Recovered orphaned running work item → failed (interrupted)');
     }
     log.info({ count: orphanedRunning.length }, 'Recovered orphaned running work items');
+  }
+
+  // Reconcile in-flight calls that were left in non-terminal states
+  // after a daemon crash or restart.
+  try {
+    const twilioProvider = new TwilioConversationRelayProvider();
+    await reconcileCallsOnStartup(twilioProvider, log);
+  } catch (err) {
+    log.warn({ err }, 'Call recovery failed — continuing startup');
   }
 
   log.info('Daemon startup: loading config');


### PR DESCRIPTION
Part of #5296. Closes #5301.

## Changes
- Add listRecoverableCalls() to call store for non-terminal session queries
- Create call-recovery.ts with startup reconciliation logic
- Integrate recovery into daemon lifecycle startup
- Add dead-letter logging for malformed provider events
- Add comprehensive tests for recovery scenarios
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
