### PR TITLE
M3: Webhook security hardening and idempotency

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -45,6 +45,7 @@ mock.module('../config/loader.js', () => ({
 // Mock Twilio provider to avoid real API calls
 mock.module('../calls/twilio-provider.js', () => ({
   TwilioConversationRelayProvider: class {
+    static getAuthToken() { return 'mock-auth-token'; }
     static verifyWebhookSignature() { return true; }
     async initiateCall() { return { callSid: 'CA_mock_sid_123' }; }
     async endCall() { return; }

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for TwilioConversationRelayProvider — signature validation and
+ * fail-closed auth token behavior.
+ */
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'twilio-provider-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Start with a configured auth token
+let mockAuthToken: string | undefined = 'test-auth-token-secret';
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => {
+    if (account === 'twilio_auth_token') return mockAuthToken;
+    return undefined;
+  },
+}));
+
+import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function computeValidSignature(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+  return createHmac('sha1', authToken).update(data).digest('base64');
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('TwilioConversationRelayProvider', () => {
+  beforeEach(() => {
+    mockAuthToken = 'test-auth-token-secret';
+  });
+
+  describe('verifyWebhookSignature', () => {
+    const testUrl = 'https://example.com/v1/calls/twilio/status';
+    const testParams = { CallSid: 'CA123', CallStatus: 'completed' };
+
+    test('returns true for a valid signature', () => {
+      const authToken = 'test-auth-token-secret';
+      const sig = computeValidSignature(testUrl, testParams, authToken);
+      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+        testUrl,
+        testParams,
+        sig,
+        authToken,
+      );
+      expect(result).toBe(true);
+    });
+
+    test('returns false for an invalid signature', () => {
+      const authToken = 'test-auth-token-secret';
+      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+        testUrl,
+        testParams,
+        'invalid-signature-base64',
+        authToken,
+      );
+      expect(result).toBe(false);
+    });
+
+    test('returns false when signature is computed with a different auth token', () => {
+      const authToken = 'test-auth-token-secret';
+      const wrongTokenSig = computeValidSignature(testUrl, testParams, 'wrong-token');
+      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+        testUrl,
+        testParams,
+        wrongTokenSig,
+        authToken,
+      );
+      expect(result).toBe(false);
+    });
+
+    test('handles empty params', () => {
+      const authToken = 'test-auth-token-secret';
+      const sig = computeValidSignature(testUrl, {}, authToken);
+      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+        testUrl,
+        {},
+        sig,
+        authToken,
+      );
+      expect(result).toBe(true);
+    });
+
+    test('sorts params alphabetically for signature computation', () => {
+      const authToken = 'test-auth-token-secret';
+      const params = { Zebra: '1', Alpha: '2', Middle: '3' };
+      const sig = computeValidSignature(testUrl, params, authToken);
+      const result = TwilioConversationRelayProvider.verifyWebhookSignature(
+        testUrl,
+        params,
+        sig,
+        authToken,
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getAuthToken', () => {
+    test('returns the auth token when configured', () => {
+      mockAuthToken = 'my-secret-token';
+      const token = TwilioConversationRelayProvider.getAuthToken();
+      expect(token).toBe('my-secret-token');
+    });
+
+    test('returns null when auth token is not configured', () => {
+      mockAuthToken = undefined;
+      const token = TwilioConversationRelayProvider.getAuthToken();
+      expect(token).toBeNull();
+    });
+  });
+});

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Integration tests for Twilio webhook route handlers.
+ *
+ * Tests:
+ * - Signature valid/invalid/missing header
+ * - Fail-closed behavior when auth token is not configured
+ * - TWILIO_WEBHOOK_VALIDATION_DISABLED env flag bypass
+ * - Duplicate callback replay (idempotency)
+ * - Unknown status and malformed payload handling
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'twilio-routes-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+// Configurable mock auth token — tests can switch between configured/unconfigured
+let mockAuthToken: string | undefined = 'test-auth-token-for-webhooks';
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => {
+    if (account === 'twilio_auth_token') return mockAuthToken;
+    return undefined;
+  },
+}));
+
+// Use the real TwilioConversationRelayProvider (not mocked) for signature validation
+// but mock the instance methods that hit Twilio API
+mock.module('../calls/twilio-provider.js', () => {
+  const { createHmac: createHmacNode } = require('node:crypto');
+  const { timingSafeEqual: timingSafeEqualNode } = require('node:crypto');
+  const { getSecureKey } = require('../security/secure-keys.js');
+
+  return {
+    TwilioConversationRelayProvider: class {
+      readonly name = 'twilio';
+
+      static getAuthToken(): string | null {
+        return getSecureKey('twilio_auth_token') ?? null;
+      }
+
+      static verifyWebhookSignature(
+        url: string,
+        params: Record<string, string>,
+        signature: string,
+        authToken: string,
+      ): boolean {
+        const sortedKeys = Object.keys(params).sort();
+        let data = url;
+        for (const key of sortedKeys) {
+          data += key + params[key];
+        }
+        const computed = createHmacNode('sha1', authToken).update(data).digest('base64');
+        const a = Buffer.from(computed);
+        const b = Buffer.from(signature);
+        if (a.length !== b.length) return false;
+        return timingSafeEqualNode(a, b);
+      }
+
+      async initiateCall() { return { callSid: 'CA_mock_test' }; }
+      async endCall() { return; }
+    },
+  };
+});
+
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test-auth-token-for-webhooks',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import { RuntimeHttpServer } from '../runtime/http-server.js';
+import {
+  createCallSession,
+  updateCallSession,
+  getCallEvents,
+} from '../calls/call-store.js';
+
+initializeDb();
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const TEST_TOKEN = 'test-bearer-token-twilio-routes';
+const AUTH_TOKEN = 'test-auth-token-for-webhooks';
+
+let ensuredConvIds = new Set<string>();
+
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM processed_callbacks');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+function computeSignature(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+  return createHmac('sha1', authToken).update(data).digest('base64');
+}
+
+function createTestSession(convId: string, callSid: string) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15559998888',
+    task: 'test task',
+  });
+  updateCallSession(session.id, { providerCallSid: callSid });
+  return session;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('twilio webhook routes', () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(() => {
+    resetTables();
+    mockAuthToken = AUTH_TOKEN;
+    delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  async function startServer(): Promise<void> {
+    port = 20000 + Math.floor(Math.random() * 1000);
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
+    await server.start();
+  }
+
+  async function stopServer(): Promise<void> {
+    await server?.stop();
+  }
+
+  function statusUrl(): string {
+    return `http://127.0.0.1:${port}/v1/calls/twilio/status`;
+  }
+
+  function buildFormBody(params: Record<string, string>): string {
+    return new URLSearchParams(params).toString();
+  }
+
+  function signedRequest(
+    url: string,
+    params: Record<string, string>,
+  ): { body: string; headers: Record<string, string> } {
+    const body = buildFormBody(params);
+    const sig = computeSignature(url, params, AUTH_TOKEN);
+    return {
+      body,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Twilio-Signature': sig,
+      },
+    };
+  }
+
+  // ── Signature validation tests ─────────────────────────────────────
+
+  describe('signature validation', () => {
+    test('valid signature returns 200', async () => {
+      await startServer();
+      const session = createTestSession('conv-sig-1', 'CA_sig_valid');
+      const url = statusUrl();
+      const params = { CallSid: 'CA_sig_valid', CallStatus: 'completed' };
+      const { body, headers } = signedRequest(url, params);
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+
+    test('missing X-Twilio-Signature header returns 403', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = { CallSid: 'CA_no_sig', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe('Forbidden');
+
+      await stopServer();
+    });
+
+    test('invalid signature returns 403', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = { CallSid: 'CA_bad_sig', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-Twilio-Signature': 'totally-wrong-signature',
+        },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(403);
+
+      await stopServer();
+    });
+
+    test('signature computed with wrong token returns 403', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = { CallSid: 'CA_wrong_token', CallStatus: 'completed' };
+      const wrongSig = computeSignature(url, params, 'wrong-auth-token');
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-Twilio-Signature': wrongSig,
+        },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(403);
+
+      await stopServer();
+    });
+  });
+
+  // ── Fail-closed behavior ──────────────────────────────────────────
+
+  describe('fail-closed when auth token missing', () => {
+    test('returns 403 when auth token is not configured', async () => {
+      mockAuthToken = undefined;
+      await startServer();
+
+      const url = statusUrl();
+      const params = { CallSid: 'CA_no_token', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(403);
+
+      await stopServer();
+    });
+  });
+
+  // ── TWILIO_WEBHOOK_VALIDATION_DISABLED bypass ─────────────────────
+
+  describe('validation disabled env flag', () => {
+    test('skips validation when TWILIO_WEBHOOK_VALIDATION_DISABLED=true', async () => {
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
+      mockAuthToken = undefined; // Token not configured, but bypass should work
+      await startServer();
+
+      const session = createTestSession('conv-bypass-1', 'CA_bypass');
+      const url = statusUrl();
+      const params = { CallSid: 'CA_bypass', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+
+    test('does NOT skip validation when TWILIO_WEBHOOK_VALIDATION_DISABLED is set but not "true"', async () => {
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = '1';
+      mockAuthToken = undefined;
+      await startServer();
+
+      const url = statusUrl();
+      const params = { CallSid: 'CA_no_bypass', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: buildFormBody(params),
+      });
+
+      // Should fail-closed: token missing and bypass not activated
+      expect(res.status).toBe(403);
+
+      await stopServer();
+    });
+
+    test('does NOT skip validation when env var is empty string', async () => {
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = '';
+      mockAuthToken = undefined;
+      await startServer();
+
+      const url = statusUrl();
+      const params = { CallSid: 'CA_empty_env', CallStatus: 'completed' };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: buildFormBody(params),
+      });
+
+      expect(res.status).toBe(403);
+
+      await stopServer();
+    });
+  });
+
+  // ── Callback idempotency / replay tests ───────────────────────────
+
+  describe('callback idempotency', () => {
+    test('replaying the same status callback does not create duplicate events', async () => {
+      await startServer();
+      const session = createTestSession('conv-idem-1', 'CA_idem_1');
+      const url = statusUrl();
+      const params = {
+        CallSid: 'CA_idem_1',
+        CallStatus: 'in-progress',
+        Timestamp: '2025-01-15T10:00:00Z',
+      };
+      const { body, headers } = signedRequest(url, params);
+
+      // First callback — should process
+      const res1 = await fetch(url, { method: 'POST', headers, body });
+      expect(res1.status).toBe(200);
+
+      // Second callback (replay) — should return 200 but not create new events
+      const res2 = await fetch(url, { method: 'POST', headers, body });
+      expect(res2.status).toBe(200);
+
+      // Verify only one event was recorded
+      const events = getCallEvents(session.id);
+      const connectedEvents = events.filter(e => e.eventType === 'call_connected');
+      expect(connectedEvents.length).toBe(1);
+
+      await stopServer();
+    });
+
+    test('different statuses for the same call create separate events', async () => {
+      await startServer();
+      const session = createTestSession('conv-idem-2', 'CA_idem_2');
+      const url = statusUrl();
+
+      // First: ringing
+      const params1 = { CallSid: 'CA_idem_2', CallStatus: 'ringing', Timestamp: 'T1' };
+      const req1 = signedRequest(url, params1);
+      await fetch(url, { method: 'POST', headers: req1.headers, body: req1.body });
+
+      // Second: in-progress (different status)
+      const params2 = { CallSid: 'CA_idem_2', CallStatus: 'in-progress', Timestamp: 'T2' };
+      const req2 = signedRequest(url, params2);
+      await fetch(url, { method: 'POST', headers: req2.headers, body: req2.body });
+
+      const events = getCallEvents(session.id);
+      expect(events.length).toBe(2);
+
+      await stopServer();
+    });
+
+    test('third replay of same callback is still no-op', async () => {
+      await startServer();
+      const session = createTestSession('conv-idem-3', 'CA_idem_3');
+      const url = statusUrl();
+      const params = {
+        CallSid: 'CA_idem_3',
+        CallStatus: 'completed',
+        Timestamp: '2025-01-15T11:00:00Z',
+      };
+      const { body, headers } = signedRequest(url, params);
+
+      // Process three times
+      await fetch(url, { method: 'POST', headers, body });
+      await fetch(url, { method: 'POST', headers, body });
+      await fetch(url, { method: 'POST', headers, body });
+
+      const events = getCallEvents(session.id);
+      const endedEvents = events.filter(e => e.eventType === 'call_ended');
+      expect(endedEvents.length).toBe(1);
+
+      await stopServer();
+    });
+  });
+
+  // ── Unknown status + malformed payload tests ──────────────────────
+
+  describe('unknown status and malformed payloads', () => {
+    test('unknown Twilio status returns 200 but does not record event', async () => {
+      await startServer();
+      const session = createTestSession('conv-unknown-1', 'CA_unknown_1');
+      const url = statusUrl();
+      const params = {
+        CallSid: 'CA_unknown_1',
+        CallStatus: 'some-future-status',
+        Timestamp: 'T1',
+      };
+      const { body, headers } = signedRequest(url, params);
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      expect(res.status).toBe(200);
+
+      const events = getCallEvents(session.id);
+      expect(events.length).toBe(0);
+
+      await stopServer();
+    });
+
+    test('missing CallSid returns 200 (graceful handling)', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = { CallStatus: 'completed' };
+      const { body, headers } = signedRequest(url, params);
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+
+    test('missing CallStatus returns 200 (graceful handling)', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = { CallSid: 'CA_no_status' };
+      const { body, headers } = signedRequest(url, params);
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+
+    test('CallSid not matching any session returns 200 without error', async () => {
+      await startServer();
+      const url = statusUrl();
+      const params = {
+        CallSid: 'CA_nonexistent_session',
+        CallStatus: 'completed',
+        Timestamp: 'T1',
+      };
+      const { body, headers } = signedRequest(url, params);
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+  });
+});

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -1,7 +1,7 @@
 import { eq, and, notInArray, desc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
-import { callSessions, callEvents, callPendingQuestions } from '../memory/schema.js';
+import { callSessions, callEvents, callPendingQuestions, processedCallbacks } from '../memory/schema.js';
 import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
 import { validateTransition } from './call-state-machine.js';
 import { getLogger } from '../util/logger.js';
@@ -240,4 +240,43 @@ export function expirePendingQuestions(callSessionId: string): void {
       ),
     )
     .run();
+}
+
+// ── Callback Idempotency ─────────────────────────────────────────────
+
+/**
+ * Build a dedupe key for a Twilio status callback.
+ * Combines CallSid + CallStatus + Timestamp (or SequenceNumber if present)
+ * to uniquely identify each callback.
+ */
+export function buildCallbackDedupeKey(
+  callSid: string,
+  callStatus: string,
+  timestamp?: string | null,
+  sequenceNumber?: string | null,
+): string {
+  const discriminator = sequenceNumber ?? timestamp ?? '';
+  return `${callSid}:${callStatus}:${discriminator}`;
+}
+
+/**
+ * Try to record a processed callback. Returns true if this is a new callback
+ * (inserted successfully). Returns false if the callback was already processed
+ * (dedupe key already exists), indicating a replay.
+ *
+ * Uses INSERT ... ON CONFLICT DO NOTHING pattern for atomicity.
+ */
+export function tryRecordProcessedCallback(
+  dedupeKey: string,
+  callSessionId: string,
+): boolean {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+
+  raw.query(
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+
+  const changes = raw.query('SELECT changes() as c').get() as { c: number };
+  return changes.c > 0;
 }

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -129,6 +129,15 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── Webhook signature verification ──────────────────────────────────
 
   /**
+   * Returns the Twilio auth token from the secure key store, or null if
+   * not configured. Exposed as a static method so callers (e.g. the
+   * HTTP server webhook middleware) can check availability independently.
+   */
+  static getAuthToken(): string | null {
+    return getSecureKey('twilio_auth_token') ?? null;
+  }
+
+  /**
    * Validates an X-Twilio-Signature header using HMAC-SHA1.
    *
    * Algorithm (from Twilio docs):
@@ -143,13 +152,8 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     url: string,
     params: Record<string, string>,
     signature: string,
+    authToken: string,
   ): boolean {
-    const authToken = getSecureKey('twilio_auth_token');
-    if (!authToken) {
-      log.error('Cannot verify Twilio webhook signature: auth token not configured');
-      return false;
-    }
-
     const sortedKeys = Object.keys(params).sort();
     let data = url;
     for (const key of sortedKeys) {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -13,6 +13,8 @@ import {
   updateCallSession,
   recordCallEvent,
   expirePendingQuestions,
+  buildCallbackDedupeKey,
+  tryRecordProcessedCallback,
 } from './call-store.js';
 import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
@@ -139,6 +141,17 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
   const mappedStatus = mapTwilioStatus(callStatus);
   if (!mappedStatus) {
     log.warn({ callSid, callStatus }, 'Status callback: unknown Twilio status');
+    return new Response(null, { status: 200 });
+  }
+
+  // ── Idempotency check ────────────────────────────────────────────
+  const timestamp = formBody.get('Timestamp');
+  const sequenceNumber = formBody.get('SequenceNumber');
+  const dedupeKey = buildCallbackDedupeKey(callSid, callStatus, timestamp, sequenceNumber);
+
+  const isNew = tryRecordProcessedCallback(dedupeKey, session.id);
+  if (!isNew) {
+    log.info({ callSid, callStatus, dedupeKey }, 'Duplicate status callback — skipping');
     return new Response(null, { status: 200 });
   }
 

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -731,12 +731,26 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS processed_callbacks (
+      id TEXT PRIMARY KEY,
+      dedupe_key TEXT NOT NULL UNIQUE,
+      call_session_id TEXT NOT NULL REFERENCES call_sessions(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_sessions_conversation_id ON call_sessions(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_sessions_provider_call_sid ON call_sessions(provider_call_sid)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_sessions_status ON call_sessions(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_events_call_session_id ON call_events(call_session_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_pending_questions_call_session_id ON call_pending_questions(call_session_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_pending_questions_status ON call_pending_questions(status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processed_callbacks_dedupe_key ON processed_callbacks(dedupe_key)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processed_callbacks_call_session_id ON processed_callbacks(call_session_id)`);
+
+  // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid)
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_call_sessions_provider_sid_unique ON call_sessions(provider, provider_call_sid) WHERE provider_call_sid IS NOT NULL`);
 
   // ── Follow-ups ─────────────────────────────────────────────────────
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -571,3 +571,12 @@ export const callPendingQuestions = sqliteTable('call_pending_questions', {
   answeredAt: integer('answered_at'),
   answerText: text('answer_text'),
 });
+
+export const processedCallbacks = sqliteTable('processed_callbacks', {
+  id: text('id').primaryKey(),
+  dedupeKey: text('dedupe_key').notNull().unique(),
+  callSessionId: text('call_session_id')
+    .notNull()
+    .references(() => callSessions.id, { onDelete: 'cascade' }),
+  createdAt: integer('created_at').notNull(),
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -10,7 +10,6 @@ import { resolve } from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
-import { getSecureKey } from '../security/secure-keys.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 
@@ -125,17 +124,28 @@ const TWILIO_WEBHOOK_RE = /^\/v1\/(?:assistants\/[^/]+\/)?calls\/twilio\/(.+)$/;
  * Returns the raw body text on success so callers can reconstruct the Request
  * for downstream handlers (which also need to read the body).
  * Returns a 403 Response if signature validation fails.
- * If the Twilio auth token is not configured, skips validation with a warning.
+ *
+ * Fail-closed: if the auth token is not configured, the request is rejected
+ * with 403 rather than silently skipping validation. An explicit local-dev
+ * bypass is available via TWILIO_WEBHOOK_VALIDATION_DISABLED=true.
  */
 async function validateTwilioWebhook(
   req: Request,
 ): Promise<{ body: string } | Response> {
   const rawBody = await req.text();
-  const authToken = getSecureKey('twilio_auth_token');
 
-  if (!authToken) {
-    log.warn('Twilio auth token not configured — skipping webhook signature validation');
+  // Allow explicit local-dev bypass — must be exactly "true"
+  if (process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED === 'true') {
+    log.warn('Twilio webhook signature validation explicitly disabled via TWILIO_WEBHOOK_VALIDATION_DISABLED');
     return { body: rawBody };
+  }
+
+  const authToken = TwilioConversationRelayProvider.getAuthToken();
+
+  // Fail-closed: reject if no auth token is configured
+  if (!authToken) {
+    log.error('Twilio auth token not configured — rejecting webhook request (fail-closed)');
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
   }
 
   const signature = req.headers.get('x-twilio-signature');
@@ -165,6 +175,7 @@ async function validateTwilioWebhook(
     publicUrl,
     params,
     signature,
+    authToken,
   );
 
   if (!isValid) {


### PR DESCRIPTION
Part of #5296. Closes #5299.

## Changes
- Make Twilio webhook signature validation fail-closed (403 on missing/invalid)
- Add callback idempotency via dedupe keys to prevent replay-driven duplicates
- Add unique constraint on (provider, provider_call_sid)
- Add comprehensive tests for signature validation and replay behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
