### PR TITLE
refactor: extract centralized truncate() string utility

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -13,6 +13,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
 import { Spinner } from './util/spinner.js';
+import { truncate } from './util/truncate.js';
 import { copyToClipboard, extractLastCodeBlock, formatSessionForExport } from './util/clipboard.js';
 import { timeAgo } from './util/time.js';
 import { ensureDaemonRunning } from './daemon/lifecycle.js';
@@ -331,7 +332,7 @@ export async function startCli(): Promise<void> {
     for (let i = 0; i < sessions.length; i++) {
       const s = sessions[i];
       const ago = timeAgo(s.updatedAt);
-      const title = s.title.length > 50 ? s.title.slice(0, 47) + '...' : s.title;
+      const title = truncate(s.title, 50);
       const padding = ' '.repeat(Math.max(1, 55 - title.length));
       process.stdout.write(`  [${i + 1}] ${title}${padding}${ago}\n`);
     }
@@ -585,7 +586,7 @@ export async function startCli(): Promise<void> {
         } else {
           for (const m of msg.messages) {
             const label = m.role === 'user' ? 'you' : 'assistant';
-            const preview = m.text.length > 120 ? m.text.slice(0, 117) + '...' : m.text;
+            const preview = truncate(m.text, 120);
             process.stdout.write(`  ${label}> ${preview.replace(/\n/g, ' ')}\n`);
           }
         }

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { truncate } from '../util/truncate.js';
 import type { ThreadMessage, ThreadSummary } from './types.js';
 
 const log = getLogger('thread-summarizer');
@@ -172,14 +173,10 @@ function extractParticipants(messages: ThreadMessage[]): Array<{ name: string }>
 
 function summarizeSingleMessage(message: ThreadMessage): ThreadSummary {
   return {
-    summary: message.body.length > 200
-      ? message.body.slice(0, 197) + '...'
-      : message.body,
+    summary: truncate(message.body, 200),
     participants: [{ name: message.sender }],
     openQuestions: [],
-    lastAction: message.body.length > 200
-      ? message.body.slice(0, 197) + '...'
-      : message.body,
+    lastAction: truncate(message.body, 200),
     sentiment: 'neutral',
     messageCount: 1,
   };
@@ -280,9 +277,7 @@ function buildFallbackSummary(messages: ThreadMessage[]): ThreadSummary {
     summary: `Thread with ${messages.length} message(s) from ${extractParticipants(messages).map((p) => p.name).join(', ')}.`,
     participants: extractParticipants(messages),
     openQuestions: [],
-    lastAction: lastMsg.body.length > 200
-      ? lastMsg.body.slice(0, 197) + '...'
-      : lastMsg.body,
+    lastAction: truncate(lastMsg.body, 200),
     sentiment: 'neutral',
     messageCount: messages.length,
   };

--- a/assistant/src/tasks/task-compiler.ts
+++ b/assistant/src/tasks/task-compiler.ts
@@ -3,6 +3,7 @@ import { getDb } from '../memory/db.js';
 import { messages as messagesTable } from '../memory/schema.js';
 import { createTask } from './task-store.js';
 import type { Task } from './task-store.js';
+import { truncate } from '../util/truncate.js';
 
 /** Output schema for the task compiler. */
 export interface CompiledTask {
@@ -193,6 +194,5 @@ function buildTemplate(text: string): {
 function deriveTitle(text: string): string {
   // Take the first line and trim whitespace
   const firstLine = text.split('\n')[0].trim();
-  if (firstLine.length <= 60) return firstLine;
-  return firstLine.slice(0, 57) + '...';
+  return truncate(firstLine, 60);
 }

--- a/assistant/src/util/truncate.ts
+++ b/assistant/src/util/truncate.ts
@@ -1,0 +1,5 @@
+/** Truncate a string to `maxLen` characters, appending `suffix` if truncated. */
+export function truncate(str: string, maxLen: number, suffix = '...'): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - suffix.length) + suffix;
+}


### PR DESCRIPTION
## Summary
- Added `assistant/src/util/truncate.ts` with a reusable `truncate(str, maxLen, suffix = '...')` function
- Replaced 6 inline truncation patterns (`str.slice(0, N) + '...'` and ternary variants) in `cli.ts`, `thread-summarizer.ts`, and `task-compiler.ts`
- All call sites preserve their original max-length semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
