### PR TITLE
fix: add waiting_on_user transition from initiated/ringing states

### DIFF
--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -1,12 +1,22 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
+
+// ---------------------------------------------------------------------------
+// Guard against module mock leakage from earlier test files (e.g. session-queue).
+// Re-register the real workspace modules so our static imports bind to them.
+// The ?real query string forces Bun to bypass the mock cache.
+// ---------------------------------------------------------------------------
+mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+mock.module('../workspace/turn-commit.js', async () => await import('../workspace/turn-commit.js?real'));
+mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
+
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
 import { _resetEnrichmentService, getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
-import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('commitTurnChanges', () => {
   let testDir: string;

--- a/assistant/src/calls/call-state-machine.ts
+++ b/assistant/src/calls/call-state-machine.ts
@@ -15,8 +15,8 @@ import type { CallStatus } from './types.js';
  * Terminal states map to an empty set.
  */
 const ALLOWED_TRANSITIONS: Record<CallStatus, Set<CallStatus>> = {
-  initiated: new Set<CallStatus>(['ringing', 'in_progress', 'completed', 'failed', 'cancelled']),
-  ringing: new Set<CallStatus>(['in_progress', 'completed', 'failed', 'cancelled']),
+  initiated: new Set<CallStatus>(['ringing', 'in_progress', 'waiting_on_user', 'completed', 'failed', 'cancelled']),
+  ringing: new Set<CallStatus>(['in_progress', 'waiting_on_user', 'completed', 'failed', 'cancelled']),
   in_progress: new Set<CallStatus>(['waiting_on_user', 'completed', 'failed', 'cancelled']),
   waiting_on_user: new Set<CallStatus>(['in_progress', 'completed', 'failed', 'cancelled']),
   // Terminal states — no further transitions allowed


### PR DESCRIPTION
Addresses Codex P1 feedback on #5312: CallOrchestrator can transition to waiting_on_user before Twilio's in-progress callback fires, so the state machine must allow initiated->waiting_on_user and ringing->waiting_on_user.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
