### PR TITLE
refactor: extract magic numbers into named constants

### DIFF
--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -25,6 +25,8 @@ const bundlerLog = getLogger('app-bundler');
 import { APP_VERSION } from '../version.js';
 const PACKAGE_VERSION = APP_VERSION;
 
+const SHORT_HASH_LENGTH = 8;
+const HASH_DISPLAY_LENGTH = 12;
 const MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB
 const ASSET_FETCH_TIMEOUT_MS = 10_000;
 
@@ -79,7 +81,7 @@ export function extractRemoteUrls(html: string): string[] {
  * Uses a hash of the URL to avoid collisions, preserving the original extension.
  */
 function assetFilename(url: string): string {
-  const hash = createHash('sha256').update(url).digest('hex').slice(0, 12);
+  const hash = createHash('sha256').update(url).digest('hex').slice(0, HASH_DISPLAY_LENGTH);
   let ext = '';
   try {
     const parsed = new URL(url);
@@ -215,7 +217,7 @@ export async function packageApp(
   const allAssets = [...allAssetsMap.values()];
 
   // Create the zip archive
-  const bundleFilename = `${app.name.replace(/[^a-zA-Z0-9_-]/g, '_')}-${randomUUID().slice(0, 8)}.vellumapp`;
+  const bundleFilename = `${app.name.replace(/[^a-zA-Z0-9_-]/g, '_')}-${randomUUID().slice(0, SHORT_HASH_LENGTH)}.vellumapp`;
   const bundlePath = join(tmpdir(), bundleFilename);
 
   await new Promise<void>((resolve, reject) => {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -20,6 +20,7 @@ import { ensureDaemonRunning } from './daemon/lifecycle.js';
 import { shouldAutoStartDaemon } from './daemon/connection-policy.js';
 import { renderMainScreen, updateStatusText, updateDaemonText, type MainScreenLayout } from './cli/main-screen.jsx';
 
+const SHORT_HASH_LENGTH = 8;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 10_000;
 const RECONNECT_BASE_DELAY_MS = 1_000;
@@ -52,7 +53,7 @@ export function formatPrincipalTag(req: Pick<ConfirmationRequest, 'principalKind
   const name = req.principalId ?? req.principalKind;
   // Show a shortened version hash when available (first 8 hex chars after any scheme prefix)
   const versionSuffix = req.principalVersion
-    ? `@${req.principalVersion.replace(/^[^:]+:/, '').slice(0, 8)}`
+    ? `@${req.principalVersion.replace(/^[^:]+:/, '').slice(0, SHORT_HASH_LENGTH)}`
     : '';
   const target = req.executionTarget ? ` \u2192 ${req.executionTarget}` : '';
   return `[${req.principalKind}: ${name}${versionSuffix}${target}]`;

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -4,6 +4,8 @@ import { getLogger } from '../util/logger.js';
 
 const log = getLogger('classifier');
 
+const CLASSIFICATION_TIMEOUT_MS = 5000;
+
 export type InteractionType = 'computer_use' | 'text_qa';
 
 /**
@@ -53,7 +55,7 @@ export async function classifyInteraction(task: string, source?: 'voice' | 'text
         messages: [{ role: 'user' as const, content: task }],
       }),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Classification timeout')), 5000),
+        setTimeout(() => reject(new Error('Classification timeout')), CLASSIFICATION_TIMEOUT_MS),
       ),
     ]);
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -21,7 +21,7 @@ import type {
   SlackWebhookConfigRequest,
   VercelApiConfigRequest,
 } from '../ipc-protocol.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
@@ -96,7 +96,7 @@ export function handleModelSet(
     }
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
     if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
     ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
     // Re-initialize provider with the new model so LLM calls use it
@@ -145,7 +145,7 @@ export function handleImageGenModelSet(
     }
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
     if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
     ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
     ctx.updateConfigFingerprint();

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -13,6 +13,9 @@ const log = getLogger('handlers');
 
 export { log };
 
+/** Debounce window for suppressing file-watcher config reloads after programmatic saves. */
+export const CONFIG_RELOAD_DEBOUNCE_MS = 300;
+
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
 export const FALLBACK_SCREEN = { width: 1920, height: 1080 };

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -19,7 +19,7 @@ import type {
   SkillsSearchRequest,
   SkillsInspectRequest,
 } from '../ipc-protocol.js';
-import { log, ensureSkillEntry, type HandlerContext } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, type HandlerContext } from './shared.js';
 
 export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
@@ -63,7 +63,7 @@ export function handleSkillsEnable(
 
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
     if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
     ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
     ctx.updateConfigFingerprint();
@@ -110,7 +110,7 @@ export function handleSkillsDisable(
 
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
     if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
     ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
     ctx.updateConfigFingerprint();
@@ -167,7 +167,7 @@ export function handleSkillsConfigure(
 
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
     if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
     ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
     ctx.updateConfigFingerprint();
@@ -228,7 +228,7 @@ export async function handleSkillsInstall(
       invalidateConfigCache();
       const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
       if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-      const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+      const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
       ctx.debounceTimers.set('__suppress_reset__', resetTimer);
       ctx.updateConfigFingerprint();
     } catch (err) {
@@ -323,7 +323,7 @@ export async function handleSkillsUninstall(
 
       const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
       if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-      const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+      const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
       ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
       ctx.updateConfigFingerprint();

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -64,6 +64,8 @@ import { registerContactsCommand } from './cli/contacts.js';
 import { registerAutonomyCommand } from './cli/autonomy.js';
 import { registerDoordashCommand } from './cli/doordash.js';
 
+const SHORT_HASH_LENGTH = 8;
+
 function sendOneMessage(
   msg: ClientMessage,
 ): Promise<ServerMessage> {
@@ -517,7 +519,7 @@ trust
     );
     log.info('-'.repeat(idW + toolW + patternW + scopeW + decW + priW + 20));
     for (const r of rules) {
-      const id = r.id.slice(0, 8);
+      const id = r.id.slice(0, SHORT_HASH_LENGTH);
       const created = new Date(r.createdAt).toISOString().slice(0, 10);
       log.info(
         id.padEnd(idW) +
@@ -548,7 +550,7 @@ trust
       log.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
-    log.info(`Removed rule ${match.id.slice(0, 8)} (${match.tool}: ${match.pattern})`);
+    log.info(`Removed rule ${match.id.slice(0, SHORT_HASH_LENGTH)} (${match.tool}: ${match.pattern})`);
   });
 
 trust

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -8,6 +8,8 @@ import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './sch
 
 const log = getLogger('memory-entity-extractor');
 
+const ENTITY_EXTRACTION_TIMEOUT_MS = 15_000;
+
 export type EntityType =
   | 'person'
   | 'project'
@@ -145,7 +147,7 @@ export async function extractEntitiesWithLLM(
         messages: [{ role: 'user' as const, content: text }],
       }) as Promise<Anthropic.Message>,
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Entity extraction LLM timeout')), 15000),
+        setTimeout(() => reject(new Error('Entity extraction LLM timeout')), ENTITY_EXTRACTION_TIMEOUT_MS),
       ),
     ]) as Anthropic.Message;
 

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -7,6 +7,7 @@ import type { ThreadMessage, ThreadSummary } from './types.js';
 const log = getLogger('thread-summarizer');
 
 const SUMMARIZATION_MODEL = 'claude-haiku-4-5-20251001';
+const SUMMARIZATION_TIMEOUT_MS = 20_000;
 const DEFAULT_MAX_TOKENS = 4000;
 const CHARS_PER_TOKEN = 4;
 
@@ -222,7 +223,7 @@ async function summarizeWithLLM(
         timer = setTimeout(() => {
           abortController.abort();
           reject(new Error('Thread summarization LLM timeout'));
-        }, 20000);
+        }, SUMMARIZATION_TIMEOUT_MS);
       }),
     ]);
 

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -24,6 +24,7 @@ import { DEFAULT_TRIAGE_CATEGORIES } from './types.js';
 const log = getLogger('triage-engine');
 
 const TRIAGE_MODEL = 'claude-haiku-4-5-20251001';
+const TRIAGE_CLASSIFICATION_TIMEOUT_MS = 15_000;
 
 // ── Playbook fetching ────────────────────────────────────────────────
 
@@ -244,7 +245,7 @@ async function classifyWithLLM(
       timer = setTimeout(() => {
         abortController.abort();
         reject(new Error('Triage classification LLM timeout'));
-      }, 15000);
+      }, TRIAGE_CLASSIFICATION_TIMEOUT_MS);
     }),
   ]);
 

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -9,6 +9,8 @@ import type { SandboxBackend, SandboxResult } from './types.js';
 
 const log = getLogger('sandbox');
 
+const HASH_DISPLAY_LENGTH = 12;
+
 /**
  * macOS sandbox-exec profile that restricts shell commands:
  * - Denies all by default
@@ -81,7 +83,7 @@ function getProfilePath(workingDir: string): string {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const hash = createHash('sha256').update(workingDir).digest('hex').slice(0, 12);
+  const hash = createHash('sha256').update(workingDir).digest('hex').slice(0, HASH_DISPLAY_LENGTH);
   const path = join(dir, `sandbox-profile-${hash}.sb`);
 
   const profile = SANDBOX_PROFILE.replace(/__WORKING_DIR__/g, workingDir);

--- a/assistant/src/tools/watch/screen-watch.ts
+++ b/assistant/src/tools/watch/screen-watch.ts
@@ -13,6 +13,8 @@ import type { WatchSession } from './watch-state.js';
 
 const log = getLogger('screen-watch');
 
+const SHORT_HASH_LENGTH = 8;
+
 class ScreenWatchTool implements Tool {
   name = 'start_screen_watch';
   description = 'Start observing the screen at regular intervals for a specified duration. Captures OCR text from the active window and provides periodic commentary.';
@@ -77,7 +79,7 @@ class ScreenWatchTool implements Tool {
     }
 
     // Generate watchId
-    const watchId = crypto.randomUUID().slice(0, 8);
+    const watchId = crypto.randomUUID().slice(0, SHORT_HASH_LENGTH);
     const now = Date.now();
     const durationSeconds = durationMinutes * 60;
 


### PR DESCRIPTION
## Summary
- Extract config reload debounce timeout (300ms) used across 7 handler call-sites into `CONFIG_RELOAD_DEBOUNCE_MS` in shared.ts
- Extract LLM operation timeouts (5s, 15s, 20s, 15s) into named constants in their respective files (classifier, entity-extractor, thread-summarizer, triage-engine)
- Extract hash/ID truncation lengths (8-char and 12-char) into `SHORT_HASH_LENGTH` and `HASH_DISPLAY_LENGTH` constants in their respective files

🤖 Generated with [Claude Code](https://claude.com/claude-code)