### PR TITLE
fix: preserve unbound execGit when patching prototype in test

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -959,8 +959,8 @@ describe('WorkspaceGitService', () => {
       // a real git error rather than the expected exit code 1 for
       // "staged changes exist").
       const proto = Object.getPrototypeOf(service);
-      const originalExecGit = proto.execGit.bind(service);
-      proto.execGit = async function (args: string[]) {
+      const originalExecGit = proto.execGit;
+      proto.execGit = async function (this: unknown, args: string[]) {
         if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--quiet') {
           const err = new Error(
             'Git command failed: git diff --cached --quiet\nError: simulated error\nStderr: ',
@@ -968,7 +968,7 @@ describe('WorkspaceGitService', () => {
           err.code = 2;
           throw err;
         }
-        return originalExecGit(args);
+        return originalExecGit.call(this, args);
       };
 
       try {


### PR DESCRIPTION
Addresses Codex+Devin feedback on #5313: the test saved execGit with .bind(service) and restored the bound version on the prototype, permanently polluting it. Now saves the unbound method and uses .call(this, args) in the mock.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
