### PR TITLE
M4: Gateway-owned Twilio ingress and forwarding

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -569,6 +569,45 @@ export class RuntimeHttpServer {
         }
       }
 
+      // ── Internal Twilio forwarding endpoints (gateway → runtime) ──
+      // These accept JSON payloads from the gateway (which already validated
+      // the Twilio signature) and reconstruct requests for the existing
+      // Twilio route handlers.
+      if (endpoint === 'internal/twilio/voice-webhook' && req.method === 'POST') {
+        const json = await req.json() as { params: Record<string, string>; originalUrl?: string };
+        const formBody = new URLSearchParams(json.params).toString();
+        // Reconstruct request URL: keep the original URL query string (callSessionId)
+        const reconstructedUrl = json.originalUrl ?? req.url;
+        const fakeReq = new Request(reconstructedUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formBody,
+        });
+        return await handleVoiceWebhook(fakeReq);
+      }
+
+      if (endpoint === 'internal/twilio/status' && req.method === 'POST') {
+        const json = await req.json() as { params: Record<string, string> };
+        const formBody = new URLSearchParams(json.params).toString();
+        const fakeReq = new Request(req.url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formBody,
+        });
+        return await handleStatusCallback(fakeReq);
+      }
+
+      if (endpoint === 'internal/twilio/connect-action' && req.method === 'POST') {
+        const json = await req.json() as { params: Record<string, string> };
+        const formBody = new URLSearchParams(json.params).toString();
+        const fakeReq = new Request(req.url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formBody,
+        });
+        return await handleConnectAction(fakeReq);
+      }
+
       return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });
     } catch (err) {
       if (err instanceof IngressBlockedError) {

--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -27,6 +27,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     logFile: { dir: undefined, retentionDays: 30 },
     maxAttachmentBytes: 20971520,
     maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioWebhookBaseUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -27,6 +27,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     logFile: { dir: undefined, retentionDays: 30 },
     maxAttachmentBytes: 20971520,
     maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioWebhookBaseUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { forwardToRuntime, downloadAttachment } from "../runtime/client.js";
+import {
+  forwardToRuntime,
+  downloadAttachment,
+  forwardTwilioVoiceWebhook,
+  forwardTwilioStatusWebhook,
+  forwardTwilioConnectActionWebhook,
+} from "../runtime/client.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -27,6 +33,8 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   logFile: { dir: undefined, retentionDays: 30 },
   maxAttachmentBytes: 20971520,
   maxAttachmentConcurrency: 3,
+  twilioAuthToken: undefined,
+  twilioWebhookBaseUrl: undefined,
   ...overrides,
 });
 
@@ -224,5 +232,115 @@ describe("downloadAttachment", () => {
     await expect(
       downloadAttachment(config, "assistant-a", "nonexistent"),
     ).rejects.toThrow("Attachment download failed (404)");
+  });
+});
+
+describe("forwardTwilioVoiceWebhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends params and originalUrl to runtime internal endpoint", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const config = makeConfig({ runtimeBearerToken: "rt-tok" });
+    const params = { CallSid: "CA123", AccountSid: "AC456" };
+    const originalUrl = "https://example.com/webhooks/twilio/voice?callSessionId=sess-1";
+
+    const result = await forwardTwilioVoiceWebhook(config, params, originalUrl);
+    expect(result.status).toBe(200);
+    expect(result.body).toBe(twiml);
+    expect(result.headers["Content-Type"]).toBe("text/xml");
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:7821/v1/internal/twilio/voice-webhook");
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const sentBody = JSON.parse(calledInit.body as string);
+    expect(sentBody.params).toEqual(params);
+    expect(sentBody.originalUrl).toBe(originalUrl);
+
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer rt-tok");
+  });
+});
+
+describe("forwardTwilioStatusWebhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends params to runtime internal status endpoint", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+
+    const config = makeConfig({ runtimeBearerToken: "rt-tok" });
+    const params = { CallSid: "CA123", CallStatus: "completed" };
+
+    const result = await forwardTwilioStatusWebhook(config, params);
+    expect(result.status).toBe(200);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:7821/v1/internal/twilio/status");
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const sentBody = JSON.parse(calledInit.body as string);
+    expect(sentBody.params).toEqual(params);
+  });
+});
+
+describe("forwardTwilioConnectActionWebhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends params to runtime internal connect-action endpoint", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const config = makeConfig({ runtimeBearerToken: "rt-tok" });
+    const params = { CallSid: "CA123" };
+
+    const result = await forwardTwilioConnectActionWebhook(config, params);
+    expect(result.status).toBe(200);
+    expect(result.body).toBe(twiml);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:7821/v1/internal/twilio/connect-action");
+  });
+
+  test("returns runtime error status and body", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response('{"error":"Not found"}', { status: 404 }),
+      ),
+    );
+
+    const config = makeConfig();
+    const result = await forwardTwilioConnectActionWebhook(config, { CallSid: "CA999" });
+    expect(result.status).toBe(404);
+    expect(result.body).toContain("Not found");
   });
 });

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -29,6 +29,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     logFile: { dir: undefined, retentionDays: 30 },
     maxAttachmentBytes: 20971520,
     maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioWebhookBaseUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -27,6 +27,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     logFile: { dir: undefined, retentionDays: 30 },
     maxAttachmentBytes: 20971520,
     maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioWebhookBaseUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -27,6 +27,8 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   logFile: { dir: undefined, retentionDays: 30 },
   maxAttachmentBytes: 20971520,
   maxAttachmentConcurrency: 3,
+  twilioAuthToken: undefined,
+  twilioWebhookBaseUrl: undefined,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -1,0 +1,381 @@
+import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
+import { createHmac } from "node:crypto";
+import type { GatewayConfig } from "../config.js";
+import { createTwilioVoiceWebhookHandler } from "../http/routes/twilio-voice-webhook.js";
+import { createTwilioStatusWebhookHandler } from "../http/routes/twilio-status-webhook.js";
+import { createTwilioConnectActionWebhookHandler } from "../http/routes/twilio-connect-action-webhook.js";
+
+const AUTH_TOKEN = "test-twilio-auth-token";
+
+const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
+  telegramBotToken: "tok",
+  telegramWebhookSecret: "wh-ver",
+  telegramApiBaseUrl: "https://api.telegram.org",
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  routingEntries: [],
+  defaultAssistantId: undefined,
+  unmappedPolicy: "reject",
+  port: 7830,
+  runtimeBearerToken: "rt-token",
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeProxyBearerToken: undefined,
+  shutdownDrainMs: 5000,
+  runtimeTimeoutMs: 30000,
+  runtimeMaxRetries: 2,
+  runtimeInitialBackoffMs: 500,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
+  telegramTimeoutMs: 15000,
+  maxWebhookPayloadBytes: 1048576,
+  logFile: { dir: undefined, retentionDays: 30 },
+  maxAttachmentBytes: 20971520,
+  maxAttachmentConcurrency: 3,
+  twilioAuthToken: AUTH_TOKEN,
+  twilioWebhookBaseUrl: undefined,
+  ...overrides,
+});
+
+/**
+ * Compute a valid Twilio signature for the given URL + params.
+ */
+function computeSignature(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+  return createHmac("sha1", authToken).update(data).digest("base64");
+}
+
+/**
+ * Build a signed Twilio webhook request.
+ */
+function buildSignedRequest(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): Request {
+  const body = new URLSearchParams(params).toString();
+  const signature = computeSignature(url, params, authToken);
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Twilio-Signature": signature,
+    },
+    body,
+  });
+}
+
+function mockFetch(fn: () => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
+
+describe("Twilio voice webhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("rejects GET requests with 405", async () => {
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+      method: "GET",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(405);
+  });
+
+  test("rejects missing signature with 403", async () => {
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "CallSid=CA123&CallStatus=ringing",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects invalid signature with 403", async () => {
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": "invalid-signature",
+      },
+      body: "CallSid=CA123&CallStatus=ringing",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects when twilioAuthToken is not configured (fail-closed)", async () => {
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig({ twilioAuthToken: undefined }),
+    );
+    const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "CallSid=CA123",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("forwards valid signed request to runtime and returns response", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/voice?callSessionId=sess-1";
+    const params = { CallSid: "CA123", AccountSid: "AC456" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.text();
+    expect(body).toBe(twiml);
+
+    // Verify the fetch was called to the runtime's internal endpoint
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toContain("/v1/internal/twilio/voice-webhook");
+  });
+
+  test("returns 502 when runtime is unreachable", async () => {
+    mockFetch(() => Promise.reject(new Error("Connection refused")));
+
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const params = { CallSid: "CA123" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(502);
+  });
+
+  test("rejects oversized payload via Content-Length header", async () => {
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig({ maxWebhookPayloadBytes: 100 }),
+    );
+    const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": "999999",
+        "X-Twilio-Signature": "irrelevant",
+      },
+      body: "x".repeat(200),
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(413);
+  });
+
+  test("rejects oversized payload via actual body size", async () => {
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig({ maxWebhookPayloadBytes: 50 }),
+    );
+    const largeBody = "CallSid=" + "A".repeat(100);
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const signature = computeSignature(
+      url,
+      Object.fromEntries(new URLSearchParams(largeBody).entries()),
+      AUTH_TOKEN,
+    );
+    const req = new Request(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body: largeBody,
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("Twilio status webhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("rejects invalid signature with 403", async () => {
+    const handler = createTwilioStatusWebhookHandler(makeConfig());
+    const req = new Request("http://localhost:7830/webhooks/twilio/status", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": "bad",
+      },
+      body: "CallSid=CA123&CallStatus=completed",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("forwards valid signed request to runtime", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+
+    const handler = createTwilioStatusWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/status";
+    const params = { CallSid: "CA123", CallStatus: "completed" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toContain("/v1/internal/twilio/status");
+  });
+
+  test("returns 502 when runtime returns error", async () => {
+    mockFetch(() => Promise.reject(new Error("Runtime down")));
+
+    const handler = createTwilioStatusWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/status";
+    const params = { CallSid: "CA123", CallStatus: "completed" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("Twilio connect-action webhook", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("rejects invalid signature with 403", async () => {
+    const handler = createTwilioConnectActionWebhookHandler(makeConfig());
+    const req = new Request("http://localhost:7830/webhooks/twilio/connect-action", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": "wrong",
+      },
+      body: "CallSid=CA123",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("forwards valid signed request to runtime", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const handler = createTwilioConnectActionWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/connect-action";
+    const params = { CallSid: "CA123" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.text();
+    expect(body).toBe(twiml);
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toContain("/v1/internal/twilio/connect-action");
+  });
+});
+
+describe("Twilio webhook signature with public base URL", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("validates signature against twilioWebhookBaseUrl when configured", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    mockFetch(() =>
+      Promise.resolve(
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const publicBaseUrl = "https://public.example.com";
+    const config = makeConfig({ twilioWebhookBaseUrl: publicBaseUrl });
+    const handler = createTwilioVoiceWebhookHandler(config);
+
+    // The local URL is different from the public URL
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
+    const publicUrl = publicBaseUrl + "/webhooks/twilio/voice";
+    const params = { CallSid: "CA123" };
+
+    // Sign against the PUBLIC URL (as Twilio would)
+    const signature = computeSignature(publicUrl, params, AUTH_TOKEN);
+    const body = new URLSearchParams(params).toString();
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body,
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects when signature matches local URL but not public URL", async () => {
+    const publicBaseUrl = "https://public.example.com";
+    const config = makeConfig({ twilioWebhookBaseUrl: publicBaseUrl });
+    const handler = createTwilioVoiceWebhookHandler(config);
+
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
+    const params = { CallSid: "CA123" };
+
+    // Sign against the LOCAL URL (incorrect — Twilio would sign against public)
+    const signature = computeSignature(localUrl, params, AUTH_TOKEN);
+    const body = new URLSearchParams(params).toString();
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body,
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -35,6 +35,10 @@ export type GatewayConfig = {
   telegramMaxRetries: number;
   telegramTimeoutMs: number;
   telegramWebhookSecret: string | undefined;
+  /** Twilio auth token for validating webhook signatures at the gateway boundary. */
+  twilioAuthToken: string | undefined;
+  /** Public base URL that Twilio uses when computing webhook signatures. */
+  twilioWebhookBaseUrl: string | undefined;
   unmappedPolicy: "reject" | "default";
 };
 
@@ -200,6 +204,9 @@ export function loadConfig(): GatewayConfig {
     );
   }
 
+  const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || undefined;
+  const twilioWebhookBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL || undefined;
+
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;
 
   const logFileRetentionDays = Number(process.env.GATEWAY_LOG_RETENTION_DAYS || "30");
@@ -222,6 +229,7 @@ export function loadConfig(): GatewayConfig {
       port,
       runtimeProxyEnabled,
       runtimeProxyRequireAuth,
+      hasTwilioAuthToken: !!twilioAuthToken,
     },
     "Configuration loaded",
   );
@@ -249,6 +257,8 @@ export function loadConfig(): GatewayConfig {
     telegramMaxRetries,
     telegramTimeoutMs,
     telegramWebhookSecret,
+    twilioAuthToken,
+    twilioWebhookBaseUrl,
     unmappedPolicy,
   };
 }

--- a/gateway/src/http/routes/twilio-connect-action-webhook.ts
+++ b/gateway/src/http/routes/twilio-connect-action-webhook.ts
@@ -1,0 +1,27 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { forwardTwilioConnectActionWebhook } from "../../runtime/client.js";
+import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+
+const log = getLogger("twilio-connect-action-webhook");
+
+export function createTwilioConnectActionWebhookHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const validation = await validateTwilioWebhookRequest(req, config);
+    if (validation instanceof Response) return validation;
+
+    const { params } = validation;
+    log.info("Twilio connect-action webhook received");
+
+    try {
+      const runtimeResponse = await forwardTwilioConnectActionWebhook(config, params);
+      return new Response(runtimeResponse.body, {
+        status: runtimeResponse.status,
+        headers: runtimeResponse.headers,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to forward Twilio connect-action webhook to runtime");
+      return Response.json({ error: "Internal server error" }, { status: 502 });
+    }
+  };
+}

--- a/gateway/src/http/routes/twilio-status-webhook.ts
+++ b/gateway/src/http/routes/twilio-status-webhook.ts
@@ -1,0 +1,30 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { forwardTwilioStatusWebhook } from "../../runtime/client.js";
+import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+
+const log = getLogger("twilio-status-webhook");
+
+export function createTwilioStatusWebhookHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const validation = await validateTwilioWebhookRequest(req, config);
+    if (validation instanceof Response) return validation;
+
+    const { params } = validation;
+    log.info(
+      { callSid: params.CallSid, callStatus: params.CallStatus },
+      "Twilio status webhook received",
+    );
+
+    try {
+      const runtimeResponse = await forwardTwilioStatusWebhook(config, params);
+      return new Response(runtimeResponse.body, {
+        status: runtimeResponse.status,
+        headers: runtimeResponse.headers,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to forward Twilio status webhook to runtime");
+      return Response.json({ error: "Internal server error" }, { status: 502 });
+    }
+  };
+}

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -1,0 +1,27 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { forwardTwilioVoiceWebhook } from "../../runtime/client.js";
+import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+
+const log = getLogger("twilio-voice-webhook");
+
+export function createTwilioVoiceWebhookHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const validation = await validateTwilioWebhookRequest(req, config);
+    if (validation instanceof Response) return validation;
+
+    const { params } = validation;
+    log.info({ callSid: params.CallSid }, "Twilio voice webhook received");
+
+    try {
+      const runtimeResponse = await forwardTwilioVoiceWebhook(config, params, req.url);
+      return new Response(runtimeResponse.body, {
+        status: runtimeResponse.status,
+        headers: runtimeResponse.headers,
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to forward Twilio voice webhook to runtime");
+      return Response.json({ error: "Internal server error" }, { status: 502 });
+    }
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,6 +1,9 @@
 import { loadConfig } from "./config.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
+import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
+import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
+import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
 import { getLogger, initLogger } from "./logger.js";
 import { buildSchema } from "./schema.js";
 import { callTelegramApi } from "./telegram/api.js";
@@ -49,6 +52,10 @@ function main() {
       )
     : null;
 
+  const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(config);
+  const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
+  const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
+
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
     : null;
@@ -81,6 +88,18 @@ function main() {
           );
         }
         return handleTelegramWebhook(req);
+      }
+
+      if (url.pathname === "/webhooks/twilio/voice") {
+        return handleTwilioVoiceWebhook(req);
+      }
+
+      if (url.pathname === "/webhooks/twilio/status") {
+        return handleTwilioStatusWebhook(req);
+      }
+
+      if (url.pathname === "/webhooks/twilio/connect-action") {
+        return handleTwilioConnectActionWebhook(req);
       }
 
       if (handleRuntimeProxy) {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -181,6 +181,89 @@ export async function downloadAttachment(
   return (await response.json()) as RuntimeAttachmentPayload;
 }
 
+// ── Twilio webhook forwarding ────────────────────────────────────────
+
+export type TwilioForwardResponse = {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+};
+
+/**
+ * Forward a validated Twilio voice webhook payload to the runtime.
+ * The gateway sends the parsed form params as JSON; the runtime's internal
+ * endpoint reconstructs what it needs.
+ */
+export async function forwardTwilioVoiceWebhook(
+  config: GatewayConfig,
+  params: Record<string, string>,
+  originalUrl: string,
+): Promise<TwilioForwardResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ params, originalUrl }),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  const body = await response.text();
+  const headers: Record<string, string> = {};
+  const contentType = response.headers.get("content-type");
+  if (contentType) headers["Content-Type"] = contentType;
+
+  return { status: response.status, body, headers };
+}
+
+/**
+ * Forward a validated Twilio status callback payload to the runtime.
+ */
+export async function forwardTwilioStatusWebhook(
+  config: GatewayConfig,
+  params: Record<string, string>,
+): Promise<TwilioForwardResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/status`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ params }),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  const body = await response.text();
+  const headers: Record<string, string> = {};
+  const contentType = response.headers.get("content-type");
+  if (contentType) headers["Content-Type"] = contentType;
+
+  return { status: response.status, body, headers };
+}
+
+/**
+ * Forward a validated Twilio connect-action callback payload to the runtime.
+ */
+export async function forwardTwilioConnectActionWebhook(
+  config: GatewayConfig,
+  params: Record<string, string>,
+): Promise<TwilioForwardResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/connect-action`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ params }),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  const body = await response.text();
+  const headers: Record<string, string> = {};
+  const contentType = response.headers.get("content-type");
+  if (contentType) headers["Content-Type"] = contentType;
+
+  return { status: response.status, body, headers };
+}
+
 export async function uploadAttachment(
   config: GatewayConfig,
   assistantId: string,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -145,6 +145,168 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/webhooks/twilio/voice": {
+        post: {
+          summary: "Twilio voice webhook",
+          description:
+            "Receives inbound Twilio voice webhooks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
+          operationId: "twilioVoiceWebhook",
+          security: [{ TwilioSignature: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/x-www-form-urlencoded": {
+                schema: { type: "object", additionalProperties: { type: "string" } },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Webhook processed, runtime response forwarded",
+            },
+            "403": {
+              description: "Twilio signature validation failed or auth token not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed (only POST accepted)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "413": {
+              description: "Webhook payload too large",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to forward to runtime",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/webhooks/twilio/status": {
+        post: {
+          summary: "Twilio status webhook",
+          description:
+            "Receives Twilio call status callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
+          operationId: "twilioStatusWebhook",
+          security: [{ TwilioSignature: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/x-www-form-urlencoded": {
+                schema: { type: "object", additionalProperties: { type: "string" } },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Status callback processed",
+            },
+            "403": {
+              description: "Twilio signature validation failed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "413": {
+              description: "Webhook payload too large",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to forward to runtime",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/webhooks/twilio/connect-action": {
+        post: {
+          summary: "Twilio connect-action webhook",
+          description:
+            "Receives Twilio ConversationRelay connect-action callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
+          operationId: "twilioConnectActionWebhook",
+          security: [{ TwilioSignature: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/x-www-form-urlencoded": {
+                schema: { type: "object", additionalProperties: { type: "string" } },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Connect-action callback processed",
+            },
+            "403": {
+              description: "Twilio signature validation failed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "413": {
+              description: "Webhook payload too large",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to forward to runtime",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",
@@ -376,6 +538,12 @@ export function buildSchema(): Record<string, unknown> {
           type: "apiKey",
           in: "header",
           name: "X-Telegram-Bot-Api-Secret-Token",
+        },
+        TwilioSignature: {
+          type: "apiKey",
+          in: "header",
+          name: "X-Twilio-Signature",
+          description: "HMAC-SHA1 signature computed by Twilio over the request URL and form parameters.",
         },
       },
     },

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -1,0 +1,89 @@
+import type { GatewayConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+import { verifyTwilioSignature } from "./verify.js";
+
+const log = getLogger("twilio-validate");
+
+export type TwilioValidationSuccess = {
+  /** Raw form-urlencoded body as a string. */
+  rawBody: string;
+  /** Parsed key-value pairs from the form body. */
+  params: Record<string, string>;
+};
+
+/**
+ * Validate an incoming Twilio webhook request:
+ * - Enforces POST method
+ * - Enforces payload size limits
+ * - Validates X-Twilio-Signature via HMAC-SHA1
+ *
+ * Returns the parsed body on success, or a Response on failure.
+ */
+export async function validateTwilioWebhookRequest(
+  req: Request,
+  config: GatewayConfig,
+): Promise<TwilioValidationSuccess | Response> {
+  if (req.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // Payload size guard (Content-Length header)
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
+    log.warn({ contentLength }, "Twilio webhook payload too large");
+    return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  // Fail-closed: reject if no auth token is configured
+  if (!config.twilioAuthToken) {
+    log.error("Twilio auth token not configured — rejecting webhook (fail-closed)");
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let rawBody: string;
+  try {
+    rawBody = await req.text();
+  } catch {
+    return Response.json({ error: "Failed to read body" }, { status: 400 });
+  }
+
+  // Payload size guard (actual body size)
+  if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
+    log.warn({ bodyLength: Buffer.byteLength(rawBody) }, "Twilio webhook payload too large");
+    return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  // Parse form-urlencoded body
+  const formData = new URLSearchParams(rawBody);
+  const params: Record<string, string> = {};
+  for (const [key, value] of formData.entries()) {
+    params[key] = value;
+  }
+
+  // Validate signature
+  const signature = req.headers.get("x-twilio-signature");
+  if (!signature) {
+    log.warn("Twilio webhook request missing X-Twilio-Signature header");
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Reconstruct the public-facing URL that Twilio signed against.
+  const parsedUrl = new URL(req.url);
+  const publicUrl = config.twilioWebhookBaseUrl
+    ? config.twilioWebhookBaseUrl.replace(/\/$/, "") + parsedUrl.pathname + parsedUrl.search
+    : req.url;
+
+  const isValid = verifyTwilioSignature(
+    publicUrl,
+    params,
+    signature,
+    config.twilioAuthToken,
+  );
+
+  if (!isValid) {
+    log.warn("Twilio webhook signature validation failed");
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return { rawBody, params };
+}

--- a/gateway/src/twilio/verify.ts
+++ b/gateway/src/twilio/verify.ts
@@ -1,0 +1,35 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Validates a Twilio X-Twilio-Signature header using HMAC-SHA1.
+ *
+ * Algorithm (from Twilio docs):
+ * 1. Take the full URL of the request.
+ * 2. Sort the POST parameters alphabetically by key.
+ * 3. Concatenate the URL with each key-value pair (key + value, no delimiters).
+ * 4. HMAC-SHA1 the result using the auth token as the key.
+ * 5. Base64-encode the hash.
+ * 6. Compare to the X-Twilio-Signature header value.
+ */
+export function verifyTwilioSignature(
+  url: string,
+  params: Record<string, string>,
+  signature: string,
+  authToken: string,
+): boolean {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+
+  const computed = createHmac("sha1", authToken)
+    .update(data)
+    .digest("base64");
+
+  // Constant-time comparison to prevent timing attacks
+  const a = Buffer.from(computed);
+  const b = Buffer.from(signature);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}


### PR DESCRIPTION
Part of #5296. Closes #5300.

## Changes
- Add gateway Twilio webhook endpoints (voice, status, connect-action)
- Validate Twilio signatures at gateway boundary
- Forward validated payloads to runtime via bearer-auth client
- Add gateway webhook tests and runtime client forwarding tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
