### PR TITLE
fix: address call-bridge integration issues in server/session

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1008,6 +1008,9 @@ export class DaemonServer {
         // runAgentLoop normally does this in its finally block, but we
         // skipped it entirely.
         resetSessionProcessingState(session);
+        // Drain any queued messages that arrived while processing was true.
+        // runAgentLoop normally drains in its finally block, but we skipped it.
+        session.drainQueue('loop_complete');
         log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
         return { messageId };
       }
@@ -1060,15 +1063,18 @@ export class DaemonServer {
         }))
       : [];
 
-    // Persist user message first so we can check the call bridge
-    const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(content, attachments, requestId);
-
-    // Attempt the call-answer bridge before launching the agent loop.
+    // Check the call-answer bridge before processing. If the message is
+    // consumed as a call answer, persist it and skip the agent loop.
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content);
       if (bridgeResult.handled) {
+        // Persist the user message so it appears in history, but skip the
+        // agent loop since the call system consumed it.
+        const requestId = crypto.randomUUID();
+        const messageId = session.persistUserMessage(content, attachments, requestId);
         resetSessionProcessingState(session);
+        // Drain any queued messages that arrived while processing was true.
+        session.drainQueue('loop_complete');
         log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
         return { messageId };
       }
@@ -1076,7 +1082,9 @@ export class DaemonServer {
       log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
     }
 
-    await session.runAgentLoop(content, messageId, () => {});
+    // Delegate to session.processMessage which handles slash-command
+    // resolution, skill preactivation, persistence, and the agent loop.
+    const messageId = await session.processMessage(content, attachments, () => {});
 
     if (!messageId) {
       throw new Error('Failed to persist user message');

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -277,6 +277,9 @@ export class Session {
         JSON.stringify([{ type: 'text', text: questionText }]),
       );
 
+      // Mirror into in-memory messages so subsequent turns see this context
+      this.messages.push(createAssistantMessage(questionText));
+
       // Emit to active clients in real-time
       this.sendToClient({
         type: 'assistant_text_delta',
@@ -304,6 +307,9 @@ export class Session {
         'assistant',
         JSON.stringify([{ type: 'text', text: summaryText }]),
       );
+
+      // Mirror into in-memory messages so subsequent turns see this context
+      this.messages.push(createAssistantMessage(summaryText));
 
       // Emit to active clients
       this.sendToClient({
@@ -519,9 +525,6 @@ export class Session {
       unregisterWatchCommentaryNotifier(this.conversationId);
       unregisterWatchCompletionNotifier(this.conversationId);
       pruneWatchSessions(this.conversationId);
-      unregisterCallQuestionNotifier(this.conversationId);
-      unregisterCallCompletionNotifier(this.conversationId);
-
       // Clear queued messages and notify each caller with a session-scoped
       // cancel event so other sessions do not receive cross-thread errors.
       for (const queued of this.queue) {
@@ -1522,7 +1525,8 @@ export class Session {
     consolidateAssistantMessages(this.conversationId, userMessageId);
   }
 
-  private drainQueue(reason: QueueDrainReason = 'loop_complete'): void {
+  /** @internal — also invoked from server.ts when the call bridge skips the agent loop. */
+  drainQueue(reason: QueueDrainReason = 'loop_complete'): void {
     drainQueueImpl(this as ProcessSessionContext, reason);
   }
 


### PR DESCRIPTION
Addresses feedback on #5319:
- P1: Drain queued messages when bridge skips agent loop (server.ts)
- P1: Keep call notifiers registered after cancellation (session.ts) 
- P2: Mirror call notification messages into session memory (session.ts)
- Restore slash-command resolution in blocking processMessage path (server.ts)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
