### PR TITLE
feat: server-side video thumbnail generation

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -3,7 +3,8 @@ import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
-import { getAttachmentsForMessageUnscoped } from '../../memory/attachments-store.js';
+import { getAttachmentsForMessageUnscoped, setAttachmentThumbnail } from '../../memory/attachments-store.js';
+import { generateVideoThumbnail } from '../video-thumbnail.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
 import type {
@@ -354,12 +355,23 @@ export function handleHistoryRequest(
         const MAX_INLINE_B64_SIZE = 512 * 1024;
         attachments = linked.map((a) => {
           const omit = a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE;
+
+          // Lazily generate thumbnails for existing video attachments on first history load.
+          if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {
+            const attachmentId = a.id;
+            const base64 = a.dataBase64;
+            generateVideoThumbnail(base64).then((thumb) => {
+              if (thumb) setAttachmentThumbnail(attachmentId, thumb);
+            }).catch(() => {});
+          }
+
           return {
             id: a.id,
             filename: a.originalFilename,
             mimeType: a.mimeType,
             data: omit ? '' : a.dataBase64,
             ...(omit ? { sizeBytes: a.sizeBytes } : {}),
+            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
           };
         });
       }

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -45,6 +45,8 @@ export interface UserMessageAttachment {
   extractedText?: string;
   /** Original file size in bytes. Present when data was omitted from history_response to reduce payload size. */
   sizeBytes?: number;
+  /** Base64-encoded JPEG thumbnail. Generated server-side for video attachments. */
+  thumbnailData?: string;
 }
 
 export interface ConfirmationResponse {

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -3,7 +3,8 @@ import type { UserMessageAttachment } from './ipc-protocol.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
-import { uploadAttachment, linkAttachmentToMessage, AttachmentUploadError } from '../memory/attachments-store.js';
+import { uploadAttachment, linkAttachmentToMessage, setAttachmentThumbnail, AttachmentUploadError } from '../memory/attachments-store.js';
+import { generateVideoThumbnail } from './video-thumbnail.js';
 import {
   resolveDirectives,
   contentBlocksToDrafts,
@@ -156,13 +157,31 @@ export async function resolveAssistantAttachments(
         throw err;
       }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
-      const omitData = draft.mimeType.startsWith('video/') && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
+      const isVideo = draft.mimeType.startsWith('video/');
+      const omitData = isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
+
+      // Generate and persist a thumbnail for video attachments.
+      let thumbnailData: string | undefined;
+      if (isVideo) {
+        const existing = stored.thumbnailBase64;
+        if (existing) {
+          thumbnailData = existing;
+        } else {
+          const generated = await generateVideoThumbnail(draft.dataBase64);
+          if (generated) {
+            setAttachmentThumbnail(stored.id, generated);
+            thumbnailData = generated;
+          }
+        }
+      }
+
       emittedAttachments.push({
         id: stored.id,
         filename: draft.filename,
         mimeType: draft.mimeType,
         data: omitData ? '' : draft.dataBase64,
         ...(omitData ? { sizeBytes: draft.sizeBytes } : {}),
+        ...(thumbnailData ? { thumbnailData } : {}),
       });
     }
   } else if (assistantAttachments.length > 0) {

--- a/assistant/src/daemon/video-thumbnail.ts
+++ b/assistant/src/daemon/video-thumbnail.ts
@@ -1,0 +1,52 @@
+/**
+ * Extract a JPEG thumbnail from a video file using ffmpeg.
+ *
+ * Writes the video to a temp file, runs ffmpeg to extract the first frame
+ * as a JPEG, and returns the result as a base64 string.
+ */
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, readFileSync, unlinkSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('video-thumbnail');
+
+/**
+ * Generate a JPEG thumbnail from base64-encoded video data.
+ * Returns null if ffmpeg is unavailable or extraction fails.
+ */
+export async function generateVideoThumbnail(dataBase64: string): Promise<string | null> {
+  const id = randomUUID();
+  const inputPath = join(tmpdir(), `vellum-thumb-in-${id}`);
+  const outputPath = join(tmpdir(), `vellum-thumb-out-${id}.jpg`);
+
+  try {
+    const videoBuffer = Buffer.from(dataBase64, 'base64');
+    writeFileSync(inputPath, videoBuffer);
+
+    const proc = Bun.spawnSync([
+      'ffmpeg', '-y',
+      '-i', inputPath,
+      '-vframes', '1',
+      '-vf', 'scale=720:-2',
+      '-q:v', '5',
+      outputPath,
+    ], { timeout: 10_000, stderr: 'pipe' });
+
+    if (proc.exitCode !== 0) {
+      log.warn({ exitCode: proc.exitCode }, 'ffmpeg thumbnail extraction failed');
+      return null;
+    }
+
+    const jpegData = readFileSync(outputPath);
+    return jpegData.toString('base64');
+  } catch (err) {
+    log.warn({ error: (err as Error).message }, 'Video thumbnail generation failed');
+    return null;
+  } finally {
+    try { unlinkSync(inputPath); } catch { /* ignore */ }
+    try { unlinkSync(outputPath); } catch { /* ignore */ }
+  }
+}

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -17,6 +17,7 @@ export interface StoredAttachment {
   mimeType: string;
   sizeBytes: number;
   kind: string;
+  thumbnailBase64: string | null;
   createdAt: number;
 }
 
@@ -183,6 +184,7 @@ export function uploadAttachment(
       mimeType: attachments.mimeType,
       sizeBytes: attachments.sizeBytes,
       kind: attachments.kind,
+      thumbnailBase64: attachments.thumbnailBase64,
       createdAt: attachments.createdAt,
     })
     .from(attachments)
@@ -222,8 +224,20 @@ export function uploadAttachment(
     mimeType,
     sizeBytes,
     kind,
+    thumbnailBase64: null,
     createdAt: now,
   };
+}
+
+/**
+ * Update the thumbnail for an existing attachment.
+ */
+export function setAttachmentThumbnail(attachmentId: string, thumbnailBase64: string): void {
+  const db = getDb();
+  db.update(attachments)
+    .set({ thumbnailBase64 })
+    .where(eq(attachments.id, attachmentId))
+    .run();
 }
 
 export type DeleteAttachmentResult = 'deleted' | 'not_found' | 'still_referenced';
@@ -288,6 +302,7 @@ export function getAttachmentsByIds(
         mimeType: row.mimeType,
         sizeBytes: row.sizeBytes,
         kind: row.kind,
+        thumbnailBase64: row.thumbnailBase64,
         dataBase64: row.dataBase64,
         createdAt: row.createdAt,
       });
@@ -365,6 +380,7 @@ export function getAttachmentMetadataForMessage(
         mimeType: attachments.mimeType,
         sizeBytes: attachments.sizeBytes,
         kind: attachments.kind,
+        thumbnailBase64: attachments.thumbnailBase64,
         createdAt: attachments.createdAt,
       })
       .from(attachments)
@@ -413,6 +429,7 @@ export function getAttachmentsForMessageUnscoped(
         mimeType: row.mimeType,
         sizeBytes: row.sizeBytes,
         kind: row.kind,
+        thumbnailBase64: row.thumbnailBase64,
         dataBase64: row.dataBase64,
         createdAt: row.createdAt,
       });
@@ -453,6 +470,7 @@ export function getAttachmentByIdUnscoped(
     mimeType: row.mimeType,
     sizeBytes: row.sizeBytes,
     kind: row.kind,
+    thumbnailBase64: row.thumbnailBase64,
     dataBase64: row.dataBase64,
     createdAt: row.createdAt,
   };

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -541,6 +541,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN raw_payload TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'standard'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -164,6 +164,7 @@ export const attachments = sqliteTable('attachments', {
   kind: text('kind').notNull(),
   dataBase64: text('data_base64').notNull(),
   contentHash: text('content_hash'),
+  thumbnailBase64: text('thumbnail_base64'),
   createdAt: integer('created_at').notNull(),
 });
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -144,23 +144,16 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func generateThumbnail() async {
-        let base64: String
-        if !attachment.data.isEmpty {
-            base64 = attachment.data
-        } else if attachment.isLazyLoad,
-                  let port = daemonHttpPort,
-                  let attachmentId = attachment.id.isEmpty ? nil : attachment.id {
-            do {
-                base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-            } catch {
-                log.error("Failed to fetch attachment for thumbnail: \(error.localizedDescription, privacy: .public)")
-                return
+        // Prefer the server-provided thumbnail (already decoded by mapIPCAttachments).
+        if let serverImage = attachment.thumbnailImage {
+            await MainActor.run {
+                thumbnailImage = serverImage
             }
-        } else {
             return
         }
 
-        guard let data = Data(base64Encoded: base64) else { return }
+        // Fallback: extract thumbnail from inline video data.
+        guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }
 
         let fileURL = safeTempURL()
         do {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -293,6 +293,14 @@ extension ChatViewModel {
                 #elseif os(iOS)
                 thumbnailImage = thumbnailData.flatMap { UIImage(data: $0) }
                 #endif
+            } else if let serverThumb = ipc.thumbnailData, !serverThumb.isEmpty,
+                      let thumbData = Data(base64Encoded: serverThumb) {
+                thumbnailData = thumbData
+                #if os(macOS)
+                thumbnailImage = NSImage(data: thumbData)
+                #elseif os(iOS)
+                thumbnailImage = UIImage(data: thumbData)
+                #endif
             }
 
             return ChatAttachment(

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1859,6 +1859,8 @@ public struct IPCUserMessageAttachment: Codable, Sendable {
     public let extractedText: String?
     /// Original file size in bytes. Present when data was omitted from history_response to reduce payload size.
     public let sizeBytes: Int?
+    /// Base64-encoded JPEG thumbnail. Generated server-side for video attachments.
+    public let thumbnailData: String?
 }
 
 public struct IPCUserMessageEcho: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Generate JPEG thumbnails for video attachments server-side using ffmpeg when attachments are stored, persisted in a new `thumbnail_base64` column
- Include thumbnails in IPC payloads (`thumbnailData` field on `UserMessageAttachment`) so clients display them instantly without downloading the full video
- Existing videos get thumbnails lazily generated on first history load (fire-and-forget, available on next load)
- Client no longer downloads the full video just to extract a thumbnail frame — uses server-provided thumbnail from `ChatAttachment.thumbnailImage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
