### PR TITLE
feat: add user confirmation before Chrome auto-restart

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -397,16 +397,29 @@ final class ComputerUseSession: ObservableObject {
                ChromeAccessibilityHelper.isChromium(frontApp),
                !ChromeAccessibilityHelper.hasWebContent(elements: result.elements) {
                 didChromeAccessibilityCheck = true
-                log.warning("Chrome detected but AX tree has no web content — restarting with accessibility")
-                let restarted = await ChromeAccessibilityHelper.restartChromeWithAccessibility(app: frontApp)
-                if restarted {
-                    AccessibilityTreeEnumerator.clearEnhancedAXCache()
-                    log.info("Chrome restarted — re-enumerating")
-                    screenshotPromise.cancel()
-                    // Re-enumerate after Chrome restart
-                    return await buildObservation(executionResult: executionResult, executionError: executionError)
+                log.warning("Chrome detected but AX tree has no web content — needs restart with accessibility")
+
+                // Ask the user before restarting Chrome — they may have unsaved work
+                let alert = NSAlert()
+                alert.messageText = "Restart Chrome?"
+                alert.informativeText = "Chrome needs to restart with accessibility enabled for computer-use to work. You may lose unsaved form data. Continue?"
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "Restart Chrome")
+                alert.addButton(withTitle: "Cancel")
+                let response = alert.runModal()
+
+                if response == .alertFirstButtonReturn {
+                    let restarted = await ChromeAccessibilityHelper.restartChromeWithAccessibility(app: frontApp)
+                    if restarted {
+                        AccessibilityTreeEnumerator.clearEnhancedAXCache()
+                        log.info("Chrome restarted — re-enumerating")
+                        screenshotPromise.cancel()
+                        return await buildObservation(executionResult: executionResult, executionError: executionError)
+                    } else {
+                        log.error("Chrome restart failed — continuing with limited AX tree")
+                    }
                 } else {
-                    log.error("Chrome restart failed — continuing with limited AX tree")
+                    log.info("User declined Chrome restart — continuing with limited AX tree")
                 }
             }
             didChromeAccessibilityCheck = true


### PR DESCRIPTION
## Summary
- Adds an NSAlert confirmation dialog before restarting Chrome with `--force-renderer-accessibility`
- User sees: "Chrome needs to restart with accessibility enabled for computer-use to work. You may lose unsaved form data. Continue?"
- If declined, the session continues with a limited AX tree instead of force-restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
