### PR TITLE
Remove deprecated gitignore rules

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -52,15 +52,6 @@ const WORKSPACE_GITIGNORE_RULES = [
   'http-token',
 ];
 
-/**
- * Rules that were used in older versions but have been superseded.
- * These are removed from existing .gitignore files during normalization
- * to prevent them from overriding the newer, more selective rules.
- */
-const DEPRECATED_GITIGNORE_RULES = [
-  'data/',
-];
-
 /** Properties added by Node's child_process errors. */
 interface ExecError extends Error {
   killed?: boolean;
@@ -550,26 +541,16 @@ export class WorkspaceGitService {
   /**
    * Ensure .gitignore contains all required workspace exclusion rules.
    * Idempotent: checks for missing rules and only appends what's needed.
-   * Also removes deprecated rules that have been superseded by newer ones.
    * Must be called with the mutex lock held.
    */
   private ensureGitignoreRulesLocked(): void {
     const gitignorePath = join(this.workspaceDir, '.gitignore');
     if (existsSync(gitignorePath)) {
-      let content = readFileSync(gitignorePath, 'utf-8');
-
-      // Remove deprecated rules (e.g. broad 'data/' replaced by selective 'data/db/' etc.)
-      const deprecatedPresent = DEPRECATED_GITIGNORE_RULES.filter(rule => content.includes(rule));
-      if (deprecatedPresent.length > 0) {
-        const lines = content.split('\n');
-        content = lines.filter(line => !DEPRECATED_GITIGNORE_RULES.includes(line.trim())).join('\n');
-      }
+      const content = readFileSync(gitignorePath, 'utf-8');
 
       const missingRules = WORKSPACE_GITIGNORE_RULES.filter(rule => !content.includes(rule));
-      if (missingRules.length > 0 || deprecatedPresent.length > 0) {
-        const updated = missingRules.length > 0
-          ? content + '\n# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n'
-          : content;
+      if (missingRules.length > 0) {
+        const updated = content + '\n# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n';
         writeFileSync(gitignorePath, updated, 'utf-8');
       }
     } else {


### PR DESCRIPTION
## Summary
- Remove `DEPRECATED_GITIGNORE_RULES` constant and its filtering logic from `ensureGitignoreRulesLocked()`
- This was a one-time migration that removed the broad `data/` rule in favor of selective `data/db/`, `data/qdrant/`, etc. — no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
