### PR TITLE
fix: add error response path for unsupported iOS signing operations

### DIFF
--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -209,7 +209,13 @@ const handlers: DispatchMap = {
     if (pending) {
       clearTimeout(pending.timer);
       pendingSignBundlePayload.delete(msg.requestId);
-      pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else if (msg.signature && msg.keyId && msg.publicKey) {
+        pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
+      } else {
+        pending.reject(new Error('Missing required fields in sign_bundle_payload_response'));
+      }
     } else {
       log.warn({ requestId: msg.requestId }, 'Received sign_bundle_payload_response with no pending request');
     }
@@ -219,7 +225,13 @@ const handlers: DispatchMap = {
     if (pending) {
       clearTimeout(pending.timer);
       pendingSigningIdentity.delete(msg.requestId);
-      pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else if (msg.keyId && msg.publicKey) {
+        pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
+      } else {
+        pending.reject(new Error('Missing required fields in get_signing_identity_response'));
+      }
     } else {
       log.warn({ requestId: msg.requestId }, 'Received get_signing_identity_response with no pending request');
     }

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -428,16 +428,18 @@ export interface OpenBundleRequest {
 export interface SignBundlePayloadResponse {
   type: 'sign_bundle_payload_response';
   requestId: string;
-  signature: string;
-  keyId: string;
-  publicKey: string;
+  signature?: string;
+  keyId?: string;
+  publicKey?: string;
+  error?: string;
 }
 
 export interface GetSigningIdentityResponse {
   type: 'get_signing_identity_response';
   requestId: string;
-  keyId: string;
-  publicKey: string;
+  keyId?: string;
+  publicKey?: string;
+  error?: string;
 }
 
 export interface GalleryListRequest {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1430,10 +1430,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         case .getSigningIdentity(let msg):
             handleGetSigningIdentity(msg)
         #elseif os(iOS)
-        case .signBundlePayload:
-            log.error("Received sign_bundle_payload request on iOS - signing operations are not supported on iOS due to sandboxing restrictions")
-        case .getSigningIdentity:
-            log.error("Received get_signing_identity request on iOS - signing operations are not supported on iOS due to sandboxing restrictions")
+        case .signBundlePayload(let msg):
+            log.warning("Received sign_bundle_payload request on iOS — signing not supported")
+            try? send(SignBundlePayloadResponseMessage(
+                requestId: msg.requestId,
+                error: "Signing operations are not available on iOS"
+            ))
+        case .getSigningIdentity(let msg):
+            log.warning("Received get_signing_identity request on iOS — signing not supported")
+            try? send(GetSigningIdentityResponseMessage(
+                requestId: msg.requestId,
+                error: "Signing operations are not available on iOS"
+            ))
         #else
         case .signBundlePayload, .getSigningIdentity:
             log.error("Signing operations are not supported on this platform")

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -671,8 +671,9 @@ public struct IPCGetSigningIdentityRequest: Codable, Sendable {
 public struct IPCGetSigningIdentityResponse: Codable, Sendable {
     public let type: String
     public let requestId: String
-    public let keyId: String
-    public let publicKey: String
+    public let keyId: String?
+    public let publicKey: String?
+    public let error: String?
 }
 
 public struct IPCHistoryRequest: Codable, Sendable {
@@ -1282,9 +1283,10 @@ public struct IPCSignBundlePayloadRequest: Codable, Sendable {
 public struct IPCSignBundlePayloadResponse: Codable, Sendable {
     public let type: String
     public let requestId: String
-    public let signature: String
-    public let keyId: String
-    public let publicKey: String
+    public let signature: String?
+    public let keyId: String?
+    public let publicKey: String?
+    public let error: String?
 }
 
 public struct IPCSkillDetailRequest: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -642,7 +642,11 @@ public typealias SignBundlePayloadResponseMessage = IPCSignBundlePayloadResponse
 
 extension IPCSignBundlePayloadResponse {
     public init(requestId: String, signature: String, keyId: String, publicKey: String) {
-        self.init(type: "sign_bundle_payload_response", requestId: requestId, signature: signature, keyId: keyId, publicKey: publicKey)
+        self.init(type: "sign_bundle_payload_response", requestId: requestId, signature: signature, keyId: keyId, publicKey: publicKey, error: nil)
+    }
+
+    public init(requestId: String, error: String) {
+        self.init(type: "sign_bundle_payload_response", requestId: requestId, signature: nil, keyId: nil, publicKey: nil, error: error)
     }
 }
 
@@ -652,7 +656,11 @@ public typealias GetSigningIdentityResponseMessage = IPCGetSigningIdentityRespon
 
 extension IPCGetSigningIdentityResponse {
     public init(requestId: String, keyId: String, publicKey: String) {
-        self.init(type: "get_signing_identity_response", requestId: requestId, keyId: keyId, publicKey: publicKey)
+        self.init(type: "get_signing_identity_response", requestId: requestId, keyId: keyId, publicKey: publicKey, error: nil)
+    }
+
+    public init(requestId: String, error: String) {
+        self.init(type: "get_signing_identity_response", requestId: requestId, keyId: nil, publicKey: nil, error: error)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add optional `error` field to `SignBundlePayloadResponse` and `GetSigningIdentityResponse` in the IPC contract (TypeScript + Swift generated types)
- iOS client now sends back error responses explaining that signing is unavailable, instead of silently dropping the request
- Daemon response handlers reject pending promises immediately on error, avoiding a 30-second timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
