### PR TITLE
feat: validate secret allowlist regexes at write time

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -10,7 +10,7 @@ import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getConfig, invalidateConfigCache } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
-import { resetAllowlist } from '../security/secret-allowlist.js';
+import { resetAllowlist, validateAllowlistFile } from '../security/secret-allowlist.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';
 import { clearEmbeddingBackendCache } from '../memory/embedding-backend.js';
@@ -331,6 +331,16 @@ export class DaemonServer {
       },
       'secret-allowlist.json': () => {
         resetAllowlist();
+        try {
+          const errors = validateAllowlistFile();
+          if (errors && errors.length > 0) {
+            for (const e of errors) {
+              log.warn({ index: e.index, pattern: e.pattern }, `Invalid regex in secret-allowlist.json: ${e.message}`);
+            }
+          }
+        } catch (err) {
+          log.warn({ err }, 'Failed to validate secret-allowlist.json');
+        }
       },
     };
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -444,6 +444,32 @@ config
     }
   });
 
+config
+  .command('validate-allowlist')
+  .description('Validate regex patterns in secret-allowlist.json')
+  .action(() => {
+    const { validateAllowlistFile } = require('./security/secret-allowlist.js') as typeof import('./security/secret-allowlist.js');
+    try {
+      const errors = validateAllowlistFile();
+      if (errors === null) {
+        log.info('No secret-allowlist.json file found');
+        return;
+      }
+      if (errors.length === 0) {
+        log.info('All patterns in secret-allowlist.json are valid');
+        return;
+      }
+      log.error(`Found ${errors.length} invalid pattern(s) in secret-allowlist.json:`);
+      for (const e of errors) {
+        log.error(`  [${e.index}] "${e.pattern}": ${e.message}`);
+      }
+      process.exit(1);
+    } catch (err) {
+      log.error(`Failed to read secret-allowlist.json: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
 // --- Keys commands ---
 const keys = program.command('keys').description('Manage API keys in secure storage');
 
@@ -1025,7 +1051,7 @@ program
     const subcommands: Record<string, string[]> = {
       daemon: ['start', 'stop', 'restart', 'status'],
       sessions: ['list', 'new', 'export', 'clear'],
-      config: ['set', 'get', 'list'],
+      config: ['set', 'get', 'list', 'validate-allowlist'],
       keys: ['list', 'set', 'delete'],
       trust: ['list', 'remove', 'clear'],
       memory: ['status', 'backfill', 'query', 'rebuild-index'],

--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -104,6 +104,48 @@ export function isAllowlisted(value: string): boolean {
   return false;
 }
 
+export interface AllowlistValidationError {
+  index: number;
+  pattern: string;
+  message: string;
+}
+
+/**
+ * Validate all regex patterns in an allowlist config without loading them.
+ * Returns an array of validation errors (empty = all valid).
+ */
+export function validateAllowlist(config: AllowlistConfig): AllowlistValidationError[] {
+  const errors: AllowlistValidationError[] = [];
+  if (!config.patterns || !Array.isArray(config.patterns)) return errors;
+
+  for (let i = 0; i < config.patterns.length; i++) {
+    const p = config.patterns[i];
+    if (typeof p !== 'string') {
+      errors.push({ index: i, pattern: String(p), message: 'Pattern is not a string' });
+      continue;
+    }
+    try {
+      new RegExp(p);
+    } catch (err) {
+      errors.push({ index: i, pattern: p, message: (err as Error).message });
+    }
+  }
+  return errors;
+}
+
+/**
+ * Read secret-allowlist.json from disk and validate it.
+ * Returns validation errors, or null if the file doesn't exist.
+ */
+export function validateAllowlistFile(): AllowlistValidationError[] | null {
+  const filePath = join(getRootDir(), 'protected', 'secret-allowlist.json');
+  if (!existsSync(filePath)) return null;
+
+  const raw = readFileSync(filePath, 'utf-8');
+  const config: AllowlistConfig = JSON.parse(raw);
+  return validateAllowlist(config);
+}
+
 /**
  * Reset cached state so the allowlist is reloaded on next check.
  * Called by the daemon file watcher when secret-allowlist.json changes,


### PR DESCRIPTION
## Summary
- Add `validateAllowlist(config)` and `validateAllowlistFile()` functions to `secret-allowlist.ts` that test all regex patterns and return structured validation errors
- Hook validation into the daemon's `secret-allowlist.json` file watcher so invalid patterns are logged immediately when the file changes
- Add `vellum config validate-allowlist` CLI subcommand for explicit validation (exits 1 on errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
