### PR TITLE
feat: differentiate tool executor error types with errorCategory

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -67,6 +67,7 @@ export class ToolExecutor {
         durationMs,
         errorMessage: msg,
         isExpected: true,
+        errorCategory: 'tool_failure',
       });
       return { content: msg, isError: true };
     }
@@ -90,6 +91,7 @@ export class ToolExecutor {
         durationMs,
         errorMessage: msg,
         isExpected: true,
+        errorCategory: 'tool_failure',
       });
       return { content: msg, isError: true };
     }
@@ -325,6 +327,7 @@ export class ToolExecutor {
           durationMs,
           errorMessage: msg,
           isExpected: true,
+          errorCategory: 'tool_failure',
         });
         return { content: msg, isError: true };
       }
@@ -358,6 +361,7 @@ export class ToolExecutor {
             durationMs,
             errorMessage: msg,
             isExpected: true,
+            errorCategory: 'tool_failure',
           });
           return { content: msg, isError: true };
         }
@@ -565,6 +569,14 @@ export class ToolExecutor {
       const msg = err instanceof Error ? err.message : String(err);
       const isExpected = err instanceof PermissionDeniedError || err instanceof ToolError || err instanceof TokenExpiredError;
 
+      const errorCategory = err instanceof PermissionDeniedError
+        ? 'permission_denied' as const
+        : err instanceof TokenExpiredError
+          ? 'auth' as const
+          : err instanceof ToolError
+            ? 'tool_failure' as const
+            : 'unexpected' as const;
+
       emitLifecycleEvent(context, {
         type: 'error',
         toolName: name,
@@ -579,6 +591,7 @@ export class ToolExecutor {
         durationMs,
         errorMessage: msg,
         isExpected,
+        errorCategory,
         errorName: err instanceof Error ? err.name : undefined,
         errorStack: err instanceof Error ? err.stack : undefined,
       });

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -52,6 +52,8 @@ export interface ToolExecutedEvent extends ToolLifecycleEventBase {
   result: ToolExecutionResult;
 }
 
+export type ErrorCategory = 'permission_denied' | 'auth' | 'tool_failure' | 'unexpected';
+
 export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
   type: 'error';
   riskLevel: string;
@@ -59,6 +61,8 @@ export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
   durationMs: number;
   errorMessage: string;
   isExpected: boolean;
+  /** Classifies the error for downstream consumers (audit, alerting, monitoring). */
+  errorCategory: ErrorCategory;
   errorName?: string;
   errorStack?: string;
 }


### PR DESCRIPTION
## Summary
- Added `ErrorCategory` type (`permission_denied` | `auth` | `tool_failure` | `unexpected`) to `ToolExecutionErrorEvent`
- Catch block now classifies errors: `PermissionDeniedError` → `permission_denied`, `TokenExpiredError` → `auth`, `ToolError` → `tool_failure`, unknown → `unexpected`
- All other pre-catch error emissions (unknown tool, inactive tool, hook-blocked, missing proxy resolver) tagged as `tool_failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
