### PR TITLE
feat(ios): add TestFlight distribution config and fix shared target build error

### DIFF
--- a/clients/ios/App/VellumIntents.swift
+++ b/clients/ios/App/VellumIntents.swift
@@ -1,18 +1,7 @@
 #if canImport(UIKit)
 import AppIntents
 import UIKit
-
-// MARK: - Deep Link Manager
-
-/// Buffers a deep-link / Siri Shortcut message so it survives cold launch
-/// (where no `ChatViewModel` may exist yet) and is consumed only by the
-/// active thread's view model.
-enum DeepLinkManager {
-    /// The pending message text. Set by `SendMessageIntent` or the URL handler;
-    /// consumed (and cleared) by the active `ChatViewModel` via
-    /// `consumeDeepLinkIfNeeded()`.
-    @MainActor static var pendingMessage: String?
-}
+import VellumAssistantShared
 
 // MARK: - App Intent
 

--- a/clients/ios/Resources/vellum-assistant-ios.entitlements
+++ b/clients/ios/Resources/vellum-assistant-ios.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/clients/ios/Resources/vellum-assistant-ios.entitlements
+++ b/clients/ios/Resources/vellum-assistant-ios.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>aps-environment</key>
-    <string>development</string>
+    <string>production</string>
 </dict>
 </plist>

--- a/clients/ios/exportOptions.plist
+++ b/clients/ios/exportOptions.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>

--- a/clients/shared/Features/Chat/DeepLinkManager.swift
+++ b/clients/shared/Features/Chat/DeepLinkManager.swift
@@ -1,0 +1,9 @@
+/// Buffers a deep-link / Siri Shortcut message so it survives cold launch
+/// (where no `ChatViewModel` may exist yet) and is consumed only by the
+/// active thread's view model.
+public enum DeepLinkManager {
+    /// The pending message text. Set by `SendMessageIntent` or the URL handler;
+    /// consumed (and cleared) by the active `ChatViewModel` via
+    /// `consumeDeepLinkIfNeeded()`.
+    @MainActor public static var pendingMessage: String?
+}


### PR DESCRIPTION
## Summary

Adds iOS TestFlight distribution configuration and fixes a cross-target build error blocking iOS archive.

- **exportOptions.plist** — Configures `xcodebuild -exportArchive` for App Store / TestFlight upload with automatic signing
- **Entitlements file** — Declares `aps-environment = production` for push notifications (required since the app uses APNS via AppDelegate)
- **DeepLinkManager moved to shared target** — Fixes compile error where `ChatViewModel` (in the shared `VellumAssistantShared` target) referenced `DeepLinkManager` which was defined in the iOS-only `VellumIntents.swift`

## Key Technical Choices

**Why move DeepLinkManager instead of wrapping with `#if`?**
Both the shared and iOS targets compile for iOS, so `#if os(iOS)` and `#if canImport(UIKit)` are true in both — they can't distinguish "shared target" from "iOS target." Moving the 4-line enum to the shared target is the simplest correct fix.

**Why \`aps-environment = production\`?**
TestFlight and App Store builds require the production APNS environment. Development is only for local debug builds via Xcode.

**Why \`method: app-store\` in exportOptions.plist?**
The \`app-store\` method covers both App Store submission and TestFlight distribution. \`destination: upload\` with automatic signing lets \`xcodebuild -exportArchive\` produce an IPA suitable for App Store Connect upload.

## Files Changed

| File | Change |
|------|--------|
| `clients/ios/exportOptions.plist` | **New** — export options for `xcodebuild -exportArchive` |
| `clients/ios/Resources/vellum-assistant-ios.entitlements` | **New** — APNS push entitlement (production) |
| `clients/shared/Features/Chat/DeepLinkManager.swift` | **New** — moved from iOS target, made `public` |
| `clients/ios/App/VellumIntents.swift` | **Modified** — removed local DeepLinkManager, imports from shared |

## Testing

1. Build the iOS target in Xcode — should compile without errors
2. Archive with `xcodebuild archive` — should succeed with the entitlements
3. Export with `xcodebuild -exportArchive -exportOptionsPlist clients/ios/exportOptions.plist` — should produce a valid IPA
4. Siri Shortcuts ("Ask Vellum") should still work — `SendMessageIntent` now imports `DeepLinkManager` from `VellumAssistantShared`

## Deferred Work

- **Code signing settings in Package.swift** — Intentionally not touched; handled in Xcode project settings
- **iOS build script** (`build.sh`) — Will be added in a follow-up PR to automate archive + export for CI/TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)