### PR TITLE
feat: show New Chat button in top bar when sidebar is collapsed

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -362,6 +362,12 @@ struct MainWindowView: View {
                                 sidebarOpen.toggle()
                             }
                         }
+                        if !sidebarOpen {
+                            VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true) {
+                                windowState.selection = nil
+                                threadManager.createThread()
+                            }
+                        }
                         Spacer()
                         if windowState.isShowingChat {
                             // Copy Thread button


### PR DESCRIPTION
## Summary
- Adds a "New Chat" icon button (`plus.circle`) next to the sidebar toggle in the top bar, visible only when the sidebar is collapsed
- Creates a new thread and clears the current selection, matching the existing "New Chat" behavior in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
