### PR TITLE
refactor: standardize remaining string truncation on truncate() utility

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -181,7 +181,7 @@ export async function startCli(): Promise<void> {
     if (req.toolName === 'browser_press_key') {
       return `press "${req.input.key ?? ''}"`;
     }
-    return `${req.toolName}: ${JSON.stringify(req.input).slice(0, 80)}`;
+    return `${req.toolName}: ${truncate(JSON.stringify(req.input), 80)}`;
   }
 
   function renderConfirmationPrompt(req: ConfirmationRequest): void {
@@ -501,7 +501,7 @@ export async function startCli(): Promise<void> {
           }
           process.stdout.write('\n');
         } else {
-          process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
+          process.stdout.write(`\n[Tool: ${truncate(msg.result, 200)}]\n`);
         }
         toolStreaming = false;
         if (msg.diff) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -6,6 +6,7 @@ import { computeMemoryFingerprint } from '../../../../memory/fingerprint.js';
 import { memoryItems } from '../../../../memory/schema.js';
 import { enqueueMemoryJob } from '../../../../memory/jobs-store.js';
 import { extractStylePatterns } from '../../../../messaging/style-analyzer.js';
+import { truncate } from '../../../../util/truncate.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
 
 function clamp(value: number, min: number, max: number): number {
@@ -100,7 +101,7 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
         upsertMemoryItem({
           kind: 'relationship',
           subject,
-          statement: `${contact.name} (${contact.email}): ${contact.toneNote}`.slice(0, 500),
+          statement: truncate(`${contact.name} (${contact.email}): ${contact.toneNote}`, 500, ''),
           importance: 0.6,
           scopeId,
         });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -35,6 +35,7 @@ import {
   type HistorySurface,
   type ParsedHistoryMessage,
 } from './shared.js';
+import { truncate } from '../../util/truncate.js';
 
 export async function handleUserMessage(
   msg: UserMessage,
@@ -327,7 +328,7 @@ export function handleHistoryRequest(
       contentOrder = rendered.contentOrder;
       surfaces = rendered.surfaces;
       if (m.role === 'assistant' && toolCalls.length > 0) {
-        log.info({ messageId: m.id, toolCallCount: toolCalls.length, text: text.substring(0, 100) }, 'History message with tool calls');
+        log.info({ messageId: m.id, toolCallCount: toolCalls.length, text: truncate(text, 100, '') }, 'History message with tool calls');
       }
     } catch (err) {
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
@@ -433,10 +434,10 @@ export async function handleRegenerate(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');
-    session.traceEmitter.emit('request_error', message.slice(0, 200), {
+    session.traceEmitter.emit('request_error', truncate(message, 200, ''), {
       requestId,
       status: 'error',
-      attributes: { errorClass: err instanceof Error ? err.constructor.name : 'Error', message: message.slice(0, 500) },
+      attributes: { errorClass: err instanceof Error ? err.constructor.name : 'Error', message: truncate(message, 500, '') },
     });
     ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
     const classified = classifySessionError(err, { phase: 'regenerate' });

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -24,6 +24,7 @@ import { getTask, getTaskRun } from '../../tasks/task-store.js';
 import { runTask } from '../../tasks/task-runner.js';
 import { getMessages } from '../../memory/conversation-store.js';
 import { classifyRisk, check } from '../../permissions/checker.js';
+import { truncate } from '../../util/truncate.js';
 
 export function handleWorkItemsList(
   msg: WorkItemsListRequest,
@@ -205,7 +206,7 @@ export function handleWorkItemOutput(
 
       if (!text.trim()) continue;
 
-      summary = text.length > 2000 ? text.slice(0, 2000) : text;
+      summary = truncate(text, 2000, '');
 
       // Extract up to 5 notable lines (bullet points or key findings)
       const lines = text.split('\n');

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,6 +47,7 @@ import {
   getSummaryFromContextMessage,
 } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
+import { truncate } from '../util/truncate.js';
 import {
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
@@ -747,7 +748,7 @@ export class Session {
     try {
       const preMessageResult = await getHookManager().trigger('pre-message', {
         sessionId: this.conversationId,
-        messagePreview: content.slice(0, 200),
+        messagePreview: truncate(content, 200, ''),
       });
 
       if (preMessageResult.blocked) {
@@ -1464,10 +1465,10 @@ export class Session {
         const message = err instanceof Error ? err.message : String(err);
         const errorClass = err instanceof Error ? err.constructor.name : 'Error';
         rlog.error({ err }, 'Session processing error');
-        this.traceEmitter.emit('request_error', message.slice(0, 200), {
+        this.traceEmitter.emit('request_error', truncate(message, 200, ''), {
           requestId: reqId,
           status: 'error',
-          attributes: { errorClass, message: message.slice(0, 500) },
+          attributes: { errorClass, message: truncate(message, 500, '') },
         });
         onEvent({ type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, errorCtx);
@@ -1598,7 +1599,7 @@ export class Session {
   }
 
   private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {
-    const prompt = `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`;
+    const prompt = `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${truncate(userMessage, 200, '')}\nAssistant: ${truncate(assistantResponse, 200, '')}`;
     const response = await this.provider.sendMessage(
       [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
       [], // no tools

--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -24,6 +24,7 @@ import {
   UPDATE_CART_ITEM_QUERY,
 } from './queries.js';
 import { loadCapturedQueries } from './query-extractor.js';
+import { truncate } from '../util/truncate.js';
 
 const GRAPHQL_BASE = 'https://www.doordash.com/graphql';
 const CDP_BASE = 'http://localhost:9222';
@@ -240,7 +241,7 @@ export async function searchItems(query: string, opts?: { debug?: boolean }): Pr
   );
   if (opts?.debug) {
     process.stderr.write(
-      `[debug] homePageFacetFeed raw: ${JSON.stringify(data.homePageFacetFeed).substring(0, 3000)}\n`,
+      `[debug] homePageFacetFeed raw: ${truncate(JSON.stringify(data.homePageFacetFeed), 3000, '')}\n`,
     );
   }
   return extractSearchResults(data.homePageFacetFeed);
@@ -360,7 +361,7 @@ export async function getStoreMenu(
     process.stderr.write(
       `[debug] storepageFeed keys: ${Object.keys(feed).join(', ')}\n` +
       `[debug] itemLists count: ${rawItemLists.length}, carousels count: ${rawCarousels.length}\n` +
-      `[debug] menuBook: ${JSON.stringify(menuBook).substring(0, 2000)}\n`,
+      `[debug] menuBook: ${truncate(JSON.stringify(menuBook), 2000, '')}\n`,
     );
   }
 
@@ -404,8 +405,8 @@ export async function getRetailStoreMenu(
     process.stderr.write(
       `[debug] retailStorePageFeed keys: ${Object.keys(feed).join(', ')}\n` +
       `[debug] l1Categories count: ${l1Cats.length}, collections count: ${collections.length}\n` +
-      `[debug] page: ${JSON.stringify(page).substring(0, 500)}\n` +
-      `[debug] collections sample: ${JSON.stringify(collections.slice(0, 2)).substring(0, 2000)}\n`,
+      `[debug] page: ${truncate(JSON.stringify(page), 500, '')}\n` +
+      `[debug] collections sample: ${truncate(JSON.stringify(collections.slice(0, 2)), 2000, '')}\n`,
     );
   }
   return extractRetailStoreInfo(data.retailStorePageFeed);

--- a/assistant/src/export/formatter.ts
+++ b/assistant/src/export/formatter.ts
@@ -2,6 +2,8 @@
  * Conversation export formatters for markdown and JSON.
  */
 
+import { truncate } from '../util/truncate.js';
+
 interface ContentBlock {
   type: string;
   text?: string;
@@ -44,7 +46,7 @@ function extractText(blocks: ContentBlock[]): string {
         if (block.is_error) {
           parts.push(`[Error: ${block.content ?? ''}]`);
         } else {
-          parts.push(`[Result: ${(block.content ?? '').slice(0, 500)}]`);
+          parts.push(`[Result: ${truncate(block.content ?? '', 500)}]`);
         }
         break;
     }

--- a/assistant/src/memory/clarification-resolver.ts
+++ b/assistant/src/memory/clarification-resolver.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from '../config/loader.js';
+import { truncate } from '../util/truncate.js';
 
 const DEFAULT_RESOLVER_MODEL = 'claude-haiku-4-5-20251001';
 const DEFAULT_RESOLVER_TIMEOUT_MS = 12_000;
@@ -85,7 +86,7 @@ export async function resolveConflictClarification(
       resolution: 'still_unclear',
       strategy: 'llm_error',
       resolvedStatement: null,
-      explanation: `Clarification resolver failed: ${message.slice(0, 300)}`,
+      explanation: `Clarification resolver failed: ${truncate(message, 300, '')}`,
     };
   }
 }
@@ -243,7 +244,7 @@ async function resolveWithLlm(
       resolution: parsed.resolution,
       strategy: 'llm',
       resolvedStatement,
-      explanation: normalize(parsed.explanation ?? 'Resolved via LLM fallback.').slice(0, 500),
+      explanation: truncate(normalize(parsed.explanation ?? 'Resolved via LLM fallback.'), 500, ''),
     };
   } catch (err) {
     clearTimeout(timer);
@@ -291,7 +292,7 @@ function buildMergedStatement(input: ClarificationResolverInput): string {
   if (normalizedUserMessage.length >= 8 && normalizedUserMessage.length <= 320) {
     return normalizedUserMessage;
   }
-  const existing = normalize(input.existingStatement).slice(0, 140);
-  const candidate = normalize(input.candidateStatement).slice(0, 140);
-  return `Merged clarification: ${existing}; ${candidate}`.slice(0, 320);
+  const existing = truncate(normalize(input.existingStatement), 140, '');
+  const candidate = truncate(normalize(input.candidateStatement), 140, '');
+  return truncate(`Merged clarification: ${existing}; ${candidate}`, 320, '');
 }

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -2,6 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { truncate } from '../util/truncate.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
 import { getDb } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
@@ -234,7 +235,7 @@ async function classifyRelationship(
 
   return {
     relationship,
-    explanation: String(input.explanation ?? '').slice(0, 500),
+    explanation: truncate(String(input.explanation ?? ''), 500, ''),
   };
 }
 
@@ -324,6 +325,6 @@ function escapeSqlLike(s: string): string {
 
 function buildClarificationQuestion(existingStatement: string, candidateStatement: string): string {
   const normalize = (input: string): string =>
-    input.replace(/\s+/g, ' ').trim().slice(0, 180);
+    truncate(input.replace(/\s+/g, ' ').trim(), 180, '');
   return `I have conflicting notes: "${normalize(existingStatement)}" vs "${normalize(candidateStatement)}". Which one is correct?`;
 }

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
+import { truncate } from '../util/truncate.js';
 import { getDb } from './db.js';
 import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 
@@ -462,12 +463,12 @@ function dedupeAliasList(rawAliases: string[], canonicalName: string): string[] 
 
 function normalizeEntityName(value: string | null | undefined): string | null {
   if (!value) return null;
-  const normalized = String(value).trim().slice(0, 200);
+  const normalized = truncate(String(value).trim(), 200, '');
   return normalized.length > 0 ? normalized : null;
 }
 
 function normalizeEvidence(value: string | null | undefined): string | null {
   if (!value) return null;
-  const normalized = String(value).trim().slice(0, 500);
+  const normalized = truncate(String(value).trim(), 500, '');
   return normalized.length > 0 ? normalized : null;
 }

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import type { MemoryExtractionConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
+import { truncate } from '../util/truncate.js';
 import { computeMemoryFingerprint } from './fingerprint.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
@@ -199,8 +200,8 @@ async function extractItemsWithLLM(
     for (const raw of input.items) {
       if (!VALID_KINDS.has(raw.kind)) continue;
       if (!raw.subject || !raw.statement) continue;
-      const subject = String(raw.subject).slice(0, 80);
-      const statement = String(raw.statement).slice(0, 500);
+      const subject = truncate(String(raw.subject), 80, '');
+      const statement = truncate(String(raw.statement), 500, '');
       const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
       const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
       const fingerprint = computeMemoryFingerprint(scopeId, raw.kind, subject, statement);
@@ -333,7 +334,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
     db.insert(memoryItemSources).values({
       memoryItemId,
       messageId,
-      evidence: item.statement.slice(0, 500),
+      evidence: truncate(item.statement, 500, ''),
       createdAt: now,
     }).onConflictDoNothing().run();
 
@@ -410,7 +411,7 @@ function inferSubject(sentence: string, kind: MemoryItemKind): string {
     if (match) return match[1];
   }
   const words = trimmed.split(/\s+/).slice(0, 6).join(' ');
-  return words.slice(0, 80);
+  return truncate(words, 80, '');
 }
 
 function includesAny(text: string, needles: string[]): boolean {

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, lte, notInArray, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { memoryJobs } from './schema.js';
+import { truncate } from '../util/truncate.js';
 
 export type MemoryJobType =
   | 'embed_segment'
@@ -331,7 +332,7 @@ export function failMemoryJob(
         status: 'failed',
         attempts,
         updatedAt: now,
-        lastError: error.slice(0, 2000),
+        lastError: truncate(error, 2000, ''),
       })
       .where(eq(memoryJobs.id, id))
       .run();
@@ -343,7 +344,7 @@ export function failMemoryJob(
       attempts,
       runAfter: now + retryDelayMs,
       updatedAt: now,
-      lastError: error.slice(0, 2000),
+      lastError: truncate(error, 2000, ''),
     })
     .where(eq(memoryJobs.id, id))
     .run();

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -8,6 +8,7 @@
 
 import type { Message as ProviderMessage } from './provider-types.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
+import { truncate } from '../util/truncate.js';
 import { getProvider } from '../providers/registry.js';
 import { getConfig } from '../config/loader.js';
 
@@ -97,7 +98,7 @@ function buildCorpus(messages: ProviderMessage[]): string[] {
   for (const msg of messages) {
     if (!msg.text.trim()) continue;
     const to = msg.conversationId;
-    const truncatedBody = msg.text.slice(0, 500);
+    const truncatedBody = truncate(msg.text, 500, '');
     entries.push(`To: ${to}\n\n${truncatedBody}`);
   }
   return entries;
@@ -143,7 +144,7 @@ export async function extractStylePatterns(
 
   const stylePatterns: StylePattern[] = (result.style_patterns ?? []).map((p) => ({
     aspect: p.aspect,
-    summary: p.summary.slice(0, 500),
+    summary: truncate(p.summary, 500, ''),
     importance: p.importance,
     examples: p.examples,
   }));

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -247,7 +247,7 @@ async function summarizeWithLLM(
       : 'neutral';
 
     return {
-      summary: String(input.summary ?? '').slice(0, 2000),
+      summary: truncate(String(input.summary ?? ''), 2000, ''),
       participants: Array.isArray(input.participants)
         ? input.participants.map((p) => ({
             name: String(p.name),
@@ -257,7 +257,7 @@ async function summarizeWithLLM(
       openQuestions: Array.isArray(input.openQuestions)
         ? input.openQuestions.map((q) => String(q))
         : [],
-      lastAction: String(input.lastAction ?? '').slice(0, 500),
+      lastAction: truncate(String(input.lastAction ?? ''), 500, ''),
       sentiment,
       messageCount: messages.length,
     };

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -8,6 +8,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { truncate } from '../util/truncate.js';
 import { v4 as uuid } from 'uuid';
 import { and, eq, isNull, desc } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
@@ -283,7 +284,7 @@ async function classifyWithLLM(
     category: typeof input.category === 'string' ? input.category : 'needs_response',
     confidence,
     suggestedAction: typeof input.suggestedAction === 'string'
-      ? input.suggestedAction.slice(0, 500)
+      ? truncate(input.suggestedAction, 500, '')
       : 'Review manually',
     matchedPlaybooks,
   };

--- a/assistant/src/swarm/worker-prompts.ts
+++ b/assistant/src/swarm/worker-prompts.ts
@@ -1,4 +1,5 @@
 import type { SwarmRole, SwarmTaskResult } from './types.js';
+import { truncate } from '../util/truncate.js';
 
 /**
  * Build a role-specific worker prompt for a swarm task.
@@ -70,7 +71,7 @@ export function parseWorkerOutput(raw: string): Pick<SwarmTaskResult, 'summary' 
   }
 
   return {
-    summary: raw.slice(0, 500),
+    summary: truncate(raw, 500, ''),
     artifacts: [],
     issues: [],
     nextSteps: [],

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1,6 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import type { ImageContent } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 import {
   parseUrl,
   isPrivateOrLocalHost,
@@ -826,7 +827,7 @@ export async function executeBrowserWaitFor(
         `document.body?.innerText?.includes(${escaped})`,
         { timeout },
       );
-      return { content: `Text "${text.slice(0, 80)}" appeared on page.`, isError: false };
+      return { content: `Text "${truncate(text, 80)}" appeared on page.`, isError: false };
     }
 
     // duration mode (milliseconds)

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -6,6 +6,7 @@
  */
 
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 import type { NetworkRecordedEntry, NetworkRecordedRequest, ExtractedCredential } from './network-recording-types.js';
 
 const log = getLogger('network-recorder');
@@ -273,7 +274,7 @@ export class NetworkRecorder {
     const method = (request.method as string) ?? 'GET';
     const postData = request.postData as string | undefined;
 
-    log.debug({ url: url.slice(0, 120), method, requestId }, 'Request captured');
+    log.debug({ url: truncate(url, 120, ''), method, requestId }, 'Request captured');
 
     const recordedRequest: NetworkRecordedRequest = { method, url, headers, postData };
     const entry: NetworkRecordedEntry = {
@@ -307,7 +308,7 @@ export class NetworkRecorder {
       this.loginSignals.some(sig => entry.request.url.includes(sig))
     ) {
       this.loginDetectedFired = true;
-      log.info({ url: entry.request.url.slice(0, 120) }, 'Login detected — will auto-stop in 5s');
+      log.info({ url: truncate(entry.request.url, 120, '') }, 'Login detected — will auto-stop in 5s');
       // Delay to let remaining network requests (cookies, session data) settle
       setTimeout(() => this.onLoginDetected?.(), 5000);
     }

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 import { getProfilePolicy } from '../../swarm/worker-backend.js';
 import type { WorkerProfile } from '../../swarm/worker-backend.js';
 
@@ -108,7 +109,7 @@ export const claudeCodeTool: Tool = {
 
     const { query } = sdkModule;
 
-    log.info({ prompt: prompt.slice(0, 100), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
+    log.info({ prompt: truncate(prompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
     // Build the canUseTool callback, enforcing profile-based restrictions
     const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName, toolInput, _options) => {

--- a/assistant/src/tools/host-terminal/cli-discover.ts
+++ b/assistant/src/tools/host-terminal/cli-discover.ts
@@ -3,6 +3,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 
 const log = getLogger('cli-discover');
 
@@ -141,7 +142,7 @@ class CliDiscoverTool implements Tool {
         result.authenticated = authOutput !== null && authOutput.length > 0;
         if (authOutput) {
           // Keep auth info brief — first line, max 200 chars
-          result.authInfo = authOutput.split('\n')[0].slice(0, 200);
+          result.authInfo = truncate(authOutput.split('\n')[0], 200, '');
         }
       }
 

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 import { getDb } from '../../memory/db.js';
 import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
@@ -84,14 +85,14 @@ export async function handleMemorySave(
   }
 
   const subject = typeof args.subject === 'string' && args.subject.trim().length > 0
-    ? args.subject.trim().slice(0, 80)
+    ? truncate(args.subject.trim(), 80, '')
     : inferSubjectFromStatement(statement.trim());
 
   try {
     const db = getDb();
     const id = uuid();
     const now = Date.now();
-    const trimmedStatement = statement.trim().slice(0, 500);
+    const trimmedStatement = truncate(statement.trim(), 500, '');
 
     const fingerprint = computeMemoryFingerprint(scopeId, kind, subject, trimmedStatement);
 
@@ -185,7 +186,7 @@ export async function handleMemoryUpdate(
     }
 
     const now = Date.now();
-    const trimmedStatement = statement.trim().slice(0, 500);
+    const trimmedStatement = truncate(statement.trim(), 500, '');
 
     const fingerprint = computeMemoryFingerprint(scopeId, existing.kind, existing.subject, trimmedStatement);
 
@@ -232,7 +233,7 @@ export async function handleMemoryUpdate(
 function inferSubjectFromStatement(statement: string): string {
   // Take first few words as a subject label
   const words = statement.split(/\s+/).slice(0, 6).join(' ');
-  return words.slice(0, 80);
+  return truncate(words, 80, '');
 }
 
 /**

--- a/assistant/src/tools/playbooks/playbook-create.ts
+++ b/assistant/src/tools/playbooks/playbook-create.ts
@@ -8,6 +8,7 @@ import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import type { Playbook, PlaybookAutonomyLevel } from '../../playbooks/types.js';
+import { truncate } from '../../util/truncate.js';
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
 
@@ -32,7 +33,7 @@ async function execute(input: Record<string, unknown>, context: ToolContext): Pr
 
   const playbook: Playbook = { trigger, channel, category, action, autonomyLevel, priority };
   const statement = JSON.stringify(playbook);
-  const subject = `Playbook: ${trigger}`.slice(0, 80);
+  const subject = truncate(`Playbook: ${trigger}`, 80, '');
   const scopeId = context.memoryScopeId ?? 'default';
 
   const fingerprint = computeMemoryFingerprint(scopeId, 'playbook', subject, statement);

--- a/assistant/src/tools/playbooks/playbook-update.ts
+++ b/assistant/src/tools/playbooks/playbook-update.ts
@@ -8,6 +8,7 @@ import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
 import type { Playbook, PlaybookAutonomyLevel } from '../../playbooks/types.js';
+import { truncate } from '../../util/truncate.js';
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
 
@@ -55,7 +56,7 @@ async function execute(input: Record<string, unknown>, context: ToolContext): Pr
     };
 
     const statement = JSON.stringify(updated);
-    const subject = `Playbook: ${updated.trigger}`.slice(0, 80);
+    const subject = truncate(`Playbook: ${updated.trigger}`, 80, '');
     const now = Date.now();
 
     const fingerprint = computeMemoryFingerprint(scopeId, 'playbook', subject, statement);

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { truncate } from '../../util/truncate.js';
 import { getFailoverProvider } from '../../providers/registry.js';
 import { resolveSwarmLimits } from '../../swarm/limits.js';
 import { generatePlan } from '../../swarm/router-planner.js';
@@ -94,7 +95,7 @@ export const swarmDelegateTool: Tool = {
 
       context.onOutput?.(`Plan: ${plan.tasks.length} tasks\n`);
       for (const task of plan.tasks) {
-        context.onOutput?.(`  - [${task.role}] ${task.id}: ${task.objective.slice(0, 80)}\n`);
+        context.onOutput?.(`  - [${task.role}] ${task.id}: ${truncate(task.objective, 80)}\n`);
       }
       context.onOutput?.('\nExecuting...\n');
 

--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -8,6 +8,7 @@
  */
 
 import { withValidToken } from '../../security/token-manager.js';
+import { truncate } from '../../util/truncate.js';
 import * as slack from '../../messaging/providers/slack/client.js';
 import type { WatcherProvider, WatcherItem, FetchResult } from '../provider-types.js';
 import { getLogger } from '../../util/logger.js';
@@ -22,7 +23,7 @@ function messageToItem(
   return {
     externalId: `${msg.channel}:${msg.ts}`,
     eventType,
-    summary: `Slack ${eventType.replace('slack_', '')}: ${msg.text.slice(0, 100)}`,
+    summary: `Slack ${eventType.replace('slack_', '')}: ${truncate(msg.text, 100)}`,
     payload: {
       channel: msg.channel,
       channelName,

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
 import { watchers, watcherEvents } from '../memory/schema.js';
 import { DEFAULT_POLL_INTERVAL_MS } from './constants.js';
+import { truncate } from '../util/truncate.js';
 
 // ── Interfaces ──────────────────────────────────────────────────────
 
@@ -227,7 +228,7 @@ export function failWatcherPoll(id: string, error: string): void {
     .set({
       status: 'idle',
       consecutiveErrors: errors,
-      lastError: error.slice(0, 2000),
+      lastError: truncate(error, 2000, ''),
       lastPollAt: now,
       nextPollAt: now + backoff,
       updatedAt: now,
@@ -245,7 +246,7 @@ export function disableWatcher(id: string, reason: string): void {
     .set({
       status: 'disabled',
       enabled: false,
-      lastError: reason.slice(0, 2000),
+      lastError: truncate(reason, 2000, ''),
       updatedAt: Date.now(),
     })
     .where(eq(watchers.id, id))


### PR DESCRIPTION
## Summary
- Replaced ~50 inline `.slice(0, N)` and `.substring(0, N)` string truncation patterns with the centralized `truncate()` utility across 26 files
- Display-facing truncations (CLI output, summaries, previews) now append `...` when truncated, improving UX
- Internal truncations (DB fields, logs, LLM inputs) use `truncate(str, N, '')` for codebase consistency
- Skipped patterns that aren't string truncation: optional chaining, browser-context code, date formatting, array slicing, hash extraction, spinner "in progress" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
