### PR TITLE
fix: hide New Chat button on empty chats and add spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -362,7 +362,10 @@ struct MainWindowView: View {
                                 sidebarOpen.toggle()
                             }
                         }
-                        if !sidebarOpen {
+                        if !sidebarOpen,
+                           let vm = threadManager.activeViewModel,
+                           vm.messages.contains(where: { $0.role == .user }) {
+                            Spacer().frame(width: VSpacing.xs)
                             VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true) {
                                 windowState.selection = nil
                                 threadManager.createThread()


### PR DESCRIPTION
## Summary
- Hide the "New Chat" button when the active chat has no user messages (already a new chat)
- Add `VSpacing.xs` padding between the sidebar toggle and the new chat button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
