### PR TITLE
Fix config/orchestrator review feedback from PR #5326

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -342,13 +342,15 @@ export class CallOrchestrator {
     const maxDurationMs = getMaxCallDurationMs();
     const warningMs = maxDurationMs - 2 * 60 * 1000; // 2 minutes before max
 
-    this.durationWarningTimer = setTimeout(() => {
-      log.info({ callSessionId: this.callSessionId }, 'Call duration warning');
-      this.relay.sendTextToken(
-        'Just to let you know, we\'re running low on time for this call.',
-        true,
-      );
-    }, warningMs);
+    if (warningMs > 0) {
+      this.durationWarningTimer = setTimeout(() => {
+        log.info({ callSessionId: this.callSessionId }, 'Call duration warning');
+        this.relay.sendTextToken(
+          'Just to let you know, we\'re running low on time for this call.',
+          true,
+        );
+      }, warningMs);
+    }
 
     this.durationTimer = setTimeout(() => {
       log.info({ callSessionId: this.callSessionId }, 'Call duration limit reached');

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -810,11 +810,13 @@ export const CallsConfigSchema = z.object({
     .number({ error: 'calls.maxDurationSeconds must be a number' })
     .int('calls.maxDurationSeconds must be an integer')
     .positive('calls.maxDurationSeconds must be a positive integer')
+    .max(2_147_483, 'calls.maxDurationSeconds must be at most 2147483 (setTimeout-safe limit)')
     .default(3600),
   userConsultTimeoutSeconds: z
     .number({ error: 'calls.userConsultTimeoutSeconds must be a number' })
     .int('calls.userConsultTimeoutSeconds must be an integer')
     .positive('calls.userConsultTimeoutSeconds must be a positive integer')
+    .max(2_147_483, 'calls.userConsultTimeoutSeconds must be at most 2147483 (setTimeout-safe limit)')
     .default(120),
   disclosure: CallsDisclosureConfigSchema.default({
     enabled: true,


### PR DESCRIPTION
Addresses review feedback from #5326.

## Changes
- Cap maxDurationSeconds and userConsultTimeoutSeconds to setTimeout-safe bounds in config schema
- Guard duration warning timer to only fire when warningMs > 0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
