### PR TITLE
Fix call-recovery review feedback from PR #5325

### DIFF
--- a/assistant/src/__tests__/call-recovery.test.ts
+++ b/assistant/src/__tests__/call-recovery.test.ts
@@ -33,7 +33,7 @@ import {
   createPendingQuestion,
   getPendingQuestion,
 } from '../calls/call-store.js';
-import { reconcileCallsOnStartup, logDeadLetterEvent } from '../calls/call-recovery.js';
+import { reconcileCallsOnStartup, logDeadLetterEvent, NO_SID_GRACE_PERIOD_MS } from '../calls/call-recovery.js';
 import type { VoiceProvider } from '../calls/voice-provider.js';
 
 initializeDb();
@@ -70,6 +70,13 @@ function resetTables() {
 function createTestCallSession(opts: Parameters<typeof createCallSession>[0]) {
   ensureConversation(opts.conversationId);
   return createCallSession(opts);
+}
+
+/** Backdate a session's createdAt so it appears older than the grace period. */
+function backdateSession(sessionId: string, ageMs: number): void {
+  const db = getDb();
+  const past = Date.now() - ageMs;
+  db.run(`UPDATE call_sessions SET created_at = ${past} WHERE id = '${sessionId}'`);
 }
 
 /** Create a mock VoiceProvider that returns configurable statuses. */
@@ -196,14 +203,15 @@ describe('reconcileCallsOnStartup', () => {
     // Should complete without error
   });
 
-  test('fails calls with no provider SID', async () => {
+  test('fails stale calls with no provider SID (past grace period)', async () => {
     const session = createTestCallSession({
       conversationId: 'conv-nosid',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
     });
-    // No providerCallSid set — it's null by default
+    // Backdate session so it exceeds the grace period
+    backdateSession(session.id, NO_SID_GRACE_PERIOD_MS + 10_000);
 
     const provider = createMockProvider();
     await reconcileCallsOnStartup(provider, silentLog);
@@ -213,6 +221,26 @@ describe('reconcileCallsOnStartup', () => {
     expect(updated!.status).toBe('failed');
     expect(updated!.endedAt).not.toBeNull();
     expect(updated!.lastError).toContain('Daemon restarted before call connected to provider');
+  });
+
+  test('skips recent no-SID sessions within grace period', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-nosid-recent',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // Session was just created (createdAt ~ Date.now()), well within grace period
+
+    const provider = createMockProvider();
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    // Should NOT be failed — still in its original non-terminal state
+    expect(updated!.status).toBe('initiated');
+    expect(updated!.endedAt).toBeNull();
+    expect(updated!.lastError).toContain('awaiting webhook');
   });
 
   test('transitions to completed when provider says call completed', async () => {
@@ -396,13 +424,14 @@ describe('reconcileCallsOnStartup', () => {
   });
 
   test('handles mixed recoverable calls correctly', async () => {
-    // Call 1: no SID — should fail
+    // Call 1: no SID, stale — should fail
     const noSid = createTestCallSession({
       conversationId: 'conv-mix1',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
     });
+    backdateSession(noSid.id, NO_SID_GRACE_PERIOD_MS + 10_000);
 
     // Call 2: provider says completed — should complete
     const completed = createTestCallSession({

--- a/assistant/src/calls/call-recovery.ts
+++ b/assistant/src/calls/call-recovery.ts
@@ -17,6 +17,16 @@ type Logger = ReturnType<typeof getLogger>;
 const defaultLog = getLogger('call-recovery');
 
 /**
+ * Grace period (in ms) for no-SID sessions during startup recovery.
+ *
+ * A daemon crash can leave a live Twilio call without a persisted SID
+ * (crash after `initiateCall` succeeds but before the SID is written).
+ * Webhooks carrying the SID may still arrive after restart, so we skip
+ * very recent sessions and only fail them once the grace period expires.
+ */
+export const NO_SID_GRACE_PERIOD_MS = 60_000;
+
+/**
  * Map a Twilio provider status string to our internal CallStatus.
  * Returns the mapped status or null if the status is unrecognised.
  */
@@ -52,8 +62,10 @@ function isTerminal(status: CallStatus): boolean {
  * For each recoverable call:
  * - If it has a provider SID, fetch the current status from the provider
  *   and transition the call to match.
- * - If no provider SID exists (call never connected), fail it with an
- *   explanatory error message.
+ * - If no provider SID exists and the session is recent (< 60 s), skip it
+ *   so that webhooks carrying the SID can still arrive after a daemon crash.
+ * - If no provider SID exists and the session is older than the grace period,
+ *   fail it with an explanatory error message.
  * - If the call transitions to a terminal state, expire any pending questions.
  */
 export async function reconcileCallsOnStartup(
@@ -72,10 +84,25 @@ export async function reconcileCallsOnStartup(
   for (const session of recoverableCalls) {
     try {
       if (!session.providerCallSid) {
-        // Call never connected to provider — fail it cleanly
+        const sessionAgeMs = Date.now() - session.createdAt;
+
+        if (sessionAgeMs < NO_SID_GRACE_PERIOD_MS) {
+          // Session is recent — the SID may arrive via webhook shortly.
+          // Skip it so webhooks can still deliver the SID and resume the call.
+          log.info(
+            { callSessionId: session.id, previousStatus: session.status, sessionAgeMs },
+            'Skipping recent no-SID session (within grace period, webhooks may still arrive)',
+          );
+          updateCallSession(session.id, {
+            lastError: 'Daemon restarted before provider SID persisted; awaiting webhook',
+          });
+          continue;
+        }
+
+        // Session is older than the grace period — fail it cleanly
         log.info(
-          { callSessionId: session.id, previousStatus: session.status },
-          'Failing call with no provider SID (never connected)',
+          { callSessionId: session.id, previousStatus: session.status, sessionAgeMs },
+          'Failing stale call with no provider SID (grace period expired)',
         );
         updateCallSession(session.id, {
           status: 'failed',


### PR DESCRIPTION
Addresses review feedback from #5325.

## Changes
- Add grace period for no-SID sessions during startup recovery
- Recent sessions (< 60s old) are skipped to allow webhooks to arrive with SID
- Only fail stale no-SID sessions that are clearly abandoned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
