### PR TITLE
Fix M1 review feedback: CDP error handling + window restore

### DIFF
--- a/assistant/src/cli/doordash.ts
+++ b/assistant/src/cli/doordash.ts
@@ -148,6 +148,9 @@ export function registerDoordashCommand(program: Command): void {
       const duration = parseInt(opts.duration, 10);
 
       try {
+        // Restore minimized Chrome window so user can see the login page
+        try { await restoreChromeWindow(); } catch { /* best-effort */ }
+
         const result = await startLearnSession(duration);
         if (result.recordingPath) {
           const session = importFromRecording(result.recordingPath);
@@ -893,6 +896,54 @@ async function minimizeChromeWindow(): Promise<void> {
           method: 'Browser.setWindowBounds',
           params: { windowId: msg.result.windowId, bounds: { windowState: 'minimized' } },
         }));
+      } else if (msg.id === 1) {
+        clearTimeout(timeout);
+        ws.close();
+        reject(new Error('Browser.getWindowForTarget failed'));
+      } else if (msg.id === 2) {
+        clearTimeout(timeout);
+        ws.close();
+        resolve();
+      }
+    });
+
+    ws.addEventListener('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function restoreChromeWindow(): Promise<void> {
+  const res = await fetch(`${CDP_BASE}/json/list`);
+  const targets = (await res.json()) as Array<{ type: string; webSocketDebuggerUrl: string }>;
+  const pageTarget = targets.find(t => t.type === 'page');
+  if (!pageTarget) return;
+
+  const ws = new WebSocket(pageTarget.webSocketDebuggerUrl);
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('CDP restore timed out'));
+    }, 5000);
+
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({ id: 1, method: 'Browser.getWindowForTarget' }));
+    });
+
+    ws.addEventListener('message', (event) => {
+      const msg = JSON.parse(String(event.data)) as { id: number; result?: { windowId: number } };
+      if (msg.id === 1 && msg.result) {
+        ws.send(JSON.stringify({
+          id: 2,
+          method: 'Browser.setWindowBounds',
+          params: { windowId: msg.result.windowId, bounds: { windowState: 'normal' } },
+        }));
+      } else if (msg.id === 1) {
+        clearTimeout(timeout);
+        ws.close();
+        reject(new Error('Browser.getWindowForTarget failed'));
       } else if (msg.id === 2) {
         clearTimeout(timeout);
         ws.close();


### PR DESCRIPTION
Addresses review feedback on #5358.

- Handle CDP error responses in minimizeChromeWindow() to avoid 5-second timeout hang
- Add restoreChromeWindow() to unminimize Chrome at the start of refresh so the login page is visible on subsequent refreshes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
