### PR TITLE
Fix M2 review feedback: update lastRequestTime before request

### DIFF
--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -211,8 +211,8 @@ async function graphql<T = unknown>(
     }
 
     try {
-      const json = (await cdpFetch(wsUrl, url, body)) as GraphQLResponse<T>;
       lastRequestTime = Date.now();
+      const json = (await cdpFetch(wsUrl, url, body)) as GraphQLResponse<T>;
 
       if (json.errors?.length) {
         const msgs = json.errors.map(e => e.message || JSON.stringify(e)).join('; ');


### PR DESCRIPTION
Addresses review feedback on #5359.

- Move lastRequestTime update to before cdpFetch() call so the inter-request delay is enforced even after failed requests/retries exhaust
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
