### PR TITLE
fix: set allowHighRisk on ephemeral task permission rules

### DIFF
--- a/assistant/src/tasks/ephemeral-permissions.ts
+++ b/assistant/src/tasks/ephemeral-permissions.ts
@@ -23,8 +23,9 @@ export function clearTaskRunRules(taskRunId: string): void {
  *
  * Each rule allows the specified tool with a wildcard pattern scoped to the
  * given working directory. Priority is set to 50 — lower than user rules (100)
- * so that user deny rules still take precedence. `allowHighRisk` is NOT set,
- * so high-risk operations continue to prompt for approval.
+ * so that user deny rules still take precedence. `allowHighRisk` is set because
+ * task sessions have no client to respond to confirmation prompts — without it,
+ * high-risk tools hang indefinitely waiting for approval that never comes.
  */
 export function buildTaskRules(taskRunId: string, requiredTools: string[], workingDir: string): TrustRule[] {
   return requiredTools.map((tool) => ({
@@ -33,6 +34,7 @@ export function buildTaskRules(taskRunId: string, requiredTools: string[], worki
     pattern: '**',
     scope: workingDir,
     decision: 'allow' as const,
+    allowHighRisk: true,
     priority: 50,
     createdAt: Date.now(),
     principalKind: 'task',


### PR DESCRIPTION
## Summary
- Added `allowHighRisk: true` to ephemeral permission rules in `buildTaskRules()`
- These rules are already scoped to only user-approved tools — this flag ensures high-risk tools (bash, etc.) actually bypass the confirmation prompt
- Without this flag, task sessions hang indefinitely because the confirmation prompt has no client to respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
