### PR TITLE
fix: match video thumbnail size to player size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -146,7 +146,12 @@ struct InlineVideoAttachmentView: View {
     private func generateThumbnail() async {
         // Prefer the server-provided thumbnail (already decoded by mapIPCAttachments).
         if let serverImage = attachment.thumbnailImage {
+            let w = serverImage.size.width
+            let h = serverImage.size.height
             await MainActor.run {
+                if w > 0, h > 0 {
+                    videoAspectRatio = w / h
+                }
                 thumbnailImage = serverImage
             }
             return


### PR DESCRIPTION
## Summary
- When using server-provided thumbnails, derive `videoAspectRatio` from the thumbnail image dimensions instead of keeping the default 3:4
- This ensures the thumbnail preview and the video player render at the same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
