### PR TITLE
feat: bundle task permissions at creation time

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -63,6 +63,21 @@ export function handleWorkItemCreate(
     priorityTier: msg.priorityTier,
     sortIndex: msg.sortIndex,
   });
+
+  // Bundle the task's required tools as pre-approved permissions so the
+  // run-time preflight check can be skipped — the user implicitly approves
+  // these tools by adding the task to their queue.
+  const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+  if (requiredTools.length > 0) {
+    updateWorkItem(item.id, {
+      approvedTools: JSON.stringify(requiredTools),
+      approvalStatus: 'approved',
+    });
+    // Reflect the update in the response
+    item.approvedTools = JSON.stringify(requiredTools);
+    item.approvalStatus = 'approved';
+  }
+
   ctx.send(socket, { type: 'work_item_create_response', item });
 
   // Notify all connected clients so open Task Queue views refresh immediately
@@ -356,6 +371,17 @@ export async function handleWorkItemPreflight(
   if (!workItem) {
     ctx.send(socket, { type: 'work_item_preflight_response', id: msg.id, success: false, error: 'Work item not found' });
     return;
+  }
+
+  // If permissions were already bundled at creation time, skip the
+  // preflight entirely — return empty permissions so the client runs
+  // the task immediately without showing the permission dialog.
+  if (workItem.approvedTools) {
+    const alreadyApproved: string[] = JSON.parse(workItem.approvedTools);
+    if (alreadyApproved.length > 0) {
+      ctx.send(socket, { type: 'work_item_preflight_response', id: msg.id, success: true, permissions: [] });
+      return;
+    }
   }
 
   const task = getTask(workItem.taskId);

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -36,6 +36,11 @@ class TasksWindowViewModel: ObservableObject {
     /// Loading/loaded/error state for the preflight sheet.
     @Published var preflightState: PreflightState = .loading
 
+    /// Tracks the item awaiting a preflight response from the daemon.
+    /// Unlike `preflightItem`, this does NOT trigger the sheet — it only
+    /// becomes `preflightItem` if the response contains non-empty permissions.
+    private var pendingPreflightItem: IPCWorkItemsListResponseItem?
+
     /// Handles for pending timeout tasks keyed by work item ID, so we can
     /// cancel the timer when the daemon responds before the deadline.
     private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
@@ -116,17 +121,23 @@ class TasksWindowViewModel: ObservableObject {
 
         daemonClient.onWorkItemPreflightResponse = { [weak self] response in
             guard let self else { return }
-            guard self.preflightItem?.id == response.id else { return }
+            // Match against the pending item (not yet shown as a sheet)
+            guard self.pendingPreflightItem?.id == response.id else { return }
             if response.success, let permissions = response.permissions {
                 if permissions.isEmpty {
-                    // No permissions needed — skip the sheet and run directly
-                    self.dismissPreflight()
+                    // No permissions needed (either pre-bundled or task has no
+                    // required tools) — run directly without showing a sheet.
+                    self.pendingPreflightItem = nil
                     self.runTask(id: response.id)
                 } else {
+                    // Permissions need approval — now show the preflight sheet
+                    self.preflightItem = self.pendingPreflightItem
+                    self.pendingPreflightItem = nil
                     self.preflightState = .loaded(permissions)
                 }
             } else {
-                self.preflightState = .error(response.error ?? "Failed to check permissions.")
+                self.pendingPreflightItem = nil
+                self.errorMessage = response.error ?? "Failed to check permissions."
             }
         }
 
@@ -164,8 +175,11 @@ class TasksWindowViewModel: ObservableObject {
         }
     }
 
-    /// Initiates the run flow for a work item. If the task has required tools,
-    /// opens the permission preflight sheet first. Otherwise runs directly.
+    /// Initiates the run flow for a work item. Sends a preflight check to the
+    /// daemon but does NOT show the permission sheet yet — the sheet only
+    /// appears if the daemon reports non-empty permissions. When permissions
+    /// are pre-bundled at creation time, the daemon returns an empty list and
+    /// the task runs immediately with no UI interruption.
     func initiateRun(item: IPCWorkItemsListResponseItem) {
         logger.info("initiateRun: id=\(item.id, privacy: .public)")
 
@@ -175,14 +189,16 @@ class TasksWindowViewModel: ObservableObject {
             return
         }
 
-        // Start the preflight check to see if permissions are needed
-        preflightItem = item
+        // Track which item we're preflighting without showing the sheet yet.
+        // The sheet will only appear if the response contains permissions.
+        pendingPreflightItem = item
         preflightState = .loading
         do {
             try daemonClient.sendWorkItemPreflight(id: item.id)
         } catch {
             logger.error("initiateRun: preflight transport error for id=\(item.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            preflightState = .error(error.localizedDescription)
+            pendingPreflightItem = nil
+            errorMessage = error.localizedDescription
         }
     }
 


### PR DESCRIPTION
## Summary
- Auto-set `approvedTools` on work items at creation time from the task's `requiredTools`
- Skip the preflight permission dialog when clicking Run if permissions are already bundled
- Keep preflight as fallback for tasks without pre-defined required tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
