### PR TITLE
fix: show New Chat button for private threads even when empty

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -364,7 +364,8 @@ struct MainWindowView: View {
                         }
                         if !sidebarOpen,
                            let vm = threadManager.activeViewModel,
-                           vm.messages.contains(where: { $0.role == .user }) {
+                           threadManager.activeThread?.kind == .private
+                            || vm.messages.contains(where: { $0.role == .user }) {
                             Spacer().frame(width: VSpacing.xs)
                             VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true) {
                                 windowState.selection = nil


### PR DESCRIPTION
Addresses review feedback on #5366. The New Chat button was hidden for all empty chats, but it should remain visible for private/temporary threads so users can start a fresh normal chat without reopening the sidebar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
