### PR TITLE
Add speaker identification primitive for voice calls (#5376)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3209,7 +3209,8 @@ sequenceDiagram
 
     loop Conversation turns
         TwilioAPI->>WS: prompt (caller utterance)
-        WS->>Orch: handleCallerUtterance()
+        WS->>WS: extract speaker metadata + map speaker identity
+        WS->>Orch: handleCallerUtterance(transcript, speakerContext)
         Orch->>LLM: messages.stream()
         LLM-->>Orch: text tokens (streaming)
         Orch->>WS: sendTextToken() (for TTS)
@@ -3251,6 +3252,7 @@ sequenceDiagram
 | `assistant/src/calls/twilio-provider.ts` | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency |
 | `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML), status callback, connect action |
 | `assistant/src/calls/relay-server.ts` | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call |
+| `assistant/src/calls/speaker-identification.ts` | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
 | `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_USER and END_CALL control markers |
 | `assistant/src/calls/call-state.ts` | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and orchestrator registry |
 | `assistant/src/calls/call-constants.ts` | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers |
@@ -3310,7 +3312,7 @@ All three tables live in `~/.vellum/workspace/data/db/assistant.db` alongside ex
 
 - **`call_sessions`** — One row per outgoing call. Tracks conversation association, provider info (Twilio CallSid), phone numbers, task description, status lifecycle (`initiated` -> `ringing` -> `in_progress` -> `waiting_on_user` -> `completed`/`failed`), and timestamps. Foreign key to `conversations(id)` with cascade delete.
 
-- **`call_events`** — Append-only event log for each call session. Event types include `call_started`, `call_connected`, `caller_spoke`, `assistant_spoke`, `user_question_asked`, `user_answered`, `call_ended`, `call_failed`. Each event carries a JSON payload. Foreign key to `call_sessions(id)` with cascade delete. Includes a unique index on `(call_session_id, dedupe_key)` for callback idempotency.
+- **`call_events`** — Append-only event log for each call session. Event types include `call_started`, `call_connected`, `caller_spoke`, `assistant_spoke`, `user_question_asked`, `user_answered`, `call_ended`, `call_failed`. For voice prompts, `caller_spoke` payloads include speaker context (`speakerId`, `speakerLabel`, `speakerConfidence`, `speakerSource`) when available. Foreign key to `call_sessions(id)` with cascade delete. Includes a unique index on `(call_session_id, dedupe_key)` for callback idempotency.
 
 - **`call_pending_questions`** — Tracks questions the AI asks the user during a call (via the `[ASK_USER: ...]` pattern). Status lifecycle: `pending` -> `answered`/`expired`/`cancelled`. Foreign key to `call_sessions(id)` with cascade delete.
 

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -35,8 +35,10 @@ mock.module('../config/loader.js', () => ({
     calls: {
       enabled: true,
       provider: 'twilio',
-      maxDurationSeconds: 3600,
-      userConsultTimeoutSeconds: 120,
+      maxDurationSeconds: 12 * 60,
+      userConsultTimeoutSeconds: 90,
+      userConsultationTimeoutSeconds: 90,
+      silenceTimeoutSeconds: 30,
       disclosure: { enabled: false, text: '' },
       safety: { denyCategories: [] },
     },
@@ -96,6 +98,7 @@ import {
   createCallSession,
   getCallSession,
   getPendingQuestion,
+  updateCallSession,
 } from '../calls/call-store.js';
 import {
   getCallOrchestrator,
@@ -180,6 +183,7 @@ function setupOrchestrator(task?: string) {
     toNumber: '+15552222222',
     task,
   });
+  updateCallSession(session.id, { status: 'in_progress' });
   const relay = createMockRelay();
   const orchestrator = new CallOrchestrator(session.id, relay as unknown as RelayConnection, task ?? null);
   return { session, relay, orchestrator };
@@ -219,6 +223,27 @@ describe('call-orchestrator', () => {
     // Find the final empty-string token that marks end of turn
     const endMarkers = relay.sentTokens.filter((t) => t.last === true);
     expect(endMarkers.length).toBeGreaterThanOrEqual(1);
+
+    orchestrator.destroy();
+  });
+
+  test('handleCallerUtterance: includes speaker context in model message', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const userMessage = firstArg.messages.find((m) => m.role === 'user');
+      expect(userMessage?.content).toContain('[SPEAKER id="speaker-1" label="Aaron" source="provider" confidence="0.91"]');
+      expect(userMessage?.content).toContain('Can you summarize this meeting?');
+      return createMockStream(['Sure, here is a summary.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('Can you summarize this meeting?', {
+      speakerId: 'speaker-1',
+      speakerLabel: 'Aaron',
+      speakerConfidence: 0.91,
+      source: 'provider',
+    });
 
     orchestrator.destroy();
   });

--- a/assistant/src/__tests__/speaker-identification.test.ts
+++ b/assistant/src/__tests__/speaker-identification.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { extractPromptSpeakerMetadata, SpeakerIdentityTracker } from '../calls/speaker-identification.js';
+
+describe('speaker-identification', () => {
+  test('extractPromptSpeakerMetadata: reads top-level and nested fields', () => {
+    const metadata = extractPromptSpeakerMetadata({
+      speaker_id: 'spk-7',
+      speaker_label: 'Conference room mic',
+      speaker_confidence: '0.88',
+      metadata: {
+        participantId: 'participant-22',
+      },
+    });
+
+    expect(metadata.speakerId).toBe('spk-7');
+    expect(metadata.speakerLabel).toBe('Conference room mic');
+    expect(metadata.speakerConfidence).toBe(0.88);
+    expect(metadata.participantId).toBe('participant-22');
+  });
+
+  test('SpeakerIdentityTracker: keeps stable identity for provider speaker id', () => {
+    const tracker = new SpeakerIdentityTracker();
+
+    const first = tracker.identifySpeaker({
+      speakerId: 'speaker-a',
+      speakerName: 'Aaron',
+      speakerConfidence: 0.93,
+    });
+    const second = tracker.identifySpeaker({
+      speakerId: 'speaker-a',
+      speakerName: 'Aaron',
+      speakerConfidence: 0.81,
+    });
+
+    expect(first.speakerId).toBe('speaker-a');
+    expect(first.speakerLabel).toBe('Aaron');
+    expect(first.source).toBe('provider');
+    expect(second.speakerId).toBe('speaker-a');
+    expect(second.speakerLabel).toBe('Aaron');
+    expect(second.speakerConfidence).toBe(0.81);
+    expect(tracker.listProfiles()).toHaveLength(1);
+  });
+
+  test('SpeakerIdentityTracker: falls back to inferred primary speaker without provider ids', () => {
+    const tracker = new SpeakerIdentityTracker();
+    const speaker = tracker.identifySpeaker({});
+
+    expect(speaker.speakerId).toBe('primary-speaker');
+    expect(speaker.speakerLabel).toBe('Speaker 1');
+    expect(speaker.source).toBe('inferred');
+  });
+});

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -19,6 +19,7 @@ import {
 import { getMaxCallDurationMs, getUserConsultationTimeoutMs, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import type { RelayConnection } from './relay-server.js';
 import { registerCallOrchestrator, unregisterCallOrchestrator, fireCallQuestionNotifier, fireCallCompletionNotifier } from './call-state.js';
+import type { PromptSpeakerContext } from './speaker-identification.js';
 
 const log = getLogger('call-orchestrator');
 
@@ -60,7 +61,7 @@ export class CallOrchestrator {
   /**
    * Handle a final caller utterance from the ConversationRelay.
    */
-  async handleCallerUtterance(transcript: string): Promise<void> {
+  async handleCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): Promise<void> {
     // If we're already processing or speaking, abort the in-flight generation
     if (this.state === 'processing' || this.state === 'speaking') {
       this.abortController.abort();
@@ -71,7 +72,10 @@ export class CallOrchestrator {
     this.resetSilenceTimer();
 
     // Append caller utterance
-    this.conversationHistory.push({ role: 'user', content: transcript });
+    this.conversationHistory.push({
+      role: 'user',
+      content: this.formatCallerUtterance(transcript, speaker),
+    });
 
     await this.runLlm();
   }
@@ -154,9 +158,18 @@ export class CallOrchestrator {
       '5. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
       '6. Do not make up information — ask the user if unsure.',
       '7. Keep responses short — 1-3 sentences is ideal for phone conversation.',
+      '8. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
     ]
       .filter(Boolean)
       .join('\n');
+  }
+
+  private formatCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): string {
+    if (!speaker) return transcript;
+    const safeId = speaker.speakerId.replaceAll('"', '\'');
+    const safeLabel = speaker.speakerLabel.replaceAll('"', '\'');
+    const confidencePart = speaker.speakerConfidence !== null ? ` confidence="${speaker.speakerConfidence.toFixed(2)}"` : '';
+    return `[SPEAKER id="${safeId}" label="${safeLabel}" source="${speaker.source}"${confidencePart}] ${transcript}`;
   }
 
   /**

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -14,6 +14,11 @@ import {
   recordCallEvent,
 } from './call-store.js';
 import { CallOrchestrator } from './call-orchestrator.js';
+import {
+  extractPromptSpeakerMetadata,
+  SpeakerIdentityTracker,
+  type PromptSpeakerContext,
+} from './speaker-identification.js';
 
 const log = getLogger('relay-server');
 
@@ -33,6 +38,23 @@ export interface RelayPromptMessage {
   voicePrompt: string;
   lang: string;
   last: boolean;
+  speakerId?: string;
+  speakerLabel?: string;
+  speakerName?: string;
+  speakerConfidence?: number;
+  participantId?: string;
+  participant?: {
+    id?: string;
+    name?: string;
+  };
+  speaker?: {
+    id?: string;
+    label?: string;
+    name?: string;
+    confidence?: number;
+  };
+  metadata?: Record<string, unknown>;
+  providerMetadata?: Record<string, unknown>;
 }
 
 export interface RelayInterruptMessage {
@@ -88,15 +110,22 @@ export const activeRelayConnections = new Map<string, RelayConnection>();
 export class RelayConnection {
   private ws: ServerWebSocket<RelayWebSocketData>;
   private callSessionId: string;
-  private conversationHistory: Array<{ role: 'caller' | 'assistant'; text: string; timestamp: number }>;
+  private conversationHistory: Array<{
+    role: 'caller' | 'assistant';
+    text: string;
+    timestamp: number;
+    speaker?: PromptSpeakerContext;
+  }>;
   private abortController: AbortController;
   private orchestrator: CallOrchestrator | null = null;
+  private speakerIdentityTracker: SpeakerIdentityTracker;
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
     this.callSessionId = callSessionId;
     this.conversationHistory = [];
     this.abortController = new AbortController();
+    this.speakerIdentityTracker = new SpeakerIdentityTracker();
   }
 
   /**
@@ -162,8 +191,8 @@ export class RelayConnection {
   /**
    * Get the conversation history for context.
    */
-  getConversationHistory(): Array<{ role: string; text: string }> {
-    return this.conversationHistory.map(({ role, text }) => ({ role, text }));
+  getConversationHistory(): Array<{ role: string; text: string; speaker?: PromptSpeakerContext }> {
+    return this.conversationHistory.map(({ role, text, speaker }) => ({ role, text, speaker }));
   }
 
   /**
@@ -236,22 +265,30 @@ export class RelayConnection {
       'Caller transcript received (final)',
     );
 
+    const speakerMetadata = extractPromptSpeakerMetadata(msg as unknown as Record<string, unknown>);
+    const speaker = this.speakerIdentityTracker.identifySpeaker(speakerMetadata);
+
     // Record in conversation history
     this.conversationHistory.push({
       role: 'caller',
       text: msg.voicePrompt,
       timestamp: Date.now(),
+      speaker,
     });
 
     // Record event
     recordCallEvent(this.callSessionId, 'caller_spoke', {
       transcript: msg.voicePrompt,
       lang: msg.lang,
+      speakerId: speaker.speakerId,
+      speakerLabel: speaker.speakerLabel,
+      speakerConfidence: speaker.speakerConfidence,
+      speakerSource: speaker.source,
     });
 
     // Route to orchestrator for LLM-driven response
     if (this.orchestrator) {
-      await this.orchestrator.handleCallerUtterance(msg.voicePrompt);
+      await this.orchestrator.handleCallerUtterance(msg.voicePrompt, speaker);
     } else {
       // Fallback if orchestrator not yet initialized
       this.sendTextToken('I\'m still setting up. Please hold.', true);

--- a/assistant/src/calls/speaker-identification.ts
+++ b/assistant/src/calls/speaker-identification.ts
@@ -1,0 +1,213 @@
+export interface PromptSpeakerContext {
+  speakerId: string;
+  speakerLabel: string;
+  speakerConfidence: number | null;
+  source: 'provider' | 'inferred';
+}
+
+export interface PromptSpeakerMetadata {
+  speakerId?: string;
+  speakerLabel?: string;
+  speakerName?: string;
+  speakerConfidence?: number;
+  participantId?: string;
+}
+
+interface SpeakerProfile {
+  speakerId: string;
+  speakerLabel: string;
+  speakerConfidence: number | null;
+  source: 'provider' | 'inferred';
+  utteranceCount: number;
+  firstSeenAt: number;
+  lastSeenAt: number;
+}
+
+function toCleanString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function getObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizeSpeakerLabel(metadata: PromptSpeakerMetadata, fallbackIndex: number): string {
+  const preferredLabel = toCleanString(metadata.speakerName) ?? toCleanString(metadata.speakerLabel);
+  if (preferredLabel) return preferredLabel;
+  return `Speaker ${fallbackIndex}`;
+}
+
+export function extractPromptSpeakerMetadata(message: Record<string, unknown>): PromptSpeakerMetadata {
+  const providerMetadata = getObject(message.providerMetadata);
+  const metadata = getObject(message.metadata);
+  const participant = getObject(message.participant);
+  const speaker = getObject(message.speaker);
+
+  const pick = (...values: unknown[]): string | undefined => {
+    for (const value of values) {
+      const cleaned = toCleanString(value);
+      if (cleaned) return cleaned;
+    }
+    return undefined;
+  };
+
+  const pickNumber = (...values: unknown[]): number | undefined => {
+    for (const value of values) {
+      const parsed = toNumber(value);
+      if (parsed !== null) return parsed;
+    }
+    return undefined;
+  };
+
+  return {
+    speakerId: pick(
+      message.speakerId,
+      message.speaker_id,
+      speaker?.id,
+      speaker?.speakerId,
+      metadata?.speakerId,
+      providerMetadata?.speakerId,
+      metadata?.speaker_id,
+      providerMetadata?.speaker_id,
+    ),
+    speakerLabel: pick(
+      message.speakerLabel,
+      message.speaker_label,
+      message.speaker,
+      speaker?.label,
+      speaker?.name,
+      metadata?.speakerLabel,
+      providerMetadata?.speakerLabel,
+      metadata?.speaker_label,
+      providerMetadata?.speaker_label,
+    ),
+    speakerName: pick(
+      message.speakerName,
+      message.speaker_name,
+      participant?.name,
+      metadata?.speakerName,
+      providerMetadata?.speakerName,
+      metadata?.speaker_name,
+      providerMetadata?.speaker_name,
+    ),
+    speakerConfidence: pickNumber(
+      message.speakerConfidence,
+      message.speaker_confidence,
+      message.confidence,
+      speaker?.confidence,
+      metadata?.speakerConfidence,
+      providerMetadata?.speakerConfidence,
+      metadata?.speaker_confidence,
+      providerMetadata?.speaker_confidence,
+    ),
+    participantId: pick(
+      message.participantId,
+      message.participant_id,
+      participant?.id,
+      metadata?.participantId,
+      providerMetadata?.participantId,
+      metadata?.participant_id,
+      providerMetadata?.participant_id,
+    ),
+  };
+}
+
+export class SpeakerIdentityTracker {
+  private profiles = new Map<string, SpeakerProfile>();
+  private nextInferredIndex = 1;
+
+  identifySpeaker(metadata: PromptSpeakerMetadata): PromptSpeakerContext {
+    const providerSpeakerId =
+      toCleanString(metadata.speakerId)
+      ?? toCleanString(metadata.participantId)
+      ?? null;
+
+    if (providerSpeakerId) {
+      const existing = this.profiles.get(providerSpeakerId);
+      if (existing) {
+        existing.lastSeenAt = Date.now();
+        existing.utteranceCount += 1;
+        if (metadata.speakerConfidence !== undefined) {
+          existing.speakerConfidence = metadata.speakerConfidence;
+        }
+        return {
+          speakerId: existing.speakerId,
+          speakerLabel: existing.speakerLabel,
+          speakerConfidence: existing.speakerConfidence,
+          source: existing.source,
+        };
+      }
+
+      const profile: SpeakerProfile = {
+        speakerId: providerSpeakerId,
+        speakerLabel: normalizeSpeakerLabel(metadata, this.nextInferredIndex),
+        speakerConfidence: metadata.speakerConfidence ?? null,
+        source: 'provider',
+        utteranceCount: 1,
+        firstSeenAt: Date.now(),
+        lastSeenAt: Date.now(),
+      };
+      this.profiles.set(providerSpeakerId, profile);
+      this.nextInferredIndex += 1;
+      return {
+        speakerId: profile.speakerId,
+        speakerLabel: profile.speakerLabel,
+        speakerConfidence: profile.speakerConfidence,
+        source: profile.source,
+      };
+    }
+
+    const inferredSpeakerId = 'primary-speaker';
+    const existingPrimary = this.profiles.get(inferredSpeakerId);
+    if (existingPrimary) {
+      existingPrimary.lastSeenAt = Date.now();
+      existingPrimary.utteranceCount += 1;
+      return {
+        speakerId: existingPrimary.speakerId,
+        speakerLabel: existingPrimary.speakerLabel,
+        speakerConfidence: existingPrimary.speakerConfidence,
+        source: existingPrimary.source,
+      };
+    }
+
+    const inferredProfile: SpeakerProfile = {
+      speakerId: inferredSpeakerId,
+      speakerLabel: normalizeSpeakerLabel(metadata, this.nextInferredIndex),
+      speakerConfidence: metadata.speakerConfidence ?? null,
+      source: 'inferred',
+      utteranceCount: 1,
+      firstSeenAt: Date.now(),
+      lastSeenAt: Date.now(),
+    };
+    this.profiles.set(inferredSpeakerId, inferredProfile);
+    this.nextInferredIndex += 1;
+
+    return {
+      speakerId: inferredProfile.speakerId,
+      speakerLabel: inferredProfile.speakerLabel,
+      speakerConfidence: inferredProfile.speakerConfidence,
+      source: inferredProfile.source,
+    };
+  }
+
+  listProfiles(): PromptSpeakerContext[] {
+    return [...this.profiles.values()].map((profile) => ({
+      speakerId: profile.speakerId,
+      speakerLabel: profile.speakerLabel,
+      speakerConfidence: profile.speakerConfidence,
+      source: profile.source,
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable speaker-identification primitive for extracting and normalizing provider speaker metadata
- thread speaker context through relay prompt handling into call orchestration so model input can personalize by speaker
- record speaker metadata on caller events, add tests, and update architecture docs for the new data flow

## Testing
- bun test assistant/src/__tests__/speaker-identification.test.ts
- bun test assistant/src/__tests__/call-orchestrator.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
