### PR TITLE
feat: improve claude_code tool debugging and nesting guard

### DIFF
--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -50,6 +50,12 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           return { behavior: 'allow' as const };
         };
 
+        // Strip nesting-guard env vars so the subprocess doesn't refuse to start
+        // when we're already inside a Claude Code session.
+        const subprocessEnv: Record<string, string | undefined> = { ...process.env, ANTHROPIC_API_KEY: apiKey };
+        delete subprocessEnv.CLAUDECODE;
+        delete subprocessEnv.CLAUDE_CODE_ENTRYPOINT;
+
         const conversation = query({
           prompt: input.prompt,
           options: {
@@ -58,7 +64,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
             canUseTool,
             permissionMode: 'default',
             maxTurns: 30,
-            env: { ...process.env, ANTHROPIC_API_KEY: apiKey },
+            env: subprocessEnv,
             stderr: (data: string) => {
               const trimmed = data.trimEnd();
               if (trimmed) {

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -28,6 +28,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
 
     async runTask(input: SwarmWorkerBackendInput) {
       const start = Date.now();
+      const stderrLines: string[] = [];
       try {
         const { query } = await import('@anthropic-ai/claude-agent-sdk');
         const config = getConfig();
@@ -58,19 +59,47 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
             permissionMode: 'default',
             maxTurns: 30,
             env: { ...process.env, ANTHROPIC_API_KEY: apiKey },
+            stderr: (data: string) => {
+              const trimmed = data.trimEnd();
+              if (trimmed) {
+                stderrLines.push(trimmed);
+                log.debug({ stderr: trimmed }, 'Swarm worker subprocess stderr');
+              }
+            },
           },
         });
 
         let resultText = '';
+        let hasError = false;
         for await (const message of conversation) {
           if (input.signal?.aborted) break;
-          if (message.type === 'assistant' && message.message?.content) {
-            for (const block of message.message.content) {
-              if (block.type === 'text') resultText += block.text;
+          if (message.type === 'assistant') {
+            if (message.error) {
+              log.error({ error: message.error, sessionId: message.session_id }, 'Swarm worker assistant message error');
+              hasError = true;
+              resultText += `\n[Claude Code error: ${message.error}]`;
+            }
+            if (message.message?.content) {
+              for (const block of message.message.content) {
+                if (block.type === 'text') resultText += block.text;
+              }
             }
           } else if (message.type === 'result') {
-            if (message.subtype === 'success' && message.result && !resultText) {
-              resultText = message.result;
+            if (message.subtype === 'success') {
+              log.info({ numTurns: message.num_turns, durationMs: message.duration_ms, costUsd: message.total_cost_usd }, 'Swarm worker completed');
+              if (message.result && !resultText) {
+                resultText = message.result;
+              }
+            } else {
+              hasError = true;
+              const errors = message.errors ?? [];
+              const denials = message.permission_denials ?? [];
+              log.error({ subtype: message.subtype, errors, permissionDenials: denials.length, numTurns: message.num_turns, durationMs: message.duration_ms }, 'Swarm worker session failed');
+
+              const parts: string[] = [`[${message.subtype}] (${message.num_turns} turns, ${(message.duration_ms / 1000).toFixed(1)}s)`];
+              if (errors.length > 0) parts.push(`Errors: ${errors.join('; ')}`);
+              if (denials.length > 0) parts.push(`Permission denied: ${denials.map(d => d.tool_name).join(', ')}`);
+              resultText += `\n${parts.join('\n')}`;
             }
           }
         }
@@ -80,10 +109,17 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           return { success: false, output: 'Cancelled (aborted)', failureReason: 'cancelled' as const, durationMs: Date.now() - start };
         }
 
-        return { success: true, output: resultText || 'Completed', durationMs: Date.now() - start };
+        return { success: !hasError, output: resultText || 'Completed', durationMs: Date.now() - start };
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, output: message, failureReason: 'backend_unavailable' as const, durationMs: Date.now() - start };
+        const errMessage = err instanceof Error ? err.message : String(err);
+        const recentStderr = stderrLines.slice(-20);
+        log.error({ err, stderrTail: recentStderr }, 'Swarm worker execution failed');
+
+        const parts = [errMessage];
+        if (recentStderr.length > 0) {
+          parts.push(`\nSubprocess stderr (last ${recentStderr.length} lines):\n${recentStderr.join('\n')}`);
+        }
+        return { success: false, output: parts.join(''), failureReason: 'backend_unavailable' as const, durationMs: Date.now() - start };
       }
     },
   };

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -12,6 +12,9 @@ import { getProfilePolicy } from './worker-backend.js';
 
 const log = getLogger('swarm-backend-claude-code');
 
+const MAX_CLAUDE_CODE_DEPTH = 1;
+const DEPTH_ENV_VAR = 'VELLUM_CLAUDE_CODE_DEPTH';
+
 /**
  * Create a Claude Code worker backend that enforces profile-based tool policies.
  * Uses the Claude Agent SDK to run autonomous worker tasks.
@@ -50,9 +53,19 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           return { behavior: 'allow' as const };
         };
 
-        // Strip nesting-guard env vars so the subprocess doesn't refuse to start
-        // when we're already inside a Claude Code session.
-        const subprocessEnv: Record<string, string | undefined> = { ...process.env, ANTHROPIC_API_KEY: apiKey };
+        // Enforce nesting depth limit
+        const currentDepth = parseInt(process.env[DEPTH_ENV_VAR] ?? '0', 10);
+        if (currentDepth >= MAX_CLAUDE_CODE_DEPTH) {
+          log.warn({ currentDepth, max: MAX_CLAUDE_CODE_DEPTH }, 'Swarm worker nesting depth exceeded');
+          return { success: false, output: `Nesting depth exceeded (depth ${currentDepth}, max ${MAX_CLAUDE_CODE_DEPTH})`, failureReason: 'backend_unavailable' as const, durationMs: Date.now() - start };
+        }
+
+        // Strip the SDK's nesting guard but set our own depth counter.
+        const subprocessEnv: Record<string, string | undefined> = {
+          ...process.env,
+          ANTHROPIC_API_KEY: apiKey,
+          [DEPTH_ENV_VAR]: String(currentDepth + 1),
+        };
         delete subprocessEnv.CLAUDECODE;
         delete subprocessEnv.CLAUDE_CODE_ENTRYPOINT;
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -109,6 +109,9 @@ export const claudeCodeTool: Tool = {
 
     const { query } = sdkModule;
 
+    // Collect stderr output from the Claude Code subprocess for debugging
+    const stderrLines: string[] = [];
+
     log.info({ prompt: truncate(prompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
     // Build the canUseTool callback, enforcing profile-based restrictions
@@ -165,6 +168,13 @@ export const claudeCodeTool: Tool = {
       },
       maxTurns: 50,
       persistSession: true,
+      stderr: (data: string) => {
+        const trimmed = data.trimEnd();
+        if (trimmed) {
+          stderrLines.push(trimmed);
+          log.debug({ stderr: trimmed }, 'Claude Code subprocess stderr');
+        }
+      },
     };
 
     if (resumeSessionId) {
@@ -180,6 +190,12 @@ export const claudeCodeTool: Tool = {
       for await (const message of conversation) {
         switch (message.type) {
           case 'assistant': {
+            // Check for SDK-level errors on the assistant message
+            if (message.error) {
+              log.error({ error: message.error, sessionId: message.session_id }, 'Claude Code assistant message error');
+              hasError = true;
+              resultText += `\n\n[Claude Code error: ${message.error}]`;
+            }
             // Extract text from assistant messages
             if (message.message?.content) {
               for (const block of message.message.content) {
@@ -194,22 +210,43 @@ export const claudeCodeTool: Tool = {
           }
           case 'result': {
             sessionId = message.session_id;
+            const resultMeta = {
+              subtype: message.subtype,
+              numTurns: message.num_turns,
+              durationMs: message.duration_ms,
+              costUsd: message.total_cost_usd,
+              stopReason: message.stop_reason,
+            };
+
             if (message.subtype === 'success') {
+              log.info(resultMeta, 'Claude Code session completed successfully');
               if (message.result && !resultText) {
                 resultText = message.result;
               }
             } else {
-              // Error result
+              // Error result — surface the subtype and details
               hasError = true;
               const errors = message.errors ?? [];
+              const denials = message.permission_denials ?? [];
+
+              log.error({ ...resultMeta, errors, permissionDenials: denials.length }, 'Claude Code session failed');
+
+              const parts: string[] = [];
+              parts.push(`[${message.subtype}] (${message.num_turns} turns, ${(message.duration_ms / 1000).toFixed(1)}s)`);
               if (errors.length > 0) {
-                resultText += `\n\nErrors: ${errors.join(', ')}`;
+                parts.push(`Errors: ${errors.join('; ')}`);
               }
+              if (denials.length > 0) {
+                const denialSummary = denials.map(d => `${d.tool_name}`).join(', ');
+                parts.push(`Permission denied: ${denialSummary}`);
+              }
+              resultText += `\n\n${parts.join('\n')}`;
             }
             break;
           }
           default:
-            // Ignore other message types (system, stream_event, etc.)
+            // Log unhandled message types at debug level for diagnostics
+            log.debug({ messageType: message.type }, 'Claude Code unhandled message type');
             break;
         }
       }
@@ -222,10 +259,16 @@ export const claudeCodeTool: Tool = {
         isError: hasError,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error({ err }, 'Claude Code execution failed');
+      const errMessage = err instanceof Error ? err.message : String(err);
+      const recentStderr = stderrLines.slice(-20);
+      log.error({ err, stderrTail: recentStderr }, 'Claude Code execution failed');
+
+      const parts = [`Claude Code error: ${errMessage}`];
+      if (recentStderr.length > 0) {
+        parts.push(`\nSubprocess stderr (last ${recentStderr.length} lines):\n${recentStderr.join('\n')}`);
+      }
       return {
-        content: `Claude Code error: ${message}`,
+        content: parts.join(''),
         isError: true,
       };
     }

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -155,6 +155,12 @@ export const claudeCodeTool: Tool = {
       }
     };
 
+    // Build a clean env for the subprocess, stripping nesting-guard variables
+    // so the SDK doesn't refuse to start when we're already inside Claude Code.
+    const subprocessEnv: Record<string, string | undefined> = { ...process.env, ANTHROPIC_API_KEY: apiKey };
+    delete subprocessEnv.CLAUDECODE;
+    delete subprocessEnv.CLAUDE_CODE_ENTRYPOINT;
+
     // Build query options
     const queryOptions: import('@anthropic-ai/claude-agent-sdk').Options = {
       cwd: workingDir,
@@ -162,10 +168,7 @@ export const claudeCodeTool: Tool = {
       canUseTool,
       permissionMode: 'default',
       allowedTools: [...AUTO_APPROVE_TOOLS],
-      env: {
-        ...process.env,
-        ANTHROPIC_API_KEY: apiKey,
-      },
+      env: subprocessEnv,
       maxTurns: 50,
       persistSession: true,
       stderr: (data: string) => {

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -23,6 +23,11 @@ const APPROVAL_REQUIRED_TOOLS = new Set([
 
 const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
 
+// Maximum nesting depth for Claude Code subprocesses.
+// Depth 0 = top-level assistant, depth 1 = first subprocess, etc.
+const MAX_CLAUDE_CODE_DEPTH = 1;
+const DEPTH_ENV_VAR = 'VELLUM_CLAUDE_CODE_DEPTH';
+
 export const claudeCodeTool: Tool = {
   name: 'claude_code',
   description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
@@ -155,9 +160,23 @@ export const claudeCodeTool: Tool = {
       }
     };
 
-    // Build a clean env for the subprocess, stripping nesting-guard variables
-    // so the SDK doesn't refuse to start when we're already inside Claude Code.
-    const subprocessEnv: Record<string, string | undefined> = { ...process.env, ANTHROPIC_API_KEY: apiKey };
+    // Enforce nesting depth limit to prevent infinite recursion.
+    const currentDepth = parseInt(process.env[DEPTH_ENV_VAR] ?? '0', 10);
+    if (currentDepth >= MAX_CLAUDE_CODE_DEPTH) {
+      log.warn({ currentDepth, max: MAX_CLAUDE_CODE_DEPTH }, 'Claude Code nesting depth exceeded');
+      return {
+        content: `Error: Claude Code nesting depth exceeded (depth ${currentDepth}, max ${MAX_CLAUDE_CODE_DEPTH}). Cannot spawn another Claude Code subprocess.`,
+        isError: true,
+      };
+    }
+
+    // Build a clean env for the subprocess. Strip the SDK's own nesting guard
+    // (CLAUDECODE) so it can launch, but set our depth counter to enforce our limit.
+    const subprocessEnv: Record<string, string | undefined> = {
+      ...process.env,
+      ANTHROPIC_API_KEY: apiKey,
+      [DEPTH_ENV_VAR]: String(currentDepth + 1),
+    };
     delete subprocessEnv.CLAUDECODE;
     delete subprocessEnv.CLAUDE_CODE_ENTRYPOINT;
 


### PR DESCRIPTION
## Summary
- Add stderr capture and structured error reporting for Claude Code subprocess failures (error details, permission denials, stderr tail)
- Strip SDK nesting-guard env vars (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`) so claude_code can spawn inside Claude Code
- Replace blind env stripping with a depth-limited nesting guard (`VELLUM_CLAUDE_CODE_DEPTH`) capped at depth 1

## Test plan
- [ ] Verify claude_code tool spawns successfully from the assistant
- [ ] Verify nested claude_code calls are blocked at depth > 1
- [ ] Verify error diagnostics include stderr output on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
