### PR TITLE
daemon: wire temporal context into session agent loop runtime injections

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -415,6 +415,22 @@ describe('stripTemporalContext', () => {
     expect(result.length).toBe(1);
     expect(result[0]).toBe(messages[0]);
   });
+
+  test('preserves user-authored text that starts with <temporal_context> but not the injected prefix', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<temporal_context>some user XML content</temporal_context>' },
+          { type: 'text', text: 'Hello' },
+        ],
+      },
+    ];
+
+    const result = stripTemporalContext(messages);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(messages[0]); // Same reference — untouched
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -34,7 +34,9 @@ import {
   stripActiveSurfaceContext,
   stripWorkspaceTopLevelContext,
   stripChannelCapabilityContext,
+  stripTemporalContext,
 } from './session-runtime-assembly.js';
+import { buildTemporalContext } from './date-context.js';
 import type { ActiveSurfaceContext, ChannelCapabilities } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
@@ -278,11 +280,17 @@ export async function runAgentLoopImpl(
 
     ctx.refreshWorkspaceTopLevelContextIfNeeded();
 
+    // Compute fresh temporal context each turn for date grounding.
+    const temporalContext = buildTemporalContext({
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+
     runMessages = applyRuntimeInjections(runMessages, {
       softConflictInstruction,
       activeSurface,
       workspaceTopLevelContext: ctx.workspaceTopLevelContext,
       channelCapabilities: ctx.channelCapabilities ?? null,
+      temporalContext,
     });
 
     // Pre-run repair
@@ -567,6 +575,8 @@ export async function runAgentLoopImpl(
           softConflictInstruction,
           activeSurface,
           workspaceTopLevelContext: ctx.workspaceTopLevelContext,
+          channelCapabilities: ctx.channelCapabilities ?? null,
+          temporalContext,
         });
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
@@ -597,6 +607,8 @@ export async function runAgentLoopImpl(
             softConflictInstruction,
             activeSurface,
             workspaceTopLevelContext: ctx.workspaceTopLevelContext,
+            channelCapabilities: ctx.channelCapabilities ?? null,
+            temporalContext,
           });
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;
@@ -685,10 +697,12 @@ export async function runAgentLoopImpl(
 
     const restoredHistory = [...preRepairMessages, ...newMessages];
     const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-    ctx.messages = stripChannelCapabilityContext(
-      stripWorkspaceTopLevelContext(
-        stripActiveSurfaceContext(
-          stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+    ctx.messages = stripTemporalContext(
+      stripChannelCapabilityContext(
+        stripWorkspaceTopLevelContext(
+          stripActiveSurfaceContext(
+            stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+          ),
         ),
       ),
     );

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -330,13 +330,19 @@ export function injectTemporalContext(message: Message, temporalContext: string)
  * Strip `<temporal_context>` blocks injected by `injectTemporalContext`.
  * Called after the agent run to prevent temporal context from persisting
  * in session history.
+ *
+ * Uses a specific prefix (`<temporal_context>\nToday:`) so that
+ * user-authored text that happens to start with `<temporal_context>`
+ * is preserved.
  */
+const TEMPORAL_INJECTED_PREFIX = '<temporal_context>\nToday:';
+
 export function stripTemporalContext(messages: Message[]): Message[] {
   return messages.map((message) => {
     if (message.role !== 'user') return message;
     const nextContent = message.content.filter((block) => {
       if (block.type !== 'text') return true;
-      return !block.text.startsWith('<temporal_context>');
+      return !block.text.startsWith(TEMPORAL_INJECTED_PREFIX);
     });
     if (nextContent.length === message.content.length) return message;
     if (nextContent.length === 0) return null;


### PR DESCRIPTION
## Summary
- Import `buildTemporalContext` and compute fresh temporal context each turn in `runAgentLoop`
- Pass `temporalContext` to all three `applyRuntimeInjections()` call paths (main, compact retry, media-trim retry)
- Add `stripTemporalContext()` to the strip chain so temporal context is removed from persisted history

Part of plan: correct-dates-2.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
