### PR TITLE
feat: add send-direct button for queued messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatQueueSummaryView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatQueueSummaryView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct ChatQueueSummaryView: View {
     let queuedMessages: [ChatMessage]
     var onDeleteQueuedMessage: ((UUID) -> Void)?
+    var onSendDirectQueuedMessage: ((UUID) -> Void)?
     @Binding var isExpanded: Bool
 
     var body: some View {
@@ -57,6 +58,17 @@ struct ChatQueueSummaryView: View {
                                         .lineLimit(1)
                                 }
                                 Spacer()
+                                if let onSendDirect = onSendDirectQueuedMessage {
+                                    Button {
+                                        onSendDirect(message.id)
+                                    } label: {
+                                        Image(systemName: "arrow.up.circle.fill")
+                                            .font(.system(size: 13))
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Send this message now")
+                                }
                                 if let onDelete = onDeleteQueuedMessage {
                                     Button {
                                         onDelete(message.id)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -44,6 +44,7 @@ struct ChatView: View {
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
     var onDeleteQueuedMessage: ((UUID) -> Void)?
+    var onSendDirectQueuedMessage: ((UUID) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var isTemporaryChat: Bool = false
     var activeSubagents: [SubagentInfo] = []
@@ -225,6 +226,7 @@ struct ChatView: View {
             ChatQueueSummaryView(
                 queuedMessages: queuedMessages,
                 onDeleteQueuedMessage: onDeleteQueuedMessage,
+                onSendDirectQueuedMessage: onSendDirectQueuedMessage,
                 isExpanded: $isQueueExpanded
             )
             ComposerView(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1201,5 +1201,3 @@ private struct DrawerMenuItem: View {
         }
     }
 }
-
-

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -511,6 +511,7 @@ struct ActiveChatViewWrapper: View {
                 }
             },
             onDeleteQueuedMessage: { messageId in viewModel.deleteQueuedMessage(messageId: messageId) },
+            onSendDirectQueuedMessage: { messageId in viewModel.sendDirectQueuedMessage(messageId: messageId) },
             mediaEmbedSettings: MediaEmbedResolverSettings(
                 enabled: settingsStore.mediaEmbedsEnabled,
                 enabledSince: settingsStore.mediaEmbedsEnabledSince,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2152,4 +2152,96 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].role, .user)
         XCTAssertEqual(viewModel.messages[0].text, "Hello")
     }
+
+    // MARK: - Send Direct Queued Message
+
+    func testSendDirectQueuedMessageSavesContentAndStops() {
+        // Set up a session with a sending state and a queued message
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Add an assistant message (current generation)
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "Working...", isStreaming: true))
+
+        // Add a queued user message
+        let queuedId = UUID()
+        viewModel.messages.append(ChatMessage(id: queuedId, role: .user, text: "Jump ahead", status: .queued(position: 1)))
+
+        viewModel.sendDirectQueuedMessage(messageId: queuedId)
+
+        // The queued message should be removed from the messages array
+        XCTAssertFalse(viewModel.messages.contains(where: { $0.id == queuedId }))
+
+        // Pending send-direct state should be stored
+        XCTAssertEqual(viewModel.pendingSendDirectText, "Jump ahead")
+
+        // isCancelling should be set (daemon cancel sent)
+        XCTAssertTrue(viewModel.isCancelling)
+    }
+
+    func testSendDirectDispatcheAfterGenerationCancelled() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isCancelling = true
+
+        // Simulate pending send-direct
+        viewModel.pendingSendDirectText = "Jump ahead"
+        viewModel.pendingSendDirectAttachments = nil
+
+        // Simulate generationCancelled arriving
+        let cancelled = GenerationCancelledMessage(sessionId: "sess-1")
+        viewModel.handleServerMessage(.generationCancelled(cancelled))
+
+        // After cancellation, the pending text should have been dispatched
+        XCTAssertNil(viewModel.pendingSendDirectText)
+        // isSending should be true again (sendMessage was called)
+        XCTAssertTrue(viewModel.isSending)
+        // The dispatched message should appear in messages
+        XCTAssertTrue(viewModel.messages.contains(where: { $0.role == .user && $0.text == "Jump ahead" }))
+    }
+
+    func testSendDirectDispatchesAfterDisconnectedCancel() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+
+        // Add a queued message
+        let queuedId = UUID()
+        viewModel.messages.append(ChatMessage(id: queuedId, role: .user, text: "Urgent", status: .queued(position: 1)))
+
+        // Disconnect daemon
+        daemonClient.isConnected = false
+
+        viewModel.sendDirectQueuedMessage(messageId: queuedId)
+
+        // Disconnected path resets immediately and dispatches
+        XCTAssertNil(viewModel.pendingSendDirectText)
+        // The dispatched message should be in messages
+        XCTAssertTrue(viewModel.messages.contains(where: { $0.role == .user && $0.text == "Urgent" }))
+    }
+
+    func testSendDirectIgnoresNonQueuedMessage() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+
+        // Add a sent (non-queued) user message
+        let sentId = UUID()
+        viewModel.messages.append(ChatMessage(id: sentId, role: .user, text: "Already sent", status: .sent))
+
+        viewModel.sendDirectQueuedMessage(messageId: sentId)
+
+        // Should be a no-op — pendingSendDirectText stays nil
+        XCTAssertNil(viewModel.pendingSendDirectText)
+        // Message should still be there (not removed)
+        XCTAssertTrue(viewModel.messages.contains(where: { $0.id == sentId }))
+    }
+
+    func testSendDirectIgnoresUnknownMessageId() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+
+        viewModel.sendDirectQueuedMessage(messageId: UUID())
+
+        XCTAssertNil(viewModel.pendingSendDirectText)
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -450,8 +450,21 @@ extension ChatViewModel {
             cancelTimeoutTask = nil
             isCancelling = false
             isThinking = false
-            // Only clear isSending if no messages are still queued
-            if pendingQueuedCount == 0 {
+            // When a send-direct is pending, this messageComplete is the
+            // cancel acknowledgment. Reset all queue state so the follow-up
+            // sendMessage() starts a fresh send instead of re-queuing.
+            if pendingSendDirectText != nil {
+                isSending = false
+                pendingQueuedCount = 0
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
+            } else if pendingQueuedCount == 0 {
+                // Only clear isSending if no messages are still queued
                 isSending = false
                 #if os(iOS)
                 UIImpactFeedbackGenerator(style: .medium).impactOccurred()

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -458,6 +458,7 @@ extension ChatViewModel {
                 pendingQueuedCount = 0
                 pendingMessageIds = []
                 requestIdToMessageId = [:]
+                pendingLocalDeletions.removeAll()
                 for i in messages.indices {
                     if case .queued = messages[i].status, messages[i].role == .user {
                         messages[i].status = .sent

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -596,6 +596,7 @@ extension ChatViewModel {
                     messages[i].status = .sent
                 }
             }
+            dispatchPendingSendDirect()
 
         case .messageQueued(let queued):
             guard belongsToSession(queued.sessionId) else { return }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -571,13 +571,6 @@ extension ChatViewModel {
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
-            pendingVoiceMessage = false
-            isWorkspaceRefinementInFlight = false
-            refinementMessagePreview = nil
-            refinementStreamingText = nil
-            cancelledDuringRefinement = false
-            cancelTimeoutTask?.cancel()
-            cancelTimeoutTask = nil
             let wasCancelling = isCancelling
             isCancelling = false
             // Stale cancel event from a previous cancel cycle — the daemon
@@ -587,6 +580,13 @@ extension ChatViewModel {
             if !wasCancelling && isSending {
                 return
             }
+            pendingVoiceMessage = false
+            isWorkspaceRefinementInFlight = false
+            refinementMessagePreview = nil
+            refinementStreamingText = nil
+            cancelledDuringRefinement = false
+            cancelTimeoutTask?.cancel()
+            cancelTimeoutTask = nil
             isThinking = false
             if wasCancelling {
                 isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -580,6 +580,13 @@ extension ChatViewModel {
             cancelTimeoutTask = nil
             let wasCancelling = isCancelling
             isCancelling = false
+            // Stale cancel event from a previous cancel cycle — the daemon
+            // emits generation_cancelled for each queued entry during abort,
+            // but the first event already reset state and dispatched any
+            // pending send-direct. Ignore to avoid clobbering the new send.
+            if !wasCancelling && isSending {
+                return
+            }
             isThinking = false
             if wasCancelling {
                 isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -532,6 +532,7 @@ extension ChatViewModel {
                     messages[i].status = .sent
                 }
             }
+            dispatchPendingSendDirect()
             // Skip follow-up suggestions for workspace refinements
             if !isSending && !wasRefinement {
                 fetchSuggestion()
@@ -761,6 +762,7 @@ extension ChatViewModel {
                         messages[i].status = .sent
                     }
                 }
+                dispatchPendingSendDirect()
             } else if pendingQueuedCount == 0 {
                 // The daemon drains queued work after a non-cancellation
                 // error, so preserve queue bookkeeping when messages are

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -838,6 +838,15 @@ public final class ChatViewModel: ObservableObject {
         // Remove this message from local state (it will be re-added by sendMessage)
         messages.remove(at: index)
 
+        // If nothing is actively sending, stopGenerating() will no-op and no
+        // cancel-completion event will fire. Dispatch immediately instead.
+        guard isSending else {
+            inputText = text
+            pendingAttachments = attachments
+            sendMessage()
+            return
+        }
+
         // Store for dispatch after cancellation completes.
         // Must be set BEFORE stopGenerating() because synchronous cancel paths
         // (bootstrap, disconnected, send-failure) dispatch immediately.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -133,6 +133,11 @@ public final class ChatViewModel: ObservableObject {
     /// a cancel request (e.g. a stuck tool blocks the generation_cancelled event).
     var cancelTimeoutTask: Task<Void, Never>?
 
+    /// Saved text from a queued message that should be auto-sent after cancellation completes.
+    var pendingSendDirectText: String?
+    /// Saved attachments from a queued message that should be auto-sent after cancellation completes.
+    var pendingSendDirectAttachments: [ChatAttachment]?
+
     /// Timestamp of the most recent `toolUseStart` event received by this view model.
     /// Used by ThreadManager to route `confirmationRequest` messages to the correct
     /// ChatViewModel when multiple threads have active sessions.
@@ -592,6 +597,7 @@ public final class ChatViewModel: ObservableObject {
             refinementStreamingText = nil
             isThinking = false
             isSending = false
+            dispatchPendingSendDirect()
             return
         }
 
@@ -633,6 +639,7 @@ public final class ChatViewModel: ObservableObject {
                     messages[i].status = .sent
                 }
             }
+            dispatchPendingSendDirect()
             return
         }
 
@@ -677,6 +684,7 @@ public final class ChatViewModel: ObservableObject {
                     messages[i].status = .sent
                 }
             }
+            dispatchPendingSendDirect()
             return
         }
 
@@ -733,6 +741,7 @@ public final class ChatViewModel: ObservableObject {
                     self.messages[i].status = .sent
                 }
             }
+            self.dispatchPendingSendDirect()
         }
     }
 
@@ -815,6 +824,40 @@ public final class ChatViewModel: ObservableObject {
         if pendingQueuedCount == 0 && !isThinking {
             isSending = false
         }
+    }
+
+    /// Skip the queue: stop the current generation and immediately send a specific queued message.
+    public func sendDirectQueuedMessage(messageId: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == messageId }),
+              case .queued = messages[index].status else { return }
+
+        // Save content before stop clears everything
+        let text = messages[index].text
+        let attachments = messages[index].attachments
+
+        // Remove this message from local state (it will be re-added by sendMessage)
+        messages.remove(at: index)
+
+        // Store for dispatch after cancellation completes.
+        // Must be set BEFORE stopGenerating() because synchronous cancel paths
+        // (bootstrap, disconnected, send-failure) dispatch immediately.
+        pendingSendDirectText = text
+        pendingSendDirectAttachments = attachments
+
+        // Stop current generation — this clears all queued messages on the daemon
+        stopGenerating()
+    }
+
+    /// If a send-direct is pending, populate the composer and fire sendMessage.
+    /// Called from all cancel-completion paths (generationCancelled, timeout, disconnected, etc.).
+    func dispatchPendingSendDirect() {
+        guard let directText = pendingSendDirectText else { return }
+        let directAttachments = pendingSendDirectAttachments ?? []
+        pendingSendDirectText = nil
+        pendingSendDirectAttachments = nil
+        inputText = directText
+        pendingAttachments = directAttachments
+        sendMessage()
     }
 
     /// Stop the active watch session and notify the macOS layer.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -137,6 +137,8 @@ public final class ChatViewModel: ObservableObject {
     var pendingSendDirectText: String?
     /// Saved attachments from a queued message that should be auto-sent after cancellation completes.
     var pendingSendDirectAttachments: [ChatAttachment]?
+    /// Saved skill invocation from a queued message for send-direct dispatch.
+    var pendingSendDirectSkillInvocation: SkillInvocationData?
 
     /// Timestamp of the most recent `toolUseStart` event received by this view model.
     /// Used by ThreadManager to route `confirmationRequest` messages to the correct
@@ -834,6 +836,7 @@ public final class ChatViewModel: ObservableObject {
         // Save content before stop clears everything
         let text = messages[index].text
         let attachments = messages[index].attachments
+        let skillInvocation = messages[index].skillInvocation
 
         // Remove this message from local state (it will be re-added by sendMessage)
         messages.remove(at: index)
@@ -843,6 +846,7 @@ public final class ChatViewModel: ObservableObject {
         guard isSending else {
             inputText = text
             pendingAttachments = attachments
+            pendingSkillInvocation = skillInvocation
             sendMessage()
             return
         }
@@ -852,6 +856,7 @@ public final class ChatViewModel: ObservableObject {
         // (bootstrap, disconnected, send-failure) dispatch immediately.
         pendingSendDirectText = text
         pendingSendDirectAttachments = attachments
+        pendingSendDirectSkillInvocation = skillInvocation
 
         // Stop current generation — this clears all queued messages on the daemon
         stopGenerating()
@@ -862,10 +867,13 @@ public final class ChatViewModel: ObservableObject {
     func dispatchPendingSendDirect() {
         guard let directText = pendingSendDirectText else { return }
         let directAttachments = pendingSendDirectAttachments ?? []
+        let directSkillInvocation = pendingSendDirectSkillInvocation
         pendingSendDirectText = nil
         pendingSendDirectAttachments = nil
+        pendingSendDirectSkillInvocation = nil
         inputText = directText
         pendingAttachments = directAttachments
+        pendingSkillInvocation = directSkillInvocation
         sendMessage()
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -507,6 +507,9 @@ public final class ChatViewModel: ObservableObject {
                     self?.messages[index].isStreaming = false
                 }
                 self?.currentAssistantMessageId = nil
+                // If a send-direct was pending when the stream dropped,
+                // dispatch it now so the message isn't silently lost.
+                self?.dispatchPendingSendDirect()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds an up-arrow "send direct" button next to each queued message in the queue summary view
- Clicking it stops the current generation and immediately sends that queued message
- Handles all cancel-completion paths (daemon ack, timeout, disconnected, send-failure)
- Includes 5 new tests covering the send-direct flow

## Test plan
- [x] Unit tests pass (`swift test --filter testSendDirect` — 5/5 passing)
- [ ] Manual: queue multiple messages, click send-direct on one, verify it cancels current generation and sends the selected message
- [ ] Manual: verify delete button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
