### PR TITLE
fix: stabilize composer text view across compact/expanded transitions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -104,27 +104,30 @@ struct ComposerView: View {
                     attachmentStrip
                 }
 
-                if isComposerExpanded {
-                    // Expanded: text area on top, buttons on bottom row
+                // Text field always lives at the same structural position
+                // so that the NSViewRepresentable is never destroyed and
+                // recreated when toggling between compact/expanded layouts.
+                // In compact mode, buttons are overlaid at trailing edge;
+                // in expanded mode, they sit on a separate row below.
+                HStack(alignment: .center, spacing: VSpacing.md) {
                     composerTextField
                         .frame(height: clampedComposerHeight)
+                        .frame(maxHeight: isComposerExpanded ? clampedComposerHeight : .infinity, alignment: .center)
+                    if !isComposerExpanded {
+                        composerActionButtons
+                            .frame(maxHeight: .infinity, alignment: .center)
+                            .offset(y: compactActionOpticalYOffset)
+                    }
+                }
+                .frame(height: isComposerExpanded ? clampedComposerHeight : compactRowHeight, alignment: .center)
 
+                if isComposerExpanded {
+                    // Expanded: buttons on a separate row below the text area
                     HStack(spacing: VSpacing.md) {
                         Spacer()
                         composerActionButtons
                     }
                     .padding(.top, VSpacing.xs)
-                } else {
-                    // Compact: text and buttons on the same row
-                    HStack(alignment: .center, spacing: VSpacing.md) {
-                        composerTextField
-                            .frame(height: clampedComposerHeight)
-                            .frame(maxHeight: .infinity, alignment: .center)
-                        composerActionButtons
-                            .frame(maxHeight: .infinity, alignment: .center)
-                            .offset(y: compactActionOpticalYOffset)
-                    }
-                    .frame(height: compactRowHeight, alignment: .center)
                 }
             }
             .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.xs)
@@ -563,7 +566,7 @@ private struct ComposerTextView: NSViewRepresentable {
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
         scrollView.borderType = .noBorder
-        scrollView.hasVerticalScroller = false
+        scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
 
@@ -682,6 +685,9 @@ private struct ComposerTextView: NSViewRepresentable {
             parent.text = textView.string
             isWritingFromView = false
             syncHeight()
+            // After large pastes the scroll position may not reflect the
+            // insertion point. Scroll to the cursor so pasted text is visible.
+            textView.scrollRangeToVisible(textView.selectedRange())
         }
 
         func syncHeight() {


### PR DESCRIPTION
## Summary
- Move `composerTextField` out of the `if isComposerExpanded` branch so the `NSViewRepresentable` maintains a stable identity across layout transitions — prevents the text view from being destroyed and recreated (which caused pasted text to render invisible)
- Enable vertical scroller with `autohidesScrollers` so overflowing content is scrollable
- Scroll to insertion point after text changes so large pastes stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
