### PR TITLE
refactor: split handler dispatch map into feature groups

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -18,7 +18,7 @@ import type {
   AppUpdatePreviewRequest,
   UiSurfaceShow,
 } from '../ipc-protocol.js';
-import { log, compareSemver, createSigningCallback, type HandlerContext } from './shared.js';
+import { log, compareSemver, createSigningCallback, type HandlerContext, type DispatchMap } from './shared.js';
 
 export function handleAppDataRequest(
   msg: AppDataRequest,
@@ -444,3 +444,18 @@ export function handleGalleryInstall(
     });
   }
 }
+
+export const appHandlers: Partial<DispatchMap> = {
+  app_data_request: handleAppDataRequest,
+  app_open_request: handleAppOpenRequest,
+  app_update_preview: handleAppUpdatePreview,
+  app_preview_request: handleAppPreview,
+  apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
+  shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
+  shared_app_delete: handleSharedAppDelete,
+  fork_shared_app: handleForkSharedApp,
+  share_app_cloud: handleShareAppCloud,
+  bundle_app: handleBundleApp,
+  gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),
+  gallery_install: handleGalleryInstall,
+};

--- a/assistant/src/daemon/handlers/browser.ts
+++ b/assistant/src/daemon/handlers/browser.ts
@@ -1,0 +1,54 @@
+import { browserManager } from '../../tools/browser/browser-manager.js';
+import { log, type DispatchMap } from './shared.js';
+
+export const browserHandlers: Partial<DispatchMap> = {
+  browser_cdp_response: (msg) => {
+    browserManager.resolveCDPResponse(msg.sessionId, msg.success, msg.declined);
+  },
+
+  browser_user_click: async (msg) => {
+    try {
+      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
+      const viewport = await page.evaluate('(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()') as { vw: number; vh: number };
+      const scale = Math.min(1280 / viewport.vw, 960 / viewport.vh);
+      const pageX = msg.x / scale;
+      const pageY = msg.y / scale;
+      const options: Record<string, unknown> = {};
+      if (msg.button === 'right') options.button = 'right';
+      if (msg.doubleClick) options.clickCount = 2;
+      await page.mouse.click(pageX, pageY, options);
+    } catch (err) {
+      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user click');
+    }
+  },
+
+  browser_user_scroll: async (msg) => {
+    try {
+      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
+      await page.mouse.wheel(msg.deltaX, msg.deltaY);
+    } catch (err) {
+      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user scroll');
+    }
+  },
+
+  browser_user_keypress: async (msg) => {
+    try {
+      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
+      const combo = msg.modifiers?.length ? [...msg.modifiers, msg.key].join('+') : msg.key;
+      await page.keyboard.press(combo);
+    } catch (err) {
+      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user keypress');
+    }
+  },
+
+  browser_interactive_mode: (msg, socket, ctx) => {
+    log.info({ sessionId: msg.sessionId, enabled: msg.enabled }, 'Interactive mode toggled');
+    browserManager.setInteractiveMode(msg.sessionId, msg.enabled);
+    ctx.send(socket, {
+      type: 'browser_interactive_mode_changed',
+      sessionId: msg.sessionId,
+      surfaceId: msg.surfaceId,
+      enabled: msg.enabled,
+    });
+  },
+};

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -10,7 +10,7 @@ import type {
   CuObservation,
   ServerMessage,
 } from '../ipc-protocol.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, type HandlerContext, type DispatchMap } from './shared.js';
 
 const cuObservationSequenceBySession = new Map<string, number>();
 
@@ -179,3 +179,9 @@ export async function handleCuObservation(
     log.error({ err, sessionId: msg.sessionId }, 'Error handling CU observation');
   });
 }
+
+export const computerUseHandlers: Partial<DispatchMap> = {
+  cu_session_create: handleCuSessionCreate,
+  cu_session_abort: handleCuSessionAbort,
+  cu_observation: handleCuObservation,
+};

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -21,7 +21,7 @@ import type {
   SlackWebhookConfigRequest,
   VercelApiConfigRequest,
 } from '../ipc-protocol.js';
-import { log, CONFIG_RELOAD_DEBOUNCE_MS, type HandlerContext } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, type HandlerContext, type DispatchMap } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
@@ -462,3 +462,23 @@ export function handleEnvVarsRequest(socket: net.Socket, ctx: HandlerContext): v
   }
   ctx.send(socket, { type: 'env_vars_response', vars });
 }
+
+export const configHandlers: Partial<DispatchMap> = {
+  model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
+  model_set: handleModelSet,
+  image_gen_model_set: handleImageGenModelSet,
+  add_trust_rule: handleAddTrustRule,
+  trust_rules_list: (_msg, socket, ctx) => handleTrustRulesList(socket, ctx),
+  remove_trust_rule: handleRemoveTrustRule,
+  update_trust_rule: handleUpdateTrustRule,
+  accept_starter_bundle: (_msg, socket, ctx) => handleAcceptStarterBundle(socket, ctx),
+  schedules_list: (_msg, socket, ctx) => handleSchedulesList(socket, ctx),
+  schedule_toggle: handleScheduleToggle,
+  schedule_remove: handleScheduleRemove,
+  reminders_list: (_msg, socket, ctx) => handleRemindersList(socket, ctx),
+  reminder_cancel: handleReminderCancel,
+  share_to_slack: handleShareToSlack,
+  slack_webhook_config: handleSlackWebhookConfig,
+  vercel_api_config: handleVercelApiConfig,
+  env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
+};

--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -9,7 +9,7 @@ import archiver from 'archiver';
 import { getDb } from '../../memory/db.js';
 import { messages, toolInvocations, llmUsageEvents, llmRequestLogs } from '../../memory/schema.js';
 import type { DiagnosticsExportRequest } from '../ipc-protocol.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, type HandlerContext, type DispatchMap } from './shared.js';
 
 const MAX_CONTENT_LENGTH = 500;
 
@@ -332,3 +332,7 @@ export async function handleDiagnosticsExport(
     });
   }
 }
+
+export const diagnosticsHandlers: Partial<DispatchMap> = {
+  diagnostics_export_request: handleDiagnosticsExport,
+};

--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -1,4 +1,4 @@
-import type { HandlerContext } from './shared.js';
+import type { HandlerContext, DispatchMap } from './shared.js';
 import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
 import type * as net from 'node:net';
 import type { Database } from 'bun:sqlite';
@@ -164,3 +164,9 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
     });
   }
 }
+
+export const documentHandlers: Partial<DispatchMap> = {
+  document_save: handleDocumentSave,
+  document_load: handleDocumentLoad,
+  document_list: handleDocumentList,
+};

--- a/assistant/src/daemon/handlers/home-base.ts
+++ b/assistant/src/daemon/handlers/home-base.ts
@@ -7,7 +7,7 @@ import {
 } from '../../home-base/prebuilt/seed.js';
 import { getHomeBaseAppLink } from '../../home-base/app-link-store.js';
 import { getApp } from '../../memory/app-store.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, type HandlerContext, type DispatchMap } from './shared.js';
 
 export function handleHomeBaseGet(
   msg: HomeBaseGetRequest,
@@ -71,3 +71,7 @@ export function handleHomeBaseGet(
     ctx.send(socket, { type: 'error', message: `Failed to resolve home base metadata: ${message}` });
   }
 }
+
+export const homeBaseHandlers: Partial<DispatchMap> = {
+  home_base_get: handleHomeBaseGet,
+};

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -3,120 +3,22 @@ import type { ClientMessage } from '../ipc-protocol.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';
 import { handleOpenBundle } from './open-bundle-handler.js';
-import { log, pendingSignBundlePayload, pendingSigningIdentity, type HandlerContext } from './shared.js';
-import { browserManager } from '../../tools/browser/browser-manager.js';
+import { log, type HandlerContext, type DispatchMap } from './shared.js';
 
-import {
-  handleUserMessage,
-  handleConfirmationResponse,
-  handleSecretResponse,
-  handleSessionList,
-  handleSessionsClear,
-  handleSessionCreate,
-  handleSessionSwitch,
-  handleCancel,
-  handleDeleteQueuedMessage,
-  handleHistoryRequest,
-  handleUndo,
-  handleRegenerate,
-  handleUsageRequest,
-  handleSandboxSet,
-} from './sessions.js';
-
-import {
-  handleSkillsList,
-  handleSkillDetail,
-  handleSkillsEnable,
-  handleSkillsDisable,
-  handleSkillsConfigure,
-  handleSkillsInstall,
-  handleSkillsUninstall,
-  handleSkillsUpdate,
-  handleSkillsCheckUpdates,
-  handleSkillsSearch,
-  handleSkillsInspect,
-} from './skills.js';
-
-import {
-  handleAppDataRequest,
-  handleAppOpenRequest,
-  handleAppUpdatePreview,
-  handleAppPreview,
-  handleAppsList,
-  handleSharedAppsList,
-  handleSharedAppDelete,
-  handleForkSharedApp,
-  handleShareAppCloud,
-  handleBundleApp,
-  handleGalleryList,
-  handleGalleryInstall,
-} from './apps.js';
-
-import {
-  handleModelGet,
-  handleModelSet,
-  handleImageGenModelSet,
-  handleAddTrustRule,
-  handleTrustRulesList,
-  handleRemoveTrustRule,
-  handleUpdateTrustRule,
-  handleAcceptStarterBundle,
-  handleSchedulesList,
-  handleScheduleToggle,
-  handleScheduleRemove,
-  handleRemindersList,
-  handleReminderCancel,
-  handleShareToSlack,
-  handleSlackWebhookConfig,
-  handleVercelApiConfig,
-  handleEnvVarsRequest,
-} from './config.js';
-
-import {
-  handleCuSessionCreate,
-  handleCuSessionAbort,
-  handleCuObservation,
-} from './computer-use.js';
-
-import {
-  handlePublishPage,
-  handleUnpublishPage,
-} from './publish.js';
-import { handleHomeBaseGet } from './home-base.js';
-import { handleDiagnosticsExport } from './diagnostics.js';
-
-import {
-  handleTaskSubmit,
-  handleSuggestionRequest,
-  handleLinkOpenRequest,
-  handleIpcBlobProbe,
-} from './misc.js';
-
-import {
-  handleDocumentSave,
-  handleDocumentLoad,
-  handleDocumentList,
-} from './documents.js';
-
-import {
-  handleWorkItemsList,
-  handleWorkItemGet,
-  handleWorkItemCreate,
-  handleWorkItemUpdate,
-  handleWorkItemComplete,
-  handleWorkItemDelete,
-  handleWorkItemRunTask,
-  handleWorkItemOutput,
-  handleWorkItemPreflight,
-  handleWorkItemApprovePermissions,
-  handleWorkItemCancel,
-} from './work-items.js';
-
-import {
-  handleSubagentAbort,
-  handleSubagentStatus,
-  handleSubagentMessage,
-} from './subagents.js';
+import { sessionHandlers } from './sessions.js';
+import { skillHandlers } from './skills.js';
+import { appHandlers } from './apps.js';
+import { configHandlers } from './config.js';
+import { computerUseHandlers } from './computer-use.js';
+import { publishHandlers } from './publish.js';
+import { homeBaseHandlers } from './home-base.js';
+import { diagnosticsHandlers } from './diagnostics.js';
+import { miscHandlers } from './misc.js';
+import { documentHandlers } from './documents.js';
+import { workItemHandlers } from './work-items.js';
+import { subagentHandlers } from './subagents.js';
+import { browserHandlers } from './browser.js';
+import { signingHandlers } from './signing.js';
 
 // Re-export types and utilities for backwards compatibility
 export type {
@@ -135,118 +37,29 @@ export {
 
 // ─── Typed dispatch ──────────────────────────────────────────────────────────
 
-type MessageType = ClientMessage['type'];
-// 'auth' is handled at the transport layer (server.ts) and never reaches dispatch.
-type DispatchableType = Exclude<MessageType, 'auth'>;
-type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
-type MessageHandler<T extends MessageType> = (
-  msg: MessageOfType<T>,
-  socket: net.Socket,
-  ctx: HandlerContext,
-) => void | Promise<void>;
-type DispatchMap = { [T in DispatchableType]: MessageHandler<T> };
-
 const handlers: DispatchMap = {
-  user_message: handleUserMessage,
-  confirmation_response: handleConfirmationResponse,
-  secret_response: handleSecretResponse,
-  session_list: (_msg, socket, ctx) => handleSessionList(socket, ctx),
-  session_create: handleSessionCreate,
-  sessions_clear: (_msg, socket, ctx) => handleSessionsClear(socket, ctx),
-  session_switch: handleSessionSwitch,
-  cancel: handleCancel,
-  delete_queued_message: handleDeleteQueuedMessage,
-  model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
-  model_set: handleModelSet,
-  image_gen_model_set: handleImageGenModelSet,
-  history_request: handleHistoryRequest,
-  undo: handleUndo,
-  regenerate: handleRegenerate,
-  usage_request: handleUsageRequest,
-  sandbox_set: handleSandboxSet,
-  cu_session_create: handleCuSessionCreate,
-  cu_session_abort: handleCuSessionAbort,
-  cu_observation: handleCuObservation,
+  ...sessionHandlers,
+  ...skillHandlers,
+  ...appHandlers,
+  ...configHandlers,
+  ...computerUseHandlers,
+  ...publishHandlers,
+  ...homeBaseHandlers,
+  ...diagnosticsHandlers,
+  ...miscHandlers,
+  ...documentHandlers,
+  ...workItemHandlers,
+  ...subagentHandlers,
+  ...browserHandlers,
+  ...signingHandlers,
+
+  // Handlers imported from outside the handlers/ directory
   ride_shotgun_start: handleRideShotgunStart,
   ride_shotgun_stop: handleRideShotgunStop,
   watch_observation: handleWatchObservation,
-  task_submit: handleTaskSubmit,
-  app_data_request: handleAppDataRequest,
-  skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
-  skill_detail: handleSkillDetail,
-  skills_enable: handleSkillsEnable,
-  skills_disable: handleSkillsDisable,
-  skills_configure: handleSkillsConfigure,
-  skills_install: handleSkillsInstall,
-  skills_uninstall: handleSkillsUninstall,
-  skills_update: handleSkillsUpdate,
-  skills_check_updates: handleSkillsCheckUpdates,
-  skills_search: handleSkillsSearch,
-  skills_inspect: handleSkillsInspect,
-  suggestion_request: handleSuggestionRequest,
-  add_trust_rule: handleAddTrustRule,
-  trust_rules_list: (_msg, socket, ctx) => handleTrustRulesList(socket, ctx),
-  remove_trust_rule: handleRemoveTrustRule,
-  update_trust_rule: handleUpdateTrustRule,
-  accept_starter_bundle: (_msg, socket, ctx) => handleAcceptStarterBundle(socket, ctx),
-  schedules_list: (_msg, socket, ctx) => handleSchedulesList(socket, ctx),
-  schedule_toggle: handleScheduleToggle,
-  schedule_remove: handleScheduleRemove,
-  reminders_list: (_msg, socket, ctx) => handleRemindersList(socket, ctx),
-  reminder_cancel: handleReminderCancel,
-  share_app_cloud: handleShareAppCloud,
-  bundle_app: handleBundleApp,
   open_bundle: handleOpenBundle,
-  app_open_request: (msg, socket, ctx) => handleAppOpenRequest(msg, socket, ctx),
-  app_update_preview: handleAppUpdatePreview,
-  apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
-  app_preview_request: handleAppPreview,
-  home_base_get: handleHomeBaseGet,
-  shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
-  shared_app_delete: handleSharedAppDelete,
-  fork_shared_app: handleForkSharedApp,
-  sign_bundle_payload_response: (msg) => {
-    const pending = pendingSignBundlePayload.get(msg.requestId);
-    if (pending) {
-      clearTimeout(pending.timer);
-      pendingSignBundlePayload.delete(msg.requestId);
-      if (msg.error) {
-        pending.reject(new Error(msg.error));
-      } else if (msg.signature && msg.keyId && msg.publicKey) {
-        pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
-      } else {
-        pending.reject(new Error('Missing required fields in sign_bundle_payload_response'));
-      }
-    } else {
-      log.warn({ requestId: msg.requestId }, 'Received sign_bundle_payload_response with no pending request');
-    }
-  },
-  get_signing_identity_response: (msg) => {
-    const pending = pendingSigningIdentity.get(msg.requestId);
-    if (pending) {
-      clearTimeout(pending.timer);
-      pendingSigningIdentity.delete(msg.requestId);
-      if (msg.error) {
-        pending.reject(new Error(msg.error));
-      } else if (msg.keyId && msg.publicKey) {
-        pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
-      } else {
-        pending.reject(new Error('Missing required fields in get_signing_identity_response'));
-      }
-    } else {
-      log.warn({ requestId: msg.requestId }, 'Received get_signing_identity_response with no pending request');
-    }
-  },
-  gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),
-  gallery_install: handleGalleryInstall,
-  share_to_slack: handleShareToSlack,
-  slack_webhook_config: handleSlackWebhookConfig,
-  vercel_api_config: handleVercelApiConfig,
-  publish_page: handlePublishPage,
-  unpublish_page: handleUnpublishPage,
-  ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
-  link_open_request: handleLinkOpenRequest,
-  ipc_blob_probe: handleIpcBlobProbe,
+
+  // UI surface dispatch
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
     if (cuSession) {
@@ -270,15 +83,6 @@ const handlers: DispatchMap = {
     }
     log.warn({ sessionId: msg.sessionId, surfaceId: msg.surfaceId }, 'No session found for surface undo');
   },
-  diagnostics_export_request: handleDiagnosticsExport,
-  env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
-  document_save: handleDocumentSave,
-  document_load: handleDocumentLoad,
-  document_list: handleDocumentList,
-
-  browser_cdp_response: (msg) => {
-    browserManager.resolveCDPResponse(msg.sessionId, msg.success, msg.declined);
-  },
 
   // Stub handlers: the integration registry was removed but the Swift client
   // still sends these messages. Return safe no-op responses so the client
@@ -294,71 +98,8 @@ const handlers: DispatchMap = {
       error: 'Please use chat to connect integrations.',
     });
   },
-
-  browser_user_click: async (msg) => {
-    try {
-      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
-      const viewport = await page.evaluate('(() => ({ vw: window.innerWidth, vh: window.innerHeight }))()') as { vw: number; vh: number };
-      const scale = Math.min(1280 / viewport.vw, 960 / viewport.vh);
-      const pageX = msg.x / scale;
-      const pageY = msg.y / scale;
-      const options: Record<string, unknown> = {};
-      if (msg.button === 'right') options.button = 'right';
-      if (msg.doubleClick) options.clickCount = 2;
-      await page.mouse.click(pageX, pageY, options);
-    } catch (err) {
-      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user click');
-    }
-  },
-
-  browser_user_scroll: async (msg) => {
-    try {
-      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
-      await page.mouse.wheel(msg.deltaX, msg.deltaY);
-    } catch (err) {
-      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user scroll');
-    }
-  },
-
-  browser_user_keypress: async (msg) => {
-    try {
-      const page = await browserManager.getOrCreateSessionPage(msg.sessionId);
-      const combo = msg.modifiers?.length ? [...msg.modifiers, msg.key].join('+') : msg.key;
-      await page.keyboard.press(combo);
-    } catch (err) {
-      log.warn({ err, sessionId: msg.sessionId }, 'Failed to forward user keypress');
-    }
-  },
-
-  browser_interactive_mode: (msg, socket, ctx) => {
-    log.info({ sessionId: msg.sessionId, enabled: msg.enabled }, 'Interactive mode toggled');
-    browserManager.setInteractiveMode(msg.sessionId, msg.enabled);
-    ctx.send(socket, {
-      type: 'browser_interactive_mode_changed',
-      sessionId: msg.sessionId,
-      surfaceId: msg.surfaceId,
-      enabled: msg.enabled,
-    });
-  },
-
   integration_disconnect: () => { /* no-op — integration registry removed */ },
-
-  work_items_list: handleWorkItemsList,
-  work_item_get: handleWorkItemGet,
-  work_item_create: handleWorkItemCreate,
-  work_item_update: handleWorkItemUpdate,
-  work_item_complete: handleWorkItemComplete,
-  work_item_delete: handleWorkItemDelete,
-  work_item_run_task: handleWorkItemRunTask,
-  work_item_output: handleWorkItemOutput,
-  work_item_preflight: handleWorkItemPreflight,
-  work_item_approve_permissions: handleWorkItemApprovePermissions,
-  work_item_cancel: handleWorkItemCancel,
-
-  subagent_abort: handleSubagentAbort,
-  subagent_status: handleSubagentStatus,
-  subagent_message: handleSubagentMessage,
-};
+} as DispatchMap;
 
 export function handleMessage(
   msg: ClientMessage,

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -18,7 +18,7 @@ import type {
   IpcBlobProbe,
   CuSessionCreate,
 } from '../ipc-protocol.js';
-import { log, wireEscalationHandler, renderHistoryContent, type HandlerContext } from './shared.js';
+import { log, wireEscalationHandler, renderHistoryContent, type HandlerContext, type DispatchMap } from './shared.js';
 import { handleCuSessionCreate } from './computer-use.js';
 
 // ─── Task submit handler ────────────────────────────────────────────────────
@@ -321,3 +321,11 @@ export function handleIpcBlobProbe(
     observedNonceSha256: observedHash,
   });
 }
+
+export const miscHandlers: Partial<DispatchMap> = {
+  task_submit: handleTaskSubmit,
+  suggestion_request: handleSuggestionRequest,
+  link_open_request: handleLinkOpenRequest,
+  ipc_blob_probe: handleIpcBlobProbe,
+  ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
+};

--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -10,7 +10,7 @@ import type {
   PublishPageRequest,
   UnpublishPageRequest,
 } from '../ipc-protocol.js';
-import { log, requestSecretStandalone, type HandlerContext } from './shared.js';
+import { log, requestSecretStandalone, type HandlerContext, type DispatchMap } from './shared.js';
 
 export async function handlePublishPage(
   msg: PublishPageRequest,
@@ -180,3 +180,8 @@ export async function handleUnpublishPage(
     });
   }
 }
+
+export const publishHandlers: Partial<DispatchMap> = {
+  publish_page: handlePublishPage,
+  unpublish_page: handleUnpublishPage,
+};

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -31,6 +31,7 @@ import {
   mergeToolResults,
   pendingStandaloneSecrets,
   type HandlerContext,
+  type DispatchMap,
   type HistoryToolCall,
   type HistorySurface,
   type ParsedHistoryMessage,
@@ -497,3 +498,20 @@ export function handleDeleteQueuedMessage(
     log.warn({ sessionId: msg.sessionId, requestId: msg.requestId }, 'Queued message not found for deletion');
   }
 }
+
+export const sessionHandlers: Partial<DispatchMap> = {
+  user_message: handleUserMessage,
+  confirmation_response: handleConfirmationResponse,
+  secret_response: handleSecretResponse,
+  session_list: (_msg, socket, ctx) => handleSessionList(socket, ctx),
+  session_create: handleSessionCreate,
+  sessions_clear: (_msg, socket, ctx) => handleSessionsClear(socket, ctx),
+  session_switch: handleSessionSwitch,
+  cancel: handleCancel,
+  delete_queued_message: handleDeleteQueuedMessage,
+  history_request: handleHistoryRequest,
+  undo: handleUndo,
+  regenerate: handleRegenerate,
+  usage_request: handleUsageRequest,
+  sandbox_set: handleSandboxSet,
+};

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -5,7 +5,7 @@ import { ComputerUseSession } from '../computer-use-session.js';
 import { getLogger } from '../../util/logger.js';
 import { execSync } from 'node:child_process';
 import { estimateBase64Bytes } from '../assistant-attachments.js';
-import type { CuSessionCreate, ServerMessage, SessionTransportMetadata } from '../ipc-protocol.js';
+import type { ClientMessage, CuSessionCreate, ServerMessage, SessionTransportMetadata } from '../ipc-protocol.js';
 import type { SecretPromptResult } from '../../permissions/secret-prompter.js';
 import { getConfig } from '../../config/loader.js';
 
@@ -122,6 +122,19 @@ export interface HandlerContext {
   /** Refresh the eviction timestamp for a session that was accessed directly. */
   touchSession(sessionId: string): void;
 }
+
+// ─── Typed dispatch ──────────────────────────────────────────────────────────
+
+type MessageType = ClientMessage['type'];
+// 'auth' is handled at the transport layer (server.ts) and never reaches dispatch.
+type DispatchableType = Exclude<MessageType, 'auth'>;
+type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
+type MessageHandler<T extends MessageType> = (
+  msg: MessageOfType<T>,
+  socket: net.Socket,
+  ctx: HandlerContext,
+) => void | Promise<void>;
+export type DispatchMap = { [T in DispatchableType]: MessageHandler<T> };
 
 /**
  * Query the main display dimensions via CoreGraphics.

--- a/assistant/src/daemon/handlers/signing.ts
+++ b/assistant/src/daemon/handlers/signing.ts
@@ -1,0 +1,37 @@
+import { log, pendingSignBundlePayload, pendingSigningIdentity, type DispatchMap } from './shared.js';
+
+export const signingHandlers: Partial<DispatchMap> = {
+  sign_bundle_payload_response: (msg) => {
+    const pending = pendingSignBundlePayload.get(msg.requestId);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingSignBundlePayload.delete(msg.requestId);
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else if (msg.signature && msg.keyId && msg.publicKey) {
+        pending.resolve({ signature: msg.signature, keyId: msg.keyId, publicKey: msg.publicKey });
+      } else {
+        pending.reject(new Error('Missing required fields in sign_bundle_payload_response'));
+      }
+    } else {
+      log.warn({ requestId: msg.requestId }, 'Received sign_bundle_payload_response with no pending request');
+    }
+  },
+
+  get_signing_identity_response: (msg) => {
+    const pending = pendingSigningIdentity.get(msg.requestId);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingSigningIdentity.delete(msg.requestId);
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else if (msg.keyId && msg.publicKey) {
+        pending.resolve({ keyId: msg.keyId, publicKey: msg.publicKey });
+      } else {
+        pending.reject(new Error('Missing required fields in get_signing_identity_response'));
+      }
+    } else {
+      log.warn({ requestId: msg.requestId }, 'Received get_signing_identity_response with no pending request');
+    }
+  },
+};

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -19,7 +19,7 @@ import type {
   SkillsSearchRequest,
   SkillsInspectRequest,
 } from '../ipc-protocol.js';
-import { log, CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, type HandlerContext } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, type HandlerContext, type DispatchMap } from './shared.js';
 
 export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
@@ -485,3 +485,17 @@ export async function handleSkillDetail(
     });
   }
 }
+
+export const skillHandlers: Partial<DispatchMap> = {
+  skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
+  skill_detail: handleSkillDetail,
+  skills_enable: handleSkillsEnable,
+  skills_disable: handleSkillsDisable,
+  skills_configure: handleSkillsConfigure,
+  skills_install: handleSkillsInstall,
+  skills_uninstall: handleSkillsUninstall,
+  skills_update: handleSkillsUpdate,
+  skills_check_updates: handleSkillsCheckUpdates,
+  skills_search: handleSkillsSearch,
+  skills_inspect: handleSkillsInspect,
+};

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -4,7 +4,7 @@
 
 import * as net from 'node:net';
 import type { SubagentAbortRequest, SubagentStatusRequest, SubagentMessageRequest } from '../ipc-protocol.js';
-import type { HandlerContext } from './shared.js';
+import type { HandlerContext, DispatchMap } from './shared.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { log } from './shared.js';
 
@@ -120,3 +120,9 @@ export function handleSubagentMessage(
     });
   }
 }
+
+export const subagentHandlers: Partial<DispatchMap> = {
+  subagent_abort: handleSubagentAbort,
+  subagent_status: handleSubagentStatus,
+  subagent_message: handleSubagentMessage,
+};

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -12,7 +12,7 @@ import type {
   WorkItemApprovePermissionsRequest,
   WorkItemCancelRequest,
 } from '../ipc-protocol.js';
-import { log, type HandlerContext } from './shared.js';
+import { log, type HandlerContext, type DispatchMap } from './shared.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import {
   createWorkItem,
@@ -468,3 +468,17 @@ export function handleWorkItemCancel(
   broadcastWorkItemStatus(ctx, msg.id);
   ctx.broadcast({ type: 'tasks_changed' });
 }
+
+export const workItemHandlers: Partial<DispatchMap> = {
+  work_items_list: handleWorkItemsList,
+  work_item_get: handleWorkItemGet,
+  work_item_create: handleWorkItemCreate,
+  work_item_update: handleWorkItemUpdate,
+  work_item_complete: handleWorkItemComplete,
+  work_item_delete: handleWorkItemDelete,
+  work_item_run_task: handleWorkItemRunTask,
+  work_item_output: handleWorkItemOutput,
+  work_item_preflight: handleWorkItemPreflight,
+  work_item_approve_permissions: handleWorkItemApprovePermissions,
+  work_item_cancel: handleWorkItemCancel,
+};


### PR DESCRIPTION
## Summary
- Extract handler dispatch entries from the monolithic 200+ line object in `index.ts` into feature-grouped maps exported from their respective handler modules (e.g. `sessionHandlers`, `skillHandlers`, `appHandlers`, etc.)
- Create new `browser.ts` and `signing.ts` modules for inline handlers that previously lived in `index.ts`
- Move dispatch types (`DispatchMap`, etc.) to `shared.ts` so handler modules can type their exports
- `index.ts` now spreads 14 handler groups + a few inline outliers, down from 378 to 121 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
