### PR TITLE
test: add unit tests for script-proxy policy, router, and logging

### DIFF
--- a/assistant/src/tools/network/script-proxy/__tests__/logging.test.ts
+++ b/assistant/src/tools/network/script-proxy/__tests__/logging.test.ts
@@ -1,0 +1,248 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  sanitizeHeaders,
+  sanitizeUrl,
+  createSafeLogEntry,
+  stripQueryString,
+  buildDecisionTrace,
+  buildCredentialRefTrace,
+} from '../logging.js';
+import type { PolicyDecision } from '../types.js';
+import type { CredentialInjectionTemplate } from '../../../credentials/policy-types.js';
+
+// ---------------------------------------------------------------------------
+// sanitizeHeaders
+// ---------------------------------------------------------------------------
+
+describe('sanitizeHeaders', () => {
+  test('redacts sensitive keys', () => {
+    const headers = {
+      'Authorization': 'secret-value',
+      'Content-Type': 'application/json',
+      'X-API-Key': 'another-secret',
+    };
+    const result = sanitizeHeaders(headers, ['authorization', 'x-api-key']);
+    expect(result['Authorization']).toBe('[REDACTED]');
+    expect(result['Content-Type']).toBe('application/json');
+    expect(result['X-API-Key']).toBe('[REDACTED]');
+  });
+
+  test('case-insensitive matching', () => {
+    const headers = { 'authorization': 'bearer xyz' };
+    const result = sanitizeHeaders(headers, ['Authorization']);
+    expect(result['authorization']).toBe('[REDACTED]');
+  });
+
+  test('preserves non-sensitive headers', () => {
+    const headers = { 'Accept': 'text/html', 'Host': 'example.com' };
+    const result = sanitizeHeaders(headers, ['authorization']);
+    expect(result).toEqual(headers);
+  });
+
+  test('handles empty headers', () => {
+    const result = sanitizeHeaders({}, ['authorization']);
+    expect(result).toEqual({});
+  });
+
+  test('handles empty sensitive keys', () => {
+    const headers = { 'Authorization': 'bearer xyz' };
+    const result = sanitizeHeaders(headers, []);
+    expect(result['Authorization']).toBe('bearer xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeUrl
+// ---------------------------------------------------------------------------
+
+describe('sanitizeUrl', () => {
+  test('redacts sensitive query params from absolute URL', () => {
+    const result = sanitizeUrl('https://api.example.com/v1?api_key=secret123&format=json', ['api_key']);
+    expect(result).toContain('api_key=%5BREDACTED%5D');
+    expect(result).toContain('format=json');
+    expect(result).not.toContain('secret123');
+  });
+
+  test('redacts sensitive query params from relative path', () => {
+    const result = sanitizeUrl('/v1/search?token=abc&q=hello', ['token']);
+    expect(result).toContain('token=%5BREDACTED%5D');
+    expect(result).toContain('q=hello');
+    expect(result).not.toContain('abc');
+  });
+
+  test('returns URL unchanged when no sensitive params', () => {
+    const url = 'https://api.example.com/v1?format=json';
+    expect(sanitizeUrl(url, ['api_key'])).toBe(url);
+  });
+
+  test('returns URL unchanged when sensitiveParams is empty', () => {
+    const url = 'https://api.example.com/v1?api_key=secret';
+    expect(sanitizeUrl(url, [])).toBe(url);
+  });
+
+  test('returns URL unchanged when no query string', () => {
+    expect(sanitizeUrl('https://api.example.com/v1', ['api_key']))
+      .toBe('https://api.example.com/v1');
+  });
+
+  test('case-insensitive param matching', () => {
+    const result = sanitizeUrl('https://api.example.com/v1?API_KEY=secret', ['api_key']);
+    expect(result).not.toContain('secret');
+  });
+
+  test('strips query string entirely for unparseable URLs', () => {
+    // Malformed URL that URL constructor can't parse
+    const result = sanitizeUrl('http://[invalid:url?key=secret', ['key']);
+    expect(result).not.toContain('secret');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSafeLogEntry
+// ---------------------------------------------------------------------------
+
+describe('createSafeLogEntry', () => {
+  test('sanitizes both URL and headers', () => {
+    const req = {
+      method: 'GET',
+      url: '/api?token=secret',
+      headers: { 'Authorization': 'Bearer xyz', 'Accept': 'application/json' },
+    };
+    const result = createSafeLogEntry(req, ['authorization', 'token']);
+    expect(result.method).toBe('GET');
+    expect(result.url).not.toContain('secret');
+    expect(result.headers['Authorization']).toBe('[REDACTED]');
+    expect(result.headers['Accept']).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripQueryString
+// ---------------------------------------------------------------------------
+
+describe('stripQueryString', () => {
+  test('strips query from path', () => {
+    expect(stripQueryString('/api/v1?key=value')).toBe('/api/v1');
+  });
+
+  test('returns path unchanged when no query', () => {
+    expect(stripQueryString('/api/v1')).toBe('/api/v1');
+  });
+
+  test('handles empty path', () => {
+    expect(stripQueryString('')).toBe('');
+  });
+
+  test('handles query-only', () => {
+    expect(stripQueryString('?key=value')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDecisionTrace
+// ---------------------------------------------------------------------------
+
+describe('buildDecisionTrace', () => {
+  test('matched decision', () => {
+    const decision: PolicyDecision = {
+      kind: 'matched',
+      credentialId: 'cred-1',
+      template: {
+        hostPattern: '*.example.com',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Bearer ',
+      },
+    };
+    const trace = buildDecisionTrace('api.example.com', 443, '/api?key=secret', 'https', decision);
+    expect(trace.host).toBe('api.example.com');
+    expect(trace.port).toBe(443);
+    expect(trace.path).toBe('/api');
+    expect(trace.scheme).toBe('https');
+    expect(trace.decisionKind).toBe('matched');
+    expect(trace.candidateCount).toBe(1);
+    expect(trace.selectedPattern).toBe('*.example.com');
+    expect(trace.selectedCredentialId).toBe('cred-1');
+  });
+
+  test('ambiguous decision', () => {
+    const decision: PolicyDecision = {
+      kind: 'ambiguous',
+      candidates: [
+        { credentialId: 'cred-1', template: { hostPattern: '*.example.com', injectionType: 'header' } as CredentialInjectionTemplate },
+        { credentialId: 'cred-2', template: { hostPattern: '*.example.com', injectionType: 'header' } as CredentialInjectionTemplate },
+      ],
+    };
+    const trace = buildDecisionTrace('api.example.com', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('ambiguous');
+    expect(trace.candidateCount).toBe(2);
+    expect(trace.selectedPattern).toBeNull();
+    expect(trace.selectedCredentialId).toBeNull();
+  });
+
+  test('missing decision', () => {
+    const decision: PolicyDecision = { kind: 'missing' };
+    const trace = buildDecisionTrace('unknown.com', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('missing');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('unauthenticated decision', () => {
+    const decision: PolicyDecision = { kind: 'unauthenticated' };
+    const trace = buildDecisionTrace('example.com', null, '/', 'http', decision);
+    expect(trace.decisionKind).toBe('unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('ask_missing_credential decision', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_missing_credential',
+      target: { hostname: 'api.example.com', port: null, path: '/', scheme: 'https' },
+      matchingPatterns: ['*.example.com', 'api.example.com'],
+    };
+    const trace = buildDecisionTrace('api.example.com', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('ask_missing_credential');
+    expect(trace.candidateCount).toBe(2);
+  });
+
+  test('ask_unauthenticated decision', () => {
+    const decision: PolicyDecision = {
+      kind: 'ask_unauthenticated',
+      target: { hostname: 'unknown.com', port: null, path: '/', scheme: 'https' },
+    };
+    const trace = buildDecisionTrace('unknown.com', null, '/', 'https', decision);
+    expect(trace.decisionKind).toBe('ask_unauthenticated');
+    expect(trace.candidateCount).toBe(0);
+  });
+
+  test('strips query string from path to avoid leaking secrets', () => {
+    const decision: PolicyDecision = { kind: 'unauthenticated' };
+    const trace = buildDecisionTrace('example.com', null, '/api?secret=abc', 'https', decision);
+    expect(trace.path).toBe('/api');
+    expect(trace.path).not.toContain('secret');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCredentialRefTrace
+// ---------------------------------------------------------------------------
+
+describe('buildCredentialRefTrace', () => {
+  test('builds trace with all fields', () => {
+    const trace = buildCredentialRefTrace(
+      ['my-api-key', 'unknown-ref'],
+      ['uuid-1'],
+      ['unknown-ref'],
+    );
+    expect(trace.rawRefs).toEqual(['my-api-key', 'unknown-ref']);
+    expect(trace.resolvedIds).toEqual(['uuid-1']);
+    expect(trace.unresolvedRefs).toEqual(['unknown-ref']);
+  });
+
+  test('handles empty arrays', () => {
+    const trace = buildCredentialRefTrace([], [], []);
+    expect(trace.rawRefs).toEqual([]);
+    expect(trace.resolvedIds).toEqual([]);
+    expect(trace.unresolvedRefs).toEqual([]);
+  });
+});

--- a/assistant/src/tools/network/script-proxy/__tests__/policy.test.ts
+++ b/assistant/src/tools/network/script-proxy/__tests__/policy.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect } from 'bun:test';
+import { evaluateRequest, evaluateRequestWithApproval } from '../policy.js';
+import type { CredentialInjectionTemplate } from '../../../credentials/policy-types.js';
+
+function makeTemplate(overrides: Partial<CredentialInjectionTemplate> = {}): CredentialInjectionTemplate {
+  return {
+    hostPattern: '*.example.com',
+    injectionType: 'header',
+    headerName: 'Authorization',
+    valuePrefix: 'Bearer ',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// evaluateRequest
+// ---------------------------------------------------------------------------
+
+describe('evaluateRequest', () => {
+  test('returns unauthenticated when no credential IDs', () => {
+    const result = evaluateRequest('api.example.com', '/', [], new Map());
+    expect(result.kind).toBe('unauthenticated');
+  });
+
+  test('returns missing when credential has no templates', () => {
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], new Map());
+    expect(result.kind).toBe('missing');
+  });
+
+  test('returns missing when no template matches the host', () => {
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.other.com' })]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('missing');
+  });
+
+  test('returns matched for exact host match', () => {
+    const tpl = makeTemplate({ hostPattern: 'api.example.com' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('matched');
+    if (result.kind === 'matched') {
+      expect(result.credentialId).toBe('cred-1');
+      expect(result.template).toBe(tpl);
+    }
+  });
+
+  test('returns matched for wildcard host match', () => {
+    const tpl = makeTemplate({ hostPattern: '*.example.com' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('matched');
+    if (result.kind === 'matched') {
+      expect(result.credentialId).toBe('cred-1');
+    }
+  });
+
+  test('prefers exact match over wildcard for same credential', () => {
+    const wildcard = makeTemplate({ hostPattern: '*.example.com', headerName: 'X-Wildcard' });
+    const exact = makeTemplate({ hostPattern: 'api.example.com', headerName: 'X-Exact' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [wildcard, exact]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('matched');
+    if (result.kind === 'matched') {
+      expect(result.template.headerName).toBe('X-Exact');
+    }
+  });
+
+  test('returns ambiguous for same-specificity tie within one credential', () => {
+    const tpl1 = makeTemplate({ hostPattern: '*.example.com', headerName: 'X-One' });
+    const tpl2 = makeTemplate({ hostPattern: '*.example.com', headerName: 'X-Two' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl1, tpl2]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  test('returns ambiguous for cross-credential match', () => {
+    const tpl1 = makeTemplate({ hostPattern: '*.example.com' });
+    const tpl2 = makeTemplate({ hostPattern: '*.example.com' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl1]);
+    templates.set('cred-2', [tpl2]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1', 'cred-2'], templates);
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  test('skips query-type injection templates', () => {
+    const tpl = makeTemplate({
+      hostPattern: '*.example.com',
+      injectionType: 'query',
+      queryParamName: 'api_key',
+      headerName: undefined,
+    });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl]);
+    const result = evaluateRequest('api.example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('missing');
+  });
+
+  test('wildcard with includeApexForWildcard matches bare domain', () => {
+    const tpl = makeTemplate({ hostPattern: '*.example.com' });
+    const templates = new Map<string, CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [tpl]);
+    const result = evaluateRequest('example.com', '/', ['cred-1'], templates);
+    expect(result.kind).toBe('matched');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateRequestWithApproval
+// ---------------------------------------------------------------------------
+
+describe('evaluateRequestWithApproval', () => {
+  test('passes through matched decisions', () => {
+    const tpl = makeTemplate({ hostPattern: 'api.example.com' });
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    sessionTemplates.set('cred-1', [tpl]);
+    const result = evaluateRequestWithApproval(
+      'api.example.com', null, '/',
+      ['cred-1'], sessionTemplates, [],
+    );
+    expect(result.kind).toBe('matched');
+  });
+
+  test('passes through ambiguous decisions', () => {
+    const tpl1 = makeTemplate({ hostPattern: '*.example.com', headerName: 'X-One' });
+    const tpl2 = makeTemplate({ hostPattern: '*.example.com', headerName: 'X-Two' });
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    sessionTemplates.set('cred-1', [tpl1, tpl2]);
+    const result = evaluateRequestWithApproval(
+      'api.example.com', null, '/',
+      ['cred-1'], sessionTemplates, [],
+    );
+    expect(result.kind).toBe('ambiguous');
+  });
+
+  test('returns ask_missing_credential when known templates match', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [makeTemplate({ hostPattern: '*.example.com' })];
+    const result = evaluateRequestWithApproval(
+      'api.example.com', 443, '/api',
+      ['cred-1'], sessionTemplates, allKnown,
+    );
+    expect(result.kind).toBe('ask_missing_credential');
+    if (result.kind === 'ask_missing_credential') {
+      expect(result.target.hostname).toBe('api.example.com');
+      expect(result.target.port).toBe(443);
+      expect(result.target.path).toBe('/api');
+      expect(result.matchingPatterns).toContain('*.example.com');
+    }
+  });
+
+  test('deduplicates matching patterns', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [
+      makeTemplate({ hostPattern: '*.example.com', headerName: 'X-One' }),
+      makeTemplate({ hostPattern: '*.example.com', headerName: 'X-Two' }),
+    ];
+    const result = evaluateRequestWithApproval(
+      'api.example.com', null, '/',
+      ['cred-1'], sessionTemplates, allKnown,
+    );
+    expect(result.kind).toBe('ask_missing_credential');
+    if (result.kind === 'ask_missing_credential') {
+      expect(result.matchingPatterns).toEqual(['*.example.com']);
+    }
+  });
+
+  test('returns ask_unauthenticated when no known templates match and no credentials', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const result = evaluateRequestWithApproval(
+      'unknown.example.com', null, '/',
+      [], sessionTemplates, [],
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+    if (result.kind === 'ask_unauthenticated') {
+      expect(result.target.hostname).toBe('unknown.example.com');
+      expect(result.target.scheme).toBe('https');
+    }
+  });
+
+  test('returns ask_unauthenticated for unknown host even with known templates for other hosts', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [makeTemplate({ hostPattern: '*.other.com' })];
+    const result = evaluateRequestWithApproval(
+      'unknown.example.com', null, '/',
+      [], sessionTemplates, allKnown,
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+  });
+
+  test('skips query templates when scanning allKnownTemplates', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const allKnown = [makeTemplate({
+      hostPattern: '*.example.com',
+      injectionType: 'query',
+      queryParamName: 'key',
+      headerName: undefined,
+    })];
+    const result = evaluateRequestWithApproval(
+      'api.example.com', null, '/',
+      ['cred-1'], sessionTemplates, allKnown,
+    );
+    // Query templates are skipped, so no pattern matches → ask_unauthenticated
+    // But credentialIds is non-empty so base is 'missing' → then no known header templates → ask_unauthenticated
+    // Actually: credentialIds=['cred-1'] but sessionTemplates is empty → base='missing'
+    // allKnown only has query type → no header matches → falls through to ask_unauthenticated
+    // Wait: base is 'missing' (not unauthenticated), and uniquePatterns.length===0
+    // For 'missing' with no matching patterns, the function returns ask_unauthenticated
+    expect(result.kind).toBe('ask_unauthenticated');
+  });
+
+  test('uses provided scheme parameter', () => {
+    const sessionTemplates = new Map<string, CredentialInjectionTemplate[]>();
+    const result = evaluateRequestWithApproval(
+      'unknown.example.com', 80, '/',
+      [], sessionTemplates, [], 'http',
+    );
+    expect(result.kind).toBe('ask_unauthenticated');
+    if (result.kind === 'ask_unauthenticated') {
+      expect(result.target.scheme).toBe('http');
+    }
+  });
+});

--- a/assistant/src/tools/network/script-proxy/__tests__/router.test.ts
+++ b/assistant/src/tools/network/script-proxy/__tests__/router.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test';
+import { routeConnection } from '../router.js';
+import type { CredentialInjectionTemplate } from '../../../credentials/policy-types.js';
+
+function makeTemplate(overrides: Partial<CredentialInjectionTemplate> = {}): CredentialInjectionTemplate {
+  return {
+    hostPattern: '*.example.com',
+    injectionType: 'header',
+    headerName: 'Authorization',
+    valuePrefix: 'Bearer ',
+    ...overrides,
+  };
+}
+
+describe('routeConnection', () => {
+  test('tunnels when no credentials', () => {
+    const result = routeConnection('api.example.com', 443, [], new Map());
+    expect(result.action).toBe('tunnel');
+    expect(result.reason).toBe('tunnel:no_credentials');
+  });
+
+  test('tunnels when credentials exist but no template matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.other.com' })]);
+    const result = routeConnection('api.example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('tunnel');
+    expect(result.reason).toBe('tunnel:no_rewrite');
+  });
+
+  test('tunnels when credential has no templates in map', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    const result = routeConnection('api.example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('tunnel');
+    expect(result.reason).toBe('tunnel:no_rewrite');
+  });
+
+  test('MITMs when wildcard template matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.example.com' })]);
+    const result = routeConnection('api.example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('mitm');
+    expect(result.reason).toBe('mitm:credential_injection');
+  });
+
+  test('MITMs when exact template matches', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: 'api.example.com' })]);
+    const result = routeConnection('api.example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('mitm');
+    expect(result.reason).toBe('mitm:credential_injection');
+  });
+
+  test('MITMs when any credential matches (first wins)', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.other.com' })]);
+    templates.set('cred-2', [makeTemplate({ hostPattern: '*.example.com' })]);
+    const result = routeConnection('api.example.com', 443, ['cred-1', 'cred-2'], templates);
+    expect(result.action).toBe('mitm');
+    expect(result.reason).toBe('mitm:credential_injection');
+  });
+
+  test('wildcard matches bare apex domain with includeApexForWildcard', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.example.com' })]);
+    const result = routeConnection('example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('mitm');
+    expect(result.reason).toBe('mitm:credential_injection');
+  });
+
+  test('case-insensitive matching', () => {
+    const templates = new Map<string, readonly CredentialInjectionTemplate[]>();
+    templates.set('cred-1', [makeTemplate({ hostPattern: '*.EXAMPLE.COM' })]);
+    const result = routeConnection('API.example.com', 443, ['cred-1'], templates);
+    expect(result.action).toBe('mitm');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 18 tests for `policy.ts` covering matched/missing/unauthenticated/ambiguous decisions, query template exclusion, wildcard vs exact specificity, cross-credential ambiguity, and approval hook outcomes (ask_missing_credential, ask_unauthenticated)
- Add 8 tests for `router.ts` covering tunnel vs MITM routing decisions based on credential matching, case-insensitive host matching, and apex domain inclusion
- Add 26 tests for `logging.ts` covering header sanitization, URL query param redaction, safe log entry construction, query string stripping, decision trace building for all policy decision kinds, and credential ref traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
