### PR TITLE
fix: combined-run test isolation for workspace-git suite

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -1,14 +1,23 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import type { CommitContext } from '../workspace/commit-message-provider.js';
+
+// ---------------------------------------------------------------------------
+// Guard against module mock leakage from earlier test files (e.g. session-queue).
+// Re-register the real workspace modules so our static imports bind to them.
+// The ?real query string forces Bun to bypass the mock cache.
+// ---------------------------------------------------------------------------
+mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
+
 import {
   CommitEnrichmentService,
   _resetEnrichmentService,
 } from '../workspace/commit-message-enrichment-service.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
-import type { CommitContext } from '../workspace/commit-message-provider.js';
 
 describe('CommitEnrichmentService', () => {
   let testDir: string;

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -26,10 +26,16 @@ function ensureTestDir(): void {
   }
 }
 
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of ['info', 'warn', 'error', 'debug', 'trace', 'fatal', 'silent', 'child']) {
+    stub[m] = m === 'child' ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
 mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, {
-    get: () => () => {},
-  }),
+  getLogger: () => makeLoggerStub(),
 }));
 
 mock.module('../util/platform.js', () => ({
@@ -49,10 +55,6 @@ import { _setBackend } from '../security/secure-keys.js';
 import { loadConfig, invalidateConfigCache } from '../config/loader.js';
 import { AssistantConfigSchema } from '../config/schema.js';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
-
-afterAll(() => {
-  mock.restore();
-});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test, beforeEach } from 'bun:test';
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
 import { rmSync, writeFileSync } from 'node:fs';
 import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent, CheckpointInfo, CheckpointDecision } from '../agent/loop.js';
@@ -295,10 +295,6 @@ beforeEach(() => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
-});
-
-afterAll(() => {
-  mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -1,8 +1,19 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
+
+// ---------------------------------------------------------------------------
+// Guard against module mock leakage from earlier test files (e.g. session-queue).
+// Re-register the real workspace modules so our static imports bind to them.
+// The ?real query string forces Bun to bypass the mock cache.
+// ---------------------------------------------------------------------------
+mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+mock.module('../workspace/heartbeat-service.js', async () => await import('../workspace/heartbeat-service.js?real'));
+mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
+
 import {
   WorkspaceGitService,
   _resetGitServiceRegistry,
@@ -12,7 +23,6 @@ import {
   _resetHeartbeatState,
 } from '../workspace/heartbeat-service.js';
 import { _resetEnrichmentService, getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
-import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
 
 describe('HeartbeatService', () => {
   let testDir: string;


### PR DESCRIPTION
Fixes #5305 - Fix combined-run test isolation for the workspace-git test matrix.

- Replace no-op proxy logger with recursive stub supporting child() in session-queue and config-schema tests
- Wrap turnCommitHangForever flag in try/finally for guaranteed cleanup
- Add ?real import guards in enrichment and heartbeat test files to bypass mock leakage from session-queue
- Remove harmful afterAll mock.restore() calls that globally undo mocks needed by later test files

Note: workspace-git-service.test.ts has a pre-existing failure (`data/` gitignore normalization) that exists on main independently of these changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
