### PR TITLE
fix: match video thumbnail and player size (no black bars)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -18,10 +18,33 @@ struct InlineVideoAttachmentView: View {
     @State private var isPlaying = false
     @State private var isLoading = false
     @State private var failed = false
-    @State private var videoAspectRatio: CGFloat = 3.0 / 4.0
+    @State private var videoAspectRatio: CGFloat
     @State private var isHovering = false
     @State private var isSaving = false
     @State private var thumbnailImage: NSImage?
+
+    init(attachment: ChatAttachment, daemonHttpPort: Int?) {
+        self.attachment = attachment
+        self.daemonHttpPort = daemonHttpPort
+
+        if let img = attachment.thumbnailImage {
+            // Use pixel dimensions for accurate aspect ratio (immune to DPI metadata).
+            var w: CGFloat = 0
+            var h: CGFloat = 0
+            if let rep = img.representations.first {
+                w = CGFloat(rep.pixelsWide)
+                h = CGFloat(rep.pixelsHigh)
+            }
+            if w <= 0 || h <= 0 {
+                w = img.size.width
+                h = img.size.height
+            }
+            _videoAspectRatio = State(initialValue: w > 0 && h > 0 ? w / h : 3.0 / 4.0)
+            _thumbnailImage = State(initialValue: img)
+        } else {
+            _videoAspectRatio = State(initialValue: 3.0 / 4.0)
+        }
+    }
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -76,7 +99,7 @@ struct InlineVideoAttachmentView: View {
             if let thumbnailImage {
                 Image(nsImage: thumbnailImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .aspectRatio(contentMode: .fit)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             }
 
@@ -144,18 +167,8 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func generateThumbnail() async {
-        // Prefer the server-provided thumbnail (already decoded by mapIPCAttachments).
-        if let serverImage = attachment.thumbnailImage {
-            let w = serverImage.size.width
-            let h = serverImage.size.height
-            await MainActor.run {
-                if w > 0, h > 0 {
-                    videoAspectRatio = w / h
-                }
-                thumbnailImage = serverImage
-            }
-            return
-        }
+        // Server thumbnail and aspect ratio are set eagerly in init.
+        if thumbnailImage != nil { return }
 
         // Fallback: extract thumbnail from inline video data.
         guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }


### PR DESCRIPTION
## Summary
- Eagerly set `videoAspectRatio` and `thumbnailImage` in `init` from the server-provided thumbnail's pixel dimensions, so the container is correctly sized from the first render
- Changed thumbnail from `.fill` to `.fit` to match the video player's rendering behavior — prevents the thumbnail from appearing bigger by cropping
- Short-circuit `generateThumbnail()` when thumbnail is already set from init

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
