### PR TITLE
test: add playbook tools tests

### DIFF
--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -1,0 +1,352 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'playbook-tools-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({ memory: {} }),
+}));
+
+// Stub memory job queue to avoid side effects
+mock.module('../memory/jobs-store.js', () => ({
+  enqueueMemoryJob: () => {},
+}));
+
+import type { Database } from 'bun:sqlite';
+import { initializeDb, getDb } from '../memory/db.js';
+import type { ToolContext } from '../tools/types.js';
+
+// Register playbook tools
+await import('../tools/playbooks/index.js');
+
+import { getTool } from '../tools/registry.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+const ctx: ToolContext = {
+  workingDir: '/tmp',
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+};
+
+function clearPlaybooks(): void {
+  getRawDb().run("DELETE FROM memory_items WHERE kind = 'playbook'");
+}
+
+function extractPlaybookId(content: string): string {
+  const match = content.match(/ID: (\S+)/);
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+// ── playbook_create ─────────────────────────────────────────────────
+
+describe('playbook_create tool', () => {
+  beforeEach(clearPlaybooks);
+
+  const tool = getTool('playbook_create')!;
+
+  test('creates a playbook with required fields', async () => {
+    const result = await tool.execute({
+      trigger: 'meeting request',
+      action: 'check calendar, propose 3 times',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Playbook created successfully');
+    expect(result.content).toContain('meeting request');
+    expect(result.content).toContain('check calendar, propose 3 times');
+    expect(result.content).toContain('Autonomy: draft for review'); // default
+    expect(result.content).toContain('Channel: *'); // default
+    expect(result.content).toContain('Category: general'); // default
+    expect(result.content).toContain('Priority: 0'); // default
+  });
+
+  test('creates a playbook with all optional fields', async () => {
+    const result = await tool.execute({
+      trigger: 'from:ceo@*',
+      action: 'prioritize and draft response',
+      channel: 'email',
+      category: 'triage',
+      autonomy_level: 'auto',
+      priority: 10,
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('from:ceo@*');
+    expect(result.content).toContain('Channel: email');
+    expect(result.content).toContain('Category: triage');
+    expect(result.content).toContain('Autonomy: execute automatically');
+    expect(result.content).toContain('Priority: 10');
+  });
+
+  test('creates with notify autonomy level', async () => {
+    const result = await tool.execute({
+      trigger: 'newsletter',
+      action: 'archive',
+      autonomy_level: 'notify',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Autonomy: notify only');
+  });
+
+  test('rejects duplicate playbook', async () => {
+    await tool.execute({
+      trigger: 'unique trigger',
+      action: 'unique action',
+    }, ctx);
+
+    const result = await tool.execute({
+      trigger: 'unique trigger',
+      action: 'unique action',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('already exists');
+  });
+
+  test('rejects missing trigger', async () => {
+    const result = await tool.execute({
+      action: 'do something',
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('trigger is required');
+  });
+
+  test('rejects missing action', async () => {
+    const result = await tool.execute({
+      trigger: 'test trigger',
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('action is required');
+  });
+});
+
+// ── playbook_list ───────────────────────────────────────────────────
+
+describe('playbook_list tool', () => {
+  beforeEach(clearPlaybooks);
+
+  const createTool = getTool('playbook_create')!;
+  const listTool = getTool('playbook_list')!;
+
+  test('returns empty message when no playbooks exist', async () => {
+    const result = await listTool.execute({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No playbooks found');
+  });
+
+  test('lists all playbooks', async () => {
+    await createTool.execute({
+      trigger: 'meeting request',
+      action: 'check calendar',
+    }, ctx);
+    await createTool.execute({
+      trigger: 'newsletter',
+      action: 'archive it',
+    }, ctx);
+
+    const result = await listTool.execute({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Found 2 playbook(s)');
+    expect(result.content).toContain('meeting request');
+    expect(result.content).toContain('newsletter');
+  });
+
+  test('filters by channel', async () => {
+    await createTool.execute({
+      trigger: 'email trigger',
+      action: 'handle email',
+      channel: 'email',
+    }, ctx);
+    await createTool.execute({
+      trigger: 'slack trigger',
+      action: 'handle slack',
+      channel: 'slack',
+    }, ctx);
+
+    const result = await listTool.execute({ channel: 'email' }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('email trigger');
+    expect(result.content).not.toContain('slack trigger');
+  });
+
+  test('filters by category', async () => {
+    await createTool.execute({
+      trigger: 'scheduling trigger',
+      action: 'schedule it',
+      category: 'scheduling',
+    }, ctx);
+    await createTool.execute({
+      trigger: 'triage trigger',
+      action: 'triage it',
+      category: 'triage',
+    }, ctx);
+
+    const result = await listTool.execute({ category: 'scheduling' }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('scheduling trigger');
+    expect(result.content).not.toContain('triage trigger');
+  });
+
+  test('includes wildcard channel playbooks in channel filter', async () => {
+    await createTool.execute({
+      trigger: 'wildcard trigger',
+      action: 'handle anything',
+      channel: '*',
+    }, ctx);
+
+    const result = await listTool.execute({ channel: 'email' }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('wildcard trigger');
+  });
+});
+
+// ── playbook_update ─────────────────────────────────────────────────
+
+describe('playbook_update tool', () => {
+  beforeEach(clearPlaybooks);
+
+  const createTool = getTool('playbook_create')!;
+  const updateTool = getTool('playbook_update')!;
+
+  test('updates the trigger', async () => {
+    const createResult = await createTool.execute({
+      trigger: 'old trigger',
+      action: 'do something',
+    }, ctx);
+    const id = extractPlaybookId(createResult.content);
+
+    const result = await updateTool.execute({
+      playbook_id: id,
+      trigger: 'new trigger',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Playbook updated successfully');
+    expect(result.content).toContain('new trigger');
+  });
+
+  test('updates multiple fields at once', async () => {
+    const createResult = await createTool.execute({
+      trigger: 'test',
+      action: 'old action',
+    }, ctx);
+    const id = extractPlaybookId(createResult.content);
+
+    const result = await updateTool.execute({
+      playbook_id: id,
+      action: 'new action',
+      channel: 'slack',
+      category: 'notifications',
+      autonomy_level: 'auto',
+      priority: 5,
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('new action');
+    expect(result.content).toContain('Channel: slack');
+    expect(result.content).toContain('Category: notifications');
+    expect(result.content).toContain('Autonomy: execute automatically');
+    expect(result.content).toContain('Priority: 5');
+  });
+
+  test('rejects missing playbook_id', async () => {
+    const result = await updateTool.execute({
+      trigger: 'new trigger',
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('playbook_id is required');
+  });
+
+  test('returns error for nonexistent playbook_id', async () => {
+    const result = await updateTool.execute({
+      playbook_id: 'nonexistent',
+      trigger: 'test',
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+});
+
+// ── playbook_delete ─────────────────────────────────────────────────
+
+describe('playbook_delete tool', () => {
+  beforeEach(clearPlaybooks);
+
+  const createTool = getTool('playbook_create')!;
+  const deleteTool = getTool('playbook_delete')!;
+  const listTool = getTool('playbook_list')!;
+
+  test('deletes a playbook', async () => {
+    const createResult = await createTool.execute({
+      trigger: 'delete me',
+      action: 'to be deleted',
+    }, ctx);
+    const id = extractPlaybookId(createResult.content);
+
+    const result = await deleteTool.execute({ playbook_id: id }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Playbook deleted');
+    expect(result.content).toContain('delete me');
+
+    // Verify it no longer appears in list
+    const listResult = await listTool.execute({}, ctx);
+    expect(listResult.content).toContain('No playbooks found');
+  });
+
+  test('rejects missing playbook_id', async () => {
+    const result = await deleteTool.execute({}, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('playbook_id is required');
+  });
+
+  test('returns error for nonexistent playbook_id', async () => {
+    const result = await deleteTool.execute({ playbook_id: 'nonexistent' }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive tests for all 4 playbook tools: `playbook_create`, `playbook_list`, `playbook_update`, `playbook_delete`
- 18 test cases covering CRUD operations, duplicate detection, channel/category filtering, wildcard channel inclusion, multi-field updates, soft-delete behavior, and validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
