### PR TITLE
fix: remove black bars from inline video player

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -399,6 +399,7 @@ private struct VideoPlayerView: NSViewRepresentable {
         let view = AVPlayerView()
         view.player = player
         view.controlsStyle = .inline
+        view.videoGravity = .resizeAspectFill
         view.showsFullScreenToggleButton = true
         return view
     }


### PR DESCRIPTION
## Summary
- Set `videoGravity = .resizeAspectFill` on AVPlayerView to fill the container edge-to-edge
- Eliminates the black letterbox bars caused by the inline controls bar reserving vertical space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
