### PR TITLE
fix: resolve all TypeScript type-check errors

### DIFF
--- a/assistant/src/__tests__/call-recovery.test.ts
+++ b/assistant/src/__tests__/call-recovery.test.ts
@@ -98,7 +98,7 @@ function createMockProvider(statusMap: Record<string, string> = {}): VoiceProvid
 /** Silent logger for tests */
 const silentLog = new Proxy({} as Record<string, unknown>, {
   get: () => () => {},
-}) as ReturnType<typeof import('../util/logger.js').getLogger>;
+}) as unknown as ReturnType<typeof import('../util/logger.js').getLogger>;
 
 describe('listRecoverableCalls', () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -10,7 +10,9 @@ import type { CommitContext } from '../workspace/commit-message-provider.js';
 // Re-register the real workspace modules so our static imports bind to them.
 // The ?real query string forces Bun to bypass the mock cache.
 // ---------------------------------------------------------------------------
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import {

--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -18,6 +18,17 @@ import { requestComputerControlTool } from '../tools/computer-use/request-comput
 import { forwardComputerUseProxyTool } from '../tools/computer-use/skill-proxy-bridge.js';
 import type { ToolContext } from '../tools/types.js';
 
+interface JsonSchema {
+  type?: string;
+  required?: string[];
+  properties?: Record<string, unknown>;
+}
+
+/** Cast a tool definition's input_schema to a usable JSON Schema shape. */
+function schema(tool: { getDefinition(): { input_schema: object } }): JsonSchema {
+  return tool.getDefinition().input_schema as JsonSchema;
+}
+
 const ctx: ToolContext = {
   workingDir: '/tmp',
   sessionId: 'test-session',
@@ -70,12 +81,11 @@ describe('click tool variants', () => {
     });
 
     test(`${tool.name} schema requires reasoning`, () => {
-      const def = tool.getDefinition();
-      expect(def.input_schema.required).toContain('reasoning');
+      expect(schema(tool).required).toContain('reasoning');
     });
 
     test(`${tool.name} schema supports element_id and coordinates`, () => {
-      const props = tool.getDefinition().input_schema.properties as Record<string, { type: string }>;
+      const props = schema(tool).properties as Record<string, { type: string }>;
       expect(props.element_id.type).toBe('integer');
       expect(props.x.type).toBe('integer');
       expect(props.y.type).toBe('integer');
@@ -91,9 +101,8 @@ describe('click tool variants', () => {
 
 describe('computer_use_type_text', () => {
   test('requires text and reasoning', () => {
-    const def = computerUseTypeTextTool.getDefinition();
-    expect(def.input_schema.required).toContain('text');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseTypeTextTool).required).toContain('text');
+    expect(schema(computerUseTypeTextTool).required).toContain('reasoning');
   });
 
   test('execute throws proxy error', () => {
@@ -105,9 +114,8 @@ describe('computer_use_type_text', () => {
 
 describe('computer_use_key', () => {
   test('requires key and reasoning', () => {
-    const def = computerUseKeyTool.getDefinition();
-    expect(def.input_schema.required).toContain('key');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseKeyTool).required).toContain('key');
+    expect(schema(computerUseKeyTool).required).toContain('reasoning');
   });
 
   test('execute throws proxy error', () => {
@@ -119,14 +127,13 @@ describe('computer_use_key', () => {
 
 describe('computer_use_scroll', () => {
   test('requires direction, amount, and reasoning', () => {
-    const def = computerUseScrollTool.getDefinition();
-    expect(def.input_schema.required).toContain('direction');
-    expect(def.input_schema.required).toContain('amount');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseScrollTool).required).toContain('direction');
+    expect(schema(computerUseScrollTool).required).toContain('amount');
+    expect(schema(computerUseScrollTool).required).toContain('reasoning');
   });
 
   test('direction enum includes up, down, left, right', () => {
-    const props = computerUseScrollTool.getDefinition().input_schema.properties as Record<string, { enum?: string[] }>;
+    const props = schema(computerUseScrollTool).properties as Record<string, { enum?: string[] }>;
     expect(props.direction.enum).toEqual(['up', 'down', 'left', 'right']);
   });
 });
@@ -135,7 +142,7 @@ describe('computer_use_scroll', () => {
 
 describe('computer_use_drag', () => {
   test('supports source and destination coordinates', () => {
-    const props = computerUseDragTool.getDefinition().input_schema.properties as Record<string, { type: string }>;
+    const props = schema(computerUseDragTool).properties as Record<string, { type: string }>;
     expect(props.element_id.type).toBe('integer');
     expect(props.to_element_id.type).toBe('integer');
     expect(props.x.type).toBe('integer');
@@ -145,8 +152,7 @@ describe('computer_use_drag', () => {
   });
 
   test('requires reasoning only', () => {
-    const def = computerUseDragTool.getDefinition();
-    expect(def.input_schema.required).toEqual(['reasoning']);
+    expect(schema(computerUseDragTool).required).toEqual(['reasoning']);
   });
 });
 
@@ -154,9 +160,8 @@ describe('computer_use_drag', () => {
 
 describe('computer_use_wait', () => {
   test('requires duration_ms and reasoning', () => {
-    const def = computerUseWaitTool.getDefinition();
-    expect(def.input_schema.required).toContain('duration_ms');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseWaitTool).required).toContain('duration_ms');
+    expect(schema(computerUseWaitTool).required).toContain('reasoning');
   });
 });
 
@@ -164,9 +169,8 @@ describe('computer_use_wait', () => {
 
 describe('computer_use_open_app', () => {
   test('requires app_name and reasoning', () => {
-    const def = computerUseOpenAppTool.getDefinition();
-    expect(def.input_schema.required).toContain('app_name');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseOpenAppTool).required).toContain('app_name');
+    expect(schema(computerUseOpenAppTool).required).toContain('reasoning');
   });
 });
 
@@ -174,9 +178,8 @@ describe('computer_use_open_app', () => {
 
 describe('computer_use_run_applescript', () => {
   test('requires script and reasoning', () => {
-    const def = computerUseRunAppleScriptTool.getDefinition();
-    expect(def.input_schema.required).toContain('script');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseRunAppleScriptTool).required).toContain('script');
+    expect(schema(computerUseRunAppleScriptTool).required).toContain('reasoning');
   });
 
   test('description warns against do shell script', () => {
@@ -189,8 +192,7 @@ describe('computer_use_run_applescript', () => {
 
 describe('computer_use_done', () => {
   test('requires summary', () => {
-    const def = computerUseDoneTool.getDefinition();
-    expect(def.input_schema.required).toContain('summary');
+    expect(schema(computerUseDoneTool).required).toContain('summary');
   });
 });
 
@@ -198,9 +200,8 @@ describe('computer_use_done', () => {
 
 describe('computer_use_respond', () => {
   test('requires answer and reasoning', () => {
-    const def = computerUseRespondTool.getDefinition();
-    expect(def.input_schema.required).toContain('answer');
-    expect(def.input_schema.required).toContain('reasoning');
+    expect(schema(computerUseRespondTool).required).toContain('answer');
+    expect(schema(computerUseRespondTool).required).toContain('reasoning');
   });
 });
 
@@ -208,8 +209,7 @@ describe('computer_use_respond', () => {
 
 describe('computer_use_request_control', () => {
   test('requires task parameter', () => {
-    const def = requestComputerControlTool.getDefinition();
-    expect(def.input_schema.required).toContain('task');
+    expect(schema(requestComputerControlTool).required).toContain('task');
   });
 
   test('execute throws proxy error', () => {

--- a/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
@@ -36,6 +36,7 @@ export const FAKE_SELFIE_ATTACHMENT: StoredAttachment = {
   mimeType: 'image/png',
   sizeBytes: Buffer.from(TINY_PNG_BASE64, 'base64').length,
   kind: 'image',
+  thumbnailBase64: null,
   createdAt: NOW,
 };
 
@@ -47,6 +48,7 @@ export const FAKE_DOCUMENT_ATTACHMENT: StoredAttachment = {
   mimeType: 'application/pdf',
   sizeBytes: 4096,
   kind: 'document',
+  thumbnailBase64: null,
   createdAt: NOW,
 };
 
@@ -58,6 +60,7 @@ export const FAKE_PHOTO_ATTACHMENT: StoredAttachment = {
   mimeType: 'image/jpeg',
   sizeBytes: Buffer.from(TINY_JPEG_BASE64, 'base64').length,
   kind: 'image',
+  thumbnailBase64: null,
   createdAt: NOW,
 };
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -462,6 +462,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     id: 'wi-001',
     approvedTools: ['bash', 'file_write'],
   },
+  work_item_cancel: {
+    type: 'work_item_cancel',
+    id: 'wi-001',
+  },
   document_save: {
     type: 'document_save',
     surfaceId: 'doc-001',
@@ -1365,6 +1369,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   work_item_approve_permissions_response: {
     type: 'work_item_approve_permissions_response',
+    id: 'wi-001',
+    success: true,
+  },
+  work_item_cancel_response: {
+    type: 'work_item_cancel_response',
     id: 'wi-001',
     success: true,
   },

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -103,6 +103,7 @@ describe('tool audit listener', () => {
       durationMs: 9,
       errorMessage: 'boom',
       isExpected: false,
+      errorCategory: 'tool_failure',
     });
 
     expect(records).toHaveLength(1);

--- a/assistant/src/__tests__/tool-domain-event-publisher.test.ts
+++ b/assistant/src/__tests__/tool-domain-event-publisher.test.ts
@@ -190,6 +190,7 @@ describe('createToolDomainEventPublisher', () => {
       durationMs: 12,
       errorMessage: 'cat: /missing: No such file or directory',
       isExpected: false,
+      errorCategory: 'tool_failure',
       errorName: 'Error',
       errorStack: 'Error: cat: /missing: No such file or directory',
     });
@@ -229,6 +230,7 @@ describe('createToolDomainEventPublisher', () => {
       durationMs: 9,
       errorMessage: 'ENOENT',
       isExpected: false,
+      errorCategory: 'tool_failure',
       errorName: 'Error',
       errorStack: 'Error: ENOENT\n    at test',
     });

--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -10,8 +10,11 @@ import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '
 // Re-register the real workspace modules so our static imports bind to them.
 // The ?real query string forces Bun to bypass the mock cache.
 // ---------------------------------------------------------------------------
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/turn-commit.js', async () => await import('../workspace/turn-commit.js?real'));
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import { commitTurnChanges } from '../workspace/turn-commit.js';

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -10,8 +10,11 @@ import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '
 // Re-register the real workspace modules so our static imports bind to them.
 // The ?real query string forces Bun to bypass the mock cache.
 // ---------------------------------------------------------------------------
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/heartbeat-service.js', async () => await import('../workspace/heartbeat-service.js?real'));
+// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
 mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import {

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -53,7 +53,7 @@ function normalizeCardShowData(input: Record<string, unknown>, rawData: Record<s
     normalized.body = '';
   }
 
-  return normalized as CardSurfaceData;
+  return normalized as unknown as CardSurfaceData;
 }
 
 function normalizeTaskProgressCardPatch(existingCard: CardSurfaceData, patch: Record<string, unknown>): Record<string, unknown> {

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -214,7 +214,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_RESULTS);
     const stmt = raw.prepare(
-      `SELECT a.id, a.assistant_id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.created_at
+      `SELECT a.id, a.assistant_id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
        FROM attachments a
        WHERE ${whereParts.join(' AND ')}
        ORDER BY a.created_at DESC
@@ -228,6 +228,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       mime_type: string;
       size_bytes: number;
       kind: string;
+      thumbnail_base64: string | null;
       created_at: number;
     }>;
 
@@ -238,6 +239,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       mimeType: r.mime_type,
       sizeBytes: r.size_bytes,
       kind: r.kind,
+      thumbnailBase64: r.thumbnail_base64,
       createdAt: r.created_at,
     }));
   }
@@ -254,6 +256,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       mimeType: attachments.mimeType,
       sizeBytes: attachments.sizeBytes,
       kind: attachments.kind,
+      thumbnailBase64: attachments.thumbnailBase64,
       createdAt: attachments.createdAt,
     })
     .from(attachments)


### PR DESCRIPTION
## Summary
- Fix all `tsc --noEmit` errors that were failing CI on main
- Add missing properties (`thumbnailBase64`, `errorCategory`, `work_item_cancel`) to test fixtures and IPC snapshots
- Add `@ts-expect-error` for Bun-specific `?real` module imports that TypeScript can't resolve
- Use proper type assertions for `input_schema` property access and Logger/CardSurfaceData casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
