### PR TITLE
fix: use floating video controls to eliminate letterbox bars

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -398,8 +398,7 @@ private struct VideoPlayerView: NSViewRepresentable {
     func makeNSView(context: Context) -> AVPlayerView {
         let view = AVPlayerView()
         view.player = player
-        view.controlsStyle = .inline
-        view.videoGravity = .resizeAspectFill
+        view.controlsStyle = .floating
         view.showsFullScreenToggleButton = true
         return view
     }


### PR DESCRIPTION
## Summary
- Switch `controlsStyle` from `.inline` to `.floating` — controls now overlay on the video instead of reserving vertical space
- Revert `videoGravity` from `.resizeAspectFill` back to default `.resizeAspect` — no more cropping
- Result: video fills the container edge-to-edge with no black bars and no cropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
