### PR TITLE
fix: send session_switch IPC on thread activation to keep socket binding in sync

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -460,6 +460,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func activateThread(_ id: UUID) {
         activeThreadId = id
+
+        // Notify the daemon so it rebinds the socket to this thread's session.
+        // Without this, socketToSession stays stale after thread switches,
+        // causing ownership checks (e.g. subagent abort) to fail.
+        if let sessionId = chatViewModels[id]?.sessionId {
+            try? daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+        }
     }
 
     /// Derive a short title from the first user message, truncated at a word boundary around 50 chars.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -27,6 +27,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 if !isRestoringThreads {
                     lastActiveThreadIdString = activeThreadId.uuidString
                 }
+                // Notify the daemon so it rebinds the socket to this thread's session.
+                // Without this, socketToSession stays stale after thread switches,
+                // causing ownership checks (e.g. subagent abort) to fail.
+                if let sessionId = chatViewModels[activeThreadId]?.sessionId {
+                    try? daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+                }
             } else {
                 lastActiveThreadIdString = nil
             }
@@ -460,13 +466,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func activateThread(_ id: UUID) {
         activeThreadId = id
-
-        // Notify the daemon so it rebinds the socket to this thread's session.
-        // Without this, socketToSession stays stale after thread switches,
-        // causing ownership checks (e.g. subagent abort) to fail.
-        if let sessionId = chatViewModels[id]?.sessionId {
-            try? daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
-        }
     }
 
     /// Derive a short title from the first user message, truncated at a word boundary around 50 chars.

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1724,6 +1724,12 @@ extension IPCEnvVarsRequest {
 /// Backed by generated `IPCEnvVarsResponse`.
 public typealias EnvVarsResponseMessage = IPCEnvVarsResponse
 
+extension IPCSessionSwitchRequest {
+    public init(sessionId: String) {
+        self.init(type: "session_switch", sessionId: sessionId)
+    }
+}
+
 /// Wraps any ServerMessage emitted by a subagent session for routing to the client.
 /// Hand-maintained because `event` is a recursive `ServerMessage` reference (codegen skips ServerMessage).
 /// Wire type: `"subagent_event"`


### PR DESCRIPTION
## Summary
- Send `session_switch` IPC message when user switches threads via `ThreadManager.activateThread`
- This keeps the daemon's `socketToSession` map in sync with the active thread
- Previously, the socket binding only updated when a message was sent, causing `socketToSession` to be stale after thread switches
- Fixes subagent abort ownership check failures and other session-scoped operations after thread switching
- Adds convenience `init(sessionId:)` extension on generated `IPCSessionSwitchRequest`

## Test plan
- [ ] Manual: Switch between threads, verify subagent abort works on the thread you switched back to
- [ ] Manual: Send a message on Thread A, switch to Thread B (no message), switch back to Thread A, click abort on a running subagent — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
