### PR TITLE
fix: prevent image extraction inside code fences and validate HTTP image cache

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -171,13 +171,9 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
         i += 1
     }
 
-    // If a fence was never closed, emit accumulated code block lines as text
+    // If a fence was never closed, emit as a code block (e.g. during streaming)
     if fenceDelimiter != nil {
-        let fenceChar = fenceDelimiter!.character
-        let fenceLen = fenceDelimiter!.length
-        let opener = String(repeating: String(fenceChar), count: fenceLen) + (codeBlockLanguage ?? "")
-        currentText.append(opener)
-        currentText.append(contentsOf: codeBlockLines)
+        segments.append(.codeBlock(language: codeBlockLanguage, code: codeBlockLines.joined(separator: "\n")))
     }
 
     flushText()

--- a/clients/shared/Features/Chat/ImageCache.swift
+++ b/clients/shared/Features/Chat/ImageCache.swift
@@ -32,7 +32,10 @@ public actor ImageCache {
         }
 
         let task = Task<Data, Error> {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await URLSession.shared.data(from: url)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                throw URLError(.badServerResponse)
+            }
             return data
         }
 


### PR DESCRIPTION
## Summary
- Unclosed code fences (common during streaming) now emit as `.codeBlock` instead of `.text`, preventing `extractImageSegments` from rendering image markdown (`![alt](url)`) inside code blocks as actual images
- `ImageCache` now validates HTTP status codes (200-299) before caching response data, preventing error response bodies from being permanently cached as images

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/3514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
