### PR TITLE
M2: Slash Collision Preference Config

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -207,4 +207,5 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       denyCategories: [],
     },
   },
+  slashCollisionPreference: 'ask',
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -9,6 +9,7 @@ const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
+const VALID_SLASH_COLLISION_PREFERENCES = ['ask', 'prefer_vellum', 'prefer_cc'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -1062,6 +1063,11 @@ export const AssistantConfigSchema = z.object({
       denyCategories: [],
     },
   }),
+  slashCollisionPreference: z
+    .enum(VALID_SLASH_COLLISION_PREFERENCES, {
+      error: `slashCollisionPreference must be one of: ${VALID_SLASH_COLLISION_PREFERENCES.join(', ')}`,
+    })
+    .default('ask'),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -1121,3 +1127,4 @@ export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;
 export type CallsConfig = z.infer<typeof CallsConfigSchema>;
 export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;
 export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
+export type SlashCollisionPreference = z.infer<typeof AssistantConfigSchema>['slashCollisionPreference'];

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -33,4 +33,5 @@ export type {
   CallsConfig,
   CallsDisclosureConfig,
   CallsSafetyConfig,
+  SlashCollisionPreference,
 } from './schema.js';


### PR DESCRIPTION
## Summary
- Added `slashCollisionPreference` field to `AssistantConfigSchema` with values: `ask` (default), `prefer_vellum`, `prefer_cc`
- Exported `SlashCollisionPreference` type from config types

Part of #5396
Closes #5399
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
