### PR TITLE
Add recurrence syntax primitives (no behavior change)

### DIFF
--- a/assistant/src/__tests__/recurrence-types.test.ts
+++ b/assistant/src/__tests__/recurrence-types.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import { detectScheduleSyntax, normalizeScheduleSyntax, type ScheduleSyntax } from '../schedule/recurrence-types.js';
+
+describe('detectScheduleSyntax', () => {
+  test('detects cron for standard 5-field expressions', () => {
+    expect(detectScheduleSyntax('0 9 * * 1-5')).toBe('cron');
+    expect(detectScheduleSyntax('*/5 * * * *')).toBe('cron');
+    expect(detectScheduleSyntax('30 14 1 * *')).toBe('cron');
+    expect(detectScheduleSyntax('0 0 * * 0')).toBe('cron');
+  });
+
+  test('detects RRULE for RRULE: prefix', () => {
+    expect(detectScheduleSyntax('RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0')).toBe('rrule');
+  });
+
+  test('detects RRULE for DTSTART + RRULE multiline', () => {
+    expect(detectScheduleSyntax('DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY')).toBe('rrule');
+  });
+
+  test('detects RRULE for expression containing FREQ=', () => {
+    expect(detectScheduleSyntax('FREQ=WEEKLY;BYDAY=MO,WE,FR')).toBe('rrule');
+  });
+
+  test('returns null for empty/invalid input', () => {
+    expect(detectScheduleSyntax('')).toBeNull();
+    expect(detectScheduleSyntax('   ')).toBeNull();
+    expect(detectScheduleSyntax('hello world')).toBeNull();
+    expect(detectScheduleSyntax('not a schedule expression at all and is long')).toBeNull();
+  });
+
+  test('returns null for ambiguous expressions', () => {
+    // Single word that is not 5 fields and not RRULE
+    expect(detectScheduleSyntax('daily')).toBeNull();
+  });
+});
+
+describe('normalizeScheduleSyntax', () => {
+  test('uses explicit syntax + expression when both provided', () => {
+    const result = normalizeScheduleSyntax({
+      syntax: 'rrule',
+      expression: 'RRULE:FREQ=DAILY',
+    });
+    expect(result).toEqual({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' });
+  });
+
+  test('auto-detects syntax from expression', () => {
+    const cronResult = normalizeScheduleSyntax({ expression: '0 9 * * 1-5' });
+    expect(cronResult).toEqual({ syntax: 'cron', expression: '0 9 * * 1-5' });
+
+    const rruleResult = normalizeScheduleSyntax({ expression: 'RRULE:FREQ=DAILY' });
+    expect(rruleResult).toEqual({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' });
+  });
+
+  test('falls back to legacyCronExpression', () => {
+    const result = normalizeScheduleSyntax({ legacyCronExpression: '0 9 * * *' });
+    expect(result).toEqual({ syntax: 'cron', expression: '0 9 * * *' });
+  });
+
+  test('returns null when nothing is provided', () => {
+    expect(normalizeScheduleSyntax({})).toBeNull();
+  });
+
+  test('returns null when expression is ambiguous and no syntax hint', () => {
+    expect(normalizeScheduleSyntax({ expression: 'daily' })).toBeNull();
+  });
+
+  test('trusts explicit syntax when auto-detection fails', () => {
+    const result = normalizeScheduleSyntax({ syntax: 'cron', expression: 'some-custom-expr' });
+    expect(result).toEqual({ syntax: 'cron', expression: 'some-custom-expr' });
+  });
+});

--- a/assistant/src/schedule/recurrence-types.ts
+++ b/assistant/src/schedule/recurrence-types.ts
@@ -1,0 +1,67 @@
+export type ScheduleSyntax = 'cron' | 'rrule';
+
+/**
+ * Detect whether an expression string is cron or RRULE syntax.
+ * Returns null for ambiguous or invalid expressions.
+ */
+export function detectScheduleSyntax(expression: string): ScheduleSyntax | null {
+  if (!expression || typeof expression !== 'string') return null;
+  const trimmed = expression.trim();
+  if (!trimmed) return null;
+
+  // RRULE detection: starts with RRULE:, DTSTART, or contains FREQ=
+  if (/^(RRULE:|DTSTART)/m.test(trimmed) || /FREQ=/i.test(trimmed)) {
+    return 'rrule';
+  }
+
+  // Cron detection: 5 space-separated fields
+  const fields = trimmed.split(/\s+/);
+  if (fields.length === 5) {
+    // Basic sanity check: each field should match cron-like characters
+    const cronFieldPattern = /^[\d\*\/\-\,\?LW#]+$/;
+    if (fields.every(f => cronFieldPattern.test(f))) {
+      return 'cron';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Normalize schedule syntax from tool/API inputs.
+ * Resolution order:
+ * 1. If explicit `syntax` is provided, use it
+ * 2. If `expression` is provided, auto-detect from expression
+ * 3. If `legacyCronExpression` is provided, treat as cron
+ * 4. Return null if nothing resolved
+ */
+export function normalizeScheduleSyntax(input: {
+  syntax?: ScheduleSyntax;
+  expression?: string;
+  legacyCronExpression?: string;
+}): { syntax: ScheduleSyntax; expression: string } | null {
+  // Explicit syntax + expression
+  if (input.syntax && input.expression) {
+    return { syntax: input.syntax, expression: input.expression };
+  }
+
+  // Auto-detect from expression
+  if (input.expression) {
+    const detected = detectScheduleSyntax(input.expression);
+    if (detected) {
+      return { syntax: detected, expression: input.expression };
+    }
+    // If we have an explicit syntax but couldn't detect, trust the explicit syntax
+    if (input.syntax) {
+      return { syntax: input.syntax, expression: input.expression };
+    }
+    return null;
+  }
+
+  // Legacy cron_expression fallback
+  if (input.legacyCronExpression) {
+    return { syntax: 'cron', expression: input.legacyCronExpression };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Introduces `ScheduleSyntax = 'cron' | 'rrule'` type
- Adds `detectScheduleSyntax()` to auto-detect expression syntax
- Adds `normalizeScheduleSyntax()` for tool/API input resolution
- Pure helper module with no side effects or runtime behavior changes

## Test plan
- [x] Unit tests for cron detection (5-field expressions)
- [x] Unit tests for RRULE detection (RRULE: prefix, DTSTART, FREQ=)
- [x] Unit tests for null/ambiguous input handling
- [x] Unit tests for normalizeScheduleSyntax resolution order
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
