### PR TITLE
fix: tighten DoorDash command match to avoid false positives

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -202,7 +202,7 @@ export function createToolExecutor(
     // Auto-emit task_progress card on first DoorDash CLI command
     if (name === 'bash' && !result.isError) {
       const cmd = input.command as string | undefined;
-      if (cmd?.includes('vellum doordash') && !ctx.surfaceState.has('doordash-progress')) {
+      if (cmd && /(?:^|[;&|]\s*)vellum doordash\b/.test(cmd) && !ctx.surfaceState.has('doordash-progress')) {
         const surfaceId = 'doordash-progress';
         const data = {
           title: 'Ordering from DoorDash',


### PR DESCRIPTION
## Summary
- Use regex `/(?:^|[;&|]\s*)vellum doordash\b/` instead of `includes('vellum doordash')` to only match actual command invocations, not arbitrary substrings like `echo "vellum doordash"`

## Test plan
- [ ] `vellum doordash status --json` still triggers auto-emit
- [ ] `echo "vellum doordash"` does NOT trigger auto-emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
