### PR TITLE
fix: dismiss sidebar on click-outside

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -437,6 +437,16 @@ struct MainWindowView: View {
 
                         // Sidebar drawer
                         if sidebarVisible {
+                            // Click-outside-to-dismiss scrim (overlay mode only)
+                            if !sidebarPushesContent {
+                                Color.clear
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        withAnimation(.easeInOut(duration: 0.35)) {
+                                            sidebarOpen = false
+                                        }
+                                    }
+                            }
                             HStack(spacing: 0) {
                                 sidebarView
                                 drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)


### PR DESCRIPTION
## Summary
- Add a transparent click-outside-to-dismiss scrim behind the sidebar drawer when it's in overlay mode (chat routes)
- Sidebar in push mode (panel routes) is unaffected since it doesn't obscure content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
