### PR TITLE
feat: add TemporaryChatIndicator pill for exiting temporary chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -372,6 +372,11 @@ struct MainWindowView: View {
                                 threadManager.createThread()
                             }
                         }
+                        if threadManager.activeThread?.kind == .private {
+                            Spacer().frame(width: VSpacing.sm)
+                            TemporaryChatIndicator(onExit: { toggleTemporaryChat() })
+                                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                        }
                         Spacer()
                         if windowState.isShowingChat {
                             // Copy Thread button

--- a/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct TemporaryChatIndicator: View {
+    let onExit: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onExit) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "circle.dashed")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(VColor.accent)
+                Text("Temporary")
+                    .font(VFont.caption)
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(isHovered ? VColor.textSecondary : VColor.textMuted)
+            }
+        }
+        .buttonStyle(TemporaryChatIndicatorStyle(isHovered: isHovered))
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.set() }
+            else { NSCursor.arrow.set() }
+        }
+        .accessibilityLabel("Exit temporary chat")
+    }
+}
+
+private struct TemporaryChatIndicatorStyle: ButtonStyle {
+    let isHovered: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(VColor.textPrimary)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.buttonV)
+            .background(backgroundColor(isPressed: configuration.isPressed))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.pill)
+                    .stroke(VColor.textSecondary, lineWidth: 1)
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(VAnimation.fast, value: configuration.isPressed)
+            .animation(VAnimation.fast, value: isHovered)
+    }
+
+    private func backgroundColor(isPressed: Bool) -> Color {
+        if isPressed { return VColor.ghostPressed }
+        if isHovered { return VColor.ghostHover }
+        return VColor.surfaceBorder
+    }
+}
+
+#Preview("TemporaryChatIndicator") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        TemporaryChatIndicator(onExit: {})
+            .padding()
+    }
+    .frame(width: 250, height: 80)
+}


### PR DESCRIPTION
## Summary
- Creates a new TemporaryChatIndicator view — a pill showing dashed circle icon + 'Temporary' label + X dismiss icon
- Integrates the indicator into the left side of the MainWindowView top bar, visible when in temporary chat mode
- Clicking the pill calls toggleTemporaryChat() to exit back to the previous thread
- Styled consistently with VIconButton (same padding, radius, hover/press states, cursor behavior)

Closes #5391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
