### PR TITLE
fix: add CLI setup instructions to DoorDash skill

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -7,6 +7,18 @@ metadata: {"vellum": {"emoji": "\uD83C\uDF55"}}
 
 You can order food from DoorDash for the user using the `vellum doordash` CLI.
 
+## CLI Setup
+
+`vellum doordash` is a built-in subcommand of the Vellum assistant CLI — it is NOT a separate tool you need to find or install. It should already be on your PATH. If `vellum` is not found, run:
+```
+export PATH="$HOME/.local/bin:$PATH"
+```
+If that still fails, invoke the CLI directly via bun:
+```
+bun run ~/vellum/workspace/vellum-assistant/assistant/src/index.ts doordash <subcommand> --json
+```
+Do NOT search for the binary, inspect `vel` wrapper scripts, or try to discover how the CLI works. Just run the commands as documented below.
+
 ## Task Progress Widget
 
 A task progress card is shown automatically when you run your first `vellum doordash` command. Its surface ID is `doordash-progress`. As each step completes, call `ui_update` with surface ID `doordash-progress` to update step statuses. Update `data.templateData.steps` — set completed steps to `"status": "completed"` with a `"detail"` string, the current step to `"status": "in_progress"`, and future steps to `"status": "pending"`. Adapt the steps to the actual flow (e.g. skip "Search restaurants" if the user named a specific store).

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -202,7 +202,7 @@ export function createToolExecutor(
     // Auto-emit task_progress card on first DoorDash CLI command
     if (name === 'bash' && !result.isError) {
       const cmd = input.command as string | undefined;
-      if (cmd?.includes('vellum doordash') && !ctx.surfaceState.has('doordash-progress')) {
+      if (cmd && /(?:^|[;&|]\s*)vellum doordash\b/.test(cmd) && !ctx.surfaceState.has('doordash-progress')) {
         const surfaceId = 'doordash-progress';
         const data = {
           title: 'Ordering from DoorDash',


### PR DESCRIPTION
## Summary
- Add a "CLI Setup" section to DoorDash SKILL.md explaining that `vellum doordash` is a built-in subcommand, not something to discover
- Provide PATH fix and direct bun fallback for when `vellum` isn't on PATH
- Explicitly tell the model NOT to search for the binary or inspect wrapper scripts

## Test plan
- [ ] Load DoorDash skill and ask to order food — assistant should run `vellum doordash status --json` directly without searching for the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
