### PR TITLE
fix: use host_bash for DoorDash CLI and match in auto-emit

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -9,15 +9,9 @@ You can order food from DoorDash for the user using the `vellum doordash` CLI.
 
 ## CLI Setup
 
-`vellum doordash` is a built-in subcommand of the Vellum assistant CLI — it is NOT a separate tool you need to find or install. It should already be on your PATH. If `vellum` is not found, run:
-```
-export PATH="$HOME/.local/bin:$PATH"
-```
-If that still fails, invoke the CLI directly via bun:
-```
-bun run ~/vellum/workspace/vellum-assistant/assistant/src/index.ts doordash <subcommand> --json
-```
-Do NOT search for the binary, inspect `vel` wrapper scripts, or try to discover how the CLI works. Just run the commands as documented below.
+**IMPORTANT: Always use `host_bash` (not `bash`) for all `vellum doordash` commands.** The DoorDash CLI needs host access for Chrome CDP, session cookies, and the `vellum` binary — none of which are available inside the sandbox.
+
+`vellum doordash` is a built-in subcommand of the Vellum assistant CLI — it is NOT a separate tool you need to find or install. It should already be on your PATH. If `vellum` is not found, prepend `PATH="$HOME/.local/bin:$PATH"` to the command. Do NOT search for the binary, inspect wrapper scripts, or try to discover how the CLI works. Just run the commands as documented below.
 
 ## Task Progress Widget
 

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -200,7 +200,7 @@ export function createToolExecutor(
     }
 
     // Auto-emit task_progress card on first DoorDash CLI command
-    if (name === 'bash' && !result.isError) {
+    if ((name === 'bash' || name === 'host_bash') && !result.isError) {
       const cmd = input.command as string | undefined;
       if (cmd && /(?:^|[;&|]\s*)vellum doordash\b/.test(cmd) && !ctx.surfaceState.has('doordash-progress')) {
         const surfaceId = 'doordash-progress';


### PR DESCRIPTION
## Summary
- Update SKILL.md to instruct the model to always use `host_bash` for `vellum doordash` commands (needs Chrome CDP, session cookies, vellum binary)
- Update auto-emit check to trigger on both `bash` and `host_bash` tool names

## Test plan
- [ ] Load DoorDash skill — model uses `host_bash` for `vellum doordash` commands
- [ ] Auto-emit task_progress card fires when using `host_bash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
