### PR TITLE
bench: add context window compaction benchmark

### DIFF
--- a/assistant/src/__tests__/compaction.benchmark.test.ts
+++ b/assistant/src/__tests__/compaction.benchmark.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Context Window Compaction Benchmark
+ *
+ * Measures compaction cost with a mock provider:
+ * - compaction latency under threshold pressure
+ * - no-op fast path for below-threshold histories
+ * - token reduction ratio after compaction
+ * - summary call count within expected range
+ * - severe pressure overriding cooldown
+ */
+import { describe, expect, mock, test } from 'bun:test';
+
+import { DEFAULT_CONFIG } from '../config/defaults.js';
+import { ContextWindowManager } from '../context/window-manager.js';
+import { estimatePromptTokens } from '../context/token-estimator.js';
+import type { Message, Provider } from '../providers/types.js';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+function makeSummaryProvider(counter: { calls: number }): Provider {
+  return {
+    name: 'mock',
+    async sendMessage() {
+      counter.calls += 1;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `## Goals\n- Preserve state\n## Constraints\n- Keep PRs small\n## Decisions\n- Call ${counter.calls}`,
+          },
+        ],
+        model: 'mock-model',
+        usage: { inputTokens: 420, outputTokens: 85 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+}
+
+function makeLongMessages(turns: number): Message[] {
+  const rows: Message[] = [];
+  for (let i = 0; i < turns; i++) {
+    rows.push({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: `[U${i}] User message with enough content to estimate tokens. Topic ${i % 9}.`,
+        },
+      ],
+    });
+    rows.push({
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: `[A${i}] Assistant response with relevant content. Result ${i % 7}.`,
+        },
+      ],
+    });
+  }
+  return rows;
+}
+
+function makeConfig() {
+  return {
+    ...DEFAULT_CONFIG.contextWindow,
+    maxInputTokens: 6000,
+    targetInputTokens: 3200,
+    compactThreshold: 0.6,
+    preserveRecentUserTurns: 8,
+    chunkTokens: 1200,
+  };
+}
+
+describe('Compaction benchmark', () => {
+  test('compaction with mock provider completes under 500ms', async () => {
+    const counter = { calls: 0 };
+    const provider = makeSummaryProvider(counter);
+    const config = makeConfig();
+    const manager = new ContextWindowManager(provider, 'system prompt', config);
+
+    // 90 turns = 180 messages, well above 60% of 6000 = 3600 threshold
+    const messages = makeLongMessages(90);
+    const before = estimatePromptTokens(messages, 'system prompt', {
+      providerName: 'mock',
+    });
+    expect(before).toBeGreaterThan(config.maxInputTokens * config.compactThreshold);
+
+    const start = performance.now();
+    const result = await manager.maybeCompact(messages);
+    const elapsed = performance.now() - start;
+
+    expect(result.compacted).toBe(true);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('below-threshold check returns in under 10ms (no-op)', async () => {
+    const counter = { calls: 0 };
+    const provider = makeSummaryProvider(counter);
+    const config = makeConfig();
+    const manager = new ContextWindowManager(provider, 'system prompt', config);
+
+    // 3 turns = 6 messages, well below threshold
+    const messages = makeLongMessages(3);
+
+    const start = performance.now();
+    const result = await manager.maybeCompact(messages);
+    const elapsed = performance.now() - start;
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('below compaction threshold');
+    expect(elapsed).toBeLessThan(10);
+    expect(counter.calls).toBe(0);
+  });
+
+  test('token reduction ratio exceeds 30% after compaction', async () => {
+    const counter = { calls: 0 };
+    const provider = makeSummaryProvider(counter);
+    const config = makeConfig();
+    const manager = new ContextWindowManager(provider, 'system prompt', config);
+
+    const messages = makeLongMessages(90);
+    const result = await manager.maybeCompact(messages);
+
+    expect(result.compacted).toBe(true);
+    const reductionRatio =
+      (result.previousEstimatedInputTokens - result.estimatedInputTokens) /
+      result.previousEstimatedInputTokens;
+    expect(reductionRatio).toBeGreaterThan(0.3);
+  });
+
+  test('summary calls fall within 2-6 range', async () => {
+    const counter = { calls: 0 };
+    const provider = makeSummaryProvider(counter);
+    const config = makeConfig();
+    const manager = new ContextWindowManager(provider, 'system prompt', config);
+
+    const messages = makeLongMessages(90);
+    const result = await manager.maybeCompact(messages);
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryCalls).toBeGreaterThanOrEqual(2);
+    expect(result.summaryCalls).toBeLessThanOrEqual(6);
+    expect(result.summaryCalls).toBe(counter.calls);
+  });
+
+  test('severe pressure triggers compaction even during cooldown', async () => {
+    const counter = { calls: 0 };
+    const provider = makeSummaryProvider(counter);
+    // Use a tighter maxInputTokens so 90 turns exceeds the 95% severe threshold
+    const config = {
+      ...makeConfig(),
+      maxInputTokens: 4000,
+      targetInputTokens: 2000,
+    };
+    const manager = new ContextWindowManager(provider, 'system prompt', config);
+
+    const messages = makeLongMessages(90);
+    const estimated = estimatePromptTokens(messages, 'system prompt', {
+      providerName: 'mock',
+    });
+    expect(estimated).toBeGreaterThan(config.maxInputTokens * 0.95);
+
+    // Simulate being within cooldown by setting lastCompactedAt to now
+    const result = await manager.maybeCompact(messages, undefined, {
+      lastCompactedAt: Date.now(),
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compaction.benchmark.test.ts` measuring context window compaction cost with a mock provider
- Tests compaction latency (<500ms), no-op fast path (<10ms), token reduction ratio (>30%), summary call count (2-6), and severe pressure overriding cooldown
- Uses the same mock provider and message builder patterns as the existing memory-context-benchmark

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/compaction.benchmark.test.ts` — 5/5 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
