### PR TITLE
fix: remove scaleEffect from TemporaryChatIndicator to fix click handling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
@@ -44,7 +44,6 @@ private struct TemporaryChatIndicatorStyle: ButtonStyle {
                 RoundedRectangle(cornerRadius: VRadius.pill)
                     .stroke(VColor.textSecondary, lineWidth: 1)
             )
-            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
             .animation(VAnimation.fast, value: configuration.isPressed)
             .animation(VAnimation.fast, value: isHovered)
     }


### PR DESCRIPTION
## Summary
- Removes `.scaleEffect(configuration.isPressed ? 0.97 : 1.0)` from `TemporaryChatIndicatorStyle`
- This coordinate transform interfered with click handling in the macOS title bar zone, causing the button to not respond to clicks
- Now matches the `VIconButtonStyle` pattern exactly, which works reliably for other buttons in the same area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
