### PR TITLE
fix: cursor stuck + indicator visibility on non-chat views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -372,7 +372,7 @@ struct MainWindowView: View {
                                 threadManager.createThread()
                             }
                         }
-                        if threadManager.activeThread?.kind == .private {
+                        if windowState.isShowingChat, threadManager.activeThread?.kind == .private {
                             Spacer().frame(width: VSpacing.sm)
                             TemporaryChatIndicator(onExit: { toggleTemporaryChat() })
                                 .transition(.opacity.combined(with: .scale(scale: 0.9)))

--- a/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatIndicator.swift
@@ -22,9 +22,10 @@ struct TemporaryChatIndicator: View {
         .buttonStyle(TemporaryChatIndicatorStyle(isHovered: isHovered))
         .onHover { hovering in
             isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
+            if hovering { NSCursor.pointingHand.push() }
+            else { NSCursor.pop() }
         }
+        .onDisappear { if isHovered { NSCursor.pop() } }
         .accessibilityLabel("Exit temporary chat")
     }
 }


### PR DESCRIPTION
Addresses Codex+Devin feedback on #5434:
- Fix cursor stuck as pointing hand when TemporaryChatIndicator is removed (use push/pop + onDisappear)
- Gate TemporaryChatIndicator on windowState.isShowingChat to match TemporaryChatToggle behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
