### PR TITLE
M5: System Prompt, /commands, and Documentation

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1,0 +1,33 @@
+# Architecture
+
+## Slash Command Routing
+
+### Dual-source slash routing
+
+Slash commands (`/command-name`) can originate from two sources:
+
+1. **Vellum skills** — Installed in `~/.vellum/workspace/skills/`, loaded via `skill_load`.
+2. **CC commands** — Markdown files in `.claude/commands/*.md`, discovered by walking up from the working directory.
+
+When a user types `/something`, the router checks both sources and dispatches accordingly.
+
+### Scoped CC command registry
+
+CC command discovery walks up the directory tree from `cwd`, scanning for `.claude/commands/` directories at each level. The nearest directory wins on name collisions (child overrides parent). Results are cached per cwd with a 30-second TTL.
+
+### Collision preference
+
+When a slash command name exists in both Vellum skills and CC commands, the `slashCollisionPreference` config option controls resolution:
+
+- `ask` (default) — Prompt the user to choose which source to use.
+- `prefer_vellum` — Silently pick the Vellum skill.
+- `prefer_cc` — Silently pick the CC command.
+
+### How to add CC commands
+
+1. Create a `.claude/commands/` directory in your project (or any ancestor directory).
+2. Add a `.md` file with the command name as the filename (e.g., `review.md`).
+3. The first non-empty line (after optional YAML frontmatter) becomes the command summary shown in the system prompt.
+4. The full markdown content is used as the command template at execution time.
+
+Valid command names match `[A-Za-z0-9][A-Za-z0-9._-]*`.

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../util/logger.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { getConfig } from './loader.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import { discoverCCCommands } from '../commands/cc-command-registry.js';
 
 const log = getLogger('system-prompt');
 
@@ -81,7 +82,7 @@ export function isOnboardingComplete(): boolean {
  *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
  *   4. Append skills catalog from ~/.vellum/workspace/skills
  */
-export function buildSystemPrompt(): string {
+export function buildSystemPrompt(cwd?: string): string {
   const soulPath = getWorkspacePromptPath('SOUL.md');
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
   const userPath = getWorkspacePromptPath('USER.md');
@@ -124,6 +125,8 @@ export function buildSystemPrompt(): string {
   parts.push(buildWorkspaceReflectionSection());
   parts.push(buildLearningMemorySection());
   parts.push(buildPostToolResponseSection());
+
+  appendCCCommandsCatalog(parts, cwd);
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -933,6 +936,25 @@ function readPromptFile(path: string): string | null {
     log.warn({ err, path }, 'Failed to read prompt file');
     return null;
   }
+}
+
+function appendCCCommandsCatalog(parts: string[], cwd?: string): void {
+  if (!cwd) return;
+
+  const registry = discoverCCCommands(cwd);
+  if (registry.entries.size === 0) return;
+
+  const lines: string[] = [];
+  lines.push('## Claude Code Commands');
+  lines.push('');
+  lines.push('The following Claude Code commands are available via `.claude/commands/`. Users can invoke them with `/command-name` or you can execute them using the `claude_code` tool with the `command` parameter.');
+  lines.push('');
+
+  for (const [, entry] of registry.entries) {
+    lines.push(`- **${entry.name}**: ${entry.summary}`);
+  }
+
+  parts.push(lines.join('\n'));
 }
 
 function appendSkillsCatalog(basePrompt: string): string {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -895,7 +895,7 @@ export class DaemonServer {
         }
         const workingDir = getSandboxWorkingDir();
 
-        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
+        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt(workingDir);
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const memoryPolicy = this.deriveMemoryPolicy(conversationId);


### PR DESCRIPTION
## Summary
- Added CC commands section to system prompt listing available `.claude/commands/*.md` commands
- Updated documentation with dual-source slash routing architecture
- Model now knows about available CC commands for better tool routing

Part of #5396
Closes #5406
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
