### PR TITLE
fix: expire orphan call sessions without provider SID after timeout

### DIFF
--- a/assistant/src/__tests__/call-recovery.test.ts
+++ b/assistant/src/__tests__/call-recovery.test.ts
@@ -203,7 +203,7 @@ describe('reconcileCallsOnStartup', () => {
     // Should complete without error
   });
 
-  test('leaves stale no-SID sessions non-terminal (past grace period)', async () => {
+  test('fails stale no-SID sessions past grace period', async () => {
     const session = createTestCallSession({
       conversationId: 'conv-nosid',
       provider: 'twilio',
@@ -218,10 +218,34 @@ describe('reconcileCallsOnStartup', () => {
 
     const updated = getCallSession(session.id);
     expect(updated).not.toBeNull();
-    // Should NOT be failed — left non-terminal so late webhooks can still deliver the SID
-    expect(updated!.status).toBe('initiated');
-    expect(updated!.endedAt).toBeNull();
-    expect(updated!.lastError).toContain('grace period expired but leaving non-terminal');
+    // Should be failed — orphan session past grace period
+    expect(updated!.status).toBe('failed');
+    expect(updated!.endedAt).not.toBeNull();
+    expect(updated!.lastError).toContain('grace period expired');
+  });
+
+  test('expires pending questions when stale no-SID session is failed', async () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-nosid-pq',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+    // Backdate session so it exceeds the grace period
+    backdateSession(session.id, NO_SID_GRACE_PERIOD_MS + 10_000);
+
+    // Create a pending question
+    createPendingQuestion(session.id, 'Are you still there?');
+    const pendingBefore = getPendingQuestion(session.id);
+    expect(pendingBefore).not.toBeNull();
+    expect(pendingBefore!.status).toBe('pending');
+
+    const provider = createMockProvider();
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    // Pending question should be expired along with the session
+    const pendingAfter = getPendingQuestion(session.id);
+    expect(pendingAfter).toBeNull();
   });
 
   test('skips recent no-SID sessions within grace period', async () => {
@@ -425,7 +449,7 @@ describe('reconcileCallsOnStartup', () => {
   });
 
   test('handles mixed recoverable calls correctly', async () => {
-    // Call 1: no SID, stale — should be left non-terminal (not failed)
+    // Call 1: no SID, stale — should be failed (orphan past grace period)
     const noSid = createTestCallSession({
       conversationId: 'conv-mix1',
       provider: 'twilio',
@@ -465,10 +489,11 @@ describe('reconcileCallsOnStartup', () => {
 
     await reconcileCallsOnStartup(provider, silentLog);
 
-    // No-SID session left non-terminal so late webhooks can still resume it
+    // No-SID session failed — orphan past grace period
     const updatedNoSid = getCallSession(noSid.id);
-    expect(updatedNoSid!.status).toBe('initiated');
-    expect(updatedNoSid!.lastError).toContain('grace period expired but leaving non-terminal');
+    expect(updatedNoSid!.status).toBe('failed');
+    expect(updatedNoSid!.endedAt).not.toBeNull();
+    expect(updatedNoSid!.lastError).toContain('grace period expired');
 
     const updatedCompleted = getCallSession(completed.id);
     expect(updatedCompleted!.status).toBe('completed');

--- a/assistant/src/calls/call-recovery.ts
+++ b/assistant/src/calls/call-recovery.ts
@@ -27,12 +27,12 @@ const defaultLog = getLogger('call-recovery');
  * current non-terminal state so incoming webhooks can still deliver the
  * SID and resume the call normally.
  *
- * Sessions older than this threshold are also left non-terminal (NOT
- * failed) because the state machine rejects transitions out of terminal
- * states, which would strand the call if a late webhook arrives. They
- * are annotated with an error message for operator visibility.
+ * Sessions older than this threshold are transitioned to `failed` to
+ * prevent orphan sessions from creating false "active call" state
+ * indefinitely. 5 minutes is long enough for any legitimate webhook
+ * to arrive; after that the session is considered abandoned.
  */
-export const NO_SID_GRACE_PERIOD_MS = 60_000;
+export const NO_SID_GRACE_PERIOD_MS = 5 * 60_000;
 
 /**
  * Map a Twilio provider status string to our internal CallStatus.
@@ -70,9 +70,11 @@ function isTerminal(status: CallStatus): boolean {
  * For each recoverable call:
  * - If it has a provider SID, fetch the current status from the provider
  *   and transition the call to match.
- * - If no provider SID exists, leave it in its current non-terminal state
- *   so that webhooks carrying the SID can still arrive and resume the call.
- *   The session is annotated with a `lastError` for operator visibility.
+ * - If no provider SID exists and the session is older than the grace
+ *   period, transition it to `failed` to prevent orphan sessions from
+ *   creating false "active call" state indefinitely.
+ * - If no provider SID exists but the session is within the grace period,
+ *   leave it non-terminal so webhooks can still deliver the SID.
  * - If the call transitions to a terminal state, expire any pending questions.
  */
 export async function reconcileCallsOnStartup(
@@ -94,21 +96,31 @@ export async function reconcileCallsOnStartup(
         const sessionAgeMs = Date.now() - session.createdAt;
         const isStale = sessionAgeMs >= NO_SID_GRACE_PERIOD_MS;
 
-        // Never terminalize no-SID sessions. The state machine rejects
-        // transitions out of terminal states, so marking them `failed`
-        // would strand the call if a late webhook delivers the SID.
-        // Instead, annotate with an error and leave them non-terminal.
-        log.info(
-          { callSessionId: session.id, previousStatus: session.status, sessionAgeMs, isStale },
-          isStale
-            ? 'No-SID session past grace period — leaving non-terminal for late webhooks'
-            : 'Skipping recent no-SID session (within grace period, webhooks may still arrive)',
-        );
-        updateCallSession(session.id, {
-          lastError: isStale
-            ? 'Daemon restarted before provider SID persisted; grace period expired but leaving non-terminal for late webhooks'
-            : 'Daemon restarted before provider SID persisted; awaiting webhook',
-        });
+        if (isStale) {
+          // Session is old enough that any legitimate webhook should
+          // have arrived by now.  Transition to `failed` so it no
+          // longer appears as an active call.
+          log.info(
+            { callSessionId: session.id, previousStatus: session.status, sessionAgeMs },
+            'No-SID session past grace period — failing orphan session',
+          );
+          updateCallSession(session.id, {
+            status: 'failed',
+            endedAt: Date.now(),
+            lastError: 'Daemon restarted before provider SID persisted; grace period expired — orphan session failed',
+          });
+          expirePendingQuestions(session.id);
+        } else {
+          // Recent session — webhooks carrying the SID may still arrive.
+          // Leave in its current non-terminal state.
+          log.info(
+            { callSessionId: session.id, previousStatus: session.status, sessionAgeMs },
+            'Skipping recent no-SID session (within grace period, webhooks may still arrive)',
+          );
+          updateCallSession(session.id, {
+            lastError: 'Daemon restarted before provider SID persisted; awaiting webhook',
+          });
+        }
         continue;
       }
 


### PR DESCRIPTION
Addresses Codex P2 feedback on #5384: sessions without a providerCallSid that are older than 5 minutes are now transitioned to 'failed' during recovery, preventing false 'active call' state from persisting indefinitely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
