### PR TITLE
Scoped Slash Command Routing Between Vellum and Claude Code

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1,0 +1,33 @@
+# Architecture
+
+## Slash Command Routing
+
+### Dual-source slash routing
+
+Slash commands (`/command-name`) can originate from two sources:
+
+1. **Vellum skills** — Installed in `~/.vellum/workspace/skills/`, loaded via `skill_load`.
+2. **CC commands** — Markdown files in `.claude/commands/*.md`, discovered by walking up from the working directory.
+
+When a user types `/something`, the router checks both sources and dispatches accordingly.
+
+### Scoped CC command registry
+
+CC command discovery walks up the directory tree from `cwd`, scanning for `.claude/commands/` directories at each level. The nearest directory wins on name collisions (child overrides parent). Results are cached per cwd with a 30-second TTL.
+
+### Collision preference
+
+When a slash command name exists in both Vellum skills and CC commands, the `slashCollisionPreference` config option controls resolution:
+
+- `ask` (default) — Prompt the user to choose which source to use.
+- `prefer_vellum` — Silently pick the Vellum skill.
+- `prefer_cc` — Silently pick the CC command.
+
+### How to add CC commands
+
+1. Create a `.claude/commands/` directory in your project (or any ancestor directory).
+2. Add a `.md` file with the command name as the filename (e.g., `review.md`).
+3. The first non-empty line (after optional YAML frontmatter) becomes the command summary shown in the system prompt.
+4. The full markdown content is used as the command template at execution time.
+
+Valid command names match `[A-Za-z0-9][A-Za-z0-9._-]*`.

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -27,7 +27,7 @@ When a slash command name exists in both Vellum skills and CC commands, the `sla
 
 1. Create a `.claude/commands/` directory in your project (or any ancestor directory).
 2. Add a `.md` file with the command name as the filename (e.g., `review.md`).
-3. The first non-empty line (after optional YAML frontmatter) becomes the command summary shown in the system prompt.
+3. The first non-empty line (after optional YAML frontmatter) becomes the command summary shown in `/commands`.
 4. The full markdown content is used as the command template at execution time.
 
 Valid command names match `[A-Za-z0-9][A-Za-z0-9._-]*`.

--- a/assistant/src/__tests__/claude-code-permission-bubbleup.test.ts
+++ b/assistant/src/__tests__/claude-code-permission-bubbleup.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from 'bun:test';
+import { getProfilePolicy } from '../swarm/worker-backend.js';
+import type { ProfilePolicy } from '../swarm/worker-backend.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate the 5-tier permission check from claude-code.ts canUseTool callback.
+ * Returns the decision that would be made for a given tool under a given policy.
+ */
+function checkToolPermission(
+  policy: ProfilePolicy,
+  toolName: string,
+): 'deny' | 'allow' | 'approval_required' | 'default_allow' {
+  // 1. Deny-list: block unconditionally
+  if (policy.deny.has(toolName)) return 'deny';
+  // 2. Allow-list: auto-approve
+  if (policy.allow.has(toolName)) return 'allow';
+  // 3. Approval-required: bubble up to user
+  if (policy.approvalRequired.has(toolName)) return 'approval_required';
+  // 4. Default: allow (backward compat for tools not in any set)
+  return 'default_allow';
+}
+
+// ---------------------------------------------------------------------------
+// Tests — general profile (5-tier permission check)
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — general profile', () => {
+  const policy = getProfilePolicy('general');
+
+  test('tool in deny set is denied', () => {
+    // general profile has an empty deny set, so we verify the logic
+    // with a synthetic deny entry to prove the tier works
+    const customPolicy: ProfilePolicy = {
+      allow: new Set(policy.allow),
+      deny: new Set(['DangerousTool']),
+      approvalRequired: new Set(policy.approvalRequired),
+    };
+    expect(checkToolPermission(customPolicy, 'DangerousTool')).toBe('deny');
+  });
+
+  test('tool in allow set is allowed', () => {
+    // Read is in the allow set for the general profile
+    expect(policy.allow.has('Read')).toBe(true);
+    expect(checkToolPermission(policy, 'Read')).toBe('allow');
+  });
+
+  test('tool in approvalRequired set requires confirmation', () => {
+    // Bash is in approvalRequired for the general profile
+    expect(policy.approvalRequired.has('Bash')).toBe(true);
+    expect(checkToolPermission(policy, 'Bash')).toBe('approval_required');
+  });
+
+  test('tool not in any set defaults to allowed', () => {
+    // A completely unknown tool should fall through to default_allow
+    expect(policy.deny.has('SomeUnknownTool')).toBe(false);
+    expect(policy.allow.has('SomeUnknownTool')).toBe(false);
+    expect(policy.approvalRequired.has('SomeUnknownTool')).toBe(false);
+    expect(checkToolPermission(policy, 'SomeUnknownTool')).toBe('default_allow');
+  });
+
+  test('deny takes precedence over allow and approvalRequired', () => {
+    // If a tool appears in multiple sets, deny should win because it is checked first
+    const customPolicy: ProfilePolicy = {
+      allow: new Set(['ConflictTool']),
+      deny: new Set(['ConflictTool']),
+      approvalRequired: new Set(['ConflictTool']),
+    };
+    expect(checkToolPermission(customPolicy, 'ConflictTool')).toBe('deny');
+  });
+
+  test('allow takes precedence over approvalRequired', () => {
+    // If a tool appears in both allow and approvalRequired, allow wins (checked second)
+    const customPolicy: ProfilePolicy = {
+      allow: new Set(['OverlapTool']),
+      deny: new Set(),
+      approvalRequired: new Set(['OverlapTool']),
+    };
+    expect(checkToolPermission(customPolicy, 'OverlapTool')).toBe('allow');
+  });
+
+  test('general profile read-only tools are all in allow set', () => {
+    const readOnlyTools = ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS'];
+    for (const tool of readOnlyTools) {
+      expect(policy.allow.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('general profile write tools are in approvalRequired', () => {
+    const writeTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+    for (const tool of writeTools) {
+      expect(policy.approvalRequired.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('approval_required');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — worker profile
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — worker profile', () => {
+  const policy = getProfilePolicy('worker');
+
+  test('all tools in allow set, nothing in deny or approvalRequired', () => {
+    expect(policy.deny.size).toBe(0);
+    expect(policy.approvalRequired.size).toBe(0);
+    expect(policy.allow.size).toBeGreaterThan(0);
+  });
+
+  test('Bash is in allow (no approval needed)', () => {
+    expect(checkToolPermission(policy, 'Bash')).toBe('allow');
+  });
+
+  test('Write tools are in allow (no approval needed)', () => {
+    const writeTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+    for (const tool of writeTools) {
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('Task is in allow', () => {
+    expect(policy.allow.has('Task')).toBe(true);
+    expect(checkToolPermission(policy, 'Task')).toBe('allow');
+  });
+
+  test('read-only tools are in allow', () => {
+    const readOnlyTools = ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS'];
+    for (const tool of readOnlyTools) {
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('unknown tool defaults to allowed (not in any set)', () => {
+    expect(checkToolPermission(policy, 'SomeFutureTool')).toBe('default_allow');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — researcher profile
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — researcher profile', () => {
+  const policy = getProfilePolicy('researcher');
+
+  test('Bash is in deny set', () => {
+    expect(policy.deny.has('Bash')).toBe(true);
+    expect(checkToolPermission(policy, 'Bash')).toBe('deny');
+  });
+
+  test('Write tools are in deny set', () => {
+    const writeTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+    for (const tool of writeTools) {
+      expect(policy.deny.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('deny');
+    }
+  });
+
+  test('read-only tools are in allow set', () => {
+    const readOnlyTools = ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS'];
+    for (const tool of readOnlyTools) {
+      expect(policy.allow.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('approvalRequired is empty', () => {
+    expect(policy.approvalRequired.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — coder profile
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — coder profile', () => {
+  const policy = getProfilePolicy('coder');
+
+  test('Bash is in approvalRequired set', () => {
+    expect(policy.approvalRequired.has('Bash')).toBe(true);
+    expect(checkToolPermission(policy, 'Bash')).toBe('approval_required');
+  });
+
+  test('Write tools are in approvalRequired set', () => {
+    const writeTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+    for (const tool of writeTools) {
+      expect(policy.approvalRequired.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('approval_required');
+    }
+  });
+
+  test('read-only tools are in allow set', () => {
+    const readOnlyTools = ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS'];
+    for (const tool of readOnlyTools) {
+      expect(policy.allow.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('deny set is empty', () => {
+    expect(policy.deny.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — reviewer profile (same access pattern as researcher)
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — reviewer profile', () => {
+  const policy = getProfilePolicy('reviewer');
+
+  test('Bash is in deny set', () => {
+    expect(policy.deny.has('Bash')).toBe(true);
+    expect(checkToolPermission(policy, 'Bash')).toBe('deny');
+  });
+
+  test('Write tools are in deny set', () => {
+    const writeTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+    for (const tool of writeTools) {
+      expect(policy.deny.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('deny');
+    }
+  });
+
+  test('read-only tools are in allow set', () => {
+    const readOnlyTools = ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS'];
+    for (const tool of readOnlyTools) {
+      expect(policy.allow.has(tool)).toBe(true);
+      expect(checkToolPermission(policy, tool)).toBe('allow');
+    }
+  });
+
+  test('approvalRequired is empty', () => {
+    expect(policy.approvalRequired.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — default/fallback profile
+// ---------------------------------------------------------------------------
+
+describe('permission bubble-up — default fallback', () => {
+  test('unknown profile name falls back to general-like policy', () => {
+    // TypeScript types restrict this, but at runtime an invalid string would
+    // hit the default branch which mirrors "general"
+    const policy = getProfilePolicy('nonexistent' as never);
+    expect(policy.allow.has('Read')).toBe(true);
+    expect(policy.deny.size).toBe(0);
+    expect(policy.approvalRequired.has('Bash')).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -85,4 +85,38 @@ describe('claude_code tool profile support', () => {
     );
     expect(result.isError).toBeFalsy();
   });
+
+  test('worker profile allows all tools', () => {
+    const { getProfilePolicy } = require('../swarm/worker-backend.js') as typeof import('../swarm/worker-backend.js');
+    const policy = getProfilePolicy('worker');
+
+    // Worker should allow all tool categories
+    expect(policy.allow.has('Bash')).toBe(true);
+    expect(policy.allow.has('Write')).toBe(true);
+    expect(policy.allow.has('Edit')).toBe(true);
+    expect(policy.allow.has('Task')).toBe(true);
+    expect(policy.allow.has('Read')).toBe(true);
+    expect(policy.allow.has('Glob')).toBe(true);
+    expect(policy.allow.has('Grep')).toBe(true);
+
+    // Deny and approvalRequired should be empty
+    expect(policy.deny.size).toBe(0);
+    expect(policy.approvalRequired.size).toBe(0);
+  });
+
+  test('worker profile is valid in tool definition', () => {
+    const def = claudeCodeTool.getDefinition();
+    const props = (def.input_schema as Record<string, unknown>).properties as Record<string, { enum?: string[] }>;
+    const profileEnum = props.profile.enum;
+    expect(profileEnum).toBeDefined();
+    expect(profileEnum).toContain('worker');
+  });
+
+  test('accepts worker profile without error', async () => {
+    const result = await claudeCodeTool.execute(
+      { prompt: 'test', profile: 'worker' },
+      makeContext(),
+    );
+    expect(result.isError).toBeFalsy();
+  });
 });

--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -30,6 +30,15 @@ function createCommandsDir(base: string, files: Record<string, string>): void {
   }
 }
 
+/** Helper to create a .claude/skills/ directory with markdown files. */
+function createSkillsDir(base: string, files: Record<string, string>): void {
+  const skillsDir = join(base, '.claude', 'skills');
+  mkdirSync(skillsDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(skillsDir, name), content, 'utf-8');
+  }
+}
+
 describe('discoverCCCommands', () => {
   test('discovers commands in .claude/commands/', () => {
     createCommandsDir(tmpDir, {
@@ -45,11 +54,13 @@ describe('discoverCCCommands', () => {
     expect(hello!.name).toBe('hello');
     expect(hello!.summary).toBe('Hello World');
     expect(hello!.source).toBe(tmpDir);
+    expect(hello!.artifactType).toBe('command');
 
     const deploy = registry.entries.get('deploy');
     expect(deploy).toBeDefined();
     expect(deploy!.name).toBe('deploy');
     expect(deploy!.summary).toBe('Deploy the application to production.');
+    expect(deploy!.artifactType).toBe('command');
   });
 
   test('child directory commands override parent on name collisions', () => {
@@ -129,6 +140,107 @@ describe('discoverCCCommands', () => {
     expect(registry.entries.has('parent-only')).toBe(true);
     expect(registry.entries.has('child-only')).toBe(true);
   });
+
+  test('discovers skills in .claude/skills/', () => {
+    createSkillsDir(tmpDir, {
+      'summarize.md': '# Summarize\nSummarize any document.',
+      'translate.md': 'Translate text between languages.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    expect(registry.entries.size).toBe(2);
+
+    const summarize = registry.entries.get('summarize');
+    expect(summarize).toBeDefined();
+    expect(summarize!.name).toBe('summarize');
+    expect(summarize!.summary).toBe('Summarize');
+    expect(summarize!.source).toBe(tmpDir);
+    expect(summarize!.artifactType).toBe('skill');
+
+    const translate = registry.entries.get('translate');
+    expect(translate).toBeDefined();
+    expect(translate!.name).toBe('translate');
+    expect(translate!.summary).toBe('Translate text between languages.');
+    expect(translate!.artifactType).toBe('skill');
+  });
+
+  test('commands take precedence over skills at the same directory level', () => {
+    createCommandsDir(tmpDir, {
+      'shared.md': 'Command version of shared.',
+    });
+    createSkillsDir(tmpDir, {
+      'shared.md': 'Skill version of shared.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const shared = registry.entries.get('shared');
+    expect(shared).toBeDefined();
+    expect(shared!.summary).toBe('Command version of shared.');
+    expect(shared!.artifactType).toBe('command');
+  });
+
+  test('child skill overrides parent command (child wins across levels)', () => {
+    // Parent has a command
+    createCommandsDir(tmpDir, {
+      'analyze.md': 'Parent command version.',
+    });
+
+    // Child has a skill with the same name
+    const childDir = join(tmpDir, 'project');
+    mkdirSync(childDir, { recursive: true });
+    createSkillsDir(childDir, {
+      'analyze.md': 'Child skill version.',
+    });
+
+    const registry = discoverCCCommands(childDir);
+    const analyze = registry.entries.get('analyze');
+    expect(analyze).toBeDefined();
+    expect(analyze!.summary).toBe('Child skill version.');
+    expect(analyze!.artifactType).toBe('skill');
+    expect(analyze!.source).toBe(childDir);
+  });
+
+  test('mixed hierarchy: commands at child, skills at parent', () => {
+    // Parent has skills
+    createSkillsDir(tmpDir, {
+      'parent-skill.md': 'A parent skill.',
+    });
+
+    // Child has commands
+    const childDir = join(tmpDir, 'project');
+    mkdirSync(childDir, { recursive: true });
+    createCommandsDir(childDir, {
+      'child-cmd.md': 'A child command.',
+    });
+
+    const registry = discoverCCCommands(childDir);
+    expect(registry.entries.size).toBe(2);
+
+    const parentSkill = registry.entries.get('parent-skill');
+    expect(parentSkill).toBeDefined();
+    expect(parentSkill!.artifactType).toBe('skill');
+    expect(parentSkill!.source).toBe(tmpDir);
+
+    const childCmd = registry.entries.get('child-cmd');
+    expect(childCmd).toBeDefined();
+    expect(childCmd!.artifactType).toBe('command');
+    expect(childCmd!.source).toBe(childDir);
+  });
+
+  test('skills and commands with different names are both discovered', () => {
+    createCommandsDir(tmpDir, {
+      'deploy.md': 'Deploy command.',
+    });
+    createSkillsDir(tmpDir, {
+      'summarize.md': 'Summarize skill.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    expect(registry.entries.size).toBe(2);
+
+    expect(registry.entries.get('deploy')!.artifactType).toBe('command');
+    expect(registry.entries.get('summarize')!.artifactType).toBe('skill');
+  });
 });
 
 describe('caching', () => {
@@ -165,6 +277,25 @@ describe('caching', () => {
     const first = discoverCCCommands(tmpDir, 0);
     const second = discoverCCCommands(tmpDir, 0);
     expect(first).not.toBe(second); // different object reference due to expired TTL
+  });
+
+  test('cache covers both commands and skills', () => {
+    createCommandsDir(tmpDir, {
+      'cmd.md': 'A command.',
+    });
+    createSkillsDir(tmpDir, {
+      'skl.md': 'A skill.',
+    });
+
+    const first = discoverCCCommands(tmpDir);
+    expect(first.entries.size).toBe(2);
+    expect(first.entries.get('cmd')!.artifactType).toBe('command');
+    expect(first.entries.get('skl')!.artifactType).toBe('skill');
+
+    // Second call returns cached instance with both entries
+    const second = discoverCCCommands(tmpDir);
+    expect(first).toBe(second);
+    expect(second.entries.size).toBe(2);
   });
 });
 

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -140,7 +140,7 @@ export function discoverCCCommands(cwd: string, ttlMs: number = DEFAULT_CACHE_TT
           const nameWithoutExt = basename(file.name, '.md');
 
           // Validate command name
-          if (!COMMAND_NAME_REGEX.test(nameWithoutExt)) {
+          if (!COMMAND_NAME_REGEX.test(nameWithoutExt) || nameWithoutExt.includes('..')) {
             log.warn({ fileName: file.name, dir: commandsDir }, 'Skipping invalid CC command filename');
             continue;
           }

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -13,8 +13,10 @@ export interface CCCommandEntry {
   summary: string;
   /** Absolute path to the .md file. */
   filePath: string;
-  /** Directory containing the `.claude/commands/` folder. */
+  /** Directory containing the `.claude/commands/` or `.claude/skills/` folder. */
   source: string;
+  /** Whether this entry was discovered from a `commands/` or `skills/` directory. */
+  artifactType: 'command' | 'skill';
 }
 
 export interface CCCommandRegistry {
@@ -102,11 +104,73 @@ function extractSummary(content: string): string {
   return '';
 }
 
+// ─── Artifact scanning ───────────────────────────────────────────────────────
+
+/**
+ * Scan a single `.claude/commands/` or `.claude/skills/` directory and add
+ * discovered entries to `entries`. Entries that already exist in the map are
+ * skipped (child-level / higher-precedence entries win).
+ */
+function scanArtifactDir(
+  dir: string,
+  artifactType: 'command' | 'skill',
+  source: string,
+  entries: Map<string, CCCommandEntry>,
+): void {
+  if (!existsSync(dir)) return;
+
+  try {
+    const files = readdirSync(dir, { withFileTypes: true });
+    for (const file of files) {
+      if (!file.isFile()) continue;
+      if (!file.name.endsWith('.md')) continue;
+
+      const nameWithoutExt = basename(file.name, '.md');
+
+      // Validate command name
+      if (!COMMAND_NAME_REGEX.test(nameWithoutExt) || nameWithoutExt.includes('..')) {
+        log.warn({ fileName: file.name, dir }, 'Skipping invalid CC artifact filename');
+        continue;
+      }
+
+      const key = nameWithoutExt.toLowerCase();
+
+      // Skip if already discovered from a closer ancestor or higher-precedence source
+      if (entries.has(key)) continue;
+
+      const filePath = join(dir, file.name);
+
+      let summary = '';
+      try {
+        const head = readFileHead(filePath, SUMMARY_READ_BYTES);
+        summary = extractSummary(head);
+      } catch (err) {
+        log.warn({ err, filePath }, 'Failed to read CC artifact file for summary extraction');
+      }
+
+      entries.set(key, {
+        name: nameWithoutExt,
+        summary,
+        filePath,
+        source,
+        artifactType,
+      });
+    }
+  } catch (err) {
+    log.warn({ err, dir }, 'Failed to read CC artifact directory');
+  }
+}
+
 // ─── Discovery ───────────────────────────────────────────────────────────────
 
 /**
- * Discover `.claude/commands/*.md` files by walking up from `cwd`.
- * Nearest directory wins on name collisions (child overrides parent).
+ * Discover `.claude/commands/*.md` and `.claude/skills/*.md` files by walking
+ * up from `cwd`.
+ *
+ * Precedence rules:
+ * - Child directories win over parent directories (unchanged).
+ * - Within the same directory level, commands take precedence over skills.
+ *
  * Results are cached per cwd with a 30-second TTL.
  */
 export function discoverCCCommands(cwd: string, ttlMs: number = DEFAULT_CACHE_TTL_MS): CCCommandRegistry {
@@ -124,53 +188,16 @@ export function discoverCCCommands(cwd: string, ttlMs: number = DEFAULT_CACHE_TT
   const entries = new Map<string, CCCommandEntry>();
   let current = resolvedCwd;
 
-  // Walk up the directory tree; collect commands from each level.
+  // Walk up the directory tree; collect entries from each level.
   // Since child directories should win on name collisions, we only add entries
   // that haven't been seen yet (first occurrence = nearest ancestor).
+  // At each level, commands are scanned before skills so commands take
+  // precedence over skills with the same name at the same level.
   while (true) {
-    const commandsDir = join(current, '.claude', 'commands');
+    const claudeDir = join(current, '.claude');
 
-    if (existsSync(commandsDir)) {
-      try {
-        const files = readdirSync(commandsDir, { withFileTypes: true });
-        for (const file of files) {
-          if (!file.isFile()) continue;
-          if (!file.name.endsWith('.md')) continue;
-
-          const nameWithoutExt = basename(file.name, '.md');
-
-          // Validate command name
-          if (!COMMAND_NAME_REGEX.test(nameWithoutExt) || nameWithoutExt.includes('..')) {
-            log.warn({ fileName: file.name, dir: commandsDir }, 'Skipping invalid CC command filename');
-            continue;
-          }
-
-          const key = nameWithoutExt.toLowerCase();
-
-          // Child directories win — skip if already discovered from a closer ancestor
-          if (entries.has(key)) continue;
-
-          const filePath = join(commandsDir, file.name);
-
-          let summary = '';
-          try {
-            const head = readFileHead(filePath, SUMMARY_READ_BYTES);
-            summary = extractSummary(head);
-          } catch (err) {
-            log.warn({ err, filePath }, 'Failed to read CC command file for summary extraction');
-          }
-
-          entries.set(key, {
-            name: nameWithoutExt,
-            summary,
-            filePath,
-            source: current,
-          });
-        }
-      } catch (err) {
-        log.warn({ err, commandsDir }, 'Failed to read CC commands directory');
-      }
-    }
+    scanArtifactDir(join(claudeDir, 'commands'), 'command', current, entries);
+    scanArtifactDir(join(claudeDir, 'skills'), 'skill', current, entries);
 
     const parent = dirname(current);
     if (parent === current) break; // reached filesystem root

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -228,4 +228,5 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       denyCategories: [],
     },
   },
+  slashCollisionPreference: 'ask',
 };

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -130,6 +130,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     permissionTimeoutSec: 300,
     toolExecutionTimeoutSec: 120,
     providerStreamTimeoutSec: 300,
+    toolTimeoutOverrides: {},
   },
   sandbox: {
     enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -9,6 +9,7 @@ const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
+const VALID_SLASH_COLLISION_PREFERENCES = ['ask', 'prefer_vellum', 'prefer_cc'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -1163,6 +1164,11 @@ export const AssistantConfigSchema = z.object({
       denyCategories: [],
     },
   }),
+  slashCollisionPreference: z
+    .enum(VALID_SLASH_COLLISION_PREFERENCES, {
+      error: `slashCollisionPreference must be one of: ${VALID_SLASH_COLLISION_PREFERENCES.join(', ')}`,
+    })
+    .default('ask'),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -1223,3 +1229,4 @@ export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;
 export type CallsConfig = z.infer<typeof CallsConfigSchema>;
 export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;
 export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
+export type SlashCollisionPreference = z.infer<typeof AssistantConfigSchema>['slashCollisionPreference'];

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -37,6 +37,12 @@ export const TimeoutConfigSchema = z.object({
     .finite('timeouts.providerStreamTimeoutSec must be finite')
     .positive('timeouts.providerStreamTimeoutSec must be a positive number')
     .default(300),
+  toolTimeoutOverrides: z
+    .record(
+      z.string(),
+      z.number().finite().positive(),
+    )
+    .default({}),
 });
 
 export const DockerConfigSchema = z.object({

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1065,6 +1065,9 @@ export const AssistantConfigSchema = z.object({
       maxInjectTokens: 800,
     },
   }),
+  workingDir: z
+    .string({ error: 'workingDir must be a string' })
+    .optional(),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
     .default(getDataDir()),

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -5,7 +5,6 @@ import { getLogger } from '../util/logger.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { getConfig } from './loader.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
-import { discoverCCCommands } from '../commands/cc-command-registry.js';
 
 const log = getLogger('system-prompt');
 
@@ -82,7 +81,7 @@ export function isOnboardingComplete(): boolean {
  *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
  *   4. Append skills catalog from ~/.vellum/workspace/skills
  */
-export function buildSystemPrompt(cwd?: string): string {
+export function buildSystemPrompt(): string {
   const soulPath = getWorkspacePromptPath('SOUL.md');
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
   const userPath = getWorkspacePromptPath('USER.md');
@@ -125,8 +124,6 @@ export function buildSystemPrompt(cwd?: string): string {
   parts.push(buildWorkspaceReflectionSection());
   parts.push(buildLearningMemorySection());
   parts.push(buildPostToolResponseSection());
-
-  appendCCCommandsCatalog(parts, cwd);
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -950,25 +947,6 @@ function readPromptFile(path: string): string | null {
     log.warn({ err, path }, 'Failed to read prompt file');
     return null;
   }
-}
-
-function appendCCCommandsCatalog(parts: string[], cwd?: string): void {
-  if (!cwd) return;
-
-  const registry = discoverCCCommands(cwd);
-  if (registry.entries.size === 0) return;
-
-  const lines: string[] = [];
-  lines.push('## Claude Code Commands');
-  lines.push('');
-  lines.push('The following Claude Code commands are available via `.claude/commands/`. Users can invoke them with `/command-name` or you can execute them using the `claude_code` tool with the `command` parameter.');
-  lines.push('');
-
-  for (const [, entry] of registry.entries) {
-    lines.push(`- **${entry.name}**: ${entry.summary}`);
-  }
-
-  parts.push(lines.join('\n'));
 }
 
 function appendSkillsCatalog(basePrompt: string): string {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../util/logger.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { getConfig } from './loader.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import { discoverCCCommands } from '../commands/cc-command-registry.js';
 
 const log = getLogger('system-prompt');
 
@@ -81,7 +82,7 @@ export function isOnboardingComplete(): boolean {
  *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
  *   4. Append skills catalog from ~/.vellum/workspace/skills
  */
-export function buildSystemPrompt(): string {
+export function buildSystemPrompt(cwd?: string): string {
   const soulPath = getWorkspacePromptPath('SOUL.md');
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
   const userPath = getWorkspacePromptPath('USER.md');
@@ -124,6 +125,8 @@ export function buildSystemPrompt(): string {
   parts.push(buildWorkspaceReflectionSection());
   parts.push(buildLearningMemorySection());
   parts.push(buildPostToolResponseSection());
+
+  appendCCCommandsCatalog(parts, cwd);
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -947,6 +950,25 @@ function readPromptFile(path: string): string | null {
     log.warn({ err, path }, 'Failed to read prompt file');
     return null;
   }
+}
+
+function appendCCCommandsCatalog(parts: string[], cwd?: string): void {
+  if (!cwd) return;
+
+  const registry = discoverCCCommands(cwd);
+  if (registry.entries.size === 0) return;
+
+  const lines: string[] = [];
+  lines.push('## Claude Code Commands');
+  lines.push('');
+  lines.push('The following Claude Code commands are available via `.claude/commands/`. Users can invoke them with `/command-name` or you can execute them using the `claude_code` tool with the `command` parameter.');
+  lines.push('');
+
+  for (const [, entry] of registry.entries) {
+    lines.push(`- **${entry.name}**: ${entry.summary}`);
+  }
+
+  parts.push(lines.join('\n'));
 }
 
 function appendSkillsCatalog(basePrompt: string): string {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -34,4 +34,5 @@ export type {
   CallsConfig,
   CallsDisclosureConfig,
   CallsSafetyConfig,
+  SlashCollisionPreference,
 } from './schema.js';

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -897,7 +897,7 @@ export class DaemonServer {
         if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
           provider = new RateLimitProvider(provider, rateLimit, this.sharedRequestTimestamps);
         }
-        const workingDir = getSandboxWorkingDir();
+        const workingDir = config.workingDir ?? getSandboxWorkingDir();
 
         const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -899,7 +899,7 @@ export class DaemonServer {
         }
         const workingDir = getSandboxWorkingDir();
 
-        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt(workingDir);
+        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const memoryPolicy = this.deriveMemoryPolicy(conversationId);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1095,7 +1095,7 @@ export class DaemonServer {
       : [];
 
     // Resolve slash commands before persistence (synchronous — no race window).
-    const slashResult = resolveSlash(content);
+    const slashResult = resolveSlash(content, session.workingDir);
 
     // Unknown slash command — persist the exchange (user + assistant) and
     // return immediately. This path doesn't set processing=true since no
@@ -1124,6 +1124,8 @@ export class DaemonServer {
     // Preactivate skill tools when slash resolution identifies a known skill
     if (slashResult.kind === 'rewritten') {
       (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = [slashResult.skillId];
+    } else if (slashResult.kind === 'cc_command') {
+      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = ['claude-code'];
     }
 
     // Persist the user message immediately after the isProcessing() guard.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -899,7 +899,7 @@ export class DaemonServer {
         }
         const workingDir = getSandboxWorkingDir();
 
-        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
+        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt(workingDir);
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const memoryPolicy = this.deriveMemoryPolicy(conversationId);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -149,6 +149,8 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  } else if (slashResult.kind === 'cc_command') {
+    session.preactivatedSkillIds = ['claude-code'];
   }
 
   // Try to persist and run the dequeued message. If persistUserMessage
@@ -248,6 +250,8 @@ export async function processMessage(
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  } else if (slashResult.kind === 'cc_command') {
+    session.preactivatedSkillIds = ['claude-code'];
   }
 
   let userMessageId: string;

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -55,6 +55,8 @@ export interface ProcessSessionContext {
   currentPage?: string;
   /** Request-scoped skill IDs preactivated via slash resolution. */
   preactivatedSkillIds?: string[];
+  /** Working directory of the session, used for CC command discovery. */
+  readonly workingDir?: string;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
@@ -93,7 +95,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   });
 
   // Resolve slash commands for queued messages
-  const slashResult = resolveSlash(next.content);
+  const slashResult = resolveSlash(next.content, session.workingDir);
 
   // Unknown slash — persist the exchange and continue draining.
   // Persist each message before pushing to session.messages so that a
@@ -205,7 +207,7 @@ export async function processMessage(
   session.currentPage = currentPage;
 
   // Resolve slash commands before persistence
-  const slashResult = resolveSlash(content);
+  const slashResult = resolveSlash(content, session.workingDir);
 
   // Unknown slash command — persist the exchange (user + assistant) so the
   // messageId is real.  Persist each message before pushing to session.messages

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -408,8 +408,8 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
 function buildCCCommandResolution(commandName: string, trailingArgs: string): SlashResolution {
   const rewrittenPrompt = [
     `The user invoked the slash command \`/${commandName}\`.`,
-    `Execute the Claude Code command "${commandName}" using the claude_code tool with prompt="${commandName}".`,
-    trailingArgs ? `\nUser arguments: ${trailingArgs}` : '',
+    `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+    trailingArgs ? `\nPass the following as the \`arguments\` input: ${trailingArgs}` : '',
   ].filter(Boolean).join('\n');
 
   return {

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -294,10 +294,23 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
     if (cwd) {
       const ccRegistry = discoverCCCommands(cwd);
       if (ccRegistry.entries.size > 0) {
-        lines.push('');
-        lines.push('Claude Code commands:');
-        for (const [, entry] of ccRegistry.entries) {
-          lines.push(`- /${entry.name} — ${entry.summary}`);
+        const commands = Array.from(ccRegistry.entries.values()).filter((e) => e.artifactType === 'command');
+        const skills = Array.from(ccRegistry.entries.values()).filter((e) => e.artifactType === 'skill');
+
+        if (commands.length > 0) {
+          lines.push('');
+          lines.push('Claude Code commands:');
+          for (const entry of commands) {
+            lines.push(`- /${entry.name} — ${entry.summary}`);
+          }
+        }
+
+        if (skills.length > 0) {
+          lines.push('');
+          lines.push('Claude Code skills:');
+          for (const entry of skills) {
+            lines.push(`- /${entry.name} — ${entry.summary}`);
+          }
         }
       }
     }
@@ -353,7 +366,7 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
     };
   } else if (hasCc && !hasVellum) {
     // cc_only → route to CC command
-    result = buildCCCommandResolution(ccMatch.name, trailingArgs);
+    result = buildCCCommandResolution(ccMatch.name, trailingArgs, ccMatch.artifactType);
   } else if (hasVellum && hasCc) {
     // both → check collision preference
     const preference = config.slashCollisionPreference;
@@ -369,7 +382,7 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
         skillId: vellumMatch.canonicalId,
       };
     } else if (preference === 'prefer_cc') {
-      result = buildCCCommandResolution(ccMatch.name, trailingArgs);
+      result = buildCCCommandResolution(ccMatch.name, trailingArgs, ccMatch.artifactType);
     } else {
       // 'ask' — return disambiguation message
       result = {
@@ -405,12 +418,23 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
 }
 
 /** Build a cc_command resolution with a rewritten prompt. */
-function buildCCCommandResolution(commandName: string, trailingArgs: string): SlashResolution {
-  const rewrittenPrompt = [
-    `The user invoked the slash command \`/${commandName}\`.`,
-    `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
-    trailingArgs ? `\nPass the following as the \`arguments\` input: ${trailingArgs}` : '',
-  ].filter(Boolean).join('\n');
+function buildCCCommandResolution(commandName: string, trailingArgs: string, artifactType: 'command' | 'skill'): SlashResolution {
+  let rewrittenPrompt: string;
+
+  if (artifactType === 'skill') {
+    rewrittenPrompt = [
+      `The user invoked the slash command \`/${commandName}\`.`,
+      `Load the Claude Code skill "${commandName}" using the claude_code tool with command="${commandName}".`,
+      'The content should be used as reference context, not executed as a command.',
+      trailingArgs ? `\nUser arguments: ${trailingArgs}` : '',
+    ].filter(Boolean).join('\n');
+  } else {
+    rewrittenPrompt = [
+      `The user invoked the slash command \`/${commandName}\`.`,
+      `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+      trailingArgs ? `\nPass the following as the \`arguments\` input: ${trailingArgs}` : '',
+    ].filter(Boolean).join('\n');
+  }
 
   return {
     kind: 'cc_command',

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -5,14 +5,20 @@ import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
 import {
   buildInvocableSlashCatalog,
-  resolveSlashSkillCommand,
   rewriteKnownSlashCommandPrompt,
+  parseSlashCandidate,
+  formatUnknownSlashSkillMessage,
 } from '../skills/slash-commands.js';
 import { getWorkspacePromptPath } from '../util/platform.js';
+import { discoverCCCommands } from '../commands/cc-command-registry.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('session-slash');
 
 export type SlashResolution =
   | { kind: 'passthrough'; content: string }
   | { kind: 'rewritten'; content: string; skillId: string }
+  | { kind: 'cc_command'; content: string; commandName: string }
   | { kind: 'unknown'; message: string };
 
 // ── /model command ───────────────────────────────────────────────────
@@ -243,51 +249,174 @@ function resolveModelCommand(content: string): SlashResolution | null {
 }
 
 /**
- * Resolve slash commands against the current skill catalog.
+ * Resolve slash commands against both the Vellum skill catalog and
+ * Claude Code `.claude/commands/*.md` files.
+ *
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
  */
-export function resolveSlash(content: string): SlashResolution {
+export function resolveSlash(content: string, cwd?: string): SlashResolution {
+  const start = performance.now();
+
   // Check provider shortcuts first (/gpt4, /opus, etc.)
   const providerResult = resolveProviderModelCommand(content);
-  if (providerResult) return providerResult;
+  if (providerResult) {
+    log.debug({ durationMs: performance.now() - start, kind: providerResult.kind }, 'Slash route resolved');
+    return providerResult;
+  }
 
   // Handle /model command
   const modelResult = resolveModelCommand(content);
-  if (modelResult) return modelResult;
+  if (modelResult) {
+    log.debug({ durationMs: performance.now() - start, kind: modelResult.kind }, 'Slash route resolved');
+    return modelResult;
+  }
 
-  // Handle /commands command
+  // Handle /commands command — lists all available commands from both sources
   if (content.trim() === '/commands') {
-    return {
-      kind: 'unknown',
-      message: '/commands — List all available commands\n/model — Show or switch the current model\n/models — List all available models',
-    };
+    const lines = [
+      '/commands — List all available commands',
+      '/model — Show or switch the current model',
+      '/models — List all available models',
+    ];
+
+    const config = getConfig();
+    const catalog = loadSkillCatalog();
+    const resolved = resolveSkillStates(catalog, config);
+    const invocable = buildInvocableSlashCatalog(catalog, resolved);
+    if (invocable.size > 0) {
+      lines.push('');
+      lines.push('Skills:');
+      for (const [, skill] of invocable) {
+        lines.push(`- /${skill.canonicalId} — ${skill.name}`);
+      }
+    }
+
+    if (cwd) {
+      const ccRegistry = discoverCCCommands(cwd);
+      if (ccRegistry.entries.size > 0) {
+        lines.push('');
+        lines.push('Claude Code commands:');
+        for (const [, entry] of ccRegistry.entries) {
+          lines.push(`- /${entry.name} — ${entry.summary}`);
+        }
+      }
+    }
+
+    const result: SlashResolution = { kind: 'unknown', message: lines.join('\n') };
+    log.debug({ durationMs: performance.now() - start, kind: result.kind }, 'Slash route resolved');
+    return result;
   }
 
   const config = getConfig();
   const catalog = loadSkillCatalog();
   const resolved = resolveSkillStates(catalog, config);
   const invocable = buildInvocableSlashCatalog(catalog, resolved);
-  const resolution = resolveSlashSkillCommand(content, invocable);
 
-  if (resolution.kind === 'known') {
-    const skill = invocable.get(resolution.skillId.toLowerCase());
-    return {
+  // Parse the slash candidate before doing dual-source lookup
+  const candidate = parseSlashCandidate(content);
+  if (candidate.kind === 'none') {
+    const result: SlashResolution = { kind: 'passthrough', content };
+    log.debug({ durationMs: performance.now() - start, kind: result.kind }, 'Slash route resolved');
+    return result;
+  }
+
+  const token = candidate.token!;
+  const requestedId = token.slice(1);
+  const lookupKey = requestedId.toLowerCase();
+
+  // Extract trailing args: everything after the first token
+  const trimmed = content.trimStart();
+  const firstSpaceIdx = trimmed.search(/\s/);
+  const trailingArgs = firstSpaceIdx === -1 ? '' : trimmed.slice(firstSpaceIdx).trim();
+
+  // Lookup in both sources
+  const vellumMatch = invocable.get(lookupKey);
+  const ccRegistry = cwd ? discoverCCCommands(cwd) : null;
+  const ccMatch = ccRegistry?.entries.get(lookupKey);
+
+  const hasVellum = !!vellumMatch;
+  const hasCc = !!ccMatch;
+
+  let result: SlashResolution;
+
+  if (hasVellum && !hasCc) {
+    // vellum_only → existing rewrite logic
+    result = {
       kind: 'rewritten',
       content: rewriteKnownSlashCommandPrompt({
         rawInput: content,
-        skillId: resolution.skillId,
-        skillName: skill?.name ?? resolution.skillId,
-        trailingArgs: resolution.trailingArgs,
+        skillId: vellumMatch.canonicalId,
+        skillName: vellumMatch.name,
+        trailingArgs,
       }),
-      skillId: resolution.skillId,
+      skillId: vellumMatch.canonicalId,
+    };
+  } else if (hasCc && !hasVellum) {
+    // cc_only → route to CC command
+    result = buildCCCommandResolution(ccMatch.name, trailingArgs);
+  } else if (hasVellum && hasCc) {
+    // both → check collision preference
+    const preference = config.slashCollisionPreference;
+    if (preference === 'prefer_vellum') {
+      result = {
+        kind: 'rewritten',
+        content: rewriteKnownSlashCommandPrompt({
+          rawInput: content,
+          skillId: vellumMatch.canonicalId,
+          skillName: vellumMatch.name,
+          trailingArgs,
+        }),
+        skillId: vellumMatch.canonicalId,
+      };
+    } else if (preference === 'prefer_cc') {
+      result = buildCCCommandResolution(ccMatch.name, trailingArgs);
+    } else {
+      // 'ask' — return disambiguation message
+      result = {
+        kind: 'unknown',
+        message: [
+          `\`/${requestedId}\` matches both a Vellum skill and a Claude Code command.`,
+          '',
+          `- Vellum skill: **${vellumMatch.name}** (/${vellumMatch.canonicalId})`,
+          `- Claude Code command: **${ccMatch.name}**`,
+          '',
+          'Set `slashCollisionPreference` in your config to `prefer_vellum` or `prefer_cc` to resolve automatically.',
+        ].join('\n'),
+      };
+    }
+  } else {
+    // none → return unknown with combined listing
+    const availableSkillIds = Array.from(invocable.values())
+      .map((s) => s.canonicalId)
+      .sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
+    const ccCommandNames = ccRegistry
+      ? Array.from(ccRegistry.entries.values())
+          .map((e) => e.name)
+          .sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
+      : undefined;
+    result = {
+      kind: 'unknown',
+      message: formatUnknownSlashSkillMessage(requestedId, availableSkillIds, ccCommandNames),
     };
   }
 
-  if (resolution.kind === 'unknown') {
-    return { kind: 'unknown', message: resolution.message };
-  }
+  log.debug({ durationMs: performance.now() - start, kind: result.kind }, 'Slash route resolved');
+  return result;
+}
 
-  return { kind: 'passthrough', content };
+/** Build a cc_command resolution with a rewritten prompt. */
+function buildCCCommandResolution(commandName: string, trailingArgs: string): SlashResolution {
+  const rewrittenPrompt = [
+    `The user invoked the slash command \`/${commandName}\`.`,
+    `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+    trailingArgs ? `\nUser arguments: ${trailingArgs}` : '',
+  ].filter(Boolean).join('\n');
+
+  return {
+    kind: 'cc_command',
+    content: rewrittenPrompt,
+    commandName,
+  };
 }
 
 // ── Provider Ordering Error Detection ────────────────────────────────

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -408,7 +408,7 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
 function buildCCCommandResolution(commandName: string, trailingArgs: string): SlashResolution {
   const rewrittenPrompt = [
     `The user invoked the slash command \`/${commandName}\`.`,
-    `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+    `Execute the Claude Code command "${commandName}" using the claude_code tool with prompt="${commandName}".`,
     trailingArgs ? `\nUser arguments: ${trailingArgs}` : '',
   ].filter(Boolean).join('\n');
 

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -225,6 +225,18 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  // claude_code is an orchestration tool that spawns a Claude Code subprocess.
+  // The subprocess manages its own tool permissions via profile-based deny lists,
+  // so the outer permission prompt is redundant friction.
+  const claudeCodeRule: DefaultRuleTemplate = {
+    id: 'default:allow-claude_code-global',
+    tool: 'claude_code',
+    pattern: '**',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 100,
+  };
+
   return [
     ...hostFileRules,
     hostShellRule,
@@ -239,5 +251,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...browserToolRules,
     ...uiSurfaceRules,
     viewImageRule,
+    claudeCodeRule,
   ];
 }

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -135,6 +135,7 @@ export function resolveSlashSkillCommand(
 export function formatUnknownSlashSkillMessage(
   requestedId: string,
   availableSkillIds: string[],
+  ccCommandNames?: string[],
 ): string {
   const lines = [`Unknown command \`/${requestedId}\`.`];
   if (availableSkillIds.length > 0) {
@@ -143,7 +144,15 @@ export function formatUnknownSlashSkillMessage(
     for (const id of availableSkillIds) {
       lines.push(`- \`/${id}\``);
     }
-  } else {
+  }
+  if (ccCommandNames && ccCommandNames.length > 0) {
+    lines.push('');
+    lines.push('Claude Code commands:');
+    for (const name of ccCommandNames) {
+      lines.push(`- \`/${name}\``);
+    }
+  }
+  if (availableSkillIds.length === 0 && (!ccCommandNames || ccCommandNames.length === 0)) {
     lines.push('');
     lines.push('No slash commands are currently available.');
   }

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -3,7 +3,7 @@ import type { SwarmRole } from './types.js';
 /**
  * Profile names that scope tool access for worker tasks.
  */
-export type WorkerProfile = 'general' | 'researcher' | 'coder' | 'reviewer';
+export type WorkerProfile = 'general' | 'researcher' | 'coder' | 'reviewer' | 'worker';
 
 /**
  * Maps swarm roles to worker profiles.
@@ -70,6 +70,13 @@ export function getProfilePolicy(profile: WorkerProfile): ProfilePolicy {
       return {
         allow: new Set(READ_ONLY_TOOLS),
         deny: new Set([...WRITE_TOOLS, 'Bash']),
+        approvalRequired: new Set(),
+      };
+
+    case 'worker':
+      return {
+        allow: new Set([...READ_ONLY_TOOLS, 'Bash', ...WRITE_TOOLS, 'Task']),
+        deny: new Set(),
         approvalRequired: new Set(),
       };
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -90,6 +90,10 @@ export const claudeCodeTool: Tool = {
             type: 'string',
             description: 'Model to use (defaults to claude-sonnet-4-6)',
           },
+          max_turns: {
+            type: 'number',
+            description: 'Maximum number of agentic turns (API round-trips) before stopping. Defaults to 50.',
+          },
           profile: {
             type: 'string',
             enum: ['general', 'researcher', 'coder', 'reviewer'],
@@ -128,6 +132,7 @@ export const claudeCodeTool: Tool = {
     const workingDir = (input.working_dir as string) || context.workingDir;
     const resumeSessionId = input.resume as string | undefined;
     const model = (input.model as string) || 'claude-sonnet-4-6';
+    const maxTurns = typeof input.max_turns === 'number' && input.max_turns > 0 ? input.max_turns : 50;
     const profileName = (input.profile as WorkerProfile | undefined) ?? 'general';
 
     // Validate profile
@@ -301,7 +306,7 @@ export const claudeCodeTool: Tool = {
       permissionMode: 'default',
       allowedTools: [...AUTO_APPROVE_TOOLS],
       env: subprocessEnv,
-      maxTurns: 50,
+      maxTurns,
       persistSession: true,
       stderr: (data: string) => {
         const trimmed = data.trimEnd();

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -191,7 +191,8 @@ export const claudeCodeTool: Tool = {
       // Substitute template_vars: {{key}} patterns
       if (templateVars) {
         for (const [key, value] of Object.entries(templateVars)) {
-          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+          const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${escaped}\\}\\}`, 'g'), value);
         }
       }
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -163,12 +163,28 @@ export const claudeCodeTool: Tool = {
       const entry = getCCCommand(workingDir, command);
       if (!entry) {
         const registry = discoverCCCommands(workingDir);
-        const available = Array.from(registry.entries.values()).map(e => e.name).sort();
-        const availableList = available.length > 0
-          ? `\nAvailable commands: ${available.join(', ')}`
-          : '\nNo commands found in .claude/commands/';
+        const commands = Array.from(registry.entries.values())
+          .filter(e => e.artifactType === 'command')
+          .map(e => e.name)
+          .sort();
+        const skills = Array.from(registry.entries.values())
+          .filter(e => e.artifactType === 'skill')
+          .map(e => e.name)
+          .sort();
+
+        const parts: string[] = [];
+        if (commands.length > 0) {
+          parts.push(`Available commands: ${commands.join(', ')}`);
+        }
+        if (skills.length > 0) {
+          parts.push(`Available skills: ${skills.join(', ')}`);
+        }
+        const availableList = parts.length > 0
+          ? '\n' + parts.join('\n')
+          : '\nNo commands or skills found in .claude/';
+
         return {
-          content: `Error: Command "${command}" not found in .claude/commands/.${availableList}`,
+          content: `Error: "${command}" not found in .claude/commands/ or .claude/skills/.${availableList}`,
           isError: true,
         };
       }

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -9,16 +9,10 @@ import type { WorkerProfile } from '../../swarm/worker-backend.js';
 
 const log = getLogger('claude-code-tool');
 
-// Tools that CC can use without user approval
-const AUTO_APPROVE_TOOLS = new Set([
+// Tools passed to the SDK's allowedTools list (hints for the subprocess).
+const ALLOWED_TOOLS = new Set([
   'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch',
   'LS', 'Task', 'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
-]);
-
-// Tools that always require user approval via confirmation IPC
-const APPROVAL_REQUIRED_TOOLS = new Set([
-  'Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit',
-
 ]);
 
 const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
@@ -248,45 +242,14 @@ export const claudeCodeTool: Tool = {
 
     log.info({ prompt: truncate(resolvedPrompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
-    // Build the canUseTool callback, enforcing profile-based restrictions
-    const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName, toolInput, _options) => {
-      // Profile hard-deny check first
+    // Build the canUseTool callback, matching swarm backend behavior:
+    // deny-list only, everything else auto-approved.
+    const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName) => {
       if (profilePolicy.deny.has(toolName)) {
         log.debug({ toolName, profile: profileName }, 'Tool denied by profile policy');
         return { behavior: 'deny' as const, message: `Tool "${toolName}" is denied by profile "${profileName}"` };
       }
-
-      // Profile explicit allow (auto-approve)
-      if (profilePolicy.allow.has(toolName)) {
-        return { behavior: 'allow' as const };
-      }
-
-      // Auto-approve safe read-only tools (backward compat for general profile)
-      if (AUTO_APPROVE_TOOLS.has(toolName)) {
-        return { behavior: 'allow' as const };
-      }
-
-      // For tools that need approval, bridge to Velly's confirmation flow
-      if (!context.requestConfirmation) {
-        log.warn({ toolName }, 'Claude Code tool requires approval but no requestConfirmation callback available');
-        return { behavior: 'deny' as const, message: 'Tool approval not available in this context' };
-      }
-
-      try {
-        const result = await context.requestConfirmation({
-          toolName,
-          input: toolInput,
-          riskLevel: APPROVAL_REQUIRED_TOOLS.has(toolName) ? 'Medium' : 'Low',
-          principal: context.principal,
-        });
-        if (result.decision === 'allow') {
-          return { behavior: 'allow' as const };
-        }
-        return { behavior: 'deny' as const, message: `User denied ${toolName}` };
-      } catch (err) {
-        log.debug({ err, toolName }, 'requestConfirmation rejected (likely abort)');
-        return { behavior: 'deny' as const, message: 'Approval request cancelled' };
-      }
+      return { behavior: 'allow' as const };
     };
 
     // Enforce nesting depth limit to prevent infinite recursion.
@@ -315,7 +278,7 @@ export const claudeCodeTool: Tool = {
       model,
       canUseTool,
       permissionMode: 'default',
-      allowedTools: [...AUTO_APPROVE_TOOLS],
+      allowedTools: [...ALLOWED_TOOLS],
       env: subprocessEnv,
       maxTurns,
       persistSession: true,

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -62,7 +62,20 @@ export const claudeCodeTool: Tool = {
         properties: {
           prompt: {
             type: 'string',
-            description: 'The coding task or question for Claude Code to work on',
+            description: 'The coding task or question for Claude Code to work on (mutually exclusive with command)',
+          },
+          command: {
+            type: 'string',
+            description: 'Name of a .claude/commands/*.md command to execute (mutually exclusive with prompt)',
+          },
+          arguments: {
+            type: 'string',
+            description: 'Arguments to substitute for $ARGUMENTS in the command template',
+          },
+          template_vars: {
+            type: 'object',
+            description: 'Optional key-value pairs to substitute in the command template (e.g., {{key}} patterns)',
+            additionalProperties: { type: 'string' },
           },
           working_dir: {
             type: 'string',
@@ -82,7 +95,7 @@ export const claudeCodeTool: Tool = {
             description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
           },
         },
-        required: ['prompt'],
+        required: [],
       },
     };
   },
@@ -92,7 +105,25 @@ export const claudeCodeTool: Tool = {
       return { content: 'Cancelled', isError: true };
     }
 
-    const prompt = input.prompt as string;
+    const prompt = input.prompt as string | undefined;
+    const command = input.command as string | undefined;
+    const args = input.arguments as string | undefined;
+    const templateVars = input.template_vars as Record<string, string> | undefined;
+
+    // Validate one-of: exactly one of prompt or command
+    if (prompt && command) {
+      return {
+        content: 'Error: Cannot specify both "prompt" and "command". Use one or the other.',
+        isError: true,
+      };
+    }
+    if (!prompt && !command) {
+      return {
+        content: 'Error: Must specify either "prompt" or "command".',
+        isError: true,
+      };
+    }
+
     const workingDir = (input.working_dir as string) || context.workingDir;
     const resumeSessionId = input.resume as string | undefined;
     const model = (input.model as string) || 'claude-sonnet-4-6';
@@ -107,6 +138,67 @@ export const claudeCodeTool: Tool = {
     }
 
     const profilePolicy = getProfilePolicy(profileName);
+
+    // Resolve prompt from command template if needed
+    let resolvedPrompt: string;
+
+    if (command) {
+      // Validate command name: basename-only, no path traversal
+      if (command.includes('/') || command.includes('\\') || command.includes('..')) {
+        return {
+          content: `Error: Invalid command name "${command}". Command names must not contain path separators.`,
+          isError: true,
+        };
+      }
+      if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(command)) {
+        return {
+          content: `Error: Invalid command name "${command}". Must match pattern: alphanumeric start, then alphanumeric/dot/underscore/hyphen.`,
+          isError: true,
+        };
+      }
+
+      // Import and use CC command registry
+      const { getCCCommand, loadCCCommandTemplate, discoverCCCommands } = await import('../../commands/cc-command-registry.js');
+
+      const entry = getCCCommand(workingDir, command);
+      if (!entry) {
+        const registry = discoverCCCommands(workingDir);
+        const available = Array.from(registry.entries.values()).map(e => e.name).sort();
+        const availableList = available.length > 0
+          ? `\nAvailable commands: ${available.join(', ')}`
+          : '\nNo commands found in .claude/commands/';
+        return {
+          content: `Error: Command "${command}" not found in .claude/commands/.${availableList}`,
+          isError: true,
+        };
+      }
+
+      // Load full template
+      let template: string;
+      try {
+        template = loadCCCommandTemplate(entry);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: `Error: Failed to load command template "${command}": ${message}`,
+          isError: true,
+        };
+      }
+
+      // Substitute $ARGUMENTS
+      resolvedPrompt = template.replace(/\$ARGUMENTS/g, args ?? '');
+
+      // Substitute template_vars: {{key}} patterns
+      if (templateVars) {
+        for (const [key, value] of Object.entries(templateVars)) {
+          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+        }
+      }
+
+      log.info({ command, workingDir, hasArgs: !!args }, 'Executing Claude Code command from template');
+    } else {
+      resolvedPrompt = prompt!;
+    }
 
     // Validate API key
     const config = getConfig();
@@ -136,7 +228,7 @@ export const claudeCodeTool: Tool = {
     // Collect stderr output from the Claude Code subprocess for debugging
     const stderrLines: string[] = [];
 
-    log.info({ prompt: truncate(prompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
+    log.info({ prompt: truncate(resolvedPrompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
     // Build the canUseTool callback, enforcing profile-based restrictions
     const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName, toolInput, _options) => {
@@ -227,7 +319,7 @@ export const claudeCodeTool: Tool = {
     let activeToolUseId: string | null = null;
 
     try {
-      const conversation = query({ prompt, options: queryOptions });
+      const conversation = query({ prompt: resolvedPrompt, options: queryOptions });
       let resultText = '';
       let sessionId = '';
       let hasError = false;

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -242,13 +242,39 @@ export const claudeCodeTool: Tool = {
 
     log.info({ prompt: truncate(resolvedPrompt, 100, ''), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
-    // Build the canUseTool callback, matching swarm backend behavior:
-    // deny-list only, everything else auto-approved.
+    // Build the canUseTool callback with 5-tier permission logic:
+    // 1. deny-list → block  2. allow-list → auto-approve  3. approvalRequired → bubble up or fast-deny  4. default → allow
     const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName) => {
+      // 1. Deny-list: block unconditionally
       if (profilePolicy.deny.has(toolName)) {
         log.debug({ toolName, profile: profileName }, 'Tool denied by profile policy');
         return { behavior: 'deny' as const, message: `Tool "${toolName}" is denied by profile "${profileName}"` };
       }
+      // 2. Allow-list: auto-approve
+      if (profilePolicy.allow.has(toolName)) {
+        log.debug({ toolName, profile: profileName }, 'Tool auto-allowed by profile policy');
+        return { behavior: 'allow' as const };
+      }
+      // 3. Approval-required: bubble up to user or fast-deny when non-interactive
+      if (profilePolicy.approvalRequired.has(toolName)) {
+        if (context.requestConfirmation) {
+          log.debug({ toolName, profile: profileName }, 'Bubbling up tool approval to user');
+          const result = await context.requestConfirmation({
+            toolName,
+            input: {},
+            riskLevel: 'medium',
+            principal: context.principal,
+          });
+          log.debug({ toolName, decision: result.decision }, 'User permission decision');
+          return { behavior: result.decision === 'allow' ? 'allow' as const : 'deny' as const };
+        }
+        // Non-interactive: fast-deny
+        if (!context.isInteractive) {
+          log.debug({ toolName, profile: profileName }, 'Tool requires approval but session is non-interactive');
+          return { behavior: 'deny' as const, message: `Tool "${toolName}" requires approval but session is non-interactive` };
+        }
+      }
+      // 4. Default: allow (backward compat for tools not in any set)
       return { behavior: 'allow' as const };
     };
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -201,12 +201,28 @@ export const claudeCodeTool: Tool = {
       resolvedPrompt = prompt!;
     }
 
-    // If the project has .claude/commands/, hint the subprocess so it can discover them
+    // If the project has .claude/commands/ or .claude/skills/, hint the subprocess
     try {
       const { discoverCCCommands } = await import('../../commands/cc-command-registry.js');
       const registry = discoverCCCommands(workingDir);
       if (registry.entries.size > 0) {
-        resolvedPrompt += '\n\nNote: Custom project commands are available in .claude/commands/. Use Glob to list them and Read to view their instructions.';
+        let hasCommands = false;
+        let hasSkills = false;
+        for (const [, entry] of registry.entries) {
+          if (entry.artifactType === 'skill') hasSkills = true;
+          else hasCommands = true;
+          if (hasCommands && hasSkills) break;
+        }
+
+        let hint: string;
+        if (hasCommands && hasSkills) {
+          hint = 'Custom project commands are available in .claude/commands/ and skills in .claude/skills/.';
+        } else if (hasSkills) {
+          hint = 'Custom project skills are available in .claude/skills/.';
+        } else {
+          hint = 'Custom project commands are available in .claude/commands/.';
+        }
+        resolvedPrompt += `\n\nNote: ${hint} Use Glob to list them and Read to view their instructions.`;
       }
     } catch {
       // Non-fatal — skip hint if discovery fails

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -207,6 +207,17 @@ export const claudeCodeTool: Tool = {
       resolvedPrompt = prompt!;
     }
 
+    // If the project has .claude/commands/, hint the subprocess so it can discover them
+    try {
+      const { discoverCCCommands } = await import('../../commands/cc-command-registry.js');
+      const registry = discoverCCCommands(workingDir);
+      if (registry.entries.size > 0) {
+        resolvedPrompt += '\n\nNote: Custom project commands are available in .claude/commands/. Use Glob to list them and Read to view their instructions.';
+      }
+    } catch {
+      // Non-fatal — skip hint if discovery fails
+    }
+
     // Validate API key
     const config = getConfig();
     const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -52,6 +52,7 @@ export const claudeCodeTool: Tool = {
   description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
   category: 'coding',
   defaultRiskLevel: RiskLevel.Medium,
+  timeoutSec: 600,
 
   getDefinition(): ToolDefinition {
     return {

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -201,14 +201,15 @@ export const claudeCodeTool: Tool = {
         };
       }
 
-      // Substitute $ARGUMENTS
-      resolvedPrompt = template.replace(/\$ARGUMENTS/g, args ?? '');
+      // Substitute $ARGUMENTS (escape $ in replacement to prevent $& etc. special patterns)
+      resolvedPrompt = template.replace(/\$ARGUMENTS/g, (args ?? '').replace(/\$/g, '$$$$'));
 
       // Substitute template_vars: {{key}} patterns
       if (templateVars) {
         for (const [key, value] of Object.entries(templateVars)) {
           const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${escaped}\\}\\}`, 'g'), value);
+          const safeValue = value.replace(/\$/g, '$$$$');
+          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${escaped}\\}\\}`, 'g'), safeValue);
         }
       }
 
@@ -217,8 +218,9 @@ export const claudeCodeTool: Tool = {
       resolvedPrompt = prompt!;
     }
 
-    // If the project has .claude/commands/ or .claude/skills/, hint the subprocess
-    try {
+    // If the project has .claude/commands/ or .claude/skills/, hint the subprocess.
+    // Only append the hint for free-form prompts — command templates are self-contained.
+    if (!command) try {
       const { discoverCCCommands } = await import('../../commands/cc-command-registry.js');
       const registry = discoverCCCommands(workingDir);
       if (registry.entries.size > 0) {
@@ -287,7 +289,7 @@ export const claudeCodeTool: Tool = {
         log.debug({ toolName, profile: profileName }, 'Tool auto-allowed by profile policy');
         return { behavior: 'allow' as const };
       }
-      // 3. Approval-required: bubble up to user or fast-deny when non-interactive
+      // 3. Approval-required: bubble up to user or deny when no confirmation callback
       if (profilePolicy.approvalRequired.has(toolName)) {
         if (context.requestConfirmation) {
           log.debug({ toolName, profile: profileName }, 'Bubbling up tool approval to user');
@@ -300,11 +302,9 @@ export const claudeCodeTool: Tool = {
           log.debug({ toolName, decision: result.decision }, 'User permission decision');
           return { behavior: result.decision === 'allow' ? 'allow' as const : 'deny' as const };
         }
-        // Non-interactive: fast-deny
-        if (!context.isInteractive) {
-          log.debug({ toolName, profile: profileName }, 'Tool requires approval but session is non-interactive');
-          return { behavior: 'deny' as const, message: `Tool "${toolName}" requires approval but session is non-interactive` };
-        }
+        // No requestConfirmation callback — deny regardless of interactivity
+        log.warn({ toolName, profile: profileName }, 'Tool requires approval but no requestConfirmation callback available');
+        return { behavior: 'deny' as const, message: `Tool "${toolName}" requires approval but no confirmation callback is available` };
       }
       // 4. Default: allow (backward compat for tools not in any set)
       return { behavior: 'allow' as const };

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -12,7 +12,7 @@ const log = getLogger('claude-code-tool');
 // Tools that CC can use without user approval
 const AUTO_APPROVE_TOOLS = new Set([
   'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch',
-  'LS', 'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
+  'LS', 'Task', 'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
 ]);
 
 // Tools that always require user approval via confirmation IPC

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -15,7 +15,7 @@ const ALLOWED_TOOLS = new Set([
   'LS', 'Task', 'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
 ]);
 
-const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
+const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer', 'worker'];
 
 // Maximum nesting depth for Claude Code subprocesses.
 // Depth 0 = top-level assistant, depth 1 = first subprocess, etc.
@@ -90,7 +90,7 @@ export const claudeCodeTool: Tool = {
           },
           profile: {
             type: 'string',
-            enum: ['general', 'researcher', 'coder', 'reviewer'],
+            enum: ['general', 'researcher', 'coder', 'reviewer', 'worker'],
             description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
           },
         },

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -795,7 +795,7 @@ async function executeWithTimeout(
     if (result === TIMEOUT_SENTINEL) {
       const sec = Math.round(safeMs / 1000);
       return {
-        content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
+        content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. To increase the timeout for this tool, set timeouts.toolTimeoutOverrides.${toolName} to a higher value (in seconds) in ~/.vellum/workspace/config.json.`,
         isError: true,
       };
     }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -390,7 +390,7 @@ export class ToolExecutor {
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;
-      const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
+      const rawTimeoutSec = tool.timeoutSec ?? getConfig().timeouts.toolExecutionTimeoutSec;
       const toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
 
       // Enrich context with principal so tools (e.g. claude_code) can

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -390,7 +390,8 @@ export class ToolExecutor {
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;
-      const rawTimeoutSec = tool.timeoutSec ?? getConfig().timeouts.toolExecutionTimeoutSec;
+      const timeoutConfig = getConfig().timeouts;
+      const rawTimeoutSec = timeoutConfig.toolTimeoutOverrides?.[name] ?? tool.timeoutSec ?? timeoutConfig.toolExecutionTimeoutSec;
       const toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
 
       // Enrich context with principal so tools (e.g. claude_code) can

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -8,6 +8,7 @@ import { indexCatalogById, validateIncludes } from '../../skills/include-graph.j
 import { computeSkillVersionHash } from '../../skills/version-hash.js';
 import { getLogger } from '../../util/logger.js';
 import { discoverCCCommands } from '../../commands/cc-command-registry.js';
+import type { CCCommandEntry } from '../../commands/cc-command-registry.js';
 
 const log = getLogger('skill-load');
 
@@ -118,18 +119,37 @@ export class SkillLoadTool implements Tool {
       }
     }
 
-    // When loading the claude-code skill, append available CC commands
+    // When loading the claude-code skill, append available CC commands and skills
     let ccCommandsSection = '';
     if (skill.id === 'claude-code' && context.workingDir) {
       const ccRegistry = discoverCCCommands(context.workingDir);
       if (ccRegistry.entries.size > 0) {
-        const lines = ['Available Claude Code Commands (from .claude/commands/):'];
+        const commands: CCCommandEntry[] = [];
+        const skills: CCCommandEntry[] = [];
         for (const [, entry] of ccRegistry.entries) {
-          lines.push(`- /${entry.name}: ${entry.summary}`);
+          if (entry.artifactType === 'skill') {
+            skills.push(entry);
+          } else {
+            commands.push(entry);
+          }
         }
-        lines.push('');
-        lines.push('Users can invoke these with /command-name. You can execute them using the claude_code tool with the `command` parameter.');
-        ccCommandsSection = '\n\n' + lines.join('\n');
+
+        const sections: string[] = [];
+        if (commands.length > 0) {
+          sections.push('Available Claude Code Commands (from .claude/commands/):');
+          for (const entry of commands) {
+            sections.push(`- /${entry.name}: ${entry.summary}`);
+          }
+        }
+        if (skills.length > 0) {
+          sections.push('Available Claude Code Skills (from .claude/skills/):');
+          for (const entry of skills) {
+            sections.push(`- /${entry.name}: ${entry.summary}`);
+          }
+        }
+        sections.push('');
+        sections.push('Users can invoke these with /command-name. You can execute them using the claude_code tool with the `command` parameter.');
+        ccCommandsSection = '\n\n' + sections.join('\n');
       }
     }
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -7,6 +7,7 @@ import type { SkillSummary } from '../../config/skills.js';
 import { indexCatalogById, validateIncludes } from '../../skills/include-graph.js';
 import { computeSkillVersionHash } from '../../skills/version-hash.js';
 import { getLogger } from '../../util/logger.js';
+import { discoverCCCommands } from '../../commands/cc-command-registry.js';
 
 const log = getLogger('skill-load');
 
@@ -33,7 +34,7 @@ export class SkillLoadTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const selector = input.skill;
     if (typeof selector !== 'string' || selector.trim().length === 0) {
       return { content: 'Error: skill is required and must be a non-empty string', isError: true };
@@ -117,6 +118,21 @@ export class SkillLoadTool implements Tool {
       }
     }
 
+    // When loading the claude-code skill, append available CC commands
+    let ccCommandsSection = '';
+    if (skill.id === 'claude-code' && context.workingDir) {
+      const ccRegistry = discoverCCCommands(context.workingDir);
+      if (ccRegistry.entries.size > 0) {
+        const lines = ['Available Claude Code Commands (from .claude/commands/):'];
+        for (const [, entry] of ccRegistry.entries) {
+          lines.push(`- /${entry.name}: ${entry.summary}`);
+        }
+        lines.push('');
+        lines.push('Users can invoke these with /command-name. You can execute them using the claude_code tool with the `command` parameter.');
+        ccCommandsSection = '\n\n' + lines.join('\n');
+      }
+    }
+
     return {
       content: [
         `Skill: ${skill.name}`,
@@ -124,7 +140,7 @@ export class SkillLoadTool implements Tool {
         `Description: ${skill.description}`,
         `Path: ${skill.skillFilePath}`,
         '',
-        body,
+        body + ccCommandsSection,
         '',
         immediateChildrenSection,
         '',

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -178,6 +178,8 @@ export interface Tool {
   /** Declared execution target from the skill manifest. Used by resolveExecutionTarget
    * to accurately label lifecycle events for skill-provided tools. */
   executionTarget?: ExecutionTarget;
+  /** Per-tool execution timeout in seconds. Overrides the global toolExecutionTimeoutSec config. */
+  timeoutSec?: number;
   getDefinition(): ToolDefinition;
   execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult>;
 }


### PR DESCRIPTION
## Summary
Unified slash command routing system that seamlessly integrates Claude Code `.claude/commands/*.md` and `.claude/skills/*.md` files with Vellum skill commands. Includes subprocess permission bubble-up, configurable collision preferences, and per-tool timeout overrides.

## Changes

### Unified CC Artifact Discovery
- Extended `cc-command-registry.ts` to discover both `.claude/commands/*.md` and `.claude/skills/*.md` with walk-up, collision, and cache semantics
- Added `artifactType: 'command' | 'skill'` discriminator to `CCCommandEntry`
- Commands take precedence over skills at the same directory level

### Slash Router + /commands Output
- Dual-source lookup: checks both Vellum skills and CC artifacts
- `/commands` groups by artifact type (commands vs skills)
- Configurable collision preference: `ask`, `prefer_vellum`, `prefer_cc`
- Provider model shortcuts (`/gpt4`, `/opus`, `/gemini`, etc.)

### Subprocess Permission Bubble-Up
- `canUseTool` callback now uses 5-tier permission model: deny → allow → approvalRequired (bubble-up) → non-interactive fast-deny → default allow
- `context.requestConfirmation` bubbles approval-required tools to the user
- Fast-deny when non-interactive (no TTY)

### Tool Access Policy
- New `worker` profile for autonomous subprocess work (swarm, safe-blitz)
- Worker auto-allows Bash, Write, Edit, Task without prompting
- `general`/`coder` profiles prompt for Bash/Write via bubble-up
- `researcher`/`reviewer` profiles deny Bash/Write

### Claude Code Tool
- Command mode: execute `.claude/commands/*.md` templates with `$ARGUMENTS` and `{{key}}` substitution
- Configurable `max_turns`, `working_dir`, `model`, `profile`, `resume`
- Per-tool timeout overrides via config
- Auto-allow default trust rule
- Subprocess hints about available commands/skills

## Milestone PRs (merged into feature branch)
- #5910: M1 — Unify CC artifact discovery across commands + skills
- #5909: M3 — Implement subprocess permission bubble-up via requestConfirmation
- #5913: M2 — Update slash router + /commands output for unified artifacts
- #5912: M4 — Fix subprocess tool access policy for real workflows (worker profile)
- #5914: M5 — Wire all consumers of unified discovery + permissions
- #5915: M6 — Add tests for unified discovery, routing, permission bubbling
- #5919: Fix — Distinguish commands from skills in not-found error message

## Project issue
Closes #5900

## Test plan
- [ ] All 78 tests pass (28 registry + 16 routing + 7 profiles + 27 permission bubble-up)
- [ ] `/commands` shows grouped commands and skills
- [ ] Slash collision preference resolves correctly
- [ ] Permission bubble-up prompts for Bash/Write in general profile
- [ ] Worker profile auto-allows all tools
- [ ] Non-interactive sessions fast-deny approval-required tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)