### PR TITLE
feat: add PR title column to check-reviews table

### DIFF
--- a/.claude/check-pr-reviews
+++ b/.claude/check-pr-reviews
@@ -16,6 +16,7 @@ With multiple PR numbers, outputs a JSON array.
 Output per PR:
 {
   "pr_number": 123,
+  "title": "Fix login validation",
   "created_at": "2024-01-15T10:00:00Z",
   "age_seconds": 3600,
   "codex": {
@@ -74,7 +75,7 @@ check_pr() {
   mkdir -p "$pr_dir"
 
   # Fetch all data in parallel
-  gh pr view "$pr_number" --json comments,reviews,createdAt > "$pr_dir/pr.json" &
+  gh pr view "$pr_number" --json comments,reviews,createdAt,title > "$pr_dir/pr.json" &
   local pid1=$!
 
   gh api "repos/$REPO_SLUG/issues/$pr_number/reactions" \
@@ -86,6 +87,10 @@ check_pr() {
   local pid3=$!
 
   wait $pid1 $pid2 $pid3
+
+  # Parse title and creation time
+  local title
+  title=$(jq -r '.title // ""' "$pr_dir/pr.json")
 
   # Parse creation time and compute age
   local created_at
@@ -165,6 +170,7 @@ check_pr() {
 
   jq -n \
     --argjson pr_number "$pr_number" \
+    --arg title "$title" \
     --arg created_at "$created_at" \
     --argjson age_seconds "$age_seconds" \
     --arg codex_status "$codex_status" \
@@ -176,6 +182,7 @@ check_pr() {
     --argjson devin_inline "$devin_inline" \
     '{
       pr_number: $pr_number,
+      title: $title,
       created_at: $created_at,
       age_seconds: $age_seconds,
       codex: {

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -14,7 +14,7 @@ Extract all PR numbers from UNREVIEWED_PRS.md and check them in a single call:
 .claude/check-pr-reviews <number1> <number2> <number3> ...
 ```
 
-With multiple PR numbers, this outputs a JSON array of results. Each element has `codex.status` and `devin.status` fields (each one of: `approved`, `changes_requested`, `rate_limited`, `skipped`, `pending`), plus the raw review data (`reviews`, `inline_comments`) for contextual assessment. It also includes `age_seconds` for computing the age column. All PRs are fetched in parallel for speed.
+With multiple PR numbers, this outputs a JSON array of results. Each element has `title`, `codex.status` and `devin.status` fields (each one of: `approved`, `changes_requested`, `rate_limited`, `skipped`, `pending`), plus the raw review data (`reviews`, `inline_comments`) for contextual assessment. It also includes `age_seconds` for computing the age column. All PRs are fetched in parallel for speed.
 
 ## Contextual review assessment
 
@@ -64,9 +64,10 @@ Examples of feedback that would cause a regression:
 
 Display a table with these columns:
 
-| PR  | Age | Codex | Devin | Verdict | Added to TODO | Removed from Unreviewed |
-| --- | --- | ----- | ----- | ------- | ------------- | ----------------------- |
+| PR  | Title | Age | Codex | Devin | Verdict | TODO | Removed |
+| --- | ----- | --- | ----- | ----- | ------- | ---- | ------- |
 
+- **Title**: PR title, truncated to 30 characters with "..." if longer.
 - **Age**: How long ago the PR was created (e.g., "2h 15m", "45m").
 - **Codex/Devin columns**: Use emoji prefixes for quick scanning:
   - ✅ Approved
@@ -80,7 +81,7 @@ Display a table with these columns:
   - 📝 Valid feedback
   - ⚠️ Regression risk
   - ⏳ Pending
-- **Added to TODO / Removed from Unreviewed**: Use ✅ for yes, — for no.
+- **TODO / Removed**: Use ✅ for yes, — for no.
 
 ### Regression risk flagging
 


### PR DESCRIPTION
## Summary
- Add `title` to the data fetched by `.claude/check-pr-reviews` and include it in the output JSON
- Add a "Title" column (truncated to 30 chars) to the check-reviews output table, placed after the PR column
- Shorten "Added to TODO" → "TODO" and "Removed from Unreviewed" → "Removed" to keep the table compact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
