### PR TITLE
refactor: extract contact tool functions for skill migration

### DIFF
--- a/assistant/src/tools/contacts/contact-merge.ts
+++ b/assistant/src/tools/contacts/contact-merge.ts
@@ -23,6 +23,59 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeContactMerge(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const keepId = input.keep_id as string | undefined;
+  const mergeId = input.merge_id as string | undefined;
+
+  if (!keepId || typeof keepId !== 'string') {
+    return { content: 'Error: keep_id is required', isError: true };
+  }
+  if (!mergeId || typeof mergeId !== 'string') {
+    return { content: 'Error: merge_id is required', isError: true };
+  }
+
+  // Show what will be merged for clarity
+  const keepContact = getContact(keepId);
+  const mergeContact = getContact(mergeId);
+
+  if (!keepContact) {
+    return { content: `Error: Contact "${keepId}" not found`, isError: true };
+  }
+  if (!mergeContact) {
+    return { content: `Error: Contact "${mergeId}" not found`, isError: true };
+  }
+
+  try {
+    const merged = mergeContacts(keepId, mergeId);
+
+    const channelList = merged.channels
+      .map((ch) => `  - ${ch.type}: ${ch.address}${ch.isPrimary ? ' (primary)' : ''}`)
+      .join('\n');
+
+    return {
+      content: [
+        `Merged "${mergeContact.displayName}" into "${keepContact.displayName}".`,
+        ``,
+        `Surviving contact (${merged.id}):`,
+        `  Name: ${merged.displayName}`,
+        `  Importance: ${merged.importance.toFixed(2)}`,
+        `  Interactions: ${merged.interactionCount}`,
+        merged.relationship ? `  Relationship: ${merged.relationship}` : null,
+        merged.channels.length > 0 ? `  Channels:\n${channelList}` : null,
+        ``,
+        `Deleted contact: ${mergeContact.displayName} (${mergeId})`,
+      ].filter(Boolean).join('\n'),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class ContactMergeTool implements Tool {
   name = 'contact_merge';
   description = definition.description;
@@ -33,54 +86,8 @@ class ContactMergeTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const keepId = input.keep_id as string | undefined;
-    const mergeId = input.merge_id as string | undefined;
-
-    if (!keepId || typeof keepId !== 'string') {
-      return { content: 'Error: keep_id is required', isError: true };
-    }
-    if (!mergeId || typeof mergeId !== 'string') {
-      return { content: 'Error: merge_id is required', isError: true };
-    }
-
-    // Show what will be merged for clarity
-    const keepContact = getContact(keepId);
-    const mergeContact = getContact(mergeId);
-
-    if (!keepContact) {
-      return { content: `Error: Contact "${keepId}" not found`, isError: true };
-    }
-    if (!mergeContact) {
-      return { content: `Error: Contact "${mergeId}" not found`, isError: true };
-    }
-
-    try {
-      const merged = mergeContacts(keepId, mergeId);
-
-      const channelList = merged.channels
-        .map((ch) => `  - ${ch.type}: ${ch.address}${ch.isPrimary ? ' (primary)' : ''}`)
-        .join('\n');
-
-      return {
-        content: [
-          `Merged "${mergeContact.displayName}" into "${keepContact.displayName}".`,
-          ``,
-          `Surviving contact (${merged.id}):`,
-          `  Name: ${merged.displayName}`,
-          `  Importance: ${merged.importance.toFixed(2)}`,
-          `  Interactions: ${merged.interactionCount}`,
-          merged.relationship ? `  Relationship: ${merged.relationship}` : null,
-          merged.channels.length > 0 ? `  Channels:\n${channelList}` : null,
-          ``,
-          `Deleted contact: ${mergeContact.displayName} (${mergeId})`,
-        ].filter(Boolean).join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeContactMerge(input, context);
   }
 }
 

--- a/assistant/src/tools/contacts/contact-search.ts
+++ b/assistant/src/tools/contacts/contact-search.ts
@@ -49,6 +49,48 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeContactSearch(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const query = input.query as string | undefined;
+  const channelAddress = input.channel_address as string | undefined;
+  const channelType = input.channel_type as string | undefined;
+  const relationship = input.relationship as string | undefined;
+  const limit = input.limit as number | undefined;
+
+  if (!query && !channelAddress && !relationship) {
+    return {
+      content: 'Error: At least one search criterion is required (query, channel_address, or relationship)',
+      isError: true,
+    };
+  }
+
+  try {
+    const results = searchContacts({
+      query,
+      channelAddress,
+      channelType,
+      relationship,
+      limit,
+    });
+
+    if (results.length === 0) {
+      return { content: 'No contacts found matching the search criteria.', isError: false };
+    }
+
+    const lines = [`Found ${results.length} contact(s):\n`];
+    for (const contact of results) {
+      lines.push(formatContactSummary(contact));
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class ContactSearchTool implements Tool {
   name = 'contact_search';
   description = definition.description;
@@ -59,43 +101,8 @@ class ContactSearchTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const query = input.query as string | undefined;
-    const channelAddress = input.channel_address as string | undefined;
-    const channelType = input.channel_type as string | undefined;
-    const relationship = input.relationship as string | undefined;
-    const limit = input.limit as number | undefined;
-
-    if (!query && !channelAddress && !relationship) {
-      return {
-        content: 'Error: At least one search criterion is required (query, channel_address, or relationship)',
-        isError: true,
-      };
-    }
-
-    try {
-      const results = searchContacts({
-        query,
-        channelAddress,
-        channelType,
-        relationship,
-        limit,
-      });
-
-      if (results.length === 0) {
-        return { content: 'No contacts found matching the search criteria.', isError: false };
-      }
-
-      const lines = [`Found ${results.length} contact(s):\n`];
-      for (const contact of results) {
-        lines.push(formatContactSummary(contact));
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeContactSearch(input, context);
   }
 }
 

--- a/assistant/src/tools/contacts/contact-upsert.ts
+++ b/assistant/src/tools/contacts/contact-upsert.ts
@@ -83,6 +83,49 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeContactUpsert(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const displayName = input.display_name as string | undefined;
+  if (!displayName || typeof displayName !== 'string' || displayName.trim().length === 0) {
+    return { content: 'Error: display_name is required and must be a non-empty string', isError: true };
+  }
+
+  const importance = input.importance as number | undefined;
+  if (importance !== undefined && (typeof importance !== 'number' || importance < 0 || importance > 1)) {
+    return { content: 'Error: importance must be a number between 0 and 1', isError: true };
+  }
+
+  const rawChannels = input.channels as Array<{ type: string; address: string; is_primary?: boolean }> | undefined;
+  const channels = rawChannels?.map((ch) => ({
+    type: ch.type,
+    address: ch.address,
+    isPrimary: ch.is_primary,
+  }));
+
+  try {
+    const contact = upsertContact({
+      id: input.id as string | undefined,
+      displayName: displayName.trim(),
+      relationship: input.relationship as string | undefined,
+      importance,
+      responseExpectation: input.response_expectation as string | undefined,
+      preferredTone: input.preferred_tone as string | undefined,
+      channels,
+    });
+
+    const isNew = contact.createdAt === contact.updatedAt;
+    return {
+      content: `${isNew ? 'Created' : 'Updated'} contact:\n${formatContact(contact)}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class ContactUpsertTool implements Tool {
   name = 'contact_upsert';
   description = definition.description;
@@ -93,44 +136,8 @@ class ContactUpsertTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const displayName = input.display_name as string | undefined;
-    if (!displayName || typeof displayName !== 'string' || displayName.trim().length === 0) {
-      return { content: 'Error: display_name is required and must be a non-empty string', isError: true };
-    }
-
-    const importance = input.importance as number | undefined;
-    if (importance !== undefined && (typeof importance !== 'number' || importance < 0 || importance > 1)) {
-      return { content: 'Error: importance must be a number between 0 and 1', isError: true };
-    }
-
-    const rawChannels = input.channels as Array<{ type: string; address: string; is_primary?: boolean }> | undefined;
-    const channels = rawChannels?.map((ch) => ({
-      type: ch.type,
-      address: ch.address,
-      isPrimary: ch.is_primary,
-    }));
-
-    try {
-      const contact = upsertContact({
-        id: input.id as string | undefined,
-        displayName: displayName.trim(),
-        relationship: input.relationship as string | undefined,
-        importance,
-        responseExpectation: input.response_expectation as string | undefined,
-        preferredTone: input.preferred_tone as string | undefined,
-        channels,
-      });
-
-      const isNew = contact.createdAt === contact.updatedAt;
-      return {
-        content: `${isNew ? 'Created' : 'Updated'} contact:\n${formatContact(contact)}`,
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeContactUpsert(input, context);
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies into standalone exported functions for all 3 contact tools:

- `executeContactUpsert()` from `ContactUpsertTool`
- `executeContactSearch()` from `ContactSearchTool`
- `executeContactMerge()` from `ContactMergeTool`

Zero behavior change — pure refactor for upcoming skill migration. Classes now delegate to the exported functions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
