### PR TITLE
refactor: extract schedule tool functions for skill migration

### DIFF
--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -44,42 +44,49 @@ class ScheduleCreateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const name = input.name as string;
-    const cronExpression = input.cron_expression as string;
-    const timezone = (input.timezone as string) ?? null;
-    const message = input.message as string;
-    const enabled = (input.enabled as boolean) ?? true;
+    return executeScheduleCreate(input, _context);
+  }
+}
 
-    if (!name || typeof name !== 'string') {
-      return { content: 'Error: name is required and must be a string', isError: true };
-    }
-    if (!cronExpression || typeof cronExpression !== 'string') {
-      return { content: 'Error: cron_expression is required and must be a string', isError: true };
-    }
-    if (!message || typeof message !== 'string') {
-      return { content: 'Error: message is required and must be a string', isError: true };
-    }
-    if (!isValidCronExpression(cronExpression)) {
-      return { content: `Error: Invalid cron expression: "${cronExpression}"`, isError: true };
-    }
+export async function executeScheduleCreate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const name = input.name as string;
+  const cronExpression = input.cron_expression as string;
+  const timezone = (input.timezone as string) ?? null;
+  const message = input.message as string;
+  const enabled = (input.enabled as boolean) ?? true;
 
-    try {
-      const job = createSchedule({ name, cronExpression, timezone, message, enabled });
-      const nextRunDate = formatLocalDate(job.nextRunAt);
-      return {
-        content: [
-          `Schedule created successfully.`,
-          `  Name: ${job.name}`,
-          `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
-          `  Enabled: ${job.enabled}`,
-          `  Next run: ${nextRunDate}`,
-        ].join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error creating schedule: ${msg}`, isError: true };
-    }
+  if (!name || typeof name !== 'string') {
+    return { content: 'Error: name is required and must be a string', isError: true };
+  }
+  if (!cronExpression || typeof cronExpression !== 'string') {
+    return { content: 'Error: cron_expression is required and must be a string', isError: true };
+  }
+  if (!message || typeof message !== 'string') {
+    return { content: 'Error: message is required and must be a string', isError: true };
+  }
+  if (!isValidCronExpression(cronExpression)) {
+    return { content: `Error: Invalid cron expression: "${cronExpression}"`, isError: true };
+  }
+
+  try {
+    const job = createSchedule({ name, cronExpression, timezone, message, enabled });
+    const nextRunDate = formatLocalDate(job.nextRunAt);
+    return {
+      content: [
+        `Schedule created successfully.`,
+        `  Name: ${job.name}`,
+        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Enabled: ${job.enabled}`,
+        `  Next run: ${nextRunDate}`,
+      ].join('\n'),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error creating schedule: ${msg}`, isError: true };
   }
 }
 

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -28,27 +28,34 @@ class ScheduleDeleteTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const jobId = input.job_id as string;
-    if (!jobId || typeof jobId !== 'string') {
-      return { content: 'Error: job_id is required', isError: true };
-    }
-
-    // Fetch the job first for the confirmation message
-    const job = getSchedule(jobId);
-    if (!job) {
-      return { content: `Error: Schedule not found: ${jobId}`, isError: true };
-    }
-
-    const deleted = deleteSchedule(jobId);
-    if (!deleted) {
-      return { content: `Error: Failed to delete schedule: ${jobId}`, isError: true };
-    }
-
-    return {
-      content: `Schedule deleted: "${job.name}"`,
-      isError: false,
-    };
+    return executeScheduleDelete(input, _context);
   }
+}
+
+export async function executeScheduleDelete(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const jobId = input.job_id as string;
+  if (!jobId || typeof jobId !== 'string') {
+    return { content: 'Error: job_id is required', isError: true };
+  }
+
+  // Fetch the job first for the confirmation message
+  const job = getSchedule(jobId);
+  if (!job) {
+    return { content: `Error: Schedule not found: ${jobId}`, isError: true };
+  }
+
+  const deleted = deleteSchedule(jobId);
+  if (!deleted) {
+    return { content: `Error: Failed to delete schedule: ${jobId}`, isError: true };
+  }
+
+  return {
+    content: `Schedule deleted: "${job.name}"`,
+    isError: false,
+  };
 }
 
 registerTool(new ScheduleDeleteTool());

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -32,57 +32,64 @@ class ScheduleListTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const jobId = input.job_id as string | undefined;
-    const enabledOnly = (input.enabled_only as boolean) ?? false;
+    return executeScheduleList(input, _context);
+  }
+}
 
-    // Detail mode for a specific job
-    if (jobId) {
-      const job = getSchedule(jobId);
-      if (!job) {
-        return { content: `Error: Schedule not found: ${jobId}`, isError: true };
-      }
+export async function executeScheduleList(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const jobId = input.job_id as string | undefined;
+  const enabledOnly = (input.enabled_only as boolean) ?? false;
 
-      const runs = getScheduleRuns(jobId, 5);
-      const lines = [
-        `Schedule: ${job.name}`,
-        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
-        `  Enabled: ${job.enabled}`,
-        `  Message: ${job.message}`,
-        `  Next run: ${formatLocalDate(job.nextRunAt)}`,
-        `  Last run: ${job.lastRunAt ? formatLocalDate(job.lastRunAt) : 'never'}`,
-        `  Last status: ${job.lastStatus ?? 'n/a'}`,
-        `  Retry count: ${job.retryCount}`,
-        `  Created: ${formatLocalDate(job.createdAt)}`,
-      ];
-
-      if (runs.length > 0) {
-        lines.push('', `Recent runs (${runs.length}):`);
-        for (const run of runs) {
-          const dur = run.durationMs != null ? `${run.durationMs}ms` : 'n/a';
-          lines.push(`  - ${run.status} at ${formatLocalDate(run.startedAt)} (${dur})${run.error ? ` error: ${run.error}` : ''}`);
-        }
-      } else {
-        lines.push('', 'No runs yet.');
-      }
-
-      return { content: lines.join('\n'), isError: false };
+  // Detail mode for a specific job
+  if (jobId) {
+    const job = getSchedule(jobId);
+    if (!job) {
+      return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
-    // List mode
-    const jobs = listSchedules({ enabledOnly });
-    if (jobs.length === 0) {
-      return { content: 'No schedules found.', isError: false };
-    }
+    const runs = getScheduleRuns(jobId, 5);
+    const lines = [
+      `Schedule: ${job.name}`,
+      `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+      `  Enabled: ${job.enabled}`,
+      `  Message: ${job.message}`,
+      `  Next run: ${formatLocalDate(job.nextRunAt)}`,
+      `  Last run: ${job.lastRunAt ? formatLocalDate(job.lastRunAt) : 'never'}`,
+      `  Last status: ${job.lastStatus ?? 'n/a'}`,
+      `  Retry count: ${job.retryCount}`,
+      `  Created: ${formatLocalDate(job.createdAt)}`,
+    ];
 
-    const lines = [`Schedules (${jobs.length}):`];
-    for (const job of jobs) {
-      const status = job.enabled ? 'enabled' : 'disabled';
-      const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
-      lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next}`);
+    if (runs.length > 0) {
+      lines.push('', `Recent runs (${runs.length}):`);
+      for (const run of runs) {
+        const dur = run.durationMs != null ? `${run.durationMs}ms` : 'n/a';
+        lines.push(`  - ${run.status} at ${formatLocalDate(run.startedAt)} (${dur})${run.error ? ` error: ${run.error}` : ''}`);
+      }
+    } else {
+      lines.push('', 'No runs yet.');
     }
 
     return { content: lines.join('\n'), isError: false };
   }
+
+  // List mode
+  const jobs = listSchedules({ enabledOnly });
+  if (jobs.length === 0) {
+    return { content: 'No schedules found.', isError: false };
+  }
+
+  const lines = [`Schedules (${jobs.length}):`];
+  for (const job of jobs) {
+    const status = job.enabled ? 'enabled' : 'disabled';
+    const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
+    lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next}`);
+  }
+
+  return { content: lines.join('\n'), isError: false };
 }
 
 registerTool(new ScheduleListTool());

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -48,49 +48,56 @@ class ScheduleUpdateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const jobId = input.job_id as string;
-    if (!jobId || typeof jobId !== 'string') {
-      return { content: 'Error: job_id is required', isError: true };
+    return executeScheduleUpdate(input, _context);
+  }
+}
+
+export async function executeScheduleUpdate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const jobId = input.job_id as string;
+  if (!jobId || typeof jobId !== 'string') {
+    return { content: 'Error: job_id is required', isError: true };
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.cron_expression !== undefined) updates.cronExpression = input.cron_expression;
+  if (input.timezone !== undefined) updates.timezone = input.timezone;
+  if (input.message !== undefined) updates.message = input.message;
+  if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  if (Object.keys(updates).length === 0) {
+    return { content: 'Error: No updates provided. Specify at least one field to update.', isError: true };
+  }
+
+  try {
+    const job = updateSchedule(jobId, updates as {
+      name?: string;
+      cronExpression?: string;
+      timezone?: string | null;
+      message?: string;
+      enabled?: boolean;
+    });
+
+    if (!job) {
+      return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
-    const updates: Record<string, unknown> = {};
-    if (input.name !== undefined) updates.name = input.name;
-    if (input.cron_expression !== undefined) updates.cronExpression = input.cron_expression;
-    if (input.timezone !== undefined) updates.timezone = input.timezone;
-    if (input.message !== undefined) updates.message = input.message;
-    if (input.enabled !== undefined) updates.enabled = input.enabled;
-
-    if (Object.keys(updates).length === 0) {
-      return { content: 'Error: No updates provided. Specify at least one field to update.', isError: true };
-    }
-
-    try {
-      const job = updateSchedule(jobId, updates as {
-        name?: string;
-        cronExpression?: string;
-        timezone?: string | null;
-        message?: string;
-        enabled?: boolean;
-      });
-
-      if (!job) {
-        return { content: `Error: Schedule not found: ${jobId}`, isError: true };
-      }
-
-      return {
-        content: [
-          `Schedule updated successfully.`,
-          `  Name: ${job.name}`,
-          `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
-          `  Enabled: ${job.enabled}`,
-          `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a (disabled)'}`,
-        ].join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error updating schedule: ${msg}`, isError: true };
-    }
+    return {
+      content: [
+        `Schedule updated successfully.`,
+        `  Name: ${job.name}`,
+        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Enabled: ${job.enabled}`,
+        `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a (disabled)'}`,
+      ].join('\n'),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error updating schedule: ${msg}`, isError: true };
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies into standalone exported functions (executeScheduleCreate, executeScheduleList, executeScheduleUpdate, executeScheduleDelete). Classes delegate to the extracted functions. Zero behavior change — pure refactor for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
