### PR TITLE
refactor: extract playbook tool functions for skill migration

### DIFF
--- a/assistant/src/tools/playbooks/playbook-create.ts
+++ b/assistant/src/tools/playbooks/playbook-create.ts
@@ -12,7 +12,7 @@ import { truncate } from '../../util/truncate.js';
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
 
-async function execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+export async function executePlaybookCreate(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const trigger = input.trigger as string;
   const action = input.action as string;
 
@@ -137,5 +137,5 @@ registerTool({
       required: ['trigger', 'action'],
     },
   }),
-  execute,
+  execute: executePlaybookCreate,
 });

--- a/assistant/src/tools/playbooks/playbook-delete.ts
+++ b/assistant/src/tools/playbooks/playbook-delete.ts
@@ -6,7 +6,7 @@ import { getDb } from '../../memory/db.js';
 import { memoryItems } from '../../memory/schema.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
 
-async function execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+export async function executePlaybookDelete(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const playbookId = input.playbook_id as string;
   if (!playbookId || typeof playbookId !== 'string') {
     return { content: 'Error: playbook_id is required and must be a string', isError: true };
@@ -72,5 +72,5 @@ registerTool({
       required: ['playbook_id'],
     },
   }),
-  execute,
+  execute: executePlaybookDelete,
 });

--- a/assistant/src/tools/playbooks/playbook-list.ts
+++ b/assistant/src/tools/playbooks/playbook-list.ts
@@ -6,7 +6,7 @@ import { getDb } from '../../memory/db.js';
 import { memoryItems } from '../../memory/schema.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
 
-async function execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+export async function executePlaybookList(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const scopeId = context.memoryScopeId ?? 'default';
   const channelFilter = typeof input.channel === 'string' ? input.channel : null;
   const categoryFilter = typeof input.category === 'string' ? input.category : null;
@@ -97,5 +97,5 @@ registerTool({
       },
     },
   }),
-  execute,
+  execute: executePlaybookList,
 });

--- a/assistant/src/tools/playbooks/playbook-update.ts
+++ b/assistant/src/tools/playbooks/playbook-update.ts
@@ -12,7 +12,7 @@ import { truncate } from '../../util/truncate.js';
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(['auto', 'draft', 'notify']);
 
-async function execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+export async function executePlaybookUpdate(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const playbookId = input.playbook_id as string;
   if (!playbookId || typeof playbookId !== 'string') {
     return { content: 'Error: playbook_id is required and must be a string', isError: true };
@@ -156,5 +156,5 @@ registerTool({
       required: ['playbook_id'],
     },
   }),
-  execute,
+  execute: executePlaybookUpdate,
 });


### PR DESCRIPTION
Rename and export standalone execute functions for all 4 playbook tools:

- `executePlaybookCreate()` in `playbook-create.ts`
- `executePlaybookList()` in `playbook-list.ts`
- `executePlaybookUpdate()` in `playbook-update.ts`
- `executePlaybookDelete()` in `playbook-delete.ts`

Zero behavior change — pure refactor for upcoming skill migration. The `registerTool()` calls now reference the named exports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
