### PR TITLE
refactor: extract task template tool functions for skill migration

### DIFF
--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -23,6 +23,82 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskDelete(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const raw = input.task_ids;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { content: 'Error: task_ids must be a non-empty array of task ID strings', isError: true };
+  }
+  const ids = raw.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  if (ids.length === 0) {
+    return { content: 'Error: task_ids must contain at least one non-empty string', isError: true };
+  }
+
+  try {
+    if (ids.length === 1) {
+      const task = getTask(ids[0]);
+      const deleted = deleteTask(ids[0]);
+      if (!deleted) {
+        // The LLM may pass a work item ID instead of a task template ID.
+        // Fall back to removing from the task queue so the user's intent succeeds.
+        const result = removeWorkItemFromQueue(ids[0]);
+        if (result.success) {
+          log.info({ inputId: ids[0], fallback: true, deletedCount: 1 }, 'deleted via work item fallback');
+          return { content: result.message, isError: false };
+        }
+        log.warn({ inputId: ids[0] }, 'no task or work item found for deletion');
+        return { content: `No task template or work item found with ID "${ids[0]}". Use task_list to see task templates or task_list_show to see work items in the queue.`, isError: true };
+      }
+      log.info({ taskId: ids[0], title: task?.title, deletedCount: 1 }, 'task deleted');
+      return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };
+    }
+
+    const taskIds: string[] = [];
+    const taskTitles: string[] = [];
+    const workItemTitles: string[] = [];
+
+    for (const id of ids) {
+      const task = getTask(id);
+      if (task) {
+        taskIds.push(id);
+        taskTitles.push(task.title);
+      } else {
+        const result = removeWorkItemFromQueue(id);
+        if (result.success) {
+          log.info({ inputId: id, fallback: true }, 'deleted work item in batch (fallback)');
+          workItemTitles.push(result.title);
+        } else {
+          log.warn({ inputId: id }, 'batch delete: no task or work item found');
+        }
+      }
+    }
+
+    const taskCount = taskIds.length > 0 ? deleteTasks(taskIds) : 0;
+
+    if (taskCount === 0 && workItemTitles.length === 0) {
+      log.warn({ inputIds: ids }, 'no matching tasks found to delete');
+      return { content: 'No matching tasks found to delete.', isError: true };
+    }
+
+    log.info({ deletedTasks: taskCount, deletedWorkItems: workItemTitles.length, totalInput: ids.length }, 'batch delete completed');
+
+    const lines: string[] = [];
+    if (taskCount > 0) {
+      lines.push(`Deleted ${taskCount} task(s):`, ...taskTitles.map((t) => `- ${t}`));
+    }
+    if (workItemTitles.length > 0) {
+      lines.push(`Removed ${workItemTitles.length} item(s) from the task queue:`, ...workItemTitles.map((t) => `- ${t}`));
+    }
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ inputIds: ids, error: msg }, 'delete failed');
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskDeleteTool implements Tool {
   name = 'task_delete';
   description = definition.description;
@@ -34,76 +110,7 @@ class TaskDeleteTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const raw = input.task_ids;
-    if (!Array.isArray(raw) || raw.length === 0) {
-      return { content: 'Error: task_ids must be a non-empty array of task ID strings', isError: true };
-    }
-    const ids = raw.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
-    if (ids.length === 0) {
-      return { content: 'Error: task_ids must contain at least one non-empty string', isError: true };
-    }
-
-    try {
-      if (ids.length === 1) {
-        const task = getTask(ids[0]);
-        const deleted = deleteTask(ids[0]);
-        if (!deleted) {
-          // The LLM may pass a work item ID instead of a task template ID.
-          // Fall back to removing from the task queue so the user's intent succeeds.
-          const result = removeWorkItemFromQueue(ids[0]);
-          if (result.success) {
-            log.info({ inputId: ids[0], fallback: true, deletedCount: 1 }, 'deleted via work item fallback');
-            return { content: result.message, isError: false };
-          }
-          log.warn({ inputId: ids[0] }, 'no task or work item found for deletion');
-          return { content: `No task template or work item found with ID "${ids[0]}". Use task_list to see task templates or task_list_show to see work items in the queue.`, isError: true };
-        }
-        log.info({ taskId: ids[0], title: task?.title, deletedCount: 1 }, 'task deleted');
-        return { content: `Deleted task: ${task?.title ?? ids[0]}`, isError: false };
-      }
-
-      const taskIds: string[] = [];
-      const taskTitles: string[] = [];
-      const workItemTitles: string[] = [];
-
-      for (const id of ids) {
-        const task = getTask(id);
-        if (task) {
-          taskIds.push(id);
-          taskTitles.push(task.title);
-        } else {
-          const result = removeWorkItemFromQueue(id);
-          if (result.success) {
-            log.info({ inputId: id, fallback: true }, 'deleted work item in batch (fallback)');
-            workItemTitles.push(result.title);
-          } else {
-            log.warn({ inputId: id }, 'batch delete: no task or work item found');
-          }
-        }
-      }
-
-      const taskCount = taskIds.length > 0 ? deleteTasks(taskIds) : 0;
-
-      if (taskCount === 0 && workItemTitles.length === 0) {
-        log.warn({ inputIds: ids }, 'no matching tasks found to delete');
-        return { content: 'No matching tasks found to delete.', isError: true };
-      }
-
-      log.info({ deletedTasks: taskCount, deletedWorkItems: workItemTitles.length, totalInput: ids.length }, 'batch delete completed');
-
-      const lines: string[] = [];
-      if (taskCount > 0) {
-        lines.push(`Deleted ${taskCount} task(s):`, ...taskTitles.map((t) => `- ${t}`));
-      }
-      if (workItemTitles.length > 0) {
-        lines.push(`Removed ${workItemTitles.length} item(s) from the task queue:`, ...workItemTitles.map((t) => `- ${t}`));
-      }
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ inputIds: ids, error: msg }, 'delete failed');
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskDelete(input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/task-list.ts
+++ b/assistant/src/tools/tasks/task-list.ts
@@ -12,6 +12,48 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskList(
+  _input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  try {
+    const tasks = listTasks();
+
+    if (tasks.length === 0) {
+      return { content: 'No task templates found. Use task_save to create one from a conversation.\n\nTip: To see your active Tasks (work items in the queue), use the task_list_show tool.', isError: false };
+    }
+
+    const lines = [`Found ${tasks.length} task template(s):`, ''];
+
+    for (const task of tasks) {
+      const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+      const createdAt = new Date(task.createdAt).toISOString();
+
+      lines.push(`- ${task.title}`);
+      lines.push(`    ID: ${task.id}`);
+      lines.push(`    Status: ${task.status}`);
+      lines.push(`    Created: ${createdAt}`);
+      if (requiredTools.length > 0) {
+        lines.push(`    Required tools: ${requiredTools.join(', ')}`);
+      }
+      if (task.inputSchema) {
+        const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
+        if (schema.properties) {
+          lines.push(`    Inputs: ${Object.keys(schema.properties).join(', ')}`);
+        }
+      }
+      lines.push('');
+    }
+
+    lines.push('Tip: To see your active Tasks (work items in the queue), use the task_list_show tool.');
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskListTool implements Tool {
   name = 'task_list';
   description = definition.description;
@@ -23,42 +65,7 @@ class TaskListTool implements Tool {
   }
 
   async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    try {
-      const tasks = listTasks();
-
-      if (tasks.length === 0) {
-        return { content: 'No task templates found. Use task_save to create one from a conversation.\n\nTip: To see your active Tasks (work items in the queue), use the task_list_show tool.', isError: false };
-      }
-
-      const lines = [`Found ${tasks.length} task template(s):`, ''];
-
-      for (const task of tasks) {
-        const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
-        const createdAt = new Date(task.createdAt).toISOString();
-
-        lines.push(`- ${task.title}`);
-        lines.push(`    ID: ${task.id}`);
-        lines.push(`    Status: ${task.status}`);
-        lines.push(`    Created: ${createdAt}`);
-        if (requiredTools.length > 0) {
-          lines.push(`    Required tools: ${requiredTools.join(', ')}`);
-        }
-        if (task.inputSchema) {
-          const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
-          if (schema.properties) {
-            lines.push(`    Inputs: ${Object.keys(schema.properties).join(', ')}`);
-          }
-        }
-        lines.push('');
-      }
-
-      lines.push('Tip: To see your active Tasks (work items in the queue), use the task_list_show tool.');
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskList(_input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/task-run.ts
+++ b/assistant/src/tools/tasks/task-run.ts
@@ -29,6 +29,99 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskRun(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const taskName = input.task_name as string | undefined;
+  const taskId = input.task_id as string | undefined;
+  const inputs = (input.inputs as Record<string, string> | undefined) ?? {};
+
+  if (!taskName && !taskId) {
+    return {
+      content: 'Error: At least one of task_name or task_id must be provided',
+      isError: true,
+    };
+  }
+
+  try {
+    // Resolve the task
+    let task;
+
+    if (taskId) {
+      task = getTask(taskId);
+      if (!task) {
+        const entity = identifyEntityById(taskId);
+        if (entity.type === 'work_item') {
+          return {
+            content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_show to view work items, or task_list_update to modify them')}`,
+            isError: true,
+          };
+        }
+        return { content: `Error: No task template found with ID "${taskId}". Use task_list to see available templates.`, isError: true };
+      }
+    } else if (taskName) {
+      const allTasks = listTasks();
+      const needle = taskName.toLowerCase();
+
+      // Case-insensitive substring match
+      task = allTasks.find((t) => t.title.toLowerCase().includes(needle));
+
+      if (!task) {
+        if (allTasks.length === 0) {
+          return { content: 'Error: No task templates found. Use task_save to create one first.', isError: true };
+        }
+        const available = allTasks.map((t) => `  - "${t.title}" (${t.id})`).join('\n');
+        return {
+          content: `Error: No task template matching "${taskName}" found. Available templates:\n${available}`,
+          isError: true,
+        };
+      }
+    }
+
+    if (!task) {
+      return { content: 'Error: Could not resolve task template', isError: true };
+    }
+
+    // Check if required inputs are provided
+    if (task.inputSchema) {
+      const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
+      if (schema.properties) {
+        const requiredKeys = Object.keys(schema.properties);
+        const missingKeys = requiredKeys.filter((k) => !(k in inputs));
+        if (missingKeys.length > 0) {
+          return {
+            content: `Error: Missing required inputs: ${missingKeys.join(', ')}. Provide them in the "inputs" parameter.`,
+            isError: true,
+          };
+        }
+      }
+    }
+
+    // Render the template
+    const rendered = renderTemplate(task.template, inputs);
+
+    const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
+
+    const lines = [
+      `Template "${task.title}" resolved and rendered.`,
+      ``,
+      `I'll now execute the following:`,
+      ``,
+      rendered,
+    ];
+
+    if (requiredTools.length > 0) {
+      lines.push('', `Required tools: ${requiredTools.join(', ')}`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskRunTool implements Tool {
   name = 'task_run';
   description = definition.description;
@@ -40,93 +133,7 @@ class TaskRunTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const taskName = input.task_name as string | undefined;
-    const taskId = input.task_id as string | undefined;
-    const inputs = (input.inputs as Record<string, string> | undefined) ?? {};
-
-    if (!taskName && !taskId) {
-      return {
-        content: 'Error: At least one of task_name or task_id must be provided',
-        isError: true,
-      };
-    }
-
-    try {
-      // Resolve the task
-      let task;
-
-      if (taskId) {
-        task = getTask(taskId);
-        if (!task) {
-          const entity = identifyEntityById(taskId);
-          if (entity.type === 'work_item') {
-            return {
-              content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_show to view work items, or task_list_update to modify them')}`,
-              isError: true,
-            };
-          }
-          return { content: `Error: No task template found with ID "${taskId}". Use task_list to see available templates.`, isError: true };
-        }
-      } else if (taskName) {
-        const allTasks = listTasks();
-        const needle = taskName.toLowerCase();
-
-        // Case-insensitive substring match
-        task = allTasks.find((t) => t.title.toLowerCase().includes(needle));
-
-        if (!task) {
-          if (allTasks.length === 0) {
-            return { content: 'Error: No task templates found. Use task_save to create one first.', isError: true };
-          }
-          const available = allTasks.map((t) => `  - "${t.title}" (${t.id})`).join('\n');
-          return {
-            content: `Error: No task template matching "${taskName}" found. Available templates:\n${available}`,
-            isError: true,
-          };
-        }
-      }
-
-      if (!task) {
-        return { content: 'Error: Could not resolve task template', isError: true };
-      }
-
-      // Check if required inputs are provided
-      if (task.inputSchema) {
-        const schema = JSON.parse(task.inputSchema) as { properties?: Record<string, unknown> };
-        if (schema.properties) {
-          const requiredKeys = Object.keys(schema.properties);
-          const missingKeys = requiredKeys.filter((k) => !(k in inputs));
-          if (missingKeys.length > 0) {
-            return {
-              content: `Error: Missing required inputs: ${missingKeys.join(', ')}. Provide them in the "inputs" parameter.`,
-              isError: true,
-            };
-          }
-        }
-      }
-
-      // Render the template
-      const rendered = renderTemplate(task.template, inputs);
-
-      const requiredTools: string[] = task.requiredTools ? JSON.parse(task.requiredTools) : [];
-
-      const lines = [
-        `Template "${task.title}" resolved and rendered.`,
-        ``,
-        `I'll now execute the following:`,
-        ``,
-        rendered,
-      ];
-
-      if (requiredTools.length > 0) {
-        lines.push('', `Required tools: ${requiredTools.join(', ')}`);
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskRun(input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/task-save.ts
+++ b/assistant/src/tools/tasks/task-save.ts
@@ -23,6 +23,51 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskSave(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const conversationId = (input.conversation_id as string | undefined) || context.conversationId;
+  if (!conversationId || typeof conversationId !== 'string' || conversationId.trim().length === 0) {
+    return { content: 'Error: conversation_id is required and must be a non-empty string', isError: true };
+  }
+
+  const titleOverride = input.title as string | undefined;
+
+  try {
+    const compiled = compileTaskFromConversation(conversationId);
+
+    if (titleOverride && typeof titleOverride === 'string' && titleOverride.trim().length > 0) {
+      compiled.title = titleOverride.trim();
+    }
+
+    const task = saveCompiledTask(compiled, conversationId);
+
+    const lines = [
+      `Task saved successfully.`,
+      `  ID: ${task.id}`,
+      `  Title: ${task.title}`,
+      `  Template: ${task.template}`,
+    ];
+
+    if (compiled.requiredTools.length > 0) {
+      lines.push(`  Required tools: ${compiled.requiredTools.join(', ')}`);
+    }
+
+    if (compiled.inputSchema) {
+      const props = (compiled.inputSchema as Record<string, unknown>).properties as Record<string, unknown> | undefined;
+      if (props) {
+        lines.push(`  Input placeholders: ${Object.keys(props).join(', ')}`);
+      }
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskSaveTool implements Tool {
   name = 'task_save';
   description = definition.description;
@@ -34,45 +79,7 @@ class TaskSaveTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const conversationId = (input.conversation_id as string | undefined) || context.conversationId;
-    if (!conversationId || typeof conversationId !== 'string' || conversationId.trim().length === 0) {
-      return { content: 'Error: conversation_id is required and must be a non-empty string', isError: true };
-    }
-
-    const titleOverride = input.title as string | undefined;
-
-    try {
-      const compiled = compileTaskFromConversation(conversationId);
-
-      if (titleOverride && typeof titleOverride === 'string' && titleOverride.trim().length > 0) {
-        compiled.title = titleOverride.trim();
-      }
-
-      const task = saveCompiledTask(compiled, conversationId);
-
-      const lines = [
-        `Task saved successfully.`,
-        `  ID: ${task.id}`,
-        `  Title: ${task.title}`,
-        `  Template: ${task.template}`,
-      ];
-
-      if (compiled.requiredTools.length > 0) {
-        lines.push(`  Required tools: ${compiled.requiredTools.join(', ')}`);
-      }
-
-      if (compiled.inputSchema) {
-        const props = (compiled.inputSchema as Record<string, unknown>).properties as Record<string, unknown> | undefined;
-        if (props) {
-          lines.push(`  Input placeholders: ${Object.keys(props).join(', ')}`);
-        }
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskSave(input, context);
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies from TaskSaveTool, TaskRunTool, TaskListTool, and TaskDeleteTool into standalone exported functions (executeTaskSave, executeTaskRun, executeTaskList, executeTaskDelete). Class methods now delegate to these functions. Zero behavior change — pure refactor for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
