### PR TITLE
refactor: extract watcher tool functions for skill migration

### DIFF
--- a/assistant/src/tools/watcher/create.ts
+++ b/assistant/src/tools/watcher/create.ts
@@ -49,61 +49,68 @@ class WatcherCreateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const name = input.name as string;
-    const providerId = input.provider as string;
-    const actionPrompt = input.action_prompt as string;
-    const pollIntervalMs = (input.poll_interval_ms as number) ?? undefined;
-    const config = input.config as Record<string, unknown> | undefined;
+    return executeWatcherCreate(input, _context);
+  }
+}
 
-    if (!name || typeof name !== 'string') {
-      return { content: 'Error: name is required and must be a string', isError: true };
-    }
-    if (!providerId || typeof providerId !== 'string') {
-      return { content: 'Error: provider is required and must be a string', isError: true };
-    }
-    if (!actionPrompt || typeof actionPrompt !== 'string') {
-      return { content: 'Error: action_prompt is required and must be a string', isError: true };
-    }
+export async function executeWatcherCreate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const name = input.name as string;
+  const providerId = input.provider as string;
+  const actionPrompt = input.action_prompt as string;
+  const pollIntervalMs = (input.poll_interval_ms as number) ?? undefined;
+  const config = input.config as Record<string, unknown> | undefined;
 
-    const provider = getWatcherProvider(providerId);
-    if (!provider) {
-      const available = listWatcherProviders().map((p) => p.id).join(', ') || 'none';
-      return { content: `Error: Unknown provider "${providerId}". Available: ${available}`, isError: true };
-    }
+  if (!name || typeof name !== 'string') {
+    return { content: 'Error: name is required and must be a string', isError: true };
+  }
+  if (!providerId || typeof providerId !== 'string') {
+    return { content: 'Error: provider is required and must be a string', isError: true };
+  }
+  if (!actionPrompt || typeof actionPrompt !== 'string') {
+    return { content: 'Error: action_prompt is required and must be a string', isError: true };
+  }
 
-    if (pollIntervalMs !== undefined && pollIntervalMs < 15000) {
-      return { content: 'Error: poll_interval_ms must be at least 15000 (15 seconds)', isError: true };
-    }
+  const provider = getWatcherProvider(providerId);
+  if (!provider) {
+    const available = listWatcherProviders().map((p) => p.id).join(', ') || 'none';
+    return { content: `Error: Unknown provider "${providerId}". Available: ${available}`, isError: true };
+  }
 
-    const credentialService = (input.credential_service as string) ?? provider.requiredCredentialService;
+  if (pollIntervalMs !== undefined && pollIntervalMs < 15000) {
+    return { content: 'Error: poll_interval_ms must be at least 15000 (15 seconds)', isError: true };
+  }
 
-    try {
-      const watcher = createWatcher({
-        name,
-        providerId,
-        actionPrompt,
-        credentialService,
-        pollIntervalMs,
-        configJson: config ? JSON.stringify(config) : null,
-      });
+  const credentialService = (input.credential_service as string) ?? provider.requiredCredentialService;
 
-      const intervalSec = Math.round(watcher.pollIntervalMs / 1000);
-      return {
-        content: [
-          'Watcher created successfully.',
-          `  Name: ${watcher.name}`,
-          `  Provider: ${provider.displayName}`,
-          `  Poll interval: ${intervalSec}s`,
-          `  Credential: ${watcher.credentialService}`,
-          `  Status: ${watcher.status}`,
-          `  ID: ${watcher.id}`,
-        ].join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error creating watcher: ${msg}`, isError: true };
-    }
+  try {
+    const watcher = createWatcher({
+      name,
+      providerId,
+      actionPrompt,
+      credentialService,
+      pollIntervalMs,
+      configJson: config ? JSON.stringify(config) : null,
+    });
+
+    const intervalSec = Math.round(watcher.pollIntervalMs / 1000);
+    return {
+      content: [
+        'Watcher created successfully.',
+        `  Name: ${watcher.name}`,
+        `  Provider: ${provider.displayName}`,
+        `  Poll interval: ${intervalSec}s`,
+        `  Credential: ${watcher.credentialService}`,
+        `  Status: ${watcher.status}`,
+        `  ID: ${watcher.id}`,
+      ].join('\n'),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error creating watcher: ${msg}`, isError: true };
   }
 }
 

--- a/assistant/src/tools/watcher/delete.ts
+++ b/assistant/src/tools/watcher/delete.ts
@@ -28,26 +28,33 @@ class WatcherDeleteTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const watcherId = input.watcher_id as string;
-    if (!watcherId || typeof watcherId !== 'string') {
-      return { content: 'Error: watcher_id is required', isError: true };
-    }
-
-    const watcher = getWatcher(watcherId);
-    if (!watcher) {
-      return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
-    }
-
-    const deleted = deleteWatcher(watcherId);
-    if (!deleted) {
-      return { content: `Error: Failed to delete watcher: ${watcherId}`, isError: true };
-    }
-
-    return {
-      content: `Watcher deleted: "${watcher.name}"`,
-      isError: false,
-    };
+    return executeWatcherDelete(input, _context);
   }
+}
+
+export async function executeWatcherDelete(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const watcherId = input.watcher_id as string;
+  if (!watcherId || typeof watcherId !== 'string') {
+    return { content: 'Error: watcher_id is required', isError: true };
+  }
+
+  const watcher = getWatcher(watcherId);
+  if (!watcher) {
+    return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
+  }
+
+  const deleted = deleteWatcher(watcherId);
+  if (!deleted) {
+    return { content: `Error: Failed to delete watcher: ${watcherId}`, isError: true };
+  }
+
+  return {
+    content: `Watcher deleted: "${watcher.name}"`,
+    isError: false,
+  };
 }
 
 registerTool(new WatcherDeleteTool());

--- a/assistant/src/tools/watcher/digest.ts
+++ b/assistant/src/tools/watcher/digest.ts
@@ -36,49 +36,56 @@ class WatcherDigestTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const watcherId = input.watcher_id as string | undefined;
-    const hours = (input.hours as number) ?? 24;
-    const limit = (input.limit as number) ?? 50;
+    return executeWatcherDigest(input, _context);
+  }
+}
 
-    const since = Date.now() - hours * 60 * 60 * 1000;
+export async function executeWatcherDigest(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const watcherId = input.watcher_id as string | undefined;
+  const hours = (input.hours as number) ?? 24;
+  const limit = (input.limit as number) ?? 50;
 
-    const events = listWatcherEvents({ watcherId, limit, since });
+  const since = Date.now() - hours * 60 * 60 * 1000;
 
-    if (events.length === 0) {
-      const period = hours === 24 ? 'today' : `the last ${hours} hours`;
-      return { content: `No watcher events detected ${period}.`, isError: false };
-    }
+  const events = listWatcherEvents({ watcherId, limit, since });
 
-    // Group events by watcher
-    const watcherMap = new Map<string, typeof events>();
-    for (const event of events) {
-      const existing = watcherMap.get(event.watcherId) ?? [];
-      existing.push(event);
-      watcherMap.set(event.watcherId, existing);
-    }
+  if (events.length === 0) {
+    const period = hours === 24 ? 'today' : `the last ${hours} hours`;
+    return { content: `No watcher events detected ${period}.`, isError: false };
+  }
 
-    // Get watcher names
-    const allWatchers = listWatchers();
-    const nameMap = new Map(allWatchers.map((w) => [w.id, w.name]));
+  // Group events by watcher
+  const watcherMap = new Map<string, typeof events>();
+  for (const event of events) {
+    const existing = watcherMap.get(event.watcherId) ?? [];
+    existing.push(event);
+    watcherMap.set(event.watcherId, existing);
+  }
 
-    const lines = [`Watcher activity (last ${hours}h, ${events.length} events):`];
+  // Get watcher names
+  const allWatchers = listWatchers();
+  const nameMap = new Map(allWatchers.map((w) => [w.id, w.name]));
 
-    for (const [wId, wEvents] of watcherMap) {
-      const name = nameMap.get(wId) ?? wId;
-      lines.push('', `${name} (${wEvents.length} events):`);
+  const lines = [`Watcher activity (last ${hours}h, ${events.length} events):`];
 
-      for (const event of wEvents) {
-        const time = new Date(event.createdAt).toLocaleString();
-        const disposition = event.disposition !== 'pending' ? ` [${event.disposition}]` : '';
-        lines.push(`  - ${event.summary}${disposition} (${time})`);
-        if (event.llmAction) {
-          lines.push(`    Action: ${event.llmAction}`);
-        }
+  for (const [wId, wEvents] of watcherMap) {
+    const name = nameMap.get(wId) ?? wId;
+    lines.push('', `${name} (${wEvents.length} events):`);
+
+    for (const event of wEvents) {
+      const time = new Date(event.createdAt).toLocaleString();
+      const disposition = event.disposition !== 'pending' ? ` [${event.disposition}]` : '';
+      lines.push(`  - ${event.summary}${disposition} (${time})`);
+      if (event.llmAction) {
+        lines.push(`    Action: ${event.llmAction}`);
       }
     }
-
-    return { content: lines.join('\n'), isError: false };
   }
+
+  return { content: lines.join('\n'), isError: false };
 }
 
 registerTool(new WatcherDigestTool());

--- a/assistant/src/tools/watcher/list.ts
+++ b/assistant/src/tools/watcher/list.ts
@@ -32,59 +32,66 @@ class WatcherListTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const watcherId = input.watcher_id as string | undefined;
-    const enabledOnly = (input.enabled_only as boolean) ?? false;
+    return executeWatcherList(input, _context);
+  }
+}
 
-    if (watcherId) {
-      const watcher = getWatcher(watcherId);
-      if (!watcher) {
-        return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
-      }
+export async function executeWatcherList(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const watcherId = input.watcher_id as string | undefined;
+  const enabledOnly = (input.enabled_only as boolean) ?? false;
 
-      const events = listWatcherEvents({ watcherId, limit: 10 });
-      const lines = [
-        `Watcher: ${watcher.name}`,
-        `  ID: ${watcher.id}`,
-        `  Provider: ${watcher.providerId}`,
-        `  Status: ${watcher.status}`,
-        `  Enabled: ${watcher.enabled}`,
-        `  Poll interval: ${Math.round(watcher.pollIntervalMs / 1000)}s`,
-        `  Credential: ${watcher.credentialService}`,
-        `  Last poll: ${watcher.lastPollAt ? new Date(watcher.lastPollAt).toLocaleString() : 'never'}`,
-        `  Next poll: ${watcher.nextPollAt ? new Date(watcher.nextPollAt).toLocaleString() : 'n/a'}`,
-        `  Errors: ${watcher.consecutiveErrors}`,
-      ];
-
-      if (watcher.lastError) {
-        lines.push(`  Last error: ${watcher.lastError}`);
-      }
-
-      if (events.length > 0) {
-        lines.push('', `Recent events (${events.length}):`);
-        for (const event of events) {
-          lines.push(`  - [${event.disposition}] ${event.summary} (${new Date(event.createdAt).toLocaleString()})`);
-        }
-      } else {
-        lines.push('', 'No events detected yet.');
-      }
-
-      return { content: lines.join('\n'), isError: false };
+  if (watcherId) {
+    const watcher = getWatcher(watcherId);
+    if (!watcher) {
+      return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
     }
 
-    const allWatchers = listWatchers({ enabledOnly });
-    if (allWatchers.length === 0) {
-      return { content: 'No watchers found.', isError: false };
+    const events = listWatcherEvents({ watcherId, limit: 10 });
+    const lines = [
+      `Watcher: ${watcher.name}`,
+      `  ID: ${watcher.id}`,
+      `  Provider: ${watcher.providerId}`,
+      `  Status: ${watcher.status}`,
+      `  Enabled: ${watcher.enabled}`,
+      `  Poll interval: ${Math.round(watcher.pollIntervalMs / 1000)}s`,
+      `  Credential: ${watcher.credentialService}`,
+      `  Last poll: ${watcher.lastPollAt ? new Date(watcher.lastPollAt).toLocaleString() : 'never'}`,
+      `  Next poll: ${watcher.nextPollAt ? new Date(watcher.nextPollAt).toLocaleString() : 'n/a'}`,
+      `  Errors: ${watcher.consecutiveErrors}`,
+    ];
+
+    if (watcher.lastError) {
+      lines.push(`  Last error: ${watcher.lastError}`);
     }
 
-    const lines = [`Watchers (${allWatchers.length}):`];
-    for (const w of allWatchers) {
-      const status = w.enabled ? w.status : 'disabled';
-      const lastPoll = w.lastPollAt ? new Date(w.lastPollAt).toLocaleString() : 'never';
-      lines.push(`  - [${status}] ${w.name} (${w.providerId}) — last: ${lastPoll}`);
+    if (events.length > 0) {
+      lines.push('', `Recent events (${events.length}):`);
+      for (const event of events) {
+        lines.push(`  - [${event.disposition}] ${event.summary} (${new Date(event.createdAt).toLocaleString()})`);
+      }
+    } else {
+      lines.push('', 'No events detected yet.');
     }
 
     return { content: lines.join('\n'), isError: false };
   }
+
+  const allWatchers = listWatchers({ enabledOnly });
+  if (allWatchers.length === 0) {
+    return { content: 'No watchers found.', isError: false };
+  }
+
+  const lines = [`Watchers (${allWatchers.length}):`];
+  for (const w of allWatchers) {
+    const status = w.enabled ? w.status : 'disabled';
+    const lastPoll = w.lastPollAt ? new Date(w.lastPollAt).toLocaleString() : 'never';
+    lines.push(`  - [${status}] ${w.name} (${w.providerId}) — last: ${lastPoll}`);
+  }
+
+  return { content: lines.join('\n'), isError: false };
 }
 
 registerTool(new WatcherListTool());

--- a/assistant/src/tools/watcher/update.ts
+++ b/assistant/src/tools/watcher/update.ts
@@ -48,54 +48,61 @@ class WatcherUpdateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const watcherId = input.watcher_id as string;
-    if (!watcherId || typeof watcherId !== 'string') {
-      return { content: 'Error: watcher_id is required', isError: true };
+    return executeWatcherUpdate(input, _context);
+  }
+}
+
+export async function executeWatcherUpdate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const watcherId = input.watcher_id as string;
+  if (!watcherId || typeof watcherId !== 'string') {
+    return { content: 'Error: watcher_id is required', isError: true };
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.action_prompt !== undefined) updates.actionPrompt = input.action_prompt;
+  if (input.poll_interval_ms !== undefined) {
+    if ((input.poll_interval_ms as number) < 15000) {
+      return { content: 'Error: poll_interval_ms must be at least 15000 (15 seconds)', isError: true };
+    }
+    updates.pollIntervalMs = input.poll_interval_ms;
+  }
+  if (input.enabled !== undefined) updates.enabled = input.enabled;
+  if (input.config !== undefined) updates.configJson = JSON.stringify(input.config);
+
+  if (Object.keys(updates).length === 0) {
+    return { content: 'Error: No updates provided. Specify at least one field to update.', isError: true };
+  }
+
+  try {
+    const watcher = updateWatcher(watcherId, updates as {
+      name?: string;
+      actionPrompt?: string;
+      pollIntervalMs?: number;
+      enabled?: boolean;
+      configJson?: string | null;
+    });
+
+    if (!watcher) {
+      return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
     }
 
-    const updates: Record<string, unknown> = {};
-    if (input.name !== undefined) updates.name = input.name;
-    if (input.action_prompt !== undefined) updates.actionPrompt = input.action_prompt;
-    if (input.poll_interval_ms !== undefined) {
-      if ((input.poll_interval_ms as number) < 15000) {
-        return { content: 'Error: poll_interval_ms must be at least 15000 (15 seconds)', isError: true };
-      }
-      updates.pollIntervalMs = input.poll_interval_ms;
-    }
-    if (input.enabled !== undefined) updates.enabled = input.enabled;
-    if (input.config !== undefined) updates.configJson = JSON.stringify(input.config);
-
-    if (Object.keys(updates).length === 0) {
-      return { content: 'Error: No updates provided. Specify at least one field to update.', isError: true };
-    }
-
-    try {
-      const watcher = updateWatcher(watcherId, updates as {
-        name?: string;
-        actionPrompt?: string;
-        pollIntervalMs?: number;
-        enabled?: boolean;
-        configJson?: string | null;
-      });
-
-      if (!watcher) {
-        return { content: `Error: Watcher not found: ${watcherId}`, isError: true };
-      }
-
-      return {
-        content: [
-          'Watcher updated successfully.',
-          `  Name: ${watcher.name}`,
-          `  Enabled: ${watcher.enabled}`,
-          `  Status: ${watcher.status}`,
-          `  Poll interval: ${Math.round(watcher.pollIntervalMs / 1000)}s`,
-        ].join('\n'),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error updating watcher: ${msg}`, isError: true };
-    }
+    return {
+      content: [
+        'Watcher updated successfully.',
+        `  Name: ${watcher.name}`,
+        `  Enabled: ${watcher.enabled}`,
+        `  Status: ${watcher.status}`,
+        `  Poll interval: ${Math.round(watcher.pollIntervalMs / 1000)}s`,
+      ].join('\n'),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error updating watcher: ${msg}`, isError: true };
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies from all 5 watcher tools into standalone exported functions:

- `executeWatcherCreate()` in `create.ts`
- `executeWatcherList()` in `list.ts`
- `executeWatcherUpdate()` in `update.ts`
- `executeWatcherDelete()` in `delete.ts`
- `executeWatcherDigest()` in `digest.ts`

Zero behavior change — pure refactor. Class methods now delegate to the exported functions. Prepares for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
