### PR TITLE
refactor: extract followup tool functions for skill migration

### DIFF
--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -63,55 +63,62 @@ class FollowUpCreateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const channel = input.channel as string | undefined;
-    if (!channel || typeof channel !== 'string' || channel.trim().length === 0) {
-      return { content: 'Error: channel is required and must be a non-empty string', isError: true };
+    return executeFollowupCreate(input, _context);
+  }
+}
+
+export async function executeFollowupCreate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const channel = input.channel as string | undefined;
+  if (!channel || typeof channel !== 'string' || channel.trim().length === 0) {
+    return { content: 'Error: channel is required and must be a non-empty string', isError: true };
+  }
+
+  const threadId = input.thread_id as string | undefined;
+  if (!threadId || typeof threadId !== 'string' || threadId.trim().length === 0) {
+    return { content: 'Error: thread_id is required and must be a non-empty string', isError: true };
+  }
+
+  const contactId = input.contact_id as string | undefined;
+  const expectedResponseHours = input.expected_response_hours as number | undefined;
+  const reminderCronId = input.reminder_cron_id as string | undefined;
+
+  // Validate contact exists if provided
+  if (contactId) {
+    const contact = getContact(contactId);
+    if (!contact) {
+      return { content: `Error: Contact "${contactId}" not found`, isError: true };
     }
+  }
 
-    const threadId = input.thread_id as string | undefined;
-    if (!threadId || typeof threadId !== 'string' || threadId.trim().length === 0) {
-      return { content: 'Error: thread_id is required and must be a non-empty string', isError: true };
-    }
+  if (expectedResponseHours !== undefined && (typeof expectedResponseHours !== 'number' || expectedResponseHours <= 0)) {
+    return { content: 'Error: expected_response_hours must be a positive number', isError: true };
+  }
 
-    const contactId = input.contact_id as string | undefined;
-    const expectedResponseHours = input.expected_response_hours as number | undefined;
-    const reminderCronId = input.reminder_cron_id as string | undefined;
+  try {
+    const now = Date.now();
+    const expectedResponseBy = expectedResponseHours
+      ? now + expectedResponseHours * 60 * 60 * 1000
+      : null;
 
-    // Validate contact exists if provided
-    if (contactId) {
-      const contact = getContact(contactId);
-      if (!contact) {
-        return { content: `Error: Contact "${contactId}" not found`, isError: true };
-      }
-    }
+    const followUp = createFollowUp({
+      channel: channel.trim(),
+      threadId: threadId.trim(),
+      contactId: contactId ?? null,
+      sentAt: now,
+      expectedResponseBy,
+      reminderCronId: reminderCronId ?? null,
+    });
 
-    if (expectedResponseHours !== undefined && (typeof expectedResponseHours !== 'number' || expectedResponseHours <= 0)) {
-      return { content: 'Error: expected_response_hours must be a positive number', isError: true };
-    }
-
-    try {
-      const now = Date.now();
-      const expectedResponseBy = expectedResponseHours
-        ? now + expectedResponseHours * 60 * 60 * 1000
-        : null;
-
-      const followUp = createFollowUp({
-        channel: channel.trim(),
-        threadId: threadId.trim(),
-        contactId: contactId ?? null,
-        sentAt: now,
-        expectedResponseBy,
-        reminderCronId: reminderCronId ?? null,
-      });
-
-      return {
-        content: `Created follow-up:\n${formatFollowUp(followUp)}`,
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return {
+      content: `Created follow-up:\n${formatFollowUp(followUp)}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
   }
 }
 

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -57,43 +57,50 @@ class FollowUpListTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const status = input.status as FollowUpStatus | undefined;
-    const channel = input.channel as string | undefined;
-    const contactId = input.contact_id as string | undefined;
-    const overdueOnly = input.overdue_only as boolean | undefined;
+    return executeFollowupList(input, _context);
+  }
+}
 
-    if (status && !VALID_STATUSES.includes(status as typeof VALID_STATUSES[number])) {
-      return {
-        content: `Error: Invalid status "${status}". Must be one of: ${VALID_STATUSES.join(', ')}`,
-        isError: true,
-      };
+export async function executeFollowupList(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const status = input.status as FollowUpStatus | undefined;
+  const channel = input.channel as string | undefined;
+  const contactId = input.contact_id as string | undefined;
+  const overdueOnly = input.overdue_only as boolean | undefined;
+
+  if (status && !VALID_STATUSES.includes(status as typeof VALID_STATUSES[number])) {
+    return {
+      content: `Error: Invalid status "${status}". Must be one of: ${VALID_STATUSES.join(', ')}`,
+      isError: true,
+    };
+  }
+
+  try {
+    let results: FollowUp[];
+
+    if (overdueOnly || status === 'overdue') {
+      results = getOverdueFollowUps();
+      if (channel) results = results.filter((f) => f.channel === channel);
+      if (contactId) results = results.filter((f) => f.contactId === contactId);
+    } else {
+      results = listFollowUps({ status, channel, contactId });
     }
 
-    try {
-      let results: FollowUp[];
-
-      if (overdueOnly || status === 'overdue') {
-        results = getOverdueFollowUps();
-        if (channel) results = results.filter((f) => f.channel === channel);
-        if (contactId) results = results.filter((f) => f.contactId === contactId);
-      } else {
-        results = listFollowUps({ status, channel, contactId });
-      }
-
-      if (results.length === 0) {
-        return { content: 'No follow-ups found matching the criteria.', isError: false };
-      }
-
-      const lines = [`Found ${results.length} follow-up(s):\n`];
-      for (const followUp of results) {
-        lines.push(formatFollowUpSummary(followUp));
-      }
-
-      return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
+    if (results.length === 0) {
+      return { content: 'No follow-ups found matching the criteria.', isError: false };
     }
+
+    const lines = [`Found ${results.length} follow-up(s):\n`];
+    for (const followUp of results) {
+      lines.push(formatFollowUpSummary(followUp));
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
   }
 }
 

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -49,42 +49,49 @@ class FollowUpResolveTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const id = input.id as string | undefined;
-    const channel = input.channel as string | undefined;
-    const threadId = input.thread_id as string | undefined;
+    return executeFollowupResolve(input, _context);
+  }
+}
 
-    if (!id && !(channel && threadId)) {
+export async function executeFollowupResolve(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const id = input.id as string | undefined;
+  const channel = input.channel as string | undefined;
+  const threadId = input.thread_id as string | undefined;
+
+  if (!id && !(channel && threadId)) {
+    return {
+      content: 'Error: Either id or both channel and thread_id are required',
+      isError: true,
+    };
+  }
+
+  try {
+    if (id) {
+      const followUp = resolveFollowUp(id);
       return {
-        content: 'Error: Either id or both channel and thread_id are required',
-        isError: true,
+        content: `Resolved follow-up:\n${formatFollowUp(followUp)}`,
+        isError: false,
       };
-    }
-
-    try {
-      if (id) {
-        const followUp = resolveFollowUp(id);
+    } else {
+      const resolved = resolveByThread(channel!, threadId!);
+      if (resolved.length === 0) {
         return {
-          content: `Resolved follow-up:\n${formatFollowUp(followUp)}`,
-          isError: false,
-        };
-      } else {
-        const resolved = resolveByThread(channel!, threadId!);
-        if (resolved.length === 0) {
-          return {
-            content: `No pending follow-up found for channel="${channel}" thread="${threadId}"`,
-            isError: false,
-          };
-        }
-        const summaries = resolved.map(formatFollowUp).join('\n\n');
-        return {
-          content: `Resolved ${resolved.length} follow-up(s):\n${summaries}`,
+          content: `No pending follow-up found for channel="${channel}" thread="${threadId}"`,
           isError: false,
         };
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
+      const summaries = resolved.map(formatFollowUp).join('\n\n');
+      return {
+        content: `Resolved ${resolved.length} follow-up(s):\n${summaries}`,
+        isError: false,
+      };
     }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies into standalone exported functions (executeFollowupCreate, executeFollowupList, executeFollowupResolve). Classes delegate to the extracted functions. Zero behavior change — pure refactor for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
