### PR TITLE
refactor: split reminder into 3 separate tools (create/list/cancel)

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -52,7 +52,7 @@ mock.module('../config/loader.js', () => ({
 // ── Import after mocks ───────────────────────────────────────────────
 const { buildSystemPrompt } = await import('../config/system-prompt.js');
 const { taskListAddTool } = await import('../tools/tasks/work-item-enqueue.js');
-const { reminderTool } = await import('../tools/reminder/reminder.js');
+const { reminderCreateTool } = await import('../tools/reminder/reminder.js');
 
 // schedule_create is registered via side-effect import; import the module
 // to access the tool description through the registry.
@@ -206,22 +206,22 @@ describe('schedule_create tool description', () => {
 
 describe('reminder tool description', () => {
   test('mentions time-based reminders', () => {
-    const def = reminderTool.getDefinition();
-    expect(def.description).toContain('time-based reminders');
+    const def = reminderCreateTool.getDefinition();
+    expect(def.description).toContain('time-based reminder');
   });
 
   test('scopes to time-triggered notifications only', () => {
-    const def = reminderTool.getDefinition();
+    const def = reminderCreateTool.getDefinition();
     expect(def.description).toContain('ONLY when the user wants a time-triggered notification');
   });
 
   test('warns against using for "add to my tasks" requests', () => {
-    const def = reminderTool.getDefinition();
+    const def = reminderCreateTool.getDefinition();
     expect(def.description).toContain('Do NOT use this for "add to my tasks"');
   });
 
   test('redirects to task_list_add for task queue items', () => {
-    const def = reminderTool.getDefinition();
+    const def = reminderCreateTool.getDefinition();
     expect(def.description).toContain('task_list_add');
   });
 });
@@ -235,7 +235,7 @@ describe('cross-tool routing consistency', () => {
     const enqueueDef = taskListAddTool.getDefinition();
     const scheduleTool = getTool('schedule_create')!;
     const scheduleDef = scheduleTool.getDefinition();
-    const reminderDef = reminderTool.getDefinition();
+    const reminderDef = reminderCreateTool.getDefinition();
 
     // task_list_add is the canonical name in all three descriptions
     expect(enqueueDef.name).toBe('task_list_add');
@@ -246,7 +246,7 @@ describe('cross-tool routing consistency', () => {
   test('schedule_create and reminder both reject "add to my queue" usage', () => {
     const scheduleTool = getTool('schedule_create')!;
     const scheduleDef = scheduleTool.getDefinition();
-    const reminderDef = reminderTool.getDefinition();
+    const reminderDef = reminderCreateTool.getDefinition();
 
     // Both should redirect away from task-queue requests
     expect(scheduleDef.description).toContain('add to my queue');

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -186,7 +186,9 @@ describe('tool manifest', () => {
     expect(names).toContain('memory_update');
     expect(names).toContain('credential_store');
     expect(names).toContain('account_manage');
-    expect(names).toContain('reminder');
+    expect(names).toContain('reminder_create');
+    expect(names).toContain('reminder_list');
+    expect(names).toContain('reminder_cancel');
   });
 
   test('registered tool count is at least eager + lazy + host', async () => {

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach } from 'bun:test';
 import { initializeDb } from '../memory/db.js';
 import { getDb } from '../memory/db.js';
 import { reminders } from '../memory/schema.js';
-import { reminderTool } from '../tools/reminder/reminder.js';
+import { reminderCreateTool, reminderListTool, reminderCancelTool } from '../tools/reminder/reminder.js';
 import { claimDueReminders } from '../tools/reminder/reminder-store.js';
 
 initializeDb();
@@ -22,26 +22,11 @@ describe('reminder tool', () => {
     clearReminders();
   });
 
-  // ── action validation ───────────────────────────────────────────────
-
-  test('rejects missing action', async () => {
-    const result = await reminderTool.execute({}, dummyContext);
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('action is required');
-  });
-
-  test('rejects unknown action', async () => {
-    const result = await reminderTool.execute({ action: 'explode' }, dummyContext);
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('Unknown action');
-  });
-
   // ── create ──────────────────────────────────────────────────────────
 
   test('create with valid future ISO timestamp succeeds', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: future,
       label: 'Call Sidd',
       message: 'Remember to call Sidd',
@@ -55,8 +40,7 @@ describe('reminder tool', () => {
 
   test('create with past timestamp returns error', async () => {
     const past = new Date(Date.now() - 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: past,
       label: 'Too late',
       message: 'This is in the past',
@@ -67,8 +51,7 @@ describe('reminder tool', () => {
   });
 
   test('create with invalid timestamp string returns error', async () => {
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: 'not-a-date',
       label: 'Bad date',
       message: 'This has a bad date',
@@ -79,8 +62,7 @@ describe('reminder tool', () => {
   });
 
   test('create rejects non-ISO date formats like MM/DD/YYYY', async () => {
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: '03/04/2027',
       label: 'Ambiguous date',
       message: 'This format is locale-dependent',
@@ -91,8 +73,7 @@ describe('reminder tool', () => {
   });
 
   test('create rejects ISO timestamp without timezone', async () => {
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: '2027-03-15T09:00:00',
       label: 'No timezone',
       message: 'Missing timezone offset',
@@ -106,8 +87,7 @@ describe('reminder tool', () => {
     const future = new Date(Date.now() + 120_000);
     const offset = '-05:00';
     const isoWithOffset = future.toISOString().replace('Z', offset);
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: isoWithOffset,
       label: 'With offset',
       message: 'Has explicit timezone',
@@ -119,8 +99,7 @@ describe('reminder tool', () => {
 
   test('create defaults mode to notify', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: future,
       label: 'Default mode',
       message: 'Should be notify',
@@ -132,8 +111,7 @@ describe('reminder tool', () => {
 
   test('create with mode execute sets mode correctly', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: future,
       label: 'Execute mode',
       message: 'Should be execute',
@@ -145,8 +123,7 @@ describe('reminder tool', () => {
   });
 
   test('create requires fire_at', async () => {
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       label: 'No fire_at',
       message: 'Missing fire_at',
     }, dummyContext);
@@ -157,8 +134,7 @@ describe('reminder tool', () => {
 
   test('create requires label', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: future,
       message: 'Missing label',
     }, dummyContext);
@@ -169,8 +145,7 @@ describe('reminder tool', () => {
 
   test('create requires message', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const result = await reminderTool.execute({
-      action: 'create',
+    const result = await reminderCreateTool.execute({
       fire_at: future,
       label: 'No message',
     }, dummyContext);
@@ -182,21 +157,20 @@ describe('reminder tool', () => {
   // ── list ────────────────────────────────────────────────────────────
 
   test('list returns "No reminders found" when empty', async () => {
-    const result = await reminderTool.execute({ action: 'list' }, dummyContext);
+    const result = await reminderListTool.execute({}, dummyContext);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No reminders found');
   });
 
   test('list returns formatted reminders', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    await reminderTool.execute({
-      action: 'create',
+    await reminderCreateTool.execute({
       fire_at: future,
       label: 'Test reminder',
       message: 'Test message',
     }, dummyContext);
 
-    const result = await reminderTool.execute({ action: 'list' }, dummyContext);
+    const result = await reminderListTool.execute({}, dummyContext);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Test reminder');
     expect(result.content).toContain('pending');
@@ -206,8 +180,7 @@ describe('reminder tool', () => {
 
   test('cancel with valid pending reminder succeeds', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const createResult = await reminderTool.execute({
-      action: 'create',
+    const createResult = await reminderCreateTool.execute({
       fire_at: future,
       label: 'Cancel me',
       message: 'To be cancelled',
@@ -218,8 +191,7 @@ describe('reminder tool', () => {
     expect(idMatch).not.toBeNull();
     const id = idMatch![1].trim();
 
-    const result = await reminderTool.execute({
-      action: 'cancel',
+    const result = await reminderCancelTool.execute({
       reminder_id: id,
     }, dummyContext);
 
@@ -228,8 +200,7 @@ describe('reminder tool', () => {
   });
 
   test('cancel with nonexistent ID returns error', async () => {
-    const result = await reminderTool.execute({
-      action: 'cancel',
+    const result = await reminderCancelTool.execute({
       reminder_id: 'nonexistent',
     }, dummyContext);
 
@@ -239,8 +210,7 @@ describe('reminder tool', () => {
 
   test('cancel with already-fired reminder returns error', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
-    const createResult = await reminderTool.execute({
-      action: 'create',
+    const createResult = await reminderCreateTool.execute({
       fire_at: future,
       label: 'Fire then cancel',
       message: 'x',
@@ -252,8 +222,7 @@ describe('reminder tool', () => {
     // Force-fire by claiming with a future timestamp
     claimDueReminders(Date.now() + 120_000);
 
-    const result = await reminderTool.execute({
-      action: 'cancel',
+    const result = await reminderCancelTool.execute({
       reminder_id: id,
     }, dummyContext);
 

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -993,20 +993,16 @@ describe('isSideEffectTool', () => {
       expect(isSideEffectTool('account_manage')).toBe(false);
     });
 
-    test('reminder create is a side-effect', () => {
-      expect(isSideEffectTool('reminder', { action: 'create' })).toBe(true);
+    test('reminder_create is a side-effect', () => {
+      expect(isSideEffectTool('reminder_create')).toBe(true);
     });
 
-    test('reminder cancel is a side-effect', () => {
-      expect(isSideEffectTool('reminder', { action: 'cancel' })).toBe(true);
+    test('reminder_cancel is a side-effect', () => {
+      expect(isSideEffectTool('reminder_cancel')).toBe(true);
     });
 
-    test('reminder list is NOT a side-effect', () => {
-      expect(isSideEffectTool('reminder', { action: 'list' })).toBe(false);
-    });
-
-    test('reminder without input is NOT a side-effect', () => {
-      expect(isSideEffectTool('reminder')).toBe(false);
+    test('reminder_list is NOT a side-effect', () => {
+      expect(isSideEffectTool('reminder_list')).toBe(false);
     });
 
     test('credential_store store is a side-effect', () => {
@@ -1262,7 +1258,7 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
       { name: 'document_create', input: { title: 'doc', content: 'body' } },
       { name: 'document_update', input: { id: 'doc-1', content: 'updated' } },
       { name: 'account_manage', input: { action: 'create', name: 'acct' } },
-      { name: 'reminder', input: { action: 'create', message: 'remind me' } },
+      { name: 'reminder_create', input: { fire_at: '2030-01-01T00:00:00Z', label: 'test', message: 'remind me' } },
       { name: 'credential_store', input: { action: 'store', name: 'api-key', value: 'secret' } },
     ];
 
@@ -1550,13 +1546,13 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     expect(promptCalled).toBe(false);
   });
 
-  test('reminder create forces prompt in private thread', async () => {
+  test('reminder_create forces prompt in private thread', async () => {
     checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
     const result = await executor.execute(
-      'reminder',
-      { action: 'create', message: 'test reminder' },
+      'reminder_create',
+      { fire_at: '2030-01-01T00:00:00Z', label: 'test', message: 'test reminder' },
       makeContext({ forcePromptSideEffects: true }),
     );
 
@@ -1564,13 +1560,13 @@ describe('ToolExecutor forcePromptSideEffects enforcement', () => {
     expect(promptCalled).toBe(true);
   });
 
-  test('reminder list does NOT force prompt in private thread', async () => {
+  test('reminder_list does NOT force prompt in private thread', async () => {
     checkResultOverride = { decision: 'allow', reason: 'Matched trust rule' };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
     const result = await executor.execute(
-      'reminder',
-      { action: 'list' },
+      'reminder_list',
+      {},
       makeContext({ forcePromptSideEffects: true }),
     );
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -635,6 +635,8 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'browser_fill_credential',
   'document_create',
   'document_update',
+  'reminder_create',
+  'reminder_cancel',
   'schedule_create',
   'schedule_update',
   'schedule_delete',
@@ -656,10 +658,6 @@ export function isSideEffectTool(toolName: string, input?: Record<string, unknow
   if (toolName === 'account_manage') {
     const action = input?.action;
     return action === 'create' || action === 'update';
-  }
-  if (toolName === 'reminder') {
-    const action = input?.action;
-    return action === 'create' || action === 'cancel';
   }
   if (toolName === 'credential_store') {
     const action = input?.action;

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -8,28 +8,9 @@ import {
   cancelReminder,
 } from './reminder-store.js';
 
-function executeReminder(input: Record<string, unknown>): ToolExecutionResult {
-  const action = input.action as string | undefined;
-  if (!action) {
-    return { content: 'Error: action is required', isError: true };
-  }
+// ── Exported execute functions ──────────────────────────────────────
 
-  switch (action) {
-    case 'create':
-      return createAction(input);
-    case 'list':
-      return listAction();
-    case 'cancel':
-      return cancelAction(input);
-    default:
-      return {
-        content: `Error: Unknown action "${action}". Valid actions: create, list, cancel`,
-        isError: true,
-      };
-  }
-}
-
-function createAction(input: Record<string, unknown>): ToolExecutionResult {
+export function executeReminderCreate(input: Record<string, unknown>): ToolExecutionResult {
   const fireAtStr = input.fire_at as string | undefined;
   const label = input.label as string | undefined;
   const message = input.message as string | undefined;
@@ -68,7 +49,7 @@ function createAction(input: Record<string, unknown>): ToolExecutionResult {
   };
 }
 
-function listAction(): ToolExecutionResult {
+export function executeReminderList(): ToolExecutionResult {
   const all = listReminders();
   if (all.length === 0) {
     return { content: 'No reminders found.', isError: false };
@@ -86,7 +67,7 @@ function listAction(): ToolExecutionResult {
   return { content: `Reminders:\n${lines.join('\n')}`, isError: false };
 }
 
-function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
+export function executeReminderCancel(input: Record<string, unknown>): ToolExecutionResult {
   const reminderId = input.reminder_id as string | undefined;
   if (!reminderId) {
     return { content: 'Error: reminder_id is required for cancel', isError: true };
@@ -100,9 +81,11 @@ function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
   return { content: `Reminder "${reminderId}" cancelled.`, isError: false };
 }
 
-class ReminderTool implements Tool {
-  name = 'reminder';
-  description = 'Create, list, or cancel one-time time-based reminders. Reminders fire at a specific future time and either notify the user or execute a message through the assistant. Use this ONLY when the user wants a time-triggered notification (e.g. "remind me at 3pm", "remind me in 2 hours"). Do NOT use this for "add to my tasks" or "add to my queue" — use task_list_add for those requests.';
+// ── reminder_create ─────────────────────────────────────────────────
+
+class ReminderCreateTool implements Tool {
+  name = 'reminder_create';
+  description = 'Create a one-time time-based reminder. Reminders fire at a specific future time and either notify the user or execute a message through the assistant. Use this ONLY when the user wants a time-triggered notification (e.g. "remind me at 3pm", "remind me in 2 hours"). Do NOT use this for "add to my tasks" or "add to my queue" — use task_list_add for those requests.';
   category = 'reminder';
   defaultRiskLevel = RiskLevel.Low;
 
@@ -113,41 +96,90 @@ class ReminderTool implements Tool {
       input_schema: {
         type: 'object',
         properties: {
-          action: {
-            type: 'string',
-            enum: ['create', 'list', 'cancel'],
-            description: 'Reminder action',
-          },
           fire_at: {
             type: 'string',
-            description: 'ISO 8601 timestamp for when the reminder should fire (required for create)',
+            description: 'ISO 8601 timestamp for when the reminder should fire',
           },
           label: {
             type: 'string',
-            description: 'Human-readable label (required for create)',
+            description: 'Human-readable label',
           },
           message: {
             type: 'string',
-            description: 'Content shown in notification (notify) or sent to agent (execute). Required for create.',
+            description: 'Content shown in notification (notify) or sent to agent (execute)',
           },
           mode: {
             type: 'string',
             enum: ['notify', 'execute'],
             description: 'How the reminder fires. Defaults to notify.',
           },
-          reminder_id: {
-            type: 'string',
-            description: 'Reminder ID (required for cancel)',
-          },
         },
-        required: ['action'],
+        required: ['fire_at', 'label'],
       },
     };
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeReminder(input);
+    return executeReminderCreate(input);
   }
 }
 
-export const reminderTool = new ReminderTool();
+// ── reminder_list ───────────────────────────────────────────────────
+
+class ReminderListTool implements Tool {
+  name = 'reminder_list';
+  description = 'List all reminders and their current status.';
+  category = 'reminder';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {},
+      },
+    };
+  }
+
+  async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executeReminderList();
+  }
+}
+
+// ── reminder_cancel ─────────────────────────────────────────────────
+
+class ReminderCancelTool implements Tool {
+  name = 'reminder_cancel';
+  description = 'Cancel a pending reminder by ID.';
+  category = 'reminder';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          reminder_id: {
+            type: 'string',
+            description: 'Reminder ID to cancel',
+          },
+        },
+        required: ['reminder_id'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executeReminderCancel(input);
+  }
+}
+
+// ── Exported tool instances ─────────────────────────────────────────
+
+export const reminderCreateTool = new ReminderCreateTool();
+export const reminderListTool = new ReminderListTool();
+export const reminderCancelTool = new ReminderCancelTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -12,7 +12,7 @@ import type { Tool } from './types.js';
 import { memorySearchTool, memorySaveTool, memoryUpdateTool } from './memory/register.js';
 import { credentialStoreTool } from './credentials/vault.js';
 import { accountManageTool } from './credentials/account-registry.js';
-import { reminderTool } from './reminder/reminder.js';
+import { reminderCreateTool, reminderListTool, reminderCancelTool } from './reminder/reminder.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { documentCreateTool, documentUpdateTool } from './document/index.js';
@@ -112,7 +112,9 @@ export const explicitTools: Tool[] = [
   memoryUpdateTool,
   credentialStoreTool,
   accountManageTool,
-  reminderTool,
+  reminderCreateTool,
+  reminderListTool,
+  reminderCancelTool,
   screenWatchTool,
   vellumSkillsCatalogTool,
   documentCreateTool,


### PR DESCRIPTION
## Summary
- Split the single multi-action `ReminderTool` (`reminder`) into three focused tools: `reminder_create`, `reminder_list`, `reminder_cancel`
- Extracted execute logic into standalone exported functions (`executeReminderCreate`, `executeReminderList`, `executeReminderCancel`) for future skill migration
- Updated `executor.ts` side-effect classification to use the new tool names directly in `SIDE_EFFECT_TOOLS` set instead of action-aware branching
- Updated all tests (reminder, tool-executor, intent-routing, registry) to use the new tool names and imports

## Test plan
- [x] `bunx tsc --noEmit` passes (only pre-existing errors remain)
- [x] All reminder tests updated to use new tool instances directly
- [x] Side-effect classification tests updated for new tool names
- [x] Intent-routing tests updated to reference `reminderCreateTool`
- [x] Registry test updated to check for all 3 new tool names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
