### PR TITLE
fix: reject late webhook for terminal call sessions

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -20,6 +20,7 @@ import {
 import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
 import { logDeadLetterEvent } from './call-recovery.js';
+import { isTerminalState } from './call-state-machine.js';
 
 const log = getLogger('twilio-routes');
 
@@ -93,6 +94,11 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   if (!session) {
     log.warn({ callSessionId }, 'Voice webhook: call session not found');
     return new Response('Call session not found', { status: 404 });
+  }
+
+  if (isTerminalState(session.status)) {
+    log.warn({ callSessionId, status: session.status }, 'Voice webhook: call session is in terminal state');
+    return new Response('Call session is no longer active', { status: 410 });
   }
 
   // Parse the Twilio POST body to capture CallSid immediately, so status


### PR DESCRIPTION
Addresses Codex P2 feedback on #5457: handleVoiceWebhook now checks if the session is in a terminal state before proceeding, preventing inconsistency when a delayed Twilio webhook arrives after a no-SID session has been force-failed during recovery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
