### PR TITLE
refactor: extract subagent tool functions for skill migration

### DIFF
--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -33,30 +33,37 @@ export const subagentAbortTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const subagentId = input.subagent_id as string;
-    if (!subagentId) {
-      return { content: '"subagent_id" is required.', isError: true };
-    }
-
-    const manager = getSubagentManager();
-    const sendToClient = context.sendToClient as ((msg: unknown) => void) | undefined;
-    const aborted = manager.abort(
-      subagentId,
-      sendToClient as ((msg: unknown) => void) | undefined,
-      context.sessionId,
-      { suppressNotification: true },
-    );
-
-    if (!aborted) {
-      return {
-        content: `Could not abort subagent "${subagentId}". It may not exist or already be in a terminal state.`,
-        isError: true,
-      };
-    }
-
-    return {
-      content: JSON.stringify({ subagentId, status: 'aborted', message: 'Subagent aborted successfully.' }),
-      isError: false,
-    };
+    return executeSubagentAbort(input, context);
   },
 };
+
+export async function executeSubagentAbort(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const subagentId = input.subagent_id as string;
+  if (!subagentId) {
+    return { content: '"subagent_id" is required.', isError: true };
+  }
+
+  const manager = getSubagentManager();
+  const sendToClient = context.sendToClient as ((msg: unknown) => void) | undefined;
+  const aborted = manager.abort(
+    subagentId,
+    sendToClient as ((msg: unknown) => void) | undefined,
+    context.sessionId,
+    { suppressNotification: true },
+  );
+
+  if (!aborted) {
+    return {
+      content: `Could not abort subagent "${subagentId}". It may not exist or already be in a terminal state.`,
+      isError: true,
+    };
+  }
+
+  return {
+    content: JSON.stringify({ subagentId, status: 'aborted', message: 'Subagent aborted successfully.' }),
+    isError: false,
+  };
+}

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -37,36 +37,43 @@ export const subagentMessageTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const subagentId = input.subagent_id as string;
-    const content = input.content as string;
-
-    if (!subagentId || !content) {
-      return { content: 'Both "subagent_id" and "content" are required.', isError: true };
-    }
-
-    const manager = getSubagentManager();
-
-    // Ownership check: only the parent session can message a subagent.
-    const state = manager.getState(subagentId);
-    if (!state || state.config.parentSessionId !== context.sessionId) {
-      return {
-        content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
-        isError: true,
-      };
-    }
-
-    const sent = manager.sendMessage(subagentId, content);
-
-    if (!sent) {
-      return {
-        content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
-        isError: true,
-      };
-    }
-
-    return {
-      content: JSON.stringify({ subagentId, message: 'Message sent to subagent.' }),
-      isError: false,
-    };
+    return executeSubagentMessage(input, context);
   },
 };
+
+export async function executeSubagentMessage(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const subagentId = input.subagent_id as string;
+  const content = input.content as string;
+
+  if (!subagentId || !content) {
+    return { content: 'Both "subagent_id" and "content" are required.', isError: true };
+  }
+
+  const manager = getSubagentManager();
+
+  // Ownership check: only the parent session can message a subagent.
+  const state = manager.getState(subagentId);
+  if (!state || state.config.parentSessionId !== context.sessionId) {
+    return {
+      content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
+      isError: true,
+    };
+  }
+
+  const sent = manager.sendMessage(subagentId, content);
+
+  if (!sent) {
+    return {
+      content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
+      isError: true,
+    };
+  }
+
+  return {
+    content: JSON.stringify({ subagentId, message: 'Message sent to subagent.' }),
+    isError: false,
+  };
+}

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -36,63 +36,70 @@ export const subagentReadTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const subagentId = input.subagent_id as string;
-    if (!subagentId) {
-      return { content: '"subagent_id" is required.', isError: true };
-    }
-
-    const manager = getSubagentManager();
-    const state = manager.getState(subagentId);
-    if (!state) {
-      return { content: `No subagent found with ID "${subagentId}".`, isError: true };
-    }
-
-    // Ownership check: only the parent session can read a subagent's output.
-    if (state.config.parentSessionId !== context.sessionId) {
-      return { content: `No subagent found with ID "${subagentId}".`, isError: true };
-    }
-
-    if (!TERMINAL_STATUSES.has(state.status)) {
-      return {
-        content: `Subagent "${state.config.label}" is still ${state.status}. Wait for it to finish.`,
-        isError: false,
-      };
-    }
-
-    // Read the subagent's conversation messages from DB.
-    const dbMessages = getMessages(state.conversationId);
-    if (!dbMessages || dbMessages.length === 0) {
-      return { content: 'No messages found in subagent conversation.', isError: true };
-    }
-
-    // Extract assistant messages only — that's the subagent's output.
-    const output: string[] = [];
-    for (const msg of dbMessages) {
-      if (msg.role !== 'assistant') continue;
-      try {
-        const content = JSON.parse(msg.content);
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'text' && typeof block.text === 'string') {
-              output.push(block.text);
-            }
-          }
-        } else if (typeof content === 'string') {
-          output.push(content);
-        }
-      } catch {
-        // Content might be plain text.
-        output.push(msg.content);
-      }
-    }
-
-    if (output.length === 0) {
-      return { content: 'Subagent produced no text output.', isError: false };
-    }
-
-    return {
-      content: output.join('\n\n'),
-      isError: false,
-    };
+    return executeSubagentRead(input, context);
   },
 };
+
+export async function executeSubagentRead(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const subagentId = input.subagent_id as string;
+  if (!subagentId) {
+    return { content: '"subagent_id" is required.', isError: true };
+  }
+
+  const manager = getSubagentManager();
+  const state = manager.getState(subagentId);
+  if (!state) {
+    return { content: `No subagent found with ID "${subagentId}".`, isError: true };
+  }
+
+  // Ownership check: only the parent session can read a subagent's output.
+  if (state.config.parentSessionId !== context.sessionId) {
+    return { content: `No subagent found with ID "${subagentId}".`, isError: true };
+  }
+
+  if (!TERMINAL_STATUSES.has(state.status)) {
+    return {
+      content: `Subagent "${state.config.label}" is still ${state.status}. Wait for it to finish.`,
+      isError: false,
+    };
+  }
+
+  // Read the subagent's conversation messages from DB.
+  const dbMessages = getMessages(state.conversationId);
+  if (!dbMessages || dbMessages.length === 0) {
+    return { content: 'No messages found in subagent conversation.', isError: true };
+  }
+
+  // Extract assistant messages only — that's the subagent's output.
+  const output: string[] = [];
+  for (const msg of dbMessages) {
+    if (msg.role !== 'assistant') continue;
+    try {
+      const content = JSON.parse(msg.content);
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'text' && typeof block.text === 'string') {
+            output.push(block.text);
+          }
+        }
+      } else if (typeof content === 'string') {
+        output.push(content);
+      }
+    } catch {
+      // Content might be plain text.
+      output.push(msg.content);
+    }
+  }
+
+  if (output.length === 0) {
+    return { content: 'Subagent produced no text output.', isError: false };
+  }
+
+  return {
+    content: output.join('\n\n'),
+    isError: false,
+  };
+}

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -43,43 +43,50 @@ export const subagentSpawnTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const label = input.label as string;
-    const objective = input.objective as string;
-    const extraContext = input.context as string | undefined;
-
-    if (!label || !objective) {
-      return { content: 'Both "label" and "objective" are required.', isError: true };
-    }
-
-    const manager = getSubagentManager();
-    const sendToClient = context.sendToClient as ((msg: { type: string; [key: string]: unknown }) => void) | undefined;
-    if (!sendToClient) {
-      return { content: 'No IPC client connected — cannot spawn subagent.', isError: true };
-    }
-
-    try {
-      const subagentId = await manager.spawn(
-        {
-          parentSessionId: context.sessionId,
-          label,
-          objective,
-          context: extraContext,
-        },
-        sendToClient as (msg: unknown) => void,
-      );
-
-      return {
-        content: JSON.stringify({
-          subagentId,
-          label,
-          status: 'pending',
-          message: `Subagent "${label}" spawned. You will be notified automatically when it completes or fails — do NOT poll subagent_status. Continue the conversation normally.`,
-        }),
-        isError: false,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Failed to spawn subagent: ${msg}`, isError: true };
-    }
+    return executeSubagentSpawn(input, context);
   },
 };
+
+export async function executeSubagentSpawn(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const label = input.label as string;
+  const objective = input.objective as string;
+  const extraContext = input.context as string | undefined;
+
+  if (!label || !objective) {
+    return { content: 'Both "label" and "objective" are required.', isError: true };
+  }
+
+  const manager = getSubagentManager();
+  const sendToClient = context.sendToClient as ((msg: { type: string; [key: string]: unknown }) => void) | undefined;
+  if (!sendToClient) {
+    return { content: 'No IPC client connected — cannot spawn subagent.', isError: true };
+  }
+
+  try {
+    const subagentId = await manager.spawn(
+      {
+        parentSessionId: context.sessionId,
+        label,
+        objective,
+        context: extraContext,
+      },
+      sendToClient as (msg: unknown) => void,
+    );
+
+    return {
+      content: JSON.stringify({
+        subagentId,
+        label,
+        status: 'pending',
+        message: `Subagent "${label}" spawned. You will be notified automatically when it completes or fails — do NOT poll subagent_status. Continue the conversation normally.`,
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Failed to spawn subagent: ${msg}`, isError: true };
+  }
+}

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -33,42 +33,49 @@ export const subagentStatusTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const subagentId = input.subagent_id as string | undefined;
-    const manager = getSubagentManager();
-
-    if (subagentId) {
-      const state = manager.getState(subagentId);
-      if (!state || state.config.parentSessionId !== context.sessionId) {
-        return { content: `No subagent found with ID "${subagentId}".`, isError: true };
-      }
-      return {
-        content: JSON.stringify({
-          subagentId: state.config.id,
-          label: state.config.label,
-          status: state.status,
-          error: state.error,
-          createdAt: state.createdAt,
-          startedAt: state.startedAt,
-          completedAt: state.completedAt,
-          usage: state.usage,
-        }),
-        isError: false,
-      };
-    }
-
-    // List all subagents for this parent session.
-    const children = manager.getChildrenOf(context.sessionId);
-    if (children.length === 0) {
-      return { content: 'No subagents found for this session.', isError: false };
-    }
-
-    const summary = children.map((s) => ({
-      subagentId: s.config.id,
-      label: s.config.label,
-      status: s.status,
-      error: s.error,
-    }));
-
-    return { content: JSON.stringify(summary), isError: false };
+    return executeSubagentStatus(input, context);
   },
 };
+
+export async function executeSubagentStatus(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const subagentId = input.subagent_id as string | undefined;
+  const manager = getSubagentManager();
+
+  if (subagentId) {
+    const state = manager.getState(subagentId);
+    if (!state || state.config.parentSessionId !== context.sessionId) {
+      return { content: `No subagent found with ID "${subagentId}".`, isError: true };
+    }
+    return {
+      content: JSON.stringify({
+        subagentId: state.config.id,
+        label: state.config.label,
+        status: state.status,
+        error: state.error,
+        createdAt: state.createdAt,
+        startedAt: state.startedAt,
+        completedAt: state.completedAt,
+        usage: state.usage,
+      }),
+      isError: false,
+    };
+  }
+
+  // List all subagents for this parent session.
+  const children = manager.getChildrenOf(context.sessionId);
+  if (children.length === 0) {
+    return { content: 'No subagents found for this session.', isError: false };
+  }
+
+  const summary = children.map((s) => ({
+    subagentId: s.config.id,
+    label: s.config.label,
+    status: s.status,
+    error: s.error,
+  }));
+
+  return { content: JSON.stringify(summary), isError: false };
+}


### PR DESCRIPTION
Extract execute() bodies from all 5 subagent tools into standalone exported functions:

- `executeSubagentSpawn()` in `spawn.ts`
- `executeSubagentStatus()` in `status.ts`
- `executeSubagentAbort()` in `abort.ts`
- `executeSubagentMessage()` in `message.ts`
- `executeSubagentRead()` in `read.ts`

Zero behavior change — pure refactor. Object-literal tool methods now delegate to the exported functions. Prepares for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
