### PR TITLE
refactor: extract work-item tool functions for skill migration

### DIFF
--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -56,194 +56,99 @@ const definition: ToolDefinition = {
   },
 };
 
-class TaskListAddTool implements Tool {
-  name = 'task_list_add';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
+function handleDuplicate(
+  title: string,
+  ifExists: string,
+  input: Record<string, unknown>,
+): ToolExecutionResult | null {
+  const existing = findActiveWorkItemsByTitle(title);
+  if (existing.length === 0) return null;
 
-  getDefinition(): ToolDefinition {
-    return definition;
+  const match = existing[0];
+  log.info({ title, existingId: match.id, ifExists }, 'task_list_add: duplicate detected');
+
+  if (ifExists === 'reuse_existing') {
+    log.info({ title, existingId: match.id }, 'task_list_add: reused existing item');
+    return {
+      content: `Task "${match.title}" already exists in the queue (ID: ${match.id}, status: ${match.status}). Use task_list_update to modify it.`,
+      isError: false,
+    };
   }
 
-  /**
-   * Check for an existing active work item with the same title and handle
-   * according to the if_exists strategy. Returns a result if a duplicate was
-   * found and handled, or null if no duplicate exists (caller should proceed).
-   */
-  private handleDuplicate(
-    title: string,
-    ifExists: string,
-    input: Record<string, unknown>,
-  ): ToolExecutionResult | null {
-    const existing = findActiveWorkItemsByTitle(title);
-    if (existing.length === 0) return null;
-
-    const match = existing[0];
-    log.info({ title, existingId: match.id, ifExists }, 'task_list_add: duplicate detected');
-
-    if (ifExists === 'reuse_existing') {
-      log.info({ title, existingId: match.id }, 'task_list_add: reused existing item');
-      return {
-        content: `Task "${match.title}" already exists in the queue (ID: ${match.id}, status: ${match.status}). Use task_list_update to modify it.`,
-        isError: false,
-      };
+  if (ifExists === 'update_existing') {
+    const updates: Partial<{ title: string; notes: string; priorityTier: number; sortIndex: number }> = {};
+    if (input.priority_tier !== undefined) updates.priorityTier = input.priority_tier as number;
+    if (input.notes !== undefined) updates.notes = input.notes as string;
+    if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
+    if (Object.keys(updates).length > 0) {
+      updateWorkItem(match.id, updates);
     }
-
-    if (ifExists === 'update_existing') {
-      const updates: Partial<{ title: string; notes: string; priorityTier: number; sortIndex: number }> = {};
-      if (input.priority_tier !== undefined) updates.priorityTier = input.priority_tier as number;
-      if (input.notes !== undefined) updates.notes = input.notes as string;
-      if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
-      if (Object.keys(updates).length > 0) {
-        updateWorkItem(match.id, updates);
-      }
-      log.info({ title, existingId: match.id, updates }, 'task_list_add: updated existing item');
-      return {
-        content: `Reused existing task "${match.title}" (ID: ${match.id}) instead of creating a duplicate.${
-          Object.keys(updates).length > 0 ? ` Updated: ${Object.keys(updates).join(', ')}.` : ''
-        }`,
-        isError: false,
-      };
-    }
-
-    return null;
+    log.info({ title, existingId: match.id, updates }, 'task_list_add: updated existing item');
+    return {
+      content: `Reused existing task "${match.title}" (ID: ${match.id}) instead of creating a duplicate.${
+        Object.keys(updates).length > 0 ? ` Updated: ${Object.keys(updates).join(', ')}.` : ''
+      }`,
+      isError: false,
+    };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    try {
-      const taskId = input.task_id as string | undefined;
-      const taskName = input.task_name as string | undefined;
-      const titleOverride = input.title as string | undefined;
-      const notes = input.notes as string | undefined;
-      const priorityTier = input.priority_tier as number | undefined;
-      const sortIndex = input.sort_index as number | undefined;
+  return null;
+}
 
-      const ifExists = (input.if_exists as string) || 'reuse_existing';
+export async function executeTaskListAdd(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  try {
+    const taskId = input.task_id as string | undefined;
+    const taskName = input.task_name as string | undefined;
+    const titleOverride = input.title as string | undefined;
+    const notes = input.notes as string | undefined;
+    const priorityTier = input.priority_tier as number | undefined;
+    const sortIndex = input.sort_index as number | undefined;
 
-      // Ad-hoc mode: title provided without task_id or task_name
-      if (!taskId && !taskName) {
-        if (!titleOverride) {
-          return {
-            content: 'Error: You must provide either task_id, task_name, or title to create a work item.',
-            isError: true,
-          };
-        }
+    const ifExists = (input.if_exists as string) || 'reuse_existing';
 
-        // Duplicate-prevention guard
-        if (ifExists !== 'create_duplicate') {
-          const duplicateResult = this.handleDuplicate(titleOverride, ifExists, input);
-          if (duplicateResult) return duplicateResult;
-        } else {
-          log.info({ title: titleOverride }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
-        }
-
-        log.debug({ title: titleOverride }, 'task_list_add: creating new item');
-
-        // Auto-create a lightweight task template for the ad-hoc item
-        const adHocTask = createTask({
-          title: titleOverride,
-          template: titleOverride,
-        });
-
-        const workItem = createWorkItem({
-          taskId: adHocTask.id,
-          title: titleOverride,
-          notes,
-          priorityTier: priorityTier ?? 1,
-          sortIndex,
-        });
-
-        log.info({ selectorType: 'title', workItemId: workItem.id, title: workItem.title }, 'ad-hoc work item created');
-
-        const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
-        const lines = [
-          `Enqueued work item:`,
-          `  Title: ${workItem.title}`,
-          `  ID: ${workItem.id}`,
-          `  Priority: ${priority}`,
-          `  Status: ${workItem.status}`,
-        ];
-        if (workItem.notes) {
-          lines.push(`  Notes: ${workItem.notes}`);
-        }
-        if (workItem.sortIndex !== null) {
-          lines.push(`  Sort index: ${workItem.sortIndex}`);
-        }
-
-        return { content: lines.join('\n'), isError: false };
+    // Ad-hoc mode: title provided without task_id or task_name
+    if (!taskId && !taskName) {
+      if (!titleOverride) {
+        return {
+          content: 'Error: You must provide either task_id, task_name, or title to create a work item.',
+          isError: true,
+        };
       }
-
-      let resolvedTask;
-
-      if (taskId) {
-        resolvedTask = getTask(taskId);
-        if (!resolvedTask) {
-          const entity = identifyEntityById(taskId);
-          if (entity.type === 'work_item') {
-            return {
-              content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_update to modify the existing work item, or task_list_add with just a title for a new ad-hoc item')}`,
-              isError: true,
-            };
-          }
-          return { content: `Error: No task definition found with ID "${taskId}". Use task_list to see available task templates, or provide just a title to create an ad-hoc work item.`, isError: true };
-        }
-      } else {
-        // Search by name (case-insensitive substring match)
-        const needle = taskName!.toLowerCase();
-        const allTasks = listTasks();
-        const matches = allTasks.filter((t) => t.title.toLowerCase().includes(needle));
-
-        if (matches.length === 0) {
-          return {
-            content: `Error: No task definition found matching "${taskName}". Use task_list to see available tasks.`,
-            isError: true,
-          };
-        }
-
-        if (matches.length > 1) {
-          const lines = [
-            `Multiple task definitions match "${taskName}". Please specify by ID:`,
-            '',
-          ];
-          for (const m of matches) {
-            lines.push(`- ${m.title}  (ID: ${m.id})`);
-          }
-          return { content: lines.join('\n'), isError: true };
-        }
-
-        resolvedTask = matches[0];
-      }
-
-      const finalTitle = titleOverride ?? resolvedTask.title;
 
       // Duplicate-prevention guard
       if (ifExists !== 'create_duplicate') {
-        const duplicateResult = this.handleDuplicate(finalTitle, ifExists, input);
+        const duplicateResult = handleDuplicate(titleOverride, ifExists, input);
         if (duplicateResult) return duplicateResult;
       } else {
-        log.info({ title: finalTitle }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
+        log.info({ title: titleOverride }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
       }
 
-      log.debug({ title: finalTitle }, 'task_list_add: creating new item');
+      log.debug({ title: titleOverride }, 'task_list_add: creating new item');
 
-      const selectorType = taskId ? 'task_id' : 'task_name';
+      // Auto-create a lightweight task template for the ad-hoc item
+      const adHocTask = createTask({
+        title: titleOverride,
+        template: titleOverride,
+      });
+
       const workItem = createWorkItem({
-        taskId: resolvedTask.id,
-        title: finalTitle,
+        taskId: adHocTask.id,
+        title: titleOverride,
         notes,
         priorityTier: priorityTier ?? 1,
         sortIndex,
       });
 
-      log.info({ selectorType, taskId: resolvedTask.id, workItemId: workItem.id, title: workItem.title }, 'work item created from task definition');
+      log.info({ selectorType: 'title', workItemId: workItem.id, title: workItem.title }, 'ad-hoc work item created');
 
       const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
       const lines = [
         `Enqueued work item:`,
         `  Title: ${workItem.title}`,
         `  ID: ${workItem.id}`,
-        `  Task definition: ${resolvedTask.title} (${resolvedTask.id})`,
         `  Priority: ${priority}`,
         `  Status: ${workItem.status}`,
       ];
@@ -255,11 +160,108 @@ class TaskListAddTool implements Tool {
       }
 
       return { content: lines.join('\n'), isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ error: msg }, 'enqueue failed');
-      return { content: `Error: ${msg}`, isError: true };
     }
+
+    let resolvedTask;
+
+    if (taskId) {
+      resolvedTask = getTask(taskId);
+      if (!resolvedTask) {
+        const entity = identifyEntityById(taskId);
+        if (entity.type === 'work_item') {
+          return {
+            content: `Error: ${buildWorkItemMismatchError(taskId, entity.title!, 'task_list_update to modify the existing work item, or task_list_add with just a title for a new ad-hoc item')}`,
+            isError: true,
+          };
+        }
+        return { content: `Error: No task definition found with ID "${taskId}". Use task_list to see available task templates, or provide just a title to create an ad-hoc work item.`, isError: true };
+      }
+    } else {
+      // Search by name (case-insensitive substring match)
+      const needle = taskName!.toLowerCase();
+      const allTasks = listTasks();
+      const matches = allTasks.filter((t) => t.title.toLowerCase().includes(needle));
+
+      if (matches.length === 0) {
+        return {
+          content: `Error: No task definition found matching "${taskName}". Use task_list to see available tasks.`,
+          isError: true,
+        };
+      }
+
+      if (matches.length > 1) {
+        const lines = [
+          `Multiple task definitions match "${taskName}". Please specify by ID:`,
+          '',
+        ];
+        for (const m of matches) {
+          lines.push(`- ${m.title}  (ID: ${m.id})`);
+        }
+        return { content: lines.join('\n'), isError: true };
+      }
+
+      resolvedTask = matches[0];
+    }
+
+    const finalTitle = titleOverride ?? resolvedTask.title;
+
+    // Duplicate-prevention guard
+    if (ifExists !== 'create_duplicate') {
+      const duplicateResult = handleDuplicate(finalTitle, ifExists, input);
+      if (duplicateResult) return duplicateResult;
+    } else {
+      log.info({ title: finalTitle }, 'task_list_add: creating duplicate (if_exists=create_duplicate)');
+    }
+
+    log.debug({ title: finalTitle }, 'task_list_add: creating new item');
+
+    const selectorType = taskId ? 'task_id' : 'task_name';
+    const workItem = createWorkItem({
+      taskId: resolvedTask.id,
+      title: finalTitle,
+      notes,
+      priorityTier: priorityTier ?? 1,
+      sortIndex,
+    });
+
+    log.info({ selectorType, taskId: resolvedTask.id, workItemId: workItem.id, title: workItem.title }, 'work item created from task definition');
+
+    const priority = PRIORITY_LABELS[workItem.priorityTier] ?? `tier ${workItem.priorityTier}`;
+    const lines = [
+      `Enqueued work item:`,
+      `  Title: ${workItem.title}`,
+      `  ID: ${workItem.id}`,
+      `  Task definition: ${resolvedTask.title} (${resolvedTask.id})`,
+      `  Priority: ${priority}`,
+      `  Status: ${workItem.status}`,
+    ];
+    if (workItem.notes) {
+      lines.push(`  Notes: ${workItem.notes}`);
+    }
+    if (workItem.sortIndex !== null) {
+      lines.push(`  Sort index: ${workItem.sortIndex}`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ error: msg }, 'enqueue failed');
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
+class TaskListAddTool implements Tool {
+  name = 'task_list_add';
+  description = definition.description;
+  category = 'tasks';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return definition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executeTaskListAdd(input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -21,6 +21,45 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskListShow(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  try {
+    const statusFilter = input.status as string | string[] | undefined;
+
+    let items;
+    if (typeof statusFilter === 'string') {
+      items = listWorkItems({ status: statusFilter as WorkItemStatus });
+    } else if (Array.isArray(statusFilter)) {
+      // listWorkItems only supports a single status filter, so we fetch all
+      // and filter client-side when an array is provided
+      const allItems = listWorkItems();
+      const allowed = new Set(statusFilter);
+      items = allItems.filter((item) => allowed.has(item.status));
+    } else {
+      items = listWorkItems();
+    }
+
+    const count = items.length;
+    const filtered = statusFilter !== undefined;
+
+    if (count === 0) {
+      const suffix = filtered ? 'no items matching filter.' : 'no tasks queued.';
+      return { content: `Opened Tasks window \u2014 ${suffix}`, isError: false };
+    }
+
+    const label = filtered
+      ? `${count} ${Array.isArray(statusFilter) ? 'matching' : statusFilter} item${count === 1 ? '' : 's'}`
+      : `${count} item${count === 1 ? '' : 's'}`;
+
+    return { content: `Opened Tasks window (${label}).`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskListShowTool implements Tool {
   name = 'task_list_show';
   description = definition.description;
@@ -32,39 +71,7 @@ class TaskListShowTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    try {
-      const statusFilter = input.status as string | string[] | undefined;
-
-      let items;
-      if (typeof statusFilter === 'string') {
-        items = listWorkItems({ status: statusFilter as WorkItemStatus });
-      } else if (Array.isArray(statusFilter)) {
-        // listWorkItems only supports a single status filter, so we fetch all
-        // and filter client-side when an array is provided
-        const allItems = listWorkItems();
-        const allowed = new Set(statusFilter);
-        items = allItems.filter((item) => allowed.has(item.status));
-      } else {
-        items = listWorkItems();
-      }
-
-      const count = items.length;
-      const filtered = statusFilter !== undefined;
-
-      if (count === 0) {
-        const suffix = filtered ? 'no items matching filter.' : 'no tasks queued.';
-        return { content: `Opened Tasks window \u2014 ${suffix}`, isError: false };
-      }
-
-      const label = filtered
-        ? `${count} ${Array.isArray(statusFilter) ? 'matching' : statusFilter} item${count === 1 ? '' : 's'}`
-        : `${count} item${count === 1 ? '' : 's'}`;
-
-      return { content: `Opened Tasks window (${label}).`, isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskListShow(input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -46,6 +46,61 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskListRemove(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
+
+  try {
+    const selector = {
+      workItemId: input.work_item_id as string | undefined,
+      taskId: input.task_id as string | undefined,
+      title: (input.task_name ?? input.title) as string | undefined,
+      priorityTier: input.priority_tier as number | undefined,
+      status: input.status as WorkItemStatus | undefined,
+      createdOrder: input.created_order as number | undefined,
+    };
+
+    const resolveResult = resolveWorkItem(selector);
+
+    if (resolveResult.status === 'not_found') {
+      // When the model passes an ID directly, check if it's a task template
+      if (selector.workItemId) {
+        const entity = identifyEntityById(selector.workItemId);
+        if (entity.type === 'task_template') {
+          log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
+          return {
+            content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to delete task templates')}`,
+            isError: true,
+          };
+        }
+      }
+      log.warn({ selectorType, error: resolveResult.message }, 'work item not found for removal');
+      return { content: `Error: ${resolveResult.message}`, isError: true };
+    }
+
+    if (resolveResult.status === 'ambiguous') {
+      log.warn({ selectorType, matchCount: resolveResult.matches.length }, 'ambiguous selector for removal');
+      return { content: `Error: ${resolveResult.message}`, isError: true };
+    }
+
+    const item = resolveResult.workItem;
+
+    log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
+
+    const removeResult = removeWorkItemFromQueue(item.id);
+
+    log.info({ resolvedWorkItemId: item.id, deletedCount: 1 }, 'work item removed');
+
+    return { content: removeResult.message, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ selectorType, error: msg }, 'remove failed');
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskListRemoveTool implements Tool {
   name = 'task_list_remove';
   description = definition.description;
@@ -57,55 +112,7 @@ class TaskListRemoveTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
-
-    try {
-      const selector = {
-        workItemId: input.work_item_id as string | undefined,
-        taskId: input.task_id as string | undefined,
-        title: (input.task_name ?? input.title) as string | undefined,
-        priorityTier: input.priority_tier as number | undefined,
-        status: input.status as WorkItemStatus | undefined,
-        createdOrder: input.created_order as number | undefined,
-      };
-
-      const resolveResult = resolveWorkItem(selector);
-
-      if (resolveResult.status === 'not_found') {
-        // When the model passes an ID directly, check if it's a task template
-        if (selector.workItemId) {
-          const entity = identifyEntityById(selector.workItemId);
-          if (entity.type === 'task_template') {
-            log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
-            return {
-              content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to delete task templates')}`,
-              isError: true,
-            };
-          }
-        }
-        log.warn({ selectorType, error: resolveResult.message }, 'work item not found for removal');
-        return { content: `Error: ${resolveResult.message}`, isError: true };
-      }
-
-      if (resolveResult.status === 'ambiguous') {
-        log.warn({ selectorType, matchCount: resolveResult.matches.length }, 'ambiguous selector for removal');
-        return { content: `Error: ${resolveResult.message}`, isError: true };
-      }
-
-      const item = resolveResult.workItem;
-
-      log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id, title: item.title }, 'resolved work item for removal');
-
-      const removeResult = removeWorkItemFromQueue(item.id);
-
-      log.info({ resolvedWorkItemId: item.id, deletedCount: 1 }, 'work item removed');
-
-      return { content: removeResult.message, isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ selectorType, error: msg }, 'remove failed');
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskListRemove(input, _context);
   }
 }
 

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -72,6 +72,109 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeTaskListUpdate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
+
+  try {
+    // Build selector from whichever identifier was provided
+    const selector = {
+      workItemId: input.work_item_id as string | undefined,
+      taskId: input.task_id as string | undefined,
+      title: (input.task_name ?? input.title) as string | undefined,
+      priorityTier: input.filter_priority_tier as number | undefined,
+      status: input.filter_status as WorkItemStatus | undefined,
+      createdOrder: input.created_order as number | undefined,
+    };
+
+    // Resolve the target work item
+    const result = resolveWorkItem(selector);
+
+    if (result.status === 'not_found') {
+      // When the model passes an ID directly, check if it's a task template
+      if (selector.workItemId) {
+        const entity = identifyEntityById(selector.workItemId);
+        if (entity.type === 'task_template') {
+          log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
+          return {
+            content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to remove task templates, or task_list to view them')}`,
+            isError: true,
+          };
+        }
+      }
+      log.warn({ selectorType, error: result.message }, 'work item not found for update');
+      return { content: `Error: ${result.message}`, isError: true };
+    }
+
+    if (result.status === 'ambiguous') {
+      log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for update');
+      return { content: `Error: ${result.message}`, isError: true };
+    }
+
+    const item = result.workItem;
+
+    // Block direct transitions to 'done' — the only path to done is
+    // through the Review action (handleWorkItemComplete in the daemon).
+    if (input.status === 'done') {
+      log.warn({ selectorType, resolvedWorkItemId: item.id }, 'rejected attempt to set status to done directly');
+      return {
+        content: 'Error: Cannot set status to \'done\' directly. Use the Review action in the Tasks window.',
+        isError: true,
+      };
+    }
+
+    log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id }, 'resolved work item for update');
+
+    // Build updates from provided fields
+    const updates: Partial<{
+      priorityTier: number;
+      notes: string;
+      status: WorkItemStatus;
+      sortIndex: number;
+    }> = {};
+    if (input.priority_tier !== undefined) updates.priorityTier = input.priority_tier as number;
+    if (input.notes !== undefined) updates.notes = input.notes as string;
+    if (input.status !== undefined) updates.status = input.status as WorkItemStatus;
+    if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
+
+    if (Object.keys(updates).length === 0) {
+      log.warn({ selectorType, resolvedWorkItemId: item.id }, 'update called with no fields to update');
+      return {
+        content: 'No updates specified. Provide at least one field to update (priority_tier, notes, status, sort_index).',
+        isError: true,
+      };
+    }
+
+    const updated = updateWorkItem(item.id, updates);
+    if (!updated) {
+      log.error({ selectorType, resolvedWorkItemId: item.id, updates }, 'updateWorkItem returned null');
+      return {
+        content: `Error: Failed to update work item "${item.title}".`,
+        isError: true,
+      };
+    }
+
+    log.info({ resolvedWorkItemId: item.id, updatedFields: Object.keys(updates) }, 'work item updated');
+
+    // Build confirmation message
+    const parts: string[] = [`Updated "${updated.title}"`];
+    if (input.priority_tier !== undefined) {
+      parts.push(`priority → ${PRIORITY_LABELS[updated.priorityTier] ?? updated.priorityTier}`);
+    }
+    if (input.notes !== undefined) parts.push('notes updated');
+    if (input.status !== undefined) parts.push(`status → ${updated.status}`);
+    if (input.sort_index !== undefined) parts.push(`sort index → ${updated.sortIndex}`);
+
+    return { content: parts.join(', ') + '.', isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ selectorType, error: msg }, 'update failed');
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
 class TaskListUpdateTool implements Tool {
   name = 'task_list_update';
   description = definition.description;
@@ -83,103 +186,7 @@ class TaskListUpdateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const selectorType = input.work_item_id ? 'work_item_id' : input.task_id ? 'task_id' : input.task_name ? 'task_name' : input.title ? 'title' : 'none';
-
-    try {
-      // Build selector from whichever identifier was provided
-      const selector = {
-        workItemId: input.work_item_id as string | undefined,
-        taskId: input.task_id as string | undefined,
-        title: (input.task_name ?? input.title) as string | undefined,
-        priorityTier: input.filter_priority_tier as number | undefined,
-        status: input.filter_status as WorkItemStatus | undefined,
-        createdOrder: input.created_order as number | undefined,
-      };
-
-      // Resolve the target work item
-      const result = resolveWorkItem(selector);
-
-      if (result.status === 'not_found') {
-        // When the model passes an ID directly, check if it's a task template
-        if (selector.workItemId) {
-          const entity = identifyEntityById(selector.workItemId);
-          if (entity.type === 'task_template') {
-            log.warn({ selectorType, inputId: selector.workItemId }, 'task template ID passed as work_item_id');
-            return {
-              content: `Error: ${buildTaskTemplateMismatchError(selector.workItemId, entity.title!, 'task_delete to remove task templates, or task_list to view them')}`,
-              isError: true,
-            };
-          }
-        }
-        log.warn({ selectorType, error: result.message }, 'work item not found for update');
-        return { content: `Error: ${result.message}`, isError: true };
-      }
-
-      if (result.status === 'ambiguous') {
-        log.warn({ selectorType, matchCount: result.matches.length }, 'ambiguous selector for update');
-        return { content: `Error: ${result.message}`, isError: true };
-      }
-
-      const item = result.workItem;
-
-      // Block direct transitions to 'done' — the only path to done is
-      // through the Review action (handleWorkItemComplete in the daemon).
-      if (input.status === 'done') {
-        log.warn({ selectorType, resolvedWorkItemId: item.id }, 'rejected attempt to set status to done directly');
-        return {
-          content: 'Error: Cannot set status to \'done\' directly. Use the Review action in the Tasks window.',
-          isError: true,
-        };
-      }
-
-      log.info({ selectorType, selectorValue: input[selectorType], resolvedWorkItemId: item.id }, 'resolved work item for update');
-
-      // Build updates from provided fields
-      const updates: Partial<{
-        priorityTier: number;
-        notes: string;
-        status: WorkItemStatus;
-        sortIndex: number;
-      }> = {};
-      if (input.priority_tier !== undefined) updates.priorityTier = input.priority_tier as number;
-      if (input.notes !== undefined) updates.notes = input.notes as string;
-      if (input.status !== undefined) updates.status = input.status as WorkItemStatus;
-      if (input.sort_index !== undefined) updates.sortIndex = input.sort_index as number;
-
-      if (Object.keys(updates).length === 0) {
-        log.warn({ selectorType, resolvedWorkItemId: item.id }, 'update called with no fields to update');
-        return {
-          content: 'No updates specified. Provide at least one field to update (priority_tier, notes, status, sort_index).',
-          isError: true,
-        };
-      }
-
-      const updated = updateWorkItem(item.id, updates);
-      if (!updated) {
-        log.error({ selectorType, resolvedWorkItemId: item.id, updates }, 'updateWorkItem returned null');
-        return {
-          content: `Error: Failed to update work item "${item.title}".`,
-          isError: true,
-        };
-      }
-
-      log.info({ resolvedWorkItemId: item.id, updatedFields: Object.keys(updates) }, 'work item updated');
-
-      // Build confirmation message
-      const parts: string[] = [`Updated "${updated.title}"`];
-      if (input.priority_tier !== undefined) {
-        parts.push(`priority → ${PRIORITY_LABELS[updated.priorityTier] ?? updated.priorityTier}`);
-      }
-      if (input.notes !== undefined) parts.push('notes updated');
-      if (input.status !== undefined) parts.push(`status → ${updated.status}`);
-      if (input.sort_index !== undefined) parts.push(`sort index → ${updated.sortIndex}`);
-
-      return { content: parts.join(', ') + '.', isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error({ selectorType, error: msg }, 'update failed');
-      return { content: `Error: ${msg}`, isError: true };
-    }
+    return executeTaskListUpdate(input, _context);
   }
 }
 


### PR DESCRIPTION
Extract execute() bodies from TaskListShowTool, TaskListAddTool, TaskListUpdateTool, and TaskListRemoveTool into standalone exported functions (executeTaskListShow, executeTaskListAdd, executeTaskListUpdate, executeTaskListRemove). Also promotes TaskListAddTool's private handleDuplicate to a module-level function. Class methods now delegate to these functions. Zero behavior change — pure refactor for upcoming skill migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
