### PR TITLE
refactor: extract document tool execute functions

### DIFF
--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -3,6 +3,96 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { randomUUID } from 'node:crypto';
 
+// ── Exported execute functions ──────────────────────────────────────
+
+export function executeDocumentCreate(input: Record<string, unknown>, context: ToolContext): ToolExecutionResult {
+  const title = (input.title as string | undefined) || 'Untitled Document';
+  const initialContent = (input.initial_content as string | undefined) || '';
+  const surfaceId = `doc-${randomUUID()}`;
+
+  // Send document_editor_show IPC message to open the built-in RTE
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: 'document_editor_show',
+      sessionId: context.sessionId,
+      surfaceId,
+      title,
+      initialContent,
+    });
+
+    context.sendToClient({
+      type: 'ui_surface_show',
+      sessionId: context.sessionId,
+      surfaceId: `preview-${surfaceId}`,
+      surfaceType: 'document_preview',
+      display: 'inline',
+      title,
+      data: {
+        title,
+        surfaceId,
+        subtitle: 'Document',
+      },
+    });
+
+    return {
+      content: JSON.stringify({
+        surface_id: surfaceId,
+        title,
+        opened: true,
+        message: 'Document editor opened in Directory panel',
+      }),
+      isError: false,
+    };
+  }
+
+  // Fallback if no IPC client is connected
+  return {
+    content: JSON.stringify({
+      surface_id: surfaceId,
+      title,
+      opened: false,
+      error: 'No IPC client connected to open document editor',
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentUpdate(input: Record<string, unknown>, context: ToolContext): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const content = input.content as string;
+  const mode = (input.mode as string | undefined) || 'append';
+
+  // Send document_editor_update IPC message to update the built-in RTE
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: 'document_editor_update',
+      sessionId: context.sessionId,
+      surfaceId,
+      markdown: content,
+      mode,
+    });
+
+    return {
+      content: JSON.stringify({
+        success: true,
+        surface_id: surfaceId,
+        mode,
+        message: 'Document content updated',
+      }),
+      isError: false,
+    };
+  }
+
+  // Fallback if no IPC client is connected
+  return {
+    content: JSON.stringify({
+      success: false,
+      error: 'No IPC client connected to update document',
+    }),
+    isError: true,
+  };
+}
+
 // ── document_create ──────────────────────────────────────────────────
 
 export class DocumentCreateTool implements Tool {
@@ -34,55 +124,7 @@ export class DocumentCreateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const title = (input.title as string | undefined) || 'Untitled Document';
-    const initialContent = (input.initial_content as string | undefined) || '';
-    const surfaceId = `doc-${randomUUID()}`;
-
-    // Send document_editor_show IPC message to open the built-in RTE
-    if (context.sendToClient) {
-      context.sendToClient({
-        type: 'document_editor_show',
-        sessionId: context.sessionId,
-        surfaceId,
-        title,
-        initialContent,
-      });
-
-      context.sendToClient({
-        type: 'ui_surface_show',
-        sessionId: context.sessionId,
-        surfaceId: `preview-${surfaceId}`,
-        surfaceType: 'document_preview',
-        display: 'inline',
-        title,
-        data: {
-          title,
-          surfaceId,
-          subtitle: 'Document',
-        },
-      });
-
-      return {
-        content: JSON.stringify({
-          surface_id: surfaceId,
-          title,
-          opened: true,
-          message: 'Document editor opened in Directory panel',
-        }),
-        isError: false,
-      };
-    }
-
-    // Fallback if no IPC client is connected
-    return {
-      content: JSON.stringify({
-        surface_id: surfaceId,
-        title,
-        opened: false,
-        error: 'No IPC client connected to open document editor',
-      }),
-      isError: false,
-    };
+    return executeDocumentCreate(input, context);
   }
 }
 
@@ -123,39 +165,7 @@ export class DocumentUpdateTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const surfaceId = input.surface_id as string;
-    const content = input.content as string;
-    const mode = (input.mode as string | undefined) || 'append';
-
-    // Send document_editor_update IPC message to update the built-in RTE
-    if (context.sendToClient) {
-      context.sendToClient({
-        type: 'document_editor_update',
-        sessionId: context.sessionId,
-        surfaceId,
-        markdown: content,
-        mode,
-      });
-
-      return {
-        content: JSON.stringify({
-          success: true,
-          surface_id: surfaceId,
-          mode,
-          message: 'Document content updated',
-        }),
-        isError: false,
-      };
-    }
-
-    // Fallback if no IPC client is connected
-    return {
-      content: JSON.stringify({
-        success: false,
-        error: 'No IPC client connected to update document',
-      }),
-      isError: true,
-    };
+    return executeDocumentUpdate(input, context);
   }
 }
 


### PR DESCRIPTION
## Summary
- Extracted `DocumentCreateTool.execute()` into standalone `executeDocumentCreate()` function
- Extracted `DocumentUpdateTool.execute()` into standalone `executeDocumentUpdate()` function
- Class execute() methods now delegate to the extracted functions
- No behavioral changes; all imports, class definitions, and exports unchanged

## Test plan
- [x] `bunx tsc --noEmit` passes (only pre-existing errors remain)
- [x] No changes to imports or exports — downstream consumers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
