### PR TITLE
fix: close race condition in processMessage by persisting before bridge check

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -37,6 +37,8 @@ import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { SessionEvictor } from './session-evictor.js';
 import { getSubagentManager } from '../subagent/index.js';
 import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
+import { resolveSlash } from './session-slash.js';
+import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 
 const log = getLogger('server');
 
@@ -1019,33 +1021,31 @@ export class DaemonServer {
         }))
       : [];
 
-    // Attempt the call-answer bridge before launching the agent loop.
-    // The bridge check doesn't require persistence (the messageId param
-    // is reserved for future use), so we can check it before delegating
-    // to session.processMessage().
+    // Persist the user message immediately after the isProcessing() guard.
+    // This synchronously sets session.processing = true, closing the race
+    // window that previously existed between the guard and the async bridge
+    // check (two concurrent requests could both pass isProcessing() and
+    // race into message handling).
+    const requestId = crypto.randomUUID();
+    const messageId = session.persistUserMessage(content, attachments, requestId);
+
+    // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content);
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
       log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
     }
 
     if (bridgeHandled) {
-      // The message was consumed by the call system. Persist it so the
-      // conversation history is accurate, then release the session.
-      const requestId = crypto.randomUUID();
-      const messageId = session.persistUserMessage(content, attachments, requestId);
+      // The message was consumed by the call system. Release the session.
       resetSessionProcessingState(session);
       // Drain any queued messages that arrived while processing was true.
       session.drainQueue('loop_complete');
       log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
       return { messageId };
     }
-
-    // persistUserMessage throws if the session is busy or persistence fails
-    const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(content, attachments, requestId);
 
     // Fire-and-forget the agent loop. Errors are logged but do not
     // affect the HTTP response (the client polls GET /messages).
@@ -1092,23 +1092,57 @@ export class DaemonServer {
         }))
       : [];
 
-    // Check the call-answer bridge before launching the agent loop.
-    // The bridge check doesn't require persistence (the messageId param
-    // is reserved for future use), so we can check it before delegating
-    // to session.processMessage().
+    // Resolve slash commands before persistence (synchronous — no race window).
+    const slashResult = resolveSlash(content);
+
+    // Unknown slash command — persist the exchange (user + assistant) and
+    // return immediately. This path doesn't set processing=true since no
+    // agent loop runs, so there is no race concern.
+    if (slashResult.kind === 'unknown') {
+      const userMsg = createUserMessage(content, attachments);
+      const persisted = conversationStore.addMessage(
+        conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+      );
+      session.getMessages().push(userMsg);
+
+      const assistantMsg = createAssistantMessage(slashResult.message);
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify(assistantMsg.content),
+      );
+      session.getMessages().push(assistantMsg);
+      return { messageId: persisted.id };
+    }
+
+    const resolvedContent = slashResult.content;
+
+    // Preactivate skill tools when slash resolution identifies a known skill
+    if (slashResult.kind === 'rewritten') {
+      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = [slashResult.skillId];
+    }
+
+    // Persist the user message immediately after the isProcessing() guard.
+    // This synchronously sets session.processing = true, closing the race
+    // window that previously existed between the guard and the async bridge
+    // check.
+    const requestId = crypto.randomUUID();
+    const messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+
+    // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content);
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, resolvedContent, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
       log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
     }
 
     if (bridgeHandled) {
-      // The message was consumed by the call system. Persist it so the
-      // conversation history is accurate, then release the session.
-      const requestId = crypto.randomUUID();
-      const messageId = session.persistUserMessage(content, attachments, requestId);
+      // The message was consumed by the call system. Release the session.
+      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = undefined;
       resetSessionProcessingState(session);
       // Drain any queued messages that arrived while processing was true.
       session.drainQueue('loop_complete');
@@ -1116,10 +1150,8 @@ export class DaemonServer {
       return { messageId };
     }
 
-    // Delegate to session.processMessage() which handles slash-command
-    // resolution, skill preactivation, message persistence, and the
-    // agent loop in the correct order.
-    const messageId = await session.processMessage(content, attachments, () => {});
+    // Run the agent loop (blocking — the channel inbound endpoint needs the reply).
+    await session.runAgentLoop(resolvedContent, messageId, () => {});
 
     return { messageId };
   }


### PR DESCRIPTION
Addresses Codex+Devin feedback on #5449:
- P1: Move persistUserMessage before the bridge check to synchronously acquire the processing lock, closing the async race window
- P1: Handle empty messageId from processMessage as an error
- Preserve slash-command resolution in the non-bridge path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
