### PR TITLE
fix: update stale benchmark filename in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -831,7 +831,7 @@ graph TB
    - job queue counts for `cleanup_resolved_conflicts` / `cleanup_stale_superseded_items`
 6. Before tuning ranking or relation settings, run:
    - `cd assistant && bun test src/__tests__/context-memory-e2e.test.ts`
-   - `cd assistant && bun test src/__tests__/memory-context-benchmark.test.ts`
+   - `cd assistant && bun test src/__tests__/memory-context-benchmark.benchmark.test.ts`
    - `cd assistant && bun test src/__tests__/memory-recall-quality.test.ts`
    - `cd assistant && bun test src/__tests__/memory-regressions.test.ts -t "relation"`
 7. After tuning, rerun the same suite and compare:


### PR DESCRIPTION
## Summary
- Fix stale reference to `memory-context-benchmark.test.ts` → `memory-context-benchmark.benchmark.test.ts` on line 834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
