### PR TITLE
feat: migrate schedule tools to bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: "Schedule"
+description: "Cron-like recurring automation that dispatches messages on a schedule"
+metadata: {"vellum": {"emoji": "\ud83d\udcc5"}}
+---
+
+Manage recurring scheduled automations (cron jobs). Each schedule has a cron expression that defines when it fires, and a message that gets dispatched to the assistant at trigger time.
+
+## Cron Expression Format
+
+Standard 5-field cron syntax: `minute hour day-of-month month day-of-week`
+
+| Field         | Values        | Special characters |
+|---------------|---------------|--------------------|
+| Minute        | 0-59          | , - * /            |
+| Hour          | 0-23          | , - * /            |
+| Day of month  | 1-31          | , - * /            |
+| Month         | 1-12          | , - * /            |
+| Day of week   | 0-7 (0,7=Sun) | , - * /            |
+
+Examples:
+- `0 9 * * 1-5` — weekdays at 9:00 AM
+- `30 8 * * *` — every day at 8:30 AM
+- `0 */2 * * *` — every 2 hours
+- `0 9 1 * *` — first of every month at 9:00 AM
+
+## Lifecycle
+
+1. Create a schedule with a name, cron expression, and message.
+2. At each trigger time, the message is dispatched to the assistant as if the user sent it.
+3. Schedules can be enabled/disabled, updated, or deleted.
+
+## Tips
+
+- Only use `schedule_create` when the user explicitly wants recurring automation (e.g. "every day at 9am", "weekly on Mondays"). For one-time tasks, use the task list instead.
+- Timezones default to the system timezone if omitted. Use IANA timezone identifiers (e.g. "America/Los_Angeles").

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -1,0 +1,117 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "schedule_create",
+      "description": "Create a recurring scheduled automation that sends a message at a cron interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"weekly on Mondays\", \"every hour\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" — use task_list_add for those requests instead.",
+      "category": "schedule",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A human-readable name for the scheduled task"
+          },
+          "cron_expression": {
+            "type": "string",
+            "description": "A cron expression (e.g. \"0 9 * * 1-5\" for weekdays at 9am). Supports standard 5-field cron syntax."
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone (e.g. \"America/Los_Angeles\"). Defaults to system timezone if omitted."
+          },
+          "message": {
+            "type": "string",
+            "description": "The message to send to the assistant when the schedule triggers"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the job is enabled immediately. Defaults to true."
+          }
+        },
+        "required": ["name", "cron_expression", "message"]
+      },
+      "executor": "tools/schedule-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "schedule_list",
+      "description": "List recurring scheduled automations (cron jobs), or show details and recent runs for a specific one. For the user's task queue, use task_list_show instead.",
+      "category": "schedule",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "enabled_only": {
+            "type": "boolean",
+            "description": "When true, only show enabled jobs. Defaults to false."
+          },
+          "job_id": {
+            "type": "string",
+            "description": "If provided, show detailed info and recent runs for this specific job."
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/schedule-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "schedule_update",
+      "description": "Update an existing recurring scheduled automation (cron expression, message, name, or enabled state)",
+      "category": "schedule",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "description": "The ID of the schedule to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "New name for the job"
+          },
+          "cron_expression": {
+            "type": "string",
+            "description": "New cron expression"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "New IANA timezone"
+          },
+          "message": {
+            "type": "string",
+            "description": "New message to send when triggered"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable the job"
+          }
+        },
+        "required": ["job_id"]
+      },
+      "executor": "tools/schedule-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "schedule_delete",
+      "description": "Delete a recurring scheduled automation and all its run history",
+      "category": "schedule",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "description": "The ID of the schedule to delete"
+          }
+        },
+        "required": ["job_id"]
+      },
+      "executor": "tools/schedule-delete.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/schedule/tools/schedule-create.ts
+++ b/assistant/src/config/bundled-skills/schedule/tools/schedule-create.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeScheduleCreate } from '../../../../tools/schedule/create.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeScheduleCreate(input, context);
+}

--- a/assistant/src/config/bundled-skills/schedule/tools/schedule-delete.ts
+++ b/assistant/src/config/bundled-skills/schedule/tools/schedule-delete.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeScheduleDelete } from '../../../../tools/schedule/delete.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeScheduleDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/schedule/tools/schedule-list.ts
+++ b/assistant/src/config/bundled-skills/schedule/tools/schedule-list.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeScheduleList } from '../../../../tools/schedule/list.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeScheduleList(input, context);
+}

--- a/assistant/src/config/bundled-skills/schedule/tools/schedule-update.ts
+++ b/assistant/src/config/bundled-skills/schedule/tools/schedule-update.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeScheduleUpdate } from '../../../../tools/schedule/update.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeScheduleUpdate(input, context);
+}

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -1,52 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { createSchedule, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
-
-class ScheduleCreateTool implements Tool {
-  name = 'schedule_create';
-  description = 'Create a recurring scheduled automation that sends a message at a cron interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. "every day at 9am", "weekly on Mondays", "every hour"). Do NOT use this for "add to my tasks" or "add to my queue" — use task_list_add for those requests instead.';
-  category = 'schedule';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          name: {
-            type: 'string',
-            description: 'A human-readable name for the scheduled task',
-          },
-          cron_expression: {
-            type: 'string',
-            description: 'A cron expression (e.g. "0 9 * * 1-5" for weekdays at 9am). Supports standard 5-field cron syntax.',
-          },
-          timezone: {
-            type: 'string',
-            description: 'IANA timezone (e.g. "America/Los_Angeles"). Defaults to system timezone if omitted.',
-          },
-          message: {
-            type: 'string',
-            description: 'The message to send to the assistant when the schedule triggers',
-          },
-          enabled: {
-            type: 'boolean',
-            description: 'Whether the job is enabled immediately. Defaults to true.',
-          },
-        },
-        required: ['name', 'cron_expression', 'message'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeScheduleCreate(input, _context);
-  }
-}
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
@@ -89,5 +42,3 @@ export async function executeScheduleCreate(
     return { content: `Error creating schedule: ${msg}`, isError: true };
   }
 }
-
-registerTool(new ScheduleCreateTool());

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -1,36 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { deleteSchedule, getSchedule } from '../../schedule/schedule-store.js';
-
-class ScheduleDeleteTool implements Tool {
-  name = 'schedule_delete';
-  description = 'Delete a recurring scheduled automation and all its run history';
-  category = 'schedule';
-  defaultRiskLevel = RiskLevel.High;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          job_id: {
-            type: 'string',
-            description: 'The ID of the schedule to delete',
-          },
-        },
-        required: ['job_id'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeScheduleDelete(input, _context);
-  }
-}
 
 export async function executeScheduleDelete(
   input: Record<string, unknown>,
@@ -57,5 +26,3 @@ export async function executeScheduleDelete(
     isError: false,
   };
 }
-
-registerTool(new ScheduleDeleteTool());

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -1,40 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listSchedules, getSchedule, getScheduleRuns, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
-
-class ScheduleListTool implements Tool {
-  name = 'schedule_list';
-  description = 'List recurring scheduled automations (cron jobs), or show details and recent runs for a specific one. For the user\'s task queue, use task_list_show instead.';
-  category = 'schedule';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          enabled_only: {
-            type: 'boolean',
-            description: 'When true, only show enabled jobs. Defaults to false.',
-          },
-          job_id: {
-            type: 'string',
-            description: 'If provided, show detailed info and recent runs for this specific job.',
-          },
-        },
-        required: [],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeScheduleList(input, _context);
-  }
-}
 
 export async function executeScheduleList(
   input: Record<string, unknown>,
@@ -91,5 +56,3 @@ export async function executeScheduleList(
 
   return { content: lines.join('\n'), isError: false };
 }
-
-registerTool(new ScheduleListTool());

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,56 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { updateSchedule, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
-
-class ScheduleUpdateTool implements Tool {
-  name = 'schedule_update';
-  description = 'Update an existing recurring scheduled automation (cron expression, message, name, or enabled state)';
-  category = 'schedule';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          job_id: {
-            type: 'string',
-            description: 'The ID of the schedule to update',
-          },
-          name: {
-            type: 'string',
-            description: 'New name for the job',
-          },
-          cron_expression: {
-            type: 'string',
-            description: 'New cron expression',
-          },
-          timezone: {
-            type: 'string',
-            description: 'New IANA timezone',
-          },
-          message: {
-            type: 'string',
-            description: 'New message to send when triggered',
-          },
-          enabled: {
-            type: 'boolean',
-            description: 'Enable or disable the job',
-          },
-        },
-        required: ['job_id'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeScheduleUpdate(input, _context);
-  }
-}
 
 export async function executeScheduleUpdate(
   input: Record<string, unknown>,
@@ -100,5 +49,3 @@ export async function executeScheduleUpdate(
     return { content: `Error updating schedule: ${msg}`, isError: true };
   }
 }
-
-registerTool(new ScheduleUpdateTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -40,10 +40,6 @@ export async function loadEagerModules(): Promise<void> {
   await import('./skills/scaffold-managed.js');
   await import('./skills/delete-managed.js');
   await import('./system/request-permission.js');
-  await import('./schedule/create.js');
-  await import('./schedule/list.js');
-  await import('./schedule/update.js');
-  await import('./schedule/delete.js');
   await import('./watcher/create.js');
   await import('./watcher/list.js');
   await import('./watcher/update.js');
@@ -78,10 +74,6 @@ export const eagerModuleToolNames: string[] = [
   'scaffold_managed_skill',
   'delete_managed_skill',
   'request_system_permission',
-  'schedule_create',
-  'schedule_list',
-  'schedule_update',
-  'schedule_delete',
   'watcher_create',
   'watcher_list',
   'watcher_update',


### PR DESCRIPTION
Create bundled skill directory with SKILL.md, TOOLS.json, and executor scripts. Remove class-based tool definitions and tool-manifest.ts registration. Skill migration step 2 of 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
