### PR TITLE
fix: task status badge UX and stale runInFlightIds cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 struct TasksWindowView: View {
     @StateObject private var viewModel: TasksWindowViewModel
 
-    init(daemonClient: DaemonClient, onRunTaskInChat: ((String, String, String) -> Void)? = nil) {
+    init(daemonClient: DaemonClient, onRunTaskInChat: ((String, String, String) -> Bool)? = nil) {
         let vm = TasksWindowViewModel(daemonClient: daemonClient)
         vm.onRunTaskInChat = onRunTaskInChat
         _viewModel = StateObject(wrappedValue: vm)
@@ -256,6 +256,12 @@ private struct TasksWindowRow: View {
     private var statusColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
         let style = TasksTableContract.statusStyle(for: status)
+        // When the status has output to show, use accent color persistently
+        // (not just on hover) so the badge looks clearly clickable.
+        let textColor = hasOutput ? VColor.accent : style.color
+        let bgColor = hasOutput
+            ? VColor.accent.opacity(isStatusHovered ? 0.24 : 0.14)
+            : style.color.opacity(0.12)
         return HStack(spacing: VSpacing.xs) {
             if status == .running {
                 ProgressView()
@@ -263,11 +269,16 @@ private struct TasksWindowRow: View {
             }
             Text(style.label)
                 .font(VFont.caption)
-                .foregroundColor(hasOutput && isStatusHovered ? VColor.accent : style.color)
+                .foregroundColor(textColor)
+            if hasOutput {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(textColor.opacity(0.6))
+            }
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, 2)
-        .background(hasOutput && isStatusHovered ? VColor.accent.opacity(0.18) : style.color.opacity(0.12))
+        .background(bgColor)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         .contentShape(Rectangle())
         .onHover { hovering in isStatusHovered = hovering }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -76,6 +76,15 @@ class TasksWindowViewModel: ObservableObject {
             // A fresh list response means the daemon is alive — clear any
             // stale timeout warnings since the user can now retry.
             self?.runTimeoutIds.removeAll()
+            // Safety net: clear in-flight IDs for items whose status is no
+            // longer "running". This prevents stale IDs from keeping the
+            // Run/Rerun button disabled after a status transition.
+            if let self {
+                let nonRunningIds = Set(response.items
+                    .filter { WorkItemStatus(rawStatus: $0.status) != .running }
+                    .map(\.id))
+                self.runInFlightIds.subtract(nonRunningIds)
+            }
         }
 
         // Debounce rapid broadcasts so multiple mutations coalesce


### PR DESCRIPTION
## Summary
- Fix type mismatch in `TasksWindowView.init` (`-> Void` → `-> Bool`) that prevented compilation with the chat-routing callback
- Make the status badge persistently accent-colored with a chevron indicator when output is available, so it's clearly clickable without hovering
- Add safety net in `onWorkItemsListResponse` to clear `runInFlightIds` for items whose status is no longer "running", preventing the Rerun button from staying greyed out after status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
