### PR TITLE
fix: show PR number instead of full URL in check-reviews table

### DIFF
--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -67,6 +67,7 @@ Display a table with these columns:
 | PR  | Title | Age | Codex | Devin | Verdict | TODO | Removed |
 | --- | ----- | --- | ----- | ----- | ------- | ---- | ------- |
 
+- **PR**: Just the PR number (e.g., `#5471`), not the full URL.
 - **Title**: PR title, truncated to 30 characters with "..." if longer.
 - **Age**: How long ago the PR was created (e.g., "2h 15m", "45m").
 - **Codex/Devin columns**: Use emoji prefixes for quick scanning:


### PR DESCRIPTION
## Summary
- Updated check-reviews command to specify that the PR column should display just the PR number (e.g., `#5471`) instead of the full GitHub URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
