### PR TITLE
Fix top bar buttons unclickable in temporary chat mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -144,21 +144,23 @@ struct MainWindowView: View {
     }
 
     private func toggleTemporaryChat() {
-        if threadManager.activeThread?.kind == .private {
-            // Restore the thread the user was on before entering temporary chat.
-            // Fall back to visibleThreads.first only if the stored thread no longer exists.
-            if let savedId = preTemporaryChatThreadId,
-               threadManager.visibleThreads.contains(where: { $0.id == savedId }) {
-                threadManager.selectThread(id: savedId)
-            } else if let recent = threadManager.visibleThreads.first {
-                threadManager.selectThread(id: recent.id)
+        withAnimation(VAnimation.standard) {
+            if threadManager.activeThread?.kind == .private {
+                // Restore the thread the user was on before entering temporary chat.
+                // Fall back to visibleThreads.first only if the stored thread no longer exists.
+                if let savedId = preTemporaryChatThreadId,
+                   threadManager.visibleThreads.contains(where: { $0.id == savedId }) {
+                    threadManager.selectThread(id: savedId)
+                } else if let recent = threadManager.visibleThreads.first {
+                    threadManager.selectThread(id: recent.id)
+                } else {
+                    threadManager.createThread()
+                }
+                preTemporaryChatThreadId = nil
             } else {
-                threadManager.createThread()
+                preTemporaryChatThreadId = threadManager.activeThreadId
+                threadManager.createPrivateThread()
             }
-            preTemporaryChatThreadId = nil
-        } else {
-            preTemporaryChatThreadId = threadManager.activeThreadId
-            threadManager.createPrivateThread()
         }
     }
 
@@ -375,7 +377,6 @@ struct MainWindowView: View {
                         if windowState.isShowingChat, threadManager.activeThread?.kind == .private {
                             Spacer().frame(width: VSpacing.sm)
                             TemporaryChatIndicator(onExit: { toggleTemporaryChat() })
-                                .transition(.opacity.combined(with: .scale(scale: 0.9)))
                         }
                         Spacer()
                         if windowState.isShowingChat {


### PR DESCRIPTION
## Summary
- Remove `.transition(.opacity.combined(with: .scale(scale: 0.9)))` from TemporaryChatIndicator — applying a transition to a conditionally-inserted view without `withAnimation` left the parent HStack in a broken hit-testing state on macOS
- Wrap `toggleTemporaryChat()` body in `withAnimation(VAnimation.standard)` so entry/exit state changes animate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
