### PR TITLE
fix: cancelled tasks show 'Cancelled' instead of 'Awaiting Review'

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -91,6 +91,15 @@ export function handleWorkItemUpdate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  // Don't allow overwriting a cancelled status (e.g. from a late chat-completion observer)
+  if (msg.status !== undefined) {
+    const existing = getWorkItem(msg.id);
+    if (existing?.status === 'cancelled' && msg.status !== 'cancelled') {
+      ctx.send(socket, { type: 'work_item_update_response', item: existing });
+      return;
+    }
+  }
+
   const updates: Record<string, unknown> = {};
   if (msg.title !== undefined) updates.title = msg.title;
   if (msg.notes !== undefined) updates.notes = msg.notes;
@@ -333,13 +342,17 @@ export async function handleWorkItemRunTask(
       },
     );
 
-    const finalStatus: WorkItemStatus = result.status === 'completed' ? 'awaiting_review' : 'failed';
-    updateWorkItem(msg.id, {
-      status: finalStatus,
-      lastRunId: result.taskRunId,
-      lastRunConversationId: result.conversationId,
-      lastRunStatus: result.status,
-    });
+    // Don't overwrite cancelled status — the cancel handler already set it
+    const current = getWorkItem(msg.id);
+    if (current?.status !== 'cancelled') {
+      const finalStatus: WorkItemStatus = result.status === 'completed' ? 'awaiting_review' : 'failed';
+      updateWorkItem(msg.id, {
+        status: finalStatus,
+        lastRunId: result.taskRunId,
+        lastRunConversationId: result.conversationId,
+        lastRunStatus: result.status,
+      });
+    }
 
     broadcastWorkItemStatus(ctx, msg.id);
     ctx.broadcast({ type: 'tasks_changed' });
@@ -467,8 +480,8 @@ export function handleWorkItemCancel(
   }
 
   updateWorkItem(msg.id, {
-    status: 'failed',
-    lastRunStatus: 'failed',
+    status: 'cancelled',
+    lastRunStatus: 'cancelled',
   });
 
   ctx.send(socket, { type: 'work_item_cancel_response', id: msg.id, success: true });

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -433,7 +433,7 @@ export const workItems = sqliteTable('work_items', {
   taskId: text('task_id').notNull().references(() => tasks.id),
   title: text('title').notNull(),
   notes: text('notes'),
-  status: text('status').notNull().default('queued'),  // queued | running | awaiting_review | failed | done | archived
+  status: text('status').notNull().default('queued'),  // queued | running | awaiting_review | failed | cancelled | done | archived
   priorityTier: integer('priority_tier').notNull().default(1), // 0=high, 1=medium, 2=low
   sortIndex: integer('sort_index'),  // manual ordering within same priority tier; null = fall back to updated_at
   lastRunId: text('last_run_id'),

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -35,7 +35,7 @@ const definition: ToolDefinition = {
       },
       status: {
         type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed'],
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled'],
         description: 'Disambiguator: filter by work item status',
       },
       created_order: {

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -45,7 +45,7 @@ const definition: ToolDefinition = {
       },
       status: {
         type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'archived'],
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled', 'archived'],
         description: 'New status for the work item',
       },
       sort_index: {
@@ -59,7 +59,7 @@ const definition: ToolDefinition = {
       },
       filter_status: {
         type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'done', 'archived'],
+        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled', 'done', 'archived'],
         description:
           'Disambiguation filter: narrow by current status when multiple items share the same title/task_id.',
       },

--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -5,7 +5,7 @@ import { getTask } from '../tasks/task-store.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
-export type WorkItemStatus = 'queued' | 'running' | 'awaiting_review' | 'failed' | 'done' | 'archived';
+export type WorkItemStatus = 'queued' | 'running' | 'awaiting_review' | 'failed' | 'cancelled' | 'done' | 'archived';
 
 export interface WorkItem {
   id: string;

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
@@ -10,6 +10,7 @@ enum WorkItemStatus: Equatable {
     case running
     case awaitingReview
     case failed
+    case cancelled
     case done
     case archived
     case unknown(String)
@@ -21,6 +22,7 @@ enum WorkItemStatus: Equatable {
         case "running":         self = .running
         case "awaiting_review": self = .awaitingReview
         case "failed":          self = .failed
+        case "cancelled":       self = .cancelled
         case "done":            self = .done
         case "archived":        self = .archived
         default:                self = .unknown(rawStatus)
@@ -97,6 +99,7 @@ enum TasksTableContract {
         case .running:         return StatusStyle(label: "Running",   color: VColor.warning)
         case .awaitingReview:  return StatusStyle(label: "Awaiting Review", color: VColor.accent)
         case .failed:          return StatusStyle(label: "Failed",    color: VColor.error)
+        case .cancelled:       return StatusStyle(label: "Cancelled", color: VColor.textMuted)
         case .done:            return StatusStyle(label: "Done",      color: VColor.success)
         case .archived:        return StatusStyle(label: "Archived",  color: VColor.textMuted)
         case .unknown(let raw): return StatusStyle(label: raw,        color: VColor.textMuted)

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -294,7 +294,7 @@ private struct TasksWindowRow: View {
         let isRunning = runningIds.contains(item.id) || status == .running
         let isCancelling = cancelInFlightIds.contains(item.id)
         let isTimedOut = timeoutIds.contains(item.id)
-        let isFailed = status == .failed
+        let isFailed = status == .failed || status == .cancelled
         let isRerun = status == .done || status == .awaitingReview
         let showRun = status != .archived && !isRunning
         let runEnabled = !isRunning


### PR DESCRIPTION
## Summary
- Add `cancelled` status to `WorkItemStatus` (backend type, schema comment, Swift enum, status styles)
- Cancel handler now sets `cancelled` instead of `failed`, preventing confusion between user-cancelled and actually-failed tasks
- Guard against race condition: `handleWorkItemUpdate` rejects status changes on cancelled items, and the daemon-side run completion skips status update if already cancelled
- Swift UI treats cancelled tasks same as failed for action buttons (shows Retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
