### PR TITLE
Fix composer placeholder text vertical misalignment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -749,13 +749,11 @@ private final class ComposerNativeTextView: NSTextView {
         let x = textContainerInset.width + linePadding
         let width = max(0, bounds.width - x - textContainerInset.width - linePadding)
 
-        // Measure placeholder height to vertically center it
-        let measureSize = NSSize(width: width, height: .greatestFiniteMagnitude)
-        let placeholderSize = (placeholderText as NSString).boundingRect(
-            with: measureSize, options: .usesLineFragmentOrigin, attributes: attributes
-        ).size
-        let y = max(0, (bounds.height - placeholderSize.height) / 2)
-        let rect = NSRect(x: x, y: y, width: width, height: placeholderSize.height)
+        // Draw at the standard text insertion position and let
+        // CenteringClipView handle vertical centering of the whole
+        // scroll content — avoids double-centering misalignment.
+        let y = textContainerInset.height
+        let rect = NSRect(x: x, y: y, width: width, height: bounds.height - y)
 
         (placeholderText as NSString).draw(in: rect, withAttributes: attributes)
     }


### PR DESCRIPTION
## Summary
- Remove manual vertical centering from placeholder drawing in `ComposerNativeTextView.draw()` — it conflicted with `CenteringClipView` which also centers the scroll content, causing double-centering that clipped the placeholder at the top
- Placeholder now draws at the standard text insertion position (`textContainerInset.height`) and lets `CenteringClipView` handle centering, matching how actual typed text behaves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
