### PR TITLE
Hide copy thread button when thread has no content

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -380,38 +380,38 @@ struct MainWindowView: View {
                         }
                         Spacer()
                         if windowState.isShowingChat {
-                            // Copy Thread button
-                            Button {
-                                let messages = threadManager.activeViewModel?.messages ?? []
-                                let title = threadManager.activeThread?.title
-                                let names = resolveParticipantNames()
-                                let markdown = ChatTranscriptFormatter.threadMarkdown(
-                                    messages: messages,
-                                    threadTitle: title,
-                                    participantNames: names
-                                )
-                                guard !markdown.isEmpty else { return }
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(markdown, forType: .string)
-                                copyThreadConfirmationTimer?.cancel()
-                                showCopyThreadConfirmation = true
-                                let timer = DispatchWorkItem { showCopyThreadConfirmation = false }
-                                copyThreadConfirmationTimer = timer
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-                            } label: {
-                                Image(systemName: showCopyThreadConfirmation ? "checkmark" : "list.clipboard")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(showCopyThreadConfirmation ? VColor.success : VColor.textMuted)
-                                    .frame(width: 28, height: 28)
-                                    .contentShape(Rectangle())
+                            // Copy Thread button — only visible when there's content to copy
+                            if threadManager.activeViewModel?.messages.contains(where: {
+                                !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            }) == true {
+                                Button {
+                                    let messages = threadManager.activeViewModel?.messages ?? []
+                                    let title = threadManager.activeThread?.title
+                                    let names = resolveParticipantNames()
+                                    let markdown = ChatTranscriptFormatter.threadMarkdown(
+                                        messages: messages,
+                                        threadTitle: title,
+                                        participantNames: names
+                                    )
+                                    guard !markdown.isEmpty else { return }
+                                    NSPasteboard.general.clearContents()
+                                    NSPasteboard.general.setString(markdown, forType: .string)
+                                    copyThreadConfirmationTimer?.cancel()
+                                    showCopyThreadConfirmation = true
+                                    let timer = DispatchWorkItem { showCopyThreadConfirmation = false }
+                                    copyThreadConfirmationTimer = timer
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+                                } label: {
+                                    Image(systemName: showCopyThreadConfirmation ? "checkmark" : "list.clipboard")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(showCopyThreadConfirmation ? VColor.success : VColor.textMuted)
+                                        .frame(width: 28, height: 28)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Copy thread")
+                                .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Copy thread")
-                            .disabled({
-                                let messages = threadManager.activeViewModel?.messages ?? []
-                                return !messages.contains { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-                            }())
-                            .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
 
                             TemporaryChatToggle(
                                 isActive: threadManager.activeThread?.kind == .private,


### PR DESCRIPTION
## Summary
- Replace `.disabled()` modifier on the copy thread button with a conditional `if` that hides the button entirely when the thread has no non-empty messages
- Button appears once the first message with content arrives, keeping the top bar clean on empty/new threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
