### PR TITLE
fix: pass raw user text to call bridge and clean up preactivatedSkillIds on persist failure

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1129,12 +1129,19 @@ export class DaemonServer {
     // window that previously existed between the guard and the async bridge
     // check.
     const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+    let messageId: string;
+    try {
+      messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+    } catch (err) {
+      // runAgentLoop never ran, so its finally block won't clear this
+      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = undefined;
+      throw err;
+    }
 
     // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, resolvedContent, messageId);
+      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
       log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');


### PR DESCRIPTION
## Summary
- Pass raw user `content` (not slash-expanded `resolvedContent`) to `tryHandlePendingCallAnswer` in the blocking processMessage endpoint so the call bridge receives what the user actually typed
- Add try/catch around `persistUserMessage` to clean up `preactivatedSkillIds` if persistence fails, matching the pattern in the IPC path

Addresses review feedback on #5471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
