### PR TITLE
feat: migrate watcher tools to bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/watcher/SKILL.md
+++ b/assistant/src/config/bundled-skills/watcher/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: "Watcher"
+description: "Polling watcher system for monitoring external sources"
+metadata: {"vellum": {"emoji": "\u{1F440}"}}
+---
+
+Create and manage watchers that poll external services for events and process them with an action prompt.
+
+## Concepts
+
+- **Provider** — The external service to poll (e.g. "gmail"). Each provider defines how to fetch and parse events.
+- **Action prompt** — LLM instructions for handling detected events. Sent along with event data to a background conversation.
+- **Poll interval** — How often to check for new events (minimum 15 seconds, default 60 seconds).
+- **Digest** — Summary of recent watcher activity, grouped by watcher with time-based filtering.
+
+## Lifecycle
+
+1. Create a watcher with a name, provider, and action prompt.
+2. The system polls the provider at the configured interval.
+3. Detected events are processed according to the action prompt.
+4. Use `watcher_digest` to review recent activity.
+
+## Usage Notes
+
+- Use `watcher_create` when the user wants to monitor an external source (e.g. "watch my Gmail for important emails").
+- `watcher_digest` is the go-to tool when the user asks "what happened with my email?" or similar questions about watcher activity.
+- Watchers can be enabled/disabled via `watcher_update` without deleting them.

--- a/assistant/src/config/bundled-skills/watcher/TOOLS.json
+++ b/assistant/src/config/bundled-skills/watcher/TOOLS.json
@@ -1,0 +1,147 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "watcher_create",
+      "description": "Create a new watcher that polls an external service for events and processes them with an action prompt",
+      "category": "watcher",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A human-readable name for this watcher (e.g. \"My Gmail\")"
+          },
+          "provider": {
+            "type": "string",
+            "description": "The provider to poll (e.g. \"gmail\")"
+          },
+          "action_prompt": {
+            "type": "string",
+            "description": "Instructions for the LLM on how to handle detected events. This prompt is sent along with event data to a background conversation."
+          },
+          "poll_interval_ms": {
+            "type": "number",
+            "description": "How often to poll in milliseconds. Defaults to 60000 (1 minute). Minimum 15000."
+          },
+          "credential_service": {
+            "type": "string",
+            "description": "Override the credential service to use. Defaults to the provider's required service."
+          },
+          "config": {
+            "type": "object",
+            "description": "Provider-specific configuration (e.g. filter criteria)"
+          }
+        },
+        "required": ["name", "provider", "action_prompt"]
+      },
+      "executor": "tools/watcher-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "watcher_list",
+      "description": "List all watchers with their status, or show details for a specific watcher",
+      "category": "watcher",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "watcher_id": {
+            "type": "string",
+            "description": "If provided, show detailed info for this specific watcher including recent events."
+          },
+          "enabled_only": {
+            "type": "boolean",
+            "description": "When true, only show enabled watchers. Defaults to false."
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/watcher-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "watcher_update",
+      "description": "Update a watcher's configuration (name, action prompt, interval, enabled state)",
+      "category": "watcher",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "watcher_id": {
+            "type": "string",
+            "description": "The ID of the watcher to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "New name for the watcher"
+          },
+          "action_prompt": {
+            "type": "string",
+            "description": "New action prompt for event processing"
+          },
+          "poll_interval_ms": {
+            "type": "number",
+            "description": "New poll interval in milliseconds (minimum 15000)"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable the watcher"
+          },
+          "config": {
+            "type": "object",
+            "description": "New provider-specific configuration"
+          }
+        },
+        "required": ["watcher_id"]
+      },
+      "executor": "tools/watcher-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "watcher_delete",
+      "description": "Delete a watcher and all its event history",
+      "category": "watcher",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "watcher_id": {
+            "type": "string",
+            "description": "The ID of the watcher to delete"
+          }
+        },
+        "required": ["watcher_id"]
+      },
+      "executor": "tools/watcher-delete.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "watcher_digest",
+      "description": "Get a summary of recent watcher activity. Use this when the user asks about what happened with their email, notifications, etc.",
+      "category": "watcher",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "watcher_id": {
+            "type": "string",
+            "description": "Filter to events from a specific watcher. If omitted, shows events from all watchers."
+          },
+          "hours": {
+            "type": "number",
+            "description": "How many hours back to look. Defaults to 24."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of events to return. Defaults to 50."
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/watcher-digest.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/watcher/tools/watcher-create.ts
+++ b/assistant/src/config/bundled-skills/watcher/tools/watcher-create.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeWatcherCreate } from '../../../../tools/watcher/create.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeWatcherCreate(input, context);
+}

--- a/assistant/src/config/bundled-skills/watcher/tools/watcher-delete.ts
+++ b/assistant/src/config/bundled-skills/watcher/tools/watcher-delete.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeWatcherDelete } from '../../../../tools/watcher/delete.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeWatcherDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/watcher/tools/watcher-digest.ts
+++ b/assistant/src/config/bundled-skills/watcher/tools/watcher-digest.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeWatcherDigest } from '../../../../tools/watcher/digest.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeWatcherDigest(input, context);
+}

--- a/assistant/src/config/bundled-skills/watcher/tools/watcher-list.ts
+++ b/assistant/src/config/bundled-skills/watcher/tools/watcher-list.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeWatcherList } from '../../../../tools/watcher/list.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeWatcherList(input, context);
+}

--- a/assistant/src/config/bundled-skills/watcher/tools/watcher-update.ts
+++ b/assistant/src/config/bundled-skills/watcher/tools/watcher-update.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeWatcherUpdate } from '../../../../tools/watcher/update.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeWatcherUpdate(input, context);
+}

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -37,11 +37,6 @@ export async function loadEagerModules(): Promise<void> {
   await import('./skills/scaffold-managed.js');
   await import('./skills/delete-managed.js');
   await import('./system/request-permission.js');
-  await import('./watcher/create.js');
-  await import('./watcher/list.js');
-  await import('./watcher/update.js');
-  await import('./watcher/delete.js');
-  await import('./watcher/digest.js');
   await import('./playbooks/playbook-create.js');
   await import('./playbooks/playbook-list.js');
   await import('./playbooks/playbook-update.js');
@@ -68,11 +63,6 @@ export const eagerModuleToolNames: string[] = [
   'scaffold_managed_skill',
   'delete_managed_skill',
   'request_system_permission',
-  'watcher_create',
-  'watcher_list',
-  'watcher_update',
-  'watcher_delete',
-  'watcher_digest',
   'playbook_create',
   'playbook_list',
   'playbook_update',

--- a/assistant/src/tools/watcher/create.ts
+++ b/assistant/src/tools/watcher/create.ts
@@ -1,57 +1,6 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { createWatcher } from '../../watcher/watcher-store.js';
 import { getWatcherProvider, listWatcherProviders } from '../../watcher/provider-registry.js';
-
-class WatcherCreateTool implements Tool {
-  name = 'watcher_create';
-  description = 'Create a new watcher that polls an external service for events and processes them with an action prompt';
-  category = 'watcher';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          name: {
-            type: 'string',
-            description: 'A human-readable name for this watcher (e.g. "My Gmail")',
-          },
-          provider: {
-            type: 'string',
-            description: 'The provider to poll (e.g. "gmail")',
-          },
-          action_prompt: {
-            type: 'string',
-            description: 'Instructions for the LLM on how to handle detected events. This prompt is sent along with event data to a background conversation.',
-          },
-          poll_interval_ms: {
-            type: 'number',
-            description: 'How often to poll in milliseconds. Defaults to 60000 (1 minute). Minimum 15000.',
-          },
-          credential_service: {
-            type: 'string',
-            description: 'Override the credential service to use. Defaults to the provider\'s required service.',
-          },
-          config: {
-            type: 'object',
-            description: 'Provider-specific configuration (e.g. filter criteria)',
-          },
-        },
-        required: ['name', 'provider', 'action_prompt'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWatcherCreate(input, _context);
-  }
-}
 
 export async function executeWatcherCreate(
   input: Record<string, unknown>,
@@ -113,5 +62,3 @@ export async function executeWatcherCreate(
     return { content: `Error creating watcher: ${msg}`, isError: true };
   }
 }
-
-registerTool(new WatcherCreateTool());

--- a/assistant/src/tools/watcher/delete.ts
+++ b/assistant/src/tools/watcher/delete.ts
@@ -1,36 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getWatcher, deleteWatcher } from '../../watcher/watcher-store.js';
-
-class WatcherDeleteTool implements Tool {
-  name = 'watcher_delete';
-  description = 'Delete a watcher and all its event history';
-  category = 'watcher';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          watcher_id: {
-            type: 'string',
-            description: 'The ID of the watcher to delete',
-          },
-        },
-        required: ['watcher_id'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWatcherDelete(input, _context);
-  }
-}
 
 export async function executeWatcherDelete(
   input: Record<string, unknown>,
@@ -56,5 +25,3 @@ export async function executeWatcherDelete(
     isError: false,
   };
 }
-
-registerTool(new WatcherDeleteTool());

--- a/assistant/src/tools/watcher/digest.ts
+++ b/assistant/src/tools/watcher/digest.ts
@@ -1,44 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listWatchers, listWatcherEvents } from '../../watcher/watcher-store.js';
-
-class WatcherDigestTool implements Tool {
-  name = 'watcher_digest';
-  description = 'Get a summary of recent watcher activity. Use this when the user asks about what happened with their email, notifications, etc.';
-  category = 'watcher';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          watcher_id: {
-            type: 'string',
-            description: 'Filter to events from a specific watcher. If omitted, shows events from all watchers.',
-          },
-          hours: {
-            type: 'number',
-            description: 'How many hours back to look. Defaults to 24.',
-          },
-          limit: {
-            type: 'number',
-            description: 'Maximum number of events to return. Defaults to 50.',
-          },
-        },
-        required: [],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWatcherDigest(input, _context);
-  }
-}
 
 export async function executeWatcherDigest(
   input: Record<string, unknown>,
@@ -87,5 +48,3 @@ export async function executeWatcherDigest(
 
   return { content: lines.join('\n'), isError: false };
 }
-
-registerTool(new WatcherDigestTool());

--- a/assistant/src/tools/watcher/list.ts
+++ b/assistant/src/tools/watcher/list.ts
@@ -1,40 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listWatchers, getWatcher, listWatcherEvents } from '../../watcher/watcher-store.js';
-
-class WatcherListTool implements Tool {
-  name = 'watcher_list';
-  description = 'List all watchers with their status, or show details for a specific watcher';
-  category = 'watcher';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          watcher_id: {
-            type: 'string',
-            description: 'If provided, show detailed info for this specific watcher including recent events.',
-          },
-          enabled_only: {
-            type: 'boolean',
-            description: 'When true, only show enabled watchers. Defaults to false.',
-          },
-        },
-        required: [],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWatcherList(input, _context);
-  }
-}
 
 export async function executeWatcherList(
   input: Record<string, unknown>,
@@ -93,5 +58,3 @@ export async function executeWatcherList(
 
   return { content: lines.join('\n'), isError: false };
 }
-
-registerTool(new WatcherListTool());

--- a/assistant/src/tools/watcher/update.ts
+++ b/assistant/src/tools/watcher/update.ts
@@ -1,56 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { updateWatcher } from '../../watcher/watcher-store.js';
-
-class WatcherUpdateTool implements Tool {
-  name = 'watcher_update';
-  description = 'Update a watcher\'s configuration (name, action prompt, interval, enabled state)';
-  category = 'watcher';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: 'object',
-        properties: {
-          watcher_id: {
-            type: 'string',
-            description: 'The ID of the watcher to update',
-          },
-          name: {
-            type: 'string',
-            description: 'New name for the watcher',
-          },
-          action_prompt: {
-            type: 'string',
-            description: 'New action prompt for event processing',
-          },
-          poll_interval_ms: {
-            type: 'number',
-            description: 'New poll interval in milliseconds (minimum 15000)',
-          },
-          enabled: {
-            type: 'boolean',
-            description: 'Enable or disable the watcher',
-          },
-          config: {
-            type: 'object',
-            description: 'New provider-specific configuration',
-          },
-        },
-        required: ['watcher_id'],
-      },
-    };
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWatcherUpdate(input, _context);
-  }
-}
 
 export async function executeWatcherUpdate(
   input: Record<string, unknown>,
@@ -105,5 +54,3 @@ export async function executeWatcherUpdate(
     return { content: `Error updating watcher: ${msg}`, isError: true };
   }
 }
-
-registerTool(new WatcherUpdateTool());


### PR DESCRIPTION
## Summary

- Create bundled skill directory `assistant/src/config/bundled-skills/watcher/` with SKILL.md, TOOLS.json, and 5 executor scripts (watcher-create, watcher-list, watcher-update, watcher-delete, watcher-digest)
- Remove class definitions (`WatcherCreateTool`, `WatcherListTool`, `WatcherUpdateTool`, `WatcherDeleteTool`, `WatcherDigestTool`) and `registerTool()` calls from each watcher source file
- Remove 5 watcher eager module imports and tool names from `tool-manifest.ts`
- Keep exported `executeWatcher*` functions and their imports intact

Part of the skills migration plan (PR 6.2).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
