### PR TITLE
feat: migrate tasks tools to bundled skill

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -51,7 +51,12 @@ mock.module('../config/loader.js', () => ({
 
 // ── Import after mocks ───────────────────────────────────────────────
 const { buildSystemPrompt } = await import('../config/system-prompt.js');
-const { taskListAddTool } = await import('../tools/tasks/work-item-enqueue.js');
+
+// Load task_list_add description from the bundled skill TOOLS.json
+const tasksToolsJson = JSON.parse(
+  readFileSync(join(import.meta.dirname, '../config/bundled-skills/tasks/TOOLS.json'), 'utf-8'),
+);
+const taskListAddDef = tasksToolsJson.tools.find((t: { name: string }) => t.name === 'task_list_add');
 
 // Load reminder_create description from the bundled skill TOOLS.json
 const reminderToolsJson = JSON.parse(
@@ -149,27 +154,27 @@ describe('Task/Schedule/Reminder routing section in system prompt', () => {
 
 describe('task_list_add tool description', () => {
   test('mentions "add to my tasks" routing phrase', () => {
-    const def = taskListAddTool.getDefinition();
+    const def = taskListAddDef;
     expect(def.description).toContain('add to my tasks');
   });
 
   test('mentions "add to my queue" routing phrase', () => {
-    const def = taskListAddTool.getDefinition();
+    const def = taskListAddDef;
     expect(def.description).toContain('add to my queue');
   });
 
   test('mentions "put this on my task list" routing phrase', () => {
-    const def = taskListAddTool.getDefinition();
+    const def = taskListAddDef;
     expect(def.description).toContain('put this on my task list');
   });
 
   test('mentions ad-hoc title-only mode', () => {
-    const def = taskListAddTool.getDefinition();
+    const def = taskListAddDef;
     expect(def.description).toContain('just a title');
   });
 
   test('explicitly warns NOT to use schedule_create or reminder for task requests', () => {
-    const def = taskListAddTool.getDefinition();
+    const def = taskListAddDef;
     expect(def.description).toContain('Do NOT use schedule_create or reminder');
   });
 });
@@ -233,7 +238,7 @@ describe('reminder tool description', () => {
 
 describe('cross-tool routing consistency', () => {
   test('all three tools reference task_list_add as the task-queue tool', () => {
-    const enqueueDef = taskListAddTool.getDefinition();
+    const enqueueDef = taskListAddDef;
     const scheduleTool = getTool('schedule_create')!;
     const scheduleDef = scheduleTool.getDefinition();
 

--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -37,12 +37,12 @@ import type { Database } from 'bun:sqlite';
 import { initializeDb, getDb } from '../memory/db.js';
 import { createTask, createTaskRun } from '../tasks/task-store.js';
 import { createWorkItem } from '../work-items/work-item-store.js';
-import { taskSaveTool } from '../tools/tasks/task-save.js';
-import { taskRunTool } from '../tools/tasks/task-run.js';
-import { taskListTool } from '../tools/tasks/task-list.js';
-import { taskListShowTool } from '../tools/tasks/work-item-list.js';
-import { taskListAddTool } from '../tools/tasks/work-item-enqueue.js';
-import { taskDeleteTool } from '../tools/tasks/task-delete.js';
+import { executeTaskSave } from '../tools/tasks/task-save.js';
+import { executeTaskRun } from '../tools/tasks/task-run.js';
+import { executeTaskList } from '../tools/tasks/task-list.js';
+import { executeTaskListShow } from '../tools/tasks/work-item-list.js';
+import { executeTaskListAdd } from '../tools/tasks/work-item-enqueue.js';
+import { executeTaskDelete } from '../tools/tasks/task-delete.js';
 import type { ToolContext } from '../tools/types.js';
 
 initializeDb();
@@ -104,7 +104,7 @@ describe('task_save tool', () => {
     );
     addTestMessage(convId, 'assistant', 'Here is the summary...');
 
-    const result = await taskSaveTool.execute(
+    const result = await executeTaskSave(
       { conversation_id: convId },
       stubContext,
     );
@@ -120,7 +120,7 @@ describe('task_save tool', () => {
     addTestMessage(convId, 'user', 'Read and analyze the logs');
     addTestMessage(convId, 'assistant', 'Done!');
 
-    const result = await taskSaveTool.execute(
+    const result = await executeTaskSave(
       { conversation_id: convId, title: 'My Custom Title' },
       stubContext,
     );
@@ -134,7 +134,7 @@ describe('task_save tool', () => {
     addTestMessage(convId, 'user', 'Summarize the report');
     addTestMessage(convId, 'assistant', 'Done.');
 
-    const result = await taskSaveTool.execute({}, stubContext);
+    const result = await executeTaskSave({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Task saved successfully');
@@ -142,7 +142,7 @@ describe('task_save tool', () => {
   });
 
   test('returns error for nonexistent conversation', async () => {
-    const result = await taskSaveTool.execute(
+    const result = await executeTaskSave(
       { conversation_id: 'nonexistent' },
       stubContext,
     );
@@ -171,7 +171,7 @@ describe('task_run tool', () => {
       requiredTools: ['file_read'],
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_name: 'summarize', inputs: { file_path: '/tmp/report.txt' } },
       stubContext,
     );
@@ -188,7 +188,7 @@ describe('task_run tool', () => {
       inputSchema: { type: 'object', properties: { url: { type: 'string', description: 'URL' } } },
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_id: task.id, inputs: { url: 'https://prod.example.com' } },
       stubContext,
     );
@@ -204,7 +204,7 @@ describe('task_run tool', () => {
       template: 'Do something',
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_name: 'nonexistent' },
       stubContext,
     );
@@ -215,7 +215,7 @@ describe('task_run tool', () => {
   });
 
   test('returns error when task not found by ID', async () => {
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_id: 'bad-id' },
       stubContext,
     );
@@ -237,7 +237,7 @@ describe('task_run tool', () => {
       },
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       {
         task_name: 'multi-input',
         inputs: { file_path: '/home/user/data.csv', url: 'https://api.example.com/upload' },
@@ -259,7 +259,7 @@ describe('task_run tool', () => {
       },
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_name: 'input required' },
       stubContext,
     );
@@ -269,14 +269,14 @@ describe('task_run tool', () => {
   });
 
   test('returns error when neither task_name nor task_id provided', async () => {
-    const result = await taskRunTool.execute({}, stubContext);
+    const result = await executeTaskRun({}, stubContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('At least one of task_name or task_id must be provided');
   });
 
   test('returns error with helpful message when no tasks exist', async () => {
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_name: 'anything' },
       stubContext,
     );
@@ -292,7 +292,7 @@ describe('task_run tool', () => {
       requiredTools: ['file_read', 'bash'],
     });
 
-    const result = await taskRunTool.execute(
+    const result = await executeTaskRun(
       { task_name: 'tools' },
       stubContext,
     );
@@ -329,7 +329,7 @@ describe('task_list tool', () => {
       requiredTools: ['file_read', 'file_write'],
     });
 
-    const result = await taskListTool.execute({}, stubContext);
+    const result = await executeTaskList({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Found 2 task template(s)');
@@ -342,7 +342,7 @@ describe('task_list tool', () => {
   });
 
   test('returns empty message when no tasks exist', async () => {
-    const result = await taskListTool.execute({}, stubContext);
+    const result = await executeTaskList({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No task templates found');
@@ -355,7 +355,7 @@ describe('task_list tool', () => {
       template: 'Something',
     });
 
-    const result = await taskListTool.execute({}, stubContext);
+    const result = await executeTaskList({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Status: active');
@@ -378,14 +378,14 @@ describe('task_list_show tool', () => {
     createWorkItem({ taskId: task.id, title: 'Work Item Alpha', priorityTier: 0 });
     createWorkItem({ taskId: task.id, title: 'Work Item Beta', notes: 'some notes', priorityTier: 1 });
 
-    const result = await taskListShowTool.execute({}, stubContext);
+    const result = await executeTaskListShow({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Opened Tasks window (2 items)');
   });
 
   test('returns empty message when no work items', async () => {
-    const result = await taskListShowTool.execute({}, stubContext);
+    const result = await executeTaskListShow({}, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('no tasks queued');
@@ -399,11 +399,11 @@ describe('task_list_show tool', () => {
     const doneItem = createWorkItem({ taskId: task.id, title: 'Done Item', priorityTier: 1 });
     raw.query('UPDATE work_items SET status = ? WHERE id = ?').run('done', doneItem.id);
 
-    const resultQueued = await taskListShowTool.execute({ status: 'queued' }, stubContext);
+    const resultQueued = await executeTaskListShow({ status: 'queued' }, stubContext);
     expect(resultQueued.isError).toBe(false);
     expect(resultQueued.content).toContain('1 queued item');
 
-    const resultDone = await taskListShowTool.execute({ status: 'done' }, stubContext);
+    const resultDone = await executeTaskListShow({ status: 'done' }, stubContext);
     expect(resultDone.isError).toBe(false);
     expect(resultDone.content).toContain('1 done item');
   });
@@ -422,7 +422,7 @@ describe('task_list_add tool', () => {
   test('successfully enqueues by task_id', async () => {
     const task = createTask({ title: 'Deploy Service', template: 'deploy it' });
 
-    const result = await taskListAddTool.execute({ task_id: task.id }, stubContext);
+    const result = await executeTaskListAdd({ task_id: task.id }, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Enqueued work item');
@@ -433,7 +433,7 @@ describe('task_list_add tool', () => {
   test('successfully enqueues by task_name (case-insensitive match)', async () => {
     createTask({ title: 'Run Database Migration', template: 'migrate' });
 
-    const result = await taskListAddTool.execute({ task_name: 'database migration' }, stubContext);
+    const result = await executeTaskListAdd({ task_name: 'database migration' }, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Enqueued work item');
@@ -444,7 +444,7 @@ describe('task_list_add tool', () => {
     createTask({ title: 'Deploy Frontend', template: 'deploy fe' });
     createTask({ title: 'Deploy Backend', template: 'deploy be' });
 
-    const result = await taskListAddTool.execute({ task_name: 'deploy' }, stubContext);
+    const result = await executeTaskListAdd({ task_name: 'deploy' }, stubContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Multiple task definitions match');
@@ -455,21 +455,21 @@ describe('task_list_add tool', () => {
   test('returns error when no matching task found', async () => {
     createTask({ title: 'Existing Task', template: 'do something' });
 
-    const result = await taskListAddTool.execute({ task_name: 'nonexistent' }, stubContext);
+    const result = await executeTaskListAdd({ task_name: 'nonexistent' }, stubContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('No task definition found matching "nonexistent"');
   });
 
   test('returns error when no identifiers provided at all', async () => {
-    const result = await taskListAddTool.execute({}, stubContext);
+    const result = await executeTaskListAdd({}, stubContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('You must provide either task_id, task_name, or title');
   });
 
   test('creates ad-hoc work item with just title (no task_id or task_name)', async () => {
-    const result = await taskListAddTool.execute(
+    const result = await executeTaskListAdd(
       { title: 'Check Gmail' },
       stubContext,
     );
@@ -483,7 +483,7 @@ describe('task_list_add tool', () => {
   });
 
   test('ad-hoc work item with notes and priority', async () => {
-    const result = await taskListAddTool.execute(
+    const result = await executeTaskListAdd(
       {
         title: 'Buy groceries',
         notes: 'Milk, eggs, bread',
@@ -499,12 +499,12 @@ describe('task_list_add tool', () => {
   });
 
   test('ad-hoc work item shows up in task_list_show', async () => {
-    await taskListAddTool.execute(
+    await executeTaskListAdd(
       { title: 'Call dentist' },
       stubContext,
     );
 
-    const listResult = await taskListShowTool.execute({}, stubContext);
+    const listResult = await executeTaskListShow({}, stubContext);
 
     expect(listResult.isError).toBe(false);
     expect(listResult.content).toContain('Opened Tasks window (1 item)');
@@ -513,7 +513,7 @@ describe('task_list_add tool', () => {
   test('applies optional overrides (title, notes, priority_tier)', async () => {
     const task = createTask({ title: 'Generic Task', template: 'do it' });
 
-    const result = await taskListAddTool.execute(
+    const result = await executeTaskListAdd(
       {
         task_id: task.id,
         title: 'Custom Title Override',
@@ -543,7 +543,7 @@ describe('task_delete tool', () => {
   test('successfully deletes a single task', async () => {
     const task = createTask({ title: 'Doomed Task', template: 'bye' });
 
-    const result = await taskDeleteTool.execute({ task_ids: [task.id] }, stubContext);
+    const result = await executeTaskDelete({ task_ids: [task.id] }, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Deleted task: Doomed Task');
@@ -553,7 +553,7 @@ describe('task_delete tool', () => {
     const t1 = createTask({ title: 'Task One', template: 'one' });
     const t2 = createTask({ title: 'Task Two', template: 'two' });
 
-    const result = await taskDeleteTool.execute({ task_ids: [t1.id, t2.id] }, stubContext);
+    const result = await executeTaskDelete({ task_ids: [t1.id, t2.id] }, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Deleted 2 task(s)');
@@ -562,7 +562,7 @@ describe('task_delete tool', () => {
   });
 
   test('returns error for non-existent task ID', async () => {
-    const result = await taskDeleteTool.execute({ task_ids: ['nonexistent-id'] }, stubContext);
+    const result = await executeTaskDelete({ task_ids: ['nonexistent-id'] }, stubContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('No task template or work item found with ID "nonexistent-id"');
@@ -580,7 +580,7 @@ describe('task_delete tool', () => {
     expect(runsBefore.count).toBe(1);
     expect(itemsBefore.count).toBe(1);
 
-    const result = await taskDeleteTool.execute({ task_ids: [task.id] }, stubContext);
+    const result = await executeTaskDelete({ task_ids: [task.id] }, stubContext);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Deleted task: Parent Task');

--- a/assistant/src/config/bundled-skills/tasks/SKILL.md
+++ b/assistant/src/config/bundled-skills/tasks/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: "Tasks"
+description: "Two-layer task system with reusable templates and a prioritized work queue"
+metadata: {"vellum": {"emoji": "\u2705"}}
+---
+
+Two-layer task system: **task templates** (reusable definitions with input placeholders) and **work items** (instances in the Task Queue with priority tiers and status tracking).
+
+## Task Templates
+
+Templates are reusable definitions saved from conversations via `task_save`. They capture the conversation pattern with placeholders that can be run later with different inputs via `task_run`. List templates with `task_list`, delete with `task_delete`.
+
+## Work Items (Task Queue)
+
+Work items are the user-facing "Tasks" shown in the Tasks panel. They track status and priority:
+
+- **Priority tiers**: 0 = high, 1 = medium (default), 2 = low
+- **Status flow**: queued -> running -> awaiting_review -> done
+- **Resolution precedence**: work_item_id > task_id > task_name > title
+
+Use `task_list_add` to enqueue items (ad-hoc or from a template), `task_list_show` to view the queue, `task_list_update` to modify, and `task_list_remove` to remove.
+
+## Tips
+
+- When the user says "add to my tasks" or "add to my queue", use `task_list_add` (NOT schedule_create or reminder).
+- Use `task_save` only when the user wants to capture a conversation pattern as a reusable template.
+- `task_list` shows saved templates; `task_list_show` shows the active work queue.

--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -1,0 +1,247 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "task_save",
+      "description": "Save the current conversation as a reusable task template (definition). This is NOT for adding items to the user's task queue — use task_list_add for that. task_save extracts the conversation pattern into a reusable definition with placeholders that can be run later with different inputs.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "conversation_id": {
+            "type": "string",
+            "description": "The conversation to capture as a task template. If omitted, uses the current conversation."
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional override for the auto-generated task title"
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/task-save.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_run",
+      "description": "Run a task template. Resolves the template by name (fuzzy match) or ID, renders it with the provided inputs, and returns the rendered prompt for execution as a Task (work item).",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "task_name": {
+            "type": "string",
+            "description": "Fuzzy match a task template by name (case-insensitive substring match)"
+          },
+          "task_id": {
+            "type": "string",
+            "description": "Exact match a task template by ID"
+          },
+          "inputs": {
+            "type": "object",
+            "description": "Values for template placeholders (e.g. {\"file_path\": \"/tmp/foo.txt\", \"url\": \"https://example.com\"})",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      },
+      "executor": "tools/task-run.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_list",
+      "description": "List saved task templates (reusable definitions). To see your active Tasks (work items), use task_list_show instead.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "executor": "tools/task-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_delete",
+      "description": "Delete one or more task templates by ID. Also removes associated task runs and work items (Tasks).",
+      "category": "tasks",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "task_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "One or more task IDs to delete."
+          }
+        },
+        "required": ["task_ids"]
+      },
+      "executor": "tools/task-delete.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_list_show",
+      "description": "List the user's Task Queue (work items) with their status, priority, and last run info. Use this when the user says \"show my tasks\", \"what's in my queue\", \"what's on my task list\", or similar.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Optional status filter. A single status string (e.g. \"queued\") or an array of statuses to include."
+          }
+        }
+      },
+      "executor": "tools/task-list-show.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_list_add",
+      "description": "Add a task to the user's Task Queue. Use this when the user says \"add to my tasks\", \"add to my queue\", \"put this on my task list\", \"track this task\", or any variation of adding a one-off item they want to remember or work on. You can provide just a title for ad-hoc items, or reference an existing task definition by name or ID. Do NOT use schedule_create or reminder for simple \"add to tasks\" requests — those are for timed/recurring automation only.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "ID of an existing task definition to enqueue. Provide this, task_name, or just title."
+          },
+          "task_name": {
+            "type": "string",
+            "description": "Title/name of an existing task definition to search for (case-insensitive substring match). Provide this, task_id, or just title."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title for the work item. When provided WITHOUT task_id or task_name, creates an ad-hoc work item directly (a lightweight task template is auto-created behind the scenes). When provided WITH task_id or task_name, overrides the task definition title."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Notes to attach to the work item."
+          },
+          "priority_tier": {
+            "type": "number",
+            "description": "0 = high, 1 = medium (default), 2 = low."
+          },
+          "sort_index": {
+            "type": "number",
+            "description": "Manual sort order within the priority tier."
+          },
+          "if_exists": {
+            "type": "string",
+            "enum": ["create_duplicate", "reuse_existing", "update_existing"],
+            "description": "What to do if an active work item with the same title already exists. Defaults to \"reuse_existing\"."
+          }
+        }
+      },
+      "executor": "tools/task-list-add.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_list_update",
+      "description": "Update an existing task in the Task Queue. Can change priority, notes, status, or sort order. Identifies the task by work item ID, task ID, task name, or title.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "work_item_id": {
+            "type": "string",
+            "description": "Direct work item ID (most precise selector)"
+          },
+          "task_id": {
+            "type": "string",
+            "description": "Task definition ID to find the work item for"
+          },
+          "task_name": {
+            "type": "string",
+            "description": "Task name/title to search for (case-insensitive exact match)"
+          },
+          "title": {
+            "type": "string",
+            "description": "Work item title to search for (case-insensitive exact match)"
+          },
+          "priority_tier": {
+            "type": "number",
+            "description": "0 = high, 1 = medium, 2 = low"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Updated notes for the work item"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["queued", "running", "awaiting_review", "failed", "cancelled", "archived"],
+            "description": "New status for the work item"
+          },
+          "sort_index": {
+            "type": "number",
+            "description": "Manual sort order within the same priority tier"
+          },
+          "filter_priority_tier": {
+            "type": "number",
+            "description": "Disambiguation filter: narrow by current priority tier (0=high, 1=medium, 2=low) when multiple items share the same title/task_id. This identifies WHICH item to update — it is NOT the new priority value."
+          },
+          "filter_status": {
+            "type": "string",
+            "enum": ["queued", "running", "awaiting_review", "failed", "cancelled", "done", "archived"],
+            "description": "Disambiguation filter: narrow by current status when multiple items share the same title/task_id."
+          },
+          "created_order": {
+            "type": "number",
+            "description": "Disambiguation filter: pick the Nth oldest match (1 = oldest, 2 = second oldest, etc.) when multiple items share the same title/task_id."
+          }
+        }
+      },
+      "executor": "tools/task-list-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "task_list_remove",
+      "description": "Remove a task from the Task Queue. Identifies the task by work item ID, task ID, task name, or title. When multiple items match, use the disambiguation fields (priority_tier, status, created_order) to narrow down.",
+      "category": "tasks",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "work_item_id": {
+            "type": "string",
+            "description": "Direct work item ID (most precise selector)"
+          },
+          "task_id": {
+            "type": "string",
+            "description": "Task definition ID to find the work item for"
+          },
+          "task_name": {
+            "type": "string",
+            "description": "Task name/title to search for (case-insensitive exact match)"
+          },
+          "title": {
+            "type": "string",
+            "description": "Work item title to search for (case-insensitive exact match)"
+          },
+          "priority_tier": {
+            "type": "number",
+            "description": "Disambiguator: filter by priority tier (0 = high, 1 = medium, 2 = low)"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["queued", "running", "awaiting_review", "failed", "cancelled"],
+            "description": "Disambiguator: filter by work item status"
+          },
+          "created_order": {
+            "type": "number",
+            "description": "Disambiguator: 1-indexed creation order among matches (1 = oldest, 2 = second oldest, etc.)"
+          }
+        }
+      },
+      "executor": "tools/task-list-remove.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-delete.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-delete.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskDelete } from '../../../../tools/tasks/task-delete.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-list-add.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-list-add.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskListAdd } from '../../../../tools/tasks/work-item-enqueue.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskListAdd(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-list-remove.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-list-remove.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskListRemove } from '../../../../tools/tasks/work-item-remove.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskListRemove(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-list-show.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-list-show.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskListShow } from '../../../../tools/tasks/work-item-list.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskListShow(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-list-update.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-list-update.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskListUpdate } from '../../../../tools/tasks/work-item-update.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskListUpdate(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-list.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-list.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskList } from '../../../../tools/tasks/task-list.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskList(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-run.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-run.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskRun } from '../../../../tools/tasks/task-run.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskRun(input, context);
+}

--- a/assistant/src/config/bundled-skills/tasks/tools/task-save.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-save.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskSave } from '../../../../tools/tasks/task-save.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskSave(input, context);
+}

--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -17,11 +17,11 @@
  * comments, logs, and developer-facing docs.
  */
 
-export { taskSaveTool } from './task-save.js';
-export { taskRunTool } from './task-run.js';
-export { taskListTool } from './task-list.js';
-export { taskDeleteTool } from './task-delete.js';
-export { taskListShowTool } from './work-item-list.js';
-export { taskListAddTool } from './work-item-enqueue.js';
-export { taskListUpdateTool } from './work-item-update.js';
-export { taskListRemoveTool } from './work-item-remove.js';
+export { executeTaskSave } from './task-save.js';
+export { executeTaskRun } from './task-run.js';
+export { executeTaskList } from './task-list.js';
+export { executeTaskDelete } from './task-delete.js';
+export { executeTaskListShow } from './work-item-list.js';
+export { executeTaskListAdd } from './work-item-enqueue.js';
+export { executeTaskListUpdate } from './work-item-update.js';
+export { executeTaskListRemove } from './work-item-remove.js';

--- a/assistant/src/tools/tasks/task-delete.ts
+++ b/assistant/src/tools/tasks/task-delete.ts
@@ -1,27 +1,9 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { deleteTask, deleteTasks, getTask } from '../../tasks/task-store.js';
 import { removeWorkItemFromQueue } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-delete');
-
-const definition: ToolDefinition = {
-  name: 'task_delete',
-  description: 'Delete one or more task templates by ID. Also removes associated task runs and work items (Tasks).',
-  input_schema: {
-    type: 'object',
-    properties: {
-      task_ids: {
-        type: 'array',
-        items: { type: 'string' },
-        description: 'One or more task IDs to delete.',
-      },
-    },
-    required: ['task_ids'],
-  },
-};
 
 export async function executeTaskDelete(
   input: Record<string, unknown>,
@@ -98,20 +80,3 @@ export async function executeTaskDelete(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskDeleteTool implements Tool {
-  name = 'task_delete';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskDelete(input, _context);
-  }
-}
-
-export const taskDeleteTool = new TaskDeleteTool();

--- a/assistant/src/tools/tasks/task-list.ts
+++ b/assistant/src/tools/tasks/task-list.ts
@@ -1,16 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listTasks } from '../../tasks/task-store.js';
-
-const definition: ToolDefinition = {
-  name: 'task_list',
-  description: 'List saved task templates (reusable definitions). To see your active Tasks (work items), use task_list_show instead.',
-  input_schema: {
-    type: 'object',
-    properties: {},
-  },
-};
 
 export async function executeTaskList(
   _input: Record<string, unknown>,
@@ -53,20 +42,3 @@ export async function executeTaskList(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskListTool implements Tool {
-  name = 'task_list';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskList(_input, _context);
-  }
-}
-
-export const taskListTool = new TaskListTool();

--- a/assistant/src/tools/tasks/task-run.ts
+++ b/assistant/src/tools/tasks/task-run.ts
@@ -1,33 +1,7 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getTask, listTasks } from '../../tasks/task-store.js';
 import { renderTemplate } from '../../tasks/task-runner.js';
 import { identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
-
-const definition: ToolDefinition = {
-  name: 'task_run',
-  description:
-    'Run a task template. Resolves the template by name (fuzzy match) or ID, renders it with the provided inputs, and returns the rendered prompt for execution as a Task (work item).',
-  input_schema: {
-    type: 'object',
-    properties: {
-      task_name: {
-        type: 'string',
-        description: 'Fuzzy match a task template by name (case-insensitive substring match)',
-      },
-      task_id: {
-        type: 'string',
-        description: 'Exact match a task template by ID',
-      },
-      inputs: {
-        type: 'object',
-        description: 'Values for template placeholders (e.g. {"file_path": "/tmp/foo.txt", "url": "https://example.com"})',
-        additionalProperties: { type: 'string' },
-      },
-    },
-  },
-};
 
 export async function executeTaskRun(
   input: Record<string, unknown>,
@@ -121,20 +95,3 @@ export async function executeTaskRun(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskRunTool implements Tool {
-  name = 'task_run';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskRun(input, _context);
-  }
-}
-
-export const taskRunTool = new TaskRunTool();

--- a/assistant/src/tools/tasks/task-save.ts
+++ b/assistant/src/tools/tasks/task-save.ts
@@ -1,27 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { compileTaskFromConversation, saveCompiledTask } from '../../tasks/task-compiler.js';
-
-const definition: ToolDefinition = {
-  name: 'task_save',
-  description:
-    'Save the current conversation as a reusable task template (definition). This is NOT for adding items to the user\'s task queue — use task_list_add for that. task_save extracts the conversation pattern into a reusable definition with placeholders that can be run later with different inputs.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      conversation_id: {
-        type: 'string',
-        description: 'The conversation to capture as a task template. If omitted, uses the current conversation.',
-      },
-      title: {
-        type: 'string',
-        description: 'Optional override for the auto-generated task title',
-      },
-    },
-    required: [],
-  },
-};
 
 export async function executeTaskSave(
   input: Record<string, unknown>,
@@ -67,20 +45,3 @@ export async function executeTaskSave(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskSaveTool implements Tool {
-  name = 'task_save';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskSave(input, context);
-  }
-}
-
-export const taskSaveTool = new TaskSaveTool();

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -1,6 +1,4 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
 import { createWorkItem, findActiveWorkItemsByTitle, updateWorkItem, identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
@@ -11,49 +9,6 @@ const PRIORITY_LABELS: Record<number, string> = {
   0: 'high',
   1: 'medium',
   2: 'low',
-};
-
-const definition: ToolDefinition = {
-  name: 'task_list_add',
-  description:
-    'Add a task to the user\'s Task Queue. Use this when the user says "add to my tasks", "add to my queue", "put this on my task list", "track this task", or any variation of adding a one-off item they want to remember or work on. You can provide just a title for ad-hoc items, or reference an existing task definition by name or ID. Do NOT use schedule_create or reminder for simple "add to tasks" requests — those are for timed/recurring automation only.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      task_id: {
-        type: 'string',
-        description: 'ID of an existing task definition to enqueue. Provide this, task_name, or just title.',
-      },
-      task_name: {
-        type: 'string',
-        description:
-          'Title/name of an existing task definition to search for (case-insensitive substring match). Provide this, task_id, or just title.',
-      },
-      title: {
-        type: 'string',
-        description:
-          'Title for the work item. When provided WITHOUT task_id or task_name, creates an ad-hoc work item directly (a lightweight task template is auto-created behind the scenes). When provided WITH task_id or task_name, overrides the task definition title.',
-      },
-      notes: {
-        type: 'string',
-        description: 'Notes to attach to the work item.',
-      },
-      priority_tier: {
-        type: 'number',
-        description: '0 = high, 1 = medium (default), 2 = low.',
-      },
-      sort_index: {
-        type: 'number',
-        description: 'Manual sort order within the priority tier.',
-      },
-      if_exists: {
-        type: 'string',
-        enum: ['create_duplicate', 'reuse_existing', 'update_existing'],
-        description:
-          'What to do if an active work item with the same title already exists. Defaults to "reuse_existing".',
-      },
-    },
-  },
 };
 
 function handleDuplicate(
@@ -249,20 +204,3 @@ export async function executeTaskListAdd(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskListAddTool implements Tool {
-  name = 'task_list_add';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskListAdd(input, _context);
-  }
-}
-
-export const taskListAddTool = new TaskListAddTool();

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -1,25 +1,5 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listWorkItems, type WorkItemStatus } from '../../work-items/work-item-store.js';
-
-const definition: ToolDefinition = {
-  name: 'task_list_show',
-  description: 'List the user\'s Task Queue (work items) with their status, priority, and last run info. Use this when the user says "show my tasks", "what\'s in my queue", "what\'s on my task list", or similar.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      status: {
-        oneOf: [
-          { type: 'string' },
-          { type: 'array', items: { type: 'string' } },
-        ],
-        description:
-          'Optional status filter. A single status string (e.g. "queued") or an array of statuses to include.',
-      },
-    },
-  },
-};
 
 export async function executeTaskListShow(
   input: Record<string, unknown>,
@@ -59,20 +39,3 @@ export async function executeTaskListShow(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskListShowTool implements Tool {
-  name = 'task_list_show';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskListShow(input, _context);
-  }
-}
-
-export const taskListShowTool = new TaskListShowTool();

--- a/assistant/src/tools/tasks/work-item-remove.ts
+++ b/assistant/src/tools/tasks/work-item-remove.ts
@@ -1,50 +1,8 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { resolveWorkItem, removeWorkItemFromQueue, identifyEntityById, buildTaskTemplateMismatchError, type WorkItemStatus } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-remove');
-
-const definition: ToolDefinition = {
-  name: 'task_list_remove',
-  description:
-    'Remove a task from the Task Queue. Identifies the task by work item ID, task ID, task name, or title. When multiple items match, use the disambiguation fields (priority_tier, status, created_order) to narrow down.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      work_item_id: {
-        type: 'string',
-        description: 'Direct work item ID (most precise selector)',
-      },
-      task_id: {
-        type: 'string',
-        description: 'Task definition ID to find the work item for',
-      },
-      task_name: {
-        type: 'string',
-        description: 'Task name/title to search for (case-insensitive exact match)',
-      },
-      title: {
-        type: 'string',
-        description: 'Work item title to search for (case-insensitive exact match)',
-      },
-      priority_tier: {
-        type: 'number',
-        description: 'Disambiguator: filter by priority tier (0 = high, 1 = medium, 2 = low)',
-      },
-      status: {
-        type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled'],
-        description: 'Disambiguator: filter by work item status',
-      },
-      created_order: {
-        type: 'number',
-        description: 'Disambiguator: 1-indexed creation order among matches (1 = oldest, 2 = second oldest, etc.)',
-      },
-    },
-  },
-};
 
 export async function executeTaskListRemove(
   input: Record<string, unknown>,
@@ -100,20 +58,3 @@ export async function executeTaskListRemove(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskListRemoveTool implements Tool {
-  name = 'task_list_remove';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskListRemove(input, _context);
-  }
-}
-
-export const taskListRemoveTool = new TaskListRemoveTool();

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -1,6 +1,4 @@
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { resolveWorkItem, updateWorkItem, identifyEntityById, buildTaskTemplateMismatchError, type WorkItemStatus } from '../../work-items/work-item-store.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -10,66 +8,6 @@ const PRIORITY_LABELS: Record<number, string> = {
   0: 'high',
   1: 'medium',
   2: 'low',
-};
-
-const definition: ToolDefinition = {
-  name: 'task_list_update',
-  description:
-    'Update an existing task in the Task Queue. Can change priority, notes, status, or sort order. Identifies the task by work item ID, task ID, task name, or title.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      work_item_id: {
-        type: 'string',
-        description: 'Direct work item ID (most precise selector)',
-      },
-      task_id: {
-        type: 'string',
-        description: 'Task definition ID to find the work item for',
-      },
-      task_name: {
-        type: 'string',
-        description: 'Task name/title to search for (case-insensitive exact match)',
-      },
-      title: {
-        type: 'string',
-        description: 'Work item title to search for (case-insensitive exact match)',
-      },
-      priority_tier: {
-        type: 'number',
-        description: '0 = high, 1 = medium, 2 = low',
-      },
-      notes: {
-        type: 'string',
-        description: 'Updated notes for the work item',
-      },
-      status: {
-        type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled', 'archived'],
-        description: 'New status for the work item',
-      },
-      sort_index: {
-        type: 'number',
-        description: 'Manual sort order within the same priority tier',
-      },
-      filter_priority_tier: {
-        type: 'number',
-        description:
-          'Disambiguation filter: narrow by current priority tier (0=high, 1=medium, 2=low) when multiple items share the same title/task_id. This identifies WHICH item to update — it is NOT the new priority value.',
-      },
-      filter_status: {
-        type: 'string',
-        enum: ['queued', 'running', 'awaiting_review', 'failed', 'cancelled', 'done', 'archived'],
-        description:
-          'Disambiguation filter: narrow by current status when multiple items share the same title/task_id.',
-      },
-      created_order: {
-        type: 'number',
-        description:
-          'Disambiguation filter: pick the Nth oldest match (1 = oldest, 2 = second oldest, etc.) when multiple items share the same title/task_id.',
-      },
-    },
-  },
 };
 
 export async function executeTaskListUpdate(
@@ -174,20 +112,3 @@ export async function executeTaskListUpdate(
     return { content: `Error: ${msg}`, isError: true };
   }
 }
-
-class TaskListUpdateTool implements Tool {
-  name = 'task_list_update';
-  description = definition.description;
-  category = 'tasks';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeTaskListUpdate(input, _context);
-  }
-}
-
-export const taskListUpdateTool = new TaskListUpdateTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -15,7 +15,6 @@ import { accountManageTool } from './credentials/account-registry.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
-import { taskSaveTool, taskRunTool, taskListTool, taskDeleteTool, taskListShowTool, taskListAddTool, taskListUpdateTool, taskListRemoveTool } from './tasks/index.js';
 import {
   subagentSpawnTool,
   subagentStatusTool,
@@ -88,14 +87,6 @@ export const explicitTools: Tool[] = [
   screenWatchTool,
   vellumSkillsCatalogTool,
   cliDiscoverTool,
-  taskSaveTool,
-  taskRunTool,
-  taskListTool,
-  taskDeleteTool,
-  taskListShowTool,
-  taskListAddTool,
-  taskListUpdateTool,
-  taskListRemoveTool,
   subagentSpawnTool,
   subagentStatusTool,
   subagentAbortTool,


### PR DESCRIPTION
Create bundled skill directory with SKILL.md, TOOLS.json, and 8 executor scripts. Remove class-based tool definitions and tool-manifest.ts registration for all task tools (task_save, task_run, task_list, task_delete, task_list_show, task_list_add, task_list_update, task_list_remove). Update test imports to use execute functions directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
