### PR TITLE
feat: migrate subagent tools to bundled skill

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1,51 +1,46 @@
 import { describe, expect, test } from 'bun:test';
-import { subagentSpawnTool } from '../tools/subagent/spawn.js';
-import { subagentStatusTool } from '../tools/subagent/status.js';
-import { subagentAbortTool } from '../tools/subagent/abort.js';
-import { subagentMessageTool } from '../tools/subagent/message.js';
-import { subagentReadTool } from '../tools/subagent/read.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { executeSubagentSpawn } from '../tools/subagent/spawn.js';
+import { executeSubagentStatus } from '../tools/subagent/status.js';
+import { executeSubagentAbort } from '../tools/subagent/abort.js';
+import { executeSubagentMessage } from '../tools/subagent/message.js';
 
-describe('Subagent tool shapes', () => {
-  test('spawn tool has correct shape', () => {
-    expect(subagentSpawnTool.name).toBe('subagent_spawn');
-    expect(subagentSpawnTool.category).toBe('orchestration');
-    expect(typeof subagentSpawnTool.execute).toBe('function');
-    expect(typeof subagentSpawnTool.getDefinition).toBe('function');
-    const def = subagentSpawnTool.getDefinition!();
-    expect((def.input_schema as Record<string, unknown>).required).toEqual(['label', 'objective']);
+// Load tool definitions from the bundled skill TOOLS.json
+const toolsJson = JSON.parse(
+  readFileSync(join(import.meta.dirname, '../config/bundled-skills/subagent/TOOLS.json'), 'utf-8'),
+);
+const findTool = (name: string) => toolsJson.tools.find((t: { name: string }) => t.name === name);
+
+describe('Subagent tool definitions', () => {
+  test('spawn tool has correct definition', () => {
+    const def = findTool('subagent_spawn');
+    expect(def).toBeDefined();
+    expect(def.input_schema.required).toEqual(['label', 'objective']);
   });
 
-  test('status tool has correct shape', () => {
-    expect(subagentStatusTool.name).toBe('subagent_status');
-    expect(subagentStatusTool.category).toBe('orchestration');
-    expect(typeof subagentStatusTool.execute).toBe('function');
+  test('abort tool has correct definition', () => {
+    const def = findTool('subagent_abort');
+    expect(def).toBeDefined();
+    expect(def.input_schema.required).toEqual(['subagent_id']);
   });
 
-  test('abort tool has correct shape', () => {
-    expect(subagentAbortTool.name).toBe('subagent_abort');
-    expect(typeof subagentAbortTool.execute).toBe('function');
-    const def = subagentAbortTool.getDefinition!();
-    expect((def.input_schema as Record<string, unknown>).required).toEqual(['subagent_id']);
+  test('message tool has correct definition', () => {
+    const def = findTool('subagent_message');
+    expect(def).toBeDefined();
+    expect(def.input_schema.required).toEqual(['subagent_id', 'content']);
   });
 
-  test('message tool has correct shape', () => {
-    expect(subagentMessageTool.name).toBe('subagent_message');
-    expect(typeof subagentMessageTool.execute).toBe('function');
-    const def = subagentMessageTool.getDefinition!();
-    expect((def.input_schema as Record<string, unknown>).required).toEqual(['subagent_id', 'content']);
-  });
-
-  test('read tool has correct shape', () => {
-    expect(subagentReadTool.name).toBe('subagent_read');
-    expect(typeof subagentReadTool.execute).toBe('function');
-    const def = subagentReadTool.getDefinition!();
-    expect((def.input_schema as Record<string, unknown>).required).toEqual(['subagent_id']);
+  test('read tool has correct definition', () => {
+    const def = findTool('subagent_read');
+    expect(def).toBeDefined();
+    expect(def.input_schema.required).toEqual(['subagent_id']);
   });
 });
 
 describe('Subagent tool execute validation', () => {
   test('spawn returns error when no sendToClient', async () => {
-    const result = await subagentSpawnTool.execute(
+    const result = await executeSubagentSpawn(
       { label: 'test', objective: 'do something' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );
@@ -54,7 +49,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('spawn returns error when missing label', async () => {
-    const result = await subagentSpawnTool.execute(
+    const result = await executeSubagentSpawn(
       { objective: 'do something' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1', sendToClient: () => {} },
     );
@@ -63,7 +58,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('status returns empty when no subagents', async () => {
-    const result = await subagentStatusTool.execute(
+    const result = await executeSubagentStatus(
       {},
       { workingDir: '/tmp', sessionId: 'nonexistent-session', conversationId: 'conv-1' },
     );
@@ -72,7 +67,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('status returns error for unknown subagent_id', async () => {
-    const result = await subagentStatusTool.execute(
+    const result = await executeSubagentStatus(
       { subagent_id: 'nonexistent-id' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );
@@ -81,7 +76,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('abort returns error for unknown subagent_id', async () => {
-    const result = await subagentAbortTool.execute(
+    const result = await executeSubagentAbort(
       { subagent_id: 'nonexistent-id' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );
@@ -90,7 +85,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('abort returns error when missing subagent_id', async () => {
-    const result = await subagentAbortTool.execute(
+    const result = await executeSubagentAbort(
       {},
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );
@@ -99,7 +94,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('message returns error for unknown subagent_id', async () => {
-    const result = await subagentMessageTool.execute(
+    const result = await executeSubagentMessage(
       { subagent_id: 'nonexistent-id', content: 'hello' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );
@@ -108,7 +103,7 @@ describe('Subagent tool execute validation', () => {
   });
 
   test('message returns error when missing required fields', async () => {
-    const result = await subagentMessageTool.execute(
+    const result = await executeSubagentMessage(
       { subagent_id: 'some-id' },
       { workingDir: '/tmp', sessionId: 'sess-1', conversationId: 'conv-1' },
     );

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "Subagent"
+description: "Spawn and manage autonomous background agents for parallel work"
+metadata: {"vellum": {"emoji": "\ud83e\udd16"}}
+---
+
+Subagent orchestration -- spawn background agents to work on tasks in parallel.
+
+## Lifecycle
+
+Subagents follow this status flow: `pending` -> `running` -> `completed` / `failed` / `aborted`
+
+- **Spawn**: Use `subagent_spawn` with a label and objective. The subagent runs autonomously.
+- **Auto-notification**: The parent session is automatically notified when a subagent reaches a terminal status. Do NOT poll `subagent_status`.
+- **Read output**: Use `subagent_read` only after the subagent reaches a terminal status (completed/failed/aborted).
+
+## Ownership
+
+Only the parent session that spawned a subagent can interact with it (check status, send messages, abort, or read output).
+
+## Tips
+
+- Do NOT poll `subagent_status` in a loop. You will be notified automatically when a subagent completes.
+- Use `subagent_message` to send follow-up instructions to a running subagent.
+- Use `subagent_abort` to cancel a subagent that is no longer needed.

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -1,0 +1,107 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "subagent_spawn",
+      "description": "Spawn an independent subagent to work on a task in parallel. The subagent runs autonomously and its results are reported back when complete.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Short human-readable label for this subagent (e.g. \"Research competitor pricing\")"
+          },
+          "objective": {
+            "type": "string",
+            "description": "The task objective — what the subagent should accomplish"
+          },
+          "context": {
+            "type": "string",
+            "description": "Optional additional context to pass to the subagent"
+          }
+        },
+        "required": ["label", "objective"]
+      },
+      "executor": "tools/subagent-spawn.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "subagent_status",
+      "description": "Get the status of a specific subagent or list all subagents for the current session. Only use this when the user explicitly asks about subagent status — do NOT poll automatically, as you will be notified when subagents complete.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "subagent_id": {
+            "type": "string",
+            "description": "Optional subagent ID to query. If omitted, returns all subagents for this session."
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/subagent-status.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "subagent_abort",
+      "description": "Abort a running subagent by ID.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "subagent_id": {
+            "type": "string",
+            "description": "The ID of the subagent to abort."
+          }
+        },
+        "required": ["subagent_id"]
+      },
+      "executor": "tools/subagent-abort.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "subagent_message",
+      "description": "Send a follow-up message to a running subagent.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "subagent_id": {
+            "type": "string",
+            "description": "The ID of the subagent to send a message to."
+          },
+          "content": {
+            "type": "string",
+            "description": "The message content to send to the subagent."
+          }
+        },
+        "required": ["subagent_id", "content"]
+      },
+      "executor": "tools/subagent-message.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "subagent_read",
+      "description": "Read the full conversation output from a subagent. Use this after a subagent completes to retrieve its full work product.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "subagent_id": {
+            "type": "string",
+            "description": "The ID of the subagent whose output to read."
+          }
+        },
+        "required": ["subagent_id"]
+      },
+      "executor": "tools/subagent-read.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-abort.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-abort.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeSubagentAbort } from '../../../../tools/subagent/abort.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentAbort(input, context);
+}

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-message.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-message.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeSubagentMessage } from '../../../../tools/subagent/message.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentMessage(input, context);
+}

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-read.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-read.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeSubagentRead } from '../../../../tools/subagent/read.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentRead(input, context);
+}

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-spawn.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-spawn.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeSubagentSpawn } from '../../../../tools/subagent/spawn.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentSpawn(input, context);
+}

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-status.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-status.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeSubagentStatus } from '../../../../tools/subagent/status.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentStatus(input, context);
+}

--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -1,41 +1,5 @@
-/**
- * subagent_abort tool — abort a running subagent.
- */
-
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getSubagentManager } from '../../subagent/index.js';
-
-const definition: ToolDefinition = {
-  name: 'subagent_abort',
-  description: 'Abort a running subagent by ID.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      subagent_id: {
-        type: 'string',
-        description: 'The ID of the subagent to abort.',
-      },
-    },
-    required: ['subagent_id'],
-  },
-};
-
-export const subagentAbortTool: Tool = {
-  name: 'subagent_abort',
-  description: definition.description,
-  category: 'orchestration',
-  defaultRiskLevel: RiskLevel.Low,
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  },
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeSubagentAbort(input, context);
-  },
-};
 
 export async function executeSubagentAbort(
   input: Record<string, unknown>,

--- a/assistant/src/tools/subagent/index.ts
+++ b/assistant/src/tools/subagent/index.ts
@@ -1,5 +1,5 @@
-export { subagentSpawnTool } from './spawn.js';
-export { subagentStatusTool } from './status.js';
-export { subagentAbortTool } from './abort.js';
-export { subagentMessageTool } from './message.js';
-export { subagentReadTool } from './read.js';
+export { executeSubagentSpawn } from './spawn.js';
+export { executeSubagentStatus } from './status.js';
+export { executeSubagentAbort } from './abort.js';
+export { executeSubagentMessage } from './message.js';
+export { executeSubagentRead } from './read.js';

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -1,45 +1,5 @@
-/**
- * subagent_message tool — send a follow-up message to a running subagent.
- */
-
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getSubagentManager } from '../../subagent/index.js';
-
-const definition: ToolDefinition = {
-  name: 'subagent_message',
-  description: 'Send a follow-up message to a running subagent.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      subagent_id: {
-        type: 'string',
-        description: 'The ID of the subagent to send a message to.',
-      },
-      content: {
-        type: 'string',
-        description: 'The message content to send to the subagent.',
-      },
-    },
-    required: ['subagent_id', 'content'],
-  },
-};
-
-export const subagentMessageTool: Tool = {
-  name: 'subagent_message',
-  description: definition.description,
-  category: 'orchestration',
-  defaultRiskLevel: RiskLevel.Low,
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  },
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeSubagentMessage(input, context);
-  },
-};
 
 export async function executeSubagentMessage(
   input: Record<string, unknown>,

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,44 +1,6 @@
-/**
- * subagent_read tool — read the full output from a completed subagent's conversation.
- */
-
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getSubagentManager, TERMINAL_STATUSES } from '../../subagent/index.js';
 import { getMessages } from '../../memory/conversation-store.js';
-
-const definition: ToolDefinition = {
-  name: 'subagent_read',
-  description:
-    'Read the full conversation output from a subagent. ' +
-    'Use this after a subagent completes to retrieve its full work product.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      subagent_id: {
-        type: 'string',
-        description: 'The ID of the subagent whose output to read.',
-      },
-    },
-    required: ['subagent_id'],
-  },
-};
-
-export const subagentReadTool: Tool = {
-  name: 'subagent_read',
-  description: definition.description,
-  category: 'orchestration',
-  defaultRiskLevel: RiskLevel.Low,
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  },
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeSubagentRead(input, context);
-  },
-};
 
 export async function executeSubagentRead(
   input: Record<string, unknown>,

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,51 +1,5 @@
-/**
- * subagent_spawn tool — lets the parent LLM spawn an autonomous subagent.
- */
-
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getSubagentManager } from '../../subagent/index.js';
-
-const definition: ToolDefinition = {
-  name: 'subagent_spawn',
-  description:
-    'Spawn an independent subagent to work on a task in parallel. ' +
-    'The subagent runs autonomously and its results are reported back when complete.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      label: {
-        type: 'string',
-        description: 'Short human-readable label for this subagent (e.g. "Research competitor pricing")',
-      },
-      objective: {
-        type: 'string',
-        description: 'The task objective — what the subagent should accomplish',
-      },
-      context: {
-        type: 'string',
-        description: 'Optional additional context to pass to the subagent',
-      },
-    },
-    required: ['label', 'objective'],
-  },
-};
-
-export const subagentSpawnTool: Tool = {
-  name: 'subagent_spawn',
-  description: definition.description,
-  category: 'orchestration',
-  defaultRiskLevel: RiskLevel.Low,
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  },
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeSubagentSpawn(input, context);
-  },
-};
 
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -1,41 +1,5 @@
-/**
- * subagent_status tool — query the status of one or all subagents.
- */
-
-import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getSubagentManager } from '../../subagent/index.js';
-
-const definition: ToolDefinition = {
-  name: 'subagent_status',
-  description: 'Get the status of a specific subagent or list all subagents for the current session. Only use this when the user explicitly asks about subagent status — do NOT poll automatically, as you will be notified when subagents complete.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      subagent_id: {
-        type: 'string',
-        description: 'Optional subagent ID to query. If omitted, returns all subagents for this session.',
-      },
-    },
-    required: [],
-  },
-};
-
-export const subagentStatusTool: Tool = {
-  name: 'subagent_status',
-  description: definition.description,
-  category: 'orchestration',
-  defaultRiskLevel: RiskLevel.Low,
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  },
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeSubagentStatus(input, context);
-  },
-};
 
 export async function executeSubagentStatus(
   input: Record<string, unknown>,

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -15,13 +15,6 @@ import { accountManageTool } from './credentials/account-registry.js';
 import { screenWatchTool } from './watch/screen-watch.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
 import { cliDiscoverTool } from './host-terminal/cli-discover.js';
-import {
-  subagentSpawnTool,
-  subagentStatusTool,
-  subagentAbortTool,
-  subagentMessageTool,
-  subagentReadTool,
-} from './subagent/index.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -87,11 +80,6 @@ export const explicitTools: Tool[] = [
   screenWatchTool,
   vellumSkillsCatalogTool,
   cliDiscoverTool,
-  subagentSpawnTool,
-  subagentStatusTool,
-  subagentAbortTool,
-  subagentMessageTool,
-  subagentReadTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
Create bundled skill directory with SKILL.md, TOOLS.json, and 5 executor scripts. Remove tool object exports and tool-manifest.ts registration for all subagent tools (subagent_spawn, subagent_status, subagent_abort, subagent_message, subagent_read). Update test imports to use execute functions directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
