### PR TITLE
fix: add thread creation guard and sync dock state for relay_prompt

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -117,10 +117,19 @@ extension MainWindowView {
                     if actionId == "relay_prompt" || actionId == "agent_prompt",
                        let dataDict = actionData as? [String: Any],
                        let prompt = dataDict["prompt"] as? String,
-                       !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                       let vm = threadManager.activeViewModel {
-                        vm.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                        vm.sendMessage()
+                       !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        // Ensure a thread exists so the prompt doesn't silently fail
+                        // on fresh app launch before any chat thread is created.
+                        if threadManager.activeViewModel == nil {
+                            threadManager.createThread()
+                        }
+                        if let vm = threadManager.activeViewModel {
+                            // Sync dock state before sending so the message is
+                            // classified correctly (chat vs. workspace refinement).
+                            vm.isChatDockedToSide = windowState.isChatDockOpen
+                            vm.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                            vm.sendMessage()
+                        }
                         return
                     }
                     surfaceManager.onAction?(surface.sessionId, surface.id, actionId, actionData as? [String: Any])
@@ -610,6 +619,10 @@ struct DynamicWorkspaceWrapper: View {
                        let dataDict = actionData as? [String: Any],
                        let prompt = dataDict["prompt"] as? String,
                        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        // Eagerly sync dock state so sendMessage() sees the
+                        // up-to-date value instead of the stale pre-toggle state
+                        // (onChange(of: windowState.selection) runs asynchronously).
+                        viewModel.isChatDockedToSide = true
                         viewModel.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
                         viewModel.sendMessage()
                         return


### PR DESCRIPTION
## Summary
- Adds `threadManager.createThread()` guard in `surfaceSlotView` so `relay_prompt`/`agent_prompt` actions no longer silently fail when no active thread exists (e.g., fresh app launch)
- Eagerly syncs `viewModel.isChatDockedToSide` before `sendMessage()` in both `surfaceSlotView` and `DynamicWorkspaceWrapper` so prompts are classified correctly instead of using stale dock state from the async `onChange` handler
- Addresses review feedback from PR #4886 (Codex P1 + Devin red bug)

## Test plan
- [ ] Launch app fresh (no existing threads), open a surface with relay_prompt buttons, verify clicking them creates a thread and sends the message
- [ ] Open a full-screen app (not docked), trigger a relay_prompt action, verify the message is sent as a normal chat message (not a workspace refinement)
- [ ] Open a docked app workspace, trigger a relay_prompt action, verify behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
