### PR TITLE
fix: address pre-existing ESLint errors in test and source files

### DIFF
--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -68,7 +68,7 @@ function createMockStream(tokens: string[]) {
   return stream;
 }
 
-let mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello']));
+const mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello']));
 
 mock.module('@anthropic-ai/sdk', () => ({
   default: class MockAnthropic {
@@ -81,10 +81,9 @@ mock.module('@anthropic-ai/sdk', () => ({
 // ── Import source modules after all mocks ───────────────────────────
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
-import { conversations, messages } from '../memory/schema.js';
+import { conversations } from '../memory/schema.js';
 import {
   createCallSession,
-  getCallSession,
   getPendingQuestion,
   updateCallSession,
   recordCallEvent,
@@ -95,7 +94,6 @@ import {
   unregisterCallQuestionNotifier,
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
-  getCallOrchestrator,
   fireCallQuestionNotifier,
   fireCallCompletionNotifier,
 } from '../calls/call-state.js';
@@ -358,7 +356,7 @@ describe('call-bridge', () => {
     recordCallEvent(callSession.id, 'call_started', {});
     recordCallEvent(callSession.id, 'call_ended', {});
 
-    registerCallCompletionNotifier('conv-notifier-c', (callSessionId: string) => {
+    registerCallCompletionNotifier('conv-notifier-c', (_callSessionId: string) => {
       const summaryText = `**Call completed**. Events recorded.`;
       conversationStore.addMessage(
         'conv-notifier-c',

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -84,7 +84,7 @@ import {
   updateCallSession,
   createPendingQuestion,
 } from '../calls/call-store.js';
-import { registerCallOrchestrator, unregisterCallOrchestrator } from '../calls/call-state.js';
+import { registerCallOrchestrator as _registerCallOrchestrator, unregisterCallOrchestrator as _unregisterCallOrchestrator } from '../calls/call-state.js';
 
 initializeDb();
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -945,7 +945,7 @@ describe('Call entrypoint gating', () => {
     // Force config reload
     loadConfig();
 
-    const { CallStartTool: CallStartToolClass } = await import('../tools/calls/call-start.js') as { CallStartTool: new () => { execute: (input: Record<string, unknown>, context: { conversationId: string }) => Promise<{ content: string; isError: boolean }> } };
+    const { CallStartTool: _CallStartToolClass } = await import('../tools/calls/call-start.js') as { CallStartTool: new () => { execute: (input: Record<string, unknown>, context: { conversationId: string }) => Promise<{ content: string; isError: boolean }> } };
 
     // The tool is registered via side effect. We need to test the gating logic directly.
     // Since the module registers itself, we test by loading config and checking behavior.

--- a/assistant/src/__tests__/recurrence-types.test.ts
+++ b/assistant/src/__tests__/recurrence-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { detectScheduleSyntax, normalizeScheduleSyntax, type ScheduleSyntax } from '../schedule/recurrence-types.js';
+import { detectScheduleSyntax, normalizeScheduleSyntax } from '../schedule/recurrence-types.js';
 
 describe('detectScheduleSyntax', () => {
   test('detects cron for standard 5-field expressions', () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -103,7 +103,7 @@ import {
   createCallSession,
   getCallSession,
   getCallEvents,
-  updateCallSession,
+  updateCallSession as _updateCallSession,
 } from '../calls/call-store.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';

--- a/assistant/src/__tests__/skill-script-runner.test.ts
+++ b/assistant/src/__tests__/skill-script-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterAll } from 'bun:test';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve as _resolve } from 'node:path';
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
 import type { ToolContext } from '../tools/types.js';
 

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -16,7 +16,7 @@
  * - ToolExecutor overhead < 20ms regardless of tool execution time
  */
 import { describe, test, expect, beforeAll, mock } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -9,7 +9,7 @@
  * - Unknown status and malformed payload handling
  */
 import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
-import { createHmac } from 'node:crypto';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -59,16 +59,12 @@ mock.module('../security/secure-keys.js', () => ({
 // Use the real TwilioConversationRelayProvider (not mocked) for signature validation
 // but mock the instance methods that hit Twilio API
 mock.module('../calls/twilio-provider.js', () => {
-  const { createHmac: createHmacNode } = require('node:crypto');
-  const { timingSafeEqual: timingSafeEqualNode } = require('node:crypto');
-  const { getSecureKey } = require('../security/secure-keys.js');
-
   return {
     TwilioConversationRelayProvider: class {
       readonly name = 'twilio';
 
       static getAuthToken(): string | null {
-        return getSecureKey('twilio_auth_token') ?? null;
+        return mockAuthToken ?? null;
       }
 
       static verifyWebhookSignature(
@@ -82,11 +78,11 @@ mock.module('../calls/twilio-provider.js', () => {
         for (const key of sortedKeys) {
           data += key + params[key];
         }
-        const computed = createHmacNode('sha1', authToken).update(data).digest('base64');
+        const computed = createHmac('sha1', authToken).update(data).digest('base64');
         const a = Buffer.from(computed);
         const b = Buffer.from(signature);
         if (a.length !== b.length) return false;
-        return timingSafeEqualNode(a, b);
+        return timingSafeEqual(a, b);
       }
 
       async initiateCall() { return { callSid: 'CA_mock_test' }; }
@@ -227,7 +223,7 @@ describe('twilio webhook routes', () => {
   describe('signature validation', () => {
     test('valid signature returns 200', async () => {
       await startServer();
-      const session = createTestSession('conv-sig-1', 'CA_sig_valid');
+      const _session = createTestSession('conv-sig-1', 'CA_sig_valid');
       const url = statusUrl();
       const params = { CallSid: 'CA_sig_valid', CallStatus: 'completed' };
       const { body, headers } = signedRequest(url, params);
@@ -326,7 +322,7 @@ describe('twilio webhook routes', () => {
       mockAuthToken = undefined; // Token not configured, but bypass should work
       await startServer();
 
-      const session = createTestSession('conv-bypass-1', 'CA_bypass');
+      const _session = createTestSession('conv-bypass-1', 'CA_bypass');
       const url = statusUrl();
       const params = { CallSid: 'CA_bypass', CallStatus: 'completed' };
 

--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -86,9 +86,9 @@ describe('view_image tool', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Image loaded');
     expect(result.content).toContain('image/jpeg');
-    expect((result as any).contentBlocks).toBeDefined();
-    expect((result as any).contentBlocks[0].type).toBe('image');
-    expect((result as any).contentBlocks[0].source.media_type).toBe('image/jpeg');
+    expect((result as Record<string, unknown>).contentBlocks).toBeDefined();
+    expect(((result as Record<string, unknown>).contentBlocks as Array<Record<string, unknown>>)[0].type).toBe('image');
+    expect((((result as Record<string, unknown>).contentBlocks as Array<Record<string, unknown>>)[0].source as Record<string, unknown>).media_type).toBe('image/jpeg');
   });
 
   test('loads a PNG file', async () => {
@@ -138,9 +138,9 @@ describe('view_image tool', () => {
     const result = await tool.execute({ path: 'base64.jpg' }, makeContext());
 
     expect(result.isError).toBe(false);
-    const blocks = (result as any).contentBlocks;
-    expect(blocks[0].source.type).toBe('base64');
-    expect(blocks[0].source.data.length).toBeGreaterThan(0);
+    const blocks = (result as Record<string, unknown>).contentBlocks as Array<Record<string, unknown>>;
+    expect((blocks[0].source as Record<string, unknown>).type).toBe('base64');
+    expect(((blocks[0].source as Record<string, unknown>).data as string).length).toBeGreaterThan(0);
   });
 });
 

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -1,7 +1,7 @@
 import { eq, and, notInArray, desc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
-import { callSessions, callEvents, callPendingQuestions, processedCallbacks } from '../memory/schema.js';
+import { callSessions, callEvents, callPendingQuestions } from '../memory/schema.js';
 import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
 import { validateTransition } from './call-state-machine.js';
 import { getLogger } from '../util/logger.js';

--- a/assistant/src/cli/config-commands.ts
+++ b/assistant/src/cli/config-commands.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { validateAllowlistFile } from '../security/secret-allowlist.js';
 
 import {
   loadRawConfig,
@@ -77,7 +78,6 @@ export function registerConfigCommand(program: Command): void {
     .command('validate-allowlist')
     .description('Validate regex patterns in secret-allowlist.json')
     .action(() => {
-      const { validateAllowlistFile } = require('../security/secret-allowlist.js') as typeof import('../security/secret-allowlist.js');
       try {
         const errors = validateAllowlistFile();
         if (errors === null) {

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -11,7 +11,7 @@ import { startCall, getCallStatus, cancelCall, answerCall } from '../../calls/ca
 import { getLogger } from '../../util/logger.js';
 import { getConfig } from '../../config/loader.js';
 
-const log = getLogger('call-routes');
+const _log = getLogger('call-routes');
 
 /**
  * POST /v1/calls/start

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -89,7 +89,7 @@ describe('web_search tool', () => {
 
   test('executes Perplexity search successfully', async () => {
     mockPerplexityConfigKey = 'pplx-test-key';
-    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    globalThis.fetch = (async (_url: string, _init?: RequestInit) => {
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'Perplexity answer about TypeScript' } }],
         citations: ['https://typescriptlang.org', 'https://example.com/ts'],
@@ -182,7 +182,7 @@ describe('web_search tool', () => {
   test('executes Brave search successfully', async () => {
     mockWebSearchProvider = 'brave';
     mockBraveConfigKey = 'brave-test-key';
-    globalThis.fetch = (async (url: string) => {
+    globalThis.fetch = (async (_url: string) => {
       return new Response(JSON.stringify({
         web: {
           results: [
@@ -325,7 +325,7 @@ describe('web_search tool', () => {
     mockWebSearchProvider = 'brave';
     mockPerplexityConfigKey = 'pplx-fallback-key';
     let capturedUrl = '';
-    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    globalThis.fetch = (async (url: string, _init?: RequestInit) => {
       capturedUrl = url;
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'fallback result' } }],


### PR DESCRIPTION
## Summary

- Fix 29 pre-existing ESLint errors across 14 files that surfaced during CI on recent PRs
- Unused variables: prefix with `_` or remove from imports
- \`require()\` style imports: convert to ES \`import\` syntax
- \`no-explicit-any\`: replace with \`unknown\` / typed casts
- \`prefer-const\`: change \`let\` to \`const\` where variable is never reassigned

## Files changed

- \`src/__tests__/call-bridge.test.ts\`
- \`src/__tests__/call-routes-http.test.ts\`
- \`src/__tests__/config-schema.test.ts\`
- \`src/__tests__/recurrence-types.test.ts\`
- \`src/__tests__/relay-server.test.ts\`
- \`src/__tests__/skill-script-runner.test.ts\`
- \`src/__tests__/tool-execution-pipeline.benchmark.test.ts\`
- \`src/__tests__/twilio-routes.test.ts\`
- \`src/__tests__/view-image-tool.test.ts\`
- \`src/__tests__/workspace-git-service.test.ts\`
- \`src/calls/call-store.ts\`
- \`src/cli/config-commands.ts\`
- \`src/runtime/routes/call-routes.ts\`
- \`src/tools/network/__tests__/web-search.test.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
