### PR TITLE
fix: escape regex metacharacters in claude_code template var keys

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -172,7 +172,8 @@ export const claudeCodeTool: Tool = {
       // Substitute template_vars: {{key}} patterns
       if (templateVars) {
         for (const [key, value] of Object.entries(templateVars)) {
-          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+          const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          resolvedPrompt = resolvedPrompt.replace(new RegExp(`\\{\\{${escaped}\\}\\}`, 'g'), value);
         }
       }
 


### PR DESCRIPTION
## Summary
- Escape regex special characters in template_vars keys before interpolating them into new RegExp to prevent SyntaxError or unintended pattern matching

## Context
Addresses review feedback from PR #5439 (Devin red bug + Codex P1). Template variable keys containing regex metacharacters were interpolated directly into new RegExp, which could throw an unhandled SyntaxError at runtime or match unintended placeholders in the template.

## Changes
- Added regex escaping for template var keys before constructing the RegExp in the template variable substitution loop

## Test plan
- Verify template vars with normal keys still substitute correctly
- Verify template vars with regex metacharacter keys no longer throw SyntaxError
- Verify template vars with metacharacter keys match only their literal pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
