### PR TITLE
bench: tighten session-init thresholds to match plan targets

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -5,7 +5,7 @@
  * session creation timing (request to first-tool-ready state).
  *
  * Component targets:
- * - initializeTools: < 150ms
+ * - initializeTools: < 100ms
  * - buildSystemPrompt: < 50ms
  * - getAllToolDefinitions: < 10ms
  *
@@ -216,14 +216,14 @@ afterAll(() => {
 });
 
 describe('Session initialization benchmark', () => {
-  test('initializeTools completes under 150ms', async () => {
+  test('initializeTools completes under 100ms', async () => {
     __resetRegistryForTesting();
 
     const start = performance.now();
     await initializeTools();
     const elapsed = performance.now() - start;
 
-    expect(elapsed).toBeLessThan(150);
+    expect(elapsed).toBeLessThan(100);
   });
 
   test('getAllToolDefinitions retrieves definitions under 10ms', async () => {
@@ -370,7 +370,7 @@ describe('End-to-end session creation benchmark', () => {
     // audit, and domain-event listeners — verify at least some exist
     expect(session.eventBus.listenerCount()).toBeGreaterThan(0);
 
-    expect(elapsed).toBeLessThan(200);
+    expect(elapsed).toBeLessThan(10);
 
     session.dispose();
   });


### PR DESCRIPTION
## Summary
- Tighten `initializeTools` threshold from 150ms to 100ms to match plan target (actual: ~55ms)
- Fix event listener registration assertion from `< 200ms` to `< 10ms` to match both the test title and plan target

## Test plan
- [x] Verified 3 consecutive runs pass with tightened thresholds
- [x] `initializeTools` completes in ~55ms (well under 100ms)
- [x] Session constructor completes in < 10ms (event listener registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
