### PR TITLE
Migrate playbook tools to bundled skill (PR 9.2)

### DIFF
--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -37,11 +37,12 @@ mock.module('../memory/jobs-store.js', () => ({
 import type { Database } from 'bun:sqlite';
 import { initializeDb, getDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
-
-// Register playbook tools
-await import('../tools/playbooks/index.js');
-
-import { getTool } from '../tools/registry.js';
+import {
+  executePlaybookCreate,
+  executePlaybookList,
+  executePlaybookUpdate,
+  executePlaybookDelete,
+} from '../tools/playbooks/index.js';
 
 initializeDb();
 
@@ -74,10 +75,8 @@ function extractPlaybookId(content: string): string {
 describe('playbook_create tool', () => {
   beforeEach(clearPlaybooks);
 
-  const tool = getTool('playbook_create')!;
-
   test('creates a playbook with required fields', async () => {
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       trigger: 'meeting request',
       action: 'check calendar, propose 3 times',
     }, ctx);
@@ -93,7 +92,7 @@ describe('playbook_create tool', () => {
   });
 
   test('creates a playbook with all optional fields', async () => {
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       trigger: 'from:ceo@*',
       action: 'prioritize and draft response',
       channel: 'email',
@@ -111,7 +110,7 @@ describe('playbook_create tool', () => {
   });
 
   test('creates with notify autonomy level', async () => {
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       trigger: 'newsletter',
       action: 'archive',
       autonomy_level: 'notify',
@@ -122,12 +121,12 @@ describe('playbook_create tool', () => {
   });
 
   test('rejects duplicate playbook', async () => {
-    await tool.execute({
+    await executePlaybookCreate({
       trigger: 'unique trigger',
       action: 'unique action',
     }, ctx);
 
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       trigger: 'unique trigger',
       action: 'unique action',
     }, ctx);
@@ -137,7 +136,7 @@ describe('playbook_create tool', () => {
   });
 
   test('rejects missing trigger', async () => {
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       action: 'do something',
     }, ctx);
 
@@ -146,7 +145,7 @@ describe('playbook_create tool', () => {
   });
 
   test('rejects missing action', async () => {
-    const result = await tool.execute({
+    const result = await executePlaybookCreate({
       trigger: 'test trigger',
     }, ctx);
 
@@ -160,27 +159,24 @@ describe('playbook_create tool', () => {
 describe('playbook_list tool', () => {
   beforeEach(clearPlaybooks);
 
-  const createTool = getTool('playbook_create')!;
-  const listTool = getTool('playbook_list')!;
-
   test('returns empty message when no playbooks exist', async () => {
-    const result = await listTool.execute({}, ctx);
+    const result = await executePlaybookList({}, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No playbooks found');
   });
 
   test('lists all playbooks', async () => {
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'meeting request',
       action: 'check calendar',
     }, ctx);
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'newsletter',
       action: 'archive it',
     }, ctx);
 
-    const result = await listTool.execute({}, ctx);
+    const result = await executePlaybookList({}, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Found 2 playbook(s)');
@@ -189,18 +185,18 @@ describe('playbook_list tool', () => {
   });
 
   test('filters by channel', async () => {
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'email trigger',
       action: 'handle email',
       channel: 'email',
     }, ctx);
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'slack trigger',
       action: 'handle slack',
       channel: 'slack',
     }, ctx);
 
-    const result = await listTool.execute({ channel: 'email' }, ctx);
+    const result = await executePlaybookList({ channel: 'email' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('email trigger');
@@ -208,18 +204,18 @@ describe('playbook_list tool', () => {
   });
 
   test('filters by category', async () => {
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'scheduling trigger',
       action: 'schedule it',
       category: 'scheduling',
     }, ctx);
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'triage trigger',
       action: 'triage it',
       category: 'triage',
     }, ctx);
 
-    const result = await listTool.execute({ category: 'scheduling' }, ctx);
+    const result = await executePlaybookList({ category: 'scheduling' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('scheduling trigger');
@@ -227,13 +223,13 @@ describe('playbook_list tool', () => {
   });
 
   test('includes wildcard channel playbooks in channel filter', async () => {
-    await createTool.execute({
+    await executePlaybookCreate({
       trigger: 'wildcard trigger',
       action: 'handle anything',
       channel: '*',
     }, ctx);
 
-    const result = await listTool.execute({ channel: 'email' }, ctx);
+    const result = await executePlaybookList({ channel: 'email' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('wildcard trigger');
@@ -245,17 +241,14 @@ describe('playbook_list tool', () => {
 describe('playbook_update tool', () => {
   beforeEach(clearPlaybooks);
 
-  const createTool = getTool('playbook_create')!;
-  const updateTool = getTool('playbook_update')!;
-
   test('updates the trigger', async () => {
-    const createResult = await createTool.execute({
+    const createResult = await executePlaybookCreate({
       trigger: 'old trigger',
       action: 'do something',
     }, ctx);
     const id = extractPlaybookId(createResult.content);
 
-    const result = await updateTool.execute({
+    const result = await executePlaybookUpdate({
       playbook_id: id,
       trigger: 'new trigger',
     }, ctx);
@@ -266,13 +259,13 @@ describe('playbook_update tool', () => {
   });
 
   test('updates multiple fields at once', async () => {
-    const createResult = await createTool.execute({
+    const createResult = await executePlaybookCreate({
       trigger: 'test',
       action: 'old action',
     }, ctx);
     const id = extractPlaybookId(createResult.content);
 
-    const result = await updateTool.execute({
+    const result = await executePlaybookUpdate({
       playbook_id: id,
       action: 'new action',
       channel: 'slack',
@@ -290,7 +283,7 @@ describe('playbook_update tool', () => {
   });
 
   test('rejects missing playbook_id', async () => {
-    const result = await updateTool.execute({
+    const result = await executePlaybookUpdate({
       trigger: 'new trigger',
     }, ctx);
 
@@ -299,7 +292,7 @@ describe('playbook_update tool', () => {
   });
 
   test('returns error for nonexistent playbook_id', async () => {
-    const result = await updateTool.execute({
+    const result = await executePlaybookUpdate({
       playbook_id: 'nonexistent',
       trigger: 'test',
     }, ctx);
@@ -314,37 +307,33 @@ describe('playbook_update tool', () => {
 describe('playbook_delete tool', () => {
   beforeEach(clearPlaybooks);
 
-  const createTool = getTool('playbook_create')!;
-  const deleteTool = getTool('playbook_delete')!;
-  const listTool = getTool('playbook_list')!;
-
   test('deletes a playbook', async () => {
-    const createResult = await createTool.execute({
+    const createResult = await executePlaybookCreate({
       trigger: 'delete me',
       action: 'to be deleted',
     }, ctx);
     const id = extractPlaybookId(createResult.content);
 
-    const result = await deleteTool.execute({ playbook_id: id }, ctx);
+    const result = await executePlaybookDelete({ playbook_id: id }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Playbook deleted');
     expect(result.content).toContain('delete me');
 
     // Verify it no longer appears in list
-    const listResult = await listTool.execute({}, ctx);
+    const listResult = await executePlaybookList({}, ctx);
     expect(listResult.content).toContain('No playbooks found');
   });
 
   test('rejects missing playbook_id', async () => {
-    const result = await deleteTool.execute({}, ctx);
+    const result = await executePlaybookDelete({}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('playbook_id is required');
   });
 
   test('returns error for nonexistent playbook_id', async () => {
-    const result = await deleteTool.execute({ playbook_id: 'nonexistent' }, ctx);
+    const result = await executePlaybookDelete({ playbook_id: 'nonexistent' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not found');

--- a/assistant/src/config/bundled-skills/playbooks/SKILL.md
+++ b/assistant/src/config/bundled-skills/playbooks/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: "Playbooks"
+description: "Trigger-action automation rules for handling incoming messages"
+metadata: {"vellum": {"emoji": "\ud83d\udcd6"}}
+---
+
+Playbooks are trigger-action automation rules that tell the assistant how to handle incoming messages matching a pattern.
+
+## Structure
+
+Each playbook has:
+
+- **Trigger**: Pattern or description that activates the rule (e.g. "meeting request", "from:ceo@*")
+- **Action**: What to do when triggered (natural language description)
+- **Channel**: Which channel the rule applies to ("*" = all channels, or specific like "email", "slack")
+- **Category**: Free-form grouping label (e.g. "scheduling", "triage")
+- **Autonomy level**: How much autonomy the assistant has
+  - `auto` -- execute immediately without asking
+  - `draft` -- prepare a response for user review (default)
+  - `notify` -- alert the user only
+- **Priority**: Numeric priority for overlapping rules (higher = takes precedence)
+
+## Lifecycle
+
+1. Create a playbook with `playbook_create` specifying trigger and action.
+2. List existing playbooks with `playbook_list`, optionally filtering by channel or category.
+3. Update rules with `playbook_update` or remove them with `playbook_delete`.
+
+## Storage
+
+Playbooks are stored as memory items with semantic retrieval, enabling fuzzy matching of incoming messages against trigger patterns.

--- a/assistant/src/config/bundled-skills/playbooks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/playbooks/TOOLS.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "playbook_create",
+      "description": "Create an action playbook \u2014 a trigger\u2192action rule that tells the assistant how to handle incoming messages matching a pattern",
+      "category": "playbook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "type": "string",
+            "description": "Pattern or description that triggers this playbook (e.g. \"meeting request\", \"from:ceo@*\", \"newsletter\")"
+          },
+          "action": {
+            "type": "string",
+            "description": "What to do when the trigger matches \u2014 natural language action description (e.g. \"check calendar, propose 3 times\")"
+          },
+          "channel": {
+            "type": "string",
+            "description": "Channel this rule applies to (e.g. \"email\", \"slack\"), or \"*\" for all channels. Defaults to \"*\"."
+          },
+          "category": {
+            "type": "string",
+            "description": "Free-form category for grouping (e.g. \"scheduling\", \"triage\"). Defaults to \"general\"."
+          },
+          "autonomy_level": {
+            "type": "string",
+            "enum": ["auto", "draft", "notify"],
+            "description": "How much autonomy: \"auto\" = execute automatically, \"draft\" = draft for review, \"notify\" = notify only. Defaults to \"draft\"."
+          },
+          "priority": {
+            "type": "number",
+            "description": "Relative priority \u2014 higher numbers take precedence. Defaults to 0."
+          }
+        },
+        "required": ["trigger", "action"]
+      },
+      "executor": "tools/playbook-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "playbook_list",
+      "description": "List action playbooks, optionally filtered by channel or category",
+      "category": "playbook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Filter by channel (e.g. \"email\", \"slack\"). Omit to show all."
+          },
+          "category": {
+            "type": "string",
+            "description": "Filter by category (e.g. \"scheduling\", \"triage\"). Omit to show all."
+          }
+        }
+      },
+      "executor": "tools/playbook-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "playbook_update",
+      "description": "Update an existing action playbook rule",
+      "category": "playbook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "playbook_id": {
+            "type": "string",
+            "description": "ID of the playbook to update (from playbook_list results)"
+          },
+          "trigger": {
+            "type": "string",
+            "description": "Updated trigger pattern"
+          },
+          "action": {
+            "type": "string",
+            "description": "Updated action description"
+          },
+          "channel": {
+            "type": "string",
+            "description": "Updated channel (\"*\" for all)"
+          },
+          "category": {
+            "type": "string",
+            "description": "Updated category"
+          },
+          "autonomy_level": {
+            "type": "string",
+            "enum": ["auto", "draft", "notify"],
+            "description": "Updated autonomy level"
+          },
+          "priority": {
+            "type": "number",
+            "description": "Updated priority"
+          }
+        },
+        "required": ["playbook_id"]
+      },
+      "executor": "tools/playbook-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "playbook_delete",
+      "description": "Delete an action playbook rule",
+      "category": "playbook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "playbook_id": {
+            "type": "string",
+            "description": "ID of the playbook to delete (from playbook_list results)"
+          }
+        },
+        "required": ["playbook_id"]
+      },
+      "executor": "tools/playbook-delete.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executePlaybookCreate } from '../../../../tools/playbooks/playbook-create.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executePlaybookCreate(input, context);
+}

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executePlaybookDelete } from '../../../../tools/playbooks/playbook-delete.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executePlaybookDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-list.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-list.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executePlaybookList } from '../../../../tools/playbooks/playbook-list.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executePlaybookList(input, context);
+}

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executePlaybookUpdate } from '../../../../tools/playbooks/playbook-update.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executePlaybookUpdate(input, context);
+}

--- a/assistant/src/tools/playbooks/index.ts
+++ b/assistant/src/tools/playbooks/index.ts
@@ -1,5 +1,4 @@
-// Barrel export — importing this module triggers registration of all playbook tools.
-import './playbook-create.js';
-import './playbook-list.js';
-import './playbook-update.js';
-import './playbook-delete.js';
+export { executePlaybookCreate } from './playbook-create.js';
+export { executePlaybookList } from './playbook-list.js';
+export { executePlaybookUpdate } from './playbook-update.js';
+export { executePlaybookDelete } from './playbook-delete.js';

--- a/assistant/src/tools/playbooks/playbook-create.ts
+++ b/assistant/src/tools/playbooks/playbook-create.ts
@@ -1,8 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
-import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
@@ -96,46 +94,3 @@ export async function executePlaybookCreate(input: Record<string, unknown>, cont
     return { content: `Error creating playbook: ${msg}`, isError: true };
   }
 }
-
-registerTool({
-  name: 'playbook_create',
-  description: 'Create an action playbook — a trigger→action rule that tells the assistant how to handle incoming messages matching a pattern',
-  category: 'playbook',
-  defaultRiskLevel: RiskLevel.Low,
-  getDefinition: () => ({
-    name: 'playbook_create',
-    description: 'Create an action playbook — a trigger→action rule that tells the assistant how to handle incoming messages matching a pattern',
-    input_schema: {
-      type: 'object',
-      properties: {
-        trigger: {
-          type: 'string',
-          description: 'Pattern or description that triggers this playbook (e.g. "meeting request", "from:ceo@*", "newsletter")',
-        },
-        action: {
-          type: 'string',
-          description: 'What to do when the trigger matches — natural language action description (e.g. "check calendar, propose 3 times")',
-        },
-        channel: {
-          type: 'string',
-          description: 'Channel this rule applies to (e.g. "email", "slack"), or "*" for all channels. Defaults to "*".',
-        },
-        category: {
-          type: 'string',
-          description: 'Free-form category for grouping (e.g. "scheduling", "triage"). Defaults to "general".',
-        },
-        autonomy_level: {
-          type: 'string',
-          enum: ['auto', 'draft', 'notify'],
-          description: 'How much autonomy: "auto" = execute automatically, "draft" = draft for review, "notify" = notify only. Defaults to "draft".',
-        },
-        priority: {
-          type: 'number',
-          description: 'Relative priority — higher numbers take precedence. Defaults to 0.',
-        },
-      },
-      required: ['trigger', 'action'],
-    },
-  }),
-  execute: executePlaybookCreate,
-});

--- a/assistant/src/tools/playbooks/playbook-delete.ts
+++ b/assistant/src/tools/playbooks/playbook-delete.ts
@@ -1,7 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
-import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { memoryItems } from '../../memory/schema.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
@@ -52,25 +50,3 @@ export async function executePlaybookDelete(input: Record<string, unknown>, cont
     return { content: `Error deleting playbook: ${msg}`, isError: true };
   }
 }
-
-registerTool({
-  name: 'playbook_delete',
-  description: 'Delete an action playbook rule',
-  category: 'playbook',
-  defaultRiskLevel: RiskLevel.Low,
-  getDefinition: () => ({
-    name: 'playbook_delete',
-    description: 'Delete an action playbook rule',
-    input_schema: {
-      type: 'object',
-      properties: {
-        playbook_id: {
-          type: 'string',
-          description: 'ID of the playbook to delete (from playbook_list results)',
-        },
-      },
-      required: ['playbook_id'],
-    },
-  }),
-  execute: executePlaybookDelete,
-});

--- a/assistant/src/tools/playbooks/playbook-list.ts
+++ b/assistant/src/tools/playbooks/playbook-list.ts
@@ -1,7 +1,5 @@
 import { and, desc, eq, isNull } from 'drizzle-orm';
-import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
-import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { memoryItems } from '../../memory/schema.js';
 import { parsePlaybookStatement } from '../../playbooks/types.js';
@@ -74,28 +72,3 @@ export async function executePlaybookList(input: Record<string, unknown>, contex
     return { content: `Error listing playbooks: ${msg}`, isError: true };
   }
 }
-
-registerTool({
-  name: 'playbook_list',
-  description: 'List action playbooks, optionally filtered by channel or category',
-  category: 'playbook',
-  defaultRiskLevel: RiskLevel.Low,
-  getDefinition: () => ({
-    name: 'playbook_list',
-    description: 'List action playbooks, optionally filtered by channel or category',
-    input_schema: {
-      type: 'object',
-      properties: {
-        channel: {
-          type: 'string',
-          description: 'Filter by channel (e.g. "email", "slack"). Omit to show all.',
-        },
-        category: {
-          type: 'string',
-          description: 'Filter by category (e.g. "scheduling", "triage"). Omit to show all.',
-        },
-      },
-    },
-  }),
-  execute: executePlaybookList,
-});

--- a/assistant/src/tools/playbooks/playbook-update.ts
+++ b/assistant/src/tools/playbooks/playbook-update.ts
@@ -1,7 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { RiskLevel } from '../../permissions/types.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
-import { registerTool } from '../registry.js';
 import { getDb } from '../../memory/db.js';
 import { computeMemoryFingerprint } from '../../memory/fingerprint.js';
 import { memoryItems } from '../../memory/schema.js';
@@ -111,50 +109,3 @@ export async function executePlaybookUpdate(input: Record<string, unknown>, cont
     return { content: `Error updating playbook: ${msg}`, isError: true };
   }
 }
-
-registerTool({
-  name: 'playbook_update',
-  description: 'Update an existing action playbook rule',
-  category: 'playbook',
-  defaultRiskLevel: RiskLevel.Low,
-  getDefinition: () => ({
-    name: 'playbook_update',
-    description: 'Update an existing action playbook rule',
-    input_schema: {
-      type: 'object',
-      properties: {
-        playbook_id: {
-          type: 'string',
-          description: 'ID of the playbook to update (from playbook_list results)',
-        },
-        trigger: {
-          type: 'string',
-          description: 'Updated trigger pattern',
-        },
-        action: {
-          type: 'string',
-          description: 'Updated action description',
-        },
-        channel: {
-          type: 'string',
-          description: 'Updated channel ("*" for all)',
-        },
-        category: {
-          type: 'string',
-          description: 'Updated category',
-        },
-        autonomy_level: {
-          type: 'string',
-          enum: ['auto', 'draft', 'notify'],
-          description: 'Updated autonomy level',
-        },
-        priority: {
-          type: 'number',
-          description: 'Updated priority',
-        },
-      },
-      required: ['playbook_id'],
-    },
-  }),
-  execute: executePlaybookUpdate,
-});

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -29,10 +29,6 @@ export async function loadEagerModules(): Promise<void> {
   await import('./skills/scaffold-managed.js');
   await import('./skills/delete-managed.js');
   await import('./system/request-permission.js');
-  await import('./playbooks/playbook-create.js');
-  await import('./playbooks/playbook-list.js');
-  await import('./playbooks/playbook-update.js');
-  await import('./playbooks/playbook-delete.js');
   await import('./assets/search.js');
   await import('./assets/materialize.js');
   await import('./filesystem/view-image.js');
@@ -55,10 +51,6 @@ export const eagerModuleToolNames: string[] = [
   'scaffold_managed_skill',
   'delete_managed_skill',
   'request_system_permission',
-  'playbook_create',
-  'playbook_list',
-  'playbook_update',
-  'playbook_delete',
   'asset_search',
   'asset_materialize',
   'view_image',


### PR DESCRIPTION
## Summary
- Create bundled skill directory at `config/bundled-skills/playbooks/` with `SKILL.md`, `TOOLS.json`, and 4 executor scripts (playbook-create, playbook-list, playbook-update, playbook-delete)
- Remove `registerTool()` side-effect calls from the 4 playbook source files, keeping the exported `execute*` functions
- Remove playbook entries from `loadEagerModules()` and `eagerModuleToolNames` in `tool-manifest.ts`
- Update `playbook-tools.test.ts` to call execute functions directly instead of using `getTool()` from the registry

## Test plan
- [x] All 18 playbook tool tests pass (`bun test src/__tests__/playbook-tools.test.ts`)
- [x] TypeScript type-check passes (no new errors)

Part of the skills migration plan (PR 9.2).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
