### PR TITLE
Persist schedule_syntax in DB schema + migration

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../memory/schema.js';
+import { cronJobs } from '../memory/schema.js';
+import { eq } from 'drizzle-orm';
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec('PRAGMA journal_mode=WAL');
+  sqlite.exec('PRAGMA foreign_keys = ON');
+  return drizzle(sqlite, { schema });
+}
+
+function getRawSqlite(db: ReturnType<typeof drizzle<typeof schema>>): Database {
+  return (db as unknown as { $client: Database }).$client;
+}
+
+describe('schedule_syntax column migration', () => {
+  test('fresh DB includes schedule_syntax with default cron', () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS cron_jobs (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        cron_expression TEXT NOT NULL,
+        schedule_syntax TEXT NOT NULL DEFAULT 'cron',
+        timezone TEXT,
+        message TEXT NOT NULL,
+        next_run_at INTEGER NOT NULL,
+        last_run_at INTEGER,
+        last_status TEXT,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        created_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    const now = Date.now();
+    db.insert(cronJobs).values({
+      id: 'test-1',
+      name: 'Test Job',
+      enabled: true,
+      cronExpression: '0 9 * * *',
+      timezone: null,
+      message: 'hello',
+      nextRunAt: now + 60000,
+      lastRunAt: null,
+      lastStatus: null,
+      retryCount: 0,
+      createdBy: 'agent',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'test-1')).get();
+    expect(row).toBeTruthy();
+    expect(row!.scheduleSyntax).toBe('cron');
+  });
+
+  test('upgraded DB gains schedule_syntax column via ALTER TABLE', () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+
+    // Old schema without schedule_syntax
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS cron_jobs (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        cron_expression TEXT NOT NULL,
+        timezone TEXT,
+        message TEXT NOT NULL,
+        next_run_at INTEGER NOT NULL,
+        last_run_at INTEGER,
+        last_status TEXT,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        created_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    const now = Date.now();
+    raw.exec(`INSERT INTO cron_jobs (id, name, enabled, cron_expression, timezone, message, next_run_at, last_run_at, last_status, retry_count, created_by, created_at, updated_at) VALUES ('old-1', 'Old Job', 1, '0 9 * * *', NULL, 'hello', ${now + 60000}, NULL, NULL, 0, 'agent', ${now}, ${now})`);
+
+    // Run the migration
+    try { raw.exec(`ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
+
+    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'old-1')).get();
+    expect(row).toBeTruthy();
+    expect(row!.scheduleSyntax).toBe('cron');
+  });
+
+  test('migration is idempotent', () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS cron_jobs (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        cron_expression TEXT NOT NULL,
+        timezone TEXT,
+        message TEXT NOT NULL,
+        next_run_at INTEGER NOT NULL,
+        last_run_at INTEGER,
+        last_status TEXT,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        created_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    try { raw.exec(`ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* ok */ }
+    try { raw.exec(`ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* ok */ }
+
+    const now = Date.now();
+    raw.exec(`INSERT INTO cron_jobs (id, name, enabled, cron_expression, timezone, message, next_run_at, retry_count, created_by, created_at, updated_at) VALUES ('idem-1', 'Test', 1, '0 9 * * *', NULL, 'hi', ${now + 60000}, 0, 'agent', ${now}, ${now})`);
+    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'idem-1')).get();
+    expect(row!.scheduleSyntax).toBe('cron');
+  });
+});

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -274,6 +274,7 @@ export function initializeDb(): void {
       name TEXT NOT NULL,
       enabled INTEGER NOT NULL DEFAULT 1,
       cron_expression TEXT NOT NULL,
+      schedule_syntax TEXT NOT NULL DEFAULT 'cron',
       timezone TEXT,
       message TEXT NOT NULL,
       next_run_at INTEGER NOT NULL,
@@ -542,6 +543,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'standard'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -605,6 +607,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_reminders_status_fire_at ON reminders(status, fire_at)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_syntax_enabled_next_run ON cron_jobs(schedule_syntax, enabled, next_run_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id ON cron_runs(job_id)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_service ON accounts(service)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -250,6 +250,7 @@ export const cronJobs = sqliteTable('cron_jobs', {
   name: text('name').notNull(),
   enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
   cronExpression: text('cron_expression').notNull(),    // e.g. '0 9 * * 1-5'
+  scheduleSyntax: text('schedule_syntax').notNull().default('cron'),  // 'cron' | 'rrule'
   timezone: text('timezone'),                           // e.g. 'America/Los_Angeles'
   message: text('message').notNull(),
   nextRunAt: integer('next_run_at').notNull(),


### PR DESCRIPTION
## Summary
- Adds `schedule_syntax TEXT NOT NULL DEFAULT 'cron'` column to `cron_jobs` table
- Drizzle schema updated with `scheduleSyntax` field
- Idempotent ALTER TABLE migration for existing databases
- New composite index `idx_cron_jobs_syntax_enabled_next_run` for scheduler scan

## Test plan
- [x] Fresh DB includes schedule_syntax with default 'cron'
- [x] Upgraded DB gains column via ALTER TABLE, backfills existing rows as 'cron'
- [x] Migration is idempotent (running twice doesn't error)
- [x] Full test suite passes
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
