### PR TITLE
Add RRULE/cron recurrence engine (no call-site change)

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -28,6 +28,7 @@
         "playwright": "^1.58.2",
         "postgres": "^3.4.8",
         "react": "^19.2.4",
+        "rrule": "^2.8.1",
         "tldts": "^7.0.23",
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
@@ -1104,6 +1105,8 @@
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
+    "rrule": ["rrule@2.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -45,6 +45,7 @@
     "playwright": "^1.58.2",
     "postgres": "^3.4.8",
     "react": "^19.2.4",
+    "rrule": "^2.8.1",
     "tldts": "^7.0.23",
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",

--- a/assistant/src/__tests__/recurrence-engine.test.ts
+++ b/assistant/src/__tests__/recurrence-engine.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'bun:test';
+import { isValidScheduleExpression, computeNextRunAt } from '../schedule/recurrence-engine.js';
+
+describe('recurrence engine — cron', () => {
+  test('validates valid cron expressions', () => {
+    expect(isValidScheduleExpression({ syntax: 'cron', expression: '0 9 * * 1-5' })).toBe(true);
+    expect(isValidScheduleExpression({ syntax: 'cron', expression: '*/5 * * * *' })).toBe(true);
+  });
+
+  test('rejects invalid cron expressions', () => {
+    expect(isValidScheduleExpression({ syntax: 'cron', expression: 'not valid' })).toBe(false);
+    expect(isValidScheduleExpression({ syntax: 'cron', expression: '' })).toBe(false);
+  });
+
+  test('computes next run for cron', () => {
+    const now = Date.now();
+    const next = computeNextRunAt({ syntax: 'cron', expression: '* * * * *' }, now);
+    expect(next).toBeGreaterThan(now - 1);
+    // Next minute should be within 60 seconds
+    expect(next - now).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe('recurrence engine — rrule', () => {
+  test('validates RRULE with DTSTART', () => {
+    const expr = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+  });
+
+  test('rejects RRULE without DTSTART', () => {
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toBe(false);
+  });
+
+  test('rejects RRULE set constructs', () => {
+    const withExdate = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20250105T090000Z';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withExdate })).toBe(false);
+
+    const withRdate = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nRDATE:20250115T090000Z';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withRdate })).toBe(false);
+
+    const multiRrule = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nRRULE:FREQ=WEEKLY';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: multiRrule })).toBe(false);
+  });
+
+  test('computes next run for RRULE with future DTSTART', () => {
+    // Use a date far in the future to ensure the test is stable
+    const futureDate = new Date('2099-01-01T09:00:00Z');
+    const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY';
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr });
+    expect(next).toBeGreaterThanOrEqual(futureDate.getTime());
+  });
+
+  test('throws when RRULE has no future runs (UNTIL in past)', () => {
+    const expr = 'DTSTART:20200101T090000Z\nRRULE:FREQ=DAILY;UNTIL=20200105T090000Z';
+    expect(() => computeNextRunAt({ syntax: 'rrule', expression: expr })).toThrow(/no upcoming runs/);
+  });
+
+  test('throws for RRULE missing DTSTART in computeNextRunAt', () => {
+    expect(() => computeNextRunAt({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toThrow(/DTSTART/);
+  });
+
+  test('throws for RRULE set constructs in computeNextRunAt', () => {
+    const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20990105T090000Z';
+    expect(() => computeNextRunAt({ syntax: 'rrule', expression: expr })).toThrow(/set constructs/);
+  });
+});

--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -1,0 +1,94 @@
+import { Cron } from 'croner';
+import { rrulestr } from 'rrule';
+import type { ScheduleSyntax } from './recurrence-types.js';
+
+export interface ScheduleSpec {
+  syntax: ScheduleSyntax;
+  expression: string;
+  timezone?: string | null;
+}
+
+/**
+ * Validate a schedule expression. Returns true if the expression is valid
+ * for the given syntax, false otherwise.
+ */
+export function isValidScheduleExpression(spec: ScheduleSpec): boolean {
+  try {
+    if (spec.syntax === 'cron') {
+      new Cron(spec.expression, { maxRuns: 0 });
+      return true;
+    }
+
+    if (spec.syntax === 'rrule') {
+      // Require DTSTART for deterministic anchoring
+      if (!spec.expression.includes('DTSTART')) {
+        return false;
+      }
+      // Reject set constructs for now (lifted in PR 13)
+      if (hasSetConstructs(spec.expression)) {
+        return false;
+      }
+      rrulestr(spec.expression);
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute the next run timestamp (epoch ms) for a schedule expression.
+ * Throws if no future runs exist.
+ */
+export function computeNextRunAt(spec: ScheduleSpec, nowMs?: number): number {
+  const now = nowMs ?? Date.now();
+
+  if (spec.syntax === 'cron') {
+    const cron = new Cron(spec.expression, {
+      timezone: spec.timezone ?? undefined,
+    });
+    const next = cron.nextRun(new Date(now));
+    if (!next) {
+      throw new Error(`Cron expression "${spec.expression}" has no upcoming runs`);
+    }
+    return next.getTime();
+  }
+
+  if (spec.syntax === 'rrule') {
+    if (!spec.expression.includes('DTSTART')) {
+      throw new Error('RRULE expression must include DTSTART for deterministic scheduling');
+    }
+    if (hasSetConstructs(spec.expression)) {
+      throw new Error('RRULE set constructs (RDATE, EXDATE, EXRULE, multiple RRULE) are not yet supported. Support will be added in a future update.');
+    }
+
+    const rule = rrulestr(spec.expression);
+    const next = rule.after(new Date(now), true);
+    if (!next) {
+      throw new Error(`RRULE expression has no upcoming runs after ${new Date(now).toISOString()}`);
+    }
+    return next.getTime();
+  }
+
+  throw new Error(`Unsupported schedule syntax: ${spec.syntax}`);
+}
+
+/**
+ * Check if an RRULE expression contains set constructs (RDATE, EXDATE, EXRULE,
+ * or multiple RRULE lines). These are deferred to PR 13.
+ */
+function hasSetConstructs(expression: string): boolean {
+  const lines = expression.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  let rruleCount = 0;
+  for (const line of lines) {
+    if (line.startsWith('RDATE') || line.startsWith('EXDATE') || line.startsWith('EXRULE')) {
+      return true;
+    }
+    if (line.startsWith('RRULE:')) {
+      rruleCount++;
+    }
+  }
+  return rruleCount > 1;
+}


### PR DESCRIPTION
## Summary
- Adds `rrule` npm dependency
- New `recurrence-engine.ts` with `isValidScheduleExpression()` and `computeNextRunAt()`
- Cron path delegates to existing `croner` for parity
- RRULE path uses `rrulestr`, requires `DTSTART`, rejects set constructs (deferred to PR 13)
- Pure engine module, no runtime call-sites changed

## Test plan
- [x] Cron validity and next-run computation
- [x] RRULE with DTSTART validates and computes future runs
- [x] RRULE without DTSTART rejected
- [x] RRULE set constructs (RDATE/EXDATE/multi-RRULE) rejected
- [x] UNTIL-in-past throws appropriate error
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
