### PR TITLE
fix: preactivate claude-code skill and fix rewrite param for CC commands

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -149,6 +149,8 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  } else if (slashResult.kind === 'cc_command') {
+    session.preactivatedSkillIds = ['claude-code'];
   }
 
   // Try to persist and run the dequeued message. If persistUserMessage
@@ -248,6 +250,8 @@ export async function processMessage(
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  } else if (slashResult.kind === 'cc_command') {
+    session.preactivatedSkillIds = ['claude-code'];
   }
 
   let userMessageId: string;

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -405,7 +405,7 @@ export function resolveSlash(content: string, cwd?: string): SlashResolution {
 function buildCCCommandResolution(commandName: string, trailingArgs: string): SlashResolution {
   const rewrittenPrompt = [
     `The user invoked the slash command \`/${commandName}\`.`,
-    `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+    `Execute the Claude Code command "${commandName}" using the claude_code tool with prompt="${commandName}".`,
     trailingArgs ? `\nUser arguments: ${trailingArgs}` : '',
   ].filter(Boolean).join('\n');
 


### PR DESCRIPTION
## Summary
- Ensures `cc_command` routing preactivates the `claude-code` skill so the `claude_code` tool is available during execution (previously only `rewritten` kind set `preactivatedSkillIds`)
- Fixes the rewrite prompt to use the correct `prompt` parameter name instead of `command` (which does not exist in the tool schema)

Addresses review feedback from PR #5451.

## Test plan
- [ ] Invoke a CC slash command (e.g. `/some-cc-command`) and verify the `claude_code` tool executes without hitting "Tool not active" gate
- [ ] Verify the rewritten prompt uses `prompt=` not `command=` by inspecting the resolved content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
