### PR TITLE
fix: resolve 33 eslint errors failing CI

### DIFF
--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -68,7 +68,7 @@ function createMockStream(tokens: string[]) {
   return stream;
 }
 
-let mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello']));
+const mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello']));
 
 mock.module('@anthropic-ai/sdk', () => ({
   default: class MockAnthropic {
@@ -81,10 +81,9 @@ mock.module('@anthropic-ai/sdk', () => ({
 // ── Import source modules after all mocks ───────────────────────────
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
-import { conversations, messages } from '../memory/schema.js';
+import { conversations } from '../memory/schema.js';
 import {
   createCallSession,
-  getCallSession,
   getPendingQuestion,
   updateCallSession,
   recordCallEvent,
@@ -95,7 +94,6 @@ import {
   unregisterCallQuestionNotifier,
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
-  getCallOrchestrator,
   fireCallQuestionNotifier,
   fireCallCompletionNotifier,
 } from '../calls/call-state.js';
@@ -358,7 +356,7 @@ describe('call-bridge', () => {
     recordCallEvent(callSession.id, 'call_started', {});
     recordCallEvent(callSession.id, 'call_ended', {});
 
-    registerCallCompletionNotifier('conv-notifier-c', (callSessionId: string) => {
+    registerCallCompletionNotifier('conv-notifier-c', (_callSessionId: string) => {
       const summaryText = `**Call completed**. Events recorded.`;
       conversationStore.addMessage(
         'conv-notifier-c',

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -84,7 +84,7 @@ import {
   updateCallSession,
   createPendingQuestion,
 } from '../calls/call-store.js';
-import { registerCallOrchestrator, unregisterCallOrchestrator } from '../calls/call-state.js';
+import '../calls/call-state.js';
 
 initializeDb();
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -945,7 +945,7 @@ describe('Call entrypoint gating', () => {
     // Force config reload
     loadConfig();
 
-    const { CallStartTool: CallStartToolClass } = await import('../tools/calls/call-start.js') as { CallStartTool: new () => { execute: (input: Record<string, unknown>, context: { conversationId: string }) => Promise<{ content: string; isError: boolean }> } };
+    const { CallStartTool: _CallStartToolClass } = await import('../tools/calls/call-start.js') as { CallStartTool: new () => { execute: (input: Record<string, unknown>, context: { conversationId: string }) => Promise<{ content: string; isError: boolean }> } };
 
     // The tool is registered via side effect. We need to test the gating logic directly.
     // Since the module registers itself, we test by loading config and checking behavior.

--- a/assistant/src/__tests__/recurrence-types.test.ts
+++ b/assistant/src/__tests__/recurrence-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { detectScheduleSyntax, normalizeScheduleSyntax, type ScheduleSyntax } from '../schedule/recurrence-types.js';
+import { detectScheduleSyntax, normalizeScheduleSyntax } from '../schedule/recurrence-types.js';
 
 describe('detectScheduleSyntax', () => {
   test('detects cron for standard 5-field expressions', () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -103,7 +103,6 @@ import {
   createCallSession,
   getCallSession,
   getCallEvents,
-  updateCallSession,
 } from '../calls/call-store.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';

--- a/assistant/src/__tests__/skill-script-runner.test.ts
+++ b/assistant/src/__tests__/skill-script-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterAll } from 'bun:test';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { runSkillToolScript } from '../tools/skills/skill-script-runner.js';
 import type { ToolContext } from '../tools/types.js';
 

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -16,7 +16,7 @@
  * - ToolExecutor overhead < 20ms regardless of tool execution time
  */
 import { describe, test, expect, beforeAll, mock } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -59,8 +59,11 @@ mock.module('../security/secure-keys.js', () => ({
 // Use the real TwilioConversationRelayProvider (not mocked) for signature validation
 // but mock the instance methods that hit Twilio API
 mock.module('../calls/twilio-provider.js', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { createHmac: createHmacNode } = require('node:crypto');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { timingSafeEqual: timingSafeEqualNode } = require('node:crypto');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { getSecureKey } = require('../security/secure-keys.js');
 
   return {
@@ -227,7 +230,7 @@ describe('twilio webhook routes', () => {
   describe('signature validation', () => {
     test('valid signature returns 200', async () => {
       await startServer();
-      const session = createTestSession('conv-sig-1', 'CA_sig_valid');
+      createTestSession('conv-sig-1', 'CA_sig_valid');
       const url = statusUrl();
       const params = { CallSid: 'CA_sig_valid', CallStatus: 'completed' };
       const { body, headers } = signedRequest(url, params);
@@ -326,7 +329,7 @@ describe('twilio webhook routes', () => {
       mockAuthToken = undefined; // Token not configured, but bypass should work
       await startServer();
 
-      const session = createTestSession('conv-bypass-1', 'CA_bypass');
+      createTestSession('conv-bypass-1', 'CA_bypass');
       const url = statusUrl();
       const params = { CallSid: 'CA_bypass', CallStatus: 'completed' };
 

--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, afterAll, mock } from 'bun:test';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -1,7 +1,7 @@
 import { eq, and, notInArray, desc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
-import { callSessions, callEvents, callPendingQuestions, processedCallbacks } from '../memory/schema.js';
+import { callSessions, callEvents, callPendingQuestions } from '../memory/schema.js';
 import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
 import { validateTransition } from './call-state-machine.js';
 import { getLogger } from '../util/logger.js';

--- a/assistant/src/cli/config-commands.ts
+++ b/assistant/src/cli/config-commands.ts
@@ -77,6 +77,7 @@ export function registerConfigCommand(program: Command): void {
     .command('validate-allowlist')
     .description('Validate regex patterns in secret-allowlist.json')
     .action(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { validateAllowlistFile } = require('../security/secret-allowlist.js') as typeof import('../security/secret-allowlist.js');
       try {
         const errors = validateAllowlistFile();

--- a/assistant/src/config/bundled-skills/reminder/tools/reminder-cancel.ts
+++ b/assistant/src/config/bundled-skills/reminder/tools/reminder-cancel.ts
@@ -3,7 +3,7 @@ import { executeReminderCancel } from '../../../../tools/reminder/reminder.js';
 
 export async function run(
   input: Record<string, unknown>,
-  context: ToolContext,
+  _context: ToolContext,
 ): Promise<ToolExecutionResult> {
   return executeReminderCancel(input);
 }

--- a/assistant/src/config/bundled-skills/reminder/tools/reminder-create.ts
+++ b/assistant/src/config/bundled-skills/reminder/tools/reminder-create.ts
@@ -3,7 +3,7 @@ import { executeReminderCreate } from '../../../../tools/reminder/reminder.js';
 
 export async function run(
   input: Record<string, unknown>,
-  context: ToolContext,
+  _context: ToolContext,
 ): Promise<ToolExecutionResult> {
   return executeReminderCreate(input);
 }

--- a/assistant/src/config/bundled-skills/reminder/tools/reminder-list.ts
+++ b/assistant/src/config/bundled-skills/reminder/tools/reminder-list.ts
@@ -2,8 +2,8 @@ import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.j
 import { executeReminderList } from '../../../../tools/reminder/reminder.js';
 
 export async function run(
-  input: Record<string, unknown>,
-  context: ToolContext,
+  _input: Record<string, unknown>,
+  _context: ToolContext,
 ): Promise<ToolExecutionResult> {
   return executeReminderList();
 }

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -8,10 +8,7 @@
  */
 
 import { startCall, getCallStatus, cancelCall, answerCall } from '../../calls/call-domain.js';
-import { getLogger } from '../../util/logger.js';
 import { getConfig } from '../../config/loader.js';
-
-const log = getLogger('call-routes');
 
 /**
  * POST /v1/calls/start

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -89,7 +89,7 @@ describe('web_search tool', () => {
 
   test('executes Perplexity search successfully', async () => {
     mockPerplexityConfigKey = 'pplx-test-key';
-    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    globalThis.fetch = (async (_url: string, _init?: RequestInit) => {
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'Perplexity answer about TypeScript' } }],
         citations: ['https://typescriptlang.org', 'https://example.com/ts'],
@@ -182,7 +182,7 @@ describe('web_search tool', () => {
   test('executes Brave search successfully', async () => {
     mockWebSearchProvider = 'brave';
     mockBraveConfigKey = 'brave-test-key';
-    globalThis.fetch = (async (url: string) => {
+    globalThis.fetch = (async (_url: string) => {
       return new Response(JSON.stringify({
         web: {
           results: [
@@ -325,7 +325,7 @@ describe('web_search tool', () => {
     mockWebSearchProvider = 'brave';
     mockPerplexityConfigKey = 'pplx-fallback-key';
     let capturedUrl = '';
-    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    globalThis.fetch = (async (url: string, _init?: RequestInit) => {
       capturedUrl = url;
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'fallback result' } }],


### PR DESCRIPTION
## Summary
- Fix unused variable/import lint errors across 15 files by removing unused imports, prefixing with `_`, or adding eslint-disable comments
- Add eslint-disable comments for intentional `require()` imports in mock factories and lazy-loading contexts
- Add eslint-disable for `no-explicit-any` in view-image test where result type assertions are needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
