### PR TITLE
Make schedule store recurrence-aware (cron + RRULE)

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1,0 +1,298 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mock } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'schedule-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import {
+  createSchedule,
+  getSchedule,
+  updateSchedule,
+  claimDueSchedules,
+} from '../schedule/schedule-store.js';
+
+initializeDb();
+
+/** Access the underlying bun:sqlite Database for raw parameterized queries. */
+function getRawDb(): import('bun:sqlite').Database {
+  return (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── Cron backward compatibility ─────────────────────────────────────
+
+describe('createSchedule (cron, legacy API)', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+  });
+
+  test('creates a cron schedule using only cronExpression', () => {
+    const job = createSchedule({
+      name: 'Morning ping',
+      cronExpression: '0 9 * * *',
+      message: 'good morning',
+    });
+
+    expect(job.syntax).toBe('cron');
+    expect(job.expression).toBe('0 9 * * *');
+    expect(job.cronExpression).toBe('0 9 * * *');
+    expect(job.nextRunAt).toBeGreaterThan(Date.now() - 1000);
+    expect(job.enabled).toBe(true);
+  });
+
+  test('persisted cron schedule is retrievable with new fields', () => {
+    const job = createSchedule({
+      name: 'Hourly',
+      cronExpression: '0 * * * *',
+      message: 'hourly check',
+    });
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.syntax).toBe('cron');
+    expect(retrieved!.expression).toBe('0 * * * *');
+    expect(retrieved!.cronExpression).toBe('0 * * * *');
+  });
+
+  test('stores schedule_syntax in the DB row', () => {
+    const job = createSchedule({
+      name: 'Syntax check',
+      cronExpression: '*/5 * * * *',
+      message: 'test',
+    });
+
+    const raw = getRawDb().query('SELECT schedule_syntax FROM cron_jobs WHERE id = ?').get(job.id) as { schedule_syntax: string } | null;
+    expect(raw).not.toBeNull();
+    expect(raw!.schedule_syntax).toBe('cron');
+  });
+
+  test('rejects invalid cron expression', () => {
+    expect(() => createSchedule({
+      name: 'Bad cron',
+      cronExpression: 'not-a-cron',
+      message: 'fail',
+    })).toThrow();
+  });
+});
+
+// ── RRULE schedule creation ──────────────────────────────────────────
+
+describe('createSchedule (RRULE)', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+  });
+
+  test('creates an RRULE schedule with syntax + expression', () => {
+    const rrule = 'DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;INTERVAL=1';
+    const job = createSchedule({
+      name: 'Daily RRULE',
+      cronExpression: rrule,
+      message: 'rrule test',
+      syntax: 'rrule',
+      expression: rrule,
+    });
+
+    expect(job.syntax).toBe('rrule');
+    expect(job.expression).toBe(rrule);
+    expect(job.cronExpression).toBe(rrule);
+    expect(job.nextRunAt).toBeGreaterThan(0);
+  });
+
+  test('stores rrule syntax in DB', () => {
+    const rrule = 'DTSTART:20260101T090000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO';
+    const job = createSchedule({
+      name: 'Weekly RRULE',
+      cronExpression: rrule,
+      message: 'weekly',
+      syntax: 'rrule',
+      expression: rrule,
+    });
+
+    const raw = getRawDb().query('SELECT schedule_syntax, cron_expression FROM cron_jobs WHERE id = ?').get(job.id) as { schedule_syntax: string; cron_expression: string } | null;
+    expect(raw).not.toBeNull();
+    expect(raw!.schedule_syntax).toBe('rrule');
+    expect(raw!.cron_expression).toBe(rrule);
+  });
+
+  test('rejects RRULE without DTSTART', () => {
+    expect(() => createSchedule({
+      name: 'No dtstart',
+      cronExpression: 'RRULE:FREQ=DAILY',
+      message: 'fail',
+      syntax: 'rrule',
+      expression: 'RRULE:FREQ=DAILY',
+    })).toThrow();
+  });
+});
+
+// ── updateSchedule with syntax/expression ────────────────────────────
+
+describe('updateSchedule', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+  });
+
+  test('updating cronExpression (legacy path) still works', () => {
+    const job = createSchedule({
+      name: 'Update test',
+      cronExpression: '0 9 * * *',
+      message: 'update me',
+    });
+
+    const updated = updateSchedule(job.id, { cronExpression: '0 10 * * *' });
+    expect(updated).not.toBeNull();
+    expect(updated!.cronExpression).toBe('0 10 * * *');
+    expect(updated!.expression).toBe('0 10 * * *');
+    expect(updated!.syntax).toBe('cron');
+    // nextRunAt should have been recomputed
+    expect(updated!.nextRunAt).not.toBe(job.nextRunAt);
+  });
+
+  test('updating syntax + expression switches to RRULE', () => {
+    const job = createSchedule({
+      name: 'Switch to RRULE',
+      cronExpression: '0 9 * * *',
+      message: 'switching',
+    });
+
+    const rrule = 'DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;INTERVAL=2';
+    const updated = updateSchedule(job.id, {
+      syntax: 'rrule',
+      expression: rrule,
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.syntax).toBe('rrule');
+    expect(updated!.expression).toBe(rrule);
+    expect(updated!.cronExpression).toBe(rrule);
+    expect(updated!.nextRunAt).toBeGreaterThan(0);
+
+    // Confirm DB has the right syntax
+    const raw = getRawDb().query('SELECT schedule_syntax FROM cron_jobs WHERE id = ?').get(job.id) as { schedule_syntax: string } | null;
+    expect(raw!.schedule_syntax).toBe('rrule');
+  });
+
+  test('rejects invalid expression on update', () => {
+    const job = createSchedule({
+      name: 'Reject bad update',
+      cronExpression: '0 9 * * *',
+      message: 'nope',
+    });
+
+    expect(() => updateSchedule(job.id, {
+      syntax: 'rrule',
+      expression: 'RRULE:FREQ=DAILY',
+    })).toThrow();
+  });
+});
+
+// ── claimDueSchedules ────────────────────────────────────────────────
+
+describe('claimDueSchedules', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+  });
+
+  test('claims due cron schedules and advances nextRunAt', () => {
+    const job = createSchedule({
+      name: 'Claim cron',
+      cronExpression: '* * * * *',
+      message: 'cron claim test',
+    });
+
+    // Force the schedule to be due
+    getRawDb().run('UPDATE cron_jobs SET next_run_at = ? WHERE id = ?', [Date.now() - 1000, job.id]);
+
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(1);
+    expect(claimed[0].id).toBe(job.id);
+    expect(claimed[0].syntax).toBe('cron');
+    expect(claimed[0].nextRunAt).toBeGreaterThan(Date.now() - 1000);
+  });
+
+  test('claims due RRULE schedules and advances nextRunAt', () => {
+    // Use an RRULE that fires every minute (roughly), with a DTSTART in the past
+    const rrule = 'DTSTART:20250101T000000Z\nRRULE:FREQ=MINUTELY;INTERVAL=1';
+    const job = createSchedule({
+      name: 'Claim RRULE',
+      cronExpression: rrule,
+      message: 'rrule claim test',
+      syntax: 'rrule',
+      expression: rrule,
+    });
+
+    // Force the schedule to be due
+    const pastTs = Date.now() - 60_000;
+    getRawDb().run('UPDATE cron_jobs SET next_run_at = ? WHERE id = ?', [pastTs, job.id]);
+
+    const now = Date.now();
+    const claimed = claimDueSchedules(now);
+    expect(claimed.length).toBe(1);
+    expect(claimed[0].id).toBe(job.id);
+    expect(claimed[0].syntax).toBe('rrule');
+    // nextRunAt should be in the future (at or after now)
+    expect(claimed[0].nextRunAt).toBeGreaterThanOrEqual(now);
+  });
+
+  test('does not claim schedules that are not yet due', () => {
+    createSchedule({
+      name: 'Not due yet',
+      cronExpression: '0 9 * * *',
+      message: 'future schedule',
+    });
+
+    const claimed = claimDueSchedules(0); // timestamp 0 means nothing is due
+    expect(claimed.length).toBe(0);
+  });
+
+  test('optimistic lock prevents double-claiming', () => {
+    const job = createSchedule({
+      name: 'Double claim',
+      cronExpression: '* * * * *',
+      message: 'no double',
+    });
+
+    getRawDb().run('UPDATE cron_jobs SET next_run_at = ? WHERE id = ?', [Date.now() - 1000, job.id]);
+
+    const first = claimDueSchedules(Date.now());
+    expect(first.length).toBe(1);
+
+    // Second claim should find nothing since nextRunAt was advanced
+    const second = claimDueSchedules(Date.now() - 500);
+    expect(second.length).toBe(0);
+  });
+});

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -3,11 +3,15 @@ import { v4 as uuid } from 'uuid';
 import { Cron } from 'croner';
 import { getDb } from '../memory/db.js';
 import { cronJobs, cronRuns } from '../memory/schema.js';
+import { computeNextRunAt as computeNextRunAtEngine, isValidScheduleExpression } from './recurrence-engine.js';
+import type { ScheduleSyntax } from './recurrence-types.js';
 
 export interface ScheduleJob {
   id: string;
   name: string;
   enabled: boolean;
+  syntax: ScheduleSyntax;
+  expression: string;
   cronExpression: string;
   timezone: string | null;
   message: string;
@@ -60,9 +64,16 @@ export function createSchedule(params: {
   message: string;
   enabled?: boolean;
   createdBy?: string;
+  syntax?: ScheduleSyntax;
+  expression?: string;
 }): ScheduleJob {
-  if (!isValidCronExpression(params.cronExpression)) {
-    throw new Error(`Invalid cron expression: "${params.cronExpression}"`);
+  // Resolve syntax and expression: prefer explicit syntax/expression, fall back to cron
+  const syntax: ScheduleSyntax = params.syntax ?? 'cron';
+  const expression = params.expression ?? params.cronExpression;
+
+  const spec = { syntax, expression, timezone: params.timezone };
+  if (!isValidScheduleExpression(spec)) {
+    throw new Error(`Invalid ${syntax} expression: "${expression}"`);
   }
 
   const db = getDb();
@@ -70,13 +81,14 @@ export function createSchedule(params: {
   const now = Date.now();
   const enabled = params.enabled ?? true;
   const timezone = params.timezone ?? null;
-  const nextRunAt = enabled ? computeNextRunAt(params.cronExpression, timezone) : 0;
+  const nextRunAt = enabled ? computeNextRunAtEngine(spec) : 0;
 
   const row = {
     id,
     name: params.name,
     enabled,
-    cronExpression: params.cronExpression,
+    cronExpression: expression,
+    scheduleSyntax: syntax,
     timezone,
     message: params.message,
     nextRunAt,
@@ -89,7 +101,7 @@ export function createSchedule(params: {
   };
 
   db.insert(cronJobs).values(row).run();
-  return row;
+  return parseJobRow(row);
 }
 
 export function getSchedule(id: string): ScheduleJob | null {
@@ -123,35 +135,48 @@ export function updateSchedule(
     timezone?: string | null;
     message?: string;
     enabled?: boolean;
+    syntax?: ScheduleSyntax;
+    expression?: string;
   },
 ): ScheduleJob | null {
   const db = getDb();
   const existing = db.select().from(cronJobs).where(eq(cronJobs.id, id)).get();
   if (!existing) return null;
 
-  if (updates.cronExpression && !isValidCronExpression(updates.cronExpression)) {
-    throw new Error(`Invalid cron expression: "${updates.cronExpression}"`);
+  // Resolve the effective syntax and expression after this update
+  const newSyntax = updates.syntax ?? (existing.scheduleSyntax as ScheduleSyntax) ?? 'cron';
+  const newExpr = updates.expression ?? updates.cronExpression ?? existing.cronExpression;
+  const newTimezone = updates.timezone !== undefined ? updates.timezone : existing.timezone;
+  const newEnabled = updates.enabled !== undefined ? updates.enabled : existing.enabled;
+
+  // Validate if expression or syntax changed
+  if (updates.expression !== undefined || updates.cronExpression !== undefined || updates.syntax !== undefined) {
+    const spec = { syntax: newSyntax, expression: newExpr, timezone: newTimezone };
+    if (!isValidScheduleExpression(spec)) {
+      throw new Error(`Invalid ${newSyntax} expression: "${newExpr}"`);
+    }
   }
 
   const now = Date.now();
   const set: Record<string, unknown> = { updatedAt: now };
 
   if (updates.name !== undefined) set.name = updates.name;
-  if (updates.cronExpression !== undefined) set.cronExpression = updates.cronExpression;
+  if (updates.cronExpression !== undefined || updates.expression !== undefined) set.cronExpression = newExpr;
+  if (updates.syntax !== undefined) set.scheduleSyntax = newSyntax;
   if (updates.timezone !== undefined) set.timezone = updates.timezone;
   if (updates.message !== undefined) set.message = updates.message;
   if (updates.enabled !== undefined) set.enabled = updates.enabled;
 
-  const newExpr = updates.cronExpression ?? existing.cronExpression;
-  const newTimezone = updates.timezone !== undefined ? updates.timezone : existing.timezone;
-  const newEnabled = updates.enabled !== undefined ? updates.enabled : existing.enabled;
-
+  // Recompute nextRunAt if schedule timing may have changed
   if (
     updates.cronExpression !== undefined ||
+    updates.expression !== undefined ||
+    updates.syntax !== undefined ||
     updates.timezone !== undefined ||
     updates.enabled !== undefined
   ) {
-    set.nextRunAt = newEnabled ? computeNextRunAt(newExpr, newTimezone) : 0;
+    const spec = { syntax: newSyntax, expression: newExpr, timezone: newTimezone };
+    set.nextRunAt = newEnabled ? computeNextRunAtEngine(spec) : 0;
   }
 
   db.update(cronJobs).set(set).where(eq(cronJobs.id, id)).run();
@@ -183,7 +208,12 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
   for (const row of candidates) {
     let newNextRunAt: number;
     try {
-      newNextRunAt = computeNextRunAt(row.cronExpression, row.timezone);
+      const syntax = (row.scheduleSyntax as ScheduleSyntax) ?? 'cron';
+      newNextRunAt = computeNextRunAtEngine({
+        syntax,
+        expression: row.cronExpression,
+        timezone: row.timezone,
+      });
     } catch {
       // Expression has no future runs — skip
       continue;
@@ -423,6 +453,8 @@ function parseJobRow(row: typeof cronJobs.$inferSelect): ScheduleJob {
     id: row.id,
     name: row.name,
     enabled: row.enabled,
+    syntax: (row.scheduleSyntax as ScheduleSyntax) ?? 'cron',
+    expression: row.cronExpression,
     cronExpression: row.cronExpression,
     timezone: row.timezone,
     message: row.message,


### PR DESCRIPTION
## Summary
- Upgrades the schedule store to support both cron and RRULE syntax via the recurrence engine introduced in PR 02
- Adds `syntax` and `expression` fields to the `ScheduleJob` interface while preserving `cronExpression` for backward compatibility
- `createSchedule` and `updateSchedule` now accept optional `syntax`/`expression` params; when omitted, defaults to cron behavior
- `claimDueSchedules` reads `schedule_syntax` from DB rows and delegates to `computeNextRunAtEngine` for syntax-aware next-run computation
- Persists `schedule_syntax` in the DB (`cron_jobs.schedule_syntax` column added in PR 03)
- All existing cron-only callers continue to work without changes

## Test plan
- [x] New test suite `schedule-store.test.ts` with 14 tests covering:
  - Cron schedule creation via legacy API (backward compat)
  - RRULE schedule creation with syntax + expression
  - DB persistence of `schedule_syntax` column
  - Validation rejection of invalid expressions
  - `updateSchedule` with syntax/expression switching
  - `claimDueSchedules` advancing both cron and RRULE schedules
  - Optimistic lock preventing double-claiming
- [x] Existing `task-scheduler.test.ts` passes (6/6)
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
