### PR TITLE
RRULE sets engine support (RDATE/EXDATE/EXRULE/multi-RRULE)

### DIFF
--- a/assistant/src/__tests__/recurrence-engine-rruleset.test.ts
+++ b/assistant/src/__tests__/recurrence-engine-rruleset.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test';
+import { isValidScheduleExpression, computeNextRunAt } from '../schedule/recurrence-engine.js';
+
+describe('RRULE set engine support', () => {
+  test('multiple RRULE lines are unioned — next run is earliest', () => {
+    // Daily at 9am + Weekly on Mondays at 3pm, starting Jan 1 2099
+    const expr = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=15;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr });
+    expect(next).toBeGreaterThan(Date.now());
+  });
+
+  test('RRULE + EXDATE excludes matching occurrence', () => {
+    // Daily starting Jan 1 2099, exclude Jan 2
+    const expr = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;COUNT=5',
+      'EXDATE:20990102T090000Z',
+    ].join('\n');
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+    // First occurrence: Jan 1, second should skip Jan 2 and be Jan 3
+    const jan1 = new Date('2099-01-01T09:00:00Z').getTime();
+    const jan2 = new Date('2099-01-02T09:00:00Z').getTime();
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr }, jan1 + 1);
+    // Should not be Jan 2 (excluded)
+    expect(next).not.toBe(jan2);
+  });
+
+  test('RDATE adds ad-hoc occurrence', () => {
+    // Weekly on Mondays + an extra occurrence on Jan 15 2099 (Wednesday)
+    const expr = [
+      'DTSTART:20990106T090000Z',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO',
+      'RDATE:20990115T090000Z',
+    ].join('\n');
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+  });
+
+  test('unknown line is rejected', () => {
+    const expr = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY',
+      'SUMMARY:My event',
+    ].join('\n');
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(false);
+  });
+
+  test('expression without DTSTART is rejected', () => {
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toBe(false);
+  });
+
+  test('expression without inclusion source is rejected', () => {
+    const expr = 'DTSTART:20990101T090000Z\nEXDATE:20990102T090000Z';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(false);
+  });
+
+  test('escaped newlines are normalized', () => {
+    const expr = 'DTSTART:20990101T090000Z\\nRRULE:FREQ=DAILY';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr });
+    expect(next).toBeGreaterThan(Date.now());
+  });
+
+  test('existing single RRULE still works', () => {
+    const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+  });
+
+  test('existing cron still works', () => {
+    expect(isValidScheduleExpression({ syntax: 'cron', expression: '0 9 * * 1-5' })).toBe(true);
+    const next = computeNextRunAt({ syntax: 'cron', expression: '* * * * *' });
+    expect(next).toBeGreaterThan(Date.now() - 1);
+  });
+});

--- a/assistant/src/__tests__/recurrence-engine.test.ts
+++ b/assistant/src/__tests__/recurrence-engine.test.ts
@@ -31,15 +31,15 @@ describe('recurrence engine — rrule', () => {
     expect(isValidScheduleExpression({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toBe(false);
   });
 
-  test('rejects RRULE set constructs', () => {
+  test('accepts RRULE set constructs', () => {
     const withExdate = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20250105T090000Z';
-    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withExdate })).toBe(false);
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withExdate })).toBe(true);
 
     const withRdate = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nRDATE:20250115T090000Z';
-    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withRdate })).toBe(false);
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: withRdate })).toBe(true);
 
     const multiRrule = 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY\nRRULE:FREQ=WEEKLY';
-    expect(isValidScheduleExpression({ syntax: 'rrule', expression: multiRrule })).toBe(false);
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: multiRrule })).toBe(true);
   });
 
   test('computes next run for RRULE with future DTSTART', () => {
@@ -59,8 +59,11 @@ describe('recurrence engine — rrule', () => {
     expect(() => computeNextRunAt({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toThrow(/DTSTART/);
   });
 
-  test('throws for RRULE set constructs in computeNextRunAt', () => {
-    const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20990105T090000Z';
-    expect(() => computeNextRunAt({ syntax: 'rrule', expression: expr })).toThrow(/set constructs/);
+  test('computes next run for RRULE with EXDATE set construct', () => {
+    const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20990101T090000Z';
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr });
+    // Should skip the excluded date and return January 2
+    const jan2 = new Date('2099-01-02T09:00:00Z').getTime();
+    expect(next).toBe(jan2);
   });
 });

--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -1,11 +1,56 @@
 import { Cron } from 'croner';
-import { rrulestr } from 'rrule';
+import { rrulestr, RRuleSet } from 'rrule';
 import type { ScheduleSyntax } from './recurrence-types.js';
 
 export interface ScheduleSpec {
   syntax: ScheduleSyntax;
   expression: string;
   timezone?: string | null;
+}
+
+const SUPPORTED_RRULE_PREFIXES = ['DTSTART', 'RRULE:', 'RDATE', 'EXDATE', 'EXRULE'];
+
+function normalizeRruleExpression(expression: string): string {
+  // Handle escaped newlines from JSON transport
+  return expression.replace(/\\n/g, '\n').trim();
+}
+
+function parseRruleLines(expression: string): string[] {
+  return normalizeRruleExpression(expression)
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(Boolean);
+}
+
+function validateRruleLines(lines: string[]): string | null {
+  let hasInclusion = false;
+  let hasDtstart = false;
+
+  for (const line of lines) {
+    if (!SUPPORTED_RRULE_PREFIXES.some(p => line.startsWith(p))) {
+      return `Unsupported recurrence line: ${line}`;
+    }
+    if (line.startsWith('DTSTART')) hasDtstart = true;
+    if (line.startsWith('RRULE:') || line.startsWith('RDATE')) hasInclusion = true;
+  }
+
+  if (!hasDtstart) return 'RRULE expression must include DTSTART for deterministic scheduling';
+  if (!hasInclusion) return 'RRULE expression must include at least one RRULE or RDATE';
+  return null;
+}
+
+/**
+ * Detect whether an RRULE expression contains set constructs (RDATE, EXDATE,
+ * EXRULE, or multiple RRULE lines) that require RRuleSet parsing.
+ */
+function hasSetConstructs(expression: string): boolean {
+  const lines = parseRruleLines(expression);
+  let rruleCount = 0;
+  for (const line of lines) {
+    if (line.startsWith('RDATE') || line.startsWith('EXDATE') || line.startsWith('EXRULE')) return true;
+    if (line.startsWith('RRULE:')) rruleCount++;
+  }
+  return rruleCount > 1;
 }
 
 /**
@@ -20,15 +65,16 @@ export function isValidScheduleExpression(spec: ScheduleSpec): boolean {
     }
 
     if (spec.syntax === 'rrule') {
-      // Require DTSTART for deterministic anchoring
-      if (!spec.expression.includes('DTSTART')) {
-        return false;
+      const lines = parseRruleLines(spec.expression);
+      const error = validateRruleLines(lines);
+      if (error) return false;
+
+      const normalized = normalizeRruleExpression(spec.expression);
+      if (hasSetConstructs(normalized)) {
+        rrulestr(normalized, { forceset: true });
+      } else {
+        rrulestr(normalized);
       }
-      // Reject set constructs for now (lifted in PR 13)
-      if (hasSetConstructs(spec.expression)) {
-        return false;
-      }
-      rrulestr(spec.expression);
       return true;
     }
 
@@ -57,15 +103,16 @@ export function computeNextRunAt(spec: ScheduleSpec, nowMs?: number): number {
   }
 
   if (spec.syntax === 'rrule') {
-    if (!spec.expression.includes('DTSTART')) {
-      throw new Error('RRULE expression must include DTSTART for deterministic scheduling');
-    }
-    if (hasSetConstructs(spec.expression)) {
-      throw new Error('RRULE set constructs (RDATE, EXDATE, EXRULE, multiple RRULE) are not yet supported. Support will be added in a future update.');
-    }
+    const normalized = normalizeRruleExpression(spec.expression);
+    const lines = parseRruleLines(normalized);
+    const error = validateRruleLines(lines);
+    if (error) throw new Error(error);
 
-    const rule = rrulestr(spec.expression);
-    const next = rule.after(new Date(now), true);
+    const useSet = hasSetConstructs(normalized);
+    const parsed = useSet
+      ? (rrulestr(normalized, { forceset: true }) as RRuleSet)
+      : rrulestr(normalized);
+    const next = parsed.after(new Date(now), true);
     if (!next) {
       throw new Error(`RRULE expression has no upcoming runs after ${new Date(now).toISOString()}`);
     }
@@ -73,22 +120,4 @@ export function computeNextRunAt(spec: ScheduleSpec, nowMs?: number): number {
   }
 
   throw new Error(`Unsupported schedule syntax: ${spec.syntax}`);
-}
-
-/**
- * Check if an RRULE expression contains set constructs (RDATE, EXDATE, EXRULE,
- * or multiple RRULE lines). These are deferred to PR 13.
- */
-function hasSetConstructs(expression: string): boolean {
-  const lines = expression.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-  let rruleCount = 0;
-  for (const line of lines) {
-    if (line.startsWith('RDATE') || line.startsWith('EXDATE') || line.startsWith('EXRULE')) {
-      return true;
-    }
-    if (line.startsWith('RRULE:')) {
-      rruleCount++;
-    }
-  }
-  return rruleCount > 1;
 }


### PR DESCRIPTION
## Summary
- Lifts the temporary set-construct rejection from the recurrence engine, adding full RRULE set semantics
- Supports multiple RRULE union, RDATE injection, and EXDATE/EXRULE exclusion via `rrulestr(..., { forceset: true })`
- Adds `normalizeRruleExpression` for escaped newline handling from JSON transport, plus `validateRruleLines` to reject unsupported iCalendar properties and require DTSTART + at least one inclusion source

## Test plan
- [x] New test suite `recurrence-engine-rruleset.test.ts` covers multi-RRULE union, EXDATE exclusion, RDATE injection, unknown line rejection, missing DTSTART, missing inclusion source, escaped newlines, and backward compatibility
- [x] Existing `recurrence-engine.test.ts` updated to expect set constructs are accepted (not rejected)
- [x] All 19 tests pass across both files
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
