### PR TITLE
fix: remove unused CCCommandEntry import in test

### DIFF
--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -7,7 +7,6 @@ import {
   getCCCommand,
   loadCCCommandTemplate,
   invalidateCCCommandCache,
-  type CCCommandEntry,
 } from '../cc-command-registry.js';
 
 let tmpDir: string;


### PR DESCRIPTION
## Summary
- Remove unused `CCCommandEntry` type import from `cc-command-registry.test.ts` to fix eslint `no-unused-vars` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
