### PR TITLE
IPC contract: add syntax/expression (keep cronExpression)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -734,6 +734,20 @@ exports[`IPC message snapshots ClientMessage types work_item_approve_permissions
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types work_item_cancel serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_cancel",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types work_item_render serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "type": "work_item_render",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types document_save serializes to expected JSON 1`] = `
 {
   "content": "# Hello",
@@ -1476,12 +1490,14 @@ exports[`IPC message snapshots ServerMessage types schedules_list_response seria
       "cronExpression": "0 9 * * 1-5",
       "description": "Every weekday at 9:00 AM",
       "enabled": true,
+      "expression": "0 9 * * 1-5",
       "id": "sched-001",
       "lastRunAt": 1700000000000,
       "lastStatus": "ok",
       "message": "Remind me about the standup",
       "name": "Daily standup reminder",
       "nextRunAt": 1700100000000,
+      "syntax": "cron",
       "timezone": "America/Los_Angeles",
     },
   ],
@@ -2114,6 +2130,24 @@ exports[`IPC message snapshots ServerMessage types work_item_approve_permissions
   "id": "wi-001",
   "success": true,
   "type": "work_item_approve_permissions_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_cancel_response serializes to expected JSON 1`] = `
+{
+  "id": "wi-001",
+  "success": true,
+  "type": "work_item_cancel_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types work_item_render_response serializes to expected JSON 1`] = `
+{
+  "content": "# Rendered Work Item",
+  "id": "wi-001",
+  "success": true,
+  "title": "Process report",
+  "type": "work_item_render_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -924,6 +924,8 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         id: 'sched-001',
         name: 'Daily standup reminder',
         enabled: true,
+        syntax: 'cron',
+        expression: '0 9 * * 1-5',
         cronExpression: '0 9 * * 1-5',
         timezone: 'America/Los_Angeles',
         message: 'Remind me about the standup',

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -237,13 +237,15 @@ export function handleSchedulesList(socket: net.Socket, ctx: HandlerContext): vo
       id: j.id,
       name: j.name,
       enabled: j.enabled,
+      syntax: j.syntax,
+      expression: j.expression,
       cronExpression: j.cronExpression,
       timezone: j.timezone,
       message: j.message,
       nextRunAt: j.nextRunAt,
       lastRunAt: j.lastRunAt,
       lastStatus: j.lastStatus,
-      description: describeCronExpression(j.cronExpression),
+      description: j.syntax === 'cron' ? describeCronExpression(j.cronExpression) : j.expression,
     })),
   });
 }

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1454,6 +1454,8 @@ export interface SchedulesListResponse {
     id: string;
     name: string;
     enabled: boolean;
+    syntax: string;
+    expression: string;
     cronExpression: string;
     timezone: string | null;
     message: string;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1099,6 +1099,8 @@ public struct IPCSchedulesListResponseSchedule: Codable, Sendable {
     public let id: String
     public let name: String
     public let enabled: Bool
+    public let syntax: String
+    public let expression: String
     public let cronExpression: String
     public let timezone: String?
     public let message: String


### PR DESCRIPTION
## Summary
- Adds `syntax` and `expression` fields to the `SchedulesListResponse` IPC message type, enabling clients to distinguish between cron and RRULE schedules
- Keeps `cronExpression` for backward compatibility with existing clients
- Updates the handler to use syntax-aware description generation (cron descriptions for cron schedules, raw expression for RRULE)
- Regenerates Swift DTOs and updates test snapshots

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass with updated fixtures
- [x] IPC contract inventory tests pass
- [x] Generated Swift file includes new fields
- [x] Pre-commit hooks pass (IPC contract validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
