### PR TITLE
Tool contract: syntax + expression with cron alias

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -32,14 +32,10 @@ mock.module('../config/loader.js', () => ({
 import type { Database } from 'bun:sqlite';
 import { initializeDb, getDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
-
-// Register schedule tools
-await import('../tools/schedule/create.js');
-await import('../tools/schedule/list.js');
-await import('../tools/schedule/update.js');
-await import('../tools/schedule/delete.js');
-
-import { getTool } from '../tools/registry.js';
+import { executeScheduleCreate } from '../tools/schedule/create.js';
+import { executeScheduleList } from '../tools/schedule/list.js';
+import { executeScheduleUpdate } from '../tools/schedule/update.js';
+import { executeScheduleDelete } from '../tools/schedule/delete.js';
 
 initializeDb();
 
@@ -65,10 +61,8 @@ describe('schedule_create tool', () => {
     getRawDb().run('DELETE FROM cron_jobs');
   });
 
-  const tool = getTool('schedule_create')!;
-
   test('creates a schedule with valid cron expression', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       name: 'Daily standup',
       cron_expression: '0 9 * * 1-5',
       message: 'Time for standup!',
@@ -82,7 +76,7 @@ describe('schedule_create tool', () => {
   });
 
   test('creates a disabled schedule', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       name: 'Paused job',
       cron_expression: '0 12 * * *',
       message: 'Noon check',
@@ -94,7 +88,7 @@ describe('schedule_create tool', () => {
   });
 
   test('creates a schedule with timezone', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       name: 'LA morning',
       cron_expression: '0 8 * * *',
       message: 'Good morning LA',
@@ -106,7 +100,7 @@ describe('schedule_create tool', () => {
   });
 
   test('rejects missing name', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
@@ -115,18 +109,18 @@ describe('schedule_create tool', () => {
     expect(result.content).toContain('name is required');
   });
 
-  test('rejects missing cron_expression', async () => {
-    const result = await tool.execute({
+  test('rejects missing expression', async () => {
+    const result = await executeScheduleCreate({
       name: 'Test',
       message: 'test',
     }, ctx);
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('cron_expression is required');
+    expect(result.content).toContain('expression (or cron_expression) is required');
   });
 
   test('rejects missing message', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       name: 'Test',
       cron_expression: '0 9 * * *',
     }, ctx);
@@ -136,7 +130,7 @@ describe('schedule_create tool', () => {
   });
 
   test('rejects invalid cron expression', async () => {
-    const result = await tool.execute({
+    const result = await executeScheduleCreate({
       name: 'Bad cron',
       cron_expression: 'not-a-cron',
       message: 'test',
@@ -155,29 +149,26 @@ describe('schedule_list tool', () => {
     getRawDb().run('DELETE FROM cron_jobs');
   });
 
-  const createTool = getTool('schedule_create')!;
-  const listTool = getTool('schedule_list')!;
-
   test('returns empty message when no schedules exist', async () => {
-    const result = await listTool.execute({}, ctx);
+    const result = await executeScheduleList({}, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No schedules found');
   });
 
   test('lists all schedules', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Job Alpha',
       cron_expression: '0 9 * * *',
       message: 'Alpha',
     }, ctx);
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Job Beta',
       cron_expression: '0 17 * * *',
       message: 'Beta',
     }, ctx);
 
-    const result = await listTool.execute({}, ctx);
+    const result = await executeScheduleList({}, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Schedules (2)');
@@ -186,19 +177,19 @@ describe('schedule_list tool', () => {
   });
 
   test('filters to enabled only', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Enabled Job',
       cron_expression: '0 9 * * *',
       message: 'enabled',
     }, ctx);
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Disabled Job',
       cron_expression: '0 17 * * *',
       message: 'disabled',
       enabled: false,
     }, ctx);
 
-    const result = await listTool.execute({ enabled_only: true }, ctx);
+    const result = await executeScheduleList({ enabled_only: true }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Enabled Job');
@@ -206,16 +197,15 @@ describe('schedule_list tool', () => {
   });
 
   test('shows detail for a specific job', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Detail Job',
       cron_expression: '30 14 * * *',
       message: 'Afternoon check',
     }, ctx);
 
-    // Get the job ID from the DB
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
 
-    const result = await listTool.execute({ job_id: row.id }, ctx);
+    const result = await executeScheduleList({ job_id: row.id }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Schedule: Detail Job');
@@ -226,7 +216,7 @@ describe('schedule_list tool', () => {
   });
 
   test('returns error for nonexistent job_id', async () => {
-    const result = await listTool.execute({ job_id: 'nonexistent' }, ctx);
+    const result = await executeScheduleList({ job_id: 'nonexistent' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Schedule not found');
@@ -241,18 +231,15 @@ describe('schedule_update tool', () => {
     getRawDb().run('DELETE FROM cron_jobs');
   });
 
-  const createTool = getTool('schedule_create')!;
-  const updateTool = getTool('schedule_update')!;
-
   test('updates the name of a schedule', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Old Name',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await updateTool.execute({
+    const result = await executeScheduleUpdate({
       job_id: row.id,
       name: 'New Name',
     }, ctx);
@@ -263,14 +250,14 @@ describe('schedule_update tool', () => {
   });
 
   test('updates the cron expression', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Timing Test',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await updateTool.execute({
+    const result = await executeScheduleUpdate({
       job_id: row.id,
       cron_expression: '0 17 * * *',
     }, ctx);
@@ -280,14 +267,14 @@ describe('schedule_update tool', () => {
   });
 
   test('disables a schedule', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Disable Me',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await updateTool.execute({
+    const result = await executeScheduleUpdate({
       job_id: row.id,
       enabled: false,
     }, ctx);
@@ -298,28 +285,28 @@ describe('schedule_update tool', () => {
   });
 
   test('rejects missing job_id', async () => {
-    const result = await updateTool.execute({ name: 'test' }, ctx);
+    const result = await executeScheduleUpdate({ name: 'test' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('job_id is required');
   });
 
   test('rejects update with no fields', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'No Update',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await updateTool.execute({ job_id: row.id }, ctx);
+    const result = await executeScheduleUpdate({ job_id: row.id }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('No updates provided');
   });
 
   test('returns error for nonexistent job_id', async () => {
-    const result = await updateTool.execute({
+    const result = await executeScheduleUpdate({
       job_id: 'nonexistent',
       name: 'test',
     }, ctx);
@@ -329,20 +316,161 @@ describe('schedule_update tool', () => {
   });
 
   test('rejects invalid cron expression in update', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Bad Update',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await updateTool.execute({
+    const result = await executeScheduleUpdate({
       job_id: row.id,
       cron_expression: 'invalid',
     }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Invalid cron expression');
+  });
+});
+
+// ── RRULE support in schedule tools ─────────────────────────────────
+
+describe('schedule_create with RRULE', () => {
+  beforeEach(() => {
+    getRawDb().run('DELETE FROM cron_runs');
+    getRawDb().run('DELETE FROM cron_jobs');
+  });
+
+  test('creates a schedule with legacy cron_expression', async () => {
+    const result = await executeScheduleCreate({
+      name: 'Legacy cron',
+      cron_expression: '0 9 * * 1-5',
+      message: 'Legacy test',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Schedule created successfully');
+    expect(result.content).toContain('Syntax: cron');
+    expect(result.content).toContain('Every weekday at 9:00 AM');
+  });
+
+  test('creates a schedule with RRULE syntax + expression', async () => {
+    const result = await executeScheduleCreate({
+      name: 'RRULE daily',
+      syntax: 'rrule',
+      expression: 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY',
+      message: 'RRULE test',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Schedule created successfully');
+    expect(result.content).toContain('Syntax: rrule');
+    expect(result.content).toContain('RRULE:FREQ=DAILY');
+  });
+
+  test('auto-detects RRULE syntax when syntax is omitted', async () => {
+    const result = await executeScheduleCreate({
+      name: 'Auto-detect RRULE',
+      expression: 'DTSTART:20250601T120000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO',
+      message: 'Auto-detect test',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Syntax: rrule');
+    expect(result.content).toContain('RRULE:FREQ=WEEKLY');
+  });
+
+  test('rejects RRULE missing DTSTART with deterministic message', async () => {
+    const result = await executeScheduleCreate({
+      name: 'No DTSTART',
+      syntax: 'rrule',
+      expression: 'RRULE:FREQ=DAILY',
+      message: 'Should fail',
+    }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('DTSTART');
+    expect(result.content).toContain('deterministic');
+  });
+});
+
+describe('schedule_update with RRULE', () => {
+  beforeEach(() => {
+    getRawDb().run('DELETE FROM cron_runs');
+    getRawDb().run('DELETE FROM cron_jobs');
+  });
+
+  test('switches a cron schedule to rrule', async () => {
+    await executeScheduleCreate({
+      name: 'Cron to RRULE',
+      cron_expression: '0 9 * * *',
+      message: 'test',
+    }, ctx);
+
+    const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
+    const result = await executeScheduleUpdate({
+      job_id: row.id,
+      syntax: 'rrule',
+      expression: 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Schedule updated successfully');
+    expect(result.content).toContain('Syntax: rrule');
+    expect(result.content).toContain('RRULE:FREQ=DAILY');
+  });
+});
+
+describe('schedule_list with RRULE', () => {
+  beforeEach(() => {
+    getRawDb().run('DELETE FROM cron_runs');
+    getRawDb().run('DELETE FROM cron_jobs');
+  });
+
+  test('shows syntax-aware output for cron schedules', async () => {
+    await executeScheduleCreate({
+      name: 'Cron Job',
+      cron_expression: '0 9 * * 1-5',
+      message: 'Cron test',
+    }, ctx);
+
+    const result = await executeScheduleList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('[cron]');
+    expect(result.content).toContain('Every weekday at 9:00 AM');
+  });
+
+  test('shows syntax-aware output for rrule schedules', async () => {
+    await executeScheduleCreate({
+      name: 'RRULE Job',
+      syntax: 'rrule',
+      expression: 'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY',
+      message: 'RRULE test',
+    }, ctx);
+
+    const result = await executeScheduleList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('[rrule]');
+    expect(result.content).toContain('RRULE:FREQ=DAILY');
+  });
+
+  test('shows syntax and expression in detail mode', async () => {
+    await executeScheduleCreate({
+      name: 'Detail RRULE',
+      syntax: 'rrule',
+      expression: 'DTSTART:20250601T120000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO',
+      message: 'Detail test',
+    }, ctx);
+
+    const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
+    const result = await executeScheduleList({ job_id: row.id }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Syntax: rrule');
+    expect(result.content).toContain('Expression:');
+    expect(result.content).toContain('RRULE:FREQ=WEEKLY');
   });
 });
 
@@ -354,18 +482,15 @@ describe('schedule_delete tool', () => {
     getRawDb().run('DELETE FROM cron_jobs');
   });
 
-  const createTool = getTool('schedule_create')!;
-  const deleteTool = getTool('schedule_delete')!;
-
   test('deletes a schedule', async () => {
-    await createTool.execute({
+    await executeScheduleCreate({
       name: 'Delete Me',
       cron_expression: '0 9 * * *',
       message: 'test',
     }, ctx);
 
     const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
-    const result = await deleteTool.execute({ job_id: row.id }, ctx);
+    const result = await executeScheduleDelete({ job_id: row.id }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Schedule deleted');
@@ -377,14 +502,14 @@ describe('schedule_delete tool', () => {
   });
 
   test('rejects missing job_id', async () => {
-    const result = await deleteTool.execute({}, ctx);
+    const result = await executeScheduleDelete({}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('job_id is required');
   });
 
   test('returns error for nonexistent job_id', async () => {
-    const result = await deleteTool.execute({ job_id: 'nonexistent' }, ctx);
+    const result = await executeScheduleDelete({ job_id: 'nonexistent' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Schedule not found');

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: "Schedule"
-description: "Cron-like recurring automation that dispatches messages on a schedule"
+description: "Recurring automation that dispatches messages on a cron or RRULE schedule"
 metadata: {"vellum": {"emoji": "\ud83d\udcc5"}}
 ---
 
-Manage recurring scheduled automations (cron jobs). Each schedule has a cron expression that defines when it fires, and a message that gets dispatched to the assistant at trigger time.
+Manage recurring scheduled automations. Each schedule has an expression (cron or RRULE) that defines when it fires, and a message that gets dispatched to the assistant at trigger time.
 
-## Cron Expression Format
+## Schedule Syntax
+
+### Cron
 
 Standard 5-field cron syntax: `minute hour day-of-month month day-of-week`
 
@@ -24,9 +26,22 @@ Examples:
 - `0 */2 * * *` — every 2 hours
 - `0 9 1 * *` — first of every month at 9:00 AM
 
+### RRULE (RFC 5545)
+
+iCalendar recurrence rules for complex patterns. Must include a DTSTART line.
+
+Examples:
+- `DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY` — every day at 9:00 AM UTC
+- `DTSTART:20250101T090000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR` — Mon/Wed/Fri at 9:00 AM UTC
+- `DTSTART:20250101T090000Z\nRRULE:FREQ=MONTHLY;BYMONTHDAY=1,15` — 1st and 15th of each month
+
+## Tool Input
+
+Use `syntax` + `expression` to specify the schedule type explicitly, or just `expression` to auto-detect. The legacy `cron_expression` field is still accepted as a cron alias.
+
 ## Lifecycle
 
-1. Create a schedule with a name, cron expression, and message.
+1. Create a schedule with a name, expression, and message.
 2. At each trigger time, the message is dispatched to the assistant as if the user sent it.
 3. Schedules can be enabled/disabled, updated, or deleted.
 
@@ -34,3 +49,4 @@ Examples:
 
 - Only use `schedule_create` when the user explicitly wants recurring automation (e.g. "every day at 9am", "weekly on Mondays"). For one-time tasks, use the task list instead.
 - Timezones default to the system timezone if omitted. Use IANA timezone identifiers (e.g. "America/Los_Angeles").
+- Prefer RRULE for complex patterns that cron cannot express (e.g. "every other Tuesday", "last weekday of the month").

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "schedule_create",
-      "description": "Create a recurring scheduled automation that sends a message at a cron interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"weekly on Mondays\", \"every hour\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" — use task_list_add for those requests instead.",
+      "description": "Create a recurring scheduled automation that sends a message at a cron or RRULE interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"weekly on Mondays\", \"every hour\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" — use task_list_add for those requests instead.",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -13,9 +13,18 @@
             "type": "string",
             "description": "A human-readable name for the scheduled task"
           },
+          "syntax": {
+            "type": "string",
+            "enum": ["cron", "rrule"],
+            "description": "Schedule syntax type. Auto-detected if omitted."
+          },
+          "expression": {
+            "type": "string",
+            "description": "Canonical schedule expression (cron or RRULE). Preferred over cron_expression."
+          },
           "cron_expression": {
             "type": "string",
-            "description": "A cron expression (e.g. \"0 9 * * 1-5\" for weekdays at 9am). Supports standard 5-field cron syntax."
+            "description": "Deprecated alias for expression with cron syntax. Use expression + syntax instead."
           },
           "timezone": {
             "type": "string",
@@ -30,14 +39,14 @@
             "description": "Whether the job is enabled immediately. Defaults to true."
           }
         },
-        "required": ["name", "cron_expression", "message"]
+        "required": ["name", "message"]
       },
       "executor": "tools/schedule-create.ts",
       "execution_target": "host"
     },
     {
       "name": "schedule_list",
-      "description": "List recurring scheduled automations (cron jobs), or show details and recent runs for a specific one. For the user's task queue, use task_list_show instead.",
+      "description": "List recurring scheduled automations (cron jobs or RRULE schedules), or show details and recent runs for a specific one. For the user's task queue, use task_list_show instead.",
       "category": "schedule",
       "risk": "low",
       "input_schema": {
@@ -59,7 +68,7 @@
     },
     {
       "name": "schedule_update",
-      "description": "Update an existing recurring scheduled automation (cron expression, message, name, or enabled state)",
+      "description": "Update an existing recurring scheduled automation (expression, syntax, message, name, or enabled state)",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -73,9 +82,18 @@
             "type": "string",
             "description": "New name for the job"
           },
+          "syntax": {
+            "type": "string",
+            "enum": ["cron", "rrule"],
+            "description": "Schedule syntax type. Auto-detected if omitted."
+          },
+          "expression": {
+            "type": "string",
+            "description": "New schedule expression (cron or RRULE). Preferred over cron_expression."
+          },
           "cron_expression": {
             "type": "string",
-            "description": "New cron expression"
+            "description": "Deprecated alias for expression with cron syntax. Use expression + syntax instead."
           },
           "timezone": {
             "type": "string",

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -1,12 +1,12 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { createSchedule, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
+import { normalizeScheduleSyntax } from '../../schedule/recurrence-types.js';
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const name = input.name as string;
-  const cronExpression = input.cron_expression as string;
   const timezone = (input.timezone as string) ?? null;
   const message = input.message as string;
   const enabled = (input.enabled as boolean) ?? true;
@@ -14,24 +14,51 @@ export async function executeScheduleCreate(
   if (!name || typeof name !== 'string') {
     return { content: 'Error: name is required and must be a string', isError: true };
   }
-  if (!cronExpression || typeof cronExpression !== 'string') {
-    return { content: 'Error: cron_expression is required and must be a string', isError: true };
-  }
   if (!message || typeof message !== 'string') {
     return { content: 'Error: message is required and must be a string', isError: true };
   }
-  if (!isValidCronExpression(cronExpression)) {
-    return { content: `Error: Invalid cron expression: "${cronExpression}"`, isError: true };
+
+  // Resolve syntax and expression from new or legacy fields
+  const resolved = normalizeScheduleSyntax({
+    syntax: input.syntax as 'cron' | 'rrule' | undefined,
+    expression: input.expression as string | undefined,
+    legacyCronExpression: input.cron_expression as string | undefined,
+  });
+
+  if (!resolved) {
+    return { content: 'Error: expression (or cron_expression) is required', isError: true };
+  }
+
+  // Syntax-specific pre-validation for actionable error messages
+  if (resolved.syntax === 'cron' && !isValidCronExpression(resolved.expression)) {
+    return { content: `Error: Invalid cron expression: "${resolved.expression}"`, isError: true };
+  }
+  if (resolved.syntax === 'rrule' && !/^DTSTART/m.test(resolved.expression)) {
+    return { content: 'Error: RRULE expression must include DTSTART for deterministic scheduling', isError: true };
   }
 
   try {
-    const job = createSchedule({ name, cronExpression, timezone, message, enabled });
+    const job = createSchedule({
+      name,
+      cronExpression: resolved.expression,
+      timezone,
+      message,
+      enabled,
+      syntax: resolved.syntax,
+      expression: resolved.expression,
+    });
+
+    const scheduleDescription = job.syntax === 'rrule'
+      ? job.expression
+      : describeCronExpression(job.cronExpression);
+
     const nextRunDate = formatLocalDate(job.nextRunAt);
     return {
       content: [
         `Schedule created successfully.`,
         `  Name: ${job.name}`,
-        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Syntax: ${job.syntax}`,
+        `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
         `  Next run: ${nextRunDate}`,
       ].join('\n'),

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -1,6 +1,13 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { listSchedules, getSchedule, getScheduleRuns, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
 
+function describeSchedule(job: { syntax: string; expression: string; cronExpression: string }): string {
+  if (job.syntax === 'rrule') {
+    return job.expression;
+  }
+  return describeCronExpression(job.cronExpression);
+}
+
 export async function executeScheduleList(
   input: Record<string, unknown>,
   _context: ToolContext,
@@ -18,7 +25,9 @@ export async function executeScheduleList(
     const runs = getScheduleRuns(jobId, 5);
     const lines = [
       `Schedule: ${job.name}`,
-      `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+      `  Syntax: ${job.syntax}`,
+      `  Expression: ${job.expression}`,
+      `  Schedule: ${describeSchedule(job)}${job.timezone ? ` (${job.timezone})` : ''}`,
       `  Enabled: ${job.enabled}`,
       `  Message: ${job.message}`,
       `  Next run: ${formatLocalDate(job.nextRunAt)}`,
@@ -51,7 +60,7 @@ export async function executeScheduleList(
   for (const job of jobs) {
     const status = job.enabled ? 'enabled' : 'disabled';
     const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
-    lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next}`);
+    lines.push(`  - [${status}] ${job.name} ([${job.syntax}] ${describeSchedule(job)}) — next: ${next}`);
   }
 
   return { content: lines.join('\n'), isError: false };

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,5 +1,6 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { updateSchedule, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
+import type { ScheduleSyntax } from '../../schedule/recurrence-types.js';
 
 export async function executeScheduleUpdate(
   input: Record<string, unknown>,
@@ -12,10 +13,20 @@ export async function executeScheduleUpdate(
 
   const updates: Record<string, unknown> = {};
   if (input.name !== undefined) updates.name = input.name;
-  if (input.cron_expression !== undefined) updates.cronExpression = input.cron_expression;
   if (input.timezone !== undefined) updates.timezone = input.timezone;
   if (input.message !== undefined) updates.message = input.message;
   if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  // New syntax/expression fields take precedence over legacy cron_expression
+  if (input.expression !== undefined) {
+    updates.expression = input.expression;
+  } else if (input.cron_expression !== undefined) {
+    updates.cronExpression = input.cron_expression;
+  }
+
+  if (input.syntax !== undefined) {
+    updates.syntax = input.syntax;
+  }
 
   if (Object.keys(updates).length === 0) {
     return { content: 'Error: No updates provided. Specify at least one field to update.', isError: true };
@@ -28,17 +39,24 @@ export async function executeScheduleUpdate(
       timezone?: string | null;
       message?: string;
       enabled?: boolean;
+      syntax?: ScheduleSyntax;
+      expression?: string;
     });
 
     if (!job) {
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
+    const scheduleDescription = job.syntax === 'rrule'
+      ? job.expression
+      : describeCronExpression(job.cronExpression);
+
     return {
       content: [
         `Schedule updated successfully.`,
         `  Name: ${job.name}`,
-        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Syntax: ${job.syntax}`,
+        `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
         `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a (disabled)'}`,
       ].join('\n'),


### PR DESCRIPTION
## Summary
- Add `syntax` and `expression` fields to `schedule_create` and `schedule_update` tool schemas alongside the existing `cron_expression` (now a deprecated alias)
- Update `schedule_list` output to show syntax type (e.g. `[cron]` or `[rrule]`) and display syntax-aware descriptions
- Add RRULE-specific pre-validation at the tool layer for actionable error messages (e.g. missing DTSTART)
- Update SKILL.md and TOOLS.json to document RRULE support
- Fix test file to call execute functions directly instead of going through broken `getTool()` registry lookup

## Test plan
- [x] Legacy `cron_expression` still creates schedules successfully
- [x] RRULE `syntax` + `expression` creates schedules
- [x] Auto-detection works when `syntax` is omitted
- [x] RRULE without DTSTART returns deterministic error message
- [x] `schedule_update` can switch cron to rrule
- [x] `schedule_list` shows `[cron]`/`[rrule]` syntax tags
- [x] Detail mode shows syntax and raw expression
- [x] All 30 tests pass, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
