### PR TITLE
Client UI: syntax-aware schedule rendering

### DIFF
--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -46,14 +46,23 @@ struct SchedulesSection: View {
     private func scheduleRow(_ schedule: ScheduleItem) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text(schedule.name)
-                    .font(.body)
+                HStack(spacing: 6) {
+                    Text(schedule.name)
+                        .font(.body)
+                    Text(schedule.syntax == "rrule" ? "rrule" : "cron")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background((schedule.syntax == "rrule" ? Color.purple : Color.blue).opacity(0.12))
+                        .foregroundStyle(schedule.syntax == "rrule" ? .purple : .blue)
+                        .clipShape(Capsule())
+                }
                 Text(schedule.description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                 HStack(spacing: 4) {
-                    Text(schedule.cronExpression)
+                    Text(schedule.expression)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                     if schedule.enabled, schedule.nextRunAt > 0, let nextRun = formatTimestamp(schedule.nextRunAt) {

--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -140,12 +140,27 @@ private struct ScheduleRow: View {
         }
     }
 
+    private var syntaxLabel: String {
+        schedule.syntax == "rrule" ? "rrule" : "cron"
+    }
+
+    private var syntaxColor: Color {
+        schedule.syntax == "rrule" ? .purple : .blue
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
                     Text(schedule.name)
                         .fontWeight(.medium)
+                    Text(syntaxLabel)
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(syntaxColor.opacity(0.12))
+                        .foregroundStyle(syntaxColor)
+                        .clipShape(Capsule())
                     if let status = schedule.lastStatus {
                         Text(status)
                             .font(.caption)
@@ -159,6 +174,10 @@ private struct ScheduleRow: View {
                 Text(schedule.description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                Text(schedule.expression)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
                 HStack(spacing: 6) {
                     if schedule.enabled {
                         Text("Next: \(nextRunText)")


### PR DESCRIPTION
## Summary
- Add syntax badge (cron/rrule) as a colored capsule chip next to each schedule name in both macOS and iOS views
- Display the canonical `expression` field (from the IPC contract) instead of the legacy `cronExpression` in schedule rows
- Keep existing enable/disable/delete actions and relative next-run rendering unchanged

## Test plan
- [ ] Open Scheduled Tasks settings on macOS — verify cron schedules show a blue "cron" badge and rrule schedules show a purple "rrule" badge
- [ ] Verify the expression text line shows the raw cron/rrule expression and is selectable on macOS
- [ ] Open Scheduled Tasks section on iOS — verify the same syntax badge and expression rendering
- [ ] Toggle and delete schedules to confirm existing actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
