### PR TITLE
Fix stale registry test expectations after skills migration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -176,19 +176,19 @@ describe('tool manifest', () => {
   });
 
   test('eager module tool names list contains expected count', () => {
-    expect(eagerModuleToolNames.length).toBe(31);
+    expect(eagerModuleToolNames.length).toBe(15);
   });
 
-  test('explicit tools list includes memory, credential, and timer tools', () => {
+  test('explicit tools list includes memory, credential, watch, catalog, and discover tools', () => {
     const names = explicitTools.map((t) => t.name);
     expect(names).toContain('memory_search');
     expect(names).toContain('memory_save');
     expect(names).toContain('memory_update');
     expect(names).toContain('credential_store');
     expect(names).toContain('account_manage');
-    expect(names).toContain('reminder_create');
-    expect(names).toContain('reminder_list');
-    expect(names).toContain('reminder_cancel');
+    expect(names).toContain('start_screen_watch');
+    expect(names).toContain('vellum_skills_catalog');
+    expect(names).toContain('cli_discover');
   });
 
   test('registered tool count is at least eager + lazy + host', async () => {


### PR DESCRIPTION
## Summary
- Update `eagerModuleToolNames.length` assertion from `31` to `15` to match the current tool manifest
- Replace stale `reminder_create`, `reminder_list`, `reminder_cancel` checks with the current explicit tools: `start_screen_watch`, `vellum_skills_catalog`, `cli_discover`

## Test plan
- [x] `bun test src/__tests__/registry.test.ts` — all 35 tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
