### PR TITLE
fix: remove stale barrel index.ts files from skills migration

### DIFF
--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -32,11 +32,9 @@ mock.module('../config/loader.js', () => ({
 import type { Database } from 'bun:sqlite';
 import { initializeDb, getDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
-
-// Register contact tools
-await import('../tools/contacts/index.js');
-
-import { getTool } from '../tools/registry.js';
+import { executeContactUpsert } from '../tools/contacts/contact-upsert.js';
+import { executeContactSearch } from '../tools/contacts/contact-search.js';
+import { executeContactMerge } from '../tools/contacts/contact-merge.js';
 
 initializeDb();
 
@@ -64,10 +62,8 @@ function clearContacts(): void {
 describe('contact_upsert tool', () => {
   beforeEach(clearContacts);
 
-  const tool = getTool('contact_upsert')!;
-
   test('creates a new contact with display name only', async () => {
-    const result = await tool.execute({ display_name: 'Alice' }, ctx);
+    const result = await executeContactUpsert({ display_name: 'Alice' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Created contact');
@@ -76,7 +72,7 @@ describe('contact_upsert tool', () => {
   });
 
   test('creates a contact with all fields', async () => {
-    const result = await tool.execute({
+    const result = await executeContactUpsert({
       display_name: 'Bob',
       relationship: 'colleague',
       importance: 0.8,
@@ -99,7 +95,7 @@ describe('contact_upsert tool', () => {
   });
 
   test('updates an existing contact by ID', async () => {
-    const createResult = await tool.execute({ display_name: 'Charlie' }, ctx);
+    const createResult = await executeContactUpsert({ display_name: 'Charlie' }, ctx);
     expect(createResult.isError).toBe(false);
 
     // Extract ID from output
@@ -107,7 +103,7 @@ describe('contact_upsert tool', () => {
     expect(idMatch).not.toBeNull();
     const contactId = idMatch![1];
 
-    const updateResult = await tool.execute({
+    const updateResult = await executeContactUpsert({
       id: contactId,
       display_name: 'Charlie Updated',
       importance: 0.9,
@@ -121,13 +117,13 @@ describe('contact_upsert tool', () => {
 
   test('auto-matches by channel address on create', async () => {
     // Create a contact with an email
-    await tool.execute({
+    await executeContactUpsert({
       display_name: 'Diana',
       channels: [{ type: 'email', address: 'diana@example.com' }],
     }, ctx);
 
     // Upsert with same email but different display name
-    const result = await tool.execute({
+    const result = await executeContactUpsert({
       display_name: 'Diana Updated',
       channels: [{ type: 'email', address: 'diana@example.com' }],
     }, ctx);
@@ -142,21 +138,21 @@ describe('contact_upsert tool', () => {
   });
 
   test('rejects missing display_name', async () => {
-    const result = await tool.execute({}, ctx);
+    const result = await executeContactUpsert({}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('display_name is required');
   });
 
   test('rejects empty display_name', async () => {
-    const result = await tool.execute({ display_name: '   ' }, ctx);
+    const result = await executeContactUpsert({ display_name: '   ' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('display_name is required');
   });
 
   test('rejects importance out of range', async () => {
-    const result = await tool.execute({
+    const result = await executeContactUpsert({
       display_name: 'Test',
       importance: 1.5,
     }, ctx);
@@ -166,7 +162,7 @@ describe('contact_upsert tool', () => {
   });
 
   test('rejects negative importance', async () => {
-    const result = await tool.execute({
+    const result = await executeContactUpsert({
       display_name: 'Test',
       importance: -0.1,
     }, ctx);
@@ -181,14 +177,11 @@ describe('contact_upsert tool', () => {
 describe('contact_search tool', () => {
   beforeEach(clearContacts);
 
-  const upsertTool = getTool('contact_upsert')!;
-  const searchTool = getTool('contact_search')!;
-
   test('searches by display name', async () => {
-    await upsertTool.execute({ display_name: 'Alice Smith' }, ctx);
-    await upsertTool.execute({ display_name: 'Bob Jones' }, ctx);
+    await executeContactUpsert({ display_name: 'Alice Smith' }, ctx);
+    await executeContactUpsert({ display_name: 'Bob Jones' }, ctx);
 
-    const result = await searchTool.execute({ query: 'Alice' }, ctx);
+    const result = await executeContactSearch({ query: 'Alice' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Alice Smith');
@@ -196,22 +189,22 @@ describe('contact_search tool', () => {
   });
 
   test('searches by channel address', async () => {
-    await upsertTool.execute({
+    await executeContactUpsert({
       display_name: 'Charlie',
       channels: [{ type: 'email', address: 'charlie@example.com' }],
     }, ctx);
 
-    const result = await searchTool.execute({ channel_address: 'charlie@example' }, ctx);
+    const result = await executeContactSearch({ channel_address: 'charlie@example' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Charlie');
   });
 
   test('searches by relationship', async () => {
-    await upsertTool.execute({ display_name: 'Diana', relationship: 'friend' }, ctx);
-    await upsertTool.execute({ display_name: 'Eve', relationship: 'colleague' }, ctx);
+    await executeContactUpsert({ display_name: 'Diana', relationship: 'friend' }, ctx);
+    await executeContactUpsert({ display_name: 'Eve', relationship: 'colleague' }, ctx);
 
-    const result = await searchTool.execute({ relationship: 'friend' }, ctx);
+    const result = await executeContactSearch({ relationship: 'friend' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Diana');
@@ -219,23 +212,23 @@ describe('contact_search tool', () => {
   });
 
   test('returns no results message when nothing matches', async () => {
-    await upsertTool.execute({ display_name: 'Existing' }, ctx);
+    await executeContactUpsert({ display_name: 'Existing' }, ctx);
 
-    const result = await searchTool.execute({ query: 'Nonexistent' }, ctx);
+    const result = await executeContactSearch({ query: 'Nonexistent' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No contacts found');
   });
 
   test('rejects search with no criteria', async () => {
-    const result = await searchTool.execute({}, ctx);
+    const result = await executeContactSearch({}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('At least one search criterion is required');
   });
 
   test('searches by channel address with type filter', async () => {
-    await upsertTool.execute({
+    await executeContactUpsert({
       display_name: 'Frank',
       channels: [
         { type: 'email', address: 'frank@example.com' },
@@ -243,7 +236,7 @@ describe('contact_search tool', () => {
       ],
     }, ctx);
 
-    const result = await searchTool.execute({
+    const result = await executeContactSearch({
       channel_address: 'frank@example',
       channel_type: 'slack',
     }, ctx);
@@ -258,9 +251,6 @@ describe('contact_search tool', () => {
 describe('contact_merge tool', () => {
   beforeEach(clearContacts);
 
-  const upsertTool = getTool('contact_upsert')!;
-  const mergeTool = getTool('contact_merge')!;
-
   function extractContactId(result: { content: string }): string {
     const match = result.content.match(/Contact (\S+)/);
     expect(match).not.toBeNull();
@@ -268,12 +258,12 @@ describe('contact_merge tool', () => {
   }
 
   test('merges two contacts', async () => {
-    const r1 = await upsertTool.execute({
+    const r1 = await executeContactUpsert({
       display_name: 'Alice (Email)',
       importance: 0.7,
       channels: [{ type: 'email', address: 'alice@example.com' }],
     }, ctx);
-    const r2 = await upsertTool.execute({
+    const r2 = await executeContactUpsert({
       display_name: 'Alice (Slack)',
       importance: 0.9,
       channels: [{ type: 'slack', address: '@alice' }],
@@ -282,7 +272,7 @@ describe('contact_merge tool', () => {
     const keepId = extractContactId(r1);
     const mergeId = extractContactId(r2);
 
-    const result = await mergeTool.execute({
+    const result = await executeContactMerge({
       keep_id: keepId,
       merge_id: mergeId,
     }, ctx);
@@ -299,24 +289,24 @@ describe('contact_merge tool', () => {
   });
 
   test('rejects missing keep_id', async () => {
-    const result = await mergeTool.execute({ merge_id: 'some-id' }, ctx);
+    const result = await executeContactMerge({ merge_id: 'some-id' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('keep_id is required');
   });
 
   test('rejects missing merge_id', async () => {
-    const result = await mergeTool.execute({ keep_id: 'some-id' }, ctx);
+    const result = await executeContactMerge({ keep_id: 'some-id' }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('merge_id is required');
   });
 
   test('returns error for nonexistent keep_id', async () => {
-    const r = await upsertTool.execute({ display_name: 'Exists' }, ctx);
+    const r = await executeContactUpsert({ display_name: 'Exists' }, ctx);
     const existingId = extractContactId(r);
 
-    const result = await mergeTool.execute({
+    const result = await executeContactMerge({
       keep_id: 'nonexistent',
       merge_id: existingId,
     }, ctx);
@@ -326,10 +316,10 @@ describe('contact_merge tool', () => {
   });
 
   test('returns error for nonexistent merge_id', async () => {
-    const r = await upsertTool.execute({ display_name: 'Exists' }, ctx);
+    const r = await executeContactUpsert({ display_name: 'Exists' }, ctx);
     const existingId = extractContactId(r);
 
-    const result = await mergeTool.execute({
+    const result = await executeContactMerge({
       keep_id: existingId,
       merge_id: 'nonexistent',
     }, ctx);

--- a/assistant/src/tools/contacts/index.ts
+++ b/assistant/src/tools/contacts/index.ts
@@ -1,4 +1,0 @@
-// Side-effect imports — each module calls registerTool() at the top level.
-import './contact-upsert.js';
-import './contact-search.js';
-import './contact-merge.js';

--- a/assistant/src/tools/document/index.ts
+++ b/assistant/src/tools/document/index.ts
@@ -1,1 +1,0 @@
-export * from './document-tool.js';

--- a/assistant/src/tools/followups/index.ts
+++ b/assistant/src/tools/followups/index.ts
@@ -1,3 +1,0 @@
-export { executeFollowupCreate } from './followup_create.js';
-export { executeFollowupList } from './followup_list.js';
-export { executeFollowupResolve } from './followup_resolve.js';

--- a/assistant/src/tools/subagent/index.ts
+++ b/assistant/src/tools/subagent/index.ts
@@ -1,5 +1,0 @@
-export { executeSubagentSpawn } from './spawn.js';
-export { executeSubagentStatus } from './status.js';
-export { executeSubagentAbort } from './abort.js';
-export { executeSubagentMessage } from './message.js';
-export { executeSubagentRead } from './read.js';


### PR DESCRIPTION
## Summary
- Removed `contacts/index.ts` which had a stale comment claiming modules "call registerTool() at the top level" -- no longer true after skills migration
- Removed three other dead barrel files (`document/index.ts`, `followups/index.ts`, `subagent/index.ts`) that had no imports anywhere in the codebase
- Fixed `contacts-tools.test.ts` to call execute functions directly instead of using `getTool()` from the old registry -- the test was already fully broken (0/19 passing) because the contact modules no longer call `registerTool()`; now 18/19 pass (the 1 remaining failure is a pre-existing channel-matching behavior issue)
- Kept `playbooks/index.ts` (imported by its test) and `tasks/index.ts` (has useful UX glossary comment)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test contacts-tools` -- 18/19 pass (up from 0/19), 1 pre-existing failure unrelated to this change
- [x] `bun run lint` -- only pre-existing lint error in unrelated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
