### PR TITLE
refactor: rename cron-centric abstractions to recurrence-centric terminology

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../memory/schema.js';
-import { cronJobs } from '../memory/schema.js';
+import { scheduleJobs } from '../memory/schema.js';
 import { eq } from 'drizzle-orm';
 
 function createTestDb() {
@@ -41,7 +41,7 @@ describe('schedule_syntax column migration', () => {
     `);
 
     const now = Date.now();
-    db.insert(cronJobs).values({
+    db.insert(scheduleJobs).values({
       id: 'test-1',
       name: 'Test Job',
       enabled: true,
@@ -57,7 +57,7 @@ describe('schedule_syntax column migration', () => {
       updatedAt: now,
     }).run();
 
-    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'test-1')).get();
+    const row = db.select().from(scheduleJobs).where(eq(scheduleJobs.id, 'test-1')).get();
     expect(row).toBeTruthy();
     expect(row!.scheduleSyntax).toBe('cron');
   });
@@ -91,7 +91,7 @@ describe('schedule_syntax column migration', () => {
     // Run the migration
     try { raw.exec(`ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
 
-    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'old-1')).get();
+    const row = db.select().from(scheduleJobs).where(eq(scheduleJobs.id, 'old-1')).get();
     expect(row).toBeTruthy();
     expect(row!.scheduleSyntax).toBe('cron');
   });
@@ -123,7 +123,7 @@ describe('schedule_syntax column migration', () => {
 
     const now = Date.now();
     raw.exec(`INSERT INTO cron_jobs (id, name, enabled, cron_expression, timezone, message, next_run_at, retry_count, created_by, created_at, updated_at) VALUES ('idem-1', 'Test', 1, '0 9 * * *', NULL, 'hi', ${now + 60000}, 0, 'agent', ${now}, ${now})`);
-    const row = db.select().from(cronJobs).where(eq(cronJobs.id, 'idem-1')).get();
+    const row = db.select().from(scheduleJobs).where(eq(scheduleJobs.id, 'idem-1')).get();
     expect(row!.scheduleSyntax).toBe('cron');
   });
 });

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -243,7 +243,7 @@ export const reminders = sqliteTable('reminders', {
   updatedAt: integer('updated_at').notNull(),
 });
 
-// ── Cron / Deferred Tasks ────────────────────────────────────────────
+// ── Recurrence Schedules ─────────────────────────────────────────────
 
 export const cronJobs = sqliteTable('cron_jobs', {
   id: text('id').primaryKey(),
@@ -289,6 +289,11 @@ export const cronRuns = sqliteTable('cron_runs', {
   conversationId: text('conversation_id'),
   createdAt: integer('created_at').notNull(),
 });
+
+// Recurrence-centric aliases — prefer these in new code.
+// Physical table names remain `cron_jobs` / `cron_runs` for migration compatibility.
+export const scheduleJobs = cronJobs;
+export const scheduleRuns = cronRuns;
 
 // ── LLM Usage Events (cost tracking ledger) ─────────────────────────
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -2,7 +2,7 @@ import { and, asc, desc, eq, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { Cron } from 'croner';
 import { getDb } from '../memory/db.js';
-import { cronJobs, cronRuns } from '../memory/schema.js';
+import { scheduleJobs, scheduleRuns } from '../memory/schema.js';
 import { computeNextRunAt as computeNextRunAtEngine, isValidScheduleExpression } from './recurrence-engine.js';
 import type { ScheduleSyntax } from './recurrence-types.js';
 
@@ -52,7 +52,7 @@ export function computeNextRunAt(cronExpression: string, timezone?: string | nul
   });
   const next = cron.nextRun();
   if (!next) {
-    throw new Error(`Cron expression "${cronExpression}" has no upcoming runs`);
+    throw new Error(`Schedule expression "${cronExpression}" has no upcoming runs`);
   }
   return next.getTime();
 }
@@ -67,7 +67,7 @@ export function createSchedule(params: {
   syntax?: ScheduleSyntax;
   expression?: string;
 }): ScheduleJob {
-  // Resolve syntax and expression: prefer explicit syntax/expression, fall back to cron
+  // Resolve syntax and expression: prefer explicit values, fall back to cron default
   const syntax: ScheduleSyntax = params.syntax ?? 'cron';
   const expression = params.expression ?? params.cronExpression;
 
@@ -100,7 +100,7 @@ export function createSchedule(params: {
     updatedAt: now,
   };
 
-  db.insert(cronJobs).values(row).run();
+  db.insert(scheduleJobs).values(row).run();
   return parseJobRow(row);
 }
 
@@ -108,8 +108,8 @@ export function getSchedule(id: string): ScheduleJob | null {
   const db = getDb();
   const row = db
     .select()
-    .from(cronJobs)
-    .where(eq(cronJobs.id, id))
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
     .get();
   if (!row) return null;
   return parseJobRow(row);
@@ -117,12 +117,12 @@ export function getSchedule(id: string): ScheduleJob | null {
 
 export function listSchedules(options?: { enabledOnly?: boolean }): ScheduleJob[] {
   const db = getDb();
-  const conditions = options?.enabledOnly ? eq(cronJobs.enabled, true) : undefined;
+  const conditions = options?.enabledOnly ? eq(scheduleJobs.enabled, true) : undefined;
   const rows = db
     .select()
-    .from(cronJobs)
+    .from(scheduleJobs)
     .where(conditions)
-    .orderBy(asc(cronJobs.nextRunAt))
+    .orderBy(asc(scheduleJobs.nextRunAt))
     .all();
   return rows.map(parseJobRow);
 }
@@ -140,7 +140,7 @@ export function updateSchedule(
   },
 ): ScheduleJob | null {
   const db = getDb();
-  const existing = db.select().from(cronJobs).where(eq(cronJobs.id, id)).get();
+  const existing = db.select().from(scheduleJobs).where(eq(scheduleJobs.id, id)).get();
   if (!existing) return null;
 
   // Resolve the effective syntax and expression after this update
@@ -179,29 +179,30 @@ export function updateSchedule(
     set.nextRunAt = newEnabled ? computeNextRunAtEngine(spec) : 0;
   }
 
-  db.update(cronJobs).set(set).where(eq(cronJobs.id, id)).run();
+  db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run();
 
   return getSchedule(id);
 }
 
 export function deleteSchedule(id: string): boolean {
   const db = getDb();
-  const result = db.delete(cronJobs).where(eq(cronJobs.id, id)).run() as unknown as { changes?: number };
+  const result = db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run() as unknown as { changes?: number };
   return (result.changes ?? 0) > 0;
 }
 
 /**
- * Claim due schedules atomically. For each candidate where enabled=true and
- * next_run_at <= now, we advance next_run_at using optimistic locking on the
- * old value to prevent double-claiming by concurrent ticks.
+ * Claim due recurrence schedules atomically. For each candidate where
+ * enabled=true and next_run_at <= now, we advance next_run_at using
+ * optimistic locking on the old value to prevent double-claiming by
+ * concurrent ticks. Works for both cron and RRULE syntax.
  */
 export function claimDueSchedules(now: number): ScheduleJob[] {
   const db = getDb();
   const candidates = db
     .select()
-    .from(cronJobs)
-    .where(and(eq(cronJobs.enabled, true), lte(cronJobs.nextRunAt, now)))
-    .orderBy(asc(cronJobs.nextRunAt))
+    .from(scheduleJobs)
+    .where(and(eq(scheduleJobs.enabled, true), lte(scheduleJobs.nextRunAt, now)))
+    .orderBy(asc(scheduleJobs.nextRunAt))
     .all();
 
   const claimed: ScheduleJob[] = [];
@@ -221,13 +222,13 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
 
     // Optimistic lock: only update if nextRunAt hasn't changed
     const result = db
-      .update(cronJobs)
+      .update(scheduleJobs)
       .set({
         nextRunAt: newNextRunAt,
         lastRunAt: now,
         updatedAt: now,
       })
-      .where(and(eq(cronJobs.id, row.id), eq(cronJobs.nextRunAt, row.nextRunAt)))
+      .where(and(eq(scheduleJobs.id, row.id), eq(scheduleJobs.nextRunAt, row.nextRunAt)))
       .run() as unknown as { changes?: number };
 
     if ((result.changes ?? 0) === 0) continue;
@@ -246,7 +247,7 @@ export function createScheduleRun(jobId: string, conversationId: string): string
   const db = getDb();
   const id = uuid();
   const now = Date.now();
-  db.insert(cronRuns).values({
+  db.insert(scheduleRuns).values({
     id,
     jobId,
     status: 'running',
@@ -268,12 +269,12 @@ export function completeScheduleRun(
   const db = getDb();
   const now = Date.now();
 
-  const run = db.select().from(cronRuns).where(eq(cronRuns.id, runId)).get();
+  const run = db.select().from(scheduleRuns).where(eq(scheduleRuns.id, runId)).get();
   if (!run) return;
 
   const durationMs = now - run.startedAt;
 
-  db.update(cronRuns)
+  db.update(scheduleRuns)
     .set({
       status: result.status,
       finishedAt: now,
@@ -281,23 +282,23 @@ export function completeScheduleRun(
       output: result.output?.slice(0, 10_000) ?? null,
       error: result.error?.slice(0, 2000) ?? null,
     })
-    .where(eq(cronRuns.id, runId))
+    .where(eq(scheduleRuns.id, runId))
     .run();
 
   // Update the parent job's lastStatus and retryCount
   if (result.status === 'error') {
     // Increment retry count
-    const job = db.select().from(cronJobs).where(eq(cronJobs.id, run.jobId)).get();
+    const job = db.select().from(scheduleJobs).where(eq(scheduleJobs.id, run.jobId)).get();
     if (job) {
-      db.update(cronJobs)
+      db.update(scheduleJobs)
         .set({ lastStatus: 'error', retryCount: job.retryCount + 1, updatedAt: now })
-        .where(eq(cronJobs.id, run.jobId))
+        .where(eq(scheduleJobs.id, run.jobId))
         .run();
     }
   } else {
-    db.update(cronJobs)
+    db.update(scheduleJobs)
       .set({ lastStatus: 'ok', retryCount: 0, updatedAt: now })
-      .where(eq(cronJobs.id, run.jobId))
+      .where(eq(scheduleJobs.id, run.jobId))
       .run();
   }
 }
@@ -306,9 +307,9 @@ export function getScheduleRuns(jobId: string, limit?: number): ScheduleRun[] {
   const db = getDb();
   const rows = db
     .select()
-    .from(cronRuns)
-    .where(eq(cronRuns.jobId, jobId))
-    .orderBy(desc(cronRuns.createdAt))
+    .from(scheduleRuns)
+    .where(eq(scheduleRuns.jobId, jobId))
+    .orderBy(desc(scheduleRuns.createdAt))
     .limit(limit ?? 10)
     .all();
   return rows.map(parseRunRow);
@@ -326,7 +327,8 @@ export function formatLocalDate(timestamp: number): string {
 }
 
 // Convert a cron expression to a human-readable description.
-// Uses the croner library to parse the expression and inspect its pattern fields.
+// Only applicable to cron syntax; RRULE schedules should display the
+// raw expression text instead.
 //
 // Examples:
 //   "* * * * *"     -> "Every minute"
@@ -448,7 +450,7 @@ export function describeCronExpression(expr: string): string {
   }
 }
 
-function parseJobRow(row: typeof cronJobs.$inferSelect): ScheduleJob {
+function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
   return {
     id: row.id,
     name: row.name,
@@ -468,7 +470,7 @@ function parseJobRow(row: typeof cronJobs.$inferSelect): ScheduleJob {
   };
 }
 
-function parseRunRow(row: typeof cronRuns.$inferSelect): ScheduleRun {
+function parseRunRow(row: typeof scheduleRuns.$inferSelect): ScheduleRun {
   return {
     id: row.id,
     jobId: row.jobId,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -74,7 +74,7 @@ async function runScheduleOnce(
   const now = Date.now();
   let processed = 0;
 
-  // ── Cron jobs ───────────────────────────────────────────────────────
+  // ── Recurrence schedules (cron + RRULE) ─────────────────────────────
   const jobs = claimDueSchedules(now);
   for (const job of jobs) {
     // Check if message is a task invocation (run_task:<task_id>)

--- a/assistant/src/tasks/task-scheduler.ts
+++ b/assistant/src/tasks/task-scheduler.ts
@@ -1,7 +1,7 @@
 import { createSchedule } from '../schedule/schedule-store.js';
 
 /**
- * Create a schedule that runs a task on a cron expression.
+ * Create a recurrence schedule that runs a task on a cron or RRULE expression.
  * The scheduler detects the `run_task:<taskId>` message format
  * and delegates to runTask() instead of processMessage().
  */


### PR DESCRIPTION
## Summary
- Introduce `scheduleJobs`/`scheduleRuns` as canonical exported aliases in `schema.ts`, keeping `cronJobs`/`cronRuns` as legacy compatibility re-exports. Physical SQLite table names (`cron_jobs`, `cron_runs`) remain unchanged for migration safety.
- Update `schedule-store.ts` to import and use the new `scheduleJobs`/`scheduleRuns` aliases throughout all Drizzle queries.
- Rename comments and identifiers across `scheduler.ts`, `task-scheduler.ts`, and the `db-schedule-syntax-migration` test from "cron" to "recurrence schedule" where the context is syntax-agnostic (both cron and RRULE).
- Keep `describeCronExpression` function name as-is since it genuinely only handles cron syntax.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/schedule-store.test.ts` — 20 pass
- [x] `bun test src/__tests__/task-scheduler.test.ts` — 6 pass
- [x] `bun test src/__tests__/schedule-tools.test.ts` — 38 pass
- [x] `bun test src/__tests__/scheduler-recurrence.test.ts` — 7 pass
- [x] `bun test src/__tests__/db-schedule-syntax-migration.test.ts` — 3 pass

Part of the RRULE support plan (PR 10/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
