### PR TITLE
refactor: rename follow-up reminder field from cron to schedule

### DIFF
--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -91,15 +91,39 @@ describe('followup_create tool', () => {
     expect(result.content).toContain('Expected response by');
   });
 
-  test('creates a follow-up with reminder cron ID', async () => {
+  test('creates a follow-up with reminder_schedule_id (canonical)', async () => {
     const result = await executeFollowupCreate({
       channel: 'email',
       thread_id: 'thread-456',
+      reminder_schedule_id: 'sched-abc',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Reminder schedule: sched-abc');
+  });
+
+  test('creates a follow-up with deprecated reminder_cron_id alias', async () => {
+    const result = await executeFollowupCreate({
+      channel: 'email',
+      thread_id: 'thread-789',
       reminder_cron_id: 'cron-abc',
     }, ctx);
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain('Reminder cron: cron-abc');
+    expect(result.content).toContain('Reminder schedule: cron-abc');
+  });
+
+  test('reminder_schedule_id takes precedence over reminder_cron_id', async () => {
+    const result = await executeFollowupCreate({
+      channel: 'email',
+      thread_id: 'thread-prio',
+      reminder_schedule_id: 'sched-wins',
+      reminder_cron_id: 'cron-loses',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Reminder schedule: sched-wins');
+    expect(result.content).not.toContain('cron-loses');
   });
 
   test('rejects missing channel', async () => {

--- a/assistant/src/config/bundled-skills/followups/SKILL.md
+++ b/assistant/src/config/bundled-skills/followups/SKILL.md
@@ -28,5 +28,5 @@ Follow-ups can be resolved in two ways:
 ## Tips
 
 - Use `followup_list` with `overdue_only: true` to find conversations that need attention.
-- Attach a `reminder_cron_id` to link a recurring reminder schedule to a follow-up.
+- Attach a `reminder_schedule_id` to link a recurring reminder schedule to a follow-up.
 - Filter by channel, status, or contact to narrow results.

--- a/assistant/src/config/bundled-skills/followups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/followups/TOOLS.json
@@ -25,9 +25,13 @@
             "type": "number",
             "description": "Hours to wait for a response before marking as overdue. If omitted, no deadline is set."
           },
+          "reminder_schedule_id": {
+            "type": "string",
+            "description": "Optional recurrence schedule ID to fire a reminder when overdue"
+          },
           "reminder_cron_id": {
             "type": "string",
-            "description": "Optional cron job ID to fire a reminder when overdue"
+            "description": "Deprecated alias for reminder_schedule_id. Use reminder_schedule_id instead."
           }
         },
         "required": ["channel", "thread_id"]

--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -7,6 +7,7 @@ import type { FollowUp, FollowUpCreateInput, FollowUpStatus } from './types.js';
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function parseFollowUp(row: typeof followups.$inferSelect): FollowUp {
+  const scheduleId = row.reminderCronId;
   return {
     id: row.id,
     channel: row.channel,
@@ -15,7 +16,8 @@ function parseFollowUp(row: typeof followups.$inferSelect): FollowUp {
     sentAt: row.sentAt,
     expectedResponseBy: row.expectedResponseBy,
     status: row.status as FollowUpStatus,
-    reminderCronId: row.reminderCronId,
+    reminderScheduleId: scheduleId,
+    reminderCronId: scheduleId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -36,7 +38,7 @@ export function createFollowUp(input: FollowUpCreateInput): FollowUp {
     sentAt: input.sentAt ?? now,
     expectedResponseBy: input.expectedResponseBy ?? null,
     status: 'pending',
-    reminderCronId: input.reminderCronId ?? null,
+    reminderCronId: input.reminderScheduleId ?? input.reminderCronId ?? null,
     createdAt: now,
     updatedAt: now,
   }).run();

--- a/assistant/src/followups/types.ts
+++ b/assistant/src/followups/types.ts
@@ -8,6 +8,9 @@ export interface FollowUp {
   sentAt: number;
   expectedResponseBy: number | null;
   status: FollowUpStatus;
+  /** Canonical field — the recurrence schedule ID linked to this follow-up. */
+  reminderScheduleId: string | null;
+  /** @deprecated Use {@link reminderScheduleId}. Kept for migration compatibility. */
   reminderCronId: string | null;
   createdAt: number;
   updatedAt: number;
@@ -19,5 +22,8 @@ export interface FollowUpCreateInput {
   contactId?: string | null;
   sentAt?: number;
   expectedResponseBy?: number | null;
+  /** Canonical field — the recurrence schedule ID to link. */
+  reminderScheduleId?: string | null;
+  /** @deprecated Use {@link reminderScheduleId}. Kept for migration compatibility. */
   reminderCronId?: string | null;
 }

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -15,7 +15,7 @@ function formatFollowUp(f: FollowUp): string {
   if (f.expectedResponseBy) {
     lines.push(`  Expected response by: ${new Date(f.expectedResponseBy).toISOString()}`);
   }
-  if (f.reminderCronId) lines.push(`  Reminder cron: ${f.reminderCronId}`);
+  if (f.reminderScheduleId) lines.push(`  Reminder schedule: ${f.reminderScheduleId}`);
   return lines.join('\n');
 }
 
@@ -35,7 +35,8 @@ export async function executeFollowupCreate(
 
   const contactId = input.contact_id as string | undefined;
   const expectedResponseHours = input.expected_response_hours as number | undefined;
-  const reminderCronId = input.reminder_cron_id as string | undefined;
+  // Canonical: reminder_schedule_id; deprecated alias: reminder_cron_id
+  const reminderScheduleId = (input.reminder_schedule_id ?? input.reminder_cron_id) as string | undefined;
 
   // Validate contact exists if provided
   if (contactId) {
@@ -61,7 +62,7 @@ export async function executeFollowupCreate(
       contactId: contactId ?? null,
       sentAt: now,
       expectedResponseBy,
-      reminderCronId: reminderCronId ?? null,
+      reminderScheduleId: reminderScheduleId ?? null,
     });
 
     return {


### PR DESCRIPTION
## Summary
- Add `reminderScheduleId` as the canonical field in follow-up types and tool inputs, replacing cron-centric naming
- Keep `reminderCronId` / `reminder_cron_id` as deprecated aliases for backward compatibility
- DB column `reminder_cron_id` stays unchanged — no migration needed
- Update human-readable output labels from "Reminder cron" to "Reminder schedule"
- Update TOOLS.json schema to advertise `reminder_schedule_id` as canonical input
- Add tests covering canonical input, deprecated alias fallback, and precedence when both are provided

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test --filter followup` passes (21 tests, 51 assertions)
- [x] New canonical field `reminder_schedule_id` is accepted and persisted
- [x] Deprecated `reminder_cron_id` still works as fallback
- [x] When both are provided, `reminder_schedule_id` takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
