### PR TITLE
refactor: remove chat-routed task execution, use daemon-only path

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -466,10 +466,6 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'work_item_cancel',
     id: 'wi-001',
   },
-  work_item_render: {
-    type: 'work_item_render',
-    id: 'wi-001',
-  },
   document_save: {
     type: 'document_save',
     surfaceId: 'doc-001',
@@ -1382,13 +1378,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'work_item_cancel_response',
     id: 'wi-001',
     success: true,
-  },
-  work_item_render_response: {
-    type: 'work_item_render_response',
-    id: 'wi-001',
-    success: true,
-    content: '# Rendered Work Item',
-    title: 'Process report',
   },
   work_item_status_changed: {
     type: 'work_item_status_changed',

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -11,7 +11,6 @@ import type {
   WorkItemPreflightRequest,
   WorkItemApprovePermissionsRequest,
   WorkItemCancelRequest,
-  WorkItemRenderRequest,
 } from '../ipc-protocol.js';
 import { log, type HandlerContext, type DispatchMap } from './shared.js';
 import { getSubagentManager } from '../../subagent/index.js';
@@ -24,7 +23,7 @@ import {
   type WorkItemStatus,
 } from '../../work-items/work-item-store.js';
 import { getTask, getTaskRun } from '../../tasks/task-store.js';
-import { runTask, renderTemplate } from '../../tasks/task-runner.js';
+import { runTask } from '../../tasks/task-runner.js';
 import { getMessages } from '../../memory/conversation-store.js';
 import { classifyRisk, check } from '../../permissions/checker.js';
 import { truncate } from '../../util/truncate.js';
@@ -313,13 +312,6 @@ export async function handleWorkItemRunTask(
   broadcastWorkItemStatus(ctx, msg.id);
   ctx.broadcast({ type: 'tasks_changed' });
 
-  // When chatRouted is true, the client handles execution by injecting
-  // the task content into the active chat session. The daemon only
-  // tracks status — it does NOT create a session or run the task.
-  if (msg.chatRouted) {
-    return;
-  }
-
   // Execute task asynchronously — lazily create a session inside the callback
   // using the conversationId provided by runTask, so the session references
   // the conversation that was actually inserted into the database.
@@ -490,27 +482,6 @@ export function handleWorkItemCancel(
   ctx.broadcast({ type: 'tasks_changed' });
 }
 
-export function handleWorkItemRender(
-  msg: WorkItemRenderRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  const workItem = getWorkItem(msg.id);
-  if (!workItem) {
-    ctx.send(socket, { type: 'work_item_render_response', id: msg.id, success: false, error: 'Work item not found' });
-    return;
-  }
-
-  const task = getTask(workItem.taskId);
-  if (!task) {
-    ctx.send(socket, { type: 'work_item_render_response', id: msg.id, success: false, error: `Associated task not found: ${workItem.taskId}` });
-    return;
-  }
-
-  const content = renderTemplate(task.template, {});
-  ctx.send(socket, { type: 'work_item_render_response', id: msg.id, success: true, content, title: workItem.title });
-}
-
 export const workItemHandlers: Partial<DispatchMap> = {
   work_items_list: handleWorkItemsList,
   work_item_get: handleWorkItemGet,
@@ -523,5 +494,4 @@ export const workItemHandlers: Partial<DispatchMap> = {
   work_item_preflight: handleWorkItemPreflight,
   work_item_approve_permissions: handleWorkItemApprovePermissions,
   work_item_cancel: handleWorkItemCancel,
-  work_item_render: handleWorkItemRender,
 };

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -97,7 +97,6 @@
     "WorkItemGetRequest",
     "WorkItemOutputRequest",
     "WorkItemPreflightRequest",
-    "WorkItemRenderRequest",
     "WorkItemRunTaskRequest",
     "WorkItemUpdateRequest",
     "WorkItemsListRequest"
@@ -210,7 +209,6 @@
     "WorkItemGetResponse",
     "WorkItemOutputResponse",
     "WorkItemPreflightResponse",
-    "WorkItemRenderResponse",
     "WorkItemRunTaskResponse",
     "WorkItemStatusChanged",
     "WorkItemUpdateResponse",
@@ -314,7 +312,6 @@
     "work_item_get",
     "work_item_output",
     "work_item_preflight",
-    "work_item_render",
     "work_item_run_task",
     "work_item_update",
     "work_items_list"
@@ -426,7 +423,6 @@
     "work_item_get_response",
     "work_item_output_response",
     "work_item_preflight_response",
-    "work_item_render_response",
     "work_item_run_task_response",
     "work_item_status_changed",
     "work_item_update_response",

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -810,8 +810,6 @@ export interface WorkItemDeleteRequest {
 export interface WorkItemRunTaskRequest {
   type: 'work_item_run_task';
   id: string;
-  /** When true, the daemon sets status to "running" but skips execution — the client routes task content through the active chat session instead. */
-  chatRouted?: boolean;
 }
 
 export interface WorkItemOutputRequest {
@@ -832,11 +830,6 @@ export interface WorkItemApprovePermissionsRequest {
 
 export interface WorkItemCancelRequest {
   type: 'work_item_cancel';
-  id: string;
-}
-
-export interface WorkItemRenderRequest {
-  type: 'work_item_render';
   id: string;
 }
 
@@ -938,7 +931,6 @@ export type ClientMessage =
   | WorkItemPreflightRequest
   | WorkItemApprovePermissionsRequest
   | WorkItemCancelRequest
-  | WorkItemRenderRequest
   | SubagentAbortRequest
   | SubagentStatusRequest
   | SubagentMessageRequest;
@@ -2027,15 +2019,6 @@ export interface WorkItemCancelResponse {
   error?: string;
 }
 
-export interface WorkItemRenderResponse {
-  type: 'work_item_render_response';
-  id: string;
-  success: boolean;
-  content?: string;
-  title?: string;
-  error?: string;
-}
-
 /** Server push — tells the client to open/focus the tasks window. */
 export interface OpenTasksWindow {
   type: 'open_tasks_window';
@@ -2167,7 +2150,6 @@ export type ServerMessage =
   | WorkItemPreflightResponse
   | WorkItemApprovePermissionsResponse
   | WorkItemCancelResponse
-  | WorkItemRenderResponse
   | WorkItemStatusChanged
   | TasksChanged
   | OpenTasksWindow

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1139,11 +1139,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func showTasksWindow() {
         NSApp.setActivationPolicy(.regular)
-        // Always recreate the tasks window to ensure it has the latest
-        // ThreadManager reference (mainWindow may have been created after
-        // the previous TasksWindow instance).
         if tasksWindow == nil {
-            tasksWindow = TasksWindow(daemonClient: daemonClient, threadManager: mainWindow?.threadManager)
+            tasksWindow = TasksWindow(daemonClient: daemonClient)
         }
         tasksWindow?.show()
     }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
@@ -8,11 +8,9 @@ import SwiftUI
 final class TasksWindow {
     private var window: NSWindow?
     private let daemonClient: DaemonClient
-    private weak var threadManager: ThreadManager?
 
-    init(daemonClient: DaemonClient, threadManager: ThreadManager? = nil) {
+    init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
-        self.threadManager = threadManager
     }
 
     func show() {
@@ -24,12 +22,8 @@ final class TasksWindow {
             return
         }
 
-        let onRunTaskInChat: ((String, String, String) -> Bool)? = { [weak self] workItemId, content, title in
-            self?.routeTaskToChat(workItemId: workItemId, content: content, title: title) ?? false
-        }
-
         let hostingController = NSHostingController(
-            rootView: TasksWindowView(daemonClient: daemonClient, onRunTaskInChat: onRunTaskInChat)
+            rootView: TasksWindowView(daemonClient: daemonClient)
         )
 
         let window = NSWindow(
@@ -61,58 +55,5 @@ final class TasksWindow {
     func close() {
         window?.close()
         window = nil
-    }
-
-    /// Inject the rendered task content as a user message into the active chat thread.
-    /// After the message is sent, the work item status will be updated to awaiting_review
-    /// when the assistant finishes processing the message.
-    /// Returns true if the message was successfully injected.
-    private func routeTaskToChat(workItemId: String, content: String, title: String) -> Bool {
-        guard let threadManager = threadManager else { return false }
-
-        // Get or create the active ChatViewModel
-        guard let chatVM = threadManager.activeViewModel else { return false }
-
-        // Prefix the task content so the user can see it came from a task
-        let taskMessage = "[Task: \(title)]\n\n\(content)"
-
-        // Set the input text and send it as a normal user message
-        chatVM.inputText = taskMessage
-        chatVM.sendMessage()
-
-        // Bring the main window to the foreground so the user can see progress
-        (NSApp.delegate as? AppDelegate)?.showMainWindow()
-
-        // Track the work item ID so we can update status when chat completes.
-        // The ChatViewModel's onToolCallsComplete or message_complete event
-        // will eventually fire. We use a simple observation of isSending
-        // transitioning back to false to mark the work item as awaiting_review.
-        observeChatCompletion(workItemId: workItemId, chatVM: chatVM)
-
-        return true
-    }
-
-    /// Watch for the chat session to finish processing (isSending -> false)
-    /// and then update the work item status to awaiting_review.
-    private func observeChatCompletion(workItemId: String, chatVM: ChatViewModel) {
-        Task { @MainActor [weak self, weak chatVM] in
-            guard let chatVM else { return }
-
-            // Poll until the chat finishes sending. This is simpler than
-            // wiring up a Combine subscriber for a one-shot observation.
-            while chatVM.isSending {
-                try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
-            }
-
-            // Update the work item status to awaiting_review now that
-            // the assistant has finished processing the task message.
-            guard self != nil else { return }
-            do {
-                try self?.daemonClient.sendWorkItemUpdate(id: workItemId, status: "awaiting_review")
-            } catch {
-                // Status update is best-effort — the task was already
-                // processed in chat, so the user saw the results.
-            }
-        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -5,10 +5,8 @@ import VellumAssistantShared
 struct TasksWindowView: View {
     @StateObject private var viewModel: TasksWindowViewModel
 
-    init(daemonClient: DaemonClient, onRunTaskInChat: ((String, String, String) -> Bool)? = nil) {
-        let vm = TasksWindowViewModel(daemonClient: daemonClient)
-        vm.onRunTaskInChat = onRunTaskInChat
-        _viewModel = StateObject(wrappedValue: vm)
+    init(daemonClient: DaemonClient) {
+        _viewModel = StateObject(wrappedValue: TasksWindowViewModel(daemonClient: daemonClient))
     }
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -50,16 +50,6 @@ class TasksWindowViewModel: ObservableObject {
     /// normal latency while still recovering from connection drops quickly.
     private static let runTimeoutSeconds: UInt64 = 10
 
-    /// Called when a task should be executed through the active chat thread.
-    /// Parameters: (workItemId, renderedContent, taskTitle).
-    /// Returns true if the message was successfully injected into chat.
-    /// Set by the app layer to inject the task content as a user message in chat.
-    var onRunTaskInChat: ((String, String, String) -> Bool)?
-
-    /// Tracks work item IDs awaiting a render response from the daemon.
-    /// Maps work item ID to the item itself for context in the response handler.
-    private var pendingRenderIds: Set<String> = []
-
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
         setupCallbacks()
@@ -181,35 +171,6 @@ class TasksWindowViewModel: ObservableObject {
             self.fetchItems()
         }
 
-        daemonClient.onWorkItemRenderResponse = { [weak self] response in
-            guard let self else { return }
-            self.pendingRenderIds.remove(response.id)
-
-            guard response.success, let content = response.content else {
-                self.logger.error("onWorkItemRenderResponse: render failed for id=\(response.id, privacy: .public) error=\(response.error ?? "none", privacy: .public)")
-                self.runInFlightIds.remove(response.id)
-                self.cancelRunTimeout(id: response.id)
-                self.errorMessage = response.error ?? "Failed to render task content"
-                return
-            }
-
-            let title = response.title ?? "Task"
-
-            // Try to route the rendered content through the active chat thread
-            let routed = self.onRunTaskInChat?(response.id, content, title) ?? false
-
-            // Tell the daemon to set status to "running". When chat routing
-            // succeeded, pass chatRouted=true so the daemon skips execution.
-            // Otherwise fall back to daemon-side execution.
-            do {
-                try self.daemonClient.sendWorkItemRunTask(id: response.id, chatRouted: routed)
-            } catch {
-                self.logger.error("runTask: transport error for id=\(response.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                self.runInFlightIds.remove(response.id)
-                self.cancelRunTimeout(id: response.id)
-                self.errorMessage = error.localizedDescription
-            }
-        }
     }
 
     func fetchItems() {
@@ -285,24 +246,6 @@ class TasksWindowViewModel: ObservableObject {
         runInFlightIds.insert(id)
         startRunTimeout(id: id)
 
-        // When a chat routing callback is available, request the rendered task
-        // content first. The render response handler will then send
-        // work_item_run_task with chatRouted=true and inject the content into chat.
-        if onRunTaskInChat != nil {
-            pendingRenderIds.insert(id)
-            do {
-                try daemonClient.sendWorkItemRender(id: id)
-            } catch {
-                logger.error("runTask: render transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                runInFlightIds.remove(id)
-                cancelRunTimeout(id: id)
-                pendingRenderIds.remove(id)
-                errorMessage = error.localizedDescription
-            }
-            return
-        }
-
-        // Fallback: no chat routing callback — use the legacy daemon-side execution
         do {
             try daemonClient.sendWorkItemRunTask(id: id)
         } catch {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -299,9 +299,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `work_item_cancel_response` message.
     public var onWorkItemCancelResponse: ((IPCWorkItemCancelResponse) -> Void)?
 
-    /// Called when the daemon sends a `work_item_render_response` message.
-    public var onWorkItemRenderResponse: ((IPCWorkItemRenderResponse) -> Void)?
-
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -646,11 +643,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(IPCWorkItemDeleteRequest(type: "work_item_delete", id: id))
     }
 
-    /// Run the task associated with a work item.
-    /// When `chatRouted` is true, the daemon sets status to "running" but does not
-    /// execute the task — the client routes execution through the active chat session.
-    public func sendWorkItemRunTask(id: String, chatRouted: Bool? = nil) throws {
-        try send(IPCWorkItemRunTaskRequest(type: "work_item_run_task", id: id, chatRouted: chatRouted))
+    /// Run the task associated with a work item via daemon-side execution.
+    public func sendWorkItemRunTask(id: String) throws {
+        try send(IPCWorkItemRunTaskRequest(type: "work_item_run_task", id: id))
     }
 
     /// Request the latest output for a work item.
@@ -676,11 +671,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Cancel a running work item.
     public func sendWorkItemCancel(id: String) throws {
         try send(IPCWorkItemCancelRequest(type: "work_item_cancel", id: id))
-    }
-
-    /// Request the rendered template content for a work item.
-    public func sendWorkItemRender(id: String) throws {
-        try send(IPCWorkItemRenderRequest(type: "work_item_render", id: id))
     }
 
     // MARK: - Skills Management

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -190,8 +190,6 @@ extension DaemonClient {
             onWorkItemApprovePermissionsResponse?(msg)
         case .workItemCancelResponse(let msg):
             onWorkItemCancelResponse?(msg)
-        case .workItemRenderResponse(let msg):
-            onWorkItemRenderResponse?(msg)
         case .openTasksWindow:
             onOpenTasksWindow?()
         case .subagentSpawned(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2068,25 +2068,9 @@ public struct IPCWorkItemPreflightResponsePermission: Codable, Sendable {
     public let currentDecision: String
 }
 
-public struct IPCWorkItemRenderRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemRenderResponse: Codable, Sendable {
-    public let type: String
-    public let id: String
-    public let success: Bool
-    public let content: String?
-    public let title: String?
-    public let error: String?
-}
-
 public struct IPCWorkItemRunTaskRequest: Codable, Sendable {
     public let type: String
     public let id: String
-    /// When true, the daemon sets status to "running" but skips execution — the client routes task content through the active chat session instead.
-    public let chatRouted: Bool?
 }
 
 public struct IPCWorkItemRunTaskResponse: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1834,7 +1834,6 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemPreflightResponse(IPCWorkItemPreflightResponse)
     case workItemApprovePermissionsResponse(IPCWorkItemApprovePermissionsResponse)
     case workItemCancelResponse(IPCWorkItemCancelResponse)
-    case workItemRenderResponse(IPCWorkItemRenderResponse)
     case openTasksWindow(OpenTasksWindowMessage)
     case subagentSpawned(IPCSubagentSpawned)
     case subagentStatusChanged(IPCSubagentStatusChanged)
@@ -2130,9 +2129,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "work_item_cancel_response":
             let message = try IPCWorkItemCancelResponse(from: decoder)
             self = .workItemCancelResponse(message)
-        case "work_item_render_response":
-            let message = try IPCWorkItemRenderResponse(from: decoder)
-            self = .workItemRenderResponse(message)
         case "open_tasks_window":
             let message = try OpenTasksWindowMessage(from: decoder)
             self = .openTasksWindow(message)


### PR DESCRIPTION
## Summary
- Remove the chat-routing execution path for tasks (chatRouted flag, render-and-inject flow)
- Tasks now always execute through daemon-side runTask which applies pre-approved permissions via buildTaskRules/allowHighRisk
- Remove work_item_render IPC endpoint and related Swift client code
- Keep task status lifecycle fully daemon-owned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
