### PR TITLE
M1: Emergency number normalization + malformed JSON error handling

### DIFF
--- a/assistant/src/__tests__/call-constants.test.ts
+++ b/assistant/src/__tests__/call-constants.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test';
+import { isDeniedNumber } from '../calls/call-constants.js';
+
+describe('isDeniedNumber', () => {
+  // Numbers that MUST be blocked
+  const blocked = [
+    '911',
+    '112',
+    '999',
+    '000',
+    '110',
+    '119',
+    '+112',     // '+' stripped → '112' exact match
+    '+911',     // '+' stripped → '911' exact match
+    '+1911',    // country code 1 + 911
+    '+44999',   // country code 44 + 999
+    '+61000',   // country code 61 + 000
+    '+49110',   // country code 49 + 110
+    '+81119',   // country code 81 + 119
+  ];
+
+  for (const num of blocked) {
+    test(`blocks ${num}`, () => {
+      expect(isDeniedNumber(num)).toBe(true);
+    });
+  }
+
+  // Numbers that MUST be allowed (legitimate phone numbers)
+  const allowed = [
+    '+14155551212',   // US number — digits after any CC split don't match short codes
+    '+442071234567',  // UK number
+    '+15559998888',   // US number
+  ];
+
+  for (const num of allowed) {
+    test(`allows ${num}`, () => {
+      expect(isDeniedNumber(num)).toBe(false);
+    });
+  }
+});

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -225,6 +225,22 @@ describe('runtime call routes — HTTP layer', () => {
     await stopServer();
   });
 
+  test('POST /v1/calls/start returns 400 for malformed JSON', async () => {
+    await startServer();
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: 'not-json{{',
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid JSON');
+
+    await stopServer();
+  });
+
   // ── GET /v1/calls/:id ───────────────────────────────────────────────
 
   test('GET /v1/calls/:id returns call status', async () => {
@@ -343,6 +359,30 @@ describe('runtime call routes — HTTP layer', () => {
   });
 
   // ── POST /v1/calls/:id/answer ──────────────────────────────────────
+
+  test('POST /v1/calls/:id/answer returns 400 for malformed JSON', async () => {
+    await startServer();
+    ensureConversation('conv-answer-badjson');
+
+    const session = createCallSession({
+      conversationId: 'conv-answer-badjson',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15559998888',
+    });
+
+    const res = await fetch(callsUrl(`/${session.id}/answer`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: 'not-json{{',
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid JSON');
+
+    await stopServer();
+  });
 
   test('POST /v1/calls/:id/answer returns 404 when no pending question', async () => {
     await startServer();

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -2,9 +2,35 @@ import { getConfig } from '../config/loader.js';
 
 // Emergency/high-risk numbers that should never be called
 export const DENIED_NUMBERS = new Set([
-  '911', '112', '999', '000', '110', '119',  // Emergency
-  '+1911', '+1112',
+  '911', '112', '999', '000', '110', '119',
 ]);
+
+/**
+ * Check whether a phone number is a denied emergency number.
+ *
+ * Normalizes E.164 variants by stripping the leading '+' and then checking
+ * whether the resulting digit string exactly matches a denied number or could
+ * be a country-code-prefixed emergency number (e.g. +1911, +44999, +61000).
+ * Country codes are 1–3 digits, so we try every valid split.
+ */
+export function isDeniedNumber(phoneNumber: string): boolean {
+  // Strip leading '+' to get a digits-only string
+  const digits = phoneNumber.startsWith('+') ? phoneNumber.slice(1) : phoneNumber;
+
+  // Exact match (covers bare short codes like "911", "112")
+  if (DENIED_NUMBERS.has(digits)) return true;
+
+  // Try splitting off 1-, 2-, or 3-digit country codes and check if the
+  // remainder is a denied number. This catches patterns like +1911, +44999.
+  for (let ccLen = 1; ccLen <= 3; ccLen++) {
+    if (digits.length > ccLen) {
+      const remainder = digits.slice(ccLen);
+      if (DENIED_NUMBERS.has(remainder)) return true;
+    }
+  }
+
+  return false;
+}
 
 // Call limits — backed by config with hardcoded fallbacks
 export function getMaxCallDurationMs(): number {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -6,7 +6,7 @@
  */
 
 import { getLogger } from '../util/logger.js';
-import { DENIED_NUMBERS } from './call-constants.js';
+import { isDeniedNumber } from './call-constants.js';
 import {
   createCallSession,
   getCallSession,
@@ -81,7 +81,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     return { ok: false, error: 'task is required and must be a non-empty string', status: 400 };
   }
 
-  if (DENIED_NUMBERS.has(phoneNumber)) {
+  if (isDeniedNumber(phoneNumber)) {
     return { ok: false, error: 'This phone number is not allowed to be called', status: 403 };
   }
 

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -23,12 +23,17 @@ export async function handleStartCall(req: Request): Promise<Response> {
     );
   }
 
-  const body = await req.json() as {
+  let body: {
     phoneNumber?: string;
     task?: string;
     context?: string;
     conversationId?: string;
   };
+  try {
+    body = await req.json() as typeof body;
+  } catch {
+    return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
 
   if (!body.conversationId) {
     return Response.json({ error: 'conversationId is required' }, { status: 400 });
@@ -115,7 +120,12 @@ export async function handleCancelCall(req: Request, callSessionId: string): Pro
  * Body: { answer: string }
  */
 export async function handleAnswerCall(req: Request, callSessionId: string): Promise<Response> {
-  const body = await req.json() as { answer?: string };
+  let body: { answer?: string };
+  try {
+    body = await req.json() as typeof body;
+  } catch {
+    return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
 
   const result = await answerCall({
     callSessionId,


### PR DESCRIPTION
Part of #5529: Calls Post-Implementation Hardening

## Changes

### Emergency Number Normalization
- Add `isDeniedNumber()` helper that normalizes E.164 numbers before checking against denied set
- Catches bypass variants like `+112`, `+911`, `+44999` etc.
- Non-emergency numbers like `+14155551212` continue to pass validation

### Malformed JSON Error Handling
- Wrap `req.json()` in try/catch for `handleStartCall` and `handleAnswerCall` endpoints
- Returns 400 with clear error message instead of 500

### Tests
- New `call-constants.test.ts` with emergency number normalization test matrix
- New malformed JSON test cases in `call-routes-http.test.ts`

Closes #5530
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
