### PR TITLE
M2: Atomic status callback idempotency

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -37,6 +37,8 @@ import {
   getPendingQuestion,
   answerPendingQuestion,
   expirePendingQuestions,
+  claimCallback,
+  releaseCallbackClaim,
 } from '../calls/call-store.js';
 
 initializeDb();
@@ -66,6 +68,7 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM processed_callbacks');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
 }
@@ -473,5 +476,73 @@ describe('call-store', () => {
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
     const q1Row = raw.query('SELECT status FROM call_pending_questions WHERE id = ?').get(q1.id) as { status: string };
     expect(q1Row.status).toBe('answered');
+  });
+
+  // ── Callback Claim ──────────────────────────────────────────────
+
+  test('claimCallback returns true on first call', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-22',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const result = claimCallback('test-dedupe-key-1', session.id);
+    expect(result).toBe(true);
+  });
+
+  test('claimCallback returns false on duplicate key', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-23',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const first = claimCallback('test-dedupe-key-2', session.id);
+    const second = claimCallback('test-dedupe-key-2', session.id);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  test('releaseCallbackClaim allows re-claim', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-24',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const first = claimCallback('test-dedupe-key-3', session.id);
+    expect(first).toBe(true);
+
+    releaseCallbackClaim('test-dedupe-key-3');
+
+    const second = claimCallback('test-dedupe-key-3', session.id);
+    expect(second).toBe(true);
+  });
+
+  test('claimCallback INSERT OR IGNORE pattern is safe for same key', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-25',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Claim the key
+    const first = claimCallback('test-dedupe-key-4', session.id);
+    expect(first).toBe(true);
+
+    // Subsequent claims with the same key should all return false without throwing
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
+
+    // Only one row should exist in the table for this key
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const rows = raw.query('SELECT COUNT(*) as cnt FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-4') as { cnt: number };
+    expect(rows.cnt).toBe(1);
   });
 });

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -173,6 +173,8 @@ mock.module('../calls/call-store.js', () => ({
   isCallbackProcessed: () => false,
   recordProcessedCallback: () => {},
   tryRecordProcessedCallback: () => true,
+  claimCallback: () => true,
+  releaseCallbackClaim: () => {},
 }));
 
 mock.module('../daemon/watch-handler.js', () => ({

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -318,8 +318,8 @@ export function recordProcessedCallback(
  *
  * Uses INSERT ... ON CONFLICT DO NOTHING pattern for atomicity.
  *
- * @deprecated Use isCallbackProcessed + recordProcessedCallback instead to
- * ensure the dedupe marker is only persisted after downstream writes succeed.
+ * @deprecated Use claimCallback + releaseCallbackClaim instead to
+ * atomically claim a callback and release on failure.
  */
 export function tryRecordProcessedCallback(
   dedupeKey: string,
@@ -334,4 +334,31 @@ export function tryRecordProcessedCallback(
 
   const changes = raw.query('SELECT changes() as c').get() as { c: number };
   return changes.c > 0;
+}
+
+/**
+ * Atomically claim a callback for processing. Returns true if this caller
+ * won the claim (INSERT succeeded). Returns false if another caller already
+ * claimed it (dedupe_key conflict).
+ *
+ * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow retries.
+ */
+export function claimCallback(dedupeKey: string, callSessionId: string): boolean {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  raw.query(
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+  const changes = raw.query('SELECT changes() as c').get() as { c: number };
+  return changes.c > 0;
+}
+
+/**
+ * Release a callback claim so that retries can reprocess it.
+ * Called when processing fails after a successful claim.
+ */
+export function releaseCallbackClaim(dedupeKey: string): void {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ?`).run(dedupeKey);
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -14,8 +14,8 @@ import {
   recordCallEvent,
   expirePendingQuestions,
   buildCallbackDedupeKey,
-  isCallbackProcessed,
-  recordProcessedCallback,
+  claimCallback,
+  releaseCallbackClaim,
 } from './call-store.js';
 import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
@@ -154,50 +154,52 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     return new Response(null, { status: 200 });
   }
 
-  // ── Idempotency check ────────────────────────────────────────────
+  // ── Atomic idempotency claim ────────────────────────────────────
   const timestamp = formBody.get('Timestamp');
   const sequenceNumber = formBody.get('SequenceNumber');
   const dedupeKey = buildCallbackDedupeKey(callSid, callStatus, timestamp, sequenceNumber);
 
-  if (isCallbackProcessed(dedupeKey)) {
+  if (!claimCallback(dedupeKey, session.id)) {
     log.info({ callSid, callStatus, dedupeKey }, 'Duplicate status callback — skipping');
     return new Response(null, { status: 200 });
   }
 
-  // Build updates
-  const updates: Parameters<typeof updateCallSession>[1] = {
-    status: mappedStatus,
-  };
+  try {
+    // Build updates
+    const updates: Parameters<typeof updateCallSession>[1] = {
+      status: mappedStatus,
+    };
 
-  if (mappedStatus === 'in_progress' && !session.startedAt) {
-    updates.startedAt = Date.now();
+    if (mappedStatus === 'in_progress' && !session.startedAt) {
+      updates.startedAt = Date.now();
+    }
+
+    const isTerminal = mappedStatus === 'completed' || mappedStatus === 'failed';
+    if (isTerminal) {
+      updates.endedAt = Date.now();
+    }
+
+    updateCallSession(session.id, updates);
+
+    // Record event
+    const eventType = isTerminal
+      ? (mappedStatus === 'completed' ? 'call_ended' : 'call_failed')
+      : (mappedStatus === 'in_progress' ? 'call_connected' : 'call_started');
+
+    recordCallEvent(session.id, eventType, {
+      twilioStatus: callStatus,
+      callSid,
+    });
+
+    // Expire pending questions on terminal status
+    if (isTerminal) {
+      expirePendingQuestions(session.id);
+    }
+  } catch (err) {
+    // Release claim so Twilio retries can reprocess
+    releaseCallbackClaim(dedupeKey);
+    throw err;
   }
-
-  const isTerminal = mappedStatus === 'completed' || mappedStatus === 'failed';
-  if (isTerminal) {
-    updates.endedAt = Date.now();
-  }
-
-  updateCallSession(session.id, updates);
-
-  // Record event
-  const eventType = isTerminal
-    ? (mappedStatus === 'completed' ? 'call_ended' : 'call_failed')
-    : (mappedStatus === 'in_progress' ? 'call_connected' : 'call_started');
-
-  recordCallEvent(session.id, eventType, {
-    twilioStatus: callStatus,
-    callSid,
-  });
-
-  // Expire pending questions on terminal status
-  if (isTerminal) {
-    expirePendingQuestions(session.id);
-  }
-
-  // Record the dedupe marker AFTER all writes have succeeded so that
-  // Twilio retries are not silently dropped if the writes above fail.
-  recordProcessedCallback(dedupeKey, session.id);
 
   return new Response(null, { status: 200 });
 }


### PR DESCRIPTION
Part of #5529: Calls Post-Implementation Hardening

## Changes

### Atomic Claim Pattern
- Add `claimCallback()` and `releaseCallbackClaim()` to call-store
- `claimCallback` uses INSERT OR IGNORE + changes() check for atomic claim semantics
- `releaseCallbackClaim` deletes the claim on processing failure so retries work

### Status Callback Refactor
- Refactor `handleStatusCallback` in twilio-routes to use claim-then-process pattern
- If processing throws, the claim is released so Twilio retries can reprocess
- Eliminates the read-then-write race window

### Tests
- Tests for claimCallback, releaseCallbackClaim, and re-claim after release

Closes #5531
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
