### PR TITLE
M3: Gateway-compatible ConversationRelay WS routing + docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3202,7 +3202,8 @@ sequenceDiagram
     Routes-->>Gateway: TwiML (ConversationRelay connect)
     Gateway-->>TwilioAPI: TwiML response
 
-    TwilioAPI->>WS: WebSocket /v1/calls/relay
+    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/relay
+    Gateway->>WS: proxy WS to runtime /v1/calls/relay
     WS->>WS: setup message (callSid)
     WS->>Orch: new CallOrchestrator()
     Orch->>State: registerCallOrchestrator()
@@ -3262,6 +3263,7 @@ sequenceDiagram
 | `gateway/src/http/routes/twilio-voice-webhook.ts` | Gateway route: validates Twilio signature, forwards voice webhook to runtime |
 | `gateway/src/http/routes/twilio-status-webhook.ts` | Gateway route: validates Twilio signature, forwards status callback to runtime |
 | `gateway/src/http/routes/twilio-connect-action-webhook.ts` | Gateway route: validates Twilio signature, forwards connect-action to runtime |
+| `gateway/src/http/routes/twilio-relay-websocket.ts` | Gateway route: WebSocket proxy for ConversationRelay frames between Twilio and runtime |
 | `gateway/src/twilio/validate-webhook.ts` | Twilio webhook validation: HMAC-SHA1 signature verification, payload size limits, fail-closed when auth token missing |
 
 ### Call State Machine
@@ -3325,6 +3327,9 @@ Internet-facing Twilio callbacks terminate at the gateway, which validates signa
 | `POST /webhooks/twilio/voice` | HMAC-SHA1 signature, payload size | `POST /v1/calls/voice-webhook` |
 | `POST /webhooks/twilio/status` | HMAC-SHA1 signature, payload size | `POST /v1/calls/status-callback` |
 | `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/calls/connect-action` |
+| `WS /webhooks/twilio/relay` | WebSocket upgrade | `WS /v1/calls/relay` (bidirectional proxy) |
+
+In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice webhook) should point to the gateway's `/webhooks/twilio/relay` endpoint rather than directly to the runtime. The gateway proxies ConversationRelay frames bidirectionally between Twilio and the runtime, preserving close and error semantics for proper cleanup.
 
 Signature validation is **fail-closed**: if the Twilio auth token is not configured, all webhook requests are rejected with `403`. Missing or invalid `X-Twilio-Signature` headers are also rejected with `403`. Payload size is capped by `maxWebhookPayloadBytes` (checked via both `Content-Length` header and actual body size).
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -21,6 +21,7 @@ import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
 import { logDeadLetterEvent } from './call-recovery.js';
 import { isTerminalState } from './call-state-machine.js';
+import { getTwilioConfig } from './twilio-config.js';
 
 const log = getLogger('twilio-routes');
 
@@ -111,7 +112,8 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
-  const wssBaseUrl = process.env.WSS_BASE_URL ?? process.env.BASE_URL ?? 'wss://localhost:7821';
+  const config = getTwilioConfig();
+  const wssBaseUrl = config.wssBaseUrl || config.webhookBaseUrl.replace(/^http/, 'ws');
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
   const twiml = generateTwiML(callSessionId, wssBaseUrl, welcomeGreeting);

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -1,0 +1,93 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("twilio-relay-ws");
+
+/**
+ * Create a WebSocket upgrade handler that proxies Twilio ConversationRelay
+ * frames between Twilio and the runtime's /v1/calls/relay endpoint.
+ */
+export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
+  return function handleUpgrade(req: Request, server: import("bun").Server): Response | undefined {
+    const url = new URL(req.url);
+    const callSessionId = url.searchParams.get("callSessionId");
+
+    if (!callSessionId) {
+      log.warn("Relay WS upgrade without callSessionId");
+      return new Response("Missing callSessionId", { status: 400 });
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: { callSessionId, config },
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    // Return undefined to indicate upgrade was handled
+    return undefined;
+  };
+}
+
+type RelaySocketData = {
+  callSessionId: string;
+  config: GatewayConfig;
+  upstream?: WebSocket;
+};
+
+/**
+ * WebSocket handler config for Bun.serve() that proxies frames to runtime.
+ */
+export function getRelayWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<RelaySocketData>) {
+      const { callSessionId, config } = ws.data;
+
+      // Build upstream URL to runtime
+      const runtimeBase = config.assistantRuntimeBaseUrl.replace(/^http/, 'ws');
+      const upstreamUrl = `${runtimeBase}/v1/calls/relay?callSessionId=${encodeURIComponent(callSessionId)}`;
+
+      log.info({ callSessionId, upstreamUrl }, "Opening upstream WS to runtime");
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info({ callSessionId }, "Upstream WS connected");
+      });
+
+      upstream.addEventListener("message", (event) => {
+        // Forward runtime -> Twilio
+        const data = typeof event.data === "string" ? event.data : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info({ callSessionId, code: event.code }, "Upstream WS closed");
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error({ callSessionId, error: event }, "Upstream WS error");
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(ws: import("bun").ServerWebSocket<RelaySocketData>, message: string | ArrayBuffer | Uint8Array) {
+      // Forward Twilio -> runtime
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      }
+    },
+
+    close(ws: import("bun").ServerWebSocket<RelaySocketData>, code: number, reason: string) {
+      const { callSessionId, upstream } = ws.data;
+      log.info({ callSessionId, code, reason }, "Twilio WS closed");
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -4,6 +4,7 @@ import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js"
 import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
 import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
+import { createTwilioRelayWebsocketHandler, getRelayWebsocketHandlers } from "./http/routes/twilio-relay-websocket.js";
 import { getLogger, initLogger } from "./logger.js";
 import { buildSchema } from "./schema.js";
 import { callTelegramApi } from "./telegram/api.js";
@@ -55,6 +56,7 @@ function main() {
   const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(config);
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
+  const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
@@ -62,6 +64,7 @@ function main() {
 
   const server = Bun.serve({
     port: config.port,
+    websocket: getRelayWebsocketHandlers(),
     async fetch(req) {
       const url = new URL(req.url);
 
@@ -109,6 +112,13 @@ function main() {
         url.pathname === "/v1/calls/twilio/connect-action"
       ) {
         return handleTwilioConnectActionWebhook(req);
+      }
+
+      if (url.pathname === "/webhooks/twilio/relay") {
+        const upgradeResult = handleTwilioRelayWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        // If upgrade was handled, Bun doesn't need a response
+        return undefined as unknown as Response;
       }
 
       if (handleRuntimeProxy) {


### PR DESCRIPTION
Part of #5529: Calls Post-Implementation Hardening

## Changes

### TwiML URL Generation
- Use `getTwilioConfig().wssBaseUrl` instead of raw env vars for WS URL in TwiML
- Falls back to deriving WS URL from webhookBaseUrl when wssBaseUrl not set

### Gateway WS Relay
- New `/webhooks/twilio/relay` WebSocket route in gateway
- Proxies frames bidirectionally between Twilio and runtime `/v1/calls/relay`
- Preserves close/error semantics for proper runtime cleanup

### Documentation
- Updated ARCHITECTURE.md with gateway WS relay route and data flow

Closes #5532
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
