### PR TITLE
feat: fix DoorDash task_progress widget + floating overlay

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -66,6 +66,59 @@ export function buildToolDefinitions(): ToolDefinition[] {
   ];
 }
 
+// ── DoorDash task_progress auto-update ────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+interface DoordashStep { label: string; status: string; detail?: string }
+
+/**
+ * Map a `vellum doordash <subcommand>` to the step label it corresponds to.
+ */
+function doordashCommandToStep(cmd: string): string | null {
+  if (/vellum doordash status\b/.test(cmd) || /vellum doordash refresh\b/.test(cmd) || /vellum doordash login\b/.test(cmd)) return 'Check session';
+  if (/vellum doordash search\b/.test(cmd) || /vellum doordash search-items\b/.test(cmd)) return 'Search restaurants';
+  if (/vellum doordash menu\b/.test(cmd) || /vellum doordash item\b/.test(cmd) || /vellum doordash store-search\b/.test(cmd)) return 'Browse menu';
+  if (/vellum doordash cart\b/.test(cmd)) return 'Add to cart';
+  if (/vellum doordash checkout\b/.test(cmd) || /vellum doordash payment-methods\b/.test(cmd)) return 'Add to cart';
+  if (/vellum doordash order\b/.test(cmd)) return 'Place order';
+  return null;
+}
+
+/**
+ * Given a completed DoorDash CLI command, return updated steps array or null if no change.
+ */
+function updateDoordashSteps(cmd: string, steps: DoordashStep[], isError: boolean): DoordashStep[] | null {
+  const stepLabel = doordashCommandToStep(cmd);
+  if (!stepLabel) return null;
+
+  const stepIndex = steps.findIndex(s => s.label === stepLabel);
+  if (stepIndex < 0) return null;
+
+  const updated = steps.map((s, i) => {
+    if (i < stepIndex) {
+      // Steps before current should be completed
+      return s.status === 'completed' ? s : { ...s, status: 'completed' };
+    }
+    if (i === stepIndex) {
+      if (isError) {
+        // If the command failed, mark as in_progress still (will retry)
+        return { ...s, status: 'in_progress' };
+      }
+      return { ...s, status: 'completed' };
+    }
+    if (i === stepIndex + 1 && !isError) {
+      // Next step becomes waiting (user may need to respond before it starts)
+      return { ...s, status: 'waiting' };
+    }
+    return s;
+  });
+
+  return updated;
+}
+
 // ── createToolExecutor ───────────────────────────────────────────────
 
 /**
@@ -86,6 +139,41 @@ export function createToolExecutor(
   registerSessionSender(ctx.conversationId, (msg) => ctx.sendToClient(msg));
 
   return async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
+    // Pre-execution: mark the current DoorDash step as in_progress when command starts
+    if (name === 'bash' || name === 'host_bash') {
+      const preCmd = input.command as string | undefined;
+      if (preCmd?.includes('vellum doordash')) {
+        const surfaceId = 'doordash-progress';
+        const stored = ctx.surfaceState.get(surfaceId);
+        if (stored && stored.surfaceType === 'card') {
+          const card = stored.data as import('./ipc-contract.js').CardSurfaceData;
+          if (card.template === 'task_progress' && isPlainObject(card.templateData)) {
+            const steps = (card.templateData as Record<string, unknown>).steps;
+            if (Array.isArray(steps)) {
+              const stepLabel = doordashCommandToStep(preCmd);
+              if (stepLabel) {
+                const stepIndex = (steps as DoordashStep[]).findIndex(s => s.label === stepLabel);
+                if (stepIndex >= 0 && (steps as DoordashStep[])[stepIndex].status !== 'in_progress') {
+                  const updatedSteps = (steps as DoordashStep[]).map((s, i) =>
+                    i === stepIndex ? { ...s, status: 'in_progress' } : s
+                  );
+                  const updatedTemplateData = { ...card.templateData as Record<string, unknown>, steps: updatedSteps };
+                  const updatedData = { ...card, templateData: updatedTemplateData };
+                  stored.data = updatedData as import('./ipc-contract.js').CardSurfaceData;
+                  ctx.sendToClient({
+                    type: 'ui_surface_update',
+                    sessionId: ctx.conversationId,
+                    surfaceId,
+                    data: updatedData,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     const result = await executor.execute(name, input, {
       workingDir: ctx.workingDir,
       sessionId: ctx.conversationId,
@@ -200,43 +288,70 @@ export function createToolExecutor(
     }
 
     // Auto-emit task_progress card on first DoorDash CLI command
-    if ((name === 'bash' || name === 'host_bash') && !result.isError) {
+    if (name === 'bash' || name === 'host_bash') {
       const cmd = input.command as string | undefined;
-      if (cmd && /(?:^|[;&|]\s*)vellum doordash\b/.test(cmd) && !ctx.surfaceState.has('doordash-progress')) {
+      if (cmd?.includes('vellum doordash')) {
         const surfaceId = 'doordash-progress';
-        const data = {
-          title: 'Ordering from DoorDash',
-          body: '',
-          template: 'task_progress' as const,
-          templateData: {
+
+        if (!ctx.surfaceState.has(surfaceId)) {
+          // First DoorDash command — auto-emit the task_progress card
+          const data = {
             title: 'Ordering from DoorDash',
-            status: 'in_progress',
-            steps: [
-              { label: 'Check session', status: 'in_progress' },
-              { label: 'Search restaurants', status: 'pending' },
-              { label: 'Browse menu', status: 'pending' },
-              { label: 'Add to cart', status: 'pending' },
-              { label: 'Place order', status: 'pending' },
-            ],
-          },
-        } satisfies import('./ipc-contract.js').CardSurfaceData;
-        ctx.surfaceState.set(surfaceId, { surfaceType: 'card', data });
-        ctx.sendToClient({
-          type: 'ui_surface_show',
-          sessionId: ctx.conversationId,
-          surfaceId,
-          surfaceType: 'card',
-          title: 'Ordering from DoorDash',
-          data,
-          display: 'inline',
-        });
-        ctx.currentTurnSurfaces.push({
-          surfaceId,
-          surfaceType: 'card',
-          title: 'Ordering from DoorDash',
-          data,
-          display: 'inline',
-        });
+            body: '',
+            template: 'task_progress' as const,
+            templateData: {
+              title: 'Ordering from DoorDash',
+              status: 'in_progress',
+              steps: [
+                { label: 'Check session', status: 'in_progress' },
+                { label: 'Search restaurants', status: 'pending' },
+                { label: 'Browse menu', status: 'pending' },
+                { label: 'Add to cart', status: 'pending' },
+                { label: 'Place order', status: 'pending' },
+              ],
+            },
+          } satisfies import('./ipc-contract.js').CardSurfaceData;
+          ctx.surfaceState.set(surfaceId, { surfaceType: 'card', data });
+          ctx.sendToClient({
+            type: 'ui_surface_show',
+            sessionId: ctx.conversationId,
+            surfaceId,
+            surfaceType: 'card',
+            title: 'Ordering from DoorDash',
+            data,
+            display: 'inline',
+          });
+          ctx.currentTurnSurfaces.push({
+            surfaceId,
+            surfaceType: 'card',
+            title: 'Ordering from DoorDash',
+            data,
+            display: 'inline',
+          });
+        }
+
+        // Auto-update step statuses based on the command that just ran
+        const stored = ctx.surfaceState.get(surfaceId);
+        if (stored && stored.surfaceType === 'card') {
+          const card = stored.data as import('./ipc-contract.js').CardSurfaceData;
+          if (card.template === 'task_progress' && isPlainObject(card.templateData)) {
+            const steps = (card.templateData as Record<string, unknown>).steps;
+            if (Array.isArray(steps)) {
+              const updatedSteps = updateDoordashSteps(cmd, steps as Array<{ label: string; status: string; detail?: string }>, result.isError);
+              if (updatedSteps) {
+                const updatedTemplateData = { ...card.templateData as Record<string, unknown>, steps: updatedSteps };
+                const updatedData = { ...card, templateData: updatedTemplateData };
+                stored.data = updatedData as import('./ipc-contract.js').CardSurfaceData;
+                ctx.sendToClient({
+                  type: 'ui_surface_update',
+                  sessionId: ctx.conversationId,
+                  surfaceId,
+                  data: updatedData,
+                });
+              }
+            }
+          }
+        }
       }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -28,6 +28,7 @@ struct ChatBubble: View {
     @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     @State private var stepsExpanded = false
+    @ObservedObject private var taskProgressOverlay = TaskProgressOverlayManager.shared
 
     private var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
@@ -83,9 +84,11 @@ struct ChatBubble: View {
     /// that should not appear above the rendered dynamic UI surface.
     private var shouldShowBubble: Bool {
         if isUser { return true }
-        if !message.inlineSurfaces.isEmpty {
-            // Show bubble text when all surfaces are completed (collapsed to chips)
-            let allCompleted = message.inlineSurfaces.allSatisfy { $0.completionState != nil }
+        // Filter out the surface shown in the floating overlay
+        let visibleSurfaces = message.inlineSurfaces.filter { $0.id != taskProgressOverlay.activeSurfaceId }
+        if !visibleSurfaces.isEmpty {
+            // Show bubble text when all visible surfaces are completed (collapsed to chips)
+            let allCompleted = visibleSurfaces.allSatisfy { $0.completionState != nil }
             if !allCompleted { return false }
         }
         return hasText || !message.attachments.isEmpty
@@ -114,8 +117,9 @@ struct ChatBubble: View {
                     }
 
                     // Inline surfaces render below the bubble as full-width cards
+                    // Skip surfaces that are currently shown in the floating overlay
                     if !message.inlineSurfaces.isEmpty {
-                        ForEach(message.inlineSurfaces) { surface in
+                        ForEach(message.inlineSurfaces.filter { $0.id != taskProgressOverlay.activeSurfaceId }) { surface in
                             InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
                         }
                     }
@@ -670,7 +674,8 @@ struct ChatBubble: View {
                 // Tool calls are rendered by trailingStatus below the message
                 EmptyView()
             case .surface(let i):
-                if i < message.inlineSurfaces.count {
+                if i < message.inlineSurfaces.count,
+                   message.inlineSurfaces[i].id != taskProgressOverlay.activeSurfaceId {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
                 }
             }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -920,6 +920,16 @@ extension ChatViewModel {
                 break
             }
 
+            // Show floating overlay for task_progress cards (macOS only)
+            #if os(macOS)
+            if case .card(let cardData) = surface.data,
+               cardData.template == "task_progress",
+               let templateData = cardData.templateData,
+               let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: cardData.title) {
+                TaskProgressOverlayManager.shared.show(data: progressData, surfaceId: msg.surfaceId)
+            }
+            #endif
+
             // On macOS, dynamic pages with no explicit display mode (or "panel")
             // are routed to the workspace by SurfaceManager. If the dynamic page
             // has a preview, also render a compact preview card inline in chat.
@@ -1004,6 +1014,15 @@ extension ChatViewModel {
                             actions: updated.actions,
                             surfaceMessage: existing.surfaceMessage
                         )
+                        // Update floating overlay for task_progress cards (macOS only)
+                        #if os(macOS)
+                        if case .card(let cardData) = updated.data,
+                           cardData.template == "task_progress",
+                           let templateData = cardData.templateData,
+                           let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: cardData.title) {
+                            TaskProgressOverlayManager.shared.update(data: progressData, surfaceId: msg.surfaceId)
+                        }
+                        #endif
                     }
                     return
                 }
@@ -1021,6 +1040,10 @@ extension ChatViewModel {
 
         case .uiSurfaceComplete(let msg):
             guard belongsToSession(msg.sessionId) else { return }
+            // Dismiss floating overlay for task_progress cards (macOS only)
+            #if os(macOS)
+            TaskProgressOverlayManager.shared.dismiss(surfaceId: msg.surfaceId)
+            #endif
             // Find the inline surface across all messages and set its completionState
             for msgIndex in messages.indices {
                 if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -154,6 +154,9 @@ public struct InlineTaskProgressWidget: View {
             ProgressView()
                 .controlSize(.small)
                 .tint(Amber._500)
+        case "waiting":
+            Image(systemName: "clock.fill")
+                .foregroundColor(Amber._500)
         case "failed":
             Image(systemName: "xmark.circle.fill")
                 .foregroundColor(Rose._500)
@@ -169,6 +172,8 @@ public struct InlineTaskProgressWidget: View {
             return ("Completed", "checkmark.circle.fill", Emerald._500)
         case "in_progress":
             return ("In Progress", "arrow.triangle.2.circlepath", Amber._500)
+        case "waiting":
+            return ("Waiting", "clock.fill", Amber._500)
         case "failed":
             return ("Failed", "xmark.circle.fill", Rose._500)
         default:

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -1,0 +1,159 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "TaskProgressOverlay")
+
+/// Manages a floating NSPanel that shows a task_progress widget pinned to the
+/// top-right of the screen. Follows BrowserPiPManager / SessionOverlayWindow patterns.
+@MainActor
+public final class TaskProgressOverlayManager: ObservableObject {
+    public static let shared = TaskProgressOverlayManager()
+
+    @Published var data: TaskProgressData?
+    /// The surface ID currently shown in the floating overlay.
+    /// ChatView uses this to suppress inline rendering for the same surface.
+    @Published public private(set) var activeSurfaceId: String?
+
+    private var panel: NSPanel?
+    private var dismissTask: Task<Void, Never>?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    public func show(data: TaskProgressData, surfaceId: String) {
+        dismissTask?.cancel()
+        dismissTask = nil
+        self.activeSurfaceId = surfaceId
+        self.data = data
+
+        if panel == nil {
+            createPanel()
+        }
+        panel?.orderFront(nil)
+        log.info("Showing task progress overlay: surfaceId=\(surfaceId, privacy: .public)")
+    }
+
+    public func update(data: TaskProgressData, surfaceId: String) {
+        guard surfaceId == self.activeSurfaceId else { return }
+        self.data = data
+
+        // Resize panel to fit updated content
+        if let panel, let fittingSize = panel.contentView?.fittingSize {
+            panel.setContentSize(fittingSize)
+        }
+
+        // Auto-dismiss when all steps are completed
+        if data.status == "completed" || data.steps.allSatisfy({ $0.status == "completed" }) {
+            scheduleDismiss()
+        }
+    }
+
+    public func dismiss(surfaceId: String) {
+        guard surfaceId == self.activeSurfaceId else { return }
+        scheduleDismiss()
+    }
+
+    /// Immediately close the overlay (e.g. user tapped the X button).
+    public func close() {
+        dismissTask?.cancel()
+        dismissTask = nil
+        closePanel()
+    }
+
+    // MARK: - Private
+
+    private func scheduleDismiss() {
+        dismissTask?.cancel()
+        dismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.closePanel()
+        }
+    }
+
+    private func closePanel() {
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.3
+            panel?.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            self?.panel?.close()
+            self?.panel = nil
+        })
+        activeSurfaceId = nil
+        data = nil
+        log.info("Dismissed task progress overlay")
+    }
+
+    private func createPanel() {
+        let view = TaskProgressOverlayView(manager: self)
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 280, height: 200),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.9
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.hasShadow = true
+
+        // Position top-right of screen
+        positionTopRight(panel)
+
+        self.panel = panel
+    }
+
+    private func positionTopRight(_ panel: NSPanel) {
+        guard let screen = NSScreen.main else { return }
+        let padding: CGFloat = 20
+        if let fittingSize = panel.contentView?.fittingSize {
+            panel.setContentSize(fittingSize)
+        }
+        let frame = panel.frame
+        let x = screen.visibleFrame.maxX - frame.width - padding
+        let y = screen.visibleFrame.maxY - frame.height - padding
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+}
+
+// MARK: - Overlay SwiftUI View
+
+private struct TaskProgressOverlayView: View {
+    @ObservedObject var manager: TaskProgressOverlayManager
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let data = manager.data {
+                HStack {
+                    Spacer()
+                    Button {
+                        manager.close()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, VSpacing.sm)
+                    .padding(.trailing, VSpacing.sm)
+                }
+                InlineTaskProgressWidget(data: data)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.bottom, VSpacing.md)
+            }
+        }
+        .frame(width: 260)
+        .background(VColor.background)
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -32,6 +32,8 @@ public final class TaskProgressOverlayManager: ObservableObject {
         if panel == nil {
             createPanel()
         }
+        // Reset alpha in case we're racing with a fade-out animation from closePanel()
+        panel?.alphaValue = 0.9
         panel?.orderFront(nil)
         log.info("Showing task progress overlay: surfaceId=\(surfaceId, privacy: .public)")
     }
@@ -75,15 +77,18 @@ public final class TaskProgressOverlayManager: ObservableObject {
     }
 
     private func closePanel() {
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.3
-            panel?.animator().alphaValue = 0
-        }, completionHandler: { [weak self] in
-            self?.panel?.close()
-            self?.panel = nil
-        })
+        // Capture and nil the panel reference synchronously to prevent
+        // show() from reusing a panel that's mid-fade-out.
+        let closingPanel = panel
+        panel = nil
         activeSurfaceId = nil
         data = nil
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.3
+            closingPanel?.animator().alphaValue = 0
+        }, completionHandler: {
+            closingPanel?.close()
+        })
         log.info("Dismissed task progress overlay")
     }
 


### PR DESCRIPTION
## Summary
- Fix daemon auto-emit: tool name check (`bash` → `host_bash`), remove `!result.isError` guard, add step auto-update helpers
- Add `waiting` step status (clock icon) for steps awaiting user input instead of showing a spinner
- Add floating NSPanel overlay pinned to top-right showing task_progress widget, with dismiss X button
- Suppress inline rendering while overlay is active; inline reappears on dismiss

## Test plan
- [ ] Start daemon + app, ask "what can I order for a late lunch?"
- [ ] Verify floating overlay appears in top-right with DoorDash steps
- [ ] Verify steps update as commands complete (spinner → checkmark)
- [ ] Verify next step shows clock icon (waiting) when assistant asks a question
- [ ] Verify X button dismisses overlay immediately
- [ ] Verify overlay auto-dismisses when all steps complete
- [ ] Verify inline widget reappears in chat after overlay dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
