### PR TITLE
fix: show neutral step count instead of scary failure indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -10,25 +10,15 @@ struct UsedToolsList: View {
 
     @State private var isHovered = false
 
-    private var hasErrors: Bool { toolCalls.contains { $0.isError } }
-
     private var pillLabel: String {
         let count = toolCalls.count
         if count == 1 { return toolCalls[0].actionDescription }
-        if hasErrors {
-            let errCount = toolCalls.filter { $0.isError }.count
-            return errCount == count ? "All \(count) steps failed" : "\(errCount) of \(count) steps failed"
-        }
         return "Completed \(count) steps"
     }
 
-    private var pillIcon: String {
-        hasErrors ? "xmark.circle.fill" : "checkmark.circle.fill"
-    }
+    private var pillIcon: String { "checkmark.circle.fill" }
 
-    private var pillIconColor: Color {
-        hasErrors ? VColor.error : VColor.success
-    }
+    private var pillIconColor: Color { VColor.success }
 
     var body: some View {
         Button {

--- a/clients/shared/Features/Chat/UsedToolsListCompact.swift
+++ b/clients/shared/Features/Chat/UsedToolsListCompact.swift
@@ -6,25 +6,15 @@ public struct UsedToolsListCompact: View {
     let toolCalls: [ToolCallData]
     @State private var isExpanded = false
 
-    private var hasErrors: Bool { toolCalls.contains { $0.isError } }
-
     private var pillLabel: String {
         let count = toolCalls.count
         if count == 1 { return toolCalls[0].actionDescription }
-        if hasErrors {
-            let errCount = toolCalls.filter { $0.isError }.count
-            return errCount == count ? "All \(count) steps failed" : "\(errCount) of \(count) steps failed"
-        }
         return "Completed \(count) steps"
     }
 
-    private var pillIcon: String {
-        hasErrors ? "xmark.circle.fill" : "checkmark.circle.fill"
-    }
+    private var pillIcon: String { "checkmark.circle.fill" }
 
-    private var pillIconColor: Color {
-        hasErrors ? VColor.error : VColor.success
-    }
+    private var pillIconColor: Color { VColor.success }
 
     public init(toolCalls: [ToolCallData]) {
         self.toolCalls = toolCalls


### PR DESCRIPTION
## Summary
- The step summary pill below assistant messages previously showed "X of Y steps failed" with a red X icon, which was alarming to users
- Changed to always show "Completed N steps" with a green checkmark, matching the non-error state
- Individual step error details remain visible when the pill is expanded

## Test plan
- [ ] Verify the pill shows "Completed N steps" with green checkmark when all steps succeed
- [ ] Verify the pill shows "Completed N steps" with green checkmark when some steps fail (no red X)
- [ ] Verify expanding the pill still shows per-step error/success indicators
- [ ] Check both macOS and compact (mobile) variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
