### PR TITLE
chore: remove redundant console.log from daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -257,7 +257,6 @@ function loadDotEnv(): void {
 
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
-  console.log('[daemon] Starting up...');
   loadDotEnv();
   initSentry();
   await initLogfire();
@@ -336,11 +335,9 @@ export async function runDaemon(): Promise<void> {
     log.warn({ err }, 'Qdrant failed to start — memory features will be unavailable');
   }
 
-  console.log('[daemon] Starting DaemonServer (IPC socket)...');
   log.info('Daemon startup: starting DaemonServer (IPC socket)');
   const server = new DaemonServer();
   await server.start();
-  console.log('[daemon] DaemonServer started');
   log.info('Daemon startup: DaemonServer started, starting memory worker');
   const memoryWorker = startMemoryJobsWorker();
   // Initialize watcher engine and register providers
@@ -429,7 +426,6 @@ export async function runDaemon(): Promise<void> {
   }
 
   writePid(process.pid);
-  console.log(`[daemon] Ready (pid=${process.pid})`);
   log.info({ pid: process.pid }, 'Daemon started');
 
   const hookManager = getHookManager();


### PR DESCRIPTION
## Summary
- Remove 4 `console.log` statements from daemon lifecycle that duplicate structured `log.info` calls right next to them
- Keeps daemon stdout output clean

## Test plan
- [ ] Daemon starts without errors
- [ ] Structured logs still appear in log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
