### PR TITLE
Inject current datetime into system prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -96,6 +96,7 @@ export function buildSystemPrompt(): string {
   const bootstrap = readPromptFile(bootstrapPath);
 
   const parts: string[] = [];
+  parts.push(buildDatetimeSection());
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
@@ -126,6 +127,21 @@ export function buildSystemPrompt(): string {
   parts.push(buildPostToolResponseSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
+}
+
+function buildDatetimeSection(): string {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const now = new Date().toLocaleString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: tz,
+  });
+  return `Current datetime: ${now}${tz ? ` (${tz})` : ' (user timezone unknown)'}`;
 }
 
 function buildToolRoutingSection(): string {


### PR DESCRIPTION
## Summary
- Adds a `buildDatetimeSection()` that injects the current datetime at the top of the system prompt
- Uses system timezone via `Intl.DateTimeFormat` — falls back to "(user timezone unknown)" if unavailable
- Output is minimal, e.g. `Current datetime: Thursday, February 19, 2026 at 3:45 PM (America/New_York)`

cc @emmiekehoe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
