### PR TITLE
Fix: use REST API for lock issue creation in devin-doctor

### DIFF
--- a/.github/workflows/devin-doctor.yml
+++ b/.github/workflows/devin-doctor.yml
@@ -235,10 +235,10 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           PR_AUTHORS: ${{ steps.pr.outputs.pr_authors }}
         run: |
-          gh issue create -R "$REPO" \
-            --title "[devin-doctor-lock] ${CTX_WORKFLOW_NAME} failure in progress" \
-            --body "Lock created for failing run: ${CTX_RUN_URL}
+          TITLE="[devin-doctor-lock] ${CTX_WORKFLOW_NAME} failure in progress"
+          BODY="Lock created for failing run: ${CTX_RUN_URL}
           Devin Session ID: \`${SESSION_ID}\`
           Devin Session URL: ${SESSION_URL}
           Original PR: #${PR_NUMBER}
           Reviewer(s): ${PR_AUTHORS}"
+          gh api "repos/${REPO}/issues" -f title="$TITLE" -f body="$BODY"


### PR DESCRIPTION
## Summary
- Switch lock issue creation from `gh issue create` (GraphQL) to `gh api repos/.../issues` (REST)
- Fixes 'Resource not accessible by integration' error when creating lock issues in workflow_run context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
