### PR TITLE
fix: add missing IPCWorkItemRenderRequest struct

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1956,6 +1956,11 @@ public struct IPCWorkItemCompleteRequest: Codable, Sendable {
     public let id: String
 }
 
+public struct IPCWorkItemRenderRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
 public struct IPCWorkItemDeleteRequest: Codable, Sendable {
     public let type: String
     public let id: String


### PR DESCRIPTION
## Summary
- `DaemonClient.sendWorkItemRender` referenced `IPCWorkItemRenderRequest` but the struct was never added to `IPCContractGenerated.swift`, breaking the Swift build on main.
- Added the missing struct (same `type` + `id` shape as other work item request types).

## Test plan
- [x] `./build.sh run` compiles and launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
