### PR TITLE
fix: use explicit created flag in contact upsert

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -70,7 +70,7 @@ export function upsertContact(params: {
   responseExpectation?: string | null;
   preferredTone?: string | null;
   channels?: Array<{ type: string; address: string; isPrimary?: boolean }>;
-}): ContactWithChannels {
+}): ContactWithChannels & { created: boolean } {
   const db = getDb();
   const now = Date.now();
 
@@ -96,7 +96,7 @@ export function upsertContact(params: {
         syncChannels(contactId, params.channels, now);
       }
 
-      return getContact(contactId)!;
+      return { ...getContact(contactId)!, created: false };
     }
   }
 
@@ -124,7 +124,7 @@ export function upsertContact(params: {
           .run();
 
         syncChannels(contactId, params.channels, now);
-        return getContact(contactId)!;
+        return { ...getContact(contactId)!, created: false };
       }
     }
   }
@@ -148,7 +148,7 @@ export function upsertContact(params: {
     syncChannels(contactId, params.channels, now);
   }
 
-  return getContact(contactId)!;
+  return { ...getContact(contactId)!, created: true };
 }
 
 /**

--- a/assistant/src/tools/contacts/contact-upsert.ts
+++ b/assistant/src/tools/contacts/contact-upsert.ts
@@ -53,9 +53,8 @@ export async function executeContactUpsert(
       channels,
     });
 
-    const isNew = contact.createdAt === contact.updatedAt;
     return {
-      content: `${isNew ? 'Created' : 'Updated'} contact:\n${formatContact(contact)}`,
+      content: `${contact.created ? 'Created' : 'Updated'} contact:\n${formatContact(contact)}`,
       isError: false,
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- `contact-upsert.ts` inferred create vs update by comparing `createdAt === updatedAt`, which is unreliable when both happen within the same millisecond
- Changed `upsertContact()` to return an explicit `created: boolean` flag since it already knows which code path it took
- Fixes flaky test at `contacts-tools.test.ts:113` where fast updates produced "Created contact" instead of "Updated contact"

## Test plan
- [ ] `bun test src/__tests__/contacts-tools.test.ts` passes — "updates an existing contact by ID" reliably says "Updated contact"
- [ ] No other callers of `upsertContact` are affected (only `contact-upsert.ts` uses it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
