### PR TITLE
Revert static datetime injection from system prompt

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -96,7 +96,6 @@ export function buildSystemPrompt(): string {
   const bootstrap = readPromptFile(bootstrapPath);
 
   const parts: string[] = [];
-  parts.push(buildDatetimeSection());
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
@@ -127,21 +126,6 @@ export function buildSystemPrompt(): string {
   parts.push(buildPostToolResponseSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
-}
-
-function buildDatetimeSection(): string {
-  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const now = new Date().toLocaleString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-    timeZone: tz,
-  });
-  return `Current datetime: ${now}${tz ? ` (${tz})` : ' (user timezone unknown)'}`;
 }
 
 function buildToolRoutingSection(): string {


### PR DESCRIPTION
## Summary
- Reverts #5557 — `buildDatetimeSection()` was injecting datetime into the static system prompt, which is built once per session and cached
- `buildTemporalContext()` in `date-context.ts` already handles this correctly by injecting fresh temporal context (date, timezone, 14-day horizon) at every turn via `session-agent-loop.ts:283-294`
- Credit to Devin's review: https://github.com/vellum-ai/vellum-assistant/pull/5557#discussion_r2830425372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
