### PR TITLE
fix: add claim expiry for crash-resilient callback idempotency

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -39,6 +39,7 @@ import {
   expirePendingQuestions,
   claimCallback,
   releaseCallbackClaim,
+  finalizeCallbackClaim,
 } from '../calls/call-store.js';
 
 initializeDb();
@@ -544,5 +545,66 @@ describe('call-store', () => {
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
     const rows = raw.query('SELECT COUNT(*) as cnt FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-4') as { cnt: number };
     expect(rows.cnt).toBe(1);
+  });
+
+  test('claimCallback reclaims expired orphaned claims', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-26',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Claim the key
+    const first = claimCallback('test-dedupe-key-expired', session.id);
+    expect(first).toBe(true);
+
+    // Simulate an orphaned claim by backdating the created_at to well past expiry
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const oldTimestamp = Date.now() - 120_000; // 2 minutes ago, well past 60s expiry
+    raw.query('UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?').run(oldTimestamp, 'test-dedupe-key-expired');
+
+    // Reclaim should succeed because the old claim has expired
+    const second = claimCallback('test-dedupe-key-expired', session.id);
+    expect(second).toBe(true);
+  });
+
+  test('claimCallback does not reclaim finalized claims', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-27',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Claim and finalize
+    const first = claimCallback('test-dedupe-key-finalized', session.id);
+    expect(first).toBe(true);
+    finalizeCallbackClaim('test-dedupe-key-finalized');
+
+    // Attempting to reclaim a finalized key should fail because the far-future
+    // timestamp means it will never be considered expired
+    const second = claimCallback('test-dedupe-key-finalized', session.id);
+    expect(second).toBe(false);
+  });
+
+  test('finalizeCallbackClaim makes claim permanent', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-28',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Claim and finalize
+    claimCallback('test-dedupe-key-permanent', session.id);
+    finalizeCallbackClaim('test-dedupe-key-permanent');
+
+    // Verify the created_at is set far in the future
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const row = raw.query('SELECT created_at FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-permanent') as { created_at: number };
+    // Should be at least 50 years in the future from now
+    const fiftyYearsMs = 50 * 365 * 24 * 60 * 60 * 1000;
+    expect(row.created_at).toBeGreaterThan(Date.now() + fiftyYearsMs);
   });
 });

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -263,6 +263,9 @@ export function expirePendingQuestions(callSessionId: string): void {
 
 // ── Callback Idempotency ─────────────────────────────────────────────
 
+/** Claims older than this are considered orphaned (crashed mid-processing) and can be reclaimed. */
+const CLAIM_EXPIRY_MS = 60_000; // 60 seconds
+
 /**
  * Build a dedupe key for a Twilio status callback.
  * Combines CallSid + CallStatus + Timestamp (or SequenceNumber if present)
@@ -341,11 +344,22 @@ export function tryRecordProcessedCallback(
  * won the claim (INSERT succeeded). Returns false if another caller already
  * claimed it (dedupe_key conflict).
  *
+ * Expired orphaned claims (older than CLAIM_EXPIRY_MS) are automatically
+ * cleared before attempting the insert, so crashes mid-processing don't
+ * permanently block retries.
+ *
  * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow retries.
+ * On success, call `finalizeCallbackClaim(dedupeKey)` to make the claim permanent.
  */
 export function claimCallback(dedupeKey: string, callSessionId: string): boolean {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+
+  // Clear any expired orphaned claims so they can be reprocessed
+  raw.query(
+    `DELETE FROM processed_callbacks WHERE dedupe_key = ? AND created_at < ?`,
+  ).run(dedupeKey, Date.now() - CLAIM_EXPIRY_MS);
+
   raw.query(
     `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
   ).run(uuid(), dedupeKey, callSessionId, Date.now());
@@ -361,4 +375,19 @@ export function releaseCallbackClaim(dedupeKey: string): void {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
   raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ?`).run(dedupeKey);
+}
+
+/**
+ * Finalize a callback claim after successful processing.
+ * Sets the created_at to a far-future value so the claim never expires,
+ * distinguishing it from in-flight claims that may need to be reclaimed.
+ */
+export function finalizeCallbackClaim(dedupeKey: string): void {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  // Set created_at far in the future so expiry check never matches
+  const NEVER_EXPIRE = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000; // ~100 years
+  raw.query(
+    `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?`,
+  ).run(NEVER_EXPIRE, dedupeKey);
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -16,6 +16,7 @@ import {
   buildCallbackDedupeKey,
   claimCallback,
   releaseCallbackClaim,
+  finalizeCallbackClaim,
 } from './call-store.js';
 import type { CallStatus } from './types.js';
 import { answerCall } from './call-domain.js';
@@ -197,6 +198,9 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     if (isTerminal) {
       expirePendingQuestions(session.id);
     }
+
+    // Mark the claim as permanently processed so it never expires
+    finalizeCallbackClaim(dedupeKey);
   } catch (err) {
     // Release claim so Twilio retries can reprocess
     releaseCallbackClaim(dedupeKey);


### PR DESCRIPTION
Addresses feedback from #5541

## Problem
If the process crashes after `claimCallback()` succeeds but before processing completes (and before the catch block can release), the claim row persists forever and all Twilio retries for that callback are permanently blocked.

## Solution
- Add claim expiry: claims older than 60s are considered orphaned and auto-deleted on next claim attempt
- Add `finalizeCallbackClaim()`: after successful processing, marks the claim as permanent (far-future timestamp) so it's never reclaimed
- Flow: claim → process → finalize (on success) / release (on error) / auto-expire (on crash)

## Tests
- Expired orphaned claims can be reclaimed
- Finalized claims cannot be reclaimed
- finalizeCallbackClaim sets far-future timestamp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
