### PR TITLE
fix: correct gateway relay URL path and buffer WS messages

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -36,12 +36,12 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function generateTwiML(callSessionId: string, wssBaseUrl: string, welcomeGreeting: string): string {
+function generateTwiML(callSessionId: string, relayUrl: string, welcomeGreeting: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <ConversationRelay
-      url="${escapeXml(wssBaseUrl)}/v1/calls/relay?callSessionId=${escapeXml(callSessionId)}"
+      url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}"
       welcomeGreeting="${escapeXml(welcomeGreeting)}"
       voice="Google.en-US-Journey-O"
       language="en-US"
@@ -113,10 +113,17 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
 
   const config = getTwilioConfig();
-  const wssBaseUrl = config.wssBaseUrl || config.webhookBaseUrl.replace(/^http/, 'ws');
+  let relayUrl: string;
+  if (config.wssBaseUrl) {
+    // wssBaseUrl points directly to runtime — use runtime's internal relay path
+    relayUrl = `${config.wssBaseUrl.replace(/\/$/, '')}/v1/calls/relay`;
+  } else {
+    // Fall back to gateway's public URL — use gateway's relay path
+    relayUrl = `${config.webhookBaseUrl.replace(/\/$/, '').replace(/^http/, 'ws')}/webhooks/twilio/relay`;
+  }
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
-  const twiml = generateTwiML(callSessionId, wssBaseUrl, welcomeGreeting);
+  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting);
 
   log.info({ callSessionId }, 'Returning ConversationRelay TwiML');
 

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -34,6 +34,7 @@ type RelaySocketData = {
   callSessionId: string;
   config: GatewayConfig;
   upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
 };
 
 /**
@@ -43,6 +44,9 @@ export function getRelayWebsocketHandlers() {
   return {
     open(ws: import("bun").ServerWebSocket<RelaySocketData>) {
       const { callSessionId, config } = ws.data;
+
+      // Initialize message buffer for frames arriving before upstream connects
+      ws.data.pendingMessages = [];
 
       // Build upstream URL to runtime
       const runtimeBase = config.assistantRuntimeBaseUrl.replace(/^http/, 'ws');
@@ -55,6 +59,14 @@ export function getRelayWebsocketHandlers() {
 
       upstream.addEventListener("open", () => {
         log.info({ callSessionId }, "Upstream WS connected");
+        // Flush any buffered messages
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
       });
 
       upstream.addEventListener("message", (event) => {
@@ -79,6 +91,9 @@ export function getRelayWebsocketHandlers() {
       const upstream = ws.data.upstream;
       if (upstream && upstream.readyState === WebSocket.OPEN) {
         upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        // Buffer messages until upstream connects
+        ws.data.pendingMessages.push(message);
       }
     },
 


### PR DESCRIPTION
Addresses feedback from #5542

## Problem 1: Wrong WS path
When wssBaseUrl is not set and the URL falls back to webhookBaseUrl (gateway), the TwiML used `/v1/calls/relay` (runtime path) instead of `/webhooks/twilio/relay` (gateway path). Twilio would try to connect to a non-existent route.

## Fix
- `generateTwiML` now accepts a full relay URL instead of just a base
- `handleVoiceWebhook` computes the correct path based on whether wssBaseUrl (direct-to-runtime) or webhookBaseUrl (through-gateway) is being used

## Problem 2: Dropped messages during connect
The WS proxy silently dropped Twilio frames received before the upstream runtime socket opened. The critical `setup` message was lost.

## Fix
- Added `pendingMessages` buffer to `RelaySocketData`
- Messages received before upstream opens are buffered
- Buffer is flushed when upstream `open` event fires
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
