### PR TITLE
Address review feedback on PR #5541

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -39,6 +39,7 @@ import {
   expirePendingQuestions,
   claimCallback,
   releaseCallbackClaim,
+  CALLBACK_CLAIM_TTL_MS,
 } from '../calls/call-store.js';
 
 initializeDb();
@@ -544,5 +545,60 @@ describe('call-store', () => {
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
     const rows = raw.query('SELECT COUNT(*) as cnt FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-4') as { cnt: number };
     expect(rows.cnt).toBe(1);
+  });
+
+  test('claimCallback re-claims an expired (orphaned) claim', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-26',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Simulate an orphaned claim from a crashed process by inserting a row
+    // with a created_at timestamp older than the TTL
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const staleTimestamp = Date.now() - CALLBACK_CLAIM_TTL_MS - 1000; // 1 second past expiry
+    raw.query(
+      `INSERT INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
+    ).run('stale-id', 'test-dedupe-key-expired', session.id, staleTimestamp);
+
+    // A new claim should succeed because the existing one is expired
+    const result = claimCallback('test-dedupe-key-expired', session.id);
+    expect(result).toBe(true);
+
+    // The row should have been updated with a fresh timestamp
+    const row = raw.query(
+      'SELECT created_at, id FROM processed_callbacks WHERE dedupe_key = ?',
+    ).get('test-dedupe-key-expired') as { created_at: number; id: string };
+    expect(row.created_at).toBeGreaterThan(staleTimestamp);
+    expect(row.id).not.toBe('stale-id');
+  });
+
+  test('claimCallback does NOT re-claim a non-expired claim', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-27',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Insert a recent claim (within TTL)
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const recentTimestamp = Date.now() - 1000; // 1 second ago, well within TTL
+    raw.query(
+      `INSERT INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
+    ).run('recent-id', 'test-dedupe-key-fresh', session.id, recentTimestamp);
+
+    // A new claim should fail because the existing one is still valid
+    const result = claimCallback('test-dedupe-key-fresh', session.id);
+    expect(result).toBe(false);
+
+    // The original row should be unchanged
+    const row = raw.query(
+      'SELECT created_at, id FROM processed_callbacks WHERE dedupe_key = ?',
+    ).get('test-dedupe-key-fresh') as { created_at: number; id: string };
+    expect(row.created_at).toBe(recentTimestamp);
+    expect(row.id).toBe('recent-id');
   });
 });

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -337,20 +337,44 @@ export function tryRecordProcessedCallback(
 }
 
 /**
+ * How long a callback claim is considered valid before it expires.
+ * If a process crashes after claiming but before the catch block releases,
+ * the claim becomes stale after this TTL and Twilio retries can re-claim it.
+ * Default: 5 minutes (300 000 ms).
+ */
+export const CALLBACK_CLAIM_TTL_MS = 5 * 60 * 1000;
+
+/**
  * Atomically claim a callback for processing. Returns true if this caller
- * won the claim (INSERT succeeded). Returns false if another caller already
- * claimed it (dedupe_key conflict).
+ * won the claim (INSERT succeeded or an expired claim was replaced).
+ * Returns false if another caller holds a non-expired claim.
  *
- * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow retries.
+ * Uses a lease/expiry pattern: claims older than CALLBACK_CLAIM_TTL_MS are
+ * treated as orphaned (e.g. from a crashed process) and can be re-claimed.
+ * This prevents hard crashes from permanently dropping callbacks.
+ *
+ * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow
+ * immediate retries without waiting for TTL expiry.
  */
 export function claimCallback(dedupeKey: string, callSessionId: string): boolean {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  const now = Date.now();
+
+  // Try fresh insert first (fast path for new callbacks)
   raw.query(
     `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  return changes.c > 0;
+  ).run(uuid(), dedupeKey, callSessionId, now);
+  const insertChanges = raw.query('SELECT changes() as c').get() as { c: number };
+  if (insertChanges.c > 0) return true;
+
+  // Existing claim found — check if it has expired (orphaned by a crash)
+  const expiryCutoff = now - CALLBACK_CLAIM_TTL_MS;
+  raw.query(
+    `UPDATE processed_callbacks SET id = ?, call_session_id = ?, created_at = ? WHERE dedupe_key = ? AND created_at < ?`,
+  ).run(uuid(), callSessionId, now, dedupeKey, expiryCutoff);
+  const updateChanges = raw.query('SELECT changes() as c').get() as { c: number };
+  return updateChanges.c > 0;
 }
 
 /**


### PR DESCRIPTION
Addresses review comments from #5541

The Codex review on PR #5541 identified that callback claims from `claimCallback()` could become permanently stuck if the process crashes after claiming but before the catch block releases the claim. This would cause all Twilio retries for that callback to be silently dropped as duplicates.

## Changes

- Add lease/expiry semantics to `claimCallback()`: claims older than `CALLBACK_CLAIM_TTL_MS` (5 minutes) are treated as orphaned and can be re-claimed by new callers
- Export `CALLBACK_CLAIM_TTL_MS` constant for configurability and test access
- Add tests for expired claim recovery and non-expired claim rejection
- No schema changes needed — uses existing `created_at` column as the lease timestamp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
