### PR TITLE
M3: Add Twitter settings UX for mode selection, connect, verify, and disconnect

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -22,6 +22,8 @@ struct SettingsPanel: View {
     @State private var imageGenKeyText: String = ""
     @State private var showingTrustRules = false
     @State private var showingReminders = false
+    @State private var twitterClientId: String = ""
+    @State private var twitterClientSecret: String = ""
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
     @State private var integrationError: (id: String, message: String)?
@@ -82,6 +84,7 @@ struct SettingsPanel: View {
         }
         .onAppear {
             store.refreshAPIKeyState()
+            store.refreshTwitterStatus()
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }
@@ -504,7 +507,155 @@ struct SettingsPanel: View {
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceSubtle)
             }
+
+            // TWITTER / X section
+            twitterSection
         }
+    }
+
+    // MARK: - Twitter Section
+
+    private var twitterSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Twitter / X")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            // Mode Picker
+            HStack {
+                Text("Integration mode")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                Picker("", selection: $store.twitterMode) {
+                    Text("Local (BYO App)").tag("local_byo")
+                    Text("Managed").tag("managed")
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+                .onChange(of: store.twitterMode) { _, newValue in
+                    store.setTwitterMode(newValue)
+                }
+            }
+
+            // Managed mode "coming soon" card
+            if store.twitterMode == "managed" {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(VColor.textSecondary)
+                    Text("Managed mode is coming soon. Switch to Local (BYO App) to connect now.")
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.textSecondary)
+                }
+            }
+
+            // Local BYO mode content
+            if store.twitterMode == "local_byo" {
+                if !store.twitterLocalClientConfigured {
+                    // Client credentials entry (when not yet configured)
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        TextField("OAuth Client ID", text: $twitterClientId)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+
+                        SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+
+                        HStack {
+                            Text("Create an app at developer.x.com")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                            Spacer()
+                            VButton(label: "Save", style: .primary) {
+                                store.saveTwitterLocalClient(
+                                    clientId: twitterClientId,
+                                    clientSecret: twitterClientSecret.isEmpty ? nil : twitterClientSecret
+                                )
+                                twitterClientId = ""
+                                twitterClientSecret = ""
+                            }
+                            .disabled(twitterClientId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                } else {
+                    // Client configured — show connect or connected state
+                    if store.twitterConnected {
+                        // Connected state
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                                .font(.system(size: 14))
+                            Text("Connected")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            if let account = store.twitterAccountInfo {
+                                Text(account)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            Spacer()
+                            VButton(label: "Disconnect", style: .danger) {
+                                store.disconnectTwitter()
+                            }
+                        }
+                    } else {
+                        // Client configured but not connected
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "circle")
+                                .foregroundColor(VColor.textMuted)
+                                .font(.system(size: 14))
+                            Text("App configured")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Spacer()
+                            if store.twitterAuthInProgress {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text("Connecting...")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textSecondary)
+                            } else {
+                                VButton(label: "Connect", style: .primary) {
+                                    store.connectTwitter()
+                                }
+                            }
+                        }
+                    }
+
+                    // Clear/reconfigure button
+                    HStack {
+                        Spacer()
+                        Button("Clear App Config") {
+                            store.clearTwitterLocalClient()
+                            twitterClientId = ""
+                            twitterClientSecret = ""
+                        }
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Trust Tab

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -65,6 +65,15 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedsEnabledSince: Date?
     @Published var mediaEmbedVideoAllowlistDomains: [String]
 
+    // MARK: - Twitter Integration State
+
+    @Published var twitterMode: String = "local_byo"
+    @Published var twitterManagedAvailable: Bool = false
+    @Published var twitterLocalClientConfigured: Bool = false
+    @Published var twitterConnected: Bool = false
+    @Published var twitterAccountInfo: String?
+    @Published var twitterAuthInProgress: Bool = false
+
     // MARK: - Trust Rules Coordination
 
     /// Whether any settings surface currently has a trust rules sheet open.
@@ -153,11 +162,37 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
+        // Wire up Twitter integration config IPC response
+        daemonClient?.onTwitterIntegrationConfigResponse = { [weak self] response in
+            guard let self else { return }
+            if response.success {
+                self.twitterMode = response.mode ?? "local_byo"
+                self.twitterManagedAvailable = response.managedAvailable
+                self.twitterLocalClientConfigured = response.localClientConfigured
+                self.twitterConnected = response.connected
+                self.twitterAccountInfo = response.accountInfo
+            }
+        }
+
+        // Wire up Twitter auth result IPC response
+        daemonClient?.onTwitterAuthResult = { [weak self] response in
+            guard let self else { return }
+            self.twitterAuthInProgress = false
+            if response.success {
+                self.twitterConnected = true
+                self.twitterAccountInfo = response.accountInfo
+            }
+            self.refreshTwitterStatus()
+        }
+
         // Refresh Vercel key state on init
         refreshVercelKeyState()
 
         // Fetch current model from daemon
         try? daemonClient?.sendModelGet()
+
+        // Refresh Twitter integration status on init
+        refreshTwitterStatus()
     }
 
     // MARK: - API Key Actions
@@ -268,6 +303,37 @@ public final class SettingsStore: ObservableObject {
 
     func refreshVercelKeyState() {
         try? daemonClient?.sendVercelApiConfig(action: "get")
+    }
+
+    // MARK: - Twitter Integration Actions
+
+    func refreshTwitterStatus() {
+        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "get"))
+    }
+
+    func setTwitterMode(_ mode: String) {
+        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "set_mode", mode: mode))
+    }
+
+    func saveTwitterLocalClient(clientId: String, clientSecret: String?) {
+        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(
+            action: "set_local_client",
+            clientId: clientId,
+            clientSecret: clientSecret
+        ))
+    }
+
+    func clearTwitterLocalClient() {
+        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "clear_local_client"))
+    }
+
+    func connectTwitter() {
+        twitterAuthInProgress = true
+        try? daemonClient?.send(TwitterAuthStartMessage())
+    }
+
+    func disconnectTwitter() {
+        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
     }
 
     // MARK: - Model Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -9,6 +9,8 @@ public struct SettingsView: View {
     @State private var perplexityKeyText = ""
     @State private var imageGenKeyText = ""
     @State private var vercelKeyText = ""
+    @State private var twitterClientId = ""
+    @State private var twitterClientSecret = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
@@ -217,6 +219,104 @@ public struct SettingsView: View {
                 }
             }
 
+            Section("Twitter / X") {
+                Picker("Integration mode", selection: $store.twitterMode) {
+                    Text("Local (BYO App)").tag("local_byo")
+                    Text("Managed").tag("managed")
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: store.twitterMode) { _, newValue in
+                    store.setTwitterMode(newValue)
+                }
+
+                if store.twitterMode == "managed" {
+                    HStack(spacing: 6) {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
+                        Text("Managed mode is coming soon. Switch to Local (BYO App) to connect now.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if store.twitterMode == "local_byo" {
+                    if !store.twitterLocalClientConfigured {
+                        VStack(alignment: .leading, spacing: 6) {
+                            TextField("OAuth Client ID", text: $twitterClientId)
+                                .textFieldStyle(.roundedBorder)
+                            SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)
+                                .textFieldStyle(.roundedBorder)
+                            HStack {
+                                Text("Create an app at developer.x.com")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Button("Save") {
+                                    store.saveTwitterLocalClient(
+                                        clientId: twitterClientId,
+                                        clientSecret: twitterClientSecret.isEmpty ? nil : twitterClientSecret
+                                    )
+                                    twitterClientId = ""
+                                    twitterClientSecret = ""
+                                }
+                                .disabled(twitterClientId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            }
+                        }
+                    } else {
+                        if store.twitterConnected {
+                            HStack(spacing: 6) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                    .font(.system(size: 14))
+                                Text("Connected")
+                                    .foregroundStyle(.secondary)
+                                if let account = store.twitterAccountInfo {
+                                    Text(account)
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
+                                }
+                                Spacer()
+                                Button("Disconnect") {
+                                    store.disconnectTwitter()
+                                }
+                                .tint(.red)
+                            }
+                        } else {
+                            HStack(spacing: 6) {
+                                Image(systemName: "circle")
+                                    .foregroundStyle(.tertiary)
+                                    .font(.system(size: 14))
+                                Text("App configured")
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                if store.twitterAuthInProgress {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text("Connecting...")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    Button("Connect") {
+                                        store.connectTwitter()
+                                    }
+                                }
+                            }
+                        }
+
+                        HStack {
+                            Spacer()
+                            Button("Clear App Config") {
+                                store.clearTwitterLocalClient()
+                                twitterClientId = ""
+                                twitterClientSecret = ""
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                        }
+                    }
+                }
+            }
+
             Section("Computer Use") {
                 HStack {
                     Text("Max steps per session")
@@ -416,6 +516,7 @@ public struct SettingsView: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshVercelKeyState()
+            store.refreshTwitterStatus()
             checkPermissions()
         }
         .onDisappear {


### PR DESCRIPTION
## Summary
- Add Twitter section to Settings with mode picker (local_byo vs managed)
- Add BYO OAuth credential entry fields (Client ID, Client Secret)
- Add Connect/Disconnect lifecycle controls
- Show connected status with account info
- Wire all actions to Twitter IPC messages from M1 and M2
- Managed mode shown as 'coming soon'

Part of #5548

Closes #5551
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
