### PR TITLE
fix: show empty state instead of Thinking when entering temporary chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -74,7 +74,7 @@ struct ChatView: View {
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private var isEmptyState: Bool {
-        messages.isEmpty && !isSending
+        messages.isEmpty
     }
 
     private let composerMinHeight: CGFloat = 34


### PR DESCRIPTION
## Summary
- When entering temporary chat, `createSessionIfNeeded` pre-allocates a daemon session, which set `isSending = true`
- The empty state condition `messages.isEmpty && !isSending` was false, so the view fell through to the message list with the "Thinking..." indicator
- Simplified the condition to just `messages.isEmpty` — the user message is always appended to `messages` immediately on send, so this correctly transitions out of empty state when the user actually sends a message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
