### PR TITLE
Address review feedback on PRs #5564 and #5565

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -114,14 +114,12 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
 
   const config = getTwilioConfig();
-  let relayUrl: string;
-  if (config.wssBaseUrl) {
-    // wssBaseUrl points directly to runtime — use runtime's internal relay path
-    relayUrl = `${config.wssBaseUrl.replace(/\/$/, '')}/v1/calls/relay`;
-  } else {
-    // Fall back to gateway's public URL — use gateway's relay path
-    relayUrl = `${config.webhookBaseUrl.replace(/\/$/, '').replace(/^http/, 'ws')}/webhooks/twilio/relay`;
-  }
+  // Always use /v1/calls/relay — the canonical relay path on both runtime and
+  // gateway. wssBaseUrl (when set) points directly at runtime; otherwise
+  // webhookBaseUrl may point at the gateway OR at the runtime in gateway-less
+  // deployments, so we use the same path either way.
+  const wsBase = (config.wssBaseUrl || config.webhookBaseUrl).replace(/\/$/, '').replace(/^http/, 'ws');
+  const relayUrl = `${wsBase}/v1/calls/relay`;
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting);

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -3,6 +3,9 @@ import { getLogger } from "../../logger.js";
 
 const log = getLogger("twilio-relay-ws");
 
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
 /**
  * Create a WebSocket upgrade handler that proxies Twilio ConversationRelay
  * frames between Twilio and the runtime's /v1/calls/relay endpoint.
@@ -92,7 +95,11 @@ export function getRelayWebsocketHandlers() {
       if (upstream && upstream.readyState === WebSocket.OPEN) {
         upstream.send(message);
       } else if (ws.data.pendingMessages) {
-        // Buffer messages until upstream connects
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn({ callSessionId: ws.data.callSessionId }, "Pending message buffer full, closing connection");
+          ws.close(1011, "Buffer overflow");
+          return;
+        }
         ws.data.pendingMessages.push(message);
       }
     },
@@ -100,7 +107,9 @@ export function getRelayWebsocketHandlers() {
     close(ws: import("bun").ServerWebSocket<RelaySocketData>, code: number, reason: string) {
       const { callSessionId, upstream } = ws.data;
       log.info({ callSessionId, code, reason }, "Twilio WS closed");
-      if (upstream && upstream.readyState === WebSocket.OPEN) {
+      // Clear pending buffer so no messages are flushed after close
+      ws.data.pendingMessages = undefined;
+      if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
         upstream.close(code, reason);
       }
     },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -114,7 +114,7 @@ function main() {
         return handleTwilioConnectActionWebhook(req);
       }
 
-      if (url.pathname === "/webhooks/twilio/relay") {
+      if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response


### PR DESCRIPTION
Addresses review comments from #5564 and #5565

## Changes

### Fix relay URL path for runtime-only deployments (PR #5564 P1)
- Unified relay URL to always use `/v1/calls/relay` regardless of deployment topology
- Updated gateway to accept both `/webhooks/twilio/relay` and `/v1/calls/relay` for WS upgrades
- Fixes runtime-only deployments where `webhookBaseUrl` points directly at runtime

### Bound WS message buffer to prevent memory exhaustion (PR #5564 P2)
- Added `MAX_PENDING_MESSAGES` cap (100) on buffered frames before upstream connects
- Closes the connection with 1011 if the buffer overflows

### Fix upstream WS leak on early Twilio disconnect (PR #5565)
- Close upstream WebSocket when in CONNECTING state (not just OPEN) during Twilio close
- Clear pending message buffer on close to prevent stale flush
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
