### PR TITLE
fix: address review feedback on PRs #5564 and #5565

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -118,7 +118,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   // gateway. wssBaseUrl (when set) points directly at runtime; otherwise
   // webhookBaseUrl may point at the gateway OR at the runtime in gateway-less
   // deployments, so we use the same path either way.
-  const wsBase = (config.wssBaseUrl || config.webhookBaseUrl).replace(/\/$/, '').replace(/^http/, 'ws');
+  const wsBase = (config.wssBaseUrl ?? config.webhookBaseUrl).replace(/\/$/, '').replace(/^http/, 'ws');
   const relayUrl = `${wsBase}/v1/calls/relay`;
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -95,9 +95,10 @@ export function getRelayWebsocketHandlers() {
       if (upstream && upstream.readyState === WebSocket.OPEN) {
         upstream.send(message);
       } else if (ws.data.pendingMessages) {
+        // Buffer messages until upstream connects
         if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
-          log.warn({ callSessionId: ws.data.callSessionId }, "Pending message buffer full, closing connection");
-          ws.close(1011, "Buffer overflow");
+          log.warn({ callSessionId: ws.data.callSessionId }, "Pending message buffer overflow — closing connection");
+          ws.close(1008, "Buffer overflow");
           return;
         }
         ws.data.pendingMessages.push(message);


### PR DESCRIPTION
## Summary
- **Relay URL fallback fixed**: Simplified relay URL construction to always use `/v1/calls/relay`, fixing runtime-only deployments where `webhookBaseUrl` points directly at runtime (not the gateway). The only variable is the host: `wssBaseUrl` if set, otherwise `webhookBaseUrl`.
- **Bounded WS buffer**: Added `MAX_PENDING_MESSAGES = 100` cap on the `pendingMessages` buffer in the gateway relay proxy. When exceeded, closes the Twilio connection with code 1008 to prevent unbounded memory growth.
- **Upstream WS leak fix**: Changed the close handler to also close upstream WebSockets in the `CONNECTING` state (not just `OPEN`), preventing orphaned connections when Twilio disconnects during the handshake.

## Test plan
- [ ] Verify relay URL uses `/v1/calls/relay` in both wssBaseUrl and webhookBaseUrl fallback cases
- [ ] Verify buffer overflow closes the downstream connection with code 1008
- [ ] Verify upstream WS is closed when Twilio disconnects during CONNECTING state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
