### PR TITLE
fix: add claim ownership tokens to prevent cross-handler claim interference

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -481,7 +481,7 @@ describe('call-store', () => {
 
   // ── Callback Claim ──────────────────────────────────────────────
 
-  test('claimCallback returns true on first call', () => {
+  test('claimCallback returns a claim ID on first call', () => {
     const session = createTestCallSession({
       conversationId: 'conv-22',
       provider: 'twilio',
@@ -490,10 +490,11 @@ describe('call-store', () => {
     });
 
     const result = claimCallback('test-dedupe-key-1', session.id);
-    expect(result).toBe(true);
+    expect(result).toBeTypeOf('string');
+    expect(result!.length).toBeGreaterThan(0);
   });
 
-  test('claimCallback returns false on duplicate key', () => {
+  test('claimCallback returns null on duplicate key', () => {
     const session = createTestCallSession({
       conversationId: 'conv-23',
       provider: 'twilio',
@@ -504,8 +505,8 @@ describe('call-store', () => {
     const first = claimCallback('test-dedupe-key-2', session.id);
     const second = claimCallback('test-dedupe-key-2', session.id);
 
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(first).toBeTypeOf('string');
+    expect(second).toBeNull();
   });
 
   test('releaseCallbackClaim allows re-claim', () => {
@@ -517,12 +518,31 @@ describe('call-store', () => {
     });
 
     const first = claimCallback('test-dedupe-key-3', session.id);
-    expect(first).toBe(true);
+    expect(first).toBeTypeOf('string');
 
-    releaseCallbackClaim('test-dedupe-key-3');
+    releaseCallbackClaim('test-dedupe-key-3', first!);
 
     const second = claimCallback('test-dedupe-key-3', session.id);
-    expect(second).toBe(true);
+    expect(second).toBeTypeOf('string');
+  });
+
+  test('releaseCallbackClaim with wrong claimId does not release', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-24b',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const claimId = claimCallback('test-dedupe-key-3b', session.id);
+    expect(claimId).toBeTypeOf('string');
+
+    // Attempt to release with a wrong claim ID — should be a no-op
+    releaseCallbackClaim('test-dedupe-key-3b', 'wrong-claim-id');
+
+    // The claim should still be held, so re-claiming should fail
+    const second = claimCallback('test-dedupe-key-3b', session.id);
+    expect(second).toBeNull();
   });
 
   test('claimCallback INSERT OR IGNORE pattern is safe for same key', () => {
@@ -535,11 +555,11 @@ describe('call-store', () => {
 
     // Claim the key
     const first = claimCallback('test-dedupe-key-4', session.id);
-    expect(first).toBe(true);
+    expect(first).toBeTypeOf('string');
 
-    // Subsequent claims with the same key should all return false without throwing
-    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
-    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
+    // Subsequent claims with the same key should all return null without throwing
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBeNull();
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBeNull();
 
     // Only one row should exist in the table for this key
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
@@ -557,7 +577,7 @@ describe('call-store', () => {
 
     // Claim the key
     const first = claimCallback('test-dedupe-key-expired', session.id);
-    expect(first).toBe(true);
+    expect(first).toBeTypeOf('string');
 
     // Simulate an orphaned claim by backdating the created_at to well past expiry
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
@@ -566,7 +586,10 @@ describe('call-store', () => {
 
     // Reclaim should succeed because the old claim has expired
     const second = claimCallback('test-dedupe-key-expired', session.id);
-    expect(second).toBe(true);
+    expect(second).toBeTypeOf('string');
+
+    // The new claim should have a different claim ID
+    expect(second).not.toBe(first);
   });
 
   test('claimCallback does not reclaim finalized claims', () => {
@@ -579,13 +602,13 @@ describe('call-store', () => {
 
     // Claim and finalize
     const first = claimCallback('test-dedupe-key-finalized', session.id);
-    expect(first).toBe(true);
-    finalizeCallbackClaim('test-dedupe-key-finalized');
+    expect(first).toBeTypeOf('string');
+    finalizeCallbackClaim('test-dedupe-key-finalized', first!);
 
     // Attempting to reclaim a finalized key should fail because the far-future
     // timestamp means it will never be considered expired
     const second = claimCallback('test-dedupe-key-finalized', session.id);
-    expect(second).toBe(false);
+    expect(second).toBeNull();
   });
 
   test('finalizeCallbackClaim makes claim permanent', () => {
@@ -597,13 +620,71 @@ describe('call-store', () => {
     });
 
     // Claim and finalize
-    claimCallback('test-dedupe-key-permanent', session.id);
-    finalizeCallbackClaim('test-dedupe-key-permanent');
+    const claimId = claimCallback('test-dedupe-key-permanent', session.id)!;
+    finalizeCallbackClaim('test-dedupe-key-permanent', claimId);
 
     // Verify the created_at is set far in the future
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
     const row = raw.query('SELECT created_at FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-permanent') as { created_at: number };
     // Should be at least 50 years in the future from now
+    const fiftyYearsMs = 50 * 365 * 24 * 60 * 60 * 1000;
+    expect(row.created_at).toBeGreaterThan(Date.now() + fiftyYearsMs);
+  });
+
+  test('finalizeCallbackClaim with wrong claimId does not finalize', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-28b',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Claim the key
+    const claimId = claimCallback('test-dedupe-key-permanent-b', session.id)!;
+    expect(claimId).toBeTypeOf('string');
+
+    // Try to finalize with wrong claimId — should be a no-op
+    finalizeCallbackClaim('test-dedupe-key-permanent-b', 'wrong-claim-id');
+
+    // Verify the created_at was NOT set to far-future (it should still be close to now)
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const row = raw.query('SELECT created_at FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-permanent-b') as { created_at: number };
+    const oneMinuteMs = 60 * 1000;
+    expect(row.created_at).toBeLessThan(Date.now() + oneMinuteMs);
+  });
+
+  test('handler A cannot release handler B claim after reclaim', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-29',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Handler A claims
+    const claimA = claimCallback('test-dedupe-key-ownership', session.id)!;
+    expect(claimA).toBeTypeOf('string');
+
+    // Simulate handler A taking too long: backdate the claim so it expires
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const oldTimestamp = Date.now() - 120_000;
+    raw.query('UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?').run(oldTimestamp, 'test-dedupe-key-ownership');
+
+    // Handler B reclaims (succeeds because the old claim expired)
+    const claimB = claimCallback('test-dedupe-key-ownership', session.id)!;
+    expect(claimB).toBeTypeOf('string');
+    expect(claimB).not.toBe(claimA);
+
+    // Handler B finalizes
+    finalizeCallbackClaim('test-dedupe-key-ownership', claimB);
+
+    // Handler A tries to release using its old claimId — should be a no-op
+    releaseCallbackClaim('test-dedupe-key-ownership', claimA);
+
+    // Verify B's finalized claim is still intact
+    const row = raw.query('SELECT created_at, claim_id FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-ownership') as { created_at: number; claim_id: string };
+    expect(row).not.toBeNull();
+    expect(row.claim_id).toBe(claimB);
     const fiftyYearsMs = 50 * 365 * 24 * 60 * 60 * 1000;
     expect(row.created_at).toBeGreaterThan(Date.now() + fiftyYearsMs);
   });

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -340,18 +340,22 @@ export function tryRecordProcessedCallback(
 }
 
 /**
- * Atomically claim a callback for processing. Returns true if this caller
- * won the claim (INSERT succeeded). Returns false if another caller already
+ * Atomically claim a callback for processing. Returns a unique claim ID
+ * (string) if this caller won the claim, or null if another caller already
  * claimed it (dedupe_key conflict).
  *
  * Expired orphaned claims (older than CLAIM_EXPIRY_MS) are automatically
  * cleared before attempting the insert, so crashes mid-processing don't
  * permanently block retries.
  *
- * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow retries.
- * On success, call `finalizeCallbackClaim(dedupeKey)` to make the claim permanent.
+ * If processing fails, call `releaseCallbackClaim(dedupeKey, claimId)` to allow retries.
+ * On success, call `finalizeCallbackClaim(dedupeKey, claimId)` to make the claim permanent.
+ *
+ * The returned claim ID acts as an ownership token: release and finalize
+ * operations require it so that handler A cannot accidentally release or
+ * finalize a claim that was reclaimed by handler B after expiry.
  */
-export function claimCallback(dedupeKey: string, callSessionId: string): boolean {
+export function claimCallback(dedupeKey: string, callSessionId: string): string | null {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
 
@@ -360,34 +364,41 @@ export function claimCallback(dedupeKey: string, callSessionId: string): boolean
     `DELETE FROM processed_callbacks WHERE dedupe_key = ? AND created_at < ?`,
   ).run(dedupeKey, Date.now() - CLAIM_EXPIRY_MS);
 
+  const claimId = uuid();
   raw.query(
-    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, claim_id, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, claimId, Date.now());
   const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  return changes.c > 0;
+  return changes.c > 0 ? claimId : null;
 }
 
 /**
  * Release a callback claim so that retries can reprocess it.
  * Called when processing fails after a successful claim.
+ *
+ * Only deletes the row if both dedupe_key AND claim_id match, preventing
+ * handler A from releasing a claim that was reclaimed by handler B.
  */
-export function releaseCallbackClaim(dedupeKey: string): void {
+export function releaseCallbackClaim(dedupeKey: string, claimId: string): void {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ?`).run(dedupeKey);
+  raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ? AND claim_id = ?`).run(dedupeKey, claimId);
 }
 
 /**
  * Finalize a callback claim after successful processing.
  * Sets the created_at to a far-future value so the claim never expires,
  * distinguishing it from in-flight claims that may need to be reclaimed.
+ *
+ * Only updates the row if both dedupe_key AND claim_id match, preventing
+ * handler A from finalizing a claim that was reclaimed by handler B.
  */
-export function finalizeCallbackClaim(dedupeKey: string): void {
+export function finalizeCallbackClaim(dedupeKey: string, claimId: string): void {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
   // Set created_at far in the future so expiry check never matches
   const NEVER_EXPIRE = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000; // ~100 years
   raw.query(
-    `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?`,
-  ).run(NEVER_EXPIRE, dedupeKey);
+    `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ? AND claim_id = ?`,
+  ).run(NEVER_EXPIRE, dedupeKey, claimId);
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -169,7 +169,8 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
   const sequenceNumber = formBody.get('SequenceNumber');
   const dedupeKey = buildCallbackDedupeKey(callSid, callStatus, timestamp, sequenceNumber);
 
-  if (!claimCallback(dedupeKey, session.id)) {
+  const claimId = claimCallback(dedupeKey, session.id);
+  if (!claimId) {
     log.info({ callSid, callStatus, dedupeKey }, 'Duplicate status callback — skipping');
     return new Response(null, { status: 200 });
   }
@@ -207,10 +208,10 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     }
 
     // Mark the claim as permanently processed so it never expires
-    finalizeCallbackClaim(dedupeKey);
+    finalizeCallbackClaim(dedupeKey, claimId);
   } catch (err) {
     // Release claim so Twilio retries can reprocess
-    releaseCallbackClaim(dedupeKey);
+    releaseCallbackClaim(dedupeKey, claimId);
     throw err;
   }
 

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -753,6 +753,9 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processed_callbacks_dedupe_key ON processed_callbacks(dedupe_key)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processed_callbacks_call_session_id ON processed_callbacks(call_session_id)`);
 
+  // Add claim ownership token to prevent cross-handler claim interference
+  try { database.run(/*sql*/ `ALTER TABLE processed_callbacks ADD COLUMN claim_id TEXT`); } catch { /* already exists */ }
+
   // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid).
   // On upgraded databases that pre-date this constraint, duplicate rows may exist; deduplicate
   // them first to avoid a UNIQUE constraint failure that would prevent startup.

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -585,5 +585,6 @@ export const processedCallbacks = sqliteTable('processed_callbacks', {
   callSessionId: text('call_session_id')
     .notNull()
     .references(() => callSessions.id, { onDelete: 'cascade' }),
+  claimId: text('claim_id'),
   createdAt: integer('created_at').notNull(),
 });


### PR DESCRIPTION
## Summary
- Adds a `claim_id` (UUID) ownership token to the `processed_callbacks` table and the `claimCallback`/`releaseCallbackClaim`/`finalizeCallbackClaim` APIs
- `claimCallback` now returns a `string | null` (claim ID on success, null on conflict) instead of `boolean`
- `releaseCallbackClaim` and `finalizeCallbackClaim` now require both `dedupeKey` and `claimId`, preventing handler A from releasing or finalizing handler B's claim after an expiry-based reclaim
- Updates `handleStatusCallback` in twilio-routes.ts to thread the claim ID through the claim lifecycle
- Adds tests covering cross-handler interference, wrong-claimId no-ops, and claim ID uniqueness across reclaims

## Motivation
Addresses Codex review feedback on PR #5563: when handler A claims, runs longer than 60s, handler B reclaims and completes, handler A could call `releaseCallbackClaim` and delete B's finalized claim by `dedupe_key` alone. This reopened the key and allowed duplicate status processing on subsequent retries.

## Test plan
- [x] All 33 call-store tests pass (including 3 new ownership-specific tests)
- [x] All 15 twilio-routes integration tests pass
- [x] New test: `releaseCallbackClaim with wrong claimId does not release`
- [x] New test: `finalizeCallbackClaim with wrong claimId does not finalize`
- [x] New test: `handler A cannot release handler B claim after reclaim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
