### PR TITLE
Address review feedback on PR #5563

### DIFF
--- a/assistant/src/__tests__/call-store.test.ts
+++ b/assistant/src/__tests__/call-store.test.ts
@@ -481,7 +481,7 @@ describe('call-store', () => {
 
   // ── Callback Claim ──────────────────────────────────────────────
 
-  test('claimCallback returns true on first call', () => {
+  test('claimCallback returns a claim token on first call', () => {
     const session = createTestCallSession({
       conversationId: 'conv-22',
       provider: 'twilio',
@@ -489,11 +489,12 @@ describe('call-store', () => {
       toNumber: '+15552222222',
     });
 
-    const result = claimCallback('test-dedupe-key-1', session.id);
-    expect(result).toBe(true);
+    const token = claimCallback('test-dedupe-key-1', session.id);
+    expect(token).not.toBeNull();
+    expect(typeof token).toBe('string');
   });
 
-  test('claimCallback returns false on duplicate key', () => {
+  test('claimCallback returns null on duplicate key', () => {
     const session = createTestCallSession({
       conversationId: 'conv-23',
       provider: 'twilio',
@@ -504,8 +505,8 @@ describe('call-store', () => {
     const first = claimCallback('test-dedupe-key-2', session.id);
     const second = claimCallback('test-dedupe-key-2', session.id);
 
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
   });
 
   test('releaseCallbackClaim allows re-claim', () => {
@@ -516,13 +517,66 @@ describe('call-store', () => {
       toNumber: '+15552222222',
     });
 
-    const first = claimCallback('test-dedupe-key-3', session.id);
-    expect(first).toBe(true);
+    const firstToken = claimCallback('test-dedupe-key-3', session.id);
+    expect(firstToken).not.toBeNull();
 
-    releaseCallbackClaim('test-dedupe-key-3');
+    releaseCallbackClaim('test-dedupe-key-3', firstToken!);
 
-    const second = claimCallback('test-dedupe-key-3', session.id);
-    expect(second).toBe(true);
+    const secondToken = claimCallback('test-dedupe-key-3', session.id);
+    expect(secondToken).not.toBeNull();
+  });
+
+  test('releaseCallbackClaim with wrong token does not release', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-24b',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const token = claimCallback('test-dedupe-key-3b', session.id);
+    expect(token).not.toBeNull();
+
+    // Attempt release with a wrong token — should be a no-op
+    releaseCallbackClaim('test-dedupe-key-3b', 'wrong-token');
+
+    // Claim should still be held, so re-claiming should fail
+    const second = claimCallback('test-dedupe-key-3b', session.id);
+    expect(second).toBeNull();
+  });
+
+  test('stale handler cannot release a reclaimed callback', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-race',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // Handler A claims
+    const tokenA = claimCallback('test-dedupe-key-race', session.id);
+    expect(tokenA).not.toBeNull();
+
+    // Simulate handler A's claim expiring by backdating created_at
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const oldTimestamp = Date.now() - 120_000;
+    raw.query('UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?').run(oldTimestamp, 'test-dedupe-key-race');
+
+    // Handler B reclaims the expired key and finalizes
+    const tokenB = claimCallback('test-dedupe-key-race', session.id);
+    expect(tokenB).not.toBeNull();
+    finalizeCallbackClaim('test-dedupe-key-race', tokenB!);
+
+    // Handler A tries to release with its stale token — should be a no-op
+    releaseCallbackClaim('test-dedupe-key-race', tokenA!);
+
+    // The finalized claim should still exist
+    const row = raw.query('SELECT 1 FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-race');
+    expect(row).not.toBeNull();
+
+    // And re-claiming should fail because it's finalized (far-future timestamp)
+    const tokenC = claimCallback('test-dedupe-key-race', session.id);
+    expect(tokenC).toBeNull();
   });
 
   test('claimCallback INSERT OR IGNORE pattern is safe for same key', () => {
@@ -535,11 +589,11 @@ describe('call-store', () => {
 
     // Claim the key
     const first = claimCallback('test-dedupe-key-4', session.id);
-    expect(first).toBe(true);
+    expect(first).not.toBeNull();
 
-    // Subsequent claims with the same key should all return false without throwing
-    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
-    expect(claimCallback('test-dedupe-key-4', session.id)).toBe(false);
+    // Subsequent claims with the same key should all return null without throwing
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBeNull();
+    expect(claimCallback('test-dedupe-key-4', session.id)).toBeNull();
 
     // Only one row should exist in the table for this key
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
@@ -557,7 +611,7 @@ describe('call-store', () => {
 
     // Claim the key
     const first = claimCallback('test-dedupe-key-expired', session.id);
-    expect(first).toBe(true);
+    expect(first).not.toBeNull();
 
     // Simulate an orphaned claim by backdating the created_at to well past expiry
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
@@ -566,7 +620,7 @@ describe('call-store', () => {
 
     // Reclaim should succeed because the old claim has expired
     const second = claimCallback('test-dedupe-key-expired', session.id);
-    expect(second).toBe(true);
+    expect(second).not.toBeNull();
   });
 
   test('claimCallback does not reclaim finalized claims', () => {
@@ -578,14 +632,14 @@ describe('call-store', () => {
     });
 
     // Claim and finalize
-    const first = claimCallback('test-dedupe-key-finalized', session.id);
-    expect(first).toBe(true);
-    finalizeCallbackClaim('test-dedupe-key-finalized');
+    const token = claimCallback('test-dedupe-key-finalized', session.id);
+    expect(token).not.toBeNull();
+    finalizeCallbackClaim('test-dedupe-key-finalized', token!);
 
     // Attempting to reclaim a finalized key should fail because the far-future
     // timestamp means it will never be considered expired
     const second = claimCallback('test-dedupe-key-finalized', session.id);
-    expect(second).toBe(false);
+    expect(second).toBeNull();
   });
 
   test('finalizeCallbackClaim makes claim permanent', () => {
@@ -597,8 +651,8 @@ describe('call-store', () => {
     });
 
     // Claim and finalize
-    claimCallback('test-dedupe-key-permanent', session.id);
-    finalizeCallbackClaim('test-dedupe-key-permanent');
+    const token = claimCallback('test-dedupe-key-permanent', session.id)!;
+    finalizeCallbackClaim('test-dedupe-key-permanent', token);
 
     // Verify the created_at is set far in the future
     const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
@@ -606,5 +660,26 @@ describe('call-store', () => {
     // Should be at least 50 years in the future from now
     const fiftyYearsMs = 50 * 365 * 24 * 60 * 60 * 1000;
     expect(row.created_at).toBeGreaterThan(Date.now() + fiftyYearsMs);
+  });
+
+  test('finalizeCallbackClaim with wrong token does not finalize', () => {
+    const session = createTestCallSession({
+      conversationId: 'conv-29',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const token = claimCallback('test-dedupe-key-wrong-finalize', session.id);
+    expect(token).not.toBeNull();
+
+    // Try to finalize with a wrong token
+    finalizeCallbackClaim('test-dedupe-key-wrong-finalize', 'wrong-token');
+
+    // The created_at should NOT have been moved to the far future
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const row = raw.query('SELECT created_at FROM processed_callbacks WHERE dedupe_key = ?').get('test-dedupe-key-wrong-finalize') as { created_at: number };
+    // Should still be near "now", not far in the future
+    expect(row.created_at).toBeLessThan(Date.now() + 60_000);
   });
 });

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -173,7 +173,7 @@ mock.module('../calls/call-store.js', () => ({
   isCallbackProcessed: () => false,
   recordProcessedCallback: () => {},
   tryRecordProcessedCallback: () => true,
-  claimCallback: () => true,
+  claimCallback: () => 'mock-claim-token',
   releaseCallbackClaim: () => {},
 }));
 

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -310,8 +310,8 @@ export function recordProcessedCallback(
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
 
   raw.query(
-    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, claim_token, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, uuid(), Date.now());
 }
 
 /**
@@ -332,26 +332,30 @@ export function tryRecordProcessedCallback(
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
 
   raw.query(
-    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, claim_token, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, uuid(), Date.now());
 
   const changes = raw.query('SELECT changes() as c').get() as { c: number };
   return changes.c > 0;
 }
 
 /**
- * Atomically claim a callback for processing. Returns true if this caller
- * won the claim (INSERT succeeded). Returns false if another caller already
- * claimed it (dedupe_key conflict).
+ * Atomically claim a callback for processing. Returns a unique claim token
+ * if this caller won the claim (INSERT succeeded), or null if another caller
+ * already claimed it (dedupe_key conflict).
  *
  * Expired orphaned claims (older than CLAIM_EXPIRY_MS) are automatically
  * cleared before attempting the insert, so crashes mid-processing don't
  * permanently block retries.
  *
- * If processing fails, call `releaseCallbackClaim(dedupeKey)` to allow retries.
- * On success, call `finalizeCallbackClaim(dedupeKey)` to make the claim permanent.
+ * The returned claim token scopes subsequent lifecycle operations: only the
+ * holder of the token can release or finalize the claim, preventing a stale
+ * handler from accidentally releasing a claim that was reclaimed by another.
+ *
+ * If processing fails, call `releaseCallbackClaim(dedupeKey, claimToken)` to allow retries.
+ * On success, call `finalizeCallbackClaim(dedupeKey, claimToken)` to make the claim permanent.
  */
-export function claimCallback(dedupeKey: string, callSessionId: string): boolean {
+export function claimCallback(dedupeKey: string, callSessionId: string): string | null {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
 
@@ -360,34 +364,44 @@ export function claimCallback(dedupeKey: string, callSessionId: string): boolean
     `DELETE FROM processed_callbacks WHERE dedupe_key = ? AND created_at < ?`,
   ).run(dedupeKey, Date.now() - CLAIM_EXPIRY_MS);
 
+  const claimToken = uuid();
   raw.query(
-    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+    `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, claim_token, created_at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(uuid(), dedupeKey, callSessionId, claimToken, Date.now());
   const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  return changes.c > 0;
+  return changes.c > 0 ? claimToken : null;
 }
 
 /**
  * Release a callback claim so that retries can reprocess it.
  * Called when processing fails after a successful claim.
+ *
+ * Only deletes the claim if the provided claimToken matches, so a stale
+ * handler that outlived the expiry window cannot release a claim that was
+ * subsequently reclaimed by another handler.
  */
-export function releaseCallbackClaim(dedupeKey: string): void {
+export function releaseCallbackClaim(dedupeKey: string, claimToken: string): void {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ?`).run(dedupeKey);
+  raw.query(
+    `DELETE FROM processed_callbacks WHERE dedupe_key = ? AND claim_token = ?`,
+  ).run(dedupeKey, claimToken);
 }
 
 /**
  * Finalize a callback claim after successful processing.
  * Sets the created_at to a far-future value so the claim never expires,
  * distinguishing it from in-flight claims that may need to be reclaimed.
+ *
+ * Only updates the claim if the provided claimToken matches, preventing
+ * a stale handler from finalizing a claim it no longer owns.
  */
-export function finalizeCallbackClaim(dedupeKey: string): void {
+export function finalizeCallbackClaim(dedupeKey: string, claimToken: string): void {
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
   // Set created_at far in the future so expiry check never matches
   const NEVER_EXPIRE = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000; // ~100 years
   raw.query(
-    `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ?`,
-  ).run(NEVER_EXPIRE, dedupeKey);
+    `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ? AND claim_token = ?`,
+  ).run(NEVER_EXPIRE, dedupeKey, claimToken);
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -169,7 +169,8 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
   const sequenceNumber = formBody.get('SequenceNumber');
   const dedupeKey = buildCallbackDedupeKey(callSid, callStatus, timestamp, sequenceNumber);
 
-  if (!claimCallback(dedupeKey, session.id)) {
+  const claimToken = claimCallback(dedupeKey, session.id);
+  if (!claimToken) {
     log.info({ callSid, callStatus, dedupeKey }, 'Duplicate status callback — skipping');
     return new Response(null, { status: 200 });
   }
@@ -207,10 +208,10 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     }
 
     // Mark the claim as permanently processed so it never expires
-    finalizeCallbackClaim(dedupeKey);
+    finalizeCallbackClaim(dedupeKey, claimToken);
   } catch (err) {
     // Release claim so Twilio retries can reprocess
-    releaseCallbackClaim(dedupeKey);
+    releaseCallbackClaim(dedupeKey, claimToken);
     throw err;
   }
 

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -740,9 +740,13 @@ export function initializeDb(): void {
       id TEXT PRIMARY KEY,
       dedupe_key TEXT NOT NULL UNIQUE,
       call_session_id TEXT NOT NULL REFERENCES call_sessions(id) ON DELETE CASCADE,
+      claim_token TEXT NOT NULL DEFAULT '',
       created_at INTEGER NOT NULL
     )
   `);
+
+  // Migration: add claim_token column for owner-scoped claim lifecycle
+  migrateProcessedCallbacksClaimToken(database);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_sessions_conversation_id ON call_sessions(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_call_sessions_provider_call_sid ON call_sessions(provider_call_sid)`);
@@ -1455,4 +1459,24 @@ function migrateCallSessionsProviderSidDedup(database: ReturnType<typeof drizzle
     try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
     throw e;
   }
+}
+
+/**
+ * One-shot migration: add the claim_token column to processed_callbacks
+ * for existing databases that pre-date owner-scoped claim lifecycle.
+ */
+function migrateProcessedCallbacksClaimToken(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+
+  const tableExists = raw.query(
+    `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'processed_callbacks'`,
+  ).get();
+  if (!tableExists) return;
+
+  const colExists = raw.query(
+    `SELECT 1 FROM pragma_table_info('processed_callbacks') WHERE name = 'claim_token'`,
+  ).get();
+  if (colExists) return;
+
+  raw.exec(`ALTER TABLE processed_callbacks ADD COLUMN claim_token TEXT NOT NULL DEFAULT ''`);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -585,5 +585,6 @@ export const processedCallbacks = sqliteTable('processed_callbacks', {
   callSessionId: text('call_session_id')
     .notNull()
     .references(() => callSessions.id, { onDelete: 'cascade' }),
+  claimToken: text('claim_token').notNull(),
   createdAt: integer('created_at').notNull(),
 });


### PR DESCRIPTION
Addresses review comments from #5563

## Problem
The callback claim lifecycle (claim/release/finalize) identified claims only by dedupe_key. This created a race condition: if handler A's claim expired and handler B reclaimed and finalized it, handler A could still release B's finalized claim using releaseCallbackClaim, reopening the key for duplicate processing.

## Solution
Add a per-claim owner token (UUID) that scopes release and finalize operations:
- claimCallback now returns a claim token (string) on success or null on failure
- releaseCallbackClaim and finalizeCallbackClaim require the matching claim token
- A stale handler whose claim was reclaimed cannot affect the new owner's claim

## Changes
- Added claim_token column to processed_callbacks table (schema + migration)
- Updated claimCallback to return owner token instead of boolean
- Updated releaseCallbackClaim/finalizeCallbackClaim to require token match
- Updated twilio-routes.ts caller to use token-based API
- Added tests for race condition, wrong-token release, and wrong-token finalize
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
