### PR TITLE
fix: don't set isSending during message-less session bootstrap

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -247,7 +247,7 @@ public final class ChatViewModel: ObservableObject {
         // When a message-less bootstrap is in flight (e.g. private thread
         // pre-allocation), adopt the user's message as the pending message
         // so it gets sent when session_info arrives instead of being dropped.
-        if isSending && sessionId == nil {
+        if (isSending || isBootstrapping) && sessionId == nil {
             if pendingUserMessage == nil {
                 let attachments = pendingAttachments
                 pendingAttachments = []
@@ -338,10 +338,11 @@ public final class ChatViewModel: ObservableObject {
     }
 
     private func bootstrapSession(userMessage: String?, attachments: [IPCAttachment]?) {
-        isSending = true
-        // Only show thinking indicator when there's an actual user message
-        // to process; message-less session creates are silent.
+        // Only set sending/thinking indicators when there's an actual user
+        // message; message-less session creates (e.g. private thread
+        // pre-allocation) are silent and shouldn't affect UI state.
         if userMessage != nil {
+            isSending = true
             isThinking = true
         }
         pendingUserMessage = userMessage
@@ -512,7 +513,7 @@ public final class ChatViewModel: ObservableObject {
     public func sendSilently(_ text: String) -> Bool {
         // Don't re-enter bootstrap if a session creation is already in progress —
         // that would overwrite pendingUserMessage and orphan the in-flight session.
-        if sessionId == nil && isSending {
+        if sessionId == nil && (isSending || isBootstrapping) {
             return false
         }
         if sessionId == nil {
@@ -528,7 +529,7 @@ public final class ChatViewModel: ObservableObject {
     /// (e.g. to store the thread in the database before the user types anything).
     /// No-op if a session already exists or a bootstrap is already in flight.
     public func createSessionIfNeeded(threadType: String? = nil) {
-        guard sessionId == nil, !isSending else { return }
+        guard sessionId == nil, !isBootstrapping else { return }
         if let threadType {
             self.threadType = threadType
         }


### PR DESCRIPTION
## Summary
- `bootstrapSession` was setting `isSending = true` even for message-less session pre-allocation (private threads), causing the composer to show a stop button and preventing proper temp chat toggling
- Moved `isSending = true` inside the `if userMessage != nil` guard so message-less bootstraps are truly silent
- Updated re-entry guards in `createSessionIfNeeded`, `sendMessage`, and `sendSilently` to use `isBootstrapping` instead of `isSending` for detecting in-flight bootstraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
