### PR TITLE
Harden workspace git test reliability and remove cross-file mock leakage

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -1,19 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import type { CommitContext } from '../workspace/commit-message-provider.js';
-
-// ---------------------------------------------------------------------------
-// Guard against module mock leakage from earlier test files (e.g. session-queue).
-// Re-register the real workspace modules so our static imports bind to them.
-// The ?real query string forces Bun to bypass the mock cache.
-// ---------------------------------------------------------------------------
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import {
   CommitEnrichmentService,
@@ -57,6 +47,16 @@ describe('CommitEnrichmentService', () => {
     writeFileSync(join(testDir, `file-${Date.now()}.txt`), 'content');
     await gitService.commitChanges('test commit');
     return await gitService.getHeadHash();
+  }
+
+  async function waitForDrain(service: CommitEnrichmentService, timeoutMs = 5000): Promise<void> {
+    const started = Date.now();
+    while (service._getQueueSize() > 0 || service._getActiveWorkers() > 0) {
+      if (Date.now() - started > timeoutMs) {
+        throw new Error(`Timed out waiting for enrichment queue to drain after ${timeoutMs}ms`);
+      }
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
   }
 
   test('enqueue and execute writes git note on success', async () => {
@@ -291,9 +291,7 @@ describe('CommitEnrichmentService', () => {
     });
 
     // Wait for queue to drain before shutdown (avoids discarding pending jobs)
-    while (service._getQueueSize() > 0 || service._getActiveWorkers() > 0) {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    }
+    await waitForDrain(service, 5000);
     await service.shutdown();
 
     // Both notes should exist
@@ -329,9 +327,7 @@ describe('CommitEnrichmentService', () => {
     // Wait for all retries to complete (initial + 2 retries, with backoff)
     // Backoff: 1s after attempt 1, 2s after attempt 2 = ~3s total
     // But since the job itself is very fast to time out, total time is dominated by backoff
-    while (service._getActiveWorkers() > 0 || service._getQueueSize() > 0) {
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
+    await waitForDrain(service, 10000);
     await service.shutdown();
 
     // After 1 initial attempt + 2 retries (3 total), the job should be counted as failed

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import { describe, expect, mock, test, beforeEach, afterAll } from 'bun:test';
 import { rmSync, writeFileSync } from 'node:fs';
 import type { Message, ProviderResponse } from '../providers/types.js';
 import type { AgentEvent, CheckpointInfo, CheckpointDecision } from '../agent/loop.js';
@@ -147,27 +147,11 @@ mock.module('../context/window-manager.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Workspace/git + attachment mocks.
+// Workspace/git turn-commit test hooks.
 // ---------------------------------------------------------------------------
 
 const turnCommitCalls: Array<{ workspaceDir: string; sessionId: string; turnNumber: number }> = [];
 let turnCommitHangForever = false;
-
-mock.module('../workspace/git-service.js', () => ({
-  getWorkspaceGitService: () => ({
-    ensureInitialized: async () => {},
-  }),
-}));
-
-mock.module('../workspace/turn-commit.js', () => ({
-  commitTurnChanges: async (workspaceDir: string, sessionId: string, turnNumber: number) => {
-    turnCommitCalls.push({ workspaceDir, sessionId, turnNumber });
-    if (turnCommitHangForever) {
-      // Simulate a commit that never resolves within the timeout budget
-      await new Promise<void>(() => {});
-    }
-  },
-}));
 
 // ---------------------------------------------------------------------------
 // Usage event capture for request-ID correlation tests.
@@ -231,6 +215,17 @@ mock.module('../agent/loop.js', () => ({
 import { Session, MAX_QUEUE_DEPTH } from '../daemon/session.js';
 import type { QueueDrainReason, QueuePolicy } from '../daemon/session.js';
 
+type SessionWithWorkspaceDeps = Session & {
+  getWorkspaceGitService?: (_workspaceDir: string) => { ensureInitialized: () => Promise<void> };
+  commitTurnChanges?: (
+    workspaceDir: string,
+    sessionId: string,
+    turnNumber: number,
+    provider?: unknown,
+    deadlineMs?: number,
+  ) => Promise<void>;
+};
+
 function makeSession(sendToClient?: (msg: ServerMessage) => void): Session {
   const provider = {
     name: 'mock',
@@ -243,7 +238,19 @@ function makeSession(sendToClient?: (msg: ServerMessage) => void): Session {
       };
     },
   };
-  return new Session('conv-1', provider, 'system prompt', 4096, sendToClient ?? (() => {}), '/tmp');
+  const session = new Session('conv-1', provider, 'system prompt', 4096, sendToClient ?? (() => {}), '/tmp');
+  const sessionWithWorkspaceDeps = session as SessionWithWorkspaceDeps;
+  sessionWithWorkspaceDeps.getWorkspaceGitService = () => ({
+    ensureInitialized: async () => {},
+  });
+  sessionWithWorkspaceDeps.commitTurnChanges = async (workspaceDir: string, sessionId: string, turnNumber: number) => {
+    turnCommitCalls.push({ workspaceDir, sessionId, turnNumber });
+    if (turnCommitHangForever) {
+      // Simulate a commit that never resolves within the timeout budget
+      await new Promise<void>(() => {});
+    }
+  };
+  return session;
 }
 
 /**
@@ -295,6 +302,10 @@ beforeEach(() => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -1,21 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
-
-// ---------------------------------------------------------------------------
-// Guard against module mock leakage from earlier test files (e.g. session-queue).
-// Re-register the real workspace modules so our static imports bind to them.
-// The ?real query string forces Bun to bypass the mock cache.
-// ---------------------------------------------------------------------------
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/turn-commit.js', async () => await import('../workspace/turn-commit.js?real'));
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -1,21 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
-
-// ---------------------------------------------------------------------------
-// Guard against module mock leakage from earlier test files (e.g. session-queue).
-// Re-register the real workspace modules so our static imports bind to them.
-// The ?real query string forces Bun to bypass the mock cache.
-// ---------------------------------------------------------------------------
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/git-service.js', async () => await import('../workspace/git-service.js?real'));
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/heartbeat-service.js', async () => await import('../workspace/heartbeat-service.js?real'));
-// @ts-expect-error Bun mock bypass: ?real query string forces real module resolution
-mock.module('../workspace/commit-message-enrichment-service.js', async () => await import('../workspace/commit-message-enrichment-service.js?real'));
 
 import {
   WorkspaceGitService,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -63,6 +63,10 @@ import type { SkillProjectionCache } from './session-skill-tools.js';
 
 const log = getLogger('session-agent-loop');
 
+type GitServiceInitializer = {
+  ensureInitialized(): Promise<void>;
+};
+
 // ── Context Interface ────────────────────────────────────────────────
 
 export interface AgentLoopSessionContext {
@@ -112,6 +116,9 @@ export interface AgentLoopSessionContext {
   readonly prompter: PermissionPrompter;
   readonly queue: MessageQueue;
 
+  getWorkspaceGitService?: (workspaceDir: string) => GitServiceInitializer;
+  commitTurnChanges?: typeof commitTurnChanges;
+
   refreshWorkspaceTopLevelContextIfNeeded(): void;
   markWorkspaceTopLevelDirty(): void;
   getQueueDepth(): number;
@@ -142,7 +149,8 @@ export async function runAgentLoopImpl(
 
   // Ensure workspace git repo is initialized before any tools run.
   try {
-    const gitService = getWorkspaceGitService(ctx.workingDir);
+    const getWorkspaceGitServiceFn = ctx.getWorkspaceGitService ?? getWorkspaceGitService;
+    const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
     await gitService.ensureInitialized();
   } catch (err) {
     rlog.warn({ err }, 'Failed to initialize workspace git repo (non-fatal)');
@@ -803,7 +811,8 @@ export async function runAgentLoopImpl(
       const config = getConfig();
       const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
       const deadlineMs = Date.now() + maxWait;
-      const commitPromise = commitTurnChanges(
+      const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
+      const commitPromise = commitTurnChangesFn(
         ctx.workingDir, ctx.conversationId, ctx.turnCount,
         undefined,
         deadlineMs,

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -546,11 +546,30 @@ export class WorkspaceGitService {
   private ensureGitignoreRulesLocked(): void {
     const gitignorePath = join(this.workspaceDir, '.gitignore');
     if (existsSync(gitignorePath)) {
-      const content = readFileSync(gitignorePath, 'utf-8');
+      let content = readFileSync(gitignorePath, 'utf-8');
+
+      // Migrate legacy broad ignore rule to selective data subdirectory rules.
+      // This keeps user-tracked files under data/ visible to git.
+      const lines = content.split('\n');
+      const hadLegacyDataRule = lines.some(line => line.trim() === 'data/');
+      if (hadLegacyDataRule) {
+        content = lines
+          .filter(line => line.trim() !== 'data/')
+          .join('\n');
+        if (!content.endsWith('\n')) {
+          content += '\n';
+        }
+      }
 
       const missingRules = WORKSPACE_GITIGNORE_RULES.filter(rule => !content.includes(rule));
-      if (missingRules.length > 0) {
-        const updated = content + '\n# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n';
+      if (hadLegacyDataRule || missingRules.length > 0) {
+        let updated = content;
+        if (missingRules.length > 0) {
+          if (!updated.endsWith('\n')) {
+            updated += '\n';
+          }
+          updated += '# Vellum runtime state (auto-added)\n' + missingRules.join('\n') + '\n';
+        }
         writeFileSync(gitignorePath, updated, 'utf-8');
       }
     } else {


### PR DESCRIPTION
## Summary
- remove deadlock-prone `mock.module(... ?real)` self-mock guards from workspace git-related test suites
- add bounded drain waiting in enrichment tests to avoid unbounded polling loops
- add explicit `mock.restore()` in `session-queue` to prevent module mock leakage across files
- add optional dependency injection hooks in `session-agent-loop` for workspace git init + turn commit, and use them in `session-queue` tests instead of global workspace module mocks
- restore legacy `.gitignore` migration behavior by removing broad `data/` and preserving selective workspace rules

## Why
Multi-file `bun test` runs were intermittently hanging or producing order-dependent failures due to process-global module mocks and unbounded waits.

## Validation
- `bun test assistant/src/__tests__/session-queue.test.ts assistant/src/__tests__/turn-commit.test.ts --reporter=dots --timeout 30000` (45 pass)
- `bun test assistant/src/__tests__/workspace-git-service.test.ts --reporter=dots --timeout 30000` (47 pass)
- `LOG_LEVEL=error bun test assistant/src/__tests__/workspace-git-service.test.ts assistant/src/__tests__/session-queue.test.ts assistant/src/__tests__/config-schema.test.ts assistant/src/__tests__/commit-message-enrichment-service.test.ts assistant/src/__tests__/turn-commit.test.ts assistant/src/__tests__/workspace-heartbeat-service.test.ts --reporter=dots --timeout 30000` (205 pass)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
