### PR TITLE
fix: use separate bundle ID for debug builds

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -89,7 +89,7 @@ This builds a debug `.app` bundle, codesigns it, and launches it immediately.
 ## Build
 
 ```bash
-# Build debug .app bundle (→ dist/Vellum.app)
+# Build debug .app bundle (→ dist/Vellum Dev.app)
 ./build.sh
 
 # Build + launch + watch for changes (auto-rebuild)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -189,6 +189,9 @@ if [ ! -f "$SCRIPT_DIR/cli-bin/vellum-cli" ] && [ -d "$CLI_SRC_DIR/src" ] && com
     if bun build --compile "$CLI_SRC_DIR/src/index.ts" --outfile "$SCRIPT_DIR/cli-bin/vellum-cli"; then
         chmod +x "$SCRIPT_DIR/cli-bin/vellum-cli"
         echo "CLI binary built: $SCRIPT_DIR/cli-bin/vellum-cli"
+    elif [ "$CMD" = "release" ]; then
+        echo "ERROR: CLI binary build failed — required for release builds"
+        exit 1
     else
         echo "Warning: CLI binary build failed — skipping (dev mode)"
     fi

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -33,9 +33,21 @@ export DEVELOPER_DIR
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-BUNDLE_ID="com.vellum.vellum-assistant"
+CMD="${1:-build}"
+
 APP_NAME="vellum-assistant"
-BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"
+
+# Debug builds use a separate bundle ID and display name so they can run
+# side-by-side with production without sharing TCC permissions or conflicting.
+if [ "$CMD" = "release" ]; then
+    BUNDLE_ID="com.vellum.vellum-assistant"
+    BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"
+    URL_SCHEME="vellum-assistant"
+else
+    BUNDLE_ID="com.vellum.vellum-assistant.dev"
+    BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum Dev}"
+    URL_SCHEME="vellum-assistant-dev"
+fi
 APP_DIR="$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app"
 CONTENTS="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS/MacOS"
@@ -47,8 +59,6 @@ if [ -z "${DISPLAY_VERSION:-}" ]; then
     DISPLAY_VERSION="${DISPLAY_VERSION:-0.1.0}"
 fi
 BUILD_VERSION="${BUILD_VERSION:-1}"
-
-CMD="${1:-build}"
 
 # Signing identity (overridable via env for CI)
 # Auto-detect any valid code signing certificate in keychain
@@ -176,9 +186,12 @@ if [ ! -f "$SCRIPT_DIR/cli-bin/vellum-cli" ] && [ -d "$CLI_SRC_DIR/src" ] && com
     echo "Building CLI binary from source..."
     mkdir -p "$SCRIPT_DIR/cli-bin"
     (cd "$CLI_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
-    bun build --compile "$CLI_SRC_DIR/src/index.ts" --outfile "$SCRIPT_DIR/cli-bin/vellum-cli"
-    chmod +x "$SCRIPT_DIR/cli-bin/vellum-cli"
-    echo "CLI binary built: $SCRIPT_DIR/cli-bin/vellum-cli"
+    if bun build --compile "$CLI_SRC_DIR/src/index.ts" --outfile "$SCRIPT_DIR/cli-bin/vellum-cli"; then
+        chmod +x "$SCRIPT_DIR/cli-bin/vellum-cli"
+        echo "CLI binary built: $SCRIPT_DIR/cli-bin/vellum-cli"
+    else
+        echo "Warning: CLI binary build failed — skipping (dev mode)"
+    fi
 fi
 
 # Also rebuild if CLI binary changed or newly added
@@ -307,7 +320,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
             <string>$BUNDLE_ID.auth</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>vellum-assistant</string>
+                <string>${URL_SCHEME}</string>
             </array>
         </dict>
     </array>

--- a/clients/macos/vellum-assistant/App/AuthManager.swift
+++ b/clients/macos/vellum-assistant/App/AuthManager.swift
@@ -20,16 +20,11 @@ final class AuthManager {
     var errorMessage: String?
 
     private let authService = AuthService.shared
-    private static var callbackScheme: String {
-        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
-              let firstType = urlTypes.first,
-              let schemes = firstType["CFBundleURLSchemes"] as? [String],
-              let scheme = schemes.first
-        else {
-            return "vellum-assistant"
-        }
-        return scheme
-    }
+    // Always use the production scheme for auth callbacks regardless of build
+    // configuration. ASWebAuthenticationSession intercepts the redirect in-process
+    // so it won't conflict with a production install, and WorkOS only needs one
+    // whitelisted redirect URI.
+    private static let callbackScheme = "vellum-assistant"
     private var webAuthSession: ASWebAuthenticationSession?
 
     var isAuthenticated: Bool {

--- a/clients/macos/vellum-assistant/App/AuthManager.swift
+++ b/clients/macos/vellum-assistant/App/AuthManager.swift
@@ -20,7 +20,16 @@ final class AuthManager {
     var errorMessage: String?
 
     private let authService = AuthService.shared
-    private static let callbackScheme = "vellum-assistant"
+    private static var callbackScheme: String {
+        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
+              let firstType = urlTypes.first,
+              let schemes = firstType["CFBundleURLSchemes"] as? [String],
+              let scheme = schemes.first
+        else {
+            return "vellum-assistant"
+        }
+        return scheme
+    }
     private var webAuthSession: ASWebAuthenticationSession?
 
     var isAuthenticated: Bool {


### PR DESCRIPTION
## Summary
- Debug builds now use `com.vellum.vellum-assistant.dev` bundle ID, `Vellum Dev` display name, and `vellum-assistant-dev` URL scheme so they run side-by-side with production without sharing TCC permissions or hijacking deep links
- Makes CLI binary build step non-fatal so debug builds aren't blocked by Bun compatibility issues
- Release builds (`./build.sh release`) are unchanged

## Test plan
- [ ] `./build.sh run` produces `dist/Vellum Dev.app` with bundle ID `com.vellum.vellum-assistant.dev`
- [ ] `./build.sh release` still produces `dist/Vellum.app` with bundle ID `com.vellum.vellum-assistant`
- [ ] Both apps can run simultaneously without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
