### PR TITLE
fix: use Bun.file() for CLI text imports to fix macOS build

### DIFF
--- a/cli/src/lib/interfaces-seed.ts
+++ b/cli/src/lib/interfaces-seed.ts
@@ -1,7 +1,7 @@
-// @ts-expect-error -- Bun embed: imports raw file content as a string, not supported by TypeScript
-import constantsSource from "./constants.ts" with { type: "text" };
-// @ts-expect-error -- Bun embed: imports raw file content as a string, not supported by TypeScript
-import defaultMainScreenSource from "../components/DefaultMainScreen.tsx" with { type: "text" };
+import { join } from "path";
+
+const constantsSource = await Bun.file(join(import.meta.dir, "constants.ts")).text();
+const defaultMainScreenSource = await Bun.file(join(import.meta.dir, "..", "components", "DefaultMainScreen.tsx")).text();
 
 function inlineLocalImports(source: string): string {
   return source

--- a/cli/src/lib/openclaw-runtime-server.ts
+++ b/cli/src/lib/openclaw-runtime-server.ts
@@ -1,5 +1,6 @@
-// @ts-expect-error -- Bun embed: imports raw file content as a string, not supported by TypeScript
-import serverSource from "../adapters/openclaw-http-server.ts" with { type: "text" };
+import { join } from "path";
+
+const serverSource = await Bun.file(join(import.meta.dir, "..", "adapters", "openclaw-http-server.ts")).text();
 
 export function buildOpenclawRuntimeServer(): string {
 


### PR DESCRIPTION
## Summary
- Bun's bundler ignores `with { type: "text" }` import attributes for .ts/.tsx files, causing the macOS build to fail with 'No matching export for import default'
- Replace broken text imports in `interfaces-seed.ts` and `openclaw-runtime-server.ts` with `Bun.file()` + top-level await, which works in both dev and compiled binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
