### PR TITLE
fix: add missing resetDb() in test afterAll hooks to prevent hangs

### DIFF
--- a/assistant/src/__tests__/account-registry.test.ts
+++ b/assistant/src/__tests__/account-registry.test.ts
@@ -28,7 +28,7 @@ mock.module('../tools/registry.js', () => ({
   registerTool: () => {},
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import {
   createAccount,
   listAccounts,
@@ -47,6 +47,7 @@ const _ctx: ToolContext = {
 };
 
 afterAll(() => {
+  resetDb();
   mock.restore();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -36,7 +36,7 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { assetMaterializeTool } from '../tools/assets/materialize.js';
@@ -49,6 +49,7 @@ import { mkdirSync } from 'node:fs';
 mkdirSync(sandboxDir, { recursive: true });
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -35,7 +35,7 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { searchAttachments } from '../tools/assets/search.js';
@@ -45,6 +45,7 @@ import type { ToolContext } from '../tools/types.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -34,7 +34,7 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import {
   uploadAttachment,
   deleteAttachment,
@@ -53,6 +53,7 @@ import { createConversation, addMessage } from '../memory/conversation-store.js'
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -24,7 +24,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { memoryItems } from '../memory/schema.js';
 import {
   applyConflictResolution,
@@ -40,6 +40,7 @@ import {
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -30,7 +30,7 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
 import { executeContactUpsert } from '../tools/contacts/contact-upsert.js';
 import { executeContactSearch } from '../tools/contacts/contact-search.js';
@@ -39,6 +39,7 @@ import { executeContactMerge } from '../tools/contacts/contact-merge.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -23,7 +23,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import {
   createConversation,
   getConversation,
@@ -46,6 +46,7 @@ import {
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -30,7 +30,7 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
 import { executeFollowupCreate } from '../tools/followups/followup_create.js';
 import { executeFollowupList } from '../tools/followups/followup_list.js';
@@ -39,6 +39,7 @@ import { executeFollowupResolve } from '../tools/followups/followup_resolve.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -23,7 +23,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { recordUsageEvent, listUsageEvents } from '../memory/llm-usage-store.js';
 import type { UsageEventInput, PricingResult } from '../usage/types.js';
 
@@ -31,6 +31,7 @@ import type { UsageEventInput, PricingResult } from '../usage/types.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -96,7 +96,7 @@ mock.module('../tools/network/script-proxy/certs.js', () => ({
 // Source imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { assetSearchTool, searchAttachments } from '../tools/assets/search.js';
@@ -114,6 +114,7 @@ initializeDb();
 mkdirSync(sandboxDir, { recursive: true });
 
 afterAll(async () => {
+  resetDb();
   await stopAllSessions();
   resolveByIdResults = new Map();
   secureKeyValues = new Map();

--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -35,7 +35,7 @@ mock.module('../memory/jobs-store.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
 import {
   executePlaybookCreate,
@@ -47,6 +47,7 @@ import {
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -42,13 +42,14 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import { estimateTextTokens } from '../context/token-estimator.js';
-import { getDb, initializeDb } from '../memory/db.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { compileDynamicProfile } from '../memory/profile-compiler.js';
 import { memoryItems } from '../memory/schema.js';
 
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -1,6 +1,5 @@
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { initializeDb } from '../memory/db.js';
-import { getDb } from '../memory/db.js';
+import { afterAll, describe, test, expect, beforeEach } from 'bun:test';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { reminders } from '../memory/schema.js';
 import {
   insertReminder,
@@ -18,6 +17,10 @@ initializeDb();
 function clearReminders() {
   getDb().delete(reminders).run();
 }
+
+afterAll(() => {
+  resetDb();
+});
 
 describe('reminder-store', () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -1,6 +1,5 @@
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { initializeDb } from '../memory/db.js';
-import { getDb } from '../memory/db.js';
+import { afterAll, describe, test, expect, beforeEach } from 'bun:test';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { reminders } from '../memory/schema.js';
 import { executeReminderCreate, executeReminderList, executeReminderCancel } from '../tools/reminder/reminder.js';
 import { claimDueReminders } from '../tools/reminder/reminder-store.js';
@@ -10,6 +9,10 @@ initializeDb();
 function clearReminders() {
   getDb().delete(reminders).run();
 }
+
+afterAll(() => {
+  resetDb();
+});
 
 describe('reminder tool', () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -15,7 +15,7 @@
  *   - assistant_text_delta + message_complete (onEvent path) → hub emits in order
  *   - sessionId falls back to conversationId when the message lacks it
  */
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { afterAll, describe, test, expect, beforeEach, mock } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -44,12 +44,16 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 
 initializeDb();
+
+afterAll(() => {
+  resetDb();
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -34,7 +34,7 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import {
@@ -46,6 +46,7 @@ import { RuntimeHttpServer } from '../runtime/http-server.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -26,7 +26,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import {
   createSchedule,
   getSchedule,
@@ -42,6 +42,7 @@ function getRawDb(): import('bun:sqlite').Database {
 }
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -30,7 +30,7 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import type { ToolContext } from '../tools/types.js';
 import { executeScheduleCreate } from '../tools/schedule/create.js';
 import { executeScheduleList } from '../tools/schedule/list.js';
@@ -40,6 +40,7 @@ import { executeScheduleDelete } from '../tools/schedule/delete.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createTask } from '../tasks/task-store.js';
 import {
   createSchedule,
@@ -47,6 +47,7 @@ function forceScheduleDue(scheduleId: string): void {
 }
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -24,7 +24,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import {
   uploadAttachment,
@@ -39,6 +39,7 @@ import {
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/signup-e2e.test.ts
+++ b/assistant/src/__tests__/signup-e2e.test.ts
@@ -48,7 +48,7 @@ const STORE_PATH = join(testDir, 'keys.enc');
 // ── Imports (after mocks) ───────────────────────────────────────────
 
 import { createMockSignupServer, type MockSignupServer } from './fixtures/mock-signup-server.js';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import {
   createAccount,
   listAccounts,
@@ -97,6 +97,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  resetDb();
   await executeBrowserClose({ close_all_pages: true }, ctx);
   await server.stop();
   _setMetadataPath(null);

--- a/assistant/src/__tests__/task-compiler.test.ts
+++ b/assistant/src/__tests__/task-compiler.test.ts
@@ -35,7 +35,7 @@ mock.module('./indexer.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { renderTemplate } from '../tasks/task-runner.js';
 import { compileTaskFromConversation, saveCompiledTask } from '../tasks/task-compiler.js';
 import { getTask } from '../tasks/task-store.js';
@@ -43,6 +43,7 @@ import { getTask } from '../tasks/task-store.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/task-runner.test.ts
+++ b/assistant/src/__tests__/task-runner.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createTask } from '../tasks/task-store.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 import { renderTemplate, runTask } from '../tasks/task-runner.js';
@@ -33,6 +33,7 @@ import { renderTemplate, runTask } from '../tasks/task-runner.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createTask } from '../tasks/task-store.js';
 import { scheduleTask } from '../tasks/task-scheduler.js';
 import {
@@ -48,6 +48,7 @@ function forceScheduleDue(scheduleId: string): void {
 }
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 

--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -34,7 +34,7 @@ mock.module('./indexer.js', () => ({
 }));
 
 import type { Database } from 'bun:sqlite';
-import { initializeDb, getDb } from '../memory/db.js';
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createTask, createTaskRun } from '../tasks/task-store.js';
 import { createWorkItem } from '../work-items/work-item-store.js';
 import { executeTaskSave } from '../tools/tasks/task-save.js';
@@ -48,6 +48,7 @@ import type { ToolContext } from '../tools/types.js';
 initializeDb();
 
 afterAll(() => {
+  resetDb();
   try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
 });
 


### PR DESCRIPTION
## Summary
- 25 test files called `initializeDb()` but never called `resetDb()` in their `afterAll()` hooks, leaving SQLite connections open and preventing test processes from exiting
- Added `resetDb` to imports and `resetDb()` as the first line in each `afterAll()` callback
- For `reminder.test.ts` and `reminder-store.test.ts`, also merged duplicate db.js imports and added missing `afterAll` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)