### PR TITLE
fix: sanitize IPC parse error logging to avoid leaking sensitive data

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -47,7 +47,9 @@ export function createMessageParser(options?: { maxLineSize?: number }) {
           }
           results.push(entry);
         } catch (err) {
-          log.warn({ lineLength: trimmed.length, err }, 'Skipping malformed IPC message');
+          // Log only the error name, not the message — JSON.parse errors embed
+          // fragments of the input which could contain sensitive data.
+          log.warn({ lineLength: trimmed.length, errorType: err instanceof Error ? err.name : 'unknown' }, 'Skipping malformed IPC message');
         }
       }
     }


### PR DESCRIPTION
Address reviewer feedback on PR #5288: avoid logging raw JSON.parse error messages which can embed fragments of malformed input (potentially containing credentials, prompt text, or attachment data). Now logs only the error type/name instead.