### PR TITLE
fix: clamp truncate() for max lengths shorter than suffix

### DIFF
--- a/assistant/src/util/truncate.ts
+++ b/assistant/src/util/truncate.ts
@@ -1,5 +1,6 @@
 /** Truncate a string to `maxLen` characters, appending `suffix` if truncated. */
 export function truncate(str: string, maxLen: number, suffix = '...'): string {
   if (str.length <= maxLen) return str;
+  if (maxLen <= suffix.length) return str.slice(0, maxLen);
   return str.slice(0, maxLen - suffix.length) + suffix;
 }


### PR DESCRIPTION
When maxLen < suffix.length, str.slice(0, maxLen - suffix.length) produces a negative index, causing the result to exceed maxLen. Add a guard that returns str.slice(0, maxLen) without the suffix in this case.

Addresses reviewer feedback on PR #5329.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
