### PR TITLE
fix: remove destination before copyItem to support overwrite in video save

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -291,6 +291,7 @@ struct InlineVideoAttachmentView: View {
         isSaving = true
         if let sourceURL = cachedFileURL {
             Task.detached {
+                try? FileManager.default.removeItem(at: destURL)
                 try? FileManager.default.copyItem(at: sourceURL, to: destURL)
                 await MainActor.run { isSaving = false }
             }


### PR DESCRIPTION
## Summary
- `FileManager.copyItem(at:to:)` throws when the destination already exists, unlike `Data.write(to:)` which overwrites
- When the user picks "Replace" in the NSSavePanel for a cached video, the save silently failed because the error was swallowed by `try?`
- Fix: call `removeItem(at: destURL)` before `copyItem` so the copy succeeds even when overwriting

Addresses reviewer feedback from PR #5310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
