### PR TITLE
fix: avoid double-unregister on failed skill re-registration

### DIFF
--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -241,6 +241,9 @@ export function projectSkillTools(
   const allToolDefinitions: ToolDefinition[] = [];
   const allToolNames = new Set<string>();
   const successfulEntries = new Map<string, string>();
+  // Track skills already unregistered in the version-change branch so the
+  // transiently-failed cleanup loop doesn't double-decrement their refcount.
+  const alreadyUnregistered = new Set<string>();
 
   for (const skillId of activeIds) {
     const skill = catalogById.get(skillId);
@@ -281,6 +284,7 @@ export function projectSkillTools(
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info({ skillId, prevHash, currentHash }, 'Skill version changed, re-registering tools');
         unregisterSkillTools(skillId);
+        alreadyUnregistered.add(skillId);
         try {
           registerSkillTools(tools);
         } catch (err) {
@@ -313,7 +317,7 @@ export function projectSkillTools(
   // skill would be re-registered when it recovers next turn, inflating the
   // refcount since the prior registration was never decremented.
   for (const id of prevActive.keys()) {
-    if (activeIds.has(id) && !successfulEntries.has(id)) {
+    if (activeIds.has(id) && !successfulEntries.has(id) && !alreadyUnregistered.has(id)) {
       log.info({ skillId: id }, 'Unregistering tools for transiently-failed skill');
       unregisterSkillTools(id);
     }


### PR DESCRIPTION
## Summary
- Track skills already unregistered in the version-change branch to prevent the transiently-failed cleanup loop from calling `unregisterSkillTools` a second time
- Without this fix, when `registerSkillTools` throws after `unregisterSkillTools` was already called, the cleanup loop would double-decrement the refcount, potentially removing tools that other active sessions still need

Addresses reviewer feedback on PR #5291.

## Test plan
- [ ] Verify that when a skill re-registration fails after version change, `unregisterSkillTools` is only called once
- [ ] Verify that concurrent sessions sharing a skill are not affected by a failed re-registration in another session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
