### PR TITLE
fix: address review feedback on PR #5284

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -315,11 +315,12 @@ export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDra
       emitText += tag;
     } else {
       // Only trim the trailing newline when the directive occupied its own
-      // line (preceded by \n and followed by \n or end-of-buffer). This
-      // avoids corrupting inline text like "Hello\n<directive/>world" into
-      // "Helloworld".
+      // line (preceded by \n and followed by \n or \r\n). We intentionally
+      // do NOT trim when nextChar is undefined (end-of-buffer) because in
+      // streaming mode more data may arrive in the next chunk — eagerly
+      // trimming would merge words across the directive boundary.
       const nextChar = buffer[end + 2];
-      if (emitText.endsWith('\n') && (nextChar === '\n' || nextChar === undefined)) {
+      if (emitText.endsWith('\n') && (nextChar === '\n' || nextChar === '\r')) {
         emitText = emitText.slice(0, -1);
       }
     }


### PR DESCRIPTION
Address reviewer feedback on PR #5284 regarding CRLF handling and streaming safety in attachment newline trimming.

## Changes
- Remove `nextChar === undefined` from the newline trim condition to prevent word-merging bug when a directive lands at a streaming chunk boundary (end-of-buffer does not mean end-of-text)
- Add `nextChar === '\r'` to handle CRLF line endings so directives on their own line are correctly recognized in Windows-formatted output

## Test plan
- [x] Existing tests pass (no behavioral change for cases where nextChar is a known character)
- [x] Streaming: directive at end-of-chunk no longer eagerly trims preceding newline
- [x] CRLF: directive followed by \r\n is now recognized as own-line
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
