### PR TITLE
fix: move timeout check after network/provider patterns to avoid misclassification

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -117,6 +117,34 @@ describe('classifySessionError', () => {
     }
   });
 
+  describe('timeout errors (generic, not network/gateway)', () => {
+    const cases = [
+      'timeout',
+      'deadline exceeded',
+      'request timed out',
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_API with timeout message`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe('PROVIDER_API');
+        expect(result.userMessage).toContain('took too long');
+        expect(result.retryable).toBe(true);
+      });
+    }
+
+    it('does not steal "connection timeout" from PROVIDER_NETWORK', () => {
+      const result = classifySessionError(new Error('connection timeout'), baseCtx);
+      expect(result.code).toBe('PROVIDER_NETWORK');
+    });
+
+    it('does not steal "Gateway timeout" from PROVIDER_API', () => {
+      const result = classifySessionError(new Error('Gateway timeout'), baseCtx);
+      expect(result.code).toBe('PROVIDER_API');
+      expect(result.userMessage).toContain('returned an error');
+    });
+  });
+
   describe('context-too-large errors', () => {
     const cases = [
       'context_length_exceeded',

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -45,7 +45,8 @@ const CONTEXT_TOO_LARGE_PATTERNS = [
   /exceeded.*max_tokens/i,
 ];
 
-// Timeout patterns (provider-side timeouts distinct from network-level ETIMEDOUT)
+// Generic timeout patterns — checked after NETWORK_PATTERNS and PROVIDER_API_PATTERNS
+// so that "connection timeout" → PROVIDER_NETWORK and "gateway timeout" → PROVIDER_API
 const TIMEOUT_PATTERNS = [
   /\btimeout\b/i,
   /deadline.?exceeded/i,
@@ -218,18 +219,7 @@ function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debug
     }
   }
 
-  // Timeout errors (checked before network so generic "timeout" isn't caught by NETWORK_PATTERNS)
-  for (const pattern of TIMEOUT_PATTERNS) {
-    if (pattern.test(message)) {
-      return {
-        code: 'PROVIDER_API',
-        userMessage: 'The request took too long. This is usually temporary — try again shortly.',
-        retryable: true,
-      };
-    }
-  }
-
-  // Network errors
+  // Network errors (before timeout so "connection timeout" is classified as network)
   for (const pattern of NETWORK_PATTERNS) {
     if (pattern.test(message)) {
       return {
@@ -240,12 +230,24 @@ function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debug
     }
   }
 
-  // Provider API errors (5xx)
+  // Provider API errors (before timeout so "gateway timeout" keeps its specific message)
   for (const pattern of PROVIDER_API_PATTERNS) {
     if (pattern.test(message)) {
       return {
         code: 'PROVIDER_API',
         userMessage: 'The AI provider returned an error. This is usually temporary — try again shortly.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Generic timeout errors (checked after network and provider API patterns so
+  // specific timeouts like "connection timeout" and "gateway timeout" aren't misclassified)
+  for (const pattern of TIMEOUT_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'PROVIDER_API',
+        userMessage: 'The request took too long. This is usually temporary — try again shortly.',
         retryable: true,
       };
     }


### PR DESCRIPTION
## Summary
Address reviewer feedback on PR #5317: the broad `/\btimeout\b/i` pattern in `TIMEOUT_PATTERNS` was checked before `NETWORK_PATTERNS` and `PROVIDER_API_PATTERNS`, causing "connection timeout" to be misclassified as `PROVIDER_API` instead of `PROVIDER_NETWORK`, and "Gateway timeout" to get a less accurate user message.

Fix: Reorder `classifyByMessage` so timeout patterns are checked **after** both network and provider API patterns. This ensures:
- "connection timeout" → `PROVIDER_NETWORK` (connectivity guidance)
- "Gateway timeout" → `PROVIDER_API` (server error guidance)
- Generic "timeout" / "deadline exceeded" → `PROVIDER_API` (timeout-specific guidance)

Also adds explicit tests for the timeout classification ordering.

Addresses feedback on PR #5317.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
