### PR TITLE
fix: handle keychain write failures for OAuth2 client credentials

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -591,9 +591,15 @@ class CredentialStoreTool implements Tool {
           }
 
           // Persist client credentials in keychain for defense in depth
-          setSecureKey(`credential:${service}:client_id`, clientId);
+          const clientIdStored = setSecureKey(`credential:${service}:client_id`, clientId);
+          if (!clientIdStored) {
+            return { content: 'Error: failed to store client_id in secure storage', isError: true };
+          }
           if (clientSecret) {
-            setSecureKey(`credential:${service}:client_secret`, clientSecret);
+            const clientSecretStored = setSecureKey(`credential:${service}:client_secret`, clientSecret);
+            if (!clientSecretStored) {
+              return { content: 'Error: failed to store client_secret in secure storage', isError: true };
+            }
           }
 
           upsertCredentialMetadata(service, 'access_token', {


### PR DESCRIPTION
Address reviewer feedback on PR #5311: `setSecureKey` calls for `client_id` and `client_secret` were ignoring their boolean return value, silently swallowing keychain write failures. Now checks the result and returns an error — consistent with how `access_token` and other credential storage is handled in the same file.

Fixes: https://github.com/vellum-ai/vellum-assistant/pull/5311#discussion_r2829877092

🤖 Generated with [Claude Code](https://claude.com/claude-code)