### PR TITLE
fix: send error responses from macOS signing catch blocks

### DIFF
--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -243,6 +243,10 @@ extension DaemonClient {
             ))
         } catch {
             log.error("Failed to sign bundle payload: \(error.localizedDescription)")
+            try? send(SignBundlePayloadResponseMessage(
+                requestId: msg.requestId,
+                error: error.localizedDescription
+            ))
         }
     }
 
@@ -259,6 +263,10 @@ extension DaemonClient {
             ))
         } catch {
             log.error("Failed to get signing identity: \(error.localizedDescription)")
+            try? send(GetSigningIdentityResponseMessage(
+                requestId: msg.requestId,
+                error: error.localizedDescription
+            ))
         }
     }
     #endif


### PR DESCRIPTION
## Summary
Address Devin review feedback on PR #5341: the macOS `handleSignBundlePayload` and `handleGetSigningIdentity` catch blocks only logged errors but never sent error responses back to the daemon, causing a 30-second timeout hang. The iOS path was correctly fixed in #5341 but the macOS path was missed.

Now both macOS catch blocks send error responses using the existing convenience initializers, matching the iOS behavior and enabling immediate promise rejection on the daemon side.

## Test plan
- [x] Verified error convenience initializers already exist on `SignBundlePayloadResponseMessage` and `GetSigningIdentityResponseMessage`
- [x] Follows same pattern as the iOS error response path added in #5341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
