### PR TITLE
fix: use radial distance for click proximity matching in loop detection

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -146,8 +146,8 @@ final class ActionVerifier {
 
     // MARK: - Comparison
 
-    /// Compare two actions for equivalence. Click-type actions use proximity
-    /// matching on coordinates (within 5px) to catch near-identical clicks.
+    /// Compare two actions for equivalence. Click-type actions use radial
+    /// proximity matching on coordinates (within 5px radius) to catch near-identical clicks.
     private func actionsMatch(_ a: AgentAction, _ b: AgentAction) -> Bool {
         guard a.type == b.type && a.text == b.text && a.key == b.key
               && a.appName == b.appName && a.script == b.script else {
@@ -163,8 +163,7 @@ final class ActionVerifier {
                                   _ bx: CGFloat?, _ by: CGFloat?) -> Bool {
         switch (ax, ay, bx, by) {
         case let (.some(x1), .some(y1), .some(x2), .some(y2)):
-            return abs(x1 - x2) <= Self.coordinateTolerance
-                && abs(y1 - y2) <= Self.coordinateTolerance
+            return hypot(x1 - x2, y1 - y2) <= Self.coordinateTolerance
         case (.none, .none, .none, .none):
             return true
         default:

--- a/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
+++ b/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
@@ -82,6 +82,18 @@ final class ActionVerifierTests: XCTestCase {
                        "Clicks more than 5px apart should not be treated as a loop")
     }
 
+    func testLoopDetection_diagonalClicksBeyondRadius_allowed() {
+        // Clicks differ by 5px on each axis (~7.1px radial distance) — outside 5px radius
+        let click1 = AgentAction(type: .click, reasoning: "test", x: 100, y: 200)
+        let click2 = AgentAction(type: .click, reasoning: "test", x: 105, y: 205)
+        let click3 = AgentAction(type: .click, reasoning: "test", x: 100, y: 200)
+
+        XCTAssertEqual(isAllowed(verifier.verify(click1)), true)
+        XCTAssertEqual(isAllowed(verifier.verify(click2)), true)
+        XCTAssertEqual(isAllowed(verifier.verify(click3)), true,
+                       "Diagonal clicks ~7.1px apart should not match with radial distance check")
+    }
+
     func testLoopDetection_nearIdenticalAlternating_blocked() {
         // Alternating near-identical clicks on two targets
         let a1 = AgentAction(type: .click, reasoning: "test", x: 100, y: 200)


### PR DESCRIPTION
Address Codex review feedback on PR #5337: replace per-axis coordinate tolerance (square region) with Euclidean distance (hypot) for a true 5px radius. Add test for diagonal clicks beyond the radius threshold.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
