### PR TITLE
fix: reject non-array patterns during secret allowlist validation

### DIFF
--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -116,7 +116,11 @@ export interface AllowlistValidationError {
  */
 export function validateAllowlist(config: AllowlistConfig): AllowlistValidationError[] {
   const errors: AllowlistValidationError[] = [];
-  if (!config.patterns || !Array.isArray(config.patterns)) return errors;
+  if (!config.patterns) return errors;
+  if (!Array.isArray(config.patterns)) {
+    errors.push({ index: -1, pattern: String(config.patterns), message: '"patterns" must be an array' });
+    return errors;
+  }
 
   for (let i = 0; i < config.patterns.length; i++) {
     const p = config.patterns[i];


### PR DESCRIPTION
Address Codex review feedback on PR #5349: validateAllowlist now returns a validation error when config.patterns exists but is not an array (e.g. "patterns": "^foo$"), instead of silently returning an empty errors array that falsely indicates the config is valid.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
