### PR TITLE
fix: prevent double-unregister on skill re-registration failure

### DIFF
--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -241,6 +241,9 @@ export function projectSkillTools(
   const allToolDefinitions: ToolDefinition[] = [];
   const allToolNames = new Set<string>();
   const successfulEntries = new Map<string, string>();
+  // Track skills already unregistered in the version-change branch so the
+  // transient-failure cleanup loop doesn't double-decrement the refcount.
+  const alreadyUnregistered = new Set<string>();
 
   for (const skillId of activeIds) {
     const skill = catalogById.get(skillId);
@@ -281,6 +284,7 @@ export function projectSkillTools(
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info({ skillId, prevHash, currentHash }, 'Skill version changed, re-registering tools');
         unregisterSkillTools(skillId);
+        alreadyUnregistered.add(skillId);
         try {
           registerSkillTools(tools);
         } catch (err) {
@@ -313,7 +317,7 @@ export function projectSkillTools(
   // skill would be re-registered when it recovers next turn, inflating the
   // refcount since the prior registration was never decremented.
   for (const id of prevActive.keys()) {
-    if (activeIds.has(id) && !successfulEntries.has(id)) {
+    if (activeIds.has(id) && !successfulEntries.has(id) && !alreadyUnregistered.has(id)) {
       log.info({ skillId: id }, 'Unregistering tools for transiently-failed skill');
       unregisterSkillTools(id);
     }


### PR DESCRIPTION
Address reviewer feedback on PR #5291 regarding double-unregistering on failed re-registration.

When a skill's version changes, unregisterSkillTools is called before re-registration. If registerSkillTools then throws, the skill is not added to successfulEntries, causing the transient-failure cleanup loop to call unregisterSkillTools a second time — double-decrementing the refcount and potentially removing tools that other sessions still need.

Fix: track skills already unregistered in the version-change branch and skip them in the cleanup loop.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
