### PR TITLE
fix: address review feedback on PR #5412

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -45,6 +45,8 @@ await import('../web-search.js');
 
 describe('web_search tool', () => {
   let originalFetch: typeof globalThis.fetch;
+  let savedBraveKey: string | undefined;
+  let savedPerplexityKey: string | undefined;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
@@ -53,10 +55,22 @@ describe('web_search tool', () => {
     mockPerplexityConfigKey = undefined;
     mockBraveSecureKey = undefined;
     mockPerplexitySecureKey = undefined;
+
+    // Isolate from host env so getApiKey() doesn't short-circuit on real keys
+    savedBraveKey = process.env.BRAVE_API_KEY;
+    savedPerplexityKey = process.env.PERPLEXITY_API_KEY;
+    delete process.env.BRAVE_API_KEY;
+    delete process.env.PERPLEXITY_API_KEY;
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+
+    if (savedBraveKey !== undefined) process.env.BRAVE_API_KEY = savedBraveKey;
+    else delete process.env.BRAVE_API_KEY;
+
+    if (savedPerplexityKey !== undefined) process.env.PERPLEXITY_API_KEY = savedPerplexityKey;
+    else delete process.env.PERPLEXITY_API_KEY;
   });
 
   function execute(input: Record<string, unknown>) {


### PR DESCRIPTION
Address reviewer feedback on PR #5412 regarding web-search test isolation from host environment.

Saves and restores BRAVE_API_KEY and PERPLEXITY_API_KEY environment variables in beforeEach/afterEach hooks so that tests are deterministic regardless of the host environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
