### PR TITLE
fix: add missing cleanup subcommand to memory shell completions

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -626,7 +626,7 @@ export function registerCompletionsCommand(program: Command): void {
         config: ['set', 'get', 'list', 'validate-allowlist'],
         keys: ['list', 'set', 'delete'],
         trust: ['list', 'remove', 'clear'],
-        memory: ['status', 'backfill', 'query', 'rebuild-index'],
+        memory: ['status', 'backfill', 'cleanup', 'query', 'rebuild-index'],
         hooks: ['list', 'enable', 'disable', 'install', 'remove'],
         contacts: ['list', 'get', 'merge'],
         autonomy: ['get', 'set'],


### PR DESCRIPTION
Address reviewer feedback on PR #5397 — add the missing `cleanup` subcommand to the memory shell completions map so tab-completion discovers it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
