### PR TITLE
fix: assert traversal-specific error in view_image escape-path test

### DIFF
--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -190,6 +190,7 @@ describe('view_image error handling', () => {
     const result = await tool.execute({ path: '../../etc/passwd.jpg' }, makeContext());
 
     expect(result.isError).toBe(true);
+    expect(result.content).toContain('outside the working directory');
   });
 
   test('rejects file with unrecognizable magic bytes', async () => {


### PR DESCRIPTION
Address reviewer feedback on PR #5415: the path traversal test now asserts the specific error message ('outside the working directory') instead of only checking isError, ensuring the test fails if sandbox enforcement is bypassed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
