### PR TITLE
fix: address review feedback on PR #5442

### DIFF
--- a/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
@@ -49,13 +49,13 @@ mock.module('../memory/embedding-backend.js', () => ({
   getMemoryBackendStatus: (config: { memory: { enabled: boolean } }) => ({
     enabled: config.memory.enabled,
     degraded: false,
-    provider: 'openai',
-    model: 'text-embedding-3-small',
+    provider: 'local',
+    model: 'mock-embedding',
     reason: null,
   }),
   embedWithBackend: async () => ({
-    provider: 'openai' as const,
-    model: 'text-embedding-3-small',
+    provider: 'local' as const,
+    model: 'mock-embedding',
     vectors: [new Array(1536).fill(0)],
   }),
 }));
@@ -113,7 +113,7 @@ function makeConfig(overrides?: { maxInjectTokens?: number }): AssistantConfig {
       ...DEFAULT_CONFIG.memory,
       embeddings: {
         ...DEFAULT_CONFIG.memory.embeddings,
-        provider: 'openai' as const,
+        provider: 'local' as const,
         required: false,
       },
       retrieval: {
@@ -164,7 +164,7 @@ describe('Memory retrieval benchmark', () => {
     }
   });
 
-  test('retrieval completes under 100ms for 100 items', async () => {
+  test('retrieval completes under 500ms for 100 items', async () => {
     const conversationId = 'conv-bench-100';
     const now = 1_700_500_000_000;
     seedMemoryItems(conversationId, 100, now);
@@ -180,10 +180,11 @@ describe('Memory retrieval benchmark', () => {
     expect(recall.degraded).toBe(false);
     expect(recall.lexicalHits).toBeGreaterThan(0);
     expect(recall.selectedCount).toBeGreaterThan(0);
-    expect(recall.latencyMs).toBeLessThan(100);
+    // Relaxed threshold — guards against severe regressions, not precise benchmarking
+    expect(recall.latencyMs).toBeLessThan(500);
   });
 
-  test('retrieval completes under 200ms for 500 items', async () => {
+  test('retrieval completes under 1000ms for 500 items', async () => {
     const conversationId = 'conv-bench-500';
     const now = 1_700_500_000_000;
     seedMemoryItems(conversationId, 500, now);
@@ -199,10 +200,10 @@ describe('Memory retrieval benchmark', () => {
     expect(recall.degraded).toBe(false);
     expect(recall.lexicalHits).toBeGreaterThan(0);
     expect(recall.selectedCount).toBeGreaterThan(0);
-    expect(recall.latencyMs).toBeLessThan(200);
+    expect(recall.latencyMs).toBeLessThan(1000);
   });
 
-  test('retrieval completes under 500ms for 2000 items', async () => {
+  test('retrieval completes under 2000ms for 2000 items', async () => {
     const conversationId = 'conv-bench-2000';
     const now = 1_700_500_000_000;
     seedMemoryItems(conversationId, 2000, now);
@@ -218,7 +219,7 @@ describe('Memory retrieval benchmark', () => {
     expect(recall.degraded).toBe(false);
     expect(recall.lexicalHits).toBeGreaterThan(0);
     expect(recall.selectedCount).toBeGreaterThan(0);
-    expect(recall.latencyMs).toBeLessThan(500);
+    expect(recall.latencyMs).toBeLessThan(2000);
   });
 
   test('token budget enforcement: maxInjectTokens is respected', async () => {
@@ -265,7 +266,7 @@ describe('Memory retrieval benchmark', () => {
         ...DEFAULT_CONFIG.memory,
         embeddings: {
           ...DEFAULT_CONFIG.memory.embeddings,
-          provider: 'openai' as const,
+          provider: 'local' as const,
           required: false,
         },
         retrieval: {
@@ -319,7 +320,7 @@ describe('Memory retrieval benchmark', () => {
         ...DEFAULT_CONFIG.memory,
         embeddings: {
           ...DEFAULT_CONFIG.memory.embeddings,
-          provider: 'openai' as const,
+          provider: 'local' as const,
           required: false,
         },
         retrieval: {


### PR DESCRIPTION
Address reviewer feedback on PR #5442 regarding memory retrieval benchmark decoupling from OpenAI and relaxing thresholds.

Changes:
- Replace openai embedding provider with local in benchmark config and mocks to prevent live API calls
- Relax absolute latency thresholds (100/200/500ms -> 500/1000/2000ms) to be environment-stable regression guards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
