### PR TITLE
fix: address review feedback on PR #5403

### DIFF
--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -18,7 +18,7 @@ import type {
   AppUpdatePreviewRequest,
   UiSurfaceShow,
 } from '../ipc-protocol.js';
-import { log, compareSemver, createSigningCallback, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, compareSemver, createSigningCallback, defineHandlers, type HandlerContext } from './shared.js';
 
 export function handleAppDataRequest(
   msg: AppDataRequest,
@@ -445,7 +445,7 @@ export function handleGalleryInstall(
   }
 }
 
-export const appHandlers: Partial<DispatchMap> = {
+export const appHandlers = defineHandlers({
   app_data_request: handleAppDataRequest,
   app_open_request: handleAppOpenRequest,
   app_update_preview: handleAppUpdatePreview,
@@ -458,4 +458,4 @@ export const appHandlers: Partial<DispatchMap> = {
   bundle_app: handleBundleApp,
   gallery_list: (_msg, socket, ctx) => handleGalleryList(socket, ctx),
   gallery_install: handleGalleryInstall,
-};
+});

--- a/assistant/src/daemon/handlers/browser.ts
+++ b/assistant/src/daemon/handlers/browser.ts
@@ -1,7 +1,7 @@
 import { browserManager } from '../../tools/browser/browser-manager.js';
-import { log, type DispatchMap } from './shared.js';
+import { log, defineHandlers } from './shared.js';
 
-export const browserHandlers: Partial<DispatchMap> = {
+export const browserHandlers = defineHandlers({
   browser_cdp_response: (msg) => {
     browserManager.resolveCDPResponse(msg.sessionId, msg.success, msg.declined);
   },
@@ -51,4 +51,4 @@ export const browserHandlers: Partial<DispatchMap> = {
       enabled: msg.enabled,
     });
   },
-};
+});

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -10,7 +10,7 @@ import type {
   CuObservation,
   ServerMessage,
 } from '../ipc-protocol.js';
-import { log, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
 
 const cuObservationSequenceBySession = new Map<string, number>();
 
@@ -180,8 +180,8 @@ export async function handleCuObservation(
   });
 }
 
-export const computerUseHandlers: Partial<DispatchMap> = {
+export const computerUseHandlers = defineHandlers({
   cu_session_create: handleCuSessionCreate,
   cu_session_abort: handleCuSessionAbort,
   cu_observation: handleCuObservation,
-};
+});

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -22,7 +22,7 @@ import type {
   VercelApiConfigRequest,
   TwitterIntegrationConfigRequest,
 } from '../ipc-protocol.js';
-import { log, CONFIG_RELOAD_DEBOUNCE_MS, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
@@ -598,7 +598,7 @@ export function handleEnvVarsRequest(socket: net.Socket, ctx: HandlerContext): v
   ctx.send(socket, { type: 'env_vars_response', vars });
 }
 
-export const configHandlers: Partial<DispatchMap> = {
+export const configHandlers = defineHandlers({
   model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
   model_set: handleModelSet,
   image_gen_model_set: handleImageGenModelSet,
@@ -617,4 +617,4 @@ export const configHandlers: Partial<DispatchMap> = {
   vercel_api_config: handleVercelApiConfig,
   twitter_integration_config: handleTwitterIntegrationConfig,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
-};
+});

--- a/assistant/src/daemon/handlers/diagnostics.ts
+++ b/assistant/src/daemon/handlers/diagnostics.ts
@@ -9,7 +9,7 @@ import archiver from 'archiver';
 import { getDb } from '../../memory/db.js';
 import { messages, toolInvocations, llmUsageEvents, llmRequestLogs } from '../../memory/schema.js';
 import type { DiagnosticsExportRequest } from '../ipc-protocol.js';
-import { log, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
 
 const MAX_CONTENT_LENGTH = 500;
 
@@ -333,6 +333,6 @@ export async function handleDiagnosticsExport(
   }
 }
 
-export const diagnosticsHandlers: Partial<DispatchMap> = {
+export const diagnosticsHandlers = defineHandlers({
   diagnostics_export_request: handleDiagnosticsExport,
-};
+});

--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -1,4 +1,5 @@
-import type { HandlerContext, DispatchMap } from './shared.js';
+import { defineHandlers } from './shared.js';
+import type { HandlerContext } from './shared.js';
 import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
 import type * as net from 'node:net';
 import type { Database } from 'bun:sqlite';
@@ -165,8 +166,8 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
   }
 }
 
-export const documentHandlers: Partial<DispatchMap> = {
+export const documentHandlers = defineHandlers({
   document_save: handleDocumentSave,
   document_load: handleDocumentLoad,
   document_list: handleDocumentList,
-};
+});

--- a/assistant/src/daemon/handlers/home-base.ts
+++ b/assistant/src/daemon/handlers/home-base.ts
@@ -7,7 +7,7 @@ import {
 } from '../../home-base/prebuilt/seed.js';
 import { getHomeBaseAppLink } from '../../home-base/app-link-store.js';
 import { getApp } from '../../memory/app-store.js';
-import { log, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
 
 export function handleHomeBaseGet(
   msg: HomeBaseGetRequest,
@@ -72,6 +72,6 @@ export function handleHomeBaseGet(
   }
 }
 
-export const homeBaseHandlers: Partial<DispatchMap> = {
+export const homeBaseHandlers = defineHandlers({
   home_base_get: handleHomeBaseGet,
-};
+});

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -3,7 +3,7 @@ import type { ClientMessage } from '../ipc-protocol.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';
 import { handleOpenBundle } from './open-bundle-handler.js';
-import { log, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, defineHandlers, type HandlerContext, type DispatchMap } from './shared.js';
 
 import { sessionHandlers } from './sessions.js';
 import { skillHandlers } from './skills.js';
@@ -37,29 +37,13 @@ export {
 
 // ─── Typed dispatch ──────────────────────────────────────────────────────────
 
-const handlers: DispatchMap = {
-  ...sessionHandlers,
-  ...skillHandlers,
-  ...appHandlers,
-  ...configHandlers,
-  ...computerUseHandlers,
-  ...publishHandlers,
-  ...homeBaseHandlers,
-  ...diagnosticsHandlers,
-  ...miscHandlers,
-  ...documentHandlers,
-  ...workItemHandlers,
-  ...subagentHandlers,
-  ...browserHandlers,
-  ...signingHandlers,
-
-  // Handlers imported from outside the handlers/ directory
+// Inline handlers for messages not owned by any feature group
+const inlineHandlers = defineHandlers({
   ride_shotgun_start: handleRideShotgunStart,
   ride_shotgun_stop: handleRideShotgunStop,
   watch_observation: handleWatchObservation,
   open_bundle: handleOpenBundle,
 
-  // UI surface dispatch
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
     if (cuSession) {
@@ -99,7 +83,25 @@ const handlers: DispatchMap = {
     });
   },
   integration_disconnect: () => { /* no-op — integration registry removed */ },
-} as DispatchMap;
+});
+
+const handlers = {
+  ...sessionHandlers,
+  ...skillHandlers,
+  ...appHandlers,
+  ...configHandlers,
+  ...computerUseHandlers,
+  ...publishHandlers,
+  ...homeBaseHandlers,
+  ...diagnosticsHandlers,
+  ...miscHandlers,
+  ...documentHandlers,
+  ...workItemHandlers,
+  ...subagentHandlers,
+  ...browserHandlers,
+  ...signingHandlers,
+  ...inlineHandlers,
+} satisfies DispatchMap;
 
 export function handleMessage(
   msg: ClientMessage,

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -18,7 +18,7 @@ import type {
   IpcBlobProbe,
   CuSessionCreate,
 } from '../ipc-protocol.js';
-import { log, wireEscalationHandler, renderHistoryContent, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, wireEscalationHandler, renderHistoryContent, defineHandlers, type HandlerContext } from './shared.js';
 import { handleCuSessionCreate } from './computer-use.js';
 
 // ─── Task submit handler ────────────────────────────────────────────────────
@@ -322,10 +322,10 @@ export function handleIpcBlobProbe(
   });
 }
 
-export const miscHandlers: Partial<DispatchMap> = {
+export const miscHandlers = defineHandlers({
   task_submit: handleTaskSubmit,
   suggestion_request: handleSuggestionRequest,
   link_open_request: handleLinkOpenRequest,
   ipc_blob_probe: handleIpcBlobProbe,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
-};
+});

--- a/assistant/src/daemon/handlers/publish.ts
+++ b/assistant/src/daemon/handlers/publish.ts
@@ -10,7 +10,7 @@ import type {
   PublishPageRequest,
   UnpublishPageRequest,
 } from '../ipc-protocol.js';
-import { log, requestSecretStandalone, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, requestSecretStandalone, defineHandlers, type HandlerContext } from './shared.js';
 
 export async function handlePublishPage(
   msg: PublishPageRequest,
@@ -181,7 +181,7 @@ export async function handleUnpublishPage(
   }
 }
 
-export const publishHandlers: Partial<DispatchMap> = {
+export const publishHandlers = defineHandlers({
   publish_page: handlePublishPage,
   unpublish_page: handleUnpublishPage,
-};
+});

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -31,7 +31,7 @@ import {
   mergeToolResults,
   pendingStandaloneSecrets,
   type HandlerContext,
-  type DispatchMap,
+  defineHandlers,
   type HistoryToolCall,
   type HistorySurface,
   type ParsedHistoryMessage,
@@ -499,7 +499,7 @@ export function handleDeleteQueuedMessage(
   }
 }
 
-export const sessionHandlers: Partial<DispatchMap> = {
+export const sessionHandlers = defineHandlers({
   user_message: handleUserMessage,
   confirmation_response: handleConfirmationResponse,
   secret_response: handleSecretResponse,
@@ -514,4 +514,4 @@ export const sessionHandlers: Partial<DispatchMap> = {
   regenerate: handleRegenerate,
   usage_request: handleUsageRequest,
   sandbox_set: handleSandboxSet,
-};
+});

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -127,7 +127,7 @@ export interface HandlerContext {
 
 type MessageType = ClientMessage['type'];
 // 'auth' is handled at the transport layer (server.ts) and never reaches dispatch.
-type DispatchableType = Exclude<MessageType, 'auth'>;
+export type DispatchableType = Exclude<MessageType, 'auth'>;
 type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
 type MessageHandler<T extends MessageType> = (
   msg: MessageOfType<T>,
@@ -135,6 +135,17 @@ type MessageHandler<T extends MessageType> = (
   ctx: HandlerContext,
 ) => void | Promise<void>;
 export type DispatchMap = { [T in DispatchableType]: MessageHandler<T> };
+
+/**
+ * Type-safe handler group definition. Preserves exact key types so the
+ * combined spread in index.ts can be checked for exhaustiveness via
+ * `satisfies DispatchMap` instead of an unsafe `as DispatchMap` cast.
+ */
+export function defineHandlers<K extends DispatchableType>(
+  handlers: Pick<DispatchMap, K>,
+): Pick<DispatchMap, K> {
+  return handlers;
+}
 
 /**
  * Query the main display dimensions via CoreGraphics.

--- a/assistant/src/daemon/handlers/signing.ts
+++ b/assistant/src/daemon/handlers/signing.ts
@@ -1,6 +1,6 @@
-import { log, pendingSignBundlePayload, pendingSigningIdentity, type DispatchMap } from './shared.js';
+import { log, pendingSignBundlePayload, pendingSigningIdentity, defineHandlers } from './shared.js';
 
-export const signingHandlers: Partial<DispatchMap> = {
+export const signingHandlers = defineHandlers({
   sign_bundle_payload_response: (msg) => {
     const pending = pendingSignBundlePayload.get(msg.requestId);
     if (pending) {
@@ -34,4 +34,4 @@ export const signingHandlers: Partial<DispatchMap> = {
       log.warn({ requestId: msg.requestId }, 'Received get_signing_identity_response with no pending request');
     }
   },
-};
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -19,7 +19,7 @@ import type {
   SkillsSearchRequest,
   SkillsInspectRequest,
 } from '../ipc-protocol.js';
-import { log, CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, defineHandlers, type HandlerContext } from './shared.js';
 
 export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
@@ -486,7 +486,7 @@ export async function handleSkillDetail(
   }
 }
 
-export const skillHandlers: Partial<DispatchMap> = {
+export const skillHandlers = defineHandlers({
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
   skills_enable: handleSkillsEnable,
@@ -498,4 +498,4 @@ export const skillHandlers: Partial<DispatchMap> = {
   skills_check_updates: handleSkillsCheckUpdates,
   skills_search: handleSkillsSearch,
   skills_inspect: handleSkillsInspect,
-};
+});

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -4,9 +4,9 @@
 
 import * as net from 'node:net';
 import type { SubagentAbortRequest, SubagentStatusRequest, SubagentMessageRequest } from '../ipc-protocol.js';
-import type { HandlerContext, DispatchMap } from './shared.js';
+import type { HandlerContext } from './shared.js';
 import { getSubagentManager } from '../../subagent/index.js';
-import { log } from './shared.js';
+import { log, defineHandlers } from './shared.js';
 
 export function handleSubagentAbort(
   msg: SubagentAbortRequest,
@@ -121,8 +121,8 @@ export function handleSubagentMessage(
   }
 }
 
-export const subagentHandlers: Partial<DispatchMap> = {
+export const subagentHandlers = defineHandlers({
   subagent_abort: handleSubagentAbort,
   subagent_status: handleSubagentStatus,
   subagent_message: handleSubagentMessage,
-};
+});

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -11,7 +11,7 @@ import type {
   WorkItemApprovePermissionsRequest,
   WorkItemCancelRequest,
 } from '../ipc-protocol.js';
-import { log, type HandlerContext, type DispatchMap } from './shared.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import {
   deleteWorkItem,
@@ -441,7 +441,7 @@ export function handleWorkItemCancel(
   ctx.broadcast({ type: 'tasks_changed' });
 }
 
-export const workItemHandlers: Partial<DispatchMap> = {
+export const workItemHandlers = defineHandlers({
   work_items_list: handleWorkItemsList,
   work_item_get: handleWorkItemGet,
   work_item_update: handleWorkItemUpdate,
@@ -452,4 +452,4 @@ export const workItemHandlers: Partial<DispatchMap> = {
   work_item_preflight: handleWorkItemPreflight,
   work_item_approve_permissions: handleWorkItemApprovePermissions,
   work_item_cancel: handleWorkItemCancel,
-};
+});


### PR DESCRIPTION
Address Codex review feedback on PR #5403 regarding handler dispatch map type safety.

Replaces unsafe `as DispatchMap` cast with compile-time exhaustiveness checking:
- Add `defineHandlers()` helper that preserves exact key types via `Pick<DispatchMap, K>`
- Change all handler groups from `Partial<DispatchMap>` to `defineHandlers({...})`
- Use `satisfies DispatchMap` in index.ts so missing handlers cause compile errors
- If a new message type is added to `ClientMessage`, the compiler will now catch the missing handler
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
