### PR TITLE
fix: relax no-op compaction benchmark threshold from 10ms to 50ms

### DIFF
--- a/assistant/src/__tests__/compaction.benchmark.test.ts
+++ b/assistant/src/__tests__/compaction.benchmark.test.ts
@@ -98,7 +98,7 @@ describe('Compaction benchmark', () => {
     expect(elapsed).toBeLessThan(500);
   });
 
-  test('below-threshold check returns in under 10ms (no-op)', async () => {
+  test('below-threshold check returns in under 50ms (no-op)', async () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
@@ -113,7 +113,7 @@ describe('Compaction benchmark', () => {
 
     expect(result.compacted).toBe(false);
     expect(result.reason).toBe('below compaction threshold');
-    expect(elapsed).toBeLessThan(10);
+    expect(elapsed).toBeLessThan(50);
     expect(counter.calls).toBe(0);
   });
 


### PR DESCRIPTION
Address reviewer feedback on PR #5444: relax the strict 10ms wall-clock cutoff for the no-op fast path to 50ms. The original threshold was too sensitive to machine load, CPU throttling, and runtime jitter, causing flaky results across developer and CI environments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
