### PR TITLE
fix: address review feedback on PR #5447

### DIFF
--- a/assistant/src/__tests__/provider-streaming.benchmark.test.ts
+++ b/assistant/src/__tests__/provider-streaming.benchmark.test.ts
@@ -156,6 +156,24 @@ describe('Provider streaming benchmark', () => {
   test('event throughput through provider wrappers is within 20% of source rate', async () => {
     const tokenCount = 50;
     const sourceRate = 200; // tokens/sec
+
+    // Measure unwrapped baseline in the same run so we compare against actual
+    // timer resolution rather than the theoretical sourceRate (which setTimeout
+    // may not achieve on busy or coarse-timer hosts).
+    const baseline = makeStreamingProvider(tokenCount, sourceRate);
+    const baselineEvents: number[] = [];
+    const baselineStart = performance.now();
+
+    await baseline.sendMessage(SIMPLE_MESSAGES, undefined, undefined, {
+      onEvent: () => {
+        baselineEvents.push(performance.now());
+      },
+    });
+
+    const baselineElapsed = baselineEvents[baselineEvents.length - 1] - baselineStart;
+    const baselineRate = (baselineEvents.length / baselineElapsed) * 1000;
+
+    // Now measure the wrapped provider
     const inner = makeStreamingProvider(tokenCount, sourceRate);
     const wrapped = new RetryProvider(inner);
 
@@ -170,21 +188,32 @@ describe('Provider streaming benchmark', () => {
 
     const elapsed = events[events.length - 1] - start;
     const observedRate = (events.length / elapsed) * 1000;
-    // Source rate is bounded by setTimeout resolution, so we compare against
-    // the actual elapsed time of a direct call instead of the theoretical rate.
-    // The key assertion: we received all events and throughput didn't degrade
-    // by more than 20%.
+
     expect(events.length).toBe(tokenCount);
 
-    // Calculate the expected minimum rate — 80% of source rate
-    const minAcceptableRate = sourceRate * 0.8;
+    // Wrapped throughput should be within 20% of the measured unwrapped baseline
+    const minAcceptableRate = baselineRate * 0.8;
     expect(observedRate).toBeGreaterThanOrEqual(minAcceptableRate);
   });
 
   test('failover adds < 100ms overhead when primary provider fails', async () => {
     const failing = makeFailingProvider('failing-primary', 500);
     const healthy = makeStreamingProvider(5, 100, { name: 'healthy-fallback' });
-    const wrapped = new FailoverProvider([failing, healthy]);
+
+    // Measure the fallback provider's baseline execution time directly so we
+    // can isolate the failover overhead from the stream's own runtime.
+    const baselineEvents: ProviderEvent[] = [];
+    const baselineStart = performance.now();
+
+    await healthy.sendMessage(SIMPLE_MESSAGES, undefined, undefined, {
+      onEvent: (e) => baselineEvents.push(e),
+    });
+
+    const baselineElapsed = performance.now() - baselineStart;
+
+    // Now measure through the FailoverProvider (primary fails, falls back)
+    const healthy2 = makeStreamingProvider(5, 100, { name: 'healthy-fallback' });
+    const wrapped = new FailoverProvider([failing, healthy2]);
 
     const events: ProviderEvent[] = [];
     const start = performance.now();
@@ -196,9 +225,9 @@ describe('Provider streaming benchmark', () => {
     const elapsed = performance.now() - start;
     expect(events.length).toBe(5);
 
-    // The failover decision + fallback execution should complete quickly.
-    // 5 tokens at 100/sec = 40ms base. Total should be < 200ms including failover.
-    expect(elapsed).toBeLessThan(200);
+    // Isolate the failover overhead by subtracting the fallback stream's baseline
+    const failoverOverhead = elapsed - baselineElapsed;
+    expect(failoverOverhead).toBeLessThan(100);
   });
 
   test('createStreamTimeout fires within 50ms of configured deadline', async () => {


### PR DESCRIPTION
Address reviewer feedback on PR #5447 regarding provider streaming benchmark improvements.

Changes:
- Throughput test now measures an unwrapped baseline in the same run and compares wrapped throughput to that measured baseline, instead of comparing against the theoretical sourceRate (which setTimeout may not achieve)
- Failover overhead test now isolates the actual failover overhead by subtracting the fallback stream's measured baseline execution time, ensuring the < 100ms overhead guarantee is properly enforced
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
