### PR TITLE
feat: restore subagent status chips on app restart

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -338,7 +338,8 @@ export function handleHistoryRequest(
       contentOrder = text ? ['text:0'] : [];
       surfaces = [];
     }
-    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText, textSegments, contentOrder, surfaces };
+    const subagentNotification = m.flags ? (JSON.parse(m.flags) as { subagentNotification?: { subagentId: string; label: string; status: string; error?: string } }).subagentNotification : undefined;
+    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText, textSegments, contentOrder, surfaces, ...(subagentNotification ? { subagentNotification: subagentNotification as ParsedHistoryMessage['subagentNotification'] } : {}) };
   });
 
   // Merge tool_result data from user messages into the preceding assistant
@@ -388,6 +389,7 @@ export function handleHistoryRequest(
       ...(m.textSegments.length > 0 ? { textSegments: m.textSegments } : {}),
       ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
       ...(m.surfaces.length > 0 ? { surfaces: m.surfaces } : {}),
+      ...(m.subagentNotification ? { subagentNotification: m.subagentNotification } : {}),
     };
   });
   ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -338,8 +338,15 @@ export function handleHistoryRequest(
       contentOrder = text ? ['text:0'] : [];
       surfaces = [];
     }
-    const subagentNotification = m.flags ? (JSON.parse(m.flags) as { subagentNotification?: { subagentId: string; label: string; status: string; error?: string } }).subagentNotification : undefined;
-    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText, textSegments, contentOrder, surfaces, ...(subagentNotification ? { subagentNotification: subagentNotification as ParsedHistoryMessage['subagentNotification'] } : {}) };
+    let subagentNotification: ParsedHistoryMessage['subagentNotification'];
+    if (m.metadata) {
+      try {
+        subagentNotification = (JSON.parse(m.metadata) as { subagentNotification?: ParsedHistoryMessage['subagentNotification'] }).subagentNotification;
+      } catch (err) {
+        log.debug({ err, messageId: m.id }, 'Failed to parse message metadata as JSON, ignoring');
+      }
+    }
+    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls, toolCallsBeforeText, textSegments, contentOrder, surfaces, ...(subagentNotification ? { subagentNotification } : {}) };
   });
 
   // Merge tool_result data from user messages into the preceding assistant

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -70,6 +70,13 @@ export interface RenderedHistoryContent {
   surfaces: HistorySurface[];
 }
 
+export interface SubagentNotificationData {
+  subagentId: string;
+  label: string;
+  status: 'completed' | 'failed' | 'aborted';
+  error?: string;
+}
+
 export interface ParsedHistoryMessage {
   id?: string;
   role: string;
@@ -80,6 +87,7 @@ export interface ParsedHistoryMessage {
   textSegments: string[];
   contentOrder: string[];
   surfaces: HistorySurface[];
+  subagentNotification?: SubagentNotificationData;
 }
 
 /**

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1180,6 +1180,13 @@ export interface HistoryResponse {
     contentOrder?: string[];
     /** UI surfaces (widgets) embedded in the message. */
     surfaces?: HistoryResponseSurface[];
+    /** Present when this message is a subagent lifecycle notification (completed/failed/aborted). */
+    subagentNotification?: {
+      subagentId: string;
+      label: string;
+      status: 'completed' | 'failed' | 'aborted';
+      error?: string;
+    };
   }>;
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -140,21 +140,23 @@ export class DaemonServer {
     };
     // When a subagent finishes, inject the result into the parent session
     // so the LLM automatically informs the user.
-    getSubagentManager().onSubagentFinished = (parentSessionId, message, sendToClient) => {
+    getSubagentManager().onSubagentFinished = (parentSessionId, message, sendToClient, notification) => {
       const parentSession = this.sessions.get(parentSessionId);
       if (!parentSession) {
         log.warn({ parentSessionId }, 'Subagent finished but parent session not found');
         return;
       }
       const requestId = `subagent-notify-${Date.now()}`;
-      const enqueueResult = parentSession.enqueueMessage(message, [], sendToClient, requestId);
+      // Store structured notification data in the DB for history reconstruction
+      const metadata = { subagentNotification: notification };
+      const enqueueResult = parentSession.enqueueMessage(message, [], sendToClient, requestId, undefined, undefined, metadata);
       if (enqueueResult.rejected) {
         log.warn({ parentSessionId }, 'Parent session queue full, dropping subagent notification');
         return;
       }
       if (!enqueueResult.queued) {
         // Parent is idle — send directly.
-        const messageId = parentSession.persistUserMessage(message, []);
+        const messageId = parentSession.persistUserMessage(message, [], undefined, metadata);
         parentSession.runAgentLoop(message, messageId, sendToClient).catch((err) => {
           log.error({ parentSessionId, err }, 'Failed to process subagent notification in parent');
         });

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -37,12 +37,13 @@ export function enqueueMessage(
   requestId: string,
   activeSurfaceId?: string,
   currentPage?: string,
+  metadata?: Record<string, unknown>,
 ): { queued: boolean; rejected?: boolean; requestId: string } {
   if (!ctx.processing) {
     return { queued: false, requestId };
   }
 
-  const pushed = ctx.queue.push({ content, attachments, requestId, onEvent, activeSurfaceId, currentPage });
+  const pushed = ctx.queue.push({ content, attachments, requestId, onEvent, activeSurfaceId, currentPage, metadata });
   if (!pushed) {
     return { queued: false, rejected: true, requestId };
   }
@@ -56,6 +57,7 @@ export function persistUserMessage(
   content: string,
   attachments: UserMessageAttachment[],
   requestId?: string,
+  metadata?: Record<string, unknown>,
 ): string {
   if (ctx.processing) {
     throw new Error('Session is already processing a message');
@@ -84,6 +86,7 @@ export function persistUserMessage(
       ctx.conversationId,
       'user',
       JSON.stringify(userMessage.content),
+      metadata,
     );
 
     if (!persistedUserMessage.id) {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -55,7 +55,7 @@ export interface ProcessSessionContext {
   currentPage?: string;
   /** Request-scoped skill IDs preactivated via slash resolution. */
   preactivatedSkillIds?: string[];
-  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string): string;
+  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
     userMessageId: string,
@@ -155,7 +155,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // resolves early (no runAgentLoop call), so we must continue draining.
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId);
+    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Failed to persist queued message');

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -14,6 +14,7 @@ export interface QueuedMessage {
   onEvent: (msg: ServerMessage) => void;
   activeSurfaceId?: string;
   currentPage?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export const MAX_QUEUE_DEPTH = 10;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -269,8 +269,9 @@ export class Session {
     requestId: string,
     activeSurfaceId?: string,
     currentPage?: string,
+    metadata?: Record<string, unknown>,
   ): { queued: boolean; rejected?: boolean; requestId: string } {
-    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage);
+    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata);
   }
 
   getQueueDepth(): number {
@@ -318,8 +319,9 @@ export class Session {
     content: string,
     attachments: UserMessageAttachment[],
     requestId?: string,
+    metadata?: Record<string, unknown>,
   ): string {
-    return persistUserMessageImpl(this, content, attachments, requestId);
+    return persistUserMessageImpl(this, content, attachments, requestId, metadata);
   }
 
   // ── Agent Loop ───────────────────────────────────────────────────

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -108,7 +108,7 @@ export function getLatestConversation() {
   return result ?? null;
 }
 
-export function addMessage(conversationId: string, role: string, content: string) {
+export function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>) {
   const db = getDb();
   const now = monotonicNow();
   const message = {
@@ -117,6 +117,7 @@ export function addMessage(conversationId: string, role: string, content: string
     role,
     content,
     createdAt: now,
+    ...(metadata ? { flags: JSON.stringify(metadata) } : {}),
   };
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
   db.transaction((tx) => {

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -117,7 +117,7 @@ export function addMessage(conversationId: string, role: string, content: string
     role,
     content,
     createdAt: now,
-    ...(metadata ? { flags: JSON.stringify(metadata) } : {}),
+    ...(metadata ? { metadata: JSON.stringify(metadata) } : {}),
   };
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
   db.transaction((tx) => {

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -544,6 +544,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN flags TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -544,7 +544,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
-  try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN flags TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN metadata TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -23,6 +23,7 @@ export const messages = sqliteTable('messages', {
   role: text('role').notNull(),
   content: text('content').notNull(),
   createdAt: integer('created_at').notNull(),
+  flags: text('flags'),
 });
 
 export const toolInvocations = sqliteTable('tool_invocations', {

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -23,7 +23,7 @@ export const messages = sqliteTable('messages', {
   role: text('role').notNull(),
   content: text('content').notNull(),
   createdAt: integer('created_at').notNull(),
-  flags: text('flags'),
+  metadata: text('metadata'),
 });
 
 export const toolInvocations = sqliteTable('tool_invocations', {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -52,10 +52,18 @@ interface ManagedSubagent {
   parentSendToClient: (msg: ServerMessage) => void;
 }
 
+export interface SubagentNotificationInfo {
+  subagentId: string;
+  label: string;
+  status: 'completed' | 'failed' | 'aborted';
+  error?: string;
+}
+
 export type ParentNotifyCallback = (
   parentSessionId: string,
   message: string,
   sendToClient: (msg: ServerMessage) => void,
+  notification: SubagentNotificationInfo,
 ) => void;
 
 export class SubagentManager {
@@ -288,6 +296,7 @@ export class SubagentManager {
             managed.state.config.parentSessionId,
             message,
             managed.parentSendToClient,
+            { subagentId, label, status: 'aborted' },
           );
         } catch (err) {
           log.error({ subagentId, err }, 'Failed to notify parent about abort');
@@ -481,8 +490,15 @@ export class SubagentManager {
         `Do NOT re-spawn or retry this subagent unless the user explicitly asks.`;
     }
 
+    const notification: SubagentNotificationInfo = {
+      subagentId: config.id,
+      label: config.label,
+      status: outcome,
+      ...(outcome === 'failed' ? { error: managed.state.error ?? 'Unknown error' } : {}),
+    };
+
     try {
-      this.onSubagentFinished(config.parentSessionId, message, parentSendToClient);
+      this.onSubagentFinished(config.parentSessionId, message, parentSendToClient, notification);
     } catch (err) {
       log.error({ subagentId: config.id, err }, 'Failed to notify parent session');
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -369,6 +369,7 @@ struct ChatView: View {
                     // Filter out queued messages — they're shown above the composer instead
                     let displayMessages = messages.filter { msg in
                         if case .queued = msg.status { return false }
+                        if msg.isSubagentNotification { return false }
                         return true
                     }
                     ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -861,6 +861,10 @@ public struct ChatMessage: Identifiable {
     /// Nil for freshly streamed messages that haven't been loaded from history.
     /// Used for anchoring diagnostics exports so the daemon can locate the message.
     public var daemonMessageId: String?
+    /// When true, this message is a subagent notification (e.g. completed/failed/aborted)
+    /// reconstructed from history. It should be hidden from the chat UI since the
+    /// corresponding subagent chip conveys the same information.
+    public var isSubagentNotification: Bool = false
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1096,6 +1096,8 @@ public final class ChatViewModel: ObservableObject {
     /// history before the existing messages so the user sees full context.
     public func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
         var chatMessages: [ChatMessage] = []
+        var reconstructedSubagents: [SubagentInfo] = []
+        var lastAssistantMessageId: UUID?
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user
             var toolCalls: [ToolCallData] = []
@@ -1200,7 +1202,30 @@ public final class ChatViewModel: ObservableObject {
                 log.info("Message contentOrder: \(item.contentOrder ?? []), surface refs: \(surfaceRefs.count), inlineSurfaces: \(chatMsg.inlineSurfaces.count)")
             }
 
+            // Track last assistant message ID for parenting reconstructed subagent chips
+            if role == .assistant {
+                lastAssistantMessageId = chatMsg.id
+            }
+
+            // Reconstruct subagent chips from structured notification metadata
+            if let notification = item.subagentNotification {
+                var info = SubagentInfo(
+                    id: notification.subagentId,
+                    label: notification.label,
+                    status: SubagentStatus(wire: notification.status),
+                    parentMessageId: lastAssistantMessageId
+                )
+                info.error = notification.error
+                reconstructedSubagents.append(info)
+                chatMsg.isSubagentNotification = true
+            }
+
             chatMessages.append(chatMsg)
+        }
+
+        // Merge reconstructed subagents into activeSubagents (avoid duplicates)
+        for info in reconstructedSubagents where !activeSubagents.contains(where: { $0.id == info.id }) {
+            activeSubagents.append(info)
         }
 
         // Tag assistant messages that follow "/model" or "/models" user messages

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -703,6 +703,15 @@ public struct IPCHistoryResponseMessage: Codable, Sendable {
     public let contentOrder: [String]?
     /// UI surfaces (widgets) embedded in the message.
     public let surfaces: [IPCHistoryResponseSurface]?
+    /// Present when this message is a subagent lifecycle notification (completed/failed/aborted).
+    public let subagentNotification: IPCHistoryResponseMessageSubagentNotification?
+}
+
+public struct IPCHistoryResponseMessageSubagentNotification: Codable, Sendable {
+    public let subagentId: String
+    public let label: String
+    public let status: String
+    public let error: String?
 }
 
 public struct IPCHistoryResponseSurface: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1103,9 +1103,9 @@ extension IPCHistoryResponse {
 }
 
 extension IPCHistoryResponseMessage {
-    /// Backward-compatible init without textSegments/contentOrder/surfaces (added in later IPC versions).
+    /// Backward-compatible init without textSegments/contentOrder/surfaces/subagentNotification (added in later IPC versions).
     public init(role: String, text: String, timestamp: Double, toolCalls: [IPCHistoryResponseToolCall]?, toolCallsBeforeText: Bool?, attachments: [IPCUserMessageAttachment]?) {
-        self.init(id: nil, role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil, surfaces: nil)
+        self.init(id: nil, role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- Stores structured subagent notification metadata (`subagentId`, `label`, `status`, `error`) in a new `flags` column on the `messages` table when subagent notifications are persisted
- Passes the structured `subagentNotification` object through the IPC `history_response` so the client can reconstruct `SubagentInfo` chips without any text parsing
- Filters raw notification messages from the chat UI via an `isSubagentNotification` flag on `ChatMessage`

## Test plan
- [ ] Build with `./build.sh`
- [ ] Run tests with `./build.sh test`
- [ ] Spawn subagents, let them complete/fail/abort
- [ ] Restart app, verify status chips appear with correct colors and labels
- [ ] Verify raw `[Subagent "X" completed]` messages no longer show as chat bubbles
- [ ] Verify subagent chips still work correctly during live sessions (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
