### PR TITLE
fix: address review feedback on PR #5445

### DIFF
--- a/assistant/src/__tests__/parallel-tool.benchmark.test.ts
+++ b/assistant/src/__tests__/parallel-tool.benchmark.test.ts
@@ -167,14 +167,14 @@ describe('Parallel tool execution benchmarks', () => {
     expect(lastStart).toBeLessThanOrEqual(firstEnd);
   });
 
-  // 3. Mixed latencies: 1 slow (2s) + 4 fast (10ms) = ~2s total
+  // 3. Mixed latencies: 1 slow (2s) + 4 fast (100ms) = ~2s parallel, ~2.4s sequential
   test('mixed latencies: 1 slow + 4 fast tools complete in slow-tool time', async () => {
     const toolUseBlocks = [
       { id: 'slow', name: 'delay_tool', input: { delayMs: 2000 } },
-      { id: 'fast1', name: 'delay_tool', input: { delayMs: 10 } },
-      { id: 'fast2', name: 'delay_tool', input: { delayMs: 10 } },
-      { id: 'fast3', name: 'delay_tool', input: { delayMs: 10 } },
-      { id: 'fast4', name: 'delay_tool', input: { delayMs: 10 } },
+      { id: 'fast1', name: 'delay_tool', input: { delayMs: 100 } },
+      { id: 'fast2', name: 'delay_tool', input: { delayMs: 100 } },
+      { id: 'fast3', name: 'delay_tool', input: { delayMs: 100 } },
+      { id: 'fast4', name: 'delay_tool', input: { delayMs: 100 } },
     ];
 
     const { provider } = createMockProvider([
@@ -199,9 +199,10 @@ describe('Parallel tool execution benchmarks', () => {
     await loop.run([userMessage], collectEvents(events));
     const elapsed = Date.now() - start;
 
-    // Total time should be dominated by the slow tool (~2s), not additive (~2.04s)
+    // Parallel: ~2000ms (dominated by slow tool). Sequential: ~2400ms (2000 + 4*100).
+    // Upper bound of 2200ms ensures a sequential implementation would fail.
     expect(elapsed).toBeGreaterThanOrEqual(1900);
-    expect(elapsed).toBeLessThan(2500);
+    expect(elapsed).toBeLessThan(2200);
 
     // tool_result events should be emitted in tool_use order (slow first),
     // even though fast tools finish earlier


### PR DESCRIPTION
Address reviewer feedback on PR #5445 regarding parallel tool benchmark threshold tightening.

Increases fast tool delays from 10ms to 100ms and tightens the upper bound from 2500ms to 2200ms, ensuring a sequential implementation (~2400ms) would fail while parallel execution (~2000ms) passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
