### PR TITLE
fix: use multi-sample median timing in session-init benchmarks

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -4,12 +4,16 @@
  * Measures latency of key session startup components and end-to-end
  * session creation timing (request to first-tool-ready state).
  *
- * Component targets:
+ * Uses multi-sample median timing with warm-up runs to reduce sensitivity
+ * to host load and machine class. Thresholds are intentionally loose
+ * guardrails for catching regressions, not precise performance targets.
+ *
+ * Component targets (median of 5 runs):
  * - initializeTools: < 100ms
  * - buildSystemPrompt: < 50ms
  * - getAllToolDefinitions: < 10ms
  *
- * End-to-end targets:
+ * End-to-end targets (median of 3 runs):
  * - Session creation (no preactivated skills): < 200ms
  * - Session creation (3 preactivated skills): < 300ms
  * - Event listener registration: < 10ms
@@ -18,6 +22,14 @@ import { afterAll, describe, expect, mock, test } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+/** Return the median of a sorted-ascending array of numbers. */
+function median(sorted: number[]): number {
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
 
 const testDir = mkdtempSync(join(tmpdir(), 'session-init-bench-'));
 
@@ -218,36 +230,58 @@ afterAll(() => {
 });
 
 describe('Session initialization benchmark', () => {
-  test('initializeTools completes under 100ms', async () => {
+  test('initializeTools completes under 100ms (median of 5)', async () => {
+    // Warm-up run to eliminate JIT / lazy-load overhead
     __resetRegistryForTesting();
-
-    const start = performance.now();
-    await initializeTools();
-    const elapsed = performance.now() - start;
-
-    expect(elapsed).toBeLessThan(100);
-  });
-
-  test('getAllToolDefinitions retrieves definitions under 10ms', async () => {
-    // Ensure tools are initialized first
     await initializeTools();
 
-    const start = performance.now();
-    const definitions = getAllToolDefinitions();
-    const elapsed = performance.now() - start;
+    const timings: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      __resetRegistryForTesting();
+      const start = performance.now();
+      await initializeTools();
+      timings.push(performance.now() - start);
+    }
 
-    expect(definitions.length).toBeGreaterThan(0);
-    expect(elapsed).toBeLessThan(10);
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(100);
   });
 
-  test('buildSystemPrompt assembles prompt under 50ms', () => {
-    const start = performance.now();
-    const prompt = buildSystemPrompt();
-    const elapsed = performance.now() - start;
+  test('getAllToolDefinitions retrieves definitions under 10ms (median of 5)', async () => {
+    await initializeTools();
 
-    expect(prompt.length).toBeGreaterThan(0);
-    expect(prompt).toContain('Test Identity');
-    expect(elapsed).toBeLessThan(50);
+    // Warm-up
+    getAllToolDefinitions();
+
+    const timings: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const start = performance.now();
+      const definitions = getAllToolDefinitions();
+      timings.push(performance.now() - start);
+      if (i === 0) expect(definitions.length).toBeGreaterThan(0);
+    }
+
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(10);
+  });
+
+  test('buildSystemPrompt assembles prompt under 50ms (median of 5)', () => {
+    // Warm-up
+    buildSystemPrompt();
+
+    const timings: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const start = performance.now();
+      const prompt = buildSystemPrompt();
+      timings.push(performance.now() - start);
+      if (i === 0) {
+        expect(prompt.length).toBeGreaterThan(0);
+        expect(prompt).toContain('Test Identity');
+      }
+    }
+
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(50);
   });
 
   test('repeated buildSystemPrompt calls are consistently fast (10 iterations)', () => {
@@ -294,86 +328,86 @@ describe('End-to-end session creation benchmark', () => {
   };
   const noop = () => {};
 
-  test('session creation without preactivated skills completes under 200ms', async () => {
+  test('session creation without preactivated skills completes under 200ms (median of 3)', async () => {
     __resetRegistryForTesting();
     await initializeTools();
     const systemPrompt = buildSystemPrompt();
 
-    const start = performance.now();
+    // Warm-up run
+    const warmup = new Session('bench-warmup-0', mockProvider, systemPrompt, 64000, noop, testDir);
+    await warmup.loadFromDb();
+    warmup.dispose();
 
-    const session = new Session(
-      'bench-no-skills',
-      mockProvider,
-      systemPrompt,
-      64000,
-      noop,
-      testDir,
-    );
-    await session.loadFromDb();
+    const timings: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const id = `bench-no-skills-${i}`;
+      const start = performance.now();
+      const session = new Session(id, mockProvider, systemPrompt, 64000, noop, testDir);
+      await session.loadFromDb();
+      timings.push(performance.now() - start);
 
-    const elapsed = performance.now() - start;
+      if (i === 0) {
+        expect(session.conversationId).toBe(id);
+        expect(session.getMessages()).toHaveLength(0);
+      }
+      session.dispose();
+    }
 
-    expect(session.conversationId).toBe('bench-no-skills');
-    expect(session.getMessages()).toHaveLength(0);
-
-    expect(elapsed).toBeLessThan(200);
-
-    session.dispose();
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(200);
   });
 
-  test('session creation with 3 preactivated skills completes under 300ms', async () => {
+  test('session creation with 3 preactivated skills completes under 300ms (median of 3)', async () => {
     __resetRegistryForTesting();
     await initializeTools();
     const systemPrompt = buildSystemPrompt();
 
-    const start = performance.now();
+    // Warm-up run
+    const warmup = new Session('bench-warmup-s', mockProvider, systemPrompt, 64000, noop, testDir);
+    warmup.preactivatedSkillIds = ['skill-a', 'skill-b', 'skill-c'];
+    await warmup.loadFromDb();
+    warmup.dispose();
 
-    const session = new Session(
-      'bench-with-skills',
-      mockProvider,
-      systemPrompt,
-      64000,
-      noop,
-      testDir,
-    );
-    // Simulate preactivated skills the same way the daemon does
-    session.preactivatedSkillIds = ['skill-a', 'skill-b', 'skill-c'];
-    await session.loadFromDb();
+    const timings: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const id = `bench-with-skills-${i}`;
+      const start = performance.now();
+      const session = new Session(id, mockProvider, systemPrompt, 64000, noop, testDir);
+      session.preactivatedSkillIds = ['skill-a', 'skill-b', 'skill-c'];
+      await session.loadFromDb();
+      timings.push(performance.now() - start);
 
-    const elapsed = performance.now() - start;
+      if (i === 0) {
+        expect(session.conversationId).toBe(id);
+        expect(session.getMessages()).toHaveLength(0);
+      }
+      session.dispose();
+    }
 
-    expect(session.conversationId).toBe('bench-with-skills');
-    expect(session.getMessages()).toHaveLength(0);
-
-    expect(elapsed).toBeLessThan(300);
-
-    session.dispose();
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(300);
   });
 
-  test('event listener registration is included in constructor and completes under 10ms', () => {
-    // The Session constructor registers all event listeners internally.
-    // Verify the event bus has listeners after construction.
+  test('event listener registration is included in constructor and completes under 10ms (median of 5)', () => {
     const systemPrompt = buildSystemPrompt();
 
-    const start = performance.now();
+    // Warm-up
+    const warmup = new Session('bench-events-w', mockProvider, systemPrompt, 64000, noop, testDir);
+    warmup.dispose();
 
-    const session = new Session(
-      'bench-events',
-      mockProvider,
-      systemPrompt,
-      64000,
-      noop,
-      testDir,
-    );
+    const timings: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const start = performance.now();
+      const session = new Session(`bench-events-${i}`, mockProvider, systemPrompt, 64000, noop, testDir);
+      timings.push(performance.now() - start);
 
-    const elapsed = performance.now() - start;
+      if (i === 0) {
+        expect(session.eventBus.listenerCount()).toBeGreaterThan(0);
+      }
+      session.dispose();
+    }
 
-    // The constructor wires up metrics, notification, trace, profiling,
-    // audit, and domain-event listeners — verify at least some exist
-    expect(session.eventBus.listenerCount()).toBeGreaterThan(0);
-
-    expect(elapsed).toBeLessThan(10);
-
-    session.dispose();
+    timings.sort((a, b) => a - b);
+    expect(median(timings)).toBeLessThan(10);
   });
 });


### PR DESCRIPTION
Address Codex reviewer feedback on PR #5448 — replace single-sample wall-clock assertions with warm-up + multi-sample median timing to reduce flakiness from host load and machine class variability. All timing-sensitive benchmarks now run 3-5 iterations and assert on the median.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
