### PR TITLE
fix: address review feedback on PR #5476

### DIFF
--- a/assistant/src/__tests__/ipc-roundtrip.benchmark.test.ts
+++ b/assistant/src/__tests__/ipc-roundtrip.benchmark.test.ts
@@ -160,12 +160,8 @@ describe('IPC Unix socket round-trip benchmark', () => {
   afterAll(async () => {
     client?.destroy();
     await new Promise<void>((resolve) => server?.close(() => resolve()));
-    try {
-      fs.unlinkSync(socketPath);
-      fs.rmdirSync(tmpDir);
-    } catch {
-      // cleanup best-effort
-    }
+    try { fs.unlinkSync(socketPath); } catch { /* server.close() may already remove it */ }
+    try { fs.rmdirSync(tmpDir); } catch { /* best-effort */ }
   });
 
   test('session_list round-trip p50 < 5ms, p99 < 50ms', async () => {


### PR DESCRIPTION
Address reviewer feedback on PR #5476.

Separates cleanup steps into independent try/catch blocks so that an ENOENT from fs.unlinkSync (when server.close already removed the socket) does not skip fs.rmdirSync, preventing temp directory leakage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
