### PR TITLE
fix: move ANTHROPIC_BASE_URL cleanup into finally block

### DIFF
--- a/assistant/src/__tests__/provider-streaming.benchmark.test.ts
+++ b/assistant/src/__tests__/provider-streaming.benchmark.test.ts
@@ -675,11 +675,11 @@ describe('Provider streaming benchmark', () => {
       },
     });
 
-    try {
-      // Use ANTHROPIC_BASE_URL env var to point AnthropicProvider at mock server
-      const origBaseUrl = process.env.ANTHROPIC_BASE_URL;
-      process.env.ANTHROPIC_BASE_URL = `http://localhost:${server.port}`;
+    // Save and override env var before try so it's always restored in finally
+    const origBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${server.port}`;
 
+    try {
       // Import dynamically after setting env var so SDK picks it up
       const { AnthropicProvider } = await import('../providers/anthropic/client.js');
       const provider = new AnthropicProvider(BENCH_API_KEY, 'claude-3-5-sonnet-20241022');
@@ -702,13 +702,6 @@ describe('Provider streaming benchmark', () => {
         },
       );
 
-      // Restore env var
-      if (origBaseUrl === undefined) {
-        delete process.env.ANTHROPIC_BASE_URL;
-      } else {
-        process.env.ANTHROPIC_BASE_URL = origBaseUrl;
-      }
-
       // Verify the full adapter pipeline delivered all events
       const textDeltas = receivedEvents.filter((e) => e.type === 'text_delta');
       expect(textDeltas.length).toBe(tokenCount);
@@ -727,6 +720,11 @@ describe('Provider streaming benchmark', () => {
       const rate = (textDeltas.length / elapsed) * 1000;
       expect(rate).toBeGreaterThan(500);
     } finally {
+      if (origBaseUrl === undefined) {
+        delete process.env.ANTHROPIC_BASE_URL;
+      } else {
+        process.env.ANTHROPIC_BASE_URL = origBaseUrl;
+      }
       server.stop();
     }
   });


### PR DESCRIPTION
Address reviewer feedback on PR #5480. Both Codex and Devin flagged that the ANTHROPIC_BASE_URL env var restoration was inside the try block instead of the finally block. If provider.sendMessage() or any assertion threw before the restore code, the env var would leak and cause cascading failures in subsequent tests. Moved the save/restore into finally to ensure cleanup always runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
