### PR TITLE
fix: preactivate tasks skill so task tools are available in fresh sessions

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -451,6 +451,13 @@ export function createProxyApprovalCallback(
 // ── createResolveToolsCallback ───────────────────────────────────────
 
 /**
+ * Bundled skills that must always be active regardless of conversation
+ * history or explicit preactivation. Without this, their tools are
+ * unavailable in fresh sessions until `skill_load` is called.
+ */
+const DEFAULT_PREACTIVATED_SKILL_IDS = ['tasks'];
+
+/**
  * Subset of Session state that the resolveTools callback reads at each
  * agent turn. Properties are read lazily from this reference.
  */
@@ -475,8 +482,12 @@ export function createResolveToolsCallback(
   if (toolDefs.length === 0) return undefined;
 
   return (history: Message[]) => {
+    const effectivePreactivated = [
+      ...DEFAULT_PREACTIVATED_SKILL_IDS,
+      ...(ctx.preactivatedSkillIds ?? []),
+    ];
     const projection = projectSkillTools(history, {
-      preactivatedSkillIds: ctx.preactivatedSkillIds,
+      preactivatedSkillIds: effectivePreactivated,
       previouslyActiveSkillIds: ctx.skillProjectionState,
       cache: ctx.skillProjectionCache,
     });


### PR DESCRIPTION
Address reviewer feedback on PR #5501.

The migration from class-based task tools to the bundled tasks skill removed the tools from explicitTools but didn't preactivate the skill. This meant fresh sessions (with no loaded_skill markers in history) couldn't use task_list_add, task_list_show, etc. until skill_load was explicitly called.

Fix: add a DEFAULT_PREACTIVATED_SKILL_IDS constant containing 'tasks' that is always merged into preactivatedSkillIds in the resolveTools callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
