### PR TITLE
fix: address review feedback on PR #5485

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -44,6 +44,34 @@ writeFileSync(join(testDir, 'IDENTITY.md'), '# Test Identity\nYou are a test ass
 writeFileSync(join(testDir, 'SOUL.md'), '# Test Soul\nBe helpful.');
 writeFileSync(join(testDir, 'USER.md'), '# Test User\nName: Benchmark Runner');
 
+// Create real skill directories so projectSkillTools can load them from the catalog
+const testSkillIds = ['bench-skill-a', 'bench-skill-b', 'bench-skill-c'];
+for (const skillId of testSkillIds) {
+  const skillDir = join(testDir, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), [
+    '---',
+    `name: ${skillId}`,
+    `description: Benchmark test skill ${skillId}`,
+    '---',
+    `# ${skillId}`,
+    'A test skill for benchmarking.',
+  ].join('\n'));
+  writeFileSync(join(skillDir, 'TOOLS.json'), JSON.stringify({
+    version: 1,
+    tools: [{
+      name: `${skillId}_tool`,
+      description: `Tool for ${skillId}`,
+      category: 'benchmark',
+      risk: 'low',
+      input_schema: { type: 'object', properties: {} },
+      executor: 'run.sh',
+      execution_target: 'host',
+    }],
+  }));
+  writeFileSync(join(skillDir, 'run.sh'), '#!/bin/sh\necho ok');
+}
+
 mock.module('../util/platform.js', () => ({
   getDataDir: () => testDir,
   getRootDir: () => testDir,
@@ -218,6 +246,9 @@ const { initializeTools, getAllToolDefinitions, __resetRegistryForTesting } = aw
 );
 const { buildSystemPrompt } = await import('../config/system-prompt.js');
 const { Session } = await import('../daemon/session.js');
+const { projectSkillTools, resetSkillToolProjection } = await import(
+  '../daemon/session-skill-tools.js'
+);
 import type { Provider } from '../providers/types.js';
 
 afterAll(() => {
@@ -314,7 +345,10 @@ describe('Session initialization benchmark', () => {
 describe('End-to-end session creation benchmark', () => {
   // Uses the real Session constructor + loadFromDb() path, which wires up
   // the tool executor, event bus, agent loop, context window manager, and
-  // notifiers — exactly what the daemon does.
+  // notifiers. Note: the daemon's getOrCreateSession() adds provider
+  // construction, rate limiting, concurrency guards, and evictor management
+  // on top — those are lightweight config-driven operations not benchmarked
+  // here.
 
   const mockProvider: Provider = {
     name: 'mock',
@@ -362,10 +396,16 @@ describe('End-to-end session creation benchmark', () => {
     await initializeTools();
     const systemPrompt = buildSystemPrompt();
 
-    // Warm-up run
+    // Warm-up run — includes skill projection so manifest loading is JIT'd
     const warmup = new Session('bench-warmup-s', mockProvider, systemPrompt, 64000, noop, testDir);
-    warmup.preactivatedSkillIds = ['skill-a', 'skill-b', 'skill-c'];
+    warmup.preactivatedSkillIds = testSkillIds;
     await warmup.loadFromDb();
+    projectSkillTools([], {
+      preactivatedSkillIds: warmup.preactivatedSkillIds,
+      previouslyActiveSkillIds: warmup.skillProjectionState,
+      cache: warmup.skillProjectionCache,
+    });
+    resetSkillToolProjection(warmup.skillProjectionState);
     warmup.dispose();
 
     const timings: number[] = [];
@@ -373,14 +413,23 @@ describe('End-to-end session creation benchmark', () => {
       const id = `bench-with-skills-${i}`;
       const start = performance.now();
       const session = new Session(id, mockProvider, systemPrompt, 64000, noop, testDir);
-      session.preactivatedSkillIds = ['skill-a', 'skill-b', 'skill-c'];
+      session.preactivatedSkillIds = testSkillIds;
       await session.loadFromDb();
+      // Skill projection runs at agent turn time, not during loadFromDb.
+      // Include it here to measure the full first-tool-ready path.
+      const projection = projectSkillTools([], {
+        preactivatedSkillIds: session.preactivatedSkillIds,
+        previouslyActiveSkillIds: session.skillProjectionState,
+        cache: session.skillProjectionCache,
+      });
       timings.push(performance.now() - start);
 
       if (i === 0) {
         expect(session.conversationId).toBe(id);
         expect(session.getMessages()).toHaveLength(0);
+        expect(projection.toolDefinitions.length).toBe(testSkillIds.length);
       }
+      resetSkillToolProjection(session.skillProjectionState);
       session.dispose();
     }
 


### PR DESCRIPTION
Address reviewer feedback on PR #5485.

- Clarify end-to-end describe comment to note what getOrCreateSession() does beyond Session + loadFromDb (provider construction, rate limiting, concurrency guards, evictor)
- Replace placeholder skill IDs (skill-a/b/c) with real test skill directories that have SKILL.md and TOOLS.json manifests
- Actually invoke projectSkillTools() during the preactivated-skills benchmark so it measures real catalog lookup, manifest parsing, and tool registration
- Assert that tool definitions are projected for each test skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
