### PR TITLE
fix: address review feedback on PR #5498

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -16,7 +16,7 @@
  * End-to-end targets (median of 3 runs):
  * - Session creation (no preactivated skills): < 200ms
  * - Session creation (3 preactivated skills): < 300ms
- * - Event listener registration: < 10ms
+ * - Session constructor (sync, no loadFromDb): < 10ms
  */
 import { afterAll, describe, expect, mock, test } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -437,7 +437,7 @@ describe('End-to-end session creation benchmark', () => {
     expect(median(timings)).toBeLessThan(300);
   });
 
-  test('event listener registration is included in constructor and completes under 10ms (median of 5)', () => {
+  test('Session constructor (sync, no loadFromDb) completes under 10ms (median of 5)', () => {
     const systemPrompt = buildSystemPrompt();
 
     // Warm-up


### PR DESCRIPTION
Address reviewer feedback on PR #5498.

Updates the event listener registration benchmark test name and file header comment to accurately reflect that the test measures the full Session constructor (sync portion, no loadFromDb), not just event listener registration. The threshold (10ms) was already correct.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
