### PR TITLE
fix: address review feedback on PR #5520

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -309,19 +309,21 @@ describe('scheduler RRULE execution', () => {
       expression: rruleExpr,
     });
 
-    const _beforeNextRunAt = getSchedule(schedule.id)!.nextRunAt;
+    const originalNextRunAt = getSchedule(schedule.id)!.nextRunAt;
     forceScheduleDue(schedule.id);
+    const forcedDueAt = getSchedule(schedule.id)!.nextRunAt;
 
     const processMessage = async () => {};
     const scheduler = startScheduler(processMessage, () => {}, () => {});
     await new Promise(resolve => setTimeout(resolve, 500));
     scheduler.stop();
 
-    // nextRunAt should have advanced to a future time
     const after = getSchedule(schedule.id);
     expect(after).not.toBeNull();
-    expect(after!.nextRunAt).toBeGreaterThan(Date.now() - 5000);
-    // It should differ from the forced-due value
+    // nextRunAt must have moved forward from the forced-due value
+    expect(after!.nextRunAt).toBeGreaterThan(forcedDueAt);
+    // It should be at or near the original computed value (within a few seconds tolerance)
+    expect(Math.abs(after!.nextRunAt - originalNextRunAt)).toBeLessThan(5000);
     expect(after!.lastRunAt).not.toBeNull();
   });
 });


### PR DESCRIPTION
Address reviewer feedback on PR #5520.

## Summary
- Fix weak assertion in 'RRULE schedule advances nextRunAt after firing' test
- Assert nextRunAt advances beyond the forced-due value (not just > Date.now() - 5000)
- Assert nextRunAt returns to near the original computed value after scheduler runs
- Remove unused _beforeNextRunAt variable

## Test plan
- [x] Assertion now catches regressions where scheduler fails to advance nextRunAt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
