### PR TITLE
fix: guard validateRruleSetLines against non-string inputs

### DIFF
--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -35,6 +35,9 @@ export async function executeScheduleCreate(
     return { content: `Error: Invalid cron expression: "${resolved.expression}"`, isError: true };
   }
   if (resolved.syntax === 'rrule') {
+    if (typeof resolved.expression !== 'string') {
+      return { content: 'Error: expression must be a string', isError: true };
+    }
     const setError = validateRruleSetLines(resolved.expression);
     if (setError) {
       return {

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -36,7 +36,7 @@ export async function executeScheduleUpdate(
   // Set-aware pre-validation for RRULE expressions
   const effectiveSyntax = (updates.syntax as ScheduleSyntax | undefined) ?? (input.syntax as ScheduleSyntax | undefined);
   const effectiveExpr = (updates.expression as string | undefined) ?? (updates.cronExpression as string | undefined);
-  if (effectiveExpr && (effectiveSyntax === 'rrule' || /^(DTSTART|RRULE:)/m.test(effectiveExpr))) {
+  if (effectiveExpr && typeof effectiveExpr === 'string' && (effectiveSyntax === 'rrule' || /^(DTSTART|RRULE:)/m.test(effectiveExpr))) {
     const setError = validateRruleSetLines(effectiveExpr);
     if (setError) {
       return {


### PR DESCRIPTION
Address reviewer feedback on PR #5535. Adds typeof string guards before calling validateRruleSetLines in both create.ts and update.ts to prevent TypeErrors when expression is a non-string value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
