### PR TITLE
fix: address review feedback on PR #5510

### DIFF
--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -81,10 +81,11 @@ export function isValidScheduleExpression(spec: ScheduleSpec): boolean {
       if (error) return false;
 
       const normalized = normalizeRruleExpression(spec.expression);
+      const tzid = spec.timezone ?? undefined;
       if (hasSetConstructs(normalized)) {
-        rrulestr(normalized, { forceset: true });
+        rrulestr(normalized, { forceset: true, tzid });
       } else {
-        rrulestr(normalized);
+        rrulestr(normalized, { tzid });
       }
       return true;
     }
@@ -120,10 +121,11 @@ export function computeNextRunAt(spec: ScheduleSpec, nowMs?: number): number {
     if (error) throw new Error(error);
 
     const useSet = hasSetConstructs(normalized);
+    const tzid = spec.timezone ?? undefined;
     const parsed = useSet
-      ? (rrulestr(normalized, { forceset: true }) as RRuleSet)
-      : rrulestr(normalized);
-    const next = parsed.after(new Date(now), true);
+      ? (rrulestr(normalized, { forceset: true, tzid }) as RRuleSet)
+      : rrulestr(normalized, { tzid });
+    const next = parsed.after(new Date(now));
     if (!next) {
       throw new Error(`RRULE expression has no upcoming runs after ${new Date(now).toISOString()}`);
     }


### PR DESCRIPTION
Address reviewer feedback on PR #5510.

- Fix inc=true bug in rule.after() that could cause repeated re-triggering when now falls on a recurrence boundary. Changed to exclusive (default false) to match cron path semantics.
- Pass spec.timezone as tzid to rrulestr() in both isValidScheduleExpression and computeNextRunAt so RRULE evaluation respects the configured timezone instead of using process locale.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
