### PR TITLE
fix: auto-detect syntax in schedule_update when expression changes without explicit syntax

### DIFF
--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,6 +1,6 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { updateSchedule, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
-import type { ScheduleSyntax } from '../../schedule/recurrence-types.js';
+import { normalizeScheduleSyntax, type ScheduleSyntax } from '../../schedule/recurrence-types.js';
 import { validateRruleSetLines } from '../../schedule/recurrence-engine.js';
 
 export async function executeScheduleUpdate(
@@ -18,15 +18,22 @@ export async function executeScheduleUpdate(
   if (input.message !== undefined) updates.message = input.message;
   if (input.enabled !== undefined) updates.enabled = input.enabled;
 
-  // New syntax/expression fields take precedence over legacy cron_expression
-  if (input.expression !== undefined) {
-    updates.expression = input.expression;
-  } else if (input.cron_expression !== undefined) {
-    updates.cronExpression = input.cron_expression;
-  }
-
-  if (input.syntax !== undefined) {
-    updates.syntax = input.syntax;
+  // Auto-detect syntax when expression changes without explicit syntax
+  const hasExpression = input.expression !== undefined || input.cron_expression !== undefined;
+  if (hasExpression || input.syntax !== undefined) {
+    const resolved = normalizeScheduleSyntax({
+      syntax: input.syntax as 'cron' | 'rrule' | undefined,
+      expression: input.expression as string | undefined,
+      legacyCronExpression: input.cron_expression as string | undefined,
+    });
+    if (resolved) {
+      updates.syntax = resolved.syntax;
+      updates.expression = resolved.expression;
+    } else if (input.expression !== undefined) {
+      updates.expression = input.expression;
+    } else if (input.cron_expression !== undefined) {
+      updates.cronExpression = input.cron_expression;
+    }
   }
 
   if (Object.keys(updates).length === 0) {
@@ -34,7 +41,7 @@ export async function executeScheduleUpdate(
   }
 
   // Set-aware pre-validation for RRULE expressions
-  const effectiveSyntax = (updates.syntax as ScheduleSyntax | undefined) ?? (input.syntax as ScheduleSyntax | undefined);
+  const effectiveSyntax = updates.syntax as string | undefined;
   const effectiveExpr = (updates.expression as string | undefined) ?? (updates.cronExpression as string | undefined);
   if (effectiveExpr && typeof effectiveExpr === 'string' && (effectiveSyntax === 'rrule' || /^(DTSTART|RRULE:)/m.test(effectiveExpr))) {
     const setError = validateRruleSetLines(effectiveExpr);


### PR DESCRIPTION
Address reviewer feedback on PR #5523.

When `schedule_update` receives `expression` (or legacy `cron_expression`) without an explicit `syntax`, it now uses `normalizeScheduleSyntax()` to auto-detect the syntax — matching the behavior of `schedule_create`. Previously, omitting `syntax` would fall back to the job's existing syntax, causing validation failures when switching between cron and RRULE expressions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
