### PR TITLE
M2: Add circuit breaker/backoff to git preflight init

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -9,6 +9,8 @@ import {
   _resetGitServiceRegistry,
   _resetBreaker,
   _getConsecutiveFailures,
+  _resetInitBreaker,
+  _getInitConsecutiveFailures,
   isDeadlineExpired,
 } from '../workspace/git-service.js';
 
@@ -981,6 +983,145 @@ describe('WorkspaceGitService', () => {
         // Restore the original method
         proto.execGit = originalExecGit;
       }
+    });
+  });
+
+  describe('init circuit breaker', () => {
+    test('init breaker opens after consecutive failures', async () => {
+      // Use a directory that doesn't exist so init fails
+      const badDir = '/nonexistent/path/that/does/not/exist';
+      const service = new WorkspaceGitService(badDir);
+
+      // First failure
+      await expect(service.ensureInitialized()).rejects.toThrow();
+      expect(_getInitConsecutiveFailures(service)).toBe(1);
+
+      // Second failure — need to wait for the backoff to expire.
+      // The default backoff base is 2000ms, so for the first failure
+      // the backoff is 2000ms. Override via internal state to make the
+      // breaker window expire immediately so we can test the second failure.
+      const internal = service as unknown as {
+        initNextAllowedAttemptMs: number;
+      };
+      internal.initNextAllowedAttemptMs = Date.now() - 1;
+
+      await expect(service.ensureInitialized()).rejects.toThrow();
+      expect(_getInitConsecutiveFailures(service)).toBe(2);
+    });
+
+    test('init breaker skips init attempts during backoff window', async () => {
+      const service = new WorkspaceGitService(testDir);
+
+      // Force the init breaker open
+      const internal = service as unknown as {
+        initConsecutiveFailures: number;
+        initNextAllowedAttemptMs: number;
+      };
+      internal.initConsecutiveFailures = 3;
+      internal.initNextAllowedAttemptMs = Date.now() + 60_000; // far in the future
+
+      // ensureInitialized should throw with circuit breaker message
+      await expect(service.ensureInitialized()).rejects.toThrow(
+        'Init circuit breaker open: backing off after repeated failures',
+      );
+
+      // Failure count should NOT increase (the breaker prevented the attempt)
+      expect(_getInitConsecutiveFailures(service)).toBe(3);
+    });
+
+    test('init breaker resets on success', async () => {
+      const service = new WorkspaceGitService(testDir);
+
+      // Simulate prior init failures
+      const internal = service as unknown as {
+        initConsecutiveFailures: number;
+        initNextAllowedAttemptMs: number;
+      };
+      internal.initConsecutiveFailures = 3;
+      // Set backoff in the past so the breaker is closed and allows retry
+      internal.initNextAllowedAttemptMs = Date.now() - 1;
+
+      // This should succeed and reset the init breaker
+      await service.ensureInitialized();
+
+      expect(_getInitConsecutiveFailures(service)).toBe(0);
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    test('init breaker allows retry after backoff window expires', async () => {
+      const service = new WorkspaceGitService(testDir);
+
+      // Simulate prior init failures with expired backoff
+      const internal = service as unknown as {
+        initConsecutiveFailures: number;
+        initNextAllowedAttemptMs: number;
+      };
+      internal.initConsecutiveFailures = 5;
+      internal.initNextAllowedAttemptMs = Date.now() - 1; // expired
+
+      // Breaker should be closed (backoff expired), allowing init to proceed
+      await service.ensureInitialized();
+
+      expect(_getInitConsecutiveFailures(service)).toBe(0);
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    test('init breaker is independent from commit breaker', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // Force commit breaker open
+      const internal = service as unknown as {
+        consecutiveFailures: number;
+        nextAllowedAttemptMs: number;
+      };
+      internal.consecutiveFailures = 5;
+      internal.nextAllowedAttemptMs = Date.now() + 60_000;
+
+      // Init breaker should still be clean
+      expect(_getInitConsecutiveFailures(service)).toBe(0);
+
+      // Commit breaker should be open
+      expect(_getConsecutiveFailures(service)).toBe(5);
+
+      // Reset commit breaker
+      _resetBreaker(service);
+
+      // Force init breaker open
+      const internal2 = service as unknown as {
+        initConsecutiveFailures: number;
+        initNextAllowedAttemptMs: number;
+      };
+      internal2.initConsecutiveFailures = 3;
+      internal2.initNextAllowedAttemptMs = Date.now() + 60_000;
+
+      // Commit breaker should be clean
+      expect(_getConsecutiveFailures(service)).toBe(0);
+
+      // Init breaker should be open
+      expect(_getInitConsecutiveFailures(service)).toBe(3);
+
+      // Reset init breaker
+      _resetInitBreaker(service);
+      expect(_getInitConsecutiveFailures(service)).toBe(0);
+    });
+
+    test('already initialized service bypasses init breaker check', async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+      expect(service.isInitialized()).toBe(true);
+
+      // Force init breaker open
+      const internal = service as unknown as {
+        initConsecutiveFailures: number;
+        initNextAllowedAttemptMs: number;
+      };
+      internal.initConsecutiveFailures = 5;
+      internal.initNextAllowedAttemptMs = Date.now() + 60_000;
+
+      // ensureInitialized should succeed via the fast path (already initialized)
+      // without hitting the breaker
+      await service.ensureInitialized();
     });
   });
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -136,6 +136,8 @@ export class WorkspaceGitService {
   private initPromise: Promise<void> | null = null;
   private consecutiveFailures = 0;
   private nextAllowedAttemptMs = 0;
+  private initConsecutiveFailures = 0;
+  private initNextAllowedAttemptMs = 0;
 
   constructor(workspaceDir: string) {
     this.workspaceDir = workspaceDir;
@@ -179,6 +181,42 @@ export class WorkspaceGitService {
   }
 
   /**
+   * Check if the init circuit breaker is open (too many recent init failures).
+   * When open, init attempts are skipped until the backoff window expires.
+   */
+  private isInitBreakerOpen(): boolean {
+    if (this.initConsecutiveFailures === 0) return false;
+    return Date.now() < this.initNextAllowedAttemptMs;
+  }
+
+  private recordInitSuccess(): void {
+    if (this.initConsecutiveFailures > 0) {
+      log.info(
+        { workspaceDir: this.workspaceDir, previousFailures: this.initConsecutiveFailures },
+        'Init circuit breaker closed: initialization succeeded after failures',
+      );
+    }
+    this.initConsecutiveFailures = 0;
+    this.initNextAllowedAttemptMs = 0;
+  }
+
+  private recordInitFailure(): void {
+    const config = getConfig();
+    const failureBackoffBaseMs = config.workspaceGit?.failureBackoffBaseMs ?? 2000;
+    const failureBackoffMaxMs = config.workspaceGit?.failureBackoffMaxMs ?? 60000;
+    this.initConsecutiveFailures++;
+    const delay = Math.min(
+      failureBackoffBaseMs * Math.pow(2, this.initConsecutiveFailures - 1),
+      failureBackoffMaxMs,
+    );
+    this.initNextAllowedAttemptMs = Date.now() + delay;
+    log.warn(
+      { workspaceDir: this.workspaceDir, consecutiveFailures: this.initConsecutiveFailures, backoffMs: delay },
+      'Init circuit breaker opened: initialization failed, backing off',
+    );
+  }
+
+  /**
    * Ensure the git repository is initialized.
    * Idempotent: safe to call multiple times.
    *
@@ -195,6 +233,11 @@ export class WorkspaceGitService {
     // Fast path: already initialized
     if (this.initialized) {
       return;
+    }
+
+    // Circuit breaker: skip if recent init attempts have been failing
+    if (this.isInitBreakerOpen()) {
+      throw new Error('Init circuit breaker open: backing off after repeated failures');
     }
 
     // If initialization is in progress, wait for it
@@ -294,6 +337,7 @@ export class WorkspaceGitService {
             await this.ensureCommitIdentityLocked();
             await this.ensureOnMainLocked();
             this.initialized = true;
+            this.recordInitSuccess();
             return;
           }
         }
@@ -328,12 +372,14 @@ export class WorkspaceGitService {
       await this.execGit(['commit', '-m', message, '--allow-empty']);
 
       this.initialized = true;
+      this.recordInitSuccess();
     });
 
     // If initialization fails, clear the cached promise so subsequent
     // calls can retry instead of permanently returning the rejected promise.
     this.initPromise.catch(() => {
       this.initPromise = null;
+      this.recordInitFailure();
     });
 
     return this.initPromise;
@@ -772,4 +818,19 @@ export function _resetBreaker(service: WorkspaceGitService): void {
  */
 export function _getConsecutiveFailures(service: WorkspaceGitService): number {
   return (service as unknown as { consecutiveFailures: number }).consecutiveFailures;
+}
+
+/**
+ * @internal Test-only: reset init circuit breaker state for a service instance
+ */
+export function _resetInitBreaker(service: WorkspaceGitService): void {
+  (service as unknown as { initConsecutiveFailures: number }).initConsecutiveFailures = 0;
+  (service as unknown as { initNextAllowedAttemptMs: number }).initNextAllowedAttemptMs = 0;
+}
+
+/**
+ * @internal Test-only: get init consecutive failure count
+ */
+export function _getInitConsecutiveFailures(service: WorkspaceGitService): number {
+  return (service as unknown as { initConsecutiveFailures: number }).initConsecutiveFailures;
 }


### PR DESCRIPTION
## Summary

Fixes P2 bug where git preflight init has no backoff budget.

- Adds separate init circuit breaker state (initConsecutiveFailures, initNextAllowedAttemptMs)
- Adds isInitBreakerOpen/recordInitSuccess/recordInitFailure mirroring existing commit breaker
- Integrates breaker into ensureInitialized() flow
- Session-agent-loop call site already handles init failures gracefully (non-fatal)
- Adds tests for init circuit breaker behavior

Part of #5635, closes #5637
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
