### PR TITLE
Fix: Propagate abort signal into git note write and improve cancellation test

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -392,13 +392,23 @@ describe('CommitEnrichmentService', () => {
       maxRetries: 0,
     });
 
-    // Monkey-patch writeNote to simulate slow work that respects abort
+    // Monkey-patch writeNote to simulate slow work that respects the abort signal.
+    // The real writeNote now passes the signal to execFileAsync which kills the
+    // child process on abort. This mock replicates that behavior by rejecting
+    // when the signal fires.
     const originalWriteNote = gitService.writeNote.bind(gitService);
-    gitService.writeNote = async (hash: string, note: string) => {
-      // Simulate slow work — longer than the timeout
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      enrichmentCompleted = true;
-      return originalWriteNote(hash, note);
+    gitService.writeNote = async (_hash: string, _note: string, signal?: AbortSignal) => {
+      // Simulate slow work that is cancellable via AbortSignal
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          enrichmentCompleted = true;
+          resolve();
+        }, 2000);
+        signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new Error('aborted'));
+        }, { once: true });
+      });
     };
 
     service.enqueue({
@@ -410,6 +420,10 @@ describe('CommitEnrichmentService', () => {
 
     await waitForDrain(service, 5000);
     await service.shutdown();
+
+    // Allow any zombie work to settle — if abort didn't work, the 2s timer
+    // would still be running and would set enrichmentCompleted=true.
+    await new Promise(resolve => setTimeout(resolve, 200));
 
     // The job should have timed out and been counted as failed
     expect(service._getFailedCount()).toBe(1);
@@ -431,11 +445,17 @@ describe('CommitEnrichmentService', () => {
       maxRetries: 0,
     });
 
-    // Make writeNote artificially slow so the job will always time out
+    // Make writeNote artificially slow so the job will always time out.
+    // The mock respects the abort signal so the subprocess is killed on timeout.
     const originalWriteNote = gitService.writeNote.bind(gitService);
-    gitService.writeNote = async (hash: string, note: string) => {
-      await new Promise(resolve => setTimeout(resolve, 5000));
-      return originalWriteNote(hash, note);
+    gitService.writeNote = async (_hash: string, _note: string, signal?: AbortSignal) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 5000);
+        signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new Error('aborted'));
+        }, { once: true });
+      });
     };
 
     service.enqueue({

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -250,7 +250,7 @@ export class CommitEnrichmentService {
     });
 
     if (signal?.aborted) return;
-    await job.gitService.writeNote(job.commitHash, note);
+    await job.gitService.writeNote(job.commitHash, note, signal);
   }
 }
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -694,7 +694,7 @@ export class WorkspaceGitService {
    * intentionally short for interactive workspace operations — background
    * enrichment jobs use their own dedicated timeout.
    */
-  private async execGit(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  private async execGit(args: string[], options?: { signal?: AbortSignal }): Promise<{ stdout: string; stderr: string }> {
     const config = getConfig();
     const timeoutMs = config.workspaceGit?.interactiveGitTimeoutMs ?? 10_000;
     try {
@@ -703,6 +703,7 @@ export class WorkspaceGitService {
         encoding: 'utf-8',
         timeout: timeoutMs,
         env: cleanGitEnv(this.workspaceDir),
+        signal: options?.signal,
       });
       return { stdout, stderr };
     } catch (err) {
@@ -741,8 +742,8 @@ export class WorkspaceGitService {
    * Write a git note to a specific commit.
    * Uses the 'vellum' notes ref to avoid conflicts with default notes.
    */
-  async writeNote(commitHash: string, noteContent: string): Promise<void> {
-    await this.execGit(['notes', '--ref=vellum', 'add', '-f', '-m', noteContent, commitHash]);
+  async writeNote(commitHash: string, noteContent: string, signal?: AbortSignal): Promise<void> {
+    await this.execGit(['notes', '--ref=vellum', 'add', '-f', '-m', noteContent, commitHash], { signal });
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses review feedback on #5640.

- Propagates AbortSignal through writeNote → execGit → execFileAsync so timed-out enrichment actually kills the git subprocess
- Fixes cancellation test to properly verify that writeNote does not complete after abort

Part of #5635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
