### PR TITLE
Fix: Init circuit breaker allows immediate retry after first failure

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -992,20 +992,26 @@ describe('WorkspaceGitService', () => {
       const badDir = '/nonexistent/path/that/does/not/exist';
       const service = new WorkspaceGitService(badDir);
 
-      // First failure
+      // First failure — breaker does NOT open (requires 2+ failures)
       await expect(service.ensureInitialized()).rejects.toThrow();
       expect(_getInitConsecutiveFailures(service)).toBe(1);
 
-      // Second failure — need to wait for the backoff to expire.
-      // The default backoff base is 2000ms, so for the first failure
-      // the backoff is 2000ms. Override via internal state to make the
-      // breaker window expire immediately so we can test the second failure.
+      // Second failure — expire the backoff window from the first failure
+      // so the attempt actually runs (not blocked by breaker).
       const internal = service as unknown as {
         initNextAllowedAttemptMs: number;
       };
       internal.initNextAllowedAttemptMs = Date.now() - 1;
 
       await expect(service.ensureInitialized()).rejects.toThrow();
+      expect(_getInitConsecutiveFailures(service)).toBe(2);
+
+      // Third attempt within the backoff window — breaker is now open
+      // (2+ consecutive failures) so the attempt is skipped.
+      await expect(service.ensureInitialized()).rejects.toThrow(
+        'Init circuit breaker open: backing off after repeated failures',
+      );
+      // Failure count should NOT increase (the breaker prevented the attempt)
       expect(_getInitConsecutiveFailures(service)).toBe(2);
     });
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -185,7 +185,7 @@ export class WorkspaceGitService {
    * When open, init attempts are skipped until the backoff window expires.
    */
   private isInitBreakerOpen(): boolean {
-    if (this.initConsecutiveFailures === 0) return false;
+    if (this.initConsecutiveFailures < 2) return false;
     return Date.now() < this.initNextAllowedAttemptMs;
   }
 
@@ -235,14 +235,17 @@ export class WorkspaceGitService {
       return;
     }
 
-    // Circuit breaker: skip if recent init attempts have been failing
-    if (this.isInitBreakerOpen()) {
-      throw new Error('Init circuit breaker open: backing off after repeated failures');
-    }
-
     // If initialization is in progress, wait for it
     if (this.initPromise) {
       return this.initPromise;
+    }
+
+    // Circuit breaker: skip if multiple recent init attempts have been failing.
+    // Checked AFTER initPromise so callers waiting on in-progress init aren't
+    // blocked, and only activates after 2+ consecutive failures so that a
+    // single transient failure allows immediate retry.
+    if (this.isInitBreakerOpen()) {
+      throw new Error('Init circuit breaker open: backing off after repeated failures');
     }
 
     // Start initialization


### PR DESCRIPTION
## Summary

Addresses review feedback on #5641.

- Moves breaker check after initPromise check so callers waiting on in-progress init aren't blocked
- Changes breaker to only activate after 2+ consecutive failures (not after first failure)
- Preserves existing 'failed initialization can be retried' test contract
- Updates init breaker tests accordingly

Part of #5635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
