### PR TITLE
fix: move .help() tooltips inside VIconButton to fix hit-testing regression

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -359,22 +359,20 @@ struct MainWindowView: View {
                 VStack(spacing: 0) {
                     // Top bar (always visible, above sidebar)
                     HStack(spacing: 0) {
-                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true) {
+                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true, tooltip: sidebarOpen ? "Hide sidebar" : "Show sidebar") {
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 sidebarOpen.toggle()
                             }
                         }
-                        .help(sidebarOpen ? "Hide sidebar" : "Show sidebar")
                         if !sidebarOpen,
                            !windowState.isShowingChat
                             || threadManager.activeThread?.kind == .private
                             || threadManager.activeViewModel?.messages.contains(where: { $0.role == .user }) == true {
                             Spacer().frame(width: VSpacing.xs)
-                            VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true) {
+                            VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true, tooltip: "New chat") {
                                 windowState.selection = nil
                                 threadManager.createThread()
                             }
-                            .help("New chat")
                         }
                         Spacer()
                         if windowState.isShowingChat {
@@ -413,9 +411,9 @@ struct MainWindowView: View {
 
                             TemporaryChatToggle(
                                 isActive: threadManager.activeThread?.kind == .private,
+                                tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
                                 onToggle: { toggleTemporaryChat() }
                             )
-                            .help(threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat")
                         }
                     }
                     .padding(.leading, trafficLightPadding)

--- a/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatToggle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TemporaryChatToggle.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 
 struct TemporaryChatToggle: View {
     let isActive: Bool
+    var tooltip: String? = nil
     let onToggle: () -> Void
 
     var body: some View {
@@ -11,6 +12,7 @@ struct TemporaryChatToggle: View {
             icon: "circle.dashed",
             isActive: isActive,
             iconOnly: true,
+            tooltip: tooltip,
             action: onToggle
         )
         .foregroundColor(isActive ? VColor.accent : nil)

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -9,21 +9,38 @@ public struct VIconButton: View {
     public var customIcon: Image? = nil
     public var isActive: Bool = false
     public var iconOnly: Bool = false
+    public var tooltip: String? = nil
     public let action: () -> Void
 
     @State private var isHovered = false
 
-    public init(label: String, icon: String = "", customIcon: Image? = nil, isActive: Bool = false, iconOnly: Bool = false, action: @escaping () -> Void) {
+    public init(label: String, icon: String = "", customIcon: Image? = nil, isActive: Bool = false, iconOnly: Bool = false, tooltip: String? = nil, action: @escaping () -> Void) {
         self.label = label
         self.icon = icon
         self.customIcon = customIcon
         self.isActive = isActive
         self.iconOnly = iconOnly
+        self.tooltip = tooltip
         self.action = action
     }
 
     public var body: some View {
-        Button(action: action) {
+        buttonContent
+        #if os(macOS)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.set() }
+            else { NSCursor.arrow.set() }
+        }
+        #else
+        .onHover { isHovered = $0 }
+        #endif
+        .accessibilityLabel(label)
+    }
+
+    @ViewBuilder
+    private var buttonContent: some View {
+        let button = Button(action: action) {
             HStack(spacing: VSpacing.xs) {
                 if let customIcon {
                     customIcon
@@ -39,16 +56,12 @@ public struct VIconButton: View {
             }
         }
         .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, iconOnly: iconOnly))
-        #if os(macOS)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
+
+        if let tooltip {
+            button.help(tooltip)
+        } else {
+            button
         }
-        #else
-        .onHover { isHovered = $0 }
-        #endif
-        .accessibilityLabel(label)
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `tooltip` parameter to `VIconButton` and applied `.help()` internally (before `.onHover()`) instead of externally
- Updated `TemporaryChatToggle` to accept and forward the tooltip parameter
- Removed external `.help()` modifiers from top bar `VIconButton` instances in `MainWindowView`, passing tooltip text through the new parameter instead

This fixes the regression where `.help()` applied outside `VIconButton` created an NSView wrapper that intercepted mouse events, breaking:
1. Toggling off temporary chat mode by clicking the icon button
2. Tooltip display on hover for header buttons
3. Clicking other header buttons when in temporary chat mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
