### PR TITLE
M1: Extend IPC contract with structured ToolOutputChunk fields

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1015,6 +1015,10 @@ export interface ToolUseStart {
 export interface ToolOutputChunk {
   type: 'tool_output_chunk';
   chunk: string;
+  subType?: 'tool_start' | 'tool_complete' | 'status';
+  subToolName?: string;
+  subToolInput?: string;
+  subToolIsError?: boolean;
 }
 
 export interface ToolInputDelta {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1575,6 +1575,10 @@ public struct IPCToolInputDelta: Codable, Sendable {
 public struct IPCToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
+    public let subType: String?
+    public let subToolName: String?
+    public let subToolInput: String?
+    public let subToolIsError: Bool?
 }
 
 public struct IPCToolResult: Codable, Sendable {
@@ -1971,11 +1975,6 @@ public struct IPCWorkItemCancelResponse: Codable, Sendable {
 }
 
 public struct IPCWorkItemCompleteRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemRenderRequest: Codable, Sendable {
     public let type: String
     public let id: String
 }


### PR DESCRIPTION
Add optional subType, subToolName, subToolInput, and subToolIsError fields to the ToolOutputChunk IPC interface. These fields enable the client to receive structured progress events from long-running tool calls like claude_code. Regenerated Swift types and IPC inventory. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
