### PR TITLE
fix: align subagent status chips with message text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -469,11 +469,13 @@ struct ChatView: View {
                         }
 
                         // Subagent chips anchored to the message that spawned them
+                        // Indent to align with message text (past the 28pt avatar + 8pt spacing)
                         ForEach(activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
                             SubagentStatusChip(subagent: subagent) {
                                 onAbortSubagent?(subagent.id)
                             }
                                 .frame(maxWidth: 520, alignment: .leading)
+                                .padding(.leading, 36)
                                 .id("subagent-\(subagent.id)")
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
@@ -485,6 +487,7 @@ struct ChatView: View {
                             onAbortSubagent?(subagent.id)
                         }
                             .frame(maxWidth: 520, alignment: .leading)
+                            .padding(.leading, 36)
                             .id("subagent-\(subagent.id)")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }


### PR DESCRIPTION
## Summary
- Subagent status chips (e.g. "Ocean Haiku" with green/red dots) were aligned with the avatar instead of the message text
- Adds `.padding(.leading, 36)` to indent chips past the 28pt avatar + 8pt spacing, matching message bubble alignment
- Applied to both anchored chips (with parent message) and orphaned chips (no parent)

## Test plan
- [ ] Spawn subagents, verify chips align with message text (not the avatar)
- [ ] Restart app, verify restored chips also align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
