### PR TITLE
fix: populate subagent usage stats from session

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -13,6 +13,7 @@ interface FakeManagedSubagent {
     loadFromDb?: () => Promise<void>;
     persistUserMessage?: (msg: string) => string;
     runAgentLoop?: () => Promise<void>;
+    usageStats: { inputTokens: number; outputTokens: number; estimatedCost: number };
   };
   state: SubagentState;
   parentSendToClient: () => void;
@@ -44,6 +45,7 @@ function injectFakeSubagent(
     dispose: () => {},
     messages: [],
     sendToClient: () => {},
+    usageStats: { inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 },
   };
 
   const internals = asInternals(manager);
@@ -250,6 +252,7 @@ describe('SubagentManager notifyParent (via runSubagent)', () => {
     await asInternals(manager).runSubagent(subagentId, 'Do something');
 
     expect(state.status).toBe('completed');
+    expect(state.usage).toEqual({ inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 });
     expect(notifications).toHaveLength(1);
     expect(notifications[0].parentSessionId).toBe('parent-sess-1');
     expect(notifications[0].message).toContain('[Subagent "Test subagent" completed]');
@@ -279,6 +282,7 @@ describe('SubagentManager notifyParent (via runSubagent)', () => {
 
     expect(state.status).toBe('failed');
     expect(state.error).toBe('API rate limit exceeded');
+    expect(state.usage).toEqual({ inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 });
     expect(notifications).toHaveLength(1);
     expect(notifications[0].message).toContain('failed');
     expect(notifications[0].message).toContain('API rate limit exceeded');

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -229,6 +229,8 @@ export class SubagentManager {
       await managed.session.runAgentLoop(objective, messageId, onEvent);
 
       // Agent loop completed successfully.
+      // Copy usage stats from the session before sending status (which includes usage).
+      managed.state.usage = { ...managed.session.usageStats };
       // Only update state + notify if still non-terminal (guards against abort race).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
         managed.state.completedAt = Date.now();
@@ -243,6 +245,7 @@ export class SubagentManager {
       const errorMsg = err instanceof Error ? err.message : String(err);
       managed.state.error = errorMsg;
       managed.state.completedAt = Date.now();
+      managed.state.usage = { ...managed.session.usageStats };
 
       // Only update status if not already terminal (e.g. aborted).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {


### PR DESCRIPTION
## Summary
- Subagent usage stats (tokens, cost) were always zero because `managed.state.usage` was never updated from the session's `usageStats` after the agent loop completed
- Copies usage on both success and failure paths before `setStatus` sends it to the client via IPC
- Adds test assertions verifying usage is populated on completion and failure

## Test plan
- [x] `bun test src/__tests__/subagent-manager-notify.test.ts` — 19 pass
- [ ] Spawn subagents, verify `subagent_status_changed` IPC messages include non-zero usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
