### PR TITLE
M3: Parse structured fields in session-agent-loop

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -350,9 +350,31 @@ export async function runAgentLoopImpl(
           currentTurnToolNames.push(event.name);
           onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: ctx.conversationId });
           break;
-        case 'tool_output_chunk':
-          onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+        case 'tool_output_chunk': {
+          // Try to parse structured progress fields from the chunk
+          let structured: { subType?: string; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
+          try {
+            const parsed = JSON.parse(event.chunk);
+            if (parsed && typeof parsed === 'object' && parsed.subType) {
+              structured = parsed;
+            }
+          } catch {
+            // Not JSON — pass through as plain chunk
+          }
+          if (structured) {
+            onEvent({
+              type: 'tool_output_chunk',
+              chunk: event.chunk,
+              subType: structured.subType,
+              subToolName: structured.subToolName,
+              subToolInput: structured.subToolInput,
+              subToolIsError: structured.subToolIsError,
+            });
+          } else {
+            onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+          }
           break;
+        }
         case 'input_json_delta':
           onEvent({ type: 'tool_input_delta', toolName: event.toolName, content: event.accumulatedJson, sessionId: ctx.conversationId });
           break;


### PR DESCRIPTION
Parse JSON-encoded tool_output_chunk events in the session agent loop. When the chunk contains structured progress data (subType, subToolName, etc.), spread those fields into the IPC event so the Swift client can decode them directly. Plain text chunks pass through unchanged for backward compatibility. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
