### PR TITLE
fix(ios): filter subagent notification messages from chat UI

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -32,7 +32,7 @@ struct ChatContentView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: VSpacing.md) {
-                        let messages = viewModel.messages
+                        let messages = viewModel.messages.filter { !$0.isSubagentNotification }
                         ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
                             if message.modelPicker != nil {
                                 ModelPickerBubble(


### PR DESCRIPTION
## Summary
- The macOS client already filters `isSubagentNotification` messages from the chat view, but the iOS `ChatContentView` rendered them as raw `[Subagent "X" completed]` chat bubbles after restart
- Applies the same filter so notification messages are hidden on iOS too

## Test plan
- [ ] On iOS, spawn subagents, restart the app, verify raw notification messages are hidden
- [ ] Verify subagent status chips still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
