### PR TITLE
M4: Add ClaudeCodeSubStep model and handle toolOutputChunk in Swift

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -310,6 +310,64 @@ public struct ToolConfirmationData: Equatable {
     }
 }
 
+/// A single sub-tool invocation within a claude_code tool call.
+public struct ClaudeCodeSubStep: Identifiable, Equatable {
+    public let id: UUID
+    public let toolName: String
+    public let inputSummary: String
+    public var isComplete: Bool
+    public var isError: Bool
+    public let startedAt: Date
+
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, isComplete: Bool = false, isError: Bool = false, startedAt: Date = Date()) {
+        self.id = id
+        self.toolName = toolName
+        self.inputSummary = inputSummary
+        self.isComplete = isComplete
+        self.isError = isError
+        self.startedAt = startedAt
+    }
+
+    /// Human-readable label for the sub-tool.
+    public var friendlyName: String {
+        switch toolName.lowercased() {
+        case "read", "file_read":       return "Read File"
+        case "edit", "file_edit":       return "Edit File"
+        case "write", "file_write":     return "Write File"
+        case "bash":                    return "Run Command"
+        case "glob":                    return "Find Files"
+        case "grep":                    return "Search Files"
+        case "websearch", "web_search": return "Web Search"
+        case "webfetch", "web_fetch":   return "Fetch URL"
+        case "task":                    return "Run Agent"
+        case "notebookedit":            return "Edit Notebook"
+        case "notebookread":            return "Read Notebook"
+        default:
+            return toolName
+                .replacingOccurrences(of: "_", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }
+
+    /// SF Symbol name for the sub-tool type.
+    public var toolIcon: String {
+        switch toolName.lowercased() {
+        case "read", "file_read":       return "doc.text"
+        case "edit", "file_edit":       return "pencil.line"
+        case "write", "file_write":     return "doc.badge.plus"
+        case "bash":                    return "terminal"
+        case "glob":                    return "folder.badge.magnifyingglass"
+        case "grep":                    return "magnifyingglass"
+        case "websearch", "web_search": return "magnifyingglass"
+        case "webfetch", "web_fetch":   return "arrow.down.circle"
+        case "task":                    return "person.2"
+        default:                        return "puzzlepiece.extension"
+        }
+    }
+}
+
 /// Data for a tool call displayed inline in an assistant message.
 public struct ToolCallData: Identifiable, Equatable {
     public let id: UUID
@@ -329,6 +387,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var imageData: String?
     /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
     public var buildingStatus: String?
+    /// Sub-tool steps for claude_code tool calls (live progress tracking).
+    public var claudeCodeSteps: [ClaudeCodeSubStep] = []
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
     #if os(macOS)
     public var cachedImage: NSImage?
@@ -349,6 +409,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.inputFull == rhs.inputFull
             && lhs.imageData == rhs.imageData
             && lhs.buildingStatus == rhs.buildingStatus
+            && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -899,9 +899,34 @@ extension ChatViewModel {
                 messages.append(newMsg)
             }
 
-        case .toolOutputChunk:
-            // Streaming output — ignore for now, we show the final result
-            break
+        case .toolOutputChunk(let msg):
+            guard !isCancelling else { return }
+            // Handle structured progress events from claude_code sub-tools
+            if let subType = msg.subType, !subType.isEmpty,
+               let existingId = currentAssistantMessageId,
+               let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
+               let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+                switch subType {
+                case "tool_start":
+                    if let toolName = msg.subToolName {
+                        let step = ClaudeCodeSubStep(
+                            toolName: toolName,
+                            inputSummary: msg.subToolInput ?? ""
+                        )
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.append(step)
+                    }
+                case "tool_complete":
+                    if let toolName = msg.subToolName,
+                       let stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.lastIndex(where: { $0.toolName == toolName && !$0.isComplete }) {
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isComplete = true
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isError = msg.subToolIsError ?? false
+                    }
+                case "status":
+                    messages[msgIndex].toolCalls[tcIndex].buildingStatus = msg.chunk
+                default:
+                    break
+                }
+            }
 
         case .toolResult(let msg):
             guard belongsToSession(msg.sessionId) else { return }


### PR DESCRIPTION
Add ClaudeCodeSubStep struct for tracking claude_code sub-tool progress. Extend ToolCallData with claudeCodeSteps array. Handle structured toolOutputChunk events in ChatViewModel to populate sub-steps during live execution. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
