### PR TITLE
refactor: remove unused sessionId from SubagentStatusRequest

### DIFF
--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -66,8 +66,7 @@ export function handleSubagentStatus(
   }
 
   // Return all subagents for the caller's session.
-  const sessionId = callerSessionId;
-  const children = manager.getChildrenOf(sessionId);
+  const children = manager.getChildrenOf(callerSessionId);
   for (const child of children) {
     ctx.send(socket, {
       type: 'subagent_status_changed',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2190,7 +2190,6 @@ export interface SubagentStatusRequest {
   type: 'subagent_status';
   /** If omitted, returns all subagents for the session. */
   subagentId?: string;
-  sessionId: string;
 }
 
 export interface SubagentMessageRequest {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1508,7 +1508,6 @@ public struct IPCSubagentStatusRequest: Codable, Sendable {
     public let type: String
     /// If omitted, returns all subagents for the session.
     public let subagentId: String?
-    public let sessionId: String
 }
 
 public struct IPCSuggestionRequest: Codable, Sendable {
@@ -1980,11 +1979,6 @@ public struct IPCWorkItemCancelResponse: Codable, Sendable {
 }
 
 public struct IPCWorkItemCompleteRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemRenderRequest: Codable, Sendable {
     public let type: String
     public let id: String
 }


### PR DESCRIPTION
## Summary
- `SubagentStatusRequest.sessionId` was required in the IPC contract but the handler ignored it, deriving the session from the socket binding instead
- Removes the unused field from the contract and cleans up a redundant variable in the handler
- Regenerates Swift IPC types (also picks up stale `WorkItemRenderRequest` removal)

## Test plan
- [ ] Subagent status queries still work correctly
- [ ] No client code was using `sessionId` on this request type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
