### PR TITLE
fix: robust TwiML relay URL fallback when TWILIO_WSS_BASE_URL is unset

### DIFF
--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -98,13 +98,17 @@ mock.module('../calls/twilio-provider.js', () => {
   };
 });
 
+// Configurable mock Twilio config — tests can override wssBaseUrl
+let mockWssBaseUrl: string = 'wss://test.example.com';
+let mockWebhookBaseUrl: string = 'https://test.example.com';
+
 mock.module('../calls/twilio-config.js', () => ({
   getTwilioConfig: () => ({
     accountSid: 'AC_test',
     authToken: 'test-auth-token-for-webhooks',
     phoneNumber: '+15550001111',
-    webhookBaseUrl: 'https://test.example.com',
-    wssBaseUrl: 'wss://test.example.com',
+    webhookBaseUrl: mockWebhookBaseUrl,
+    wssBaseUrl: mockWssBaseUrl,
   }),
 }));
 
@@ -116,6 +120,7 @@ import {
   updateCallSession,
   getCallEvents,
 } from '../calls/call-store.js';
+import { resolveRelayUrl } from '../calls/twilio-routes.js';
 
 initializeDb();
 
@@ -184,6 +189,8 @@ describe('twilio webhook routes', () => {
   beforeEach(() => {
     resetTables();
     mockAuthToken = AUTH_TOKEN;
+    mockWssBaseUrl = 'wss://test.example.com';
+    mockWebhookBaseUrl = 'https://test.example.com';
     delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
   });
 
@@ -518,6 +525,105 @@ describe('twilio webhook routes', () => {
 
       const res = await fetch(url, { method: 'POST', headers, body });
       expect(res.status).toBe(200);
+
+      await stopServer();
+    });
+  });
+
+  // ── resolveRelayUrl unit tests ──────────────────────────────────────
+
+  describe('resolveRelayUrl', () => {
+    test('uses wssBaseUrl when explicitly set', () => {
+      const url = resolveRelayUrl('wss://ws.example.com', 'https://web.example.com');
+      expect(url).toBe('wss://ws.example.com/v1/calls/relay');
+    });
+
+    test('falls back to webhookBaseUrl when wssBaseUrl is empty', () => {
+      const url = resolveRelayUrl('', 'https://web.example.com');
+      expect(url).toBe('wss://web.example.com/v1/calls/relay');
+    });
+
+    test('falls back to webhookBaseUrl when wssBaseUrl is whitespace-only', () => {
+      const url = resolveRelayUrl('   ', 'https://web.example.com');
+      expect(url).toBe('wss://web.example.com/v1/calls/relay');
+    });
+
+    test('normalizes http to ws in webhookBaseUrl fallback', () => {
+      const url = resolveRelayUrl('', 'http://localhost:3000');
+      expect(url).toBe('ws://localhost:3000/v1/calls/relay');
+    });
+
+    test('normalizes https to wss in webhookBaseUrl fallback', () => {
+      const url = resolveRelayUrl('', 'https://gateway.example.com');
+      expect(url).toBe('wss://gateway.example.com/v1/calls/relay');
+    });
+
+    test('strips trailing slash from wssBaseUrl', () => {
+      const url = resolveRelayUrl('wss://ws.example.com/', 'https://web.example.com');
+      expect(url).toBe('wss://ws.example.com/v1/calls/relay');
+    });
+
+    test('strips trailing slash from webhookBaseUrl fallback', () => {
+      const url = resolveRelayUrl('', 'https://web.example.com/');
+      expect(url).toBe('wss://web.example.com/v1/calls/relay');
+    });
+
+    test('preserves wss scheme in explicitly set wssBaseUrl', () => {
+      const url = resolveRelayUrl('wss://custom-relay.example.com', 'https://web.example.com');
+      expect(url).toBe('wss://custom-relay.example.com/v1/calls/relay');
+    });
+  });
+
+  // ── TwiML relay URL generation ──────────────────────────────────────
+
+  describe('voice webhook TwiML relay URL', () => {
+    function voiceUrl(sessionId: string): string {
+      return `http://127.0.0.1:${port}/v1/calls/twilio/voice-webhook?callSessionId=${sessionId}`;
+    }
+
+    test('TwiML uses explicit wssBaseUrl when set', async () => {
+      mockWssBaseUrl = 'wss://explicit-ws.example.com';
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
+      await startServer();
+
+      const session = createTestSession('conv-twiml-1', 'CA_twiml_1');
+      const url = voiceUrl(session.id);
+      const params = { CallSid: 'CA_twiml_1' };
+      const body = buildFormBody(params);
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain('wss://explicit-ws.example.com/v1/calls/relay');
+
+      await stopServer();
+    });
+
+    test('TwiML falls back to webhookBaseUrl when wssBaseUrl is empty', async () => {
+      mockWssBaseUrl = '';
+      mockWebhookBaseUrl = 'https://gateway.example.com';
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
+      await startServer();
+
+      const session = createTestSession('conv-twiml-2', 'CA_twiml_2');
+      const url = voiceUrl(session.id);
+      const params = { CallSid: 'CA_twiml_2' };
+      const body = buildFormBody(params);
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain('wss://gateway.example.com/v1/calls/relay');
 
       await stopServer();
     });

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -56,6 +56,19 @@ function generateTwiML(callSessionId: string, relayUrl: string, welcomeGreeting:
 }
 
 /**
+ * Resolve the WebSocket relay URL from Twilio config.
+ *
+ * Treats wssBaseUrl as present only when it is non-empty after trimming.
+ * Falls back to webhookBaseUrl, normalizing the scheme from http(s) to ws(s)
+ * and stripping any trailing slash.
+ */
+export function resolveRelayUrl(wssBaseUrl: string, webhookBaseUrl: string): string {
+  const base = wssBaseUrl.trim() || webhookBaseUrl;
+  const normalized = base.replace(/\/$/, '').replace(/^http(s?)/, 'ws$1');
+  return `${normalized}/v1/calls/relay`;
+}
+
+/**
  * Map Twilio call status strings to our internal CallStatus.
  */
 function mapTwilioStatus(twilioStatus: string): CallStatus | null {
@@ -114,12 +127,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
 
   const config = getTwilioConfig();
-  // Always use /v1/calls/relay — the canonical relay path on both runtime and
-  // gateway. wssBaseUrl (when set) points directly at runtime; otherwise
-  // webhookBaseUrl may point at the gateway OR at the runtime in gateway-less
-  // deployments, so we use the same path either way.
-  const wsBase = (config.wssBaseUrl ?? config.webhookBaseUrl).replace(/\/$/, '').replace(/^http/, 'ws');
-  const relayUrl = `${wsBase}/v1/calls/relay`;
+  const relayUrl = resolveRelayUrl(config.wssBaseUrl, config.webhookBaseUrl);
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting);


### PR DESCRIPTION
Closes #5643. Introduces a resolveRelayUrl helper that treats empty wssBaseUrl as absent and falls back to webhookBaseUrl with proper ws/wss scheme normalization. Adds tests for both explicit wssBaseUrl and empty-fallback scenarios.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
