### PR TITLE
M5: Add ClaudeCodeProgressView and integrate into chat UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -336,16 +336,21 @@ struct ChatBubble: View {
             }
             .frame(maxWidth: 520, alignment: .leading)
         } else if hasActuallyRunningTool && !permissionWasDenied {
-            // In progress — show single running indicator for the active tool
+            // In progress — show running indicator or claude_code progress view
             let current = message.toolCalls.first(where: { !$0.isComplete })!
-            let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
-            RunningIndicator(
-                label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
-                progressiveLabels: progressive,
-                labelInterval: progressive.isEmpty ? 6 : 15,
-                onTap: nil
-            )
-                .frame(maxWidth: 520, alignment: .leading)
+            if current.toolName == "claude_code" && !current.claudeCodeSteps.isEmpty {
+                ClaudeCodeProgressView(steps: current.claudeCodeSteps, isRunning: true)
+                    .frame(maxWidth: 520, alignment: .leading)
+            } else {
+                let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
+                RunningIndicator(
+                    label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
+                    progressiveLabels: progressive,
+                    labelInterval: progressive.isEmpty ? 6 : 15,
+                    onTap: nil
+                )
+                    .frame(maxWidth: 520, alignment: .leading)
+            }
         } else if toolsCompleteButStillStreaming && !permissionWasDenied {
             // All tools done but model is still working (generating next tool call)
             RunningIndicator(

--- a/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+struct ClaudeCodeProgressView: View {
+    let steps: [ClaudeCodeSubStep]
+    let isRunning: Bool
+
+    @State private var isExpanded: Bool = true
+
+    // Show only the last 8 steps to keep the view manageable
+    private var visibleSteps: [ClaudeCodeSubStep] {
+        if steps.count <= 8 { return steps }
+        return Array(steps.suffix(8))
+    }
+
+    private var completedCount: Int {
+        steps.filter { $0.isComplete }.count
+    }
+
+    private var currentStep: ClaudeCodeSubStep? {
+        steps.last(where: { !$0.isComplete }) ?? steps.last
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header button
+            Button(action: {
+                withAnimation(VAnimation.fast) {
+                    isExpanded.toggle()
+                }
+            }) {
+                HStack(spacing: VSpacing.sm) {
+                    // Status indicator
+                    if isRunning {
+                        // Pulsing dot for running state
+                        Circle()
+                            .fill(VColor.accent)
+                            .frame(width: 8, height: 8)
+                            .modifier(PulsingModifier())
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.success)
+                    }
+
+                    // Label
+                    if isRunning, let current = currentStep {
+                        Text(current.friendlyName)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        if !current.inputSummary.isEmpty {
+                            Text(abbreviatePath(current.inputSummary))
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                        }
+                    } else {
+                        Text("Completed \(completedCount) step\(completedCount == 1 ? "" : "s")")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+
+                    Spacer()
+
+                    // Chevron
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+
+            // Expanded step list
+            if isExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    ForEach(visibleSteps) { step in
+                        HStack(spacing: VSpacing.sm) {
+                            // Step status icon
+                            if step.isComplete {
+                                if step.isError {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(VColor.error)
+                                } else {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(VColor.success)
+                                }
+                            } else {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .frame(width: 11, height: 11)
+                            }
+
+                            // Tool icon + name
+                            Image(systemName: step.toolIcon)
+                                .font(.system(size: 10))
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 14)
+
+                            Text(step.friendlyName)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+
+                            // Input summary
+                            if !step.inputSummary.isEmpty {
+                                Text(abbreviatePath(step.inputSummary))
+                                    .font(VFont.monoSmall)
+                                    .foregroundColor(VColor.textMuted)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                    }
+
+                    if steps.count > 8 {
+                        Text("+ \(steps.count - 8) earlier steps")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                    }
+                }
+                .padding(.bottom, VSpacing.xs)
+            }
+        }
+        .background(VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onChange(of: isRunning) { _, newValue in
+            // Auto-collapse when done
+            if !newValue {
+                withAnimation(VAnimation.fast) {
+                    isExpanded = false
+                }
+            }
+        }
+    }
+
+    /// Abbreviate long file paths to just the last component
+    private func abbreviatePath(_ input: String) -> String {
+        // If it looks like a file path, show just the filename
+        if input.contains("/") && !input.contains(" ") {
+            return URL(fileURLWithPath: input).lastPathComponent
+        }
+        // For commands, truncate
+        if input.count > 60 {
+            return String(input.prefix(57)) + "..."
+        }
+        return input
+    }
+}
+
+/// A simple pulsing opacity modifier for the running indicator dot
+private struct PulsingModifier: ViewModifier {
+    @State private var isPulsing = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isPulsing ? 0.4 : 1.0)
+            .animation(
+                Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear { isPulsing = true }
+    }
+}
+
+#Preview("Running") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ClaudeCodeProgressView(
+            steps: [
+                ClaudeCodeSubStep(toolName: "Read", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Edit", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Bash", inputSummary: "npm test", isComplete: false),
+            ],
+            isRunning: true
+        )
+        .frame(width: 400)
+        .padding()
+    }
+}
+
+#Preview("Completed") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ClaudeCodeProgressView(
+            steps: [
+                ClaudeCodeSubStep(toolName: "Read", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Edit", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Bash", inputSummary: "npm test", isComplete: true),
+            ],
+            isRunning: false
+        )
+        .frame(width: 400)
+        .padding()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -167,6 +167,22 @@ private struct UsedToolsRow: View {
                     }
                     .padding(.horizontal, VSpacing.md)
 
+                    // Claude Code sub-steps (if any)
+                    if !toolCall.claudeCodeSteps.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Sub-steps")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                                .textCase(.uppercase)
+
+                            ClaudeCodeProgressView(
+                                steps: toolCall.claudeCodeSteps,
+                                isRunning: false
+                            )
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                    }
+
                     // Screenshot — use CGImage + displayScale for pixel-perfect Retina rendering
                     if let img = toolCall.cachedImage,
                        let cgImage = img.cgImage(forProposedRect: nil, context: nil, hints: nil) {


### PR DESCRIPTION
Add a new ClaudeCodeProgressView that shows live sub-tool progress during claude_code execution. Integrates into ChatBubble (replacing generic RunningIndicator for claude_code) and into UsedToolsRow (showing sub-steps in expanded completed view). Features collapsible list with pulsing dot while running, checkmarks when done, tool icons, and file path abbreviation. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
