### PR TITLE
fix: prevent temporary chat background gradient from blocking top bar hit-testing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -191,6 +191,7 @@ struct ChatTemporaryChatEmptyStateView: View {
                 endRadius: 350
             )
             .offset(y: -40)
+            .allowsHitTesting(false)
         )
     }
 }


### PR DESCRIPTION
## Summary
- Added `.allowsHitTesting(false)` to the RadialGradient background in `ChatTemporaryChatEmptyStateView`
- The gradient used `.offset(y: -40)` which extended 40px above the view's bounds, overlapping the top bar and intercepting all mouse events on the header buttons
- This fixes: toggling off temporary chat, tooltip hover on header buttons, and clicking other header buttons when in temporary chat mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
