### PR TITLE
fix: apply .help() as outermost modifier on VIconButton for tooltips

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -25,22 +25,7 @@ public struct VIconButton: View {
     }
 
     public var body: some View {
-        buttonContent
-        #if os(macOS)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
-        }
-        #else
-        .onHover { isHovered = $0 }
-        #endif
-        .accessibilityLabel(label)
-    }
-
-    @ViewBuilder
-    private var buttonContent: some View {
-        let button = Button(action: action) {
+        Button(action: action) {
             HStack(spacing: VSpacing.xs) {
                 if let customIcon {
                     customIcon
@@ -56,12 +41,17 @@ public struct VIconButton: View {
             }
         }
         .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, iconOnly: iconOnly))
-
-        if let tooltip {
-            button.help(tooltip)
-        } else {
-            button
+        #if os(macOS)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.set() }
+            else { NSCursor.arrow.set() }
         }
+        #else
+        .onHover { isHovered = $0 }
+        #endif
+        .accessibilityLabel(label)
+        .help(tooltip ?? "")
     }
 }
 


### PR DESCRIPTION
## Summary
- Moved `.help()` to be the outermost modifier on VIconButton (after `.onHover()` and `.accessibilityLabel()`)
- Previously it was applied before `.onHover()`, which shadowed the tooltip tracking area and prevented tooltips from appearing
- Simplified the body by removing the separate `buttonContent` ViewBuilder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
