### PR TITLE
Fix: Include claude_code sub-steps in UsedToolsRow detail gating

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -87,7 +87,8 @@ private struct UsedToolsRow: View {
     private var hasDetails: Bool {
         !toolCall.inputFull.isEmpty ||
         (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) ||
-        toolCall.cachedImage != nil
+        toolCall.cachedImage != nil ||
+        !toolCall.claudeCodeSteps.isEmpty
     }
 
     var body: some View {


### PR DESCRIPTION
Include non-empty claudeCodeSteps in the hasDetails check so users can expand a claude_code tool row to see sub-steps even when there's no other detail data (input/result/image). Addresses review feedback from PR #5668. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
