### PR TITLE
Fix stale sessionId in ipc-snapshot test after SubagentStatusRequest refactor

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -783,7 +783,6 @@ exports[`IPC message snapshots ClientMessage types subagent_abort serializes to 
 
 exports[`IPC message snapshots ClientMessage types subagent_status serializes to expected JSON 1`] = `
 {
-  "sessionId": "sess-001",
   "subagentId": "sub-001",
   "type": "subagent_status",
 }

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -491,7 +491,6 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   subagent_status: {
     type: 'subagent_status',
     subagentId: 'sub-001',
-    sessionId: 'sess-001',
   },
   subagent_message: {
     type: 'subagent_message',


### PR DESCRIPTION
## Summary
Removes the stale `sessionId` field from the `subagent_status` test fixture and snapshot in `ipc-snapshot.test.ts`. This field was removed from `SubagentStatusRequest` in #5664 but the test was not updated, causing a type error and snapshot mismatch in CI.

## Review & Testing Checklist for Human
- [ ] Confirm that `SubagentStatusRequest` on main no longer includes `sessionId` (see #5664)
- [ ] Verify `bunx tsc --noEmit` passes cleanly from `assistant/`

### Notes
- The original work-items preflight changes from this branch were already landed on main via #5686, so after rebasing only the test fix remains
- Pre-existing lint failure in `twilio-routes.test.ts` (unused vars) is unrelated to this PR
- Requested by: @NgoHarrison
- Session: https://app.devin.ai/sessions/06cfdd5692ff41e18dcaa2b296bdd2ba