### PR TITLE
fix: match restored subagent chips to correct parent message

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1160,7 +1160,7 @@ public final class ChatViewModel: ObservableObject {
     public func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
         var chatMessages: [ChatMessage] = []
         var reconstructedSubagents: [SubagentInfo] = []
-        var lastAssistantMessageId: UUID?
+        var spawnParentMap: [String: UUID] = [:]  // subagentId → spawning assistant message UUID
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user
             var toolCalls: [ToolCallData] = []
@@ -1265,9 +1265,17 @@ public final class ChatViewModel: ObservableObject {
                 log.info("Message contentOrder: \(item.contentOrder ?? []), surface refs: \(surfaceRefs.count), inlineSurfaces: \(chatMsg.inlineSurfaces.count)")
             }
 
-            // Track last assistant message ID for parenting reconstructed subagent chips
+            // Build a map of subagentId → spawning assistant message UUID
+            // by scanning tool call results for subagent_spawn.
             if role == .assistant {
-                lastAssistantMessageId = chatMsg.id
+                for tc in toolCalls where tc.toolName == "subagent_spawn" {
+                    if let result = tc.result,
+                       let data = result.data(using: .utf8),
+                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let spawnedId = json["subagentId"] as? String {
+                        spawnParentMap[spawnedId] = chatMsg.id
+                    }
+                }
             }
 
             // Reconstruct subagent chips from structured notification metadata
@@ -1276,7 +1284,7 @@ public final class ChatViewModel: ObservableObject {
                     id: notification.subagentId,
                     label: notification.label,
                     status: SubagentStatus(wire: notification.status),
-                    parentMessageId: lastAssistantMessageId
+                    parentMessageId: spawnParentMap[notification.subagentId]
                 )
                 info.error = notification.error
                 reconstructedSubagents.append(info)


### PR DESCRIPTION
## Summary
- Restored subagent chips used `lastAssistantMessageId` as the parent, which could attach chips to the wrong message when a subagent completed after additional assistant turns
- Now scans `subagent_spawn` tool call results in history to build an exact `subagentId → parent message UUID` map
- Lookup happens inside the existing history loop with negligible overhead (only parses JSON for the rare `subagent_spawn` tool calls)

## Test plan
- [ ] Spawn multiple subagents, let them complete with intermediate assistant replies between completions
- [ ] Restart app, verify each chip anchors to the message that spawned it (not a later one)
- [ ] Verify chips still work for single-subagent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
