### PR TITLE
Fix: Add sessionId guard and validate structured progress fields

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1015,6 +1015,7 @@ export interface ToolUseStart {
 export interface ToolOutputChunk {
   type: 'tool_output_chunk';
   chunk: string;
+  sessionId?: string;
   subType?: 'tool_start' | 'tool_complete' | 'status';
   subToolName?: string;
   subToolInput?: string;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -351,27 +351,38 @@ export async function runAgentLoopImpl(
           onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: ctx.conversationId });
           break;
         case 'tool_output_chunk': {
-          // Try to parse structured progress fields from the chunk
+          // Try to parse structured progress fields from the chunk.
+          // Cheap pre-check: only attempt JSON.parse when the chunk looks like an object.
           let structured: { subType?: string; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
-          try {
-            const parsed = JSON.parse(event.chunk);
-            if (parsed && typeof parsed === 'object' && parsed.subType) {
-              structured = parsed;
+          const trimmed = event.chunk.trimStart();
+          if (trimmed.length > 0 && trimmed[0] === '{') {
+            try {
+              const parsed = JSON.parse(event.chunk);
+              const VALID_SUB_TYPES = new Set(['tool_start', 'tool_complete', 'status']);
+              if (parsed && typeof parsed === 'object' && typeof parsed.subType === 'string' && VALID_SUB_TYPES.has(parsed.subType)) {
+                structured = {
+                  subType: parsed.subType as string,
+                  subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
+                  subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
+                  subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,
+                };
+              }
+            } catch {
+              // Not valid JSON — pass through as plain chunk
             }
-          } catch {
-            // Not JSON — pass through as plain chunk
           }
           if (structured) {
             onEvent({
               type: 'tool_output_chunk',
               chunk: event.chunk,
+              sessionId: ctx.conversationId,
               subType: structured.subType,
               subToolName: structured.subToolName,
               subToolInput: structured.subToolInput,
               subToolIsError: structured.subToolIsError,
             });
           } else {
-            onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+            onEvent({ type: 'tool_output_chunk', chunk: event.chunk, sessionId: ctx.conversationId });
           }
           break;
         }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -901,6 +901,7 @@ extension ChatViewModel {
 
         case .toolOutputChunk(let msg):
             guard !isCancelling else { return }
+            guard belongsToSession(msg.sessionId) else { return }
             // Handle structured progress events from claude_code sub-tools
             if let subType = msg.subType, !subType.isEmpty,
                let existingId = currentAssistantMessageId,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1575,6 +1575,7 @@ public struct IPCToolInputDelta: Codable, Sendable {
 public struct IPCToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
+    public let sessionId: String?
     public let subType: String?
     public let subToolName: String?
     public let subToolInput: String?


### PR DESCRIPTION
Address review feedback from PRs #5659 and #5662. Adds sessionId to the ToolOutputChunk IPC type and passes it from the session-agent-loop, preventing cross-session contamination. Adds a cheap pre-check (first char '{') before JSON.parse to avoid exception-driven control flow on non-JSON chunks. Validates subType against allowed values and type-checks all structured fields before forwarding. Adds belongsToSession guard in the Swift toolOutputChunk handler. Part of #5647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
