### PR TITLE
Live Claude Code Progress in Vellum Assistant UI

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1015,6 +1015,7 @@ export interface ToolUseStart {
 export interface ToolOutputChunk {
   type: 'tool_output_chunk';
   chunk: string;
+  sessionId?: string;
   subType?: 'tool_start' | 'tool_complete' | 'status';
   subToolName?: string;
   subToolInput?: string;

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1015,6 +1015,10 @@ export interface ToolUseStart {
 export interface ToolOutputChunk {
   type: 'tool_output_chunk';
   chunk: string;
+  subType?: 'tool_start' | 'tool_complete' | 'status';
+  subToolName?: string;
+  subToolInput?: string;
+  subToolIsError?: boolean;
 }
 
 export interface ToolInputDelta {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1020,6 +1020,7 @@ export interface ToolOutputChunk {
   subToolName?: string;
   subToolInput?: string;
   subToolIsError?: boolean;
+  subToolId?: string;
 }
 
 export interface ToolInputDelta {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -350,9 +350,31 @@ export async function runAgentLoopImpl(
           currentTurnToolNames.push(event.name);
           onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: ctx.conversationId });
           break;
-        case 'tool_output_chunk':
-          onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+        case 'tool_output_chunk': {
+          // Try to parse structured progress fields from the chunk
+          let structured: { subType?: string; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
+          try {
+            const parsed = JSON.parse(event.chunk);
+            if (parsed && typeof parsed === 'object' && parsed.subType) {
+              structured = parsed;
+            }
+          } catch {
+            // Not JSON — pass through as plain chunk
+          }
+          if (structured) {
+            onEvent({
+              type: 'tool_output_chunk',
+              chunk: event.chunk,
+              subType: structured.subType,
+              subToolName: structured.subToolName,
+              subToolInput: structured.subToolInput,
+              subToolIsError: structured.subToolIsError,
+            });
+          } else {
+            onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+          }
           break;
+        }
         case 'input_json_delta':
           onEvent({ type: 'tool_input_delta', toolName: event.toolName, content: event.accumulatedJson, sessionId: ctx.conversationId });
           break;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -353,7 +353,7 @@ export async function runAgentLoopImpl(
         case 'tool_output_chunk': {
           // Try to parse structured progress fields from the chunk.
           // Cheap pre-check: only attempt JSON.parse when the chunk looks like an object.
-          let structured: { subType?: 'tool_start' | 'tool_complete' | 'status'; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
+          let structured: { subType?: 'tool_start' | 'tool_complete' | 'status'; subToolName?: string; subToolInput?: string; subToolIsError?: boolean; subToolId?: string } | undefined;
           const trimmed = event.chunk.trimStart();
           if (trimmed.length > 0 && trimmed.length < 4096 && trimmed[0] === '{') {
             try {
@@ -365,6 +365,7 @@ export async function runAgentLoopImpl(
                   subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
                   subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
                   subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,
+                  subToolId: typeof parsed.subToolId === 'string' ? parsed.subToolId : undefined,
                 };
               }
             } catch {
@@ -380,6 +381,7 @@ export async function runAgentLoopImpl(
               subToolName: structured.subToolName,
               subToolInput: structured.subToolInput,
               subToolIsError: structured.subToolIsError,
+              subToolId: structured.subToolId,
             });
           } else {
             onEvent({ type: 'tool_output_chunk', chunk: event.chunk, sessionId: ctx.conversationId });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -351,27 +351,38 @@ export async function runAgentLoopImpl(
           onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: ctx.conversationId });
           break;
         case 'tool_output_chunk': {
-          // Try to parse structured progress fields from the chunk
+          // Try to parse structured progress fields from the chunk.
+          // Cheap pre-check: only attempt JSON.parse when the chunk looks like an object.
           let structured: { subType?: string; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
-          try {
-            const parsed = JSON.parse(event.chunk);
-            if (parsed && typeof parsed === 'object' && parsed.subType) {
-              structured = parsed;
+          const trimmed = event.chunk.trimStart();
+          if (trimmed.length > 0 && trimmed[0] === '{') {
+            try {
+              const parsed = JSON.parse(event.chunk);
+              const VALID_SUB_TYPES = new Set(['tool_start', 'tool_complete', 'status']);
+              if (parsed && typeof parsed === 'object' && typeof parsed.subType === 'string' && VALID_SUB_TYPES.has(parsed.subType)) {
+                structured = {
+                  subType: parsed.subType as string,
+                  subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
+                  subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
+                  subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,
+                };
+              }
+            } catch {
+              // Not valid JSON — pass through as plain chunk
             }
-          } catch {
-            // Not JSON — pass through as plain chunk
           }
           if (structured) {
             onEvent({
               type: 'tool_output_chunk',
               chunk: event.chunk,
+              sessionId: ctx.conversationId,
               subType: structured.subType,
               subToolName: structured.subToolName,
               subToolInput: structured.subToolInput,
               subToolIsError: structured.subToolIsError,
             });
           } else {
-            onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
+            onEvent({ type: 'tool_output_chunk', chunk: event.chunk, sessionId: ctx.conversationId });
           }
           break;
         }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -353,15 +353,15 @@ export async function runAgentLoopImpl(
         case 'tool_output_chunk': {
           // Try to parse structured progress fields from the chunk.
           // Cheap pre-check: only attempt JSON.parse when the chunk looks like an object.
-          let structured: { subType?: string; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
+          let structured: { subType?: 'tool_start' | 'tool_complete' | 'status'; subToolName?: string; subToolInput?: string; subToolIsError?: boolean } | undefined;
           const trimmed = event.chunk.trimStart();
-          if (trimmed.length > 0 && trimmed[0] === '{') {
+          if (trimmed.length > 0 && trimmed.length < 4096 && trimmed[0] === '{') {
             try {
               const parsed = JSON.parse(event.chunk);
               const VALID_SUB_TYPES = new Set(['tool_start', 'tool_complete', 'status']);
               if (parsed && typeof parsed === 'object' && typeof parsed.subType === 'string' && VALID_SUB_TYPES.has(parsed.subType)) {
                 structured = {
-                  subType: parsed.subType as string,
+                  subType: parsed.subType as 'tool_start' | 'tool_complete' | 'status',
                   subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
                   subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
                   subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -346,6 +346,7 @@ export const claudeCodeTool: Tool = {
               context.onOutput?.(JSON.stringify({
                 subType: 'tool_complete',
                 subToolName: lastSubToolName,
+                subToolId: activeToolUseId,
                 ...(isFailure && { subToolIsError: true }),
               }));
               lastSubToolName = null;

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -229,6 +229,13 @@ export const claudeCodeTool: Tool = {
       let hasError = false;
       let lastSubToolName: string | null = null;
 
+      // Track tool_use_id → {name, inputSummary} for enriching progress events.
+      const toolUseIdInfo = new Map<string, { name: string; inputSummary: string }>();
+      // Track tool_use_ids that we've already emitted tool_start for (to avoid duplicates).
+      const emittedToolUseIds = new Set<string>();
+      // Track the currently active tool_use_id from tool_progress events.
+      let activeToolUseId: string | null = null;
+
       for await (const message of conversation) {
         switch (message.type) {
           case 'assistant': {
@@ -246,24 +253,85 @@ export const claudeCodeTool: Tool = {
                   resultText += block.text;
                 }
                 if (block.type === 'tool_use') {
-                  // Mark previous sub-tool as complete
-                  if (lastSubToolName) {
-                    context.onOutput?.(JSON.stringify({
-                      subType: 'tool_complete',
-                      subToolName: lastSubToolName,
-                    }));
-                  }
+                  // Capture info keyed by tool_use_id for enriching tool_progress events.
                   const inputSummary = summarizeToolInput(block.name, block.input as Record<string, unknown>);
-                  context.onOutput?.(JSON.stringify({
-                    subType: 'tool_start',
-                    subToolName: block.name,
-                    subToolInput: inputSummary,
-                  }));
-                  lastSubToolName = block.name;
+                  toolUseIdInfo.set(block.id, { name: block.name, inputSummary });
+
+                  // Emit tool_start if we haven't already (tool_progress may have fired first).
+                  if (!emittedToolUseIds.has(block.id)) {
+                    if (lastSubToolName) {
+                      context.onOutput?.(JSON.stringify({
+                        subType: 'tool_complete',
+                        subToolName: lastSubToolName,
+                      }));
+                    }
+                    context.onOutput?.(JSON.stringify({
+                      subType: 'tool_start',
+                      subToolName: block.name,
+                      subToolInput: inputSummary,
+                    }));
+                    emittedToolUseIds.add(block.id);
+                    lastSubToolName = block.name;
+                  }
                 }
               }
             }
             sessionId = message.session_id;
+            break;
+          }
+          case 'tool_progress': {
+            // The SDK fires tool_progress periodically DURING tool execution.
+            // This is our primary signal for live sub-tool progress.
+            const toolUseId = message.tool_use_id;
+            const toolName = message.tool_name;
+            sessionId = message.session_id;
+
+            // Record tool name if we don't have it yet (tool_progress fires before assistant sometimes).
+            if (!toolUseIdInfo.has(toolUseId)) {
+              toolUseIdInfo.set(toolUseId, { name: toolName, inputSummary: '' });
+            }
+
+            if (!emittedToolUseIds.has(toolUseId)) {
+              // New tool — mark previous as complete and emit tool_start.
+              if (lastSubToolName && activeToolUseId !== toolUseId) {
+                context.onOutput?.(JSON.stringify({
+                  subType: 'tool_complete',
+                  subToolName: lastSubToolName,
+                }));
+              }
+              const inputSummary = toolUseIdInfo.get(toolUseId)?.inputSummary ?? '';
+              context.onOutput?.(JSON.stringify({
+                subType: 'tool_start',
+                subToolName: toolName,
+                subToolInput: inputSummary,
+              }));
+              emittedToolUseIds.add(toolUseId);
+              lastSubToolName = toolName;
+            }
+            activeToolUseId = toolUseId;
+            break;
+          }
+          case 'tool_use_summary': {
+            // The SDK fires tool_use_summary after tool execution with a summary
+            // and the IDs of tools that were executed.
+            sessionId = message.session_id;
+            for (const completedId of message.preceding_tool_use_ids) {
+              const info = toolUseIdInfo.get(completedId);
+              const completedName: string | null = info?.name ?? lastSubToolName;
+              if (completedName && emittedToolUseIds.has(completedId)) {
+                context.onOutput?.(JSON.stringify({
+                  subType: 'tool_complete',
+                  subToolName: completedName,
+                }));
+                if (lastSubToolName === completedName) {
+                  lastSubToolName = null;
+                }
+              }
+              // Prune completed entries to keep memory flat across long sessions.
+              toolUseIdInfo.delete(completedId);
+              emittedToolUseIds.delete(completedId);
+            }
+            activeToolUseId = null;
             break;
           }
           case 'result': {

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -28,6 +28,25 @@ const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'code
 const MAX_CLAUDE_CODE_DEPTH = 1;
 const DEPTH_ENV_VAR = 'VELLUM_CLAUDE_CODE_DEPTH';
 
+function summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
+  // Extract the most relevant field for each tool type
+  const name = toolName.toLowerCase();
+  if (name === 'bash') return String(input.command ?? '');
+  if (name === 'read' || name === 'file_read') return String(input.file_path ?? input.path ?? '');
+  if (name === 'edit' || name === 'file_edit') return String(input.file_path ?? input.path ?? '');
+  if (name === 'write' || name === 'file_write') return String(input.file_path ?? input.path ?? '');
+  if (name === 'glob') return String(input.pattern ?? '');
+  if (name === 'grep') return String(input.pattern ?? '');
+  if (name === 'websearch' || name === 'web_search') return String(input.query ?? '');
+  if (name === 'webfetch' || name === 'web_fetch') return String(input.url ?? '');
+  if (name === 'task') return String(input.description ?? '');
+  // Fallback: first string value
+  for (const val of Object.values(input)) {
+    if (typeof val === 'string' && val.length > 0 && val.length < 200) return val;
+  }
+  return '';
+}
+
 export const claudeCodeTool: Tool = {
   name: 'claude_code',
   description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
@@ -208,6 +227,7 @@ export const claudeCodeTool: Tool = {
       let resultText = '';
       let sessionId = '';
       let hasError = false;
+      let lastSubToolName: string | null = null;
 
       for await (const message of conversation) {
         switch (message.type) {
@@ -225,12 +245,36 @@ export const claudeCodeTool: Tool = {
                   context.onOutput?.(block.text);
                   resultText += block.text;
                 }
+                if (block.type === 'tool_use') {
+                  // Mark previous sub-tool as complete
+                  if (lastSubToolName) {
+                    context.onOutput?.(JSON.stringify({
+                      subType: 'tool_complete',
+                      subToolName: lastSubToolName,
+                    }));
+                  }
+                  const inputSummary = summarizeToolInput(block.name, block.input as Record<string, unknown>);
+                  context.onOutput?.(JSON.stringify({
+                    subType: 'tool_start',
+                    subToolName: block.name,
+                    subToolInput: inputSummary,
+                  }));
+                  lastSubToolName = block.name;
+                }
               }
             }
             sessionId = message.session_id;
             break;
           }
           case 'result': {
+            // Mark the final sub-tool as complete
+            if (lastSubToolName) {
+              context.onOutput?.(JSON.stringify({
+                subType: 'tool_complete',
+                subToolName: lastSubToolName,
+              }));
+              lastSubToolName = null;
+            }
             sessionId = message.session_id;
             const resultMeta = {
               subtype: message.subtype,

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -222,12 +222,14 @@ export const claudeCodeTool: Tool = {
       queryOptions.resume = resumeSessionId;
     }
 
+    // Declared outside try so the catch block can emit a final tool_complete on error.
+    let lastSubToolName: string | null = null;
+
     try {
       const conversation = query({ prompt, options: queryOptions });
       let resultText = '';
       let sessionId = '';
       let hasError = false;
-      let lastSubToolName: string | null = null;
 
       // Track tool_use_id → {name, inputSummary} for enriching progress events.
       const toolUseIdInfo = new Map<string, { name: string; inputSummary: string }>();
@@ -258,20 +260,20 @@ export const claudeCodeTool: Tool = {
                   toolUseIdInfo.set(block.id, { name: block.name, inputSummary });
 
                   // Emit tool_start if we haven't already (tool_progress may have fired first).
+                  // NOTE: Do NOT emit tool_complete for the previous tool here. An assistant
+                  // message may contain multiple tool_use blocks (parallel tool use) and none
+                  // of them have executed yet at this point. Completions are handled by
+                  // tool_use_summary and tool_progress events.
                   if (!emittedToolUseIds.has(block.id)) {
-                    if (lastSubToolName) {
-                      context.onOutput?.(JSON.stringify({
-                        subType: 'tool_complete',
-                        subToolName: lastSubToolName,
-                      }));
-                    }
                     context.onOutput?.(JSON.stringify({
                       subType: 'tool_start',
                       subToolName: block.name,
                       subToolInput: inputSummary,
+                      subToolId: block.id,
                     }));
                     emittedToolUseIds.add(block.id);
                     lastSubToolName = block.name;
+                    activeToolUseId = block.id;
                   }
                 }
               }
@@ -297,6 +299,7 @@ export const claudeCodeTool: Tool = {
                 context.onOutput?.(JSON.stringify({
                   subType: 'tool_complete',
                   subToolName: lastSubToolName,
+                  subToolId: activeToolUseId,
                 }));
               }
               const inputSummary = toolUseIdInfo.get(toolUseId)?.inputSummary ?? '';
@@ -304,6 +307,7 @@ export const claudeCodeTool: Tool = {
                 subType: 'tool_start',
                 subToolName: toolName,
                 subToolInput: inputSummary,
+                subToolId: toolUseId,
               }));
               emittedToolUseIds.add(toolUseId);
               lastSubToolName = toolName;
@@ -322,6 +326,7 @@ export const claudeCodeTool: Tool = {
                 context.onOutput?.(JSON.stringify({
                   subType: 'tool_complete',
                   subToolName: completedName,
+                  subToolId: completedId,
                 }));
                 if (lastSubToolName === completedName) {
                   lastSubToolName = null;
@@ -335,11 +340,13 @@ export const claudeCodeTool: Tool = {
             break;
           }
           case 'result': {
-            // Mark the final sub-tool as complete
+            // Mark the final sub-tool as complete (flag error if the session failed).
             if (lastSubToolName) {
+              const isFailure = message.subtype !== 'success';
               context.onOutput?.(JSON.stringify({
                 subType: 'tool_complete',
                 subToolName: lastSubToolName,
+                ...(isFailure && { subToolIsError: true }),
               }));
               lastSubToolName = null;
             }
@@ -393,6 +400,16 @@ export const claudeCodeTool: Tool = {
         isError: hasError,
       };
     } catch (err) {
+      // Mark the last sub-tool as failed so the UI shows an error icon.
+      if (lastSubToolName) {
+        context.onOutput?.(JSON.stringify({
+          subType: 'tool_complete',
+          subToolName: lastSubToolName,
+          subToolIsError: true,
+        }));
+        lastSubToolName = null;
+      }
+
       const errMessage = err instanceof Error ? err.message : String(err);
       const recentStderr = stderrLines.slice(-20);
       log.error({ err, stderrTail: recentStderr }, 'Claude Code execution failed');

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -336,16 +336,21 @@ struct ChatBubble: View {
             }
             .frame(maxWidth: 520, alignment: .leading)
         } else if hasActuallyRunningTool && !permissionWasDenied {
-            // In progress — show single running indicator for the active tool
+            // In progress — show running indicator or claude_code progress view
             let current = message.toolCalls.first(where: { !$0.isComplete })!
-            let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
-            RunningIndicator(
-                label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
-                progressiveLabels: progressive,
-                labelInterval: progressive.isEmpty ? 6 : 15,
-                onTap: nil
-            )
-                .frame(maxWidth: 520, alignment: .leading)
+            if current.toolName == "claude_code" && !current.claudeCodeSteps.isEmpty {
+                ClaudeCodeProgressView(steps: current.claudeCodeSteps, isRunning: true)
+                    .frame(maxWidth: 520, alignment: .leading)
+            } else {
+                let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
+                RunningIndicator(
+                    label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
+                    progressiveLabels: progressive,
+                    labelInterval: progressive.isEmpty ? 6 : 15,
+                    onTap: nil
+                )
+                    .frame(maxWidth: 520, alignment: .leading)
+            }
         } else if toolsCompleteButStillStreaming && !permissionWasDenied {
             // All tools done but model is still working (generating next tool call)
             RunningIndicator(

--- a/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
+import VellumAssistantShared
 
 struct ClaudeCodeProgressView: View {
     let steps: [ClaudeCodeSubStep]
     let isRunning: Bool
 
     @State private var isExpanded: Bool = true
+    @State private var userHasToggled: Bool = false
 
     // Show only the last 8 steps to keep the view manageable
     private var visibleSteps: [ClaudeCodeSubStep] {
@@ -26,6 +28,7 @@ struct ClaudeCodeProgressView: View {
             Button(action: {
                 withAnimation(VAnimation.fast) {
                     isExpanded.toggle()
+                    userHasToggled = true
                 }
             }) {
                 HStack(spacing: VSpacing.sm) {
@@ -132,8 +135,8 @@ struct ClaudeCodeProgressView: View {
         .background(VColor.surface.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onChange(of: isRunning) { _, newValue in
-            // Auto-collapse when done
-            if !newValue {
+            // Auto-collapse when done, unless the user has manually toggled
+            if !newValue && !userHasToggled {
                 withAnimation(VAnimation.fast) {
                     isExpanded = false
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+struct ClaudeCodeProgressView: View {
+    let steps: [ClaudeCodeSubStep]
+    let isRunning: Bool
+
+    @State private var isExpanded: Bool = true
+
+    // Show only the last 8 steps to keep the view manageable
+    private var visibleSteps: [ClaudeCodeSubStep] {
+        if steps.count <= 8 { return steps }
+        return Array(steps.suffix(8))
+    }
+
+    private var completedCount: Int {
+        steps.filter { $0.isComplete }.count
+    }
+
+    private var currentStep: ClaudeCodeSubStep? {
+        steps.last(where: { !$0.isComplete }) ?? steps.last
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header button
+            Button(action: {
+                withAnimation(VAnimation.fast) {
+                    isExpanded.toggle()
+                }
+            }) {
+                HStack(spacing: VSpacing.sm) {
+                    // Status indicator
+                    if isRunning {
+                        // Pulsing dot for running state
+                        Circle()
+                            .fill(VColor.accent)
+                            .frame(width: 8, height: 8)
+                            .modifier(PulsingModifier())
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.success)
+                    }
+
+                    // Label
+                    if isRunning, let current = currentStep {
+                        Text(current.friendlyName)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        if !current.inputSummary.isEmpty {
+                            Text(abbreviatePath(current.inputSummary))
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                        }
+                    } else {
+                        Text("Completed \(completedCount) step\(completedCount == 1 ? "" : "s")")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+
+                    Spacer()
+
+                    // Chevron
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+
+            // Expanded step list
+            if isExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    ForEach(visibleSteps) { step in
+                        HStack(spacing: VSpacing.sm) {
+                            // Step status icon
+                            if step.isComplete {
+                                if step.isError {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(VColor.error)
+                                } else {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(VColor.success)
+                                }
+                            } else {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .frame(width: 11, height: 11)
+                            }
+
+                            // Tool icon + name
+                            Image(systemName: step.toolIcon)
+                                .font(.system(size: 10))
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 14)
+
+                            Text(step.friendlyName)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+
+                            // Input summary
+                            if !step.inputSummary.isEmpty {
+                                Text(abbreviatePath(step.inputSummary))
+                                    .font(VFont.monoSmall)
+                                    .foregroundColor(VColor.textMuted)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                    }
+
+                    if steps.count > 8 {
+                        Text("+ \(steps.count - 8) earlier steps")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                    }
+                }
+                .padding(.bottom, VSpacing.xs)
+            }
+        }
+        .background(VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onChange(of: isRunning) { _, newValue in
+            // Auto-collapse when done
+            if !newValue {
+                withAnimation(VAnimation.fast) {
+                    isExpanded = false
+                }
+            }
+        }
+    }
+
+    /// Abbreviate long file paths to just the last component
+    private func abbreviatePath(_ input: String) -> String {
+        // If it looks like a file path, show just the filename
+        if input.contains("/") && !input.contains(" ") {
+            return URL(fileURLWithPath: input).lastPathComponent
+        }
+        // For commands, truncate
+        if input.count > 60 {
+            return String(input.prefix(57)) + "..."
+        }
+        return input
+    }
+}
+
+/// A simple pulsing opacity modifier for the running indicator dot
+private struct PulsingModifier: ViewModifier {
+    @State private var isPulsing = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isPulsing ? 0.4 : 1.0)
+            .animation(
+                Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear { isPulsing = true }
+    }
+}
+
+#Preview("Running") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ClaudeCodeProgressView(
+            steps: [
+                ClaudeCodeSubStep(toolName: "Read", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Edit", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Bash", inputSummary: "npm test", isComplete: false),
+            ],
+            isRunning: true
+        )
+        .frame(width: 400)
+        .padding()
+    }
+}
+
+#Preview("Completed") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ClaudeCodeProgressView(
+            steps: [
+                ClaudeCodeSubStep(toolName: "Read", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Edit", inputSummary: "/src/main.ts", isComplete: true),
+                ClaudeCodeSubStep(toolName: "Bash", inputSummary: "npm test", isComplete: true),
+            ],
+            isRunning: false
+        )
+        .frame(width: 400)
+        .padding()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -167,6 +167,22 @@ private struct UsedToolsRow: View {
                     }
                     .padding(.horizontal, VSpacing.md)
 
+                    // Claude Code sub-steps (if any)
+                    if !toolCall.claudeCodeSteps.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Sub-steps")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                                .textCase(.uppercase)
+
+                            ClaudeCodeProgressView(
+                                steps: toolCall.claudeCodeSteps,
+                                isRunning: false
+                            )
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                    }
+
                     // Screenshot — use CGImage + displayScale for pixel-perfect Retina rendering
                     if let img = toolCall.cachedImage,
                        let cgImage = img.cgImage(forProposedRect: nil, context: nil, hints: nil) {

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -87,7 +87,8 @@ private struct UsedToolsRow: View {
     private var hasDetails: Bool {
         !toolCall.inputFull.isEmpty ||
         (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) ||
-        toolCall.cachedImage != nil
+        toolCall.cachedImage != nil ||
+        !toolCall.claudeCodeSteps.isEmpty
     }
 
     var body: some View {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -318,14 +318,17 @@ public struct ClaudeCodeSubStep: Identifiable, Equatable {
     public var isComplete: Bool
     public var isError: Bool
     public let startedAt: Date
+    /// Stable identifier from the Claude Code SDK (tool_use_id), used for precise matching on tool_complete events.
+    public let subToolId: String?
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, isComplete: Bool = false, isError: Bool = false, startedAt: Date = Date()) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, isComplete: Bool = false, isError: Bool = false, startedAt: Date = Date(), subToolId: String? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
         self.isComplete = isComplete
         self.isError = isError
         self.startedAt = startedAt
+        self.subToolId = subToolId
     }
 
     /// Human-readable label for the sub-tool.

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -310,6 +310,64 @@ public struct ToolConfirmationData: Equatable {
     }
 }
 
+/// A single sub-tool invocation within a claude_code tool call.
+public struct ClaudeCodeSubStep: Identifiable, Equatable {
+    public let id: UUID
+    public let toolName: String
+    public let inputSummary: String
+    public var isComplete: Bool
+    public var isError: Bool
+    public let startedAt: Date
+
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, isComplete: Bool = false, isError: Bool = false, startedAt: Date = Date()) {
+        self.id = id
+        self.toolName = toolName
+        self.inputSummary = inputSummary
+        self.isComplete = isComplete
+        self.isError = isError
+        self.startedAt = startedAt
+    }
+
+    /// Human-readable label for the sub-tool.
+    public var friendlyName: String {
+        switch toolName.lowercased() {
+        case "read", "file_read":       return "Read File"
+        case "edit", "file_edit":       return "Edit File"
+        case "write", "file_write":     return "Write File"
+        case "bash":                    return "Run Command"
+        case "glob":                    return "Find Files"
+        case "grep":                    return "Search Files"
+        case "websearch", "web_search": return "Web Search"
+        case "webfetch", "web_fetch":   return "Fetch URL"
+        case "task":                    return "Run Agent"
+        case "notebookedit":            return "Edit Notebook"
+        case "notebookread":            return "Read Notebook"
+        default:
+            return toolName
+                .replacingOccurrences(of: "_", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }
+
+    /// SF Symbol name for the sub-tool type.
+    public var toolIcon: String {
+        switch toolName.lowercased() {
+        case "read", "file_read":       return "doc.text"
+        case "edit", "file_edit":       return "pencil.line"
+        case "write", "file_write":     return "doc.badge.plus"
+        case "bash":                    return "terminal"
+        case "glob":                    return "folder.badge.magnifyingglass"
+        case "grep":                    return "magnifyingglass"
+        case "websearch", "web_search": return "magnifyingglass"
+        case "webfetch", "web_fetch":   return "arrow.down.circle"
+        case "task":                    return "person.2"
+        default:                        return "puzzlepiece.extension"
+        }
+    }
+}
+
 /// Data for a tool call displayed inline in an assistant message.
 public struct ToolCallData: Identifiable, Equatable {
     public let id: UUID
@@ -329,6 +387,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var imageData: String?
     /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
     public var buildingStatus: String?
+    /// Sub-tool steps for claude_code tool calls (live progress tracking).
+    public var claudeCodeSteps: [ClaudeCodeSubStep] = []
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
     #if os(macOS)
     public var cachedImage: NSImage?
@@ -349,6 +409,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.inputFull == rhs.inputFull
             && lhs.imageData == rhs.imageData
             && lhs.buildingStatus == rhs.buildingStatus
+            && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -912,18 +912,27 @@ extension ChatViewModel {
                     if let toolName = msg.subToolName {
                         let step = ClaudeCodeSubStep(
                             toolName: toolName,
-                            inputSummary: msg.subToolInput ?? ""
+                            inputSummary: msg.subToolInput ?? "",
+                            subToolId: msg.subToolId
                         )
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.append(step)
                     }
                 case "tool_complete":
-                    if let toolName = msg.subToolName,
-                       let stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.firstIndex(where: { $0.toolName == toolName && !$0.isComplete }) {
+                    // Prefer matching by subToolId (stable SDK identifier) over tool name.
+                    let stepIndex: Int?
+                    if let subToolId = msg.subToolId {
+                        stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.firstIndex(where: { $0.subToolId == subToolId && !$0.isComplete })
+                    } else if let toolName = msg.subToolName {
+                        stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.firstIndex(where: { $0.toolName == toolName && !$0.isComplete })
+                    } else {
+                        stepIndex = nil
+                    }
+                    if let stepIndex {
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isComplete = true
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isError = msg.subToolIsError ?? false
                     }
                 case "status":
-                    messages[msgIndex].toolCalls[tcIndex].buildingStatus = msg.chunk
+                    messages[msgIndex].toolCalls[tcIndex].buildingStatus = msg.subToolInput ?? ""
                 default:
                     break
                 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -899,9 +899,34 @@ extension ChatViewModel {
                 messages.append(newMsg)
             }
 
-        case .toolOutputChunk:
-            // Streaming output — ignore for now, we show the final result
-            break
+        case .toolOutputChunk(let msg):
+            guard !isCancelling else { return }
+            // Handle structured progress events from claude_code sub-tools
+            if let subType = msg.subType, !subType.isEmpty,
+               let existingId = currentAssistantMessageId,
+               let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
+               let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+                switch subType {
+                case "tool_start":
+                    if let toolName = msg.subToolName {
+                        let step = ClaudeCodeSubStep(
+                            toolName: toolName,
+                            inputSummary: msg.subToolInput ?? ""
+                        )
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.append(step)
+                    }
+                case "tool_complete":
+                    if let toolName = msg.subToolName,
+                       let stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.lastIndex(where: { $0.toolName == toolName && !$0.isComplete }) {
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isComplete = true
+                        messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isError = msg.subToolIsError ?? false
+                    }
+                case "status":
+                    messages[msgIndex].toolCalls[tcIndex].buildingStatus = msg.chunk
+                default:
+                    break
+                }
+            }
 
         case .toolResult(let msg):
             guard belongsToSession(msg.sessionId) else { return }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -901,6 +901,7 @@ extension ChatViewModel {
 
         case .toolOutputChunk(let msg):
             guard !isCancelling else { return }
+            guard belongsToSession(msg.sessionId) else { return }
             // Handle structured progress events from claude_code sub-tools
             if let subType = msg.subType, !subType.isEmpty,
                let existingId = currentAssistantMessageId,

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -918,7 +918,7 @@ extension ChatViewModel {
                     }
                 case "tool_complete":
                     if let toolName = msg.subToolName,
-                       let stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.lastIndex(where: { $0.toolName == toolName && !$0.isComplete }) {
+                       let stepIndex = messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.firstIndex(where: { $0.toolName == toolName && !$0.isComplete }) {
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isComplete = true
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIndex].isError = msg.subToolIsError ?? false
                     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -676,11 +676,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(IPCWorkItemCancelRequest(type: "work_item_cancel", id: id))
     }
 
-    /// Request the rendered template content for a work item.
-    public func sendWorkItemRender(id: String) throws {
-        try send(IPCWorkItemRenderRequest(type: "work_item_render", id: id))
-    }
-
     // MARK: - Subagent Management
 
     /// Abort a running subagent.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1580,6 +1580,7 @@ public struct IPCToolOutputChunk: Codable, Sendable {
     public let subToolName: String?
     public let subToolInput: String?
     public let subToolIsError: Bool?
+    public let subToolId: String?
 }
 
 public struct IPCToolResult: Codable, Sendable {
@@ -2019,11 +2020,6 @@ public struct IPCWorkItemGetResponseItem: Codable, Sendable {
 }
 
 public struct IPCWorkItemOutputRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemRenderRequest: Codable, Sendable {
     public let type: String
     public let id: String
 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2023,6 +2023,11 @@ public struct IPCWorkItemOutputRequest: Codable, Sendable {
     public let id: String
 }
 
+public struct IPCWorkItemRenderRequest: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
 public struct IPCWorkItemOutputResponse: Codable, Sendable {
     public let type: String
     public let id: String

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1575,6 +1575,7 @@ public struct IPCToolInputDelta: Codable, Sendable {
 public struct IPCToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
+    public let sessionId: String?
     public let subType: String?
     public let subToolName: String?
     public let subToolInput: String?

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1575,6 +1575,10 @@ public struct IPCToolInputDelta: Codable, Sendable {
 public struct IPCToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
+    public let subType: String?
+    public let subToolName: String?
+    public let subToolInput: String?
+    public let subToolIsError: Bool?
 }
 
 public struct IPCToolResult: Codable, Sendable {
@@ -1971,11 +1975,6 @@ public struct IPCWorkItemCancelResponse: Codable, Sendable {
 }
 
 public struct IPCWorkItemCompleteRequest: Codable, Sendable {
-    public let type: String
-    public let id: String
-}
-
-public struct IPCWorkItemRenderRequest: Codable, Sendable {
     public let type: String
     public let id: String
 }


### PR DESCRIPTION
## Summary
When the `claude_code` tool runs, the user previously saw only a generic "Running..." indicator until completion. This feature adds a collapsible live progress view showing what the Claude Code subprocess is doing — reading files, editing code, running commands — all visible in real-time with status icons.

## Changes
- Extended `ToolOutputChunk` IPC type with optional structured fields (`subType`, `subToolName`, `subToolInput`, `subToolIsError`, `sessionId`)
- Claude-code tool now emits structured progress events when sub-tools are invoked
- Session-agent-loop parses JSON chunks and forwards structured fields to IPC (with pre-check and validation)
- Added `ClaudeCodeSubStep` Swift model for tracking sub-tool invocations
- `ChatViewModel` handles `toolOutputChunk` events to populate sub-steps during execution (with session guard)
- New `ClaudeCodeProgressView` — collapsible view with pulsing dot while running, checkmarks when done, tool icons, and file path abbreviation
- Integrated into `ChatBubble` (replaces generic RunningIndicator for claude_code) and `UsedToolsRow` (shows sub-steps in expanded completed view)
- `hasDetails` gating includes `claudeCodeSteps` so rows are always expandable

## Milestone PRs (merged into feature branch)
- #5656: M1 — Extend IPC contract with structured ToolOutputChunk fields
- #5660: M2 — Emit structured progress events from claude-code tool
- #5659: M3 — Parse structured fields in session-agent-loop
- #5662: M4 — Add ClaudeCodeSubStep model and handle toolOutputChunk in Swift
- #5668: M5 — Add ClaudeCodeProgressView and integrate into chat UI
- #5675: Fix — Add sessionId guard and validate structured progress fields
- #5672: Fix — Include claude_code sub-steps in UsedToolsRow detail gating

## Project issue
Closes #5647

## Test plan
- [ ] Trigger a `claude_code` tool call and verify live sub-steps appear (spinner, tool name, input)
- [ ] Verify steps transition to checkmarks on completion
- [ ] Verify collapsible chevron works during and after execution
- [ ] Verify completed state shows sub-steps in UsedToolsRow expanded view
- [ ] Verify non-claude_code tools are unaffected (no regressions)
- [ ] Verify multi-session: progress events don't leak between threads
- [ ] Verify cancellation cleans up gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
