### PR TITLE
feat: add custom VTooltip with 1s delay for top bar buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -406,7 +406,7 @@ struct MainWindowView: View {
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityLabel("Copy thread")
-                                .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
+                                .vTooltip(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
                             }
 
                             TemporaryChatToggle(

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -51,7 +51,7 @@ public struct VIconButton: View {
         .onHover { isHovered = $0 }
         #endif
         .accessibilityLabel(label)
-        .help(tooltip ?? "")
+        .vTooltip(tooltip ?? "")
     }
 }
 

--- a/clients/shared/DesignSystem/Modifiers/VTooltip.swift
+++ b/clients/shared/DesignSystem/Modifiers/VTooltip.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// A custom tooltip modifier that shows a styled tooltip after a hover delay.
+public struct VTooltipModifier: ViewModifier {
+    let text: String
+    let delay: TimeInterval
+
+    @State private var isHovered = false
+    @State private var isVisible = false
+    @State private var hoverTask: DispatchWorkItem?
+
+    public init(_ text: String, delay: TimeInterval = 1.0) {
+        self.text = text
+        self.delay = delay
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                isHovered = hovering
+                hoverTask?.cancel()
+                if hovering {
+                    let task = DispatchWorkItem {
+                        withAnimation(VAnimation.fast) { isVisible = true }
+                    }
+                    hoverTask = task
+                    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: task)
+                } else {
+                    withAnimation(VAnimation.fast) { isVisible = false }
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if isVisible && !text.isEmpty {
+                    Text(text)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                        .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+                        .fixedSize()
+                        .offset(y: 4)
+                        .offset(y: 28)
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                        .zIndex(1000)
+                }
+            }
+            .onDisappear {
+                hoverTask?.cancel()
+                isVisible = false
+            }
+    }
+}
+
+public extension View {
+    /// Shows a custom tooltip on hover with a 1s delay.
+    func vTooltip(_ text: String, delay: TimeInterval = 1.0) -> some View {
+        modifier(VTooltipModifier(text, delay: delay))
+    }
+}


### PR DESCRIPTION
## Summary
- Added \`VTooltip\` modifier (\`clients/shared/DesignSystem/Modifiers/VTooltip.swift\`) — custom tooltip with configurable delay (default 1s)
- Replaced \`.help()\` with \`.vTooltip()\` on VIconButton and the Copy Thread button in the top bar
- Tooltip uses design system tokens (VFont, VColor, VRadius) for consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
