### PR TITLE
fix: correct tooltip positioning with alignmentGuide and zIndex

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -419,6 +419,7 @@ struct MainWindowView: View {
                     .padding(.leading, trafficLightPadding)
                     .padding(.trailing, VSpacing.lg)
                     .frame(height: 36)
+                    .zIndex(1)
 
                     Divider().background(VColor.surfaceBorder)
 

--- a/clients/shared/DesignSystem/Modifiers/VTooltip.swift
+++ b/clients/shared/DesignSystem/Modifiers/VTooltip.swift
@@ -44,11 +44,10 @@ public struct VTooltipModifier: ViewModifier {
                         )
                         .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
                         .fixedSize()
-                        .offset(y: 4)
-                        .offset(y: 28)
+                        // Position tooltip so its top edge sits 4px below the parent's bottom edge
+                        .alignmentGuide(.bottom) { d in d[.top] - 4 }
                         .allowsHitTesting(false)
                         .transition(.opacity)
-                        .zIndex(1000)
                 }
             }
             .onDisappear {


### PR DESCRIPTION
## Summary
- Replace hardcoded offset(y: 4) + offset(y: 28) with alignmentGuide(.bottom) for mathematically correct tooltip positioning below the parent
- Add .zIndex(1) to top bar HStack so tooltip overlays render above the content area below

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
