### PR TITLE
chore: bump @vellumai/cli to 0.1.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps CLI package version to 0.1.4 to trigger npm publish
- The source already contains the fix for `hatchLocal()` that replaced the broken `bunx vellum daemon start` fallback with proper `bun run src/index.ts daemon start`, but the version was never bumped so npm still has the old 0.1.3 code

## Test plan
- [ ] CI publishes 0.1.4 to npm after merge
- [ ] `vellum-assistant-platform` can update to `@vellumai/cli@^0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
