### PR TITLE
feat: support explicit required_tools in task_list_add

### DIFF
--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -136,6 +136,11 @@
             "type": "string",
             "enum": ["create_duplicate", "reuse_existing", "update_existing"],
             "description": "What to do if an active work item with the same title already exists. Defaults to \"reuse_existing\"."
+          },
+          "required_tools": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tools the task needs permission for (e.g. [\"bash\", \"web_fetch\"]). Omit to inherit from the task template; pass [] to explicitly require no tools."
           }
         }
       },

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -1,6 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getTask, listTasks, createTask } from '../../tasks/task-store.js';
 import { createWorkItemWithPermissions, findActiveWorkItemsByTitle, updateWorkItem, identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
+import { sanitizeToolList } from '../../tasks/tool-sanitizer.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('task-list-add');
@@ -61,8 +62,13 @@ export async function executeTaskListAdd(
     const notes = input.notes as string | undefined;
     const priorityTier = input.priority_tier as number | undefined;
     const sortIndex = input.sort_index as number | undefined;
+    const rawRequiredTools = input.required_tools as string[] | undefined;
 
     const ifExists = (input.if_exists as string) || 'reuse_existing';
+
+    // Sanitize explicit required_tools if provided (including empty array)
+    const hasExplicitTools = rawRequiredTools !== undefined;
+    const sanitizedTools = hasExplicitTools ? sanitizeToolList(rawRequiredTools) : undefined;
 
     // Ad-hoc mode: title provided without task_id or task_name
     if (!taskId && !taskName) {
@@ -89,12 +95,16 @@ export async function executeTaskListAdd(
         template: titleOverride,
       });
 
+      // For ad-hoc items: explicit tools → persist; omitted → null
+      const adHocRequiredTools = hasExplicitTools ? JSON.stringify(sanitizedTools) : undefined;
+
       const workItem = createWorkItemWithPermissions({
         taskId: adHocTask.id,
         title: titleOverride,
         notes,
         priorityTier: priorityTier ?? 1,
         sortIndex,
+        requiredTools: adHocRequiredTools,
       });
 
       log.info({ selectorType: 'title', workItemId: workItem.id, title: workItem.title }, 'ad-hoc work item created');
@@ -171,12 +181,24 @@ export async function executeTaskListAdd(
     log.debug({ title: finalTitle }, 'task_list_add: creating new item');
 
     const selectorType = taskId ? 'task_id' : 'task_name';
+
+    // Snapshot precedence: explicit required_tools > template tools > null
+    let resolvedRequiredTools: string | undefined;
+    if (hasExplicitTools) {
+      resolvedRequiredTools = JSON.stringify(sanitizedTools);
+    } else if (resolvedTask.requiredTools) {
+      // Snapshot template tools at add time
+      const templateTools = sanitizeToolList(JSON.parse(resolvedTask.requiredTools));
+      resolvedRequiredTools = JSON.stringify(templateTools);
+    }
+
     const workItem = createWorkItemWithPermissions({
       taskId: resolvedTask.id,
       title: finalTitle,
       notes,
       priorityTier: priorityTier ?? 1,
       sortIndex,
+      requiredTools: resolvedRequiredTools,
     });
 
     log.info({ selectorType, taskId: resolvedTask.id, workItemId: workItem.id, title: workItem.title }, 'work item created from task definition');


### PR DESCRIPTION
## Summary
- Add optional required_tools parameter to task_list_add tool schema
- Sanitize tool names via sanitizeToolList before persistence
- Snapshot precedence: explicit > template > null
- No permission prompting at add time

## Test plan
- [ ] Verify required_tools flows through to work item
- [ ] Verify omitted vs [] is preserved
- [ ] Verify unknown tools are sanitized out
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
