### PR TITLE
fix: strict Twitter verification gate + full metadata + refresh token lifecycle

### DIFF
--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -1,6 +1,6 @@
 import * as net from 'node:net';
 import { loadRawConfig } from '../../config/loader.js';
-import { getSecureKey, setSecureKey } from '../../security/secure-keys.js';
+import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secure-keys.js';
 import { startOAuth2Flow } from '../../security/oauth2.js';
 import { upsertCredentialMetadata, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import type { TwitterAuthStartRequest, TwitterAuthStatusRequest } from '../ipc-protocol.js';
@@ -51,30 +51,59 @@ export async function handleTwitterAuthStart(
       },
     });
 
-    setSecureKey('credential:integration:twitter:access_token', result.tokens.accessToken);
-    if (result.tokens.refreshToken) {
-      setSecureKey('credential:integration:twitter:refresh_token', result.tokens.refreshToken);
-    }
-
-    // Verify identity via Twitter API
-    let accountInfo: string | undefined;
+    // Verify identity via Twitter API before persisting any tokens
+    let accountInfo: string;
     try {
       const userResp = await fetch('https://api.x.com/2/users/me', {
         headers: { Authorization: `Bearer ${result.tokens.accessToken}` },
       });
-      if (userResp.ok) {
-        const userData = (await userResp.json()) as { data?: { username?: string } };
-        if (userData.data?.username) {
-          accountInfo = `@${userData.data.username}`;
-        }
+      if (!userResp.ok) {
+        log.error({ status: userResp.status }, 'Twitter identity verification returned non-2xx');
+        ctx.send(socket, {
+          type: 'twitter_auth_result',
+          success: false,
+          error: 'Failed to verify Twitter identity. Please try again.',
+        });
+        return;
       }
+      const userData = (await userResp.json()) as { data?: { username?: string } };
+      if (!userData.data?.username) {
+        log.error({ userData }, 'Twitter identity verification returned no username');
+        ctx.send(socket, {
+          type: 'twitter_auth_result',
+          success: false,
+          error: 'Failed to verify Twitter identity. Please try again.',
+        });
+        return;
+      }
+      accountInfo = `@${userData.data.username}`;
     } catch (err) {
-      log.warn({ err }, 'Failed to verify Twitter identity after OAuth');
+      log.error({ err }, 'Twitter identity verification fetch failed');
+      ctx.send(socket, {
+        type: 'twitter_auth_result',
+        success: false,
+        error: 'Failed to verify Twitter identity. Please try again.',
+      });
+      return;
+    }
+
+    // Persist tokens only after successful verification
+    setSecureKey('credential:integration:twitter:access_token', result.tokens.accessToken);
+    if (result.tokens.refreshToken) {
+      setSecureKey('credential:integration:twitter:refresh_token', result.tokens.refreshToken);
+    } else {
+      deleteSecureKey('credential:integration:twitter:refresh_token');
     }
 
     upsertCredentialMetadata('integration:twitter', 'access_token', {
       accountInfo,
       allowedTools: ['twitter_post', 'twitter_read'],
+      allowedDomains: [],
+      oauth2TokenUrl: 'https://api.x.com/2/oauth2/token',
+      oauth2ClientId: clientId,
+      ...(clientSecret != null ? { oauth2ClientSecret: clientSecret } : {}),
+      grantedScopes: result.grantedScopes,
+      expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : undefined,
     });
 
     ctx.send(socket, {
@@ -85,10 +114,23 @@ export async function handleTwitterAuthStart(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Twitter OAuth flow failed');
+
+    let userError: string;
+    const lower = message.toLowerCase();
+    if (lower.includes('timed out')) {
+      userError = 'Twitter authentication timed out. Please try again.';
+    } else if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
+      userError = 'Twitter authentication was cancelled.';
+    } else if (lower.includes('denied') || lower.includes('invalid_grant')) {
+      userError = 'Twitter denied the authorization request. Please try again.';
+    } else {
+      userError = 'Twitter authentication failed. Please try again.';
+    }
+
     ctx.send(socket, {
       type: 'twitter_auth_result',
       success: false,
-      error: `Twitter authentication failed: ${message}`,
+      error: userError,
     });
   }
 }


### PR DESCRIPTION
Closes #5684. Part of #5683.

## Changes
- Make identity verification (/2/users/me) a hard success gate - no success:true without verified identity
- Move token persistence to after verification passes; clean up on failure
- Persist full OAuth metadata (tokenUrl, clientId, grantedScopes, expiresAt, allowedDomains)
- Clear stale refresh token when provider omits one on re-auth (deleteSecureKey)
- Add deterministic error classification for user-safe error messages

## Risk
Low — only changes daemon-side Twitter auth handler. No IPC contract changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
