### PR TITLE
fix: wire ephemeral task rules into executor policy context

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -281,12 +281,14 @@ export async function handleWorkItemRunTask(
     const approvedTools: string[] | undefined = workItem.approvedTools ? JSON.parse(workItem.approvedTools) : undefined;
     const result = await runTask(
       { taskId: workItem.taskId, workingDir: process.cwd(), approvedTools },
-      async (conversationId, message) => {
+      async (conversationId, message, taskRunId) => {
         if (!session) {
           // Store conversationId on the work item immediately so the cancel
           // handler can locate the session while the task is still running.
           updateWorkItem(msg.id, { lastRunConversationId: conversationId });
           session = await ctx.getOrCreateSession(conversationId);
+          // Wire the taskRunId so the executor can retrieve ephemeral permission rules
+          (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
         }
         await session.processMessage(message, [], (event) => {
           ctx.broadcast(event);

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -47,6 +47,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   memoryPolicy: { scopeId: string; strictSideEffects: boolean };
   /** True when the session has no connected IPC client (HTTP-only path). */
   hasNoClient?: boolean;
+  /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
+  taskRunId?: string;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -179,6 +181,7 @@ export function createToolExecutor(
       sessionId: ctx.conversationId,
       conversationId: ctx.conversationId,
       requestId: ctx.currentRequestId,
+      taskRunId: ctx.taskRunId,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -121,6 +121,7 @@ export class Session {
   /** @internal */ currentRequestId?: string;
   /** @internal */ conflictGate = new ConflictGate();
   /** @internal */ hasNoClient = false;
+  /** @internal */ taskRunId?: string;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -87,7 +87,7 @@ async function runScheduleOnce(
         const { runTask } = await import('../tasks/task-runner.js');
         const result = await runTask(
           { taskId, workingDir: process.cwd() },
-          processMessage as (conversationId: string, message: string) => Promise<void>,
+          processMessage as (conversationId: string, message: string, taskRunId: string) => Promise<void>,
         );
 
         // Track the schedule run using the task's conversation

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -35,7 +35,7 @@ export function renderTemplate(template: string, inputs: Record<string, string>)
  */
 export async function runTask(
   opts: TaskRunOptions,
-  processMessage: (conversationId: string, message: string) => Promise<void>,
+  processMessage: (conversationId: string, message: string, taskRunId: string) => Promise<void>,
 ): Promise<TaskRunResult> {
   const task = getTask(opts.taskId);
   if (!task) {
@@ -64,7 +64,7 @@ export async function runTask(
     updateTaskRun(run.id, { status: 'running', startedAt: Date.now() });
 
     log.info({ taskId: task.id, taskRunId: run.id, conversationId: conversation.id }, 'Executing task');
-    await processMessage(conversation.id, renderedTemplate);
+    await processMessage(conversation.id, renderedTemplate, run.id);
 
     updateTaskRun(run.id, { status: 'completed', finishedAt: Date.now() });
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -17,6 +17,7 @@ import { getConfig } from '../config/loader.js';
 import { scanText, redactSecrets } from '../security/secret-scanner.js';
 import { redactSensitiveFields } from '../security/redaction.js';
 import { getHookManager } from '../hooks/manager.js';
+import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 
 const log = getLogger('tool-executor');
 
@@ -102,8 +103,9 @@ export class ToolExecutor {
       riskLevel = risk;
 
       // Build principal context from tool metadata so policy rules can
-      // distinguish skill-provided tools from core built-ins.
-      const policyContext = buildPolicyContext(tool);
+      // distinguish skill-provided tools from core built-ins. Also includes
+      // ephemeral rules when executing within a task run.
+      const policyContext = buildPolicyContext(tool, context);
       const result = await check(name, input, context.workingDir, policyContext);
 
       // Private threads force prompting for side-effect tools even when a
@@ -716,11 +718,16 @@ async function executeWithTimeout(
 }
 
 /**
- * Build a PolicyContext from tool metadata. Skill-origin tools carry a
- * principal identifying the owning skill; core tools yield an undefined
- * context so the checker applies default (user) policy.
+ * Build a PolicyContext from tool metadata and execution context. Skill-origin
+ * tools carry a principal identifying the owning skill. When executing within
+ * a task run, ephemeral permission rules are included so pre-approved tools
+ * are auto-allowed without prompting.
  */
-function buildPolicyContext(tool: Tool): PolicyContext | undefined {
+function buildPolicyContext(tool: Tool, context?: ToolContext): PolicyContext | undefined {
+  const ephemeralRules = context?.taskRunId
+    ? getTaskRunRules(context.taskRunId)
+    : undefined;
+
   if (tool.origin === 'skill') {
     return {
       principal: {
@@ -729,8 +736,22 @@ function buildPolicyContext(tool: Tool): PolicyContext | undefined {
         version: tool.ownerSkillVersionHash,
       },
       executionTarget: tool.executionTarget,
+      ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
     };
   }
+
+  // For non-skill tools in a task run, create a context with task principal
+  // and ephemeral rules so pre-approved tools are honored.
+  if (context?.taskRunId && ephemeralRules?.length) {
+    return {
+      principal: {
+        kind: 'task',
+        id: context.taskRunId,
+      },
+      ephemeralRules,
+    };
+  }
+
   return undefined;
 }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -93,6 +93,8 @@ export interface ToolContext {
   workingDir: string;
   sessionId: string;
   conversationId: string;
+  /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
+  taskRunId?: string;
   /** Per-message request ID for log correlation across session/connection boundaries. */
   requestId?: string;
   /** Optional callback for streaming incremental output to the client. */


### PR DESCRIPTION
## Summary
- Thread taskRunId through ToolContext so the executor knows when it's in a task run
- Include getTaskRunRules(taskRunId) as policyContext.ephemeralRules during permission checks
- Set task principal context so trust rules can distinguish task-originated tool calls
- Fixes: approved tools in task runs were silently ignored, causing 5-min hangs on permission prompts

## Test plan
- [ ] Verify ephemeral rules are included in policyContext during task runs
- [ ] Verify approved tools are auto-allowed without prompting
- [ ] Verify non-task sessions are unaffected
- [ ] Verify skill-origin tool permissions still work
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
