### PR TITLE
Fix: dismiss outfit dropdown when tapping outside

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -75,6 +75,13 @@ struct AvatarCustomizationPanel: View {
             .frame(maxWidth: .infinity)
         }
         .background(VColor.backgroundSubtle)
+        .onTapGesture {
+            if expandedField != nil {
+                withAnimation(VAnimation.fast) {
+                    expandedField = nil
+                }
+            }
+        }
         .onAppear {
             evolutionState.load()
             identity = IdentityInfo.load()


### PR DESCRIPTION
## Summary
- Adds `onTapGesture` to the scroll view to close the expanded outfit dropdown when clicking anywhere outside of it
- Follows up on the custom themed dropdown PR (#5690)

## Test plan
- [ ] Open avatar customization panel and expand an outfit dropdown
- [ ] Click on empty space outside the dropdown — it should close
- [ ] Verify selecting dropdown options still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
