### PR TITLE
test: Twitter auth hardening regression coverage

### DIFF
--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -89,11 +89,13 @@ mock.module('../security/oauth2.js', () => ({
 
 // Mock credential metadata store
 let credentialMetadataStore: Array<{ service: string; field: string; accountInfo?: string }> = [];
+let lastUpsertPolicy: Record<string, unknown> | undefined;
 
 mock.module('../tools/credentials/metadata-store.js', () => ({
   getCredentialMetadata: (service: string, field: string) =>
     credentialMetadataStore.find((m) => m.service === service && m.field === field) ?? undefined,
   upsertCredentialMetadata: (service: string, field: string, policy?: Record<string, unknown>) => {
+    lastUpsertPolicy = policy;
     const existing = credentialMetadataStore.find((m) => m.service === service && m.field === field);
     if (existing) {
       if (policy?.accountInfo !== undefined) existing.accountInfo = policy.accountInfo as string;
@@ -160,6 +162,7 @@ describe('Twitter auth handler', () => {
     credentialMetadataStore = [];
     oauthFlowResult = null;
     oauthFlowError = null;
+    lastUpsertPolicy = undefined;
     // Mock fetch for Twitter API
     globalThis.fetch = (async (_url: string | URL | Request) => {
       return mockFetchResponse;
@@ -262,6 +265,269 @@ describe('Twitter auth handler', () => {
       );
       expect(meta).toBeDefined();
       expect(meta!.accountInfo).toBe('@testuser');
+    });
+
+    describe('auth hardening', () => {
+      test('OAuth cancel path returns sanitized failure', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+        oauthFlowError = new Error('OAuth2 authorization denied: user_cancelled');
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+          error?: string;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Twitter authentication was cancelled.');
+
+        // No tokens should have been stored
+        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
+        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
+
+        // No credential metadata should have been created
+        expect(credentialMetadataStore).toHaveLength(0);
+      });
+
+      test('OAuth timeout path returns sanitized failure', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+        oauthFlowError = new Error('OAuth2 flow timed out waiting for user authorization');
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+          error?: string;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Twitter authentication timed out. Please try again.');
+
+        // No tokens stored
+        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
+        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
+
+        // No metadata created
+        expect(credentialMetadataStore).toHaveLength(0);
+      });
+
+      test('verification endpoint non-2xx causes auth failure', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+        oauthFlowResult = {
+          tokens: {
+            accessToken: 'mock-access-token',
+            refreshToken: 'mock-refresh-token',
+            expiresIn: 7200,
+            scope: 'tweet.read users.read offline.access',
+            tokenType: 'bearer',
+          },
+          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
+          rawTokenResponse: {},
+        };
+
+        mockFetchResponse = { ok: false, json: async () => ({}) };
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+          error?: string;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(false);
+
+        // No tokens should have been persisted
+        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
+        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
+
+        // No credential metadata
+        expect(credentialMetadataStore).toHaveLength(0);
+      });
+
+      test('verification payload missing username causes auth failure', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+        oauthFlowResult = {
+          tokens: {
+            accessToken: 'mock-access-token',
+            refreshToken: 'mock-refresh-token',
+            expiresIn: 7200,
+            scope: 'tweet.read users.read offline.access',
+            tokenType: 'bearer',
+          },
+          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
+          rawTokenResponse: {},
+        };
+
+        mockFetchResponse = { ok: true, json: async () => ({ data: {} }) };
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+          error?: string;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(false);
+
+        // No tokens or metadata persisted
+        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
+        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
+        expect(credentialMetadataStore).toHaveLength(0);
+      });
+
+      test('re-auth without refresh token clears stale stored refresh token', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+        // Pre-populate a stale refresh token
+        secureKeyStore['credential:integration:twitter:refresh_token'] = 'old-stale-token';
+
+        oauthFlowResult = {
+          tokens: {
+            accessToken: 'new-access-token',
+            refreshToken: undefined,
+            expiresIn: 7200,
+            scope: 'tweet.read users.read offline.access',
+            tokenType: 'bearer',
+          },
+          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
+          rawTokenResponse: {},
+        };
+
+        mockFetchResponse = {
+          ok: true,
+          json: async () => ({ data: { username: 'testuser' } }),
+        };
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(true);
+
+        // New access token should be set
+        expect(secureKeyStore['credential:integration:twitter:access_token']).toBe('new-access-token');
+        // Stale refresh token should have been deleted, not left as 'old-stale-token'
+        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
+      });
+
+      test('error payload never includes secrets or raw provider bodies', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+        oauthFlowError = new Error(
+          'OAuth2 token exchange failed (403): {"error":"invalid_client","client_secret":"super-secret-123"}',
+        );
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+          error?: string;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(false);
+
+        // The error should NOT contain any secrets or raw provider details
+        expect(result.error).not.toContain('super-secret-123');
+        expect(result.error).not.toContain('invalid_client');
+        expect(result.error).not.toContain('client_secret');
+
+        // Should fall to default classification since the raw message does not match
+        // "denied", "invalid_grant", "timed out", or "cancelled"
+        expect(result.error).toBe('Twitter authentication failed. Please try again.');
+      });
+
+      test('full metadata fields are persisted on success', async () => {
+        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'my-client-id';
+        secureKeyStore['credential:integration:twitter:oauth_client_secret'] = 'my-client-secret';
+
+        oauthFlowResult = {
+          tokens: {
+            accessToken: 'mock-access-token',
+            refreshToken: 'mock-refresh-token',
+            expiresIn: 7200,
+            scope: 'tweet.read users.read offline.access',
+            tokenType: 'bearer',
+          },
+          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
+          rawTokenResponse: {},
+        };
+
+        mockFetchResponse = {
+          ok: true,
+          json: async () => ({ data: { username: 'testuser' } }),
+        };
+
+        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+        const { ctx, sent } = createTestContext();
+        await handleMessage(msg, {} as net.Socket, ctx);
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+          type: string;
+          success: boolean;
+        };
+        expect(result).toBeDefined();
+        expect(result.success).toBe(true);
+
+        // Verify the full policy was captured
+        expect(lastUpsertPolicy).toBeDefined();
+        expect(lastUpsertPolicy!.oauth2TokenUrl).toBe('https://api.x.com/2/oauth2/token');
+        expect(lastUpsertPolicy!.oauth2ClientId).toBe('my-client-id');
+        expect(lastUpsertPolicy!.oauth2ClientSecret).toBe('my-client-secret');
+        expect(lastUpsertPolicy!.grantedScopes).toEqual(['tweet.read', 'users.read', 'offline.access']);
+        expect(lastUpsertPolicy!.allowedDomains).toEqual([]);
+        expect(lastUpsertPolicy!.allowedTools).toEqual(['twitter_post', 'twitter_read']);
+
+        // expiresAt should be roughly Date.now() + 7200 * 1000
+        const expiresAt = lastUpsertPolicy!.expiresAt as number;
+        expect(typeof expiresAt).toBe('number');
+        expect(expiresAt).toBeGreaterThan(Date.now() + 7100 * 1000);
+        expect(expiresAt).toBeLessThan(Date.now() + 7300 * 1000);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #5688. Part of #5683.

## Changes
- OAuth cancel/timeout paths return sanitized errors with no state left behind
- Verification endpoint non-2xx and missing username both fail cleanly
- Re-auth without refresh token clears stale stored token
- Error payloads never leak secrets, tokens, or raw provider bodies
- Full metadata fields (tokenUrl, clientId, grantedScopes, expiresAt, etc.) verified on success

## Risk
Test-only — no production code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
