### PR TITLE
fix: secret-safe OAuth errors + Settings Twitter auth error UX

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -6,6 +6,9 @@
  */
 
 import { randomBytes, createHash } from 'node:crypto';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('oauth2');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -171,7 +174,8 @@ export async function startOAuth2Flow(
 
     if (!tokenResp.ok) {
       const body = await tokenResp.text().catch(() => '');
-      throw new Error(`OAuth2 token exchange failed (${tokenResp.status}): ${body}`);
+      log.error({ status: tokenResp.status, body }, 'OAuth2 token exchange failed');
+      throw new Error(`OAuth2 token exchange failed (HTTP ${tokenResp.status})`);
     }
 
     const tokenData = await tokenResp.json() as Record<string, unknown>;
@@ -226,7 +230,8 @@ export async function refreshOAuth2Token(
 
   if (!resp.ok) {
     const body = await resp.text().catch(() => '');
-    throw new Error(`OAuth2 token refresh failed (${resp.status}): ${body}`);
+    log.error({ status: resp.status, body }, 'OAuth2 token refresh failed');
+    throw new Error(`OAuth2 token refresh failed (HTTP ${resp.status})`);
   }
 
   const data = await resp.json() as Record<string, unknown>;

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -640,6 +640,12 @@ struct SettingsPanel: View {
                         }
                     }
 
+                    if let error = store.twitterAuthError {
+                        Text(error)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.error)
+                    }
+
                     // Clear/reconfigure button
                     HStack {
                         Spacer()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -73,6 +73,7 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterConnected: Bool = false
     @Published var twitterAccountInfo: String?
     @Published var twitterAuthInProgress: Bool = false
+    @Published var twitterAuthError: String?
 
     // MARK: - Trust Rules Coordination
 
@@ -181,6 +182,9 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 self.twitterConnected = true
                 self.twitterAccountInfo = response.accountInfo
+                self.twitterAuthError = nil
+            } else {
+                self.twitterAuthError = response.error
             }
             self.refreshTwitterStatus()
         }
@@ -329,6 +333,7 @@ public final class SettingsStore: ObservableObject {
 
     func connectTwitter() {
         twitterAuthInProgress = true
+        twitterAuthError = nil
         try? daemonClient?.send(TwitterAuthStartMessage())
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -303,6 +303,12 @@ public struct SettingsView: View {
                             }
                         }
 
+                        if let error = store.twitterAuthError {
+                            Text(error)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.error)
+                        }
+
                         HStack {
                             Spacer()
                             Button("Clear App Config") {


### PR DESCRIPTION
Closes #5687. Part of #5683.

## Changes
- Stop embedding raw provider response bodies in OAuth2 error messages (oauth2.ts)
- Log raw error details server-side only for debugging
- Add twitterAuthError state to SettingsStore with clear-on-retry semantics
- Render inline error text in both SettingsView and SettingsPanel when auth fails

## Risk
Low — oauth2.ts error string changes are safe (downstream catch blocks pattern-match on known prefixes like 'timed out', not on response bodies). Settings changes are additive UI only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
