### PR TITLE
fix: clear stale expiresAt on Twitter re-auth when provider omits expires_in

### DIFF
--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -103,7 +103,7 @@ export async function handleTwitterAuthStart(
       oauth2ClientId: clientId,
       ...(clientSecret != null ? { oauth2ClientSecret: clientSecret } : {}),
       grantedScopes: result.grantedScopes,
-      expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : undefined,
+      expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : null,
     });
 
     ctx.send(socket, {


### PR DESCRIPTION
Addresses review feedback on #5693.

Changes expiresAt from undefined to null when expiresIn is absent, so upsertCredentialMetadata correctly clears the field instead of preserving a stale value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
