### PR TITLE
feat: scope blitz sweep to namespace-matching PRs and TODO items

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -157,11 +157,11 @@ gh issue close <issue-number>
 1. Unless `--auto` was passed, pause and ask the user: **"Initial swarm complete. Run sweep for review feedback?"**
    - If the user declines, skip to Phase 6.
 
-2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`.
+2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace.
 
 3. After check-reviews completes, read `.private/TODO.md`:
-   - If new "Address the feedback" items were added, run another swarm pass (back to Phase 4).
-   - If no new feedback items, proceed to Phase 6.
+   - If new `[<namespace>]`-prefixed "Address the feedback" or "Fix CI failures" items were added, run another swarm pass (back to Phase 4).
+   - If no new namespaced feedback items, proceed to Phase 6.
 
 4. If `--auto` was passed, skip the pause and run the sweep automatically. Still loop back to Phase 4 if feedback items were added.
 

--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -2,15 +2,15 @@ Run `/check-reviews` to triage pending PR reviews, then immediately `/swarm` to 
 
 Arguments (optional): $ARGUMENTS
 
-Parse positional arguments and flags (these are passed through to `/swarm`):
+Parse positional arguments and flags (these are passed through to both `/check-reviews` and `/swarm`):
 
 - **First argument** (optional): number of parallel workers (default: 12).
 - **Second argument** (optional): maximum number of tasks to complete before shutting down.
-- **`--namespace NAME`** (optional): namespace for swarm branch naming (passed through to `/swarm`).
+- **`--namespace NAME`** (optional): namespace for scoping the sweep. Passed as `--namespace` to both `/check-reviews` (to filter PRs and prefix TODO items) and `/swarm` (to filter TODO items and namespace branches).
 
 ## Phase 1: Check reviews
 
-Run the `/check-reviews` skill. Wait for it to complete and note how many "Address the feedback" items and "Fix CI failures" items were added to `.private/TODO.md`.
+Run the `/check-reviews` skill, passing `--namespace` if one was provided. Wait for it to complete and note how many "Address the feedback" items and "Fix CI failures" items were added to `.private/TODO.md`.
 
 If no items were added (all PRs were approved or still pending, and no CI failures on main), report the results and stop — there's nothing to swarm on.
 

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -1,8 +1,18 @@
 You are running a single iteration of a cronjob that runs periodically for task scheduling.
 
+Arguments (optional): $ARGUMENTS
+
+Parse optional flags from `$ARGUMENTS`:
+
+- **`--namespace NAME`** (optional): when provided, only process PRs whose head branch starts with `swarm/<NAME>/`. Any TODO items added will be prefixed with `[<NAME>]` (e.g., `- [<NAME>] Address the feedback on <link>`). When omitted, process all PRs and add items without a namespace prefix (default behavior).
+
+To check a PR's head branch name, include `headRefName` in the `--json` fields when fetching PR data.
+
 <instructions>
 
 Look at every item in .private/UNREVIEWED_PRS.md. Each line is a PR URL like `https://github.com/<owner>/<repo>/pull/123`.
+
+**If `--namespace` was provided**: before processing, filter the PR list to only include PRs whose head branch starts with `swarm/<namespace>/`. Skip all other PRs (leave them in UNREVIEWED_PRS.md untouched).
 
 Check each PR to see if **both** chatgpt-codex-connector and devin-ai-integration have reviewed it and whether they have feedback.
 
@@ -55,7 +65,7 @@ Examples of feedback that would cause a regression:
 - **Rate-limited Codex:** If Codex is rate-limited, re-trigger the review by commenting `@codex review` on the PR and keep the PR in UNREVIEWED_PRS.md. Do NOT remove the PR.
 - **Skipped Devin:** If Devin's status is `skipped` (pending for 30+ minutes), treat it as if Devin approved — Devin likely errored out and won't review.
 - If either reviewer hasn't reviewed yet (status is `pending`, not `skipped`), keep the PR in UNREVIEWED_PRS.md for next time.
-- If both have reviewed and either review requested changes with **valid feedback**, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
+- If both have reviewed and either review requested changes with **valid feedback**, add the feedback item to the **top** of .private/TODO.md (ordered by PR number, lowest first). If `--namespace` was provided, prefix the item: `- [<namespace>] Address the feedback on <link to PR>`. Otherwise: `- Address the feedback on <link to PR>`.
 - If all feedback on a PR was classified as nonsensical, treat that reviewer as having approved.
 - If any feedback is classified as **regression risk**, do NOT add it to TODO. Instead, flag it to the user (see output section) and **stop processing further PRs**. Keep the PR in .private/UNREVIEWED_PRS.md so it is revisited on the next run. Wait for the user to decide what to do.
 - If fully reviewed (both have reviewed), Codex is not rate-limited, and no feedback was classified as regression risk, remove the PR from .private/UNREVIEWED_PRS.md.
@@ -101,15 +111,18 @@ Do NOT continue processing remaining PRs until the user responds.
 
 After processing all items in UNREVIEWED_PRS.md, check for recently merged PRs where CI failed on the main branch.
 
+**If `--namespace` was provided**: only consider CI failures from PRs whose head branch started with `swarm/<namespace>/`. Skip failures from unrelated PRs.
+
 ### How to detect CI failures
 
 Run: `gh run list --branch main --status failure --limit 10 --json databaseId,headSha,displayTitle,url,conclusion,createdAt,event`
 
 This returns failed workflow runs on main. For each failed run:
 
-1. **Find the associated PR**: Use `gh pr list --state merged --search "<headSha>" --json number,url,title,mergedAt --limit 1` or cross-reference the run's `displayTitle` / `headSha` with merged PRs. If you can't find a matching PR, use the run URL directly.
-2. **Skip if already in TODO**: Read .private/TODO.md and check if there's already a `Fix CI failures` entry for that PR or run. Don't add duplicates.
-3. **Add to TODO**: For each new CI failure, add `- Fix CI failures from merged PR <link to PR> (run: <link to failed run>)` to the **top** of .private/TODO.md (after any "Address the feedback" items, but before other tasks).
+1. **Find the associated PR**: Use `gh pr list --state merged --search "<headSha>" --json number,url,title,mergedAt,headRefName --limit 1` or cross-reference the run's `displayTitle` / `headSha` with merged PRs. If you can't find a matching PR, use the run URL directly.
+2. **Namespace filter**: If `--namespace` was provided, check the PR's `headRefName`. Skip this failure if the branch does NOT start with `swarm/<namespace>/`.
+3. **Skip if already in TODO**: Read .private/TODO.md and check if there's already a `Fix CI failures` entry for that PR or run. Don't add duplicates.
+4. **Add to TODO**: For each new CI failure, add the item to the **top** of .private/TODO.md (after any "Address the feedback" items, but before other tasks). If `--namespace` was provided, prefix it: `- [<namespace>] Fix CI failures from merged PR <link to PR> (run: <link to failed run>)`. Otherwise: `- Fix CI failures from merged PR <link to PR> (run: <link to failed run>)`.
 
 ### Output
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -247,11 +247,11 @@ gh issue close <issue-number>
 1. Unless `--auto` was passed, pause and ask the user: **"Initial swarm complete. Run sweep for review feedback?"**
    - If the user declines, skip to Phase 6.
 
-2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`.
+2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace.
 
 3. After check-reviews completes, read `.private/TODO.md`:
-   - If new "Address the feedback" items were added, run another swarm pass (back to Phase 4).
-   - If no new feedback items, proceed to Phase 6.
+   - If new `[<namespace>]`-prefixed "Address the feedback" or "Fix CI failures" items were added, run another swarm pass (back to Phase 4).
+   - If no new namespaced feedback items, proceed to Phase 6.
 
 4. If `--auto` was passed, skip the pause and run the sweep automatically. Still loop back to Phase 4 if feedback items were added.
 

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -21,7 +21,8 @@ If no arguments are provided, default to 12 workers with no task limit (run unti
 
 1. Read .private/TODO.md. Keep an internal list of which items are currently in-flight.
 2. Parse the arguments: note the worker count (default: 12), max-tasks limit (if provided), and namespace (or generate a random 4-char hex default). Track a **completed count** starting at 0.
-3. Create a team with `TeamCreate` (team name: `swarm`).
+3. **Namespace filtering**: When a `--namespace` is provided (not auto-generated), only consider TODO items that are prefixed with `[<namespace>]` (e.g., `- [ws-daemon-ipc] M1: ...`). Ignore all other items — leave them in TODO.md for other runs. When namespace is auto-generated (no `--namespace` flag was passed), process all items as before.
+4. Create a team with `TeamCreate` (team name: `swarm`).
 
 ## Phase 2: Pick the next task
 


### PR DESCRIPTION
## Summary
- Add `--namespace` flag to `check-reviews` to filter unreviewed PRs by branch prefix (`swarm/<namespace>/`) and prefix TODO items with `[<namespace>]`
- Update `swarm` to only process namespace-prefixed TODO items when `--namespace` is explicitly provided
- Update `blitz`, `safe-blitz`, and `check-reviews-and-swarm` to pass namespace through to check-reviews during sweep phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
