### PR TITLE
Fix skill README not showing in detail view

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -395,7 +395,7 @@ export async function clawhubInspect(slug: string): Promise<{ data?: ClawhubInsp
           size: (f.size as number) ?? 0,
           contentType: (f.contentType as string) ?? undefined,
         })) : null,
-        skillMdContent: parsed.skillMdContent ?? parsed.fileContents?.['SKILL.md'] ?? null,
+        skillMdContent: parsed.skillMdContent ?? parsed.fileContents?.['SKILL.md'] ?? parsed.file?.content ?? null,
       };
       return { data };
     } catch {


### PR DESCRIPTION
## Summary
- Fixes SKILL.md content not appearing in the skill detail view
- The `clawhub inspect --file SKILL.md` CLI returns content at `parsed.file.content`, but we only checked `parsed.skillMdContent` and `parsed.fileContents['SKILL.md']`

## Test plan
- [ ] Open Available Skills and click on any skill (e.g. "summarize")
- [ ] Verify the README section now appears with the skill's SKILL.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
