### PR TITLE
Make entire skill card tappable to open detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -355,13 +355,6 @@ struct AgentPanelContent: View {
                             .lineLimit(2)
                     }
                 }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation(VAnimation.standard) {
-                        selectedSkillSlug = skill.slug
-                        skillsManager.inspectSkill(slug: skill.slug)
-                    }
-                }
 
                 Spacer()
 
@@ -418,6 +411,13 @@ struct AgentPanelContent: View {
             .font(VFont.small)
             .foregroundColor(VColor.textMuted)
             .padding(.leading, 24 + VSpacing.md)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(VAnimation.standard) {
+                selectedSkillSlug = skill.slug
+                skillsManager.inspectSkill(slug: skill.slug)
+            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Moves the tap gesture from just the title/description area to the entire skill card
- Now clicking anywhere on the card (including stats row) navigates to the detail view
- Install button still works since SwiftUI buttons take priority over gesture recognizers

## Test plan
- [ ] Open Available Skills in the agent panel
- [ ] Click on the stats row area of a skill card — should navigate to detail view
- [ ] Click the Install button — should still install without navigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
