### PR TITLE
fix: clear stale OAuth client secret on PKCE re-auth

### DIFF
--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -101,7 +101,7 @@ export async function handleTwitterAuthStart(
       allowedDomains: [],
       oauth2TokenUrl: 'https://api.x.com/2/oauth2/token',
       oauth2ClientId: clientId,
-      ...(clientSecret != null ? { oauth2ClientSecret: clientSecret } : {}),
+      oauth2ClientSecret: clientSecret ?? null,
       grantedScopes: result.grantedScopes,
       expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : null,
     });


### PR DESCRIPTION
Addresses review feedback on PR #5693. When clientSecret is absent during re-auth, explicitly set oauth2ClientSecret to null so upsertCredentialMetadata clears the stale value instead of preserving it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
