### PR TITLE
fix: roll back client ID when secret storage fails in Twitter config

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -518,6 +518,8 @@ export function handleTwitterIntegrationConfig(
       if (msg.clientSecret) {
         const storedSecret = setSecureKey('credential:integration:twitter:oauth_client_secret', msg.clientSecret);
         if (!storedSecret) {
+          // Roll back the already-persisted client ID to avoid inconsistent OAuth state
+          deleteSecureKey('credential:integration:twitter:oauth_client_id');
           ctx.send(socket, {
             type: 'twitter_integration_config_response',
             success: false,


### PR DESCRIPTION
Addresses review feedback on PR #5576. When storing the client secret fails, the already-persisted client ID is now deleted to prevent inconsistent OAuth state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
