### PR TITLE
fix: make .help() conditional on VIconButton to avoid empty tooltip wrappers

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -51,7 +51,22 @@ public struct VIconButton: View {
         .onHover { isHovered = $0 }
         #endif
         .accessibilityLabel(label)
-        .help(tooltip ?? "")
+        .modifier(OptionalHelpModifier(tooltip: tooltip))
+    }
+}
+
+/// Applies `.help()` only when a tooltip string is provided, avoiding an
+/// empty help wrapper that can affect hit-testing and hover behavior.
+private struct OptionalHelpModifier: ViewModifier {
+    let tooltip: String?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let tooltip {
+            content.help(tooltip)
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
Addresses review feedback on PR #5671. Makes .help() conditional so it only applies when tooltip is non-nil, preventing empty help wrappers on icon buttons that don't have tooltips.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
