### PR TITLE
fix: preserve OAuth error codes and use native styling in SettingsView

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -175,7 +175,10 @@ export async function startOAuth2Flow(
     if (!tokenResp.ok) {
       const body = await tokenResp.text().catch(() => '');
       log.error({ status: tokenResp.status, body }, 'OAuth2 token exchange failed');
-      throw new Error(`OAuth2 token exchange failed (HTTP ${tokenResp.status})`);
+      let errorCode = '';
+      try { errorCode = (JSON.parse(body) as Record<string, unknown>).error as string ?? ''; } catch {}
+      const detail = errorCode ? `HTTP ${tokenResp.status}: ${errorCode}` : `HTTP ${tokenResp.status}`;
+      throw new Error(`OAuth2 token exchange failed (${detail})`);
     }
 
     const tokenData = await tokenResp.json() as Record<string, unknown>;
@@ -231,7 +234,10 @@ export async function refreshOAuth2Token(
   if (!resp.ok) {
     const body = await resp.text().catch(() => '');
     log.error({ status: resp.status, body }, 'OAuth2 token refresh failed');
-    throw new Error(`OAuth2 token refresh failed (HTTP ${resp.status})`);
+    let errorCode = '';
+    try { errorCode = (JSON.parse(body) as Record<string, unknown>).error as string ?? ''; } catch {}
+    const detail = errorCode ? `HTTP ${resp.status}: ${errorCode}` : `HTTP ${resp.status}`;
+    throw new Error(`OAuth2 token refresh failed (${detail})`);
   }
 
   const data = await resp.json() as Record<string, unknown>;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -305,8 +305,8 @@ public struct SettingsView: View {
 
                         if let error = store.twitterAuthError {
                             Text(error)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.error)
+                                .font(.caption)
+                                .foregroundColor(.red)
                         }
 
                         HStack {


### PR DESCRIPTION
Addresses review feedback on PR #5699. Extracts the OAuth error code from response body and includes it in thrown errors (without exposing raw body), so downstream error classification (e.g. invalid_grant) still works. Also fixes SettingsView to use native SwiftUI font/color instead of design-system tokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
