### PR TITLE
fix: set isSending when adopting user message during message-less bootstrap

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -256,6 +256,7 @@ public final class ChatViewModel: ObservableObject {
         // so it gets sent when session_info arrives instead of being dropped.
         if (isSending || isBootstrapping) && sessionId == nil {
             if pendingUserMessage == nil {
+                isSending = true
                 let attachments = pendingAttachments
                 pendingAttachments = []
                 pendingUserMessage = text


### PR DESCRIPTION
Addresses review feedback on PR #5585. Sets isSending = true when a user message is adopted during a message-less bootstrap, ensuring the stop button appears and cancel functionality works correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
