### PR TITLE
fix: use null instead of undefined for expiresAt in vault oauth2_connect

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -573,7 +573,7 @@ class CredentialStoreTool implements Tool {
             return { content: 'Error: failed to store access token in secure storage', isError: true };
           }
 
-          const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : undefined;
+          const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
 
           let accountInfo: string | undefined;
           if (userinfoUrl && grantedScopes.some((s) => s.includes('userinfo'))) {


### PR DESCRIPTION
Addresses review feedback on PR #5701. Fixes the same stale-expiresAt bug in vault.ts oauth2_connect that was previously fixed for twitter-auth.ts. Changes the fallback from undefined to null so upsertCredentialMetadata properly clears the field.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
