### PR TITLE
fix: handle orphaned doEnrichment rejection on timeout and strengthen test

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -422,8 +422,9 @@ describe('CommitEnrichmentService', () => {
     await service.shutdown();
 
     // Allow any zombie work to settle — if abort didn't work, the 2s timer
-    // would still be running and would set enrichmentCompleted=true.
-    await new Promise(resolve => setTimeout(resolve, 200));
+    // would still be running and would set enrichmentCompleted=true. Wait
+    // longer than the 2000ms mock delay to reliably catch the regression.
+    await new Promise(resolve => setTimeout(resolve, 2500));
 
     // The job should have timed out and been counted as failed
     expect(service._getFailedCount()).toBe(1);

--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -177,9 +177,14 @@ export class CommitEnrichmentService {
     const controller = new AbortController();
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
-      // Race the enrichment work against a timeout
+      // Race the enrichment work against a timeout.
+      // When the timeout wins, controller.abort() kills in-progress work,
+      // causing doEnrichment to reject with an AbortError. Since Promise.race
+      // has already settled with the timeout error, that rejection is orphaned.
+      // The .catch() swallows it to prevent an unhandled promise rejection.
+      const enrichmentPromise = this.doEnrichment(job, controller.signal);
       await Promise.race([
-        this.doEnrichment(job, controller.signal),
+        enrichmentPromise,
         new Promise<never>((_, reject) => {
           timeoutHandle = setTimeout(() => {
             controller.abort();
@@ -187,6 +192,9 @@ export class CommitEnrichmentService {
           }, this.jobTimeoutMs);
         }),
       ]);
+      enrichmentPromise.catch(() => {
+        // Intentionally swallowed — the timeout branch already handled the error
+      });
       this.succeededCount++;
       log.debug(
         { commitHash: job.commitHash, attempts: job.attempts },


### PR DESCRIPTION
Addresses review feedback on PR #5653. Adds .catch() to the doEnrichment promise in Promise.race to prevent unhandled promise rejections when timeout aborts the child process. Also increases the test settle delay from 200ms to 2500ms to exceed the mock timer, ensuring the test catches regression if abort signal propagation breaks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
