### PR TITLE
fix: lazy-load openclaw-http-server.ts to fix compiled CLI binary

### DIFF
--- a/cli/src/adapters/openclaw.ts
+++ b/cli/src/adapters/openclaw.ts
@@ -1,15 +1,15 @@
 import { GATEWAY_PORT } from "../lib/constants";
 import { buildOpenclawRuntimeServer } from "../lib/openclaw-runtime-server";
 
-export function buildOpenclawStartupScript(
+export async function buildOpenclawStartupScript(
   bearerToken: string,
   sshUser: string,
   anthropicApiKey: string,
   timestampRedirect: string,
   userSetup: string,
   ownershipFixup: string,
-): string {
-  const runtimeServer = buildOpenclawRuntimeServer();
+): Promise<string> {
+  const runtimeServer = await buildOpenclawRuntimeServer();
 
   return `#!/bin/bash
 set -e

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -76,19 +76,19 @@ chown -R "$SSH_USER:$SSH_USER" "$SSH_USER_HOME" 2>/dev/null || true
 `;
 }
 
-export function buildStartupScript(
+export async function buildStartupScript(
   species: Species,
   bearerToken: string,
   sshUser: string,
   anthropicApiKey: string,
-): string {
+): Promise<string> {
   const platformUrl = process.env.VELLUM_ASSISTANT_PLATFORM_URL ?? "https://assistant.vellum.ai";
   const timestampRedirect = buildTimestampRedirect();
   const userSetup = buildUserSetup(sshUser);
   const ownershipFixup = buildOwnershipFixup();
 
   if (species === "openclaw") {
-    return buildOpenclawStartupScript(
+    return await buildOpenclawStartupScript(
       bearerToken,
       sshUser,
       anthropicApiKey,
@@ -485,7 +485,7 @@ async function hatchGcp(
       console.error("Error: ANTHROPIC_API_KEY environment variable is not set.");
       process.exit(1);
     }
-    const startupScript = buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
+    const startupScript = await buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 
@@ -650,7 +650,7 @@ async function hatchCustom(
       process.exit(1);
     }
 
-    const startupScript = buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
+    const startupScript = await buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -420,7 +420,7 @@ export async function hatchAws(
     console.log("\u{1F50D} Finding latest Debian AMI...");
     const amiId = await getLatestDebianAmi(region);
 
-    const startupScript = buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
+    const startupScript = await buildStartupScript(species, bearerToken, sshUser, anthropicApiKey);
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 

--- a/cli/src/lib/openclaw-runtime-server.ts
+++ b/cli/src/lib/openclaw-runtime-server.ts
@@ -1,8 +1,7 @@
 import { join } from "path";
 
-const serverSource = await Bun.file(join(import.meta.dir, "..", "adapters", "openclaw-http-server.ts")).text();
-
-export function buildOpenclawRuntimeServer(): string {
+export async function buildOpenclawRuntimeServer(): Promise<string> {
+  const serverSource = await Bun.file(join(import.meta.dir, "..", "adapters", "openclaw-http-server.ts")).text();
 
   return `
 cat > /opt/openclaw-runtime-server.ts << 'RUNTIME_SERVER_EOF'


### PR DESCRIPTION
Addresses review feedback on PR #5591. Moves the Bun.file() read from module-level to inside the function that uses it, preventing ENOENT errors when the compiled CLI binary is invoked.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
