### PR TITLE
Cache skill inspect results to avoid re-fetching

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -11,6 +11,7 @@ final class SkillsManager: ObservableObject {
     @Published var inspectedSkill: ClawhubInspectData?
     @Published var isInspecting = false
     @Published var inspectError: String?
+    private var inspectCache: [String: ClawhubInspectData] = [:]
     @Published var installResult: InstallResult?
     @Published var uninstallResult: UninstallResult?
     @Published var isUninstalling = false
@@ -152,9 +153,17 @@ final class SkillsManager: ObservableObject {
 
     func inspectSkill(slug: String) {
         currentInspectSlug = slug
+        inspectError = nil
+
+        // Return cached result immediately if available
+        if let cached = inspectCache[slug] {
+            inspectedSkill = cached
+            isInspecting = false
+            return
+        }
+
         isInspecting = true
         inspectedSkill = nil
-        inspectError = nil
 
         Task {
             let stream = daemonClient.subscribe()
@@ -176,6 +185,7 @@ final class SkillsManager: ObservableObject {
                     guard currentInspectSlug == slug else { return }
                     if let data = response.data {
                         inspectedSkill = data
+                        inspectCache[slug] = data
                     } else {
                         inspectError = response.error ?? "Unknown error"
                     }


### PR DESCRIPTION
## Summary
- Adds an in-memory cache for skill inspect results in `SkillsManager`
- Revisiting a previously inspected skill now loads instantly from cache instead of re-fetching from the daemon

## Test plan
- [ ] Open Available Skills, click into a skill detail — should load normally
- [ ] Click back, then click the same skill again — should appear instantly without loading spinner
- [ ] Click a different skill — should still fetch fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
