### PR TITLE
fix: remove unimplemented twitter_read from credential policy metadata

### DIFF
--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -520,7 +520,7 @@ describe('Twitter auth handler', () => {
         expect(lastUpsertPolicy!.oauth2ClientSecret).toBe('my-client-secret');
         expect(lastUpsertPolicy!.grantedScopes).toEqual(['tweet.read', 'users.read', 'offline.access']);
         expect(lastUpsertPolicy!.allowedDomains).toEqual([]);
-        expect(lastUpsertPolicy!.allowedTools).toEqual(['twitter_post', 'twitter_read']);
+        expect(lastUpsertPolicy!.allowedTools).toEqual(['twitter_post']);
 
         // expiresAt should be roughly Date.now() + 7200 * 1000
         const expiresAt = lastUpsertPolicy!.expiresAt as number;

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -97,7 +97,7 @@ export async function handleTwitterAuthStart(
 
     upsertCredentialMetadata('integration:twitter', 'access_token', {
       accountInfo,
-      allowedTools: ['twitter_post', 'twitter_read'],
+      allowedTools: ['twitter_post'],
       allowedDomains: [],
       oauth2TokenUrl: 'https://api.x.com/2/oauth2/token',
       oauth2ClientId: clientId,


### PR DESCRIPTION
Closes #5723. Removes twitter_read from the allowedTools array in Twitter auth handler and corresponding test assertions. twitter_read was never implemented and doesn't match the narrower twitter_post-only policy direction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
