### PR TITLE
fix: sanitize OAuth error logs to prevent leaking provider response bodies

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -173,10 +173,17 @@ export async function startOAuth2Flow(
     });
 
     if (!tokenResp.ok) {
-      const body = await tokenResp.text().catch(() => '');
-      log.error({ status: tokenResp.status, body }, 'OAuth2 token exchange failed');
+      const rawBody = await tokenResp.text().catch(() => '');
+      let safeDetail: Record<string, unknown> = {};
       let errorCode = '';
-      try { errorCode = (JSON.parse(body) as Record<string, unknown>).error as string ?? ''; } catch {}
+      try {
+        const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+        if (parsed.error) { safeDetail.error = String(parsed.error); errorCode = String(parsed.error); }
+        if (parsed.error_description) safeDetail.error_description = String(parsed.error_description);
+      } catch {
+        safeDetail.error = '[non-JSON response]';
+      }
+      log.error({ status: tokenResp.status, ...safeDetail }, 'OAuth2 token exchange failed');
       const detail = errorCode ? `HTTP ${tokenResp.status}: ${errorCode}` : `HTTP ${tokenResp.status}`;
       throw new Error(`OAuth2 token exchange failed (${detail})`);
     }
@@ -232,10 +239,17 @@ export async function refreshOAuth2Token(
   });
 
   if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    log.error({ status: resp.status, body }, 'OAuth2 token refresh failed');
+    const rawBody = await resp.text().catch(() => '');
+    let safeDetail: Record<string, unknown> = {};
     let errorCode = '';
-    try { errorCode = (JSON.parse(body) as Record<string, unknown>).error as string ?? ''; } catch {}
+    try {
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+      if (parsed.error) { safeDetail.error = String(parsed.error); errorCode = String(parsed.error); }
+      if (parsed.error_description) safeDetail.error_description = String(parsed.error_description);
+    } catch {
+      safeDetail.error = '[non-JSON response]';
+    }
+    log.error({ status: resp.status, ...safeDetail }, 'OAuth2 token refresh failed');
     const detail = errorCode ? `HTTP ${resp.status}: ${errorCode}` : `HTTP ${resp.status}`;
     throw new Error(`OAuth2 token refresh failed (${detail})`);
   }


### PR DESCRIPTION
Closes #5722. Replaces raw response body logging in OAuth2 token exchange and refresh error paths with sanitized extraction of only safe fields (error, error_description). Prevents sensitive provider payloads from leaking into logs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
