### PR TITLE
Skip redundant skill list and search fetches

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -35,8 +35,9 @@ final class SkillsManager: ObservableObject {
         self.daemonClient = daemonClient
     }
 
-    func fetchSkills() {
+    func fetchSkills(force: Bool = false) {
         guard !isLoading else { return }
+        if !force && !skills.isEmpty { return }
         isLoading = true
 
         Task {
@@ -88,8 +89,10 @@ final class SkillsManager: ObservableObject {
         }
     }
 
-    func searchSkills(query: String = "") {
+    func searchSkills(query: String = "", force: Bool = false) {
         guard !isSearching else { return }
+        // Skip if we already have results for this query (unless forced)
+        if !force && !searchResults.isEmpty { return }
         isSearching = true
 
         Task {
@@ -134,7 +137,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "install" {
                     if response.success {
                         installResult = InstallResult(slug: slug, success: true, error: nil)
-                        fetchSkills()
+                        fetchSkills(force: true)
                     } else {
                         installResult = InstallResult(slug: slug, success: false, error: response.error)
                     }
@@ -220,7 +223,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "uninstall" {
                     if response.success {
                         uninstallResult = UninstallResult(id: id, success: true, error: nil)
-                        fetchSkills()
+                        fetchSkills(force: true)
                     } else {
                         uninstallResult = UninstallResult(id: id, success: false, error: response.error)
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -30,6 +30,7 @@ final class SkillsManager: ObservableObject {
 
     private let daemonClient: DaemonClient
     private var currentInspectSlug: String?
+    private var lastSearchQuery: String?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -92,7 +93,7 @@ final class SkillsManager: ObservableObject {
     func searchSkills(query: String = "", force: Bool = false) {
         guard !isSearching else { return }
         // Skip if we already have results for this query (unless forced)
-        if !force && !searchResults.isEmpty { return }
+        if !force && !searchResults.isEmpty && lastSearchQuery == query { return }
         isSearching = true
 
         Task {
@@ -110,6 +111,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "search" {
                     if response.success, let data = response.data {
                         searchResults = data.skills
+                        lastSearchQuery = query
                     }
                     isSearching = false
                     return


### PR DESCRIPTION
## Summary
- `fetchSkills()` and `searchSkills()` now skip re-fetching when results already exist in memory
- After install/uninstall, `force: true` ensures fresh data is loaded
- Eliminates unnecessary loading spinners when switching tabs or navigating back from detail views

## Test plan
- [ ] Open Skills panel — should load normally on first visit
- [ ] Switch to another tab and back — should not show loading spinner
- [ ] Navigate into a skill detail and back — available list should still be there
- [ ] Install/uninstall a skill — installed skills list should refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
