### PR TITLE
M3: Tests + Observability + Docs for provider commit messages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1125,6 +1125,8 @@ graph TB
 
 9. **Non-blocking enrichment queue**: After each successful commit, a `CommitEnrichmentService` runs async enrichment fire-and-forget. The queue has configurable max size (default 50), concurrency (default 1), per-job timeout (default 30s), and retry count (default 2 with exponential backoff). On queue overflow, the oldest job is dropped with a warning log. On graceful shutdown, in-flight jobs drain while pending jobs are discarded. Currently writes placeholder JSON metadata to git notes (`refs/notes/vellum`) as a scaffold for future LLM enrichment.
 
+10. **Provider-aware commit message generation (optional)**: When `workspaceGit.commitMessageLLM.enabled` is `true`, turn-boundary commits attempt to generate a descriptive commit message using the configured LLM provider before falling back to deterministic messages. The LLM call runs BEFORE entering the `commitIfDirty` mutex to ensure it never holds the git lock during a network call. Pre-flight checks gate the attempt: the configured provider must have an API key, the generator's circuit breaker must be closed, and sufficient turn budget must remain (`minRemainingTurnBudgetMs`). On any failure — timeout, provider error, invalid output, or missing credentials — the deterministic message is used immediately with a structured `llmFallbackReason` log field. The feature ships disabled by default and is designed to never degrade turn completion guarantees.
+
 ### Design decisions
 
 - **Commit at turn boundaries, not per-tool-call**: A single commit per turn captures all file mutations from that turn atomically. This avoids noisy per-file commits and keeps the history meaningful.
@@ -1142,6 +1144,7 @@ graph TB
 | `assistant/src/workspace/commit-message-provider.ts` | `CommitMessageProvider` interface, `DefaultCommitMessageProvider`, `CommitContext`/`CommitMessageResult` types |
 | `assistant/src/workspace/commit-message-enrichment-service.ts` | `CommitEnrichmentService`: bounded async queue, fire-and-forget enrichment, git notes output |
 | `assistant/src/workspace/turn-commit.ts` | `commitTurnChanges()`: turn-boundary commit with structured metadata + enrichment enqueue |
+| `assistant/src/workspace/provider-commit-message-generator.ts` | `ProviderCommitMessageGenerator`: LLM-based commit message generation with circuit breaker and deterministic fallback |
 | `assistant/src/workspace/heartbeat-service.ts` | `HeartbeatService`: periodic safety-net auto-commits, shutdown commits, enrichment enqueue |
 | `assistant/src/daemon/session-agent-loop.ts` | Integration: turn-boundary commit with `raceWithTimeout` protection in `runAgentLoop` finally block |
 | `assistant/src/daemon/lifecycle.ts` | Integration: `HeartbeatService` start/stop and shutdown commit |

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -514,6 +514,22 @@ describe('AssistantConfigSchema', () => {
       enrichmentConcurrency: 1,
       enrichmentJobTimeoutMs: 30000,
       enrichmentMaxRetries: 2,
+      commitMessageLLM: {
+        enabled: false,
+        useConfiguredProvider: true,
+        providerFastModelOverrides: {},
+        timeoutMs: 600,
+        maxTokens: 120,
+        temperature: 0.2,
+        maxFilesInPrompt: 30,
+        maxDiffBytes: 12000,
+        minRemainingTurnBudgetMs: 1000,
+        breaker: {
+          openAfterFailures: 3,
+          backoffBaseMs: 2000,
+          backoffMaxMs: 60000,
+        },
+      },
     });
   });
 
@@ -548,6 +564,77 @@ describe('AssistantConfigSchema', () => {
   test('rejects non-number workspaceGit.interactiveGitTimeoutMs', () => {
     const result = AssistantConfigSchema.safeParse({
       workspaceGit: { interactiveGitTimeoutMs: 'fast' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ── commitMessageLLM config ──────────────────────────────────────────
+
+  test('default commitMessageLLM values are correct', () => {
+    const result = AssistantConfigSchema.parse({});
+    const llm = result.workspaceGit.commitMessageLLM;
+    expect(llm.enabled).toBe(false);
+    expect(llm.useConfiguredProvider).toBe(true);
+    expect(llm.providerFastModelOverrides).toEqual({});
+    expect(llm.timeoutMs).toBe(600);
+    expect(llm.maxTokens).toBe(120);
+    expect(llm.temperature).toBe(0.2);
+    expect(llm.maxFilesInPrompt).toBe(30);
+    expect(llm.maxDiffBytes).toBe(12000);
+    expect(llm.minRemainingTurnBudgetMs).toBe(1000);
+  });
+
+  test('rejects negative commitMessageLLM.timeoutMs', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { commitMessageLLM: { timeoutMs: -1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects commitMessageLLM.temperature > 2', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { commitMessageLLM: { temperature: 2.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('breaker settings have correct defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    const breaker = result.workspaceGit.commitMessageLLM.breaker;
+    expect(breaker.openAfterFailures).toBe(3);
+    expect(breaker.backoffBaseMs).toBe(2000);
+    expect(breaker.backoffMaxMs).toBe(60000);
+  });
+
+  test('accepts valid commitMessageLLM overrides', () => {
+    const result = AssistantConfigSchema.parse({
+      workspaceGit: {
+        commitMessageLLM: {
+          enabled: true,
+          timeoutMs: 1000,
+          temperature: 0.5,
+          breaker: { openAfterFailures: 5 },
+        },
+      },
+    });
+    expect(result.workspaceGit.commitMessageLLM.enabled).toBe(true);
+    expect(result.workspaceGit.commitMessageLLM.timeoutMs).toBe(1000);
+    expect(result.workspaceGit.commitMessageLLM.temperature).toBe(0.5);
+    expect(result.workspaceGit.commitMessageLLM.breaker.openAfterFailures).toBe(5);
+    // Other breaker fields should still get defaults
+    expect(result.workspaceGit.commitMessageLLM.breaker.backoffBaseMs).toBe(2000);
+  });
+
+  test('rejects commitMessageLLM.temperature < 0', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { commitMessageLLM: { temperature: -0.1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-integer commitMessageLLM.maxTokens', () => {
+    const result = AssistantConfigSchema.safeParse({
+      workspaceGit: { commitMessageLLM: { maxTokens: 3.5 } },
     });
     expect(result.success).toBe(false);
   });

--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -1,9 +1,10 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import type { CommitMessageProvider, CommitContext, CommitMessageResult } from '../workspace/commit-message-provider.js';
+import type { GenerateCommitMessageResult } from '../workspace/provider-commit-message-generator.js';
 
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 import { WorkspaceGitService, _resetGitServiceRegistry } from '../workspace/git-service.js';
@@ -281,5 +282,209 @@ describe('commitTurnChanges', () => {
     expect(fullMessage).toContain('Minimal custom message');
     expect(fullMessage).toContain('enriched: false');
     expect(fullMessage).toContain('source: "unit-test"');
+  });
+});
+
+describe('LLM commit message integration', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `vellum-llm-commit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+  });
+
+  afterEach(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
+    mock.restore();
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(async () => {
+    try { await getEnrichmentService().shutdown(); } catch { /* ignore */ }
+    _resetEnrichmentService();
+  });
+
+  test('success path uses LLM output as commit message', async () => {
+    const llmResult: GenerateCommitMessageResult = {
+      message: 'feat: add user authentication module',
+      source: 'llm',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => llmResult,
+      }),
+    }));
+
+    // Re-import to pick up the mock
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'auth.ts'), 'export class Auth {}');
+
+    await commit(testDir, 'sess_llm_success', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('feat: add user authentication module');
+  });
+
+  test('missing API key returns deterministic without attempting LLM', async () => {
+    const deterministicResult: GenerateCommitMessageResult = {
+      message: 'Turn: missing-key.txt',
+      source: 'deterministic',
+      reason: 'missing_provider_api_key',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => deterministicResult,
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'missing-key.txt'), 'content');
+
+    await commit(testDir, 'sess_no_key', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    // Deterministic message is used — no LLM message in output
+    expect(fullMessage).toContain('Turn:');
+    expect(fullMessage).not.toContain('feat:');
+  });
+
+  test('provider error falls back to deterministic without propagating', async () => {
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => {
+          throw new Error('Provider connection refused');
+        },
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'error-test.txt'), 'content');
+
+    // Should NOT throw — errors are caught internally
+    await commit(testDir, 'sess_error', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    // Deterministic message is used as fallback
+    expect(fullMessage).toContain('Turn:');
+  });
+
+  test('timeout returns deterministic fallback', async () => {
+    const timeoutResult: GenerateCommitMessageResult = {
+      message: 'Turn: timeout-test.txt',
+      source: 'deterministic',
+      reason: 'timeout',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => timeoutResult,
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'timeout-test.txt'), 'content');
+
+    await commit(testDir, 'sess_timeout', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Turn:');
+  });
+
+  test('invalid output returns deterministic fallback', async () => {
+    const invalidResult: GenerateCommitMessageResult = {
+      message: 'Turn: invalid-test.txt',
+      source: 'deterministic',
+      reason: 'invalid_output',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => invalidResult,
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'invalid-test.txt'), 'content');
+
+    await commit(testDir, 'sess_invalid', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Turn:');
+  });
+
+  test('breaker open skips LLM and uses deterministic', async () => {
+    const breakerResult: GenerateCommitMessageResult = {
+      message: 'Turn: breaker-test.txt',
+      source: 'deterministic',
+      reason: 'breaker_open',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => breakerResult,
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'breaker-test.txt'), 'content');
+
+    await commit(testDir, 'sess_breaker', 1);
+
+    const fullMessage = execFileSync('git', ['log', '-1', '--pretty=%B'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(fullMessage).toContain('Turn:');
   });
 });


### PR DESCRIPTION
## Summary\n\n- Adds integration tests for all LLM fallback paths in turn-commit (success, timeout, error, breaker, missing key, invalid output)\n- Adds config schema validation tests for commitMessageLLM settings\n- Updates ARCHITECTURE.md with provider-aware commit message generation documentation\n- Full validation matrix passes\n\nPart of #5708, closes #5711
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
