### PR TITLE
Fix skill card tap target to include padding area

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -412,6 +412,7 @@ struct AgentPanelContent: View {
             .foregroundColor(VColor.textMuted)
             .padding(.leading, 24 + VSpacing.md)
         }
+        .padding(VSpacing.lg)
         .contentShape(Rectangle())
         .onTapGesture {
             withAnimation(VAnimation.standard) {
@@ -419,7 +420,6 @@ struct AgentPanelContent: View {
                 skillsManager.inspectSkill(slug: skill.slug)
             }
         }
-        .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
     }
 


### PR DESCRIPTION
## Summary
- Moves `.padding()` before `.contentShape(Rectangle())` so the entire card including padding is tappable
- Addresses review feedback from #5712 — SwiftUI modifier order matters for hit-testing

## Test plan
- [ ] Click on the padding area of a skill card — should navigate to detail view
- [ ] Install button should still work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
