### PR TITLE
fix: handle Twitter auth send failure, trim credentials, and reset stuck state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -320,24 +320,32 @@ public final class SettingsStore: ObservableObject {
     }
 
     func saveTwitterLocalClient(clientId: String, clientSecret: String?) {
+        let trimmedId = clientId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSecret = clientSecret?.trimmingCharacters(in: .whitespacesAndNewlines)
         try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(
             action: "set_local_client",
-            clientId: clientId,
-            clientSecret: clientSecret
+            clientId: trimmedId,
+            clientSecret: trimmedSecret
         ))
     }
 
     func clearTwitterLocalClient() {
+        twitterAuthInProgress = false
         try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "clear_local_client"))
     }
 
     func connectTwitter() {
         twitterAuthInProgress = true
         twitterAuthError = nil
-        try? daemonClient?.send(TwitterAuthStartMessage())
+        do {
+            try daemonClient?.send(TwitterAuthStartMessage())
+        } catch {
+            twitterAuthInProgress = false
+        }
     }
 
     func disconnectTwitter() {
+        twitterAuthInProgress = false
         try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
     }
 


### PR DESCRIPTION
Addresses review feedback on PR #5574. Resets twitterAuthInProgress when IPC send fails, trims whitespace from OAuth credentials before saving, and resets auth-in-progress state in clear/disconnect methods to prevent stuck UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
