### PR TITLE
fix: add tweet.write scope to Twitter OAuth request

### DIFF
--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -39,7 +39,7 @@ export async function handleTwitterAuthStart(
     const oauthConfig: OAuth2Config = {
       authUrl: 'https://twitter.com/i/oauth2/authorize',
       tokenUrl: 'https://api.x.com/2/oauth2/token',
-      scopes: ['tweet.read', 'users.read', 'offline.access'],
+      scopes: ['tweet.read', 'tweet.write', 'users.read', 'offline.access'],
       clientId,
       clientSecret,
       extraParams: {},


### PR DESCRIPTION
Addresses review feedback on PR #5569. Adds tweet.write to the requested OAuth scopes so the credential actually has write permission for posting tweets.

Other feedback items from #5569 were already addressed:
- Non-2xx verification gate was added by PR #5693
- allowedTools uses twitter_post consistently (no mismatch found)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
