### PR TITLE
Invalidate inspect cache on skill install/uninstall

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -226,7 +226,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "uninstall" {
                     if response.success {
                         uninstallResult = UninstallResult(id: id, success: true, error: nil)
-                        inspectCache.removeValue(forKey: id)
+                        inspectCache.removeAll()
                         fetchSkills(force: true)
                     } else {
                         uninstallResult = UninstallResult(id: id, success: false, error: response.error)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -139,6 +139,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "install" {
                     if response.success {
                         installResult = InstallResult(slug: slug, success: true, error: nil)
+                        inspectCache.removeValue(forKey: slug)
                         fetchSkills(force: true)
                     } else {
                         installResult = InstallResult(slug: slug, success: false, error: response.error)
@@ -225,6 +226,7 @@ final class SkillsManager: ObservableObject {
                    response.operation == "uninstall" {
                     if response.success {
                         uninstallResult = UninstallResult(id: id, success: true, error: nil)
+                        inspectCache.removeValue(forKey: id)
                         fetchSkills(force: true)
                     } else {
                         uninstallResult = UninstallResult(id: id, success: false, error: response.error)


### PR DESCRIPTION
## Summary
- Clears the inspect cache entry for a skill after install or uninstall
- Addresses review feedback from #5727 — prevents serving stale cached data after state changes

## Test plan
- [ ] Inspect a skill, go back, install it, then re-inspect — should show fresh data
- [ ] Uninstall a skill and re-inspect — should re-fetch from daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
