### PR TITLE
fix: remove hard API key gate for keyless providers and fix byte-based diff truncation

### DIFF
--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -338,11 +338,11 @@ describe('LLM commit message integration', () => {
     expect(fullMessage).toContain('feat: add user authentication module');
   });
 
-  test('missing API key returns deterministic without attempting LLM', async () => {
+  test('uninitialized provider returns deterministic without attempting LLM', async () => {
     const deterministicResult: GenerateCommitMessageResult = {
       message: 'Turn: missing-key.txt',
       source: 'deterministic',
-      reason: 'missing_provider_api_key',
+      reason: 'provider_not_initialized',
     };
 
     mock.module('../workspace/provider-commit-message-generator.js', () => ({

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -9,7 +9,6 @@ const log = getLogger('commit-message-llm');
 export type CommitMessageSource = 'llm' | 'deterministic';
 export type LLMFallbackReason =
   | 'disabled'
-  | 'missing_provider_api_key'
   | 'provider_not_initialized'
   | 'breaker_open'
   | 'insufficient_budget'
@@ -104,14 +103,7 @@ export class ProviderCommitMessageGenerator {
       return buildDeterministicResult(context, 'disabled');
     }
 
-    // Step 3: API key check
-    const apiKey = config.apiKeys[config.provider];
-    if (!apiKey) {
-      log.debug({ provider: config.provider }, 'No API key for provider; falling back to deterministic');
-      return buildDeterministicResult(context, 'missing_provider_api_key');
-    }
-
-    // Step 4: Circuit breaker
+    // Step 3: Circuit breaker
     if (this.isBreakerOpen()) {
       log.debug(
         { consecutiveFailures: this.consecutiveFailures },
@@ -120,7 +112,7 @@ export class ProviderCommitMessageGenerator {
       return buildDeterministicResult(context, 'breaker_open');
     }
 
-    // Step 5: Budget check
+    // Step 4: Budget check
     if (options.deadlineMs !== undefined) {
       const remaining = options.deadlineMs - Date.now();
       if (remaining < llmConfig.minRemainingTurnBudgetMs) {
@@ -132,7 +124,7 @@ export class ProviderCommitMessageGenerator {
       }
     }
 
-    // Step 6: Call the provider
+    // Step 5: Call the provider
     try {
       const { getProvider } = await import('../providers/registry.js');
 
@@ -156,7 +148,7 @@ export class ProviderCommitMessageGenerator {
       if (options.diffSummary) {
         const diffBytes = new TextEncoder().encode(options.diffSummary).length;
         const diff = diffBytes > llmConfig.maxDiffBytes
-          ? options.diffSummary.slice(0, llmConfig.maxDiffBytes) + '\n... (truncated)'
+          ? new TextDecoder().decode(new TextEncoder().encode(options.diffSummary).slice(0, llmConfig.maxDiffBytes)) + '\n... (truncated)'
           : options.diffSummary;
         userText += `\n\nDiff summary:\n${diff}`;
       }
@@ -225,7 +217,7 @@ export class ProviderCommitMessageGenerator {
       this.recordSuccess();
       return { message: text, source: 'llm' };
     } catch (err: unknown) {
-      // Step 7: Any error -> deterministic fallback
+      // Step 6: Any error -> deterministic fallback
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
         'Commit message LLM provider error; falling back to deterministic',


### PR DESCRIPTION
## Summary
- Remove explicit `apiKeys[config.provider]` pre-check that prevented LLM commit messages for keyless providers like Ollama
- Fix diff truncation to use `TextEncoder/TextDecoder` for proper byte-based limits instead of character-based `String.slice()`
- Renumber step comments and update test to reflect removed API key gate

Addresses review feedback on #5726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
