### PR TITLE
feat: allow viewing .md workspace files from constellation graph

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -53,6 +53,7 @@ private struct OrbitItem: Identifiable {
     let icon: String
     let emoji: String?
     let color: Color
+    let filePath: String? // non-nil for workspace .md files
 }
 
 private struct CategoryGroup: Identifiable {
@@ -222,6 +223,7 @@ struct ConstellationView: View {
     let identity: IdentityInfo?
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
+    var onFileSelected: ((String) -> Void)?
     @State private var appearance = AvatarAppearanceManager.shared
 
     @State private var phase: AnimationPhase = .hidden
@@ -237,7 +239,8 @@ struct ConstellationView: View {
 
     private var groups: [CategoryGroup] {
         let fileItems = existingFiles.enumerated().map { idx, node in
-            OrbitItem(id: "core-\(idx)", label: node.label, icon: "doc.text.fill", emoji: nil, color: Amber._400)
+            let path: String? = node.label.hasSuffix(".md") ? node.path : nil
+            return OrbitItem(id: "core-\(idx)", label: node.label, icon: "doc.text.fill", emoji: nil, color: Amber._400, filePath: path)
         }
 
         var categoryMap: [SkillCategory: [OrbitItem]] = [:]
@@ -249,7 +252,8 @@ struct ConstellationView: View {
                 label: skill.name,
                 icon: cat.icon,
                 emoji: skill.emoji,
-                color: cat.color
+                color: cat.color,
+                filePath: nil
             )
             categoryMap[cat, default: []].append(item)
         }
@@ -440,7 +444,10 @@ struct ConstellationView: View {
             DraggableNode(nodeKey: item.id, offsets: $nodeOffsets) {
                 ConstellationPill(
                     label: item.label, icon: item.icon,
-                    emoji: item.emoji, color: item.color
+                    emoji: item.emoji, color: item.color,
+                    onTap: item.filePath.map { path in
+                        { onFileSelected?(path) }
+                    }
                 )
             }
             .position(leafBasePositions[leafIdx])
@@ -521,8 +528,11 @@ private struct ConstellationPill: View {
     let icon: String
     let emoji: String?
     let color: Color
+    var onTap: (() -> Void)?
 
     @State private var isHovered = false
+
+    private var isTappable: Bool { onTap != nil }
 
     var body: some View {
         HStack(spacing: VSpacing.sm) {
@@ -569,6 +579,14 @@ private struct ConstellationPill: View {
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
             }
+            #if os(macOS)
+            if isTappable {
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            #endif
+        }
+        .onTapGesture {
+            onTap?()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -11,6 +11,7 @@ struct IdentityPanel: View {
     @State private var metadata: AssistantMetadata?
     @State private var workspaceFiles: [WorkspaceFileNode] = []
     @State private var skills: [SkillInfo] = []
+    @State private var viewingFilePath: String?
 
     private let maxContentWidth: CGFloat = 1100
 
@@ -69,12 +70,23 @@ struct IdentityPanel: View {
             ConstellationView(
                 identity: identity,
                 skills: skills,
-                workspaceFiles: workspaceFiles
+                workspaceFiles: workspaceFiles,
+                onFileSelected: { path in
+                    viewingFilePath = path
+                }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(VColor.background)
         }
         .background(VColor.backgroundSubtle)
+        .sheet(isPresented: Binding(
+            get: { viewingFilePath != nil },
+            set: { if !$0 { viewingFilePath = nil } }
+        )) {
+            if let path = viewingFilePath {
+                WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
+            }
+        }
         .onAppear {
             identity = IdentityInfo.load()
             metadata = AssistantMetadata.load()
@@ -185,5 +197,61 @@ struct IdentityPanel: View {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+// MARK: - Workspace File Sheet
+
+private struct WorkspaceFileSheet: View {
+    let filePath: String
+    let onClose: () -> Void
+
+    private var fileName: String {
+        (filePath as NSString).lastPathComponent
+    }
+
+    private var fileContent: String {
+        (try? String(contentsOfFile: filePath, encoding: .utf8)) ?? "Unable to read file."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Image(systemName: "doc.text.fill")
+                    .font(.system(size: 13))
+                    .foregroundColor(Amber._400)
+                Text(fileName)
+                    .font(VFont.cardTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close")
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.vertical, VSpacing.lg)
+
+            Divider().background(VColor.surfaceBorder)
+
+            // Content
+            ScrollView {
+                Text(fileContent)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VSpacing.xl)
+            }
+        }
+        .frame(minWidth: 500, minHeight: 400)
+        .frame(idealWidth: 600, idealHeight: 500)
+        .background(VColor.backgroundSubtle)
     }
 }


### PR DESCRIPTION
## Summary
- Clicking IDENTITY.md, SOUL.md, or USER.md nodes in the constellation graph now opens a sheet displaying the file contents
- Added `onFileSelected` callback to `ConstellationView` and `onTap` to `ConstellationPill` (with pointing-hand cursor for tappable nodes)
- `WorkspaceFileSheet` shows a header with file icon/name/close button and scrollable monospace content

## Test plan
- [ ] Click a `.md` file node (IDENTITY.md, SOUL.md, USER.md) in the constellation → sheet opens with file contents
- [ ] Click the X button or press Escape → sheet closes
- [ ] Click `skills/` directory node → nothing happens (not tappable)
- [ ] Hover over `.md` nodes → cursor changes to pointing hand
- [ ] Text in the sheet is selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
