### PR TITLE
fix: dismiss file viewer on backdrop click

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -79,14 +79,21 @@ struct IdentityPanel: View {
             .background(VColor.background)
         }
         .background(VColor.backgroundSubtle)
-        .sheet(isPresented: Binding(
-            get: { viewingFilePath != nil },
-            set: { if !$0 { viewingFilePath = nil } }
-        )) {
+        .overlay {
             if let path = viewingFilePath {
+                // Dismiss backdrop
+                Color.black.opacity(0.4)
+                    .ignoresSafeArea()
+                    .onTapGesture { viewingFilePath = nil }
+
                 WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
+                    .frame(width: 600, height: 500)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                    .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
             }
         }
+        .animation(VAnimation.standard, value: viewingFilePath != nil)
         .onAppear {
             identity = IdentityInfo.load()
             metadata = AssistantMetadata.load()
@@ -250,8 +257,6 @@ private struct WorkspaceFileSheet: View {
                     .padding(VSpacing.xl)
             }
         }
-        .frame(minWidth: 500, minHeight: 400)
-        .frame(idealWidth: 600, idealHeight: 500)
         .background(VColor.backgroundSubtle)
     }
 }


### PR DESCRIPTION
## Summary
- Replace modal `.sheet` with an overlay + backdrop so clicking outside the file viewer dismisses it
- Adds smooth scale+opacity transition animation

## Test plan
- [ ] Click a `.md` file node → viewer appears with dark backdrop
- [ ] Click the dark backdrop → viewer dismisses
- [ ] Click the X button → viewer dismisses
- [ ] Viewer animates in/out smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
