### PR TITLE
fix: pop NSCursor on disappear to prevent stuck pointing-hand cursor

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -585,6 +585,13 @@ private struct ConstellationPill: View {
             }
             #endif
         }
+        #if os(macOS)
+        .onDisappear {
+            if isHovered && isTappable {
+                NSCursor.pop()
+            }
+        }
+        #endif
         .onTapGesture {
             onTap?()
         }


### PR DESCRIPTION
## Summary
- Add `onDisappear` cleanup to `ConstellationPill` that pops the pointing-hand cursor if the view disappears while still hovered
- Prevents cursor stack imbalance when pills are removed from the view hierarchy mid-hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
