### PR TITLE
fix: load workspace file content once via task instead of on every render

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -206,12 +206,10 @@ private struct WorkspaceFileSheet: View {
     let filePath: String
     let onClose: () -> Void
 
+    @State private var fileContent: String = ""
+
     private var fileName: String {
         (filePath as NSString).lastPathComponent
-    }
-
-    private var fileContent: String {
-        (try? String(contentsOfFile: filePath, encoding: .utf8)) ?? "Unable to read file."
     }
 
     var body: some View {
@@ -253,5 +251,8 @@ private struct WorkspaceFileSheet: View {
         .frame(minWidth: 500, minHeight: 400)
         .frame(idealWidth: 600, idealHeight: 500)
         .background(VColor.backgroundSubtle)
+        .task {
+            fileContent = (try? String(contentsOfFile: filePath, encoding: .utf8)) ?? "Unable to read file."
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace computed property that performs synchronous disk I/O on every SwiftUI body recomputation with `@State` + `.task` to load file content once when the sheet appears
- Prevents repeated main-thread blocking for larger workspace markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
