### PR TITLE
feat: render workspace files with MarkdownRenderer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -249,11 +249,7 @@ private struct WorkspaceFileSheet: View {
 
             // Content
             ScrollView {
-                Text(fileContent)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textSecondary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                MarkdownRenderer(text: fileContent)
                     .padding(VSpacing.xl)
             }
         }


### PR DESCRIPTION
## Summary
- Use `MarkdownRenderer` instead of plain `Text` in the workspace file viewer sheet so headings, bold, lists, code blocks, etc. render properly

## Test plan
- [ ] Click a `.md` file node in the constellation → file content renders with proper markdown formatting
- [ ] Code blocks, headings, lists, bold/italic all display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
