### PR TITLE
feat: add subagent detail side panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -49,6 +49,7 @@ struct ChatView: View {
     var isTemporaryChat: Bool = false
     var activeSubagents: [SubagentInfo] = []
     var onAbortSubagent: ((String) -> Void)?
+    var onSubagentTap: ((String) -> Void)?
     var daemonHttpPort: Int?
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
@@ -471,9 +472,11 @@ struct ChatView: View {
                         // Subagent chips anchored to the message that spawned them
                         // Indent to align with message text (past the 28pt avatar + 8pt spacing)
                         ForEach(activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
-                            SubagentStatusChip(subagent: subagent) {
-                                onAbortSubagent?(subagent.id)
-                            }
+                            SubagentStatusChip(
+                                subagent: subagent,
+                                onAbort: { onAbortSubagent?(subagent.id) },
+                                onTap: { onSubagentTap?(subagent.id) }
+                            )
                                 .frame(maxWidth: 520, alignment: .leading)
                                 .padding(.leading, 36)
                                 .id("subagent-\(subagent.id)")
@@ -483,9 +486,11 @@ struct ChatView: View {
 
                     // Subagents with no parent message (e.g. from history load)
                     ForEach(activeSubagents.filter { $0.parentMessageId == nil }) { subagent in
-                        SubagentStatusChip(subagent: subagent) {
-                            onAbortSubagent?(subagent.id)
-                        }
+                        SubagentStatusChip(
+                            subagent: subagent,
+                            onAbort: { onAbortSubagent?(subagent.id) },
+                            onTap: { onSubagentTap?(subagent.id) }
+                        )
                             .frame(maxWidth: 520, alignment: .leading)
                             .padding(.leading, 36)
                             .id("subagent-\(subagent.id)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -31,6 +31,7 @@ final class MainWindowState: ObservableObject {
     /// Tracks the "background" thread that persists even when viewing an app or panel overlay.
     @Published var persistentThreadId: UUID?
 
+    @Published var selectedSubagentId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -580,6 +580,8 @@ struct MainWindowView: View {
             if case .panel(.identity) = windowState.selection {
                 windowState.selection = nil
             }
+            // Clear subagent detail panel on thread switch
+            windowState.selectedSubagentId = nil
             // Clear stale activeSurfaceId on the old thread and sync the new one
             if let oldId {
                 threadManager.clearActiveSurface(threadId: oldId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -260,7 +260,7 @@ extension MainWindowView {
     var defaultChatLayout: some View {
         let config = windowState.layoutConfig
         let showConfigPanel = config.right.visible && config.right.content != .empty
-        let showSubagentPanel = windowState.selectedSubagentId != nil
+        let showSubagentPanel = windowState.selectedSubagentId != nil && threadManager.activeViewModel != nil
 
         VSplitView(
             panelWidth: $sidePanelWidth,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -260,13 +260,24 @@ extension MainWindowView {
     var defaultChatLayout: some View {
         let config = windowState.layoutConfig
         let showConfigPanel = config.right.visible && config.right.content != .empty
+        let showSubagentPanel = windowState.selectedSubagentId != nil
 
         VSplitView(
             panelWidth: $sidePanelWidth,
-            showPanel: showConfigPanel,
+            showPanel: showConfigPanel || showSubagentPanel,
             main: { slotView(for: config.center.content) },
             panel: {
-                slotView(for: config.right.content)
+                if let subagentId = windowState.selectedSubagentId,
+                   let viewModel = threadManager.activeViewModel {
+                    SubagentDetailPanel(
+                        subagentId: subagentId,
+                        detailStore: viewModel.subagentDetailStore,
+                        subagentInfo: viewModel.activeSubagents.first(where: { $0.id == subagentId }),
+                        onClose: { windowState.selectedSubagentId = nil }
+                    )
+                } else {
+                    slotView(for: config.right.content)
+                }
             }
         )
     }
@@ -530,6 +541,9 @@ struct ActiveChatViewWrapper: View {
             activeSubagents: viewModel.activeSubagents,
             onAbortSubagent: { subagentId in
                 try? daemonClient.sendSubagentAbort(subagentId: subagentId)
+            },
+            onSubagentTap: { subagentId in
+                windowState.selectedSubagentId = subagentId
             },
             daemonHttpPort: daemonClient.httpPort,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -249,11 +249,7 @@ private struct WorkspaceFileSheet: View {
 
             // Content
             ScrollView {
-                Text(fileContent)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textSecondary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                MarkdownRenderer(text: fileContent)
                     .padding(VSpacing.xl)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -209,6 +209,7 @@ struct SubagentDetailPanel: View {
     }
 
     private func formatCost(_ cost: Double) -> String {
+        if cost == 0 { return "$0.00" }
         if cost < 0.01 { return "<$0.01" }
         return String(format: "$%.2f", cost)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct SubagentDetailPanel: View {
+    let subagentId: String
+    @ObservedObject var detailStore: SubagentDetailStore
+    let subagentInfo: SubagentInfo?
+    var onClose: () -> Void
+
+    private var objective: String? { detailStore.objectives[subagentId] }
+    private var usage: SubagentUsageStats? { detailStore.usageStats[subagentId] }
+    private var events: [SubagentEventItem] { detailStore.eventsBySubagent[subagentId] ?? [] }
+
+    var body: some View {
+        VSidePanel(title: subagentInfo?.label ?? "Subagent", onClose: onClose, pinnedContent: {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Status badge
+                if let info = subagentInfo {
+                    statusBadge(info)
+                }
+
+                // Objective
+                if let objective, !objective.isEmpty {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text("Objective")
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textMuted)
+                        Text(objective)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(4)
+                    }
+                }
+
+                // Usage metrics
+                if let usage {
+                    usageMetrics(usage)
+                }
+
+                // Error
+                if let error = subagentInfo?.error, !error.isEmpty {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(Rose._400)
+                        .padding(VSpacing.xs)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(Rose._500.opacity(0.1))
+                        )
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+
+            Divider().background(VColor.surfaceBorder)
+        }) {
+            if events.isEmpty {
+                VEmptyState(
+                    title: "No events yet",
+                    subtitle: "Events will appear as the subagent runs",
+                    icon: "waveform.path"
+                )
+            } else {
+                LazyVStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(events) { event in
+                        eventRow(event)
+                    }
+                }
+                .padding(.horizontal, VSpacing.sm)
+            }
+        }
+    }
+
+    // MARK: - Status Badge
+
+    @ViewBuilder
+    private func statusBadge(_ info: SubagentInfo) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Circle()
+                .fill(statusColor(info.status))
+                .frame(width: 8, height: 8)
+            Text(info.status.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textSecondary)
+        }
+    }
+
+    private func statusColor(_ status: SubagentStatus) -> Color {
+        switch status {
+        case .completed: return Emerald._500
+        case .failed, .aborted: return Rose._500
+        case .running: return Violet._500
+        default: return Slate._400
+        }
+    }
+
+    // MARK: - Usage Metrics
+
+    @ViewBuilder
+    private func usageMetrics(_ usage: SubagentUsageStats) -> some View {
+        HStack(spacing: VSpacing.lg) {
+            metricItem(icon: "arrow.down.circle", label: "Input", value: "\(formatNumber(usage.inputTokens)) tokens")
+            metricItem(icon: "arrow.up.circle", label: "Output", value: "\(formatNumber(usage.outputTokens)) tokens")
+            metricItem(icon: "dollarsign.circle", label: "Cost", value: formatCost(usage.estimatedCost))
+        }
+    }
+
+    @ViewBuilder
+    private func metricItem(icon: String, label: String, value: String) -> some View {
+        HStack(spacing: VSpacing.xxs) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundColor(VColor.textMuted)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(label)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+                Text(value)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+    }
+
+    // MARK: - Event Row
+
+    @ViewBuilder
+    private func eventRow(_ event: SubagentEventItem) -> some View {
+        switch event.kind {
+        case .text:
+            Text(event.content)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+                .padding(VSpacing.xs)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.backgroundSubtle.opacity(0.3))
+                )
+
+        case .toolUse(let name):
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "wrench.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(Violet._400)
+                Text(name)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(Violet._400)
+                if !event.content.isEmpty {
+                    Text(event.content)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .padding(VSpacing.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(Violet._500.opacity(0.08))
+            )
+
+        case .toolResult(let isError):
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                Image(systemName: isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(isError ? Rose._400 : Emerald._400)
+                Text(event.content)
+                    .font(VFont.monoSmall)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(6)
+                    .textSelection(.enabled)
+            }
+            .padding(VSpacing.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(VColor.backgroundSubtle.opacity(0.2))
+            )
+
+        case .error:
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(Rose._500)
+                Text(event.content)
+                    .font(VFont.caption)
+                    .foregroundColor(Rose._400)
+                    .textSelection(.enabled)
+            }
+            .padding(VSpacing.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(Rose._500.opacity(0.1))
+            )
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formatNumber(_ n: Int) -> String {
+        if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
+        if n >= 1_000 { return String(format: "%.1fK", Double(n) / 1_000) }
+        return "\(n)"
+    }
+
+    private func formatCost(_ cost: Double) -> String {
+        if cost < 0.01 { return "<$0.01" }
+        return String(format: "$%.2f", cost)
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1180,19 +1180,17 @@ extension ChatViewModel {
             guard belongsToSession(msg.parentSessionId) else { return }
             let info = SubagentInfo(id: msg.subagentId, label: msg.label, status: .running, parentMessageId: currentAssistantMessageId)
             activeSubagents.append(info)
+            subagentDetailStore.recordSpawned(subagentId: msg.subagentId, objective: msg.objective)
 
         case .subagentStatusChanged(let msg):
             if let index = activeSubagents.firstIndex(where: { $0.id == msg.subagentId }) {
                 activeSubagents[index].status = SubagentStatus(wire: msg.status)
                 activeSubagents[index].error = msg.error
             }
+            subagentDetailStore.recordStatusChanged(subagentId: msg.subagentId, usage: msg.usage)
 
-        case .subagentEvent:
-            // Subagent internal events (assistant_message, tool_use, etc.) carry the
-            // subagent's session ID, not the parent's, so they cannot be routed through
-            // the normal belongsToSession-guarded handlers. These will be displayed in
-            // the dedicated subagents panel once it's built.
-            break
+        case .subagentEvent(let msg):
+            subagentDetailStore.handleEvent(subagentId: msg.subagentId, event: msg.event)
 
         case .modelInfo(let msg):
             selectedModel = msg.model

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1186,10 +1186,11 @@ extension ChatViewModel {
             if let index = activeSubagents.firstIndex(where: { $0.id == msg.subagentId }) {
                 activeSubagents[index].status = SubagentStatus(wire: msg.status)
                 activeSubagents[index].error = msg.error
+                subagentDetailStore.recordStatusChanged(subagentId: msg.subagentId, usage: msg.usage)
             }
-            subagentDetailStore.recordStatusChanged(subagentId: msg.subagentId, usage: msg.usage)
 
         case .subagentEvent(let msg):
+            guard activeSubagents.contains(where: { $0.id == msg.subagentId }) else { break }
             subagentDetailStore.handleEvent(subagentId: msg.subagentId, event: msg.event)
 
         case .modelInfo(let msg):

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,7 @@ public final class ChatViewModel: ObservableObject {
     @Published public var pendingSkillInvocation: SkillInvocationData?
     @Published public var isWatchSessionActive: Bool = false
     @Published public var activeSubagents: [SubagentInfo] = []
+    public let subagentDetailStore = SubagentDetailStore()
     /// Widget IDs dismissed by the user, persisted across view recreation.
     @Published public var dismissedDocumentSurfaceIds: Set<String> = []
 

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -61,11 +61,11 @@ public final class SubagentDetailStore: ObservableObject {
     public func handleEvent(subagentId: String, event: ServerMessage) {
         switch event {
         case .assistantTextDelta(let delta):
-            // Accumulate text into the last text event, or create a new one
+            // Accumulate text into the last event only if it's a text event
             if var events = eventsBySubagent[subagentId],
-               let lastIndex = events.lastIndex(where: { if case .text = $0.kind { return true }; return false }),
-               case .text = events[lastIndex].kind {
-                events[lastIndex].content += delta.text
+               let last = events.last,
+               case .text = last.kind {
+                events[events.count - 1].content += delta.text
                 eventsBySubagent[subagentId] = events
             } else {
                 let item = SubagentEventItem(timestamp: Date(), kind: .text, content: delta.text)

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Represents a single event in a subagent's activity stream.
+public struct SubagentEventItem: Identifiable {
+    public let id = UUID()
+    public let timestamp: Date
+
+    public enum Kind {
+        case text
+        case toolUse(name: String)
+        case toolResult(isError: Bool)
+        case error
+    }
+
+    public let kind: Kind
+    public var content: String
+}
+
+/// Aggregated usage stats for a subagent session.
+public struct SubagentUsageStats {
+    public var inputTokens: Int
+    public var outputTokens: Int
+    public var estimatedCost: Double
+
+    public init(inputTokens: Int = 0, outputTokens: Int = 0, estimatedCost: Double = 0) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.estimatedCost = estimatedCost
+    }
+}
+
+/// Stores subagent detail data (events, objectives, usage) for display in the side panel.
+@MainActor
+public final class SubagentDetailStore: ObservableObject {
+    @Published public var eventsBySubagent: [String: [SubagentEventItem]] = [:]
+    @Published public var objectives: [String: String] = [:]
+    @Published public var usageStats: [String: SubagentUsageStats] = [:]
+
+    public init() {}
+
+    /// Record that a subagent was spawned with an objective.
+    public func recordSpawned(subagentId: String, objective: String) {
+        objectives[subagentId] = objective
+        if eventsBySubagent[subagentId] == nil {
+            eventsBySubagent[subagentId] = []
+        }
+    }
+
+    /// Record a status change with optional usage stats.
+    public func recordStatusChanged(subagentId: String, usage: IPCUsageStats?) {
+        if let usage {
+            usageStats[subagentId] = SubagentUsageStats(
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                estimatedCost: usage.estimatedCost
+            )
+        }
+    }
+
+    /// Handle a subagent event (forwarded ServerMessage from the subagent's session).
+    public func handleEvent(subagentId: String, event: ServerMessage) {
+        switch event {
+        case .assistantTextDelta(let delta):
+            // Accumulate text into the last text event, or create a new one
+            if var events = eventsBySubagent[subagentId],
+               let lastIndex = events.lastIndex(where: { if case .text = $0.kind { return true }; return false }),
+               case .text = events[lastIndex].kind {
+                events[lastIndex].content += delta.text
+                eventsBySubagent[subagentId] = events
+            } else {
+                let item = SubagentEventItem(timestamp: Date(), kind: .text, content: delta.text)
+                eventsBySubagent[subagentId, default: []].append(item)
+            }
+
+        case .toolUseStart(let msg):
+            let item = SubagentEventItem(
+                timestamp: Date(),
+                kind: .toolUse(name: msg.toolName),
+                content: summarizeToolInput(msg.input)
+            )
+            eventsBySubagent[subagentId, default: []].append(item)
+
+        case .toolResult(let msg):
+            let truncated = msg.result.count > 500 ? String(msg.result.prefix(497)) + "..." : msg.result
+            let item = SubagentEventItem(
+                timestamp: Date(),
+                kind: .toolResult(isError: msg.isError ?? false),
+                content: truncated
+            )
+            eventsBySubagent[subagentId, default: []].append(item)
+
+        case .error(let err):
+            let item = SubagentEventItem(
+                timestamp: Date(),
+                kind: .error,
+                content: err.message
+            )
+            eventsBySubagent[subagentId, default: []].append(item)
+
+        default:
+            break
+        }
+    }
+
+    /// Simple tool input summary for subagent event display.
+    private func summarizeToolInput(_ input: [String: AnyCodable]) -> String {
+        let priorityKeys = ["command", "file_path", "path", "query", "url", "pattern", "glob"]
+        if let key = priorityKeys.first(where: { input[$0] != nil }),
+           let value = input[key],
+           let str = value.value as? String {
+            return str.count > 120 ? String(str.prefix(117)) + "..." : str
+        }
+        return ""
+    }
+}

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct SubagentStatusChip: View {
     let subagent: SubagentInfo
     var onAbort: (() -> Void)?
+    var onTap: (() -> Void)?
 
     @State private var phase: Int = 0
     @State private var timer: Timer?
@@ -24,9 +25,10 @@ public struct SubagentStatusChip: View {
         }
     }
 
-    public init(subagent: SubagentInfo, onAbort: (() -> Void)? = nil) {
+    public init(subagent: SubagentInfo, onAbort: (() -> Void)? = nil, onTap: (() -> Void)? = nil) {
         self.subagent = subagent
         self.onAbort = onAbort
+        self.onTap = onTap
     }
 
     public var body: some View {
@@ -80,6 +82,8 @@ public struct SubagentStatusChip: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .fill(VColor.backgroundSubtle.opacity(0.3))
         )
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
         .onAppear { startDotAnimation() }
         .onDisappear { timer?.invalidate() }
         .onChange(of: subagent.status) {


### PR DESCRIPTION
## Summary
- Clicking a subagent status chip opens a right side panel showing objective, status, token usage, cost, and a live event stream
- Created `SubagentDetailStore` to capture and store subagent events (text deltas, tool calls, results, errors)
- Wired `subagent_event` IPC messages (previously ignored) through to the store for display
- Panel clears on thread switch

## Test plan
- [ ] Build with `./build.sh`
- [ ] Spawn subagents, click chips → panel opens with live events
- [ ] Click different chips → panel switches to selected subagent
- [ ] Close panel via X button
- [ ] Switch threads → panel dismisses
- [ ] Completed subagents show full event log and usage stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
