### PR TITLE
fix: reset isHovered state on disappear to prevent unbalanced cursor pop

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -589,6 +589,7 @@ private struct ConstellationPill: View {
         .onDisappear {
             if isHovered && isTappable {
                 NSCursor.pop()
+                isHovered = false
             }
         }
         #endif


### PR DESCRIPTION
## Summary
- Reset `isHovered = false` after popping cursor in `onDisappear` to prevent stale state causing an extra unbalanced `NSCursor.pop()` if the view reappears
- Follows existing pattern in `UsedToolsList.swift`
- Addresses review feedback from #5744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
