### PR TITLE
fix: add id parameter to .task modifier for file content loading

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -256,7 +256,7 @@ private struct WorkspaceFileSheet: View {
             }
         }
         .background(VColor.backgroundSubtle)
-        .task {
+        .task(id: filePath) {
             fileContent = (try? String(contentsOfFile: filePath, encoding: .utf8)) ?? "Unable to read file."
         }
     }


### PR DESCRIPTION
## Summary
- Add `id: filePath` to the `.task` modifier on `WorkspaceFileSheet` so the file content reloads when the file path changes
- Addresses review feedback from PR #5745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
