### PR TITLE
feat: add OpenRouter as an LLM provider

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -379,6 +379,7 @@ export function registerDoctorCommand(program: Command): void {
         gemini: 'GEMINI_API_KEY',
         ollama: 'OLLAMA_API_KEY',
         fireworks: 'FIREWORKS_API_KEY',
+        openrouter: 'OPENROUTER_API_KEY',
       };
       const configKey = (raw.apiKeys as Record<string, string> | undefined)?.[provider];
       const envVar = providerEnvVar[provider];

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -10,7 +10,7 @@ import type { AssistantConfig } from './types.js';
 const log = getLogger('config');
 
 // Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
-export const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave', 'perplexity'] as const;
+export const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'openrouter', 'brave', 'perplexity'] as const;
 
 let cached: AssistantConfig | null = null;
 let loading = false;
@@ -197,6 +197,9 @@ export function loadConfig(): AssistantConfig {
     }
     if (process.env.FIREWORKS_API_KEY) {
       config.apiKeys.fireworks = process.env.FIREWORKS_API_KEY;
+    }
+    if (process.env.OPENROUTER_API_KEY) {
+      config.apiKeys.openrouter = process.env.OPENROUTER_API_KEY;
     }
     if (process.env.BRAVE_API_KEY) {
       config.apiKeys.brave = process.env.BRAVE_API_KEY;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getDataDir } from '../util/platform.js';
 
-const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
+const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'openrouter'] as const;
 const VALID_WEB_SEARCH_PROVIDERS = ['perplexity', 'brave', 'anthropic-native'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block', 'prompt'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -51,6 +51,9 @@ const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string
 
   // Fireworks
   'fireworks': { provider: 'fireworks', model: 'accounts/fireworks/models/kimi-k2p5', displayName: 'Kimi K2.5' },
+
+  // OpenRouter
+  'openrouter': { provider: 'openrouter', model: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4 (OpenRouter)' },
 };
 
 /** Reverse lookup: model ID → provider, derived from PROVIDER_MODEL_SHORTCUTS. */

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,0 +1,20 @@
+import { OpenAIProvider } from '../openai/client.js';
+
+export interface OpenRouterProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+  streamTimeoutMs?: number;
+}
+
+const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+export class OpenRouterProvider extends OpenAIProvider {
+  constructor(apiKey: string, model: string, options: OpenRouterProviderOptions = {}) {
+    super(apiKey, model, {
+      baseURL: options.baseURL?.trim() || DEFAULT_OPENROUTER_BASE_URL,
+      providerName: 'openrouter',
+      providerLabel: 'OpenRouter',
+      streamTimeoutMs: options.streamTimeoutMs,
+    });
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -4,6 +4,7 @@ import { OpenAIProvider } from "./openai/client.js";
 import { GeminiProvider } from "./gemini/client.js";
 import { OllamaProvider } from "./ollama/client.js";
 import { FireworksProvider } from "./fireworks/client.js";
+import { OpenRouterProvider } from "./openrouter/client.js";
 import { RetryProvider } from "./retry.js";
 import { FailoverProvider } from "./failover.js";
 import { wrapWithLogfire } from "../logfire.js";
@@ -15,6 +16,7 @@ const DEFAULT_MODELS: Record<string, string> = {
   gemini: 'gemini-3-flash',
   ollama: 'llama3.2',
   fireworks: 'accounts/fireworks/models/kimi-k2p5',
+  openrouter: 'anthropic/claude-sonnet-4',
 };
 
 const providers = new Map<string, Provider>();
@@ -133,6 +135,12 @@ export function initializeProviders(config: ProvidersConfig): void {
     const model = resolveModel(config, 'fireworks');
     registerProvider('fireworks', new RetryProvider(
       wrapWithLogfire(new FireworksProvider(config.apiKeys.fireworks, model, { streamTimeoutMs })),
+    ));
+  }
+  if (config.apiKeys.openrouter) {
+    const model = resolveModel(config, 'openrouter');
+    registerProvider('openrouter', new RetryProvider(
+      wrapWithLogfire(new OpenRouterProvider(config.apiKeys.openrouter, model, { streamTimeoutMs })),
     ));
   }
 }


### PR DESCRIPTION
## Summary
- Add OpenRouter provider extending OpenAIProvider (OpenAI-compatible API at openrouter.ai/api/v1)
- Register `openrouter` in config schema, provider registry, API key loader, CLI doctor, and model shortcuts
- Supports `OPENROUTER_API_KEY` env var, secure storage, and config.json; default model is `anthropic/claude-sonnet-4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
