### PR TITLE
feat: set OpenRouter default model to Grok 4

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -53,7 +53,7 @@ const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string
   'fireworks': { provider: 'fireworks', model: 'accounts/fireworks/models/kimi-k2p5', displayName: 'Kimi K2.5' },
 
   // OpenRouter
-  'openrouter': { provider: 'openrouter', model: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4 (OpenRouter)' },
+  'openrouter': { provider: 'openrouter', model: 'x-ai/grok-4', displayName: 'Grok 4 (OpenRouter)' },
 };
 
 /** Reverse lookup: model ID → provider, derived from PROVIDER_MODEL_SHORTCUTS. */

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -16,7 +16,7 @@ const DEFAULT_MODELS: Record<string, string> = {
   gemini: 'gemini-3-flash',
   ollama: 'llama3.2',
   fireworks: 'accounts/fireworks/models/kimi-k2p5',
-  openrouter: 'anthropic/claude-sonnet-4',
+  openrouter: 'x-ai/grok-4',
 };
 
 const providers = new Map<string, Provider>();


### PR DESCRIPTION
## Summary
- Change OpenRouter default model from `anthropic/claude-sonnet-4` to `x-ai/grok-4`
- Update model shortcut display name to "Grok 4 (OpenRouter)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
