### PR TITLE
fix: use literal emoji in skill frontmatter to fix JSON parse errors

### DIFF
--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Document"
 description: "Document creation and editing for UI surfaces"
-metadata: {"vellum": {"emoji": "\u{1F4C4}"}}
+metadata: {"vellum": {"emoji": "📄"}}
 ---
 
 Create and edit long-form documents using the built-in rich text editor. Documents open in workspace mode with chat docked to the side.

--- a/assistant/src/config/bundled-skills/reminder/SKILL.md
+++ b/assistant/src/config/bundled-skills/reminder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Reminder"
 description: "One-time time-based reminders that fire at a specific future time"
-metadata: {"vellum": {"emoji": "\u{1F514}"}}
+metadata: {"vellum": {"emoji": "🔔"}}
 ---
 
 Create, list, and cancel one-time reminders. Reminders fire at a specific future time and either notify the user or execute a message through the assistant.

--- a/assistant/src/config/bundled-skills/watcher/SKILL.md
+++ b/assistant/src/config/bundled-skills/watcher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Watcher"
 description: "Polling watcher system for monitoring external sources"
-metadata: {"vellum": {"emoji": "\u{1F440}"}}
+metadata: {"vellum": {"emoji": "👀"}}
 ---
 
 Create and manage watchers that poll external services for events and process them with an action prompt.


### PR DESCRIPTION
## Summary
- Replaced ES6 unicode escapes (`\u{1F4C4}`, `\u{1F514}`, `\u{1F440}`) with literal emoji characters (📄, 🔔, 👀) in document, reminder, and watcher skill frontmatter
- Fixes `JSON Parse error: "\u{1F4" is not a valid unicode escape` when loading skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
