### PR TITLE
fix: guard getStatus() pre-check in turn-commit to prevent skipping commits

### DIFF
--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -70,8 +70,18 @@ export async function commitTurnChanges(
     let llmFallbackReason: LLMFallbackReason | undefined;
 
     if (!provider) {
-      const preStatus = await gitService.getStatus();
-      if (!preStatus.clean) {
+      // Guard: skip pre-check if deadline already elapsed to avoid unnecessary mutex contention
+      let preClean = false;
+      if (!deadlineMs || Date.now() < deadlineMs) {
+        try {
+          const preStatus = await gitService.getStatus();
+          preClean = preStatus.clean;
+        } catch {
+          // If we can't determine status, assume dirty so we don't skip the commit
+        }
+      }
+
+      if (!preClean) {
         try {
           const generator = getCommitMessageGenerator();
           const result = await generator.generateCommitMessage(


### PR DESCRIPTION
## Summary
- Wrap `getStatus()` pre-check in try/catch so failures assume dirty (don't skip commit)
- Add deadline guard before `getStatus()` to avoid unnecessary mutex contention when expired
- Addresses unresolved review feedback from PR #5741 (devin 🔴 + codex P2 × 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
