### PR TITLE
fix: handle nil daemonClient in connectTwitter() to prevent stuck auth state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -338,7 +338,11 @@ public final class SettingsStore: ObservableObject {
         twitterAuthInProgress = true
         twitterAuthError = nil
         do {
-            try daemonClient?.send(TwitterAuthStartMessage())
+            guard let daemonClient else {
+                twitterAuthInProgress = false
+                return
+            }
+            try daemonClient.send(TwitterAuthStartMessage())
         } catch {
             twitterAuthInProgress = false
         }


### PR DESCRIPTION
## Summary
- Guard against nil `daemonClient` in `connectTwitter()` so `twitterAuthInProgress` is reset instead of stuck at `true`
- Swift optional chaining on nil doesn't throw, so the catch block was never reached
- Addresses unresolved review feedback from PR #5736 (devin 🟡)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
