### PR TITLE
fix: bind SubagentDetailPanel to live subagent state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -271,8 +271,7 @@ extension MainWindowView {
                    let viewModel = threadManager.activeViewModel {
                     SubagentDetailPanel(
                         subagentId: subagentId,
-                        detailStore: viewModel.subagentDetailStore,
-                        subagentInfo: viewModel.activeSubagents.first(where: { $0.id == subagentId }),
+                        viewModel: viewModel,
                         onClose: { windowState.selectedSubagentId = nil }
                     )
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -272,6 +272,7 @@ extension MainWindowView {
                     SubagentDetailPanel(
                         subagentId: subagentId,
                         viewModel: viewModel,
+                        detailStore: viewModel.subagentDetailStore,
                         onClose: { windowState.selectedSubagentId = nil }
                     )
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -4,9 +4,9 @@ import VellumAssistantShared
 struct SubagentDetailPanel: View {
     let subagentId: String
     @ObservedObject var viewModel: ChatViewModel
+    @ObservedObject var detailStore: SubagentDetailStore
     var onClose: () -> Void
 
-    private var detailStore: SubagentDetailStore { viewModel.subagentDetailStore }
     private var subagentInfo: SubagentInfo? { viewModel.activeSubagents.first(where: { $0.id == subagentId }) }
     private var objective: String? { detailStore.objectives[subagentId] }
     private var usage: SubagentUsageStats? { detailStore.usageStats[subagentId] }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -3,10 +3,11 @@ import VellumAssistantShared
 
 struct SubagentDetailPanel: View {
     let subagentId: String
-    @ObservedObject var detailStore: SubagentDetailStore
-    let subagentInfo: SubagentInfo?
+    @ObservedObject var viewModel: ChatViewModel
     var onClose: () -> Void
 
+    private var detailStore: SubagentDetailStore { viewModel.subagentDetailStore }
+    private var subagentInfo: SubagentInfo? { viewModel.activeSubagents.first(where: { $0.id == subagentId }) }
     private var objective: String? { detailStore.objectives[subagentId] }
     private var usage: SubagentUsageStats? { detailStore.usageStats[subagentId] }
     private var events: [SubagentEventItem] { detailStore.eventsBySubagent[subagentId] ?? [] }


### PR DESCRIPTION
## Summary
- Replace one-time `SubagentInfo` snapshot with `@ObservedObject var viewModel: ChatViewModel` so the panel reactively updates when subagent status/error changes
- Derive `subagentInfo` and `detailStore` as computed properties from the observed view model
- Addresses unresolved review feedback from #5747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
