### PR TITLE
fix: prevent abort button tap from also opening subagent panel

### DIFF
--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -33,36 +33,41 @@ public struct SubagentStatusChip: View {
 
     public var body: some View {
         HStack(spacing: VSpacing.sm) {
-            Image(systemName: statusIcon)
-                .font(.system(size: 11))
-                .foregroundColor(statusColor)
+            // Content area — tappable to open detail panel
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: statusIcon)
+                    .font(.system(size: 11))
+                    .foregroundColor(statusColor)
 
-            VStack(alignment: .leading, spacing: 1) {
-                HStack(spacing: VSpacing.xs) {
-                    Text(subagent.label)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: VSpacing.xs) {
+                        Text(subagent.label)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textPrimary)
 
-                    if !subagent.isTerminal {
-                        // Animated dots
-                        HStack(spacing: 2) {
-                            ForEach(0..<3, id: \.self) { index in
-                                Circle()
-                                    .fill(VColor.textSecondary)
-                                    .frame(width: 4, height: 4)
-                                    .opacity(dotOpacity(for: index))
+                        if !subagent.isTerminal {
+                            // Animated dots
+                            HStack(spacing: 2) {
+                                ForEach(0..<3, id: \.self) { index in
+                                    Circle()
+                                        .fill(VColor.textSecondary)
+                                        .frame(width: 4, height: 4)
+                                        .opacity(dotOpacity(for: index))
+                                }
                             }
                         }
                     }
-                }
 
-                if let error = subagent.error, !error.isEmpty {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(Rose._400)
-                        .lineLimit(2)
+                    if let error = subagent.error, !error.isEmpty {
+                        Text(error)
+                            .font(VFont.caption)
+                            .foregroundColor(Rose._400)
+                            .lineLimit(2)
+                    }
                 }
             }
+            .contentShape(Rectangle())
+            .onTapGesture { onTap?() }
 
             Spacer()
 
@@ -82,8 +87,6 @@ public struct SubagentStatusChip: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .fill(VColor.backgroundSubtle.opacity(0.3))
         )
-        .contentShape(Rectangle())
-        .onTapGesture { onTap?() }
         .onAppear { startDotAnimation() }
         .onDisappear { timer?.invalidate() }
         .onChange(of: subagent.status) {


### PR DESCRIPTION
## Summary
- Move `.contentShape(Rectangle()).onTapGesture` from the outer chip container to just the content area (icon + label)
- The abort button now sits outside the tap gesture scope, so clicking X only triggers `onAbort` without also firing `onTap`
- Addresses unresolved review feedback from #5747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
