### PR TITLE
fix: add button accessibility trait to subagent abort control

### DIFF
--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -73,6 +73,7 @@ public struct SubagentStatusChip: View {
                     .padding(VSpacing.xs)
                     .contentShape(Rectangle())
                     .highPriorityGesture(TapGesture().onEnded { onAbort() })
+                    .accessibilityAddTraits(.isButton)
                     .accessibilityLabel("Abort subagent")
             }
         }


### PR DESCRIPTION
## Summary
- Adds `.accessibilityAddTraits(.isButton)` to the abort image in `SubagentStatusChip`
- Restores VoiceOver activation support lost when `Button` was replaced with `Image` + `highPriorityGesture` in #5758
- Follows existing codebase pattern (see `InlineDocumentPreview`, `VToggle`, `InlineDynamicPagePreview`)

Addresses unresolved review feedback from #5758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
