### PR TITLE
fix: guard nil daemonClient in setModel() to prevent stuck model state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -357,8 +357,9 @@ public final class SettingsStore: ObservableObject {
 
     func setModel(_ model: String) {
         guard model != lastDaemonModel else { return }
+        guard let daemonClient else { return }
         do {
-            try daemonClient?.sendModelSet(model: model)
+            try daemonClient.sendModelSet(model: model)
             lastDaemonModel = model
         } catch {
             // Send failed — don't update lastDaemonModel so the next attempt isn't suppressed


### PR DESCRIPTION
## Summary
- Apply `guard let daemonClient` pattern to `setModel()`, matching the fix in `connectTwitter()` from #5754
- Prevents `lastDaemonModel` from being set when the daemon never received the command
- Without this fix, model selection silently fails after daemon reconnection

Addresses unresolved feedback from #5754

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
