### PR TITLE
fix: stop chat context clobber when task run starts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -151,9 +151,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func createTaskRunThread(conversationId: String, workItemId: String, title: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
         if threads.contains(where: { $0.sessionId == conversationId }) {
-            if let existing = threads.first(where: { $0.sessionId == conversationId }) {
-                activeThreadId = existing.id
-            }
             return
         }
 
@@ -165,7 +162,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
-        activeThreadId = thread.id
 
         log.info("Created task run thread \(thread.id) for conversation \(conversationId) (work item \(workItemId))")
     }


### PR DESCRIPTION
## Summary
- Task run thread creation no longer auto-switches activeThreadId
- User stays on their current chat thread when clicking Run from Tasks
- Thread is still created and tracked for later navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
