### PR TITLE
fix: enforce approved tool snapshot at execution boundary

### DIFF
--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -432,8 +432,17 @@ export function handleWorkItemApprovePermissions(
     return;
   }
 
+  // Merge newly approved tools with any previously approved ones so reruns
+  // that only need a subset of previously-approved tools don't require
+  // re-approval.
+  const existingApproved: string[] = workItem.approvedTools
+    ? JSON.parse(workItem.approvedTools)
+    : [];
+  const newApproved = sanitizeToolList(msg.approvedTools);
+  const merged = [...new Set([...existingApproved, ...newApproved])];
+
   updateWorkItem(msg.id, {
-    approvedTools: JSON.stringify(sanitizeToolList(msg.approvedTools)),
+    approvedTools: JSON.stringify(sanitizeToolList(merged)),
     approvalStatus: 'approved',
   });
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -73,6 +73,34 @@ export class ToolExecutor {
       return { content: msg, isError: true };
     }
 
+    // Belt-and-suspenders guard for task runs: only preflight-approved tools
+    // may execute. This catches cases where ephemeral rules might not cover
+    // a tool, ensuring unapproved calls fail deterministically instead of
+    // falling through to the interactive prompter.
+    if (context.taskRunId) {
+      const taskRules = getTaskRunRules(context.taskRunId);
+      const approvedToolNames = new Set(taskRules.map((r) => r.tool));
+      if (approvedToolNames.size > 0 && !approvedToolNames.has(name)) {
+        const msg = `Tool '${name}' was not approved in the task's preflight. Add it to required tools and re-approve.`;
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent(context, {
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'deny',
+          reason: msg,
+          durationMs,
+        });
+        return { content: msg, isError: true };
+      }
+    }
+
     const tool = getTool(name);
     if (!tool) {
       const available = getAllTools().filter((t) => t.executionMode !== 'proxy' || context.proxyToolResolver).map((t) => t.name).sort().join(', ');


### PR DESCRIPTION
## Summary
- Approval persistence is now additive: merge new approvals with existing set
- Add executor-side guard: unapproved tool calls in task runs fail with deterministic error
- Reruns reuse persisted approvals without re-prompting
- Belt-and-suspenders alongside ephemeral rules check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
