### PR TITLE
fix: keep task sessions headless during execution with lock

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -274,14 +274,27 @@ export async function handleSessionSwitch(
     ctx.send(socket, { type: 'error', message: `Session ${msg.sessionId} not found` });
     return;
   }
+
+  // If the target session is headless-locked (actively executing a task run),
+  // skip rebinding the socket so tool confirmations stay suppressed.
+  const existingSession = ctx.sessions.get(msg.sessionId);
+  const isHeadlessLocked = existingSession && (existingSession as unknown as { headlessLock?: boolean }).headlessLock;
+
   ctx.socketToSession.set(socket, msg.sessionId);
-  const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
-  // Only wire the escalation handler if one isn't already set — handleTaskSubmit
-  // sets a handler with the client's actual screen dimensions, and overwriting it
-  // here would replace those dimensions with the daemon's defaults.
-  if (!session.hasEscalationHandler()) {
-    wireEscalationHandler(session, socket, ctx);
+
+  if (isHeadlessLocked) {
+    // Load the session without rebinding the client — the session stays headless
+    await ctx.getOrCreateSession(msg.sessionId, socket, false);
+  } else {
+    const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+    // Only wire the escalation handler if one isn't already set — handleTaskSubmit
+    // sets a handler with the client's actual screen dimensions, and overwriting it
+    // here would replace those dimensions with the daemon's defaults.
+    if (!session.hasEscalationHandler()) {
+      wireEscalationHandler(session, socket, ctx);
+    }
   }
+
   ctx.send(socket, {
     type: 'session_info',
     sessionId: conversation.id,

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -326,12 +326,19 @@ export async function handleWorkItemRunTask(
           });
           // Wire the taskRunId so the executor can retrieve ephemeral permission rules
           (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
+          // Prevent interactive clients from rebinding to this session mid-run
+          (session as unknown as { headlessLock: boolean }).headlessLock = true;
         }
         await session.processMessage(message, [], (event) => {
           ctx.broadcast(event);
         });
       },
     );
+
+    // Release the headless lock now that the task run is done
+    if (session) {
+      (session as unknown as { headlessLock: boolean }).headlessLock = false;
+    }
 
     // Don't overwrite cancelled status — the cancel handler already set it
     const current = getWorkItem(msg.id);
@@ -348,6 +355,10 @@ export async function handleWorkItemRunTask(
     broadcastWorkItemStatus(ctx, msg.id);
     ctx.broadcast({ type: 'tasks_changed' });
   } catch (err) {
+    // Release the headless lock on failure
+    if (session) {
+      (session as unknown as { headlessLock: boolean }).headlessLock = false;
+    }
     log.error({ err, workItemId: msg.id }, 'work_item_run_task failed');
     updateWorkItem(msg.id, {
       status: 'failed',
@@ -461,6 +472,7 @@ export function handleWorkItemCancel(
   if (conversationId) {
     const session = ctx.sessions.get(conversationId);
     if (session) {
+      (session as unknown as { headlessLock: boolean }).headlessLock = false;
       session.abort();
       getSubagentManager().abortAllForParent(conversationId);
     }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -47,6 +47,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   memoryPolicy: { scopeId: string; strictSideEffects: boolean };
   /** True when the session has no connected IPC client (HTTP-only path). */
   hasNoClient?: boolean;
+  /** When true, the session is executing a task run and must not become interactive. */
+  headlessLock?: boolean;
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
 }
@@ -206,7 +208,7 @@ export function createToolExecutor(
           });
         }
       },
-      isInteractive: !ctx.hasNoClient,
+      isInteractive: !ctx.hasNoClient && !ctx.headlessLock,
       proxyToolResolver: (toolName: string, proxyInput: Record<string, unknown>) => surfaceProxyResolver(ctx, toolName, proxyInput),
       proxyApprovalCallback: createProxyApprovalCallback(prompter, ctx),
       requestSecret: async (params) => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -121,6 +121,7 @@ export class Session {
   /** @internal */ currentRequestId?: string;
   /** @internal */ conflictGate = new ConflictGate();
   /** @internal */ hasNoClient = false;
+  /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;


### PR DESCRIPTION
## Summary
- Add headlessLock flag on Session to prevent rebinding during task execution
- session_switch skips rebind for locked sessions
- isInteractive stays false for headless-locked sessions
- Lock set before processMessage, cleared after completion/cancel/failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
