### PR TITLE
feat: preserve real execution intent for ad-hoc queue items

### DIFF
--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -120,6 +120,10 @@
             "type": "string",
             "description": "Title for the work item. When provided WITHOUT task_id or task_name, creates an ad-hoc work item directly (a lightweight task template is auto-created behind the scenes). When provided WITH task_id or task_name, overrides the task definition title."
           },
+          "execution_prompt": {
+            "type": "string",
+            "description": "The full instruction to execute when this task runs. If omitted, the title is used as the execution prompt. Use this to preserve detailed instructions (e.g. full file paths, specific parameters) that would be lost in a short display title."
+          },
           "notes": {
             "type": "string",
             "description": "Notes to attach to the work item."

--- a/assistant/src/tools/tasks/work-item-enqueue.ts
+++ b/assistant/src/tools/tasks/work-item-enqueue.ts
@@ -59,6 +59,7 @@ export async function executeTaskListAdd(
     const taskId = input.task_id as string | undefined;
     const taskName = input.task_name as string | undefined;
     const titleOverride = input.title as string | undefined;
+    const executionPrompt = input.execution_prompt as string | undefined;
     const notes = input.notes as string | undefined;
     const priorityTier = input.priority_tier as number | undefined;
     const sortIndex = input.sort_index as number | undefined;
@@ -89,10 +90,15 @@ export async function executeTaskListAdd(
 
       log.debug({ title: titleOverride }, 'task_list_add: creating new item');
 
-      // Auto-create a lightweight task template for the ad-hoc item
+      // Auto-create a lightweight task template for the ad-hoc item.
+      // Use execution_prompt as the template (the actual instruction sent to the
+      // model at run time), falling back to notes then title. This preserves
+      // detailed instructions (e.g. full file paths) that may be shortened in
+      // the display title.
+      const adHocTemplate = executionPrompt ?? notes ?? titleOverride;
       const adHocTask = createTask({
         title: titleOverride,
-        template: titleOverride,
+        template: adHocTemplate,
       });
 
       // For ad-hoc items: explicit tools → persist; omitted → null


### PR DESCRIPTION
## Summary
- Add execution_prompt parameter to task_list_add tool
- Ad-hoc tasks store the full instruction, not just the display title
- Task runner uses execution_prompt for actual execution
- Title/notes UI behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
