### PR TITLE
feat: replace implicit chat mirroring with explicit open-in-chat

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -466,13 +466,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.showTasksWindow()
         }
 
-        daemonClient.onTaskRunThreadCreated = { [weak self] msg in
-            self?.mainWindow?.threadManager.createTaskRunThread(
-                conversationId: msg.conversationId,
-                workItemId: msg.workItemId,
-                title: msg.title
-            )
-        }
+        // Task run threads are no longer created automatically. Users can
+        // opt in via the "Open in Chat" button in the task output view.
 
         // Handle escalation: text_qa -> computer_use via computer_use_request_control
         daemonClient.onTaskRouted = { [weak self] routed in
@@ -1142,7 +1137,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func showTasksWindow() {
         NSApp.setActivationPolicy(.regular)
         if tasksWindow == nil {
-            tasksWindow = TasksWindow(daemonClient: daemonClient)
+            let window = TasksWindow(daemonClient: daemonClient)
+            window.onOpenInChat = { [weak self] conversationId, workItemId, title in
+                guard let self else { return }
+                self.mainWindow?.threadManager.createTaskRunThread(
+                    conversationId: conversationId,
+                    workItemId: workItemId,
+                    title: title
+                )
+                if let thread = self.mainWindow?.threadManager.threads.first(where: { $0.sessionId == conversationId }) {
+                    self.mainWindow?.threadManager.activeThreadId = thread.id
+                }
+                self.showMainWindow()
+            }
+            tasksWindow = window
         }
         tasksWindow?.show()
     }

--- a/clients/macos/vellum-assistant/Features/Tasks/TaskOutputDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TaskOutputDetailView.swift
@@ -16,6 +16,9 @@ struct TaskOutputDetailView: View {
     let itemTitle: String
     let state: TaskOutputState
     let onDismiss: () -> Void
+    /// When non-nil, shows an "Open in Chat" button that creates a thread
+    /// for this task's conversation in the main window.
+    var onOpenInChat: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -37,6 +40,23 @@ struct TaskOutputDetailView: View {
                 .foregroundColor(VColor.textPrimary)
                 .lineLimit(2)
             Spacer()
+            if let onOpenInChat {
+                Button(action: onOpenInChat) {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "bubble.left.and.text.bubble.right")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Open in Chat")
+                            .font(VFont.caption)
+                    }
+                    .foregroundColor(VColor.accent)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(VColor.accent.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open in Chat")
+            }
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .semibold))

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindow.swift
@@ -8,6 +8,9 @@ import SwiftUI
 final class TasksWindow {
     private var window: NSWindow?
     private let daemonClient: DaemonClient
+    /// Called when the user taps "Open in Chat" — creates the thread and
+    /// brings the main window forward.
+    var onOpenInChat: ((String, String, String) -> Void)?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -23,7 +26,7 @@ final class TasksWindow {
         }
 
         let hostingController = NSHostingController(
-            rootView: TasksWindowView(daemonClient: daemonClient)
+            rootView: TasksWindowView(daemonClient: daemonClient, onOpenInChat: onOpenInChat)
         )
 
         let window = NSWindow(

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -5,8 +5,8 @@ import VellumAssistantShared
 struct TasksWindowView: View {
     @StateObject private var viewModel: TasksWindowViewModel
 
-    init(daemonClient: DaemonClient) {
-        _viewModel = StateObject(wrappedValue: TasksWindowViewModel(daemonClient: daemonClient))
+    init(daemonClient: DaemonClient, onOpenInChat: ((String, String, String) -> Void)? = nil) {
+        _viewModel = StateObject(wrappedValue: TasksWindowViewModel(daemonClient: daemonClient, onOpenInChat: onOpenInChat))
     }
 
     var body: some View {
@@ -126,7 +126,10 @@ struct TasksWindowView: View {
                 TaskOutputDetailView(
                     itemTitle: item.title,
                     state: viewModel.outputState,
-                    onDismiss: { viewModel.dismissOutput() }
+                    onDismiss: { viewModel.dismissOutput() },
+                    onOpenInChat: viewModel.canOpenInChat ? {
+                        viewModel.openInChat()
+                    } : nil
                 )
             }
         }

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowViewModel.swift
@@ -50,8 +50,14 @@ class TasksWindowViewModel: ObservableObject {
     /// normal latency while still recovering from connection drops quickly.
     private static let runTimeoutSeconds: UInt64 = 10
 
-    init(daemonClient: DaemonClient) {
+    /// Called when the user taps "Open in Chat" — creates the thread in
+    /// the main window and brings it forward. Parameters: conversationId,
+    /// workItemId, title.
+    private let onOpenInChat: ((String, String, String) -> Void)?
+
+    init(daemonClient: DaemonClient, onOpenInChat: ((String, String, String) -> Void)? = nil) {
         self.daemonClient = daemonClient
+        self.onOpenInChat = onOpenInChat
         setupCallbacks()
         fetchItems()
     }
@@ -366,6 +372,25 @@ class TasksWindowViewModel: ObservableObject {
     /// Dismisses the output detail sheet.
     func dismissOutput() {
         selectedOutputItem = nil
+    }
+
+    /// Whether the currently loaded output has a conversation that can be
+    /// opened in chat.
+    var canOpenInChat: Bool {
+        guard onOpenInChat != nil else { return false }
+        if case .loaded(let output) = outputState {
+            return output.conversationId != nil
+        }
+        return false
+    }
+
+    /// Opens the current task output's conversation in the main chat window.
+    func openInChat() {
+        guard let item = selectedOutputItem,
+              case .loaded(let output) = outputState,
+              let conversationId = output.conversationId else { return }
+        onOpenInChat?(conversationId, item.id, item.title)
+        dismissOutput()
     }
 
     func updatePriority(id: String, tier: Double) {


### PR DESCRIPTION
## Summary
- Remove automatic thread creation on task_run_thread_created
- Add explicit Open in Chat button in task output view
- Tasks stay in Tasks UX by default; chat is opt-in
- Daemon-side execution path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
