### PR TITLE
Expand X client with full read API + auto-capture + workflows

### DIFF
--- a/assistant/scripts/capture-x-graphql.ts
+++ b/assistant/scripts/capture-x-graphql.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+/**
+ * Capture X.com GraphQL API calls via Chrome CDP.
+ *
+ * Usage:
+ *   1. Make sure Chrome is running with CDP (vellum x refresh will do this)
+ *   2. Run: bun run scripts/capture-x-graphql.ts
+ *   3. Browse X in Chrome — visit a profile, scroll their tweets, reply to one
+ *   4. Press Ctrl+C to stop. Captured queries are printed as JSON.
+ */
+
+const CDP_BASE = 'http://localhost:9222';
+
+interface CapturedQuery {
+  queryName: string;
+  queryId: string;
+  method: string;
+  url: string;
+  variables: unknown;
+  features?: unknown;
+  responsePreview?: unknown;
+}
+
+const captured: CapturedQuery[] = [];
+
+// Minimal CDP WebSocket client
+class CDPClient {
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private callbacks = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private eventHandlers = new Map<string, Array<(params: Record<string, unknown>) => void>>();
+
+  async connect(wsUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(wsUrl);
+      ws.onopen = () => { this.ws = ws; resolve(); };
+      ws.onerror = (e) => reject(new Error(`CDP error: ${e}`));
+      ws.onclose = () => { this.ws = null; };
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(String(event.data));
+        if (msg.id != null) {
+          const cb = this.callbacks.get(msg.id);
+          if (cb) { this.callbacks.delete(msg.id); msg.error ? cb.reject(new Error(msg.error.message)) : cb.resolve(msg.result); }
+        } else if (msg.method) {
+          for (const h of this.eventHandlers.get(msg.method) ?? []) h(msg.params ?? {});
+        }
+      };
+    });
+  }
+
+  async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.callbacks.set(id, { resolve, reject });
+      this.ws!.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  on(event: string, handler: (params: Record<string, unknown>) => void) {
+    const list = this.eventHandlers.get(event) ?? [];
+    list.push(handler);
+    this.eventHandlers.set(event, list);
+  }
+
+  close() { this.ws?.close(); }
+}
+
+// Discover Chrome tabs
+const res = await fetch(`${CDP_BASE}/json/list`);
+if (!res.ok) {
+  console.error('Chrome CDP not available. Run `vellum x refresh` first.');
+  process.exit(1);
+}
+const targets = (await res.json()) as Array<{ type: string; url: string; webSocketDebuggerUrl: string }>;
+const pages = targets.filter(t => t.type === 'page');
+
+if (pages.length === 0) {
+  console.error('No pages found in Chrome.');
+  process.exit(1);
+}
+
+console.log(`Found ${pages.length} tab(s). Attaching to all...`);
+
+// Pending request data (requestId -> partial info)
+const pendingRequests = new Map<string, { url: string; postData?: string }>();
+
+for (const page of pages) {
+  const client = new CDPClient();
+  await client.connect(page.webSocketDebuggerUrl);
+  await client.send('Network.enable');
+
+  client.on('Network.requestWillBeSent', (params) => {
+    const req = params.request as Record<string, unknown> | undefined;
+    const url = (req?.url ?? params.url) as string | undefined;
+    if (!url?.includes('/i/api/graphql/')) return;
+    const method = (req?.method as string) ?? 'GET';
+    pendingRequests.set(params.requestId as string, {
+      url,
+      postData: req.postData as string | undefined,
+    });
+
+    // Extract query name from URL: /graphql/<queryId>/<QueryName>
+    const match = url.match(/\/graphql\/([^/]+)\/([^?]+)/);
+    const queryId = match?.[1] ?? 'unknown';
+    const queryName = match?.[2] ?? 'unknown';
+
+    let variables: unknown = undefined;
+    let features: unknown = undefined;
+
+    if (method === 'POST' && req.postData) {
+      try {
+        const body = JSON.parse(req.postData as string);
+        variables = body.variables;
+        features = body.features;
+      } catch { /* ignore */ }
+    } else if (method === 'GET') {
+      // GET requests encode variables in query params
+      try {
+        const u = new URL(url);
+        const v = u.searchParams.get('variables');
+        if (v) variables = JSON.parse(v);
+        const f = u.searchParams.get('features');
+        if (f) features = JSON.parse(f);
+      } catch { /* ignore */ }
+    }
+
+    console.log(`\n>>> ${method} ${queryName} (${queryId})`);
+    if (variables) console.log(`    variables: ${JSON.stringify(variables).slice(0, 200)}`);
+
+    captured.push({ queryName, queryId, method, url, variables, features });
+  });
+
+  client.on('Network.responseReceived', (params) => {
+    const requestId = params.requestId as string;
+    const pending = pendingRequests.get(requestId);
+    if (!pending) return;
+
+    const response = params.response as Record<string, unknown>;
+    const status = response.status as number;
+    console.log(`    <<< ${status}`);
+
+    // Try to get response body
+    client.send('Network.getResponseBody', { requestId }).then((result) => {
+      const body = (result as Record<string, unknown>).body as string;
+      try {
+        const json = JSON.parse(body);
+        // Attach a preview to the last captured entry with matching URL
+        const entry = [...captured].reverse().find(e => e.url === pending.url);
+        if (entry) entry.responsePreview = JSON.stringify(json).slice(0, 500);
+      } catch { /* ignore */ }
+    }).catch(() => { /* body not available yet */ });
+
+    pendingRequests.delete(requestId);
+  });
+}
+
+console.log('\nRecording X.com GraphQL requests...');
+console.log('Browse X in Chrome — visit a profile, scroll tweets, reply to one.');
+console.log('Press Ctrl+C to stop and dump results.\n');
+
+// Wait for Ctrl+C
+process.on('SIGINT', () => {
+  console.log(`\n\n=== Captured ${captured.length} GraphQL requests ===\n`);
+
+  // Dedupe by queryName, keep first occurrence
+  const seen = new Set<string>();
+  const unique = captured.filter(q => {
+    if (seen.has(q.queryName)) return false;
+    seen.add(q.queryName);
+    return true;
+  });
+
+  for (const q of unique) {
+    console.log(`--- ${q.queryName} ---`);
+    console.log(`  Query ID: ${q.queryId}`);
+    console.log(`  Method: ${q.method}`);
+    console.log(`  Variables: ${JSON.stringify(q.variables, null, 2)}`);
+    if (q.responsePreview) {
+      console.log(`  Response preview: ${q.responsePreview}`);
+    }
+    console.log('');
+  }
+
+  // Also dump full JSON
+  const outPath = '/tmp/x-graphql-capture.json';
+  Bun.write(outPath, JSON.stringify(captured, null, 2));
+  console.log(`Full capture saved to ${outPath}`);
+  process.exit(0);
+});

--- a/assistant/scripts/capture-x-graphql.ts
+++ b/assistant/scripts/capture-x-graphql.ts
@@ -4,26 +4,49 @@
  *
  * Usage:
  *   1. Make sure Chrome is running with CDP (vellum x refresh will do this)
- *   2. Run: bun run scripts/capture-x-graphql.ts
- *   3. Browse X in Chrome — visit a profile, scroll their tweets, reply to one
- *   4. Press Ctrl+C to stop. Captured queries are printed as JSON.
+ *   2. Run: bun run scripts/capture-x-graphql.ts [--auto] [--all]
+ *   3. In --auto mode, Chrome is navigated automatically. Otherwise browse X manually.
+ *   4. Press Ctrl+C to stop (or wait for --auto to finish).
+ *
+ * Flags:
+ *   --auto  Automatically navigate Chrome through X.com pages via CDP
+ *   --all   Capture ALL GraphQL queries (skip relevance filter)
  */
 
+import { mkdirSync, existsSync } from 'node:fs';
+
 const CDP_BASE = 'http://localhost:9222';
+const CAPTURE_DIR = '/tmp/x-graphql-capture';
+
+// ─── Relevance filter ────────────────────────────────────────────────────────
+
+const RELEVANT_QUERIES = new Set([
+  // Reads
+  'UserByScreenName', 'UserTweets', 'TweetDetail', 'TweetResultByRestId',
+  'SearchTimeline', 'Bookmarks', 'Likes', 'Favoriters',
+  'Followers', 'Following', 'HomeTimeline', 'HomeLatestTimeline',
+  'NotificationsTimeline', 'ListTimeline',
+  'UserMedia',
+  // Writes
+  'CreateTweet', 'DeleteTweet', 'FavoriteTweet',
+  'UnfavoriteTweet', 'CreateRetweet', 'DeleteRetweet', 'CreateBookmark',
+  'DeleteBookmark',
+]);
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 interface CapturedQuery {
   queryName: string;
   queryId: string;
   method: string;
-  url: string;
   variables: unknown;
   features?: unknown;
-  responsePreview?: unknown;
+  response?: unknown;
+  timestamp: number;
 }
 
-const captured: CapturedQuery[] = [];
+// ─── Minimal CDP WebSocket client ────────────────────────────────────────────
 
-// Minimal CDP WebSocket client
 class CDPClient {
   private ws: WebSocket | null = null;
   private nextId = 1;
@@ -65,7 +88,104 @@ class CDPClient {
   close() { this.ws?.close(); }
 }
 
-// Discover Chrome tabs
+// ─── State ───────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const autoMode = args.includes('--auto');
+const captureAll = args.includes('--all');
+
+const captured: CapturedQuery[] = [];
+const seenQueries = new Set<string>();
+
+// Ensure capture directory exists
+if (!existsSync(CAPTURE_DIR)) mkdirSync(CAPTURE_DIR, { recursive: true });
+
+// ─── Auto-navigation steps ───────────────────────────────────────────────────
+
+interface GuideStep {
+  label: string;
+  url?: string;
+  clickSelector?: string;
+  expectedQueries: string[];
+}
+
+// Resolve the logged-in user's screen name for profile-based URLs
+async function getScreenName(): Promise<string | null> {
+  if (!navigationClient) return null;
+  try {
+    const result = await navigationClient.send('Runtime.evaluate', {
+      expression: `
+        (function() {
+          const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
+          if (link) return link.getAttribute('href')?.replace('/', '') ?? null;
+          return null;
+        })()
+      `,
+      awaitPromise: false,
+      returnByValue: true,
+    }) as { result?: { value?: string | null } };
+    return result?.result?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const GUIDE_STEPS: GuideStep[] = [
+  {
+    label: 'Home timeline',
+    url: 'https://x.com/home',
+    expectedQueries: ['HomeTimeline', 'HomeLatestTimeline'],
+  },
+  {
+    label: 'Profile',
+    // URL set dynamically in runAutoMode after resolving screen name
+    clickSelector: 'a[data-testid="AppTabBar_Profile_Link"]',
+    expectedQueries: ['UserByScreenName', 'UserTweets'],
+  },
+  {
+    label: 'Tweet detail',
+    clickSelector: 'article[data-testid="tweet"] a[href*="/status/"]',
+    expectedQueries: ['TweetDetail'],
+  },
+  {
+    label: 'Search',
+    url: 'https://x.com/search?q=hello&src=typed_query',
+    expectedQueries: ['SearchTimeline'],
+  },
+  {
+    label: 'Bookmarks',
+    url: 'https://x.com/i/bookmarks',
+    expectedQueries: ['Bookmarks'],
+  },
+  {
+    label: 'Notifications',
+    url: 'https://x.com/notifications',
+    expectedQueries: ['NotificationsTimeline'],
+  },
+  {
+    label: 'Likes',
+    // URL set dynamically
+    expectedQueries: ['Likes'],
+  },
+  {
+    label: 'Followers',
+    // URL set dynamically
+    expectedQueries: ['Followers'],
+  },
+  {
+    label: 'Following',
+    // URL set dynamically
+    expectedQueries: ['Following'],
+  },
+  {
+    label: 'Media',
+    // URL set dynamically
+    expectedQueries: ['UserMedia'],
+  },
+];
+
+// ─── Discover Chrome tabs ────────────────────────────────────────────────────
+
 const res = await fetch(`${CDP_BASE}/json/list`);
 if (!res.ok) {
   console.error('Chrome CDP not available. Run `vellum x refresh` first.');
@@ -81,40 +201,92 @@ if (pages.length === 0) {
 
 console.log(`Found ${pages.length} tab(s). Attaching to all...`);
 
-// Pending request data (requestId -> partial info)
-const pendingRequests = new Map<string, { url: string; postData?: string }>();
+// ─── Pending request tracking ────────────────────────────────────────────────
+
+const pendingRequests = new Map<string, { url: string; queryName: string }>();
+// Resolve callbacks for --auto mode: queryName → resolve function
+const queryWaiters = new Map<string, () => void>();
+
+function notifyQuerySeen(queryName: string) {
+  seenQueries.add(queryName);
+  const waiter = queryWaiters.get(queryName);
+  if (waiter) {
+    queryWaiters.delete(queryName);
+    waiter();
+  }
+}
+
+function waitForQuery(queryName: string, timeoutMs = 15000): Promise<boolean> {
+  if (seenQueries.has(queryName)) return Promise.resolve(true);
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      queryWaiters.delete(queryName);
+      resolve(false);
+    }, timeoutMs);
+    queryWaiters.set(queryName, () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+function waitForAnyQuery(queryNames: string[], timeoutMs = 15000): Promise<boolean> {
+  if (queryNames.some(q => seenQueries.has(q))) return Promise.resolve(true);
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      for (const q of queryNames) queryWaiters.delete(q);
+      resolve(false);
+    }, timeoutMs);
+    for (const q of queryNames) {
+      queryWaiters.set(q, () => {
+        clearTimeout(timer);
+        for (const q2 of queryNames) queryWaiters.delete(q2);
+        resolve(true);
+      });
+    }
+  });
+}
+
+// ─── Attach to all tabs ──────────────────────────────────────────────────────
+
+// We'll keep a reference to one client that's on an x.com tab for navigation
+let navigationClient: CDPClient | null = null;
+let navigationWsUrl: string | null = null;
 
 for (const page of pages) {
   const client = new CDPClient();
   await client.connect(page.webSocketDebuggerUrl);
   await client.send('Network.enable');
 
+  // Track which client is on an x.com tab for navigation
+  if (page.url.includes('x.com') || page.url.includes('twitter.com')) {
+    navigationClient = client;
+    navigationWsUrl = page.webSocketDebuggerUrl;
+  }
+
   client.on('Network.requestWillBeSent', (params) => {
     const req = params.request as Record<string, unknown> | undefined;
     const url = (req?.url ?? params.url) as string | undefined;
     if (!url?.includes('/i/api/graphql/')) return;
-    const method = (req?.method as string) ?? 'GET';
-    pendingRequests.set(params.requestId as string, {
-      url,
-      postData: req.postData as string | undefined,
-    });
 
-    // Extract query name from URL: /graphql/<queryId>/<QueryName>
     const match = url.match(/\/graphql\/([^/]+)\/([^?]+)/);
     const queryId = match?.[1] ?? 'unknown';
     const queryName = match?.[2] ?? 'unknown';
+    const method = (req?.method as string) ?? 'GET';
+
+    // Apply relevance filter
+    if (!captureAll && !RELEVANT_QUERIES.has(queryName)) return;
 
     let variables: unknown = undefined;
     let features: unknown = undefined;
 
-    if (method === 'POST' && req.postData) {
+    if (method === 'POST' && req?.postData) {
       try {
         const body = JSON.parse(req.postData as string);
         variables = body.variables;
         features = body.features;
       } catch { /* ignore */ }
     } else if (method === 'GET') {
-      // GET requests encode variables in query params
       try {
         const u = new URL(url);
         const v = u.searchParams.get('variables');
@@ -127,7 +299,8 @@ for (const page of pages) {
     console.log(`\n>>> ${method} ${queryName} (${queryId})`);
     if (variables) console.log(`    variables: ${JSON.stringify(variables).slice(0, 200)}`);
 
-    captured.push({ queryName, queryId, method, url, variables, features });
+    pendingRequests.set(params.requestId as string, { url, queryName });
+    captured.push({ queryName, queryId, method, variables, features, timestamp: Date.now() });
   });
 
   client.on('Network.responseReceived', (params) => {
@@ -139,30 +312,176 @@ for (const page of pages) {
     const status = response.status as number;
     console.log(`    <<< ${status}`);
 
-    // Try to get response body
+    // Get full response body
     client.send('Network.getResponseBody', { requestId }).then((result) => {
       const body = (result as Record<string, unknown>).body as string;
       try {
         const json = JSON.parse(body);
-        // Attach a preview to the last captured entry with matching URL
-        const entry = [...captured].reverse().find(e => e.url === pending.url);
-        if (entry) entry.responsePreview = JSON.stringify(json).slice(0, 500);
+        // Attach full response to the captured entry
+        const entry = [...captured].reverse().find(e => e.queryName === pending.queryName && !e.response);
+        if (entry) {
+          entry.response = json;
+
+          // Write individual file
+          const filename = `${pending.queryName}-${entry.timestamp}.json`;
+          Bun.write(`${CAPTURE_DIR}/${filename}`, JSON.stringify({
+            queryName: entry.queryName,
+            queryId: entry.queryId,
+            method: entry.method,
+            variables: entry.variables,
+            features: entry.features,
+            response: json,
+          }, null, 2));
+        }
+
+        // Notify waiters
+        notifyQuerySeen(pending.queryName);
       } catch { /* ignore */ }
-    }).catch(() => { /* body not available yet */ });
+    }).catch(() => { /* body not available */ });
 
     pendingRequests.delete(requestId);
   });
 }
 
-console.log('\nRecording X.com GraphQL requests...');
-console.log('Browse X in Chrome — visit a profile, scroll tweets, reply to one.');
-console.log('Press Ctrl+C to stop and dump results.\n');
+// If no x.com tab found, use the first page for navigation
+if (!navigationClient && pages.length > 0) {
+  navigationClient = new CDPClient();
+  await navigationClient.connect(pages[0].webSocketDebuggerUrl);
+  navigationWsUrl = pages[0].webSocketDebuggerUrl;
+}
 
-// Wait for Ctrl+C
-process.on('SIGINT', () => {
-  console.log(`\n\n=== Captured ${captured.length} GraphQL requests ===\n`);
+// ─── CDP navigation helpers ──────────────────────────────────────────────────
 
-  // Dedupe by queryName, keep first occurrence
+async function navigateTo(url: string): Promise<void> {
+  if (!navigationClient) return;
+  await navigationClient.send('Page.navigate', { url });
+  // Wait for page to load
+  await new Promise(r => setTimeout(r, 3000));
+}
+
+async function clickElement(selector: string): Promise<boolean> {
+  if (!navigationClient) return false;
+  try {
+    const result = await navigationClient.send('Runtime.evaluate', {
+      expression: `
+        (function() {
+          const el = document.querySelector(${JSON.stringify(selector)});
+          if (!el) return false;
+          el.scrollIntoView({ block: 'center' });
+          el.click();
+          return true;
+        })()
+      `,
+      awaitPromise: false,
+      returnByValue: true,
+    }) as { result?: { value?: boolean } };
+    return result?.result?.value === true;
+  } catch {
+    return false;
+  }
+}
+
+async function scrollDown(): Promise<void> {
+  if (!navigationClient) return;
+  try {
+    await navigationClient.send('Runtime.evaluate', {
+      expression: 'window.scrollBy(0, 800)',
+      awaitPromise: false,
+    });
+  } catch { /* ignore */ }
+}
+
+// ─── Auto mode ───────────────────────────────────────────────────────────────
+
+async function runAutoMode() {
+  console.log('\n🚗 Auto mode: navigating Chrome through X.com...\n');
+
+  // Enable Page domain for navigation
+  if (navigationClient) {
+    await navigationClient.send('Page.enable').catch(() => {});
+  }
+
+  // Navigate to home first to discover the screen name
+  await navigateTo('https://x.com/home');
+  const screenName = await getScreenName();
+  if (screenName) {
+    console.log(`  Detected user: @${screenName}\n`);
+    // Fill in profile-based URLs
+    for (const step of GUIDE_STEPS) {
+      if (step.label === 'Likes') step.url = `https://x.com/${screenName}/likes`;
+      if (step.label === 'Followers') step.url = `https://x.com/${screenName}/followers`;
+      if (step.label === 'Following') step.url = `https://x.com/${screenName}/following`;
+      if (step.label === 'Media') step.url = `https://x.com/${screenName}/media`;
+    }
+  } else {
+    console.log('  Could not detect screen name — some steps will use click navigation\n');
+  }
+
+  const completedSteps: string[] = [];
+  const failedSteps: string[] = [];
+
+  for (const step of GUIDE_STEPS) {
+    const alreadySeen = step.expectedQueries.some(q => seenQueries.has(q));
+    if (alreadySeen) {
+      console.log(`  ✓ ${step.label} (already captured)`);
+      completedSteps.push(step.label);
+      continue;
+    }
+
+    process.stdout.write(`  ⏳ ${step.label}...`);
+
+    // Navigate if URL provided
+    if (step.url) {
+      await navigateTo(step.url);
+    }
+
+    // Click if selector provided
+    if (step.clickSelector) {
+      await new Promise(r => setTimeout(r, 1500)); // wait for page to settle
+      const clicked = await clickElement(step.clickSelector);
+      if (!clicked) {
+        // Try scrolling and clicking again
+        await scrollDown();
+        await new Promise(r => setTimeout(r, 1000));
+        await clickElement(step.clickSelector);
+      }
+      await new Promise(r => setTimeout(r, 2000)); // wait for navigation
+    }
+
+    // Scroll to trigger lazy-loaded content
+    await scrollDown();
+
+    // Wait for any expected query
+    const seen = await waitForAnyQuery(step.expectedQueries, 10000);
+
+    if (seen) {
+      const captured = step.expectedQueries.filter(q => seenQueries.has(q));
+      console.log(`\r  ✅ ${step.label} → ${captured.join(', ')}`);
+      completedSteps.push(step.label);
+    } else {
+      console.log(`\r  ⚠️  ${step.label} → no queries captured (page may need manual interaction)`);
+      failedSteps.push(step.label);
+    }
+  }
+
+  console.log(`\n🏁 Auto navigation complete: ${completedSteps.length}/${GUIDE_STEPS.length} steps succeeded`);
+  if (failedSteps.length > 0) {
+    console.log(`   Missed: ${failedSteps.join(', ')}`);
+  }
+
+  // Finish
+  printSummary();
+  process.exit(0);
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+function printSummary() {
+  console.log(`\n\n${'='.repeat(60)}`);
+  console.log(`  Captured ${captured.length} GraphQL requests`);
+  console.log(`${'='.repeat(60)}\n`);
+
+  // Dedupe by queryName
   const seen = new Set<string>();
   const unique = captured.filter(q => {
     if (seen.has(q.queryName)) return false;
@@ -170,20 +489,74 @@ process.on('SIGINT', () => {
     return true;
   });
 
+  // Print table
+  const nameWidth = Math.max(25, ...unique.map(q => q.queryName.length));
+  const idWidth = 22;
+  const methodWidth = 6;
+
+  console.log(
+    `  ${'Query'.padEnd(nameWidth)}  ${'QueryID'.padEnd(idWidth)}  ${'Method'.padEnd(methodWidth)}  Variables`,
+  );
+  console.log(`  ${'─'.repeat(nameWidth)}  ${'─'.repeat(idWidth)}  ${'─'.repeat(methodWidth)}  ${'─'.repeat(30)}`);
+
   for (const q of unique) {
-    console.log(`--- ${q.queryName} ---`);
-    console.log(`  Query ID: ${q.queryId}`);
-    console.log(`  Method: ${q.method}`);
-    console.log(`  Variables: ${JSON.stringify(q.variables, null, 2)}`);
-    if (q.responsePreview) {
-      console.log(`  Response preview: ${q.responsePreview}`);
-    }
-    console.log('');
+    const varKeys = q.variables && typeof q.variables === 'object'
+      ? Object.keys(q.variables as Record<string, unknown>).join(', ')
+      : '—';
+    console.log(
+      `  ${q.queryName.padEnd(nameWidth)}  ${q.queryId.padEnd(idWidth)}  ${q.method.padEnd(methodWidth)}  ${varKeys}`,
+    );
   }
 
-  // Also dump full JSON
-  const outPath = '/tmp/x-graphql-capture.json';
-  Bun.write(outPath, JSON.stringify(captured, null, 2));
-  console.log(`Full capture saved to ${outPath}`);
+  // Gap analysis
+  if (!captureAll) {
+    const notSeen = [...RELEVANT_QUERIES].filter(q => !seenQueries.has(q));
+    if (notSeen.length > 0) {
+      console.log(`\n  ⚠️  Not captured (${notSeen.length}):`);
+      for (const q of notSeen) {
+        console.log(`     • ${q}`);
+      }
+    } else {
+      console.log('\n  ✅ All relevant queries captured!');
+    }
+  }
+
+  // Save summary
+  const summaryPath = `${CAPTURE_DIR}/summary.json`;
+  const summary = {
+    capturedAt: new Date().toISOString(),
+    totalRequests: captured.length,
+    uniqueQueries: unique.map(q => ({
+      queryName: q.queryName,
+      queryId: q.queryId,
+      method: q.method,
+      variableKeys: q.variables && typeof q.variables === 'object'
+        ? Object.keys(q.variables as Record<string, unknown>)
+        : [],
+    })),
+    notCaptured: captureAll ? [] : [...RELEVANT_QUERIES].filter(q => !seenQueries.has(q)),
+  };
+  Bun.write(summaryPath, JSON.stringify(summary, null, 2));
+  console.log(`\n  Summary saved to ${summaryPath}`);
+  console.log(`  Individual captures in ${CAPTURE_DIR}/`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+if (autoMode) {
+  console.log('\nRecording X.com GraphQL requests (auto mode)...');
+  console.log(`Filter: ${captureAll ? 'ALL queries' : `${RELEVANT_QUERIES.size} relevant queries`}`);
+  // Give network listeners a moment to settle, then start auto-navigation
+  setTimeout(() => runAutoMode(), 1000);
+} else {
+  console.log('\nRecording X.com GraphQL requests...');
+  console.log(`Filter: ${captureAll ? 'ALL queries' : `${RELEVANT_QUERIES.size} relevant queries`}`);
+  console.log('Browse X in Chrome — visit a profile, scroll tweets, search.');
+  console.log('Press Ctrl+C to stop and dump results.\n');
+}
+
+// Ctrl+C handler
+process.on('SIGINT', () => {
+  printSummary();
   process.exit(0);
 });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -16,6 +16,15 @@ import {
   postTweet,
   getUserByScreenName,
   getUserTweets,
+  getTweetDetail,
+  searchTweets,
+  getBookmarks,
+  getHomeTimeline,
+  getNotifications,
+  getLikes,
+  getFollowers,
+  getFollowing,
+  getUserMedia,
   SessionExpiredError,
 } from '../twitter/client.js';
 import { getSocketPath, readSessionToken } from '../util/platform.js';
@@ -237,6 +246,140 @@ export function registerTwitterCommand(program: Command): void {
       await run(cmd, async () => {
         const user = await getUserByScreenName(screenName.replace(/^@/, ''));
         const tweets = await getUserTweets(user.userId, parseInt(opts.count, 10));
+        return { user, tweets };
+      });
+    });
+
+  // =========================================================================
+  // tweet — fetch a single tweet and its replies
+  // =========================================================================
+  tw.command('tweet')
+    .description('Fetch a tweet and its reply thread')
+    .argument('<tweetIdOrUrl>', 'Tweet ID or URL')
+    .action(async (tweetIdOrUrl: string, _opts: unknown, cmd: Command) => {
+      await run(cmd, async () => {
+        const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
+        if (!idMatch) throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
+        const tweets = await getTweetDetail(idMatch[1]);
+        return { tweets };
+      });
+    });
+
+  // =========================================================================
+  // search — search tweets
+  // =========================================================================
+  tw.command('search')
+    .description('Search tweets')
+    .argument('<query>', 'Search query')
+    .option('--count <n>', 'Number of results', '20')
+    .option('--product <type>', 'Top, Latest, People, or Media', 'Top')
+    .action(async (query: string, opts: { count: string; product: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const tweets = await searchTweets(
+          query,
+          parseInt(opts.count, 10),
+          opts.product as 'Top' | 'Latest' | 'People' | 'Media',
+        );
+        return { query, tweets };
+      });
+    });
+
+  // =========================================================================
+  // bookmarks — fetch bookmarks
+  // =========================================================================
+  tw.command('bookmarks')
+    .description('Fetch your bookmarks')
+    .option('--count <n>', 'Number of bookmarks', '20')
+    .action(async (opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const tweets = await getBookmarks(parseInt(opts.count, 10));
+        return { tweets };
+      });
+    });
+
+  // =========================================================================
+  // home — fetch home timeline
+  // =========================================================================
+  tw.command('home')
+    .description('Fetch your home timeline')
+    .option('--count <n>', 'Number of tweets', '20')
+    .action(async (opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const tweets = await getHomeTimeline(parseInt(opts.count, 10));
+        return { tweets };
+      });
+    });
+
+  // =========================================================================
+  // notifications — fetch notifications
+  // =========================================================================
+  tw.command('notifications')
+    .description('Fetch your notifications')
+    .option('--count <n>', 'Number of notifications', '20')
+    .action(async (opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const notifications = await getNotifications(parseInt(opts.count, 10));
+        return { notifications };
+      });
+    });
+
+  // =========================================================================
+  // likes — fetch a user's liked tweets
+  // =========================================================================
+  tw.command('likes')
+    .description("Fetch a user's liked tweets")
+    .argument('<screenName>', 'Twitter screen name (without @)')
+    .option('--count <n>', 'Number of likes', '20')
+    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const user = await getUserByScreenName(screenName.replace(/^@/, ''));
+        const tweets = await getLikes(user.userId, parseInt(opts.count, 10));
+        return { user, tweets };
+      });
+    });
+
+  // =========================================================================
+  // followers — fetch a user's followers
+  // =========================================================================
+  tw.command('followers')
+    .description("Fetch a user's followers")
+    .argument('<screenName>', 'Twitter screen name (without @)')
+    .option('--count <n>', 'Number of followers', '20')
+    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const cleanName = screenName.replace(/^@/, '');
+        const user = await getUserByScreenName(cleanName);
+        const followers = await getFollowers(user.userId, parseInt(opts.count, 10), cleanName);
+        return { user, followers };
+      });
+    });
+
+  // =========================================================================
+  // following — fetch who a user follows
+  // =========================================================================
+  tw.command('following')
+    .description("Fetch who a user follows")
+    .argument('<screenName>', 'Twitter screen name (without @)')
+    .option('--count <n>', 'Number of following', '20')
+    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const user = await getUserByScreenName(screenName.replace(/^@/, ''));
+        const following = await getFollowing(user.userId, parseInt(opts.count, 10));
+        return { user, following };
+      });
+    });
+
+  // =========================================================================
+  // media — fetch a user's media tweets
+  // =========================================================================
+  tw.command('media')
+    .description("Fetch a user's media tweets")
+    .argument('<screenName>', 'Twitter screen name (without @)')
+    .option('--count <n>', 'Number of media tweets', '20')
+    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const user = await getUserByScreenName(screenName.replace(/^@/, ''));
+        const tweets = await getUserMedia(user.userId, parseInt(opts.count, 10));
         return { user, tweets };
       });
     });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -271,13 +271,11 @@ export function registerTwitterCommand(program: Command): void {
   tw.command('search')
     .description('Search tweets')
     .argument('<query>', 'Search query')
-    .option('--count <n>', 'Number of results', '20')
     .option('--product <type>', 'Top, Latest, People, or Media', 'Top')
-    .action(async (query: string, opts: { count: string; product: string }, cmd: Command) => {
+    .action(async (query: string, opts: { product: string }, cmd: Command) => {
       await run(cmd, async () => {
         const tweets = await searchTweets(
           query,
-          parseInt(opts.count, 10),
           opts.product as 'Top' | 'Latest' | 'People' | 'Media',
         );
         return { query, tweets };
@@ -344,12 +342,11 @@ export function registerTwitterCommand(program: Command): void {
   tw.command('followers')
     .description("Fetch a user's followers")
     .argument('<screenName>', 'Twitter screen name (without @)')
-    .option('--count <n>', 'Number of followers', '20')
-    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+    .action(async (screenName: string, _opts: unknown, cmd: Command) => {
       await run(cmd, async () => {
         const cleanName = screenName.replace(/^@/, '');
         const user = await getUserByScreenName(cleanName);
-        const followers = await getFollowers(user.userId, parseInt(opts.count, 10), cleanName);
+        const followers = await getFollowers(user.userId, cleanName);
         return { user, followers };
       });
     });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -14,6 +14,8 @@ import {
 } from '../twitter/session.js';
 import {
   postTweet,
+  getUserByScreenName,
+  getUserTweets,
   SessionExpiredError,
 } from '../twitter/client.js';
 import { getSocketPath, readSessionToken } from '../util/platform.js';
@@ -197,6 +199,45 @@ export function registerTwitterCommand(program: Command): void {
           text: result.text,
           url: result.url,
         };
+      });
+    });
+
+  // =========================================================================
+  // reply — reply to a tweet
+  // =========================================================================
+  tw.command('reply')
+    .description('Reply to a tweet')
+    .argument('<tweetUrl>', 'Tweet URL or tweet ID')
+    .argument('<text>', 'Reply text')
+    .action(async (tweetUrl: string, text: string, _opts: unknown, cmd: Command) => {
+      await run(cmd, async () => {
+        // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL
+        const idMatch = tweetUrl.match(/(\d+)\s*$/);
+        if (!idMatch) {
+          throw new Error(`Could not extract tweet ID from: ${tweetUrl}`);
+        }
+        const inReplyToTweetId = idMatch[1];
+        const result = await postTweet(text, { inReplyToTweetId });
+        return {
+          tweetId: result.tweetId,
+          text: result.text,
+          url: result.url,
+          inReplyToTweetId,
+        };
+      });
+    });
+  // =========================================================================
+  // timeline — fetch a user's recent tweets
+  // =========================================================================
+  tw.command('timeline')
+    .description("Fetch a user's recent tweets")
+    .argument('<screenName>', 'Twitter screen name (without @)')
+    .option('--count <n>', 'Number of tweets to fetch', '20')
+    .action(async (screenName: string, opts: { count: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const user = await getUserByScreenName(screenName.replace(/^@/, ''));
+        const tweets = await getUserTweets(user.userId, parseInt(opts.count, 10));
+        return { user, tweets };
       });
     });
 }

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "X"
-description: "Post on X (formerly Twitter) using your authenticated session"
+description: "Read and post on X (formerly Twitter) using your authenticated session"
 user-invocable: true
 metadata: {"vellum": {"emoji": "𝕏"}}
 ---
@@ -13,7 +13,7 @@ You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `v
 vellum x post "The post text here"
 ```
 
-The command returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share the URL with the user so they can verify the post.
+Returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share the URL with the user so they can verify the post.
 
 ## Replying
 
@@ -21,34 +21,77 @@ The command returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share t
 vellum x reply <tweetUrl> "The reply text here"
 ```
 
-The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID. The command returns the same JSON fields as `post`, plus `inReplyToTweetId`.
+The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID.
 
-## Fetching Tweets
+## Reading
 
+### User timeline
 ```bash
 vellum x timeline <screenName> [--count N]
 ```
+Returns `user` and `tweets` array.
 
-The `screenName` argument is **required** (without the `@` prefix). To find the user's own screen name, check `vellum x status` or ask them.
+### Single tweet + replies
+```bash
+vellum x tweet <tweetIdOrUrl>
+```
+Returns the focal tweet and its reply thread.
 
-Returns JSON with `user` (userId, screenName, name) and `tweets` (array of tweetId, text, url, createdAt). Use this to look up a user's recent posts — e.g. to find the latest tweet before replying to it.
+### Search
+```bash
+vellum x search "query" [--count N] [--product Top|Latest|People|Media]
+```
+
+### Home timeline
+```bash
+vellum x home [--count N]
+```
+
+### Bookmarks
+```bash
+vellum x bookmarks [--count N]
+```
+
+### Notifications
+```bash
+vellum x notifications [--count N]
+```
+Returns `notifications` array with `id`, `message`, `timestamp`, `url`.
+
+### Likes
+```bash
+vellum x likes <screenName> [--count N]
+```
+
+### Followers / Following
+```bash
+vellum x followers <screenName> [--count N]
+vellum x following <screenName> [--count N]
+```
+Returns `user` and `followers`/`following` array (userId, screenName, name).
+
+### Media
+```bash
+vellum x media <screenName> [--count N]
+```
+Returns tweets that contain media from the user's profile.
 
 ## Session Management
 
-Before posting, check if a session exists:
-
+Check if a session exists:
 ```bash
 vellum x status --json
 ```
 
-If there is no session or the session has expired, run refresh to capture a fresh one automatically:
-
+If there is no session or the session has expired, refresh it:
 ```bash
 vellum x refresh
 ```
 
-This opens Chrome, navigates to x.com, and captures auth cookies via Ride Shotgun. Do NOT tell the user to run this manually — run it yourself.
+This opens Chrome, navigates through x.com automatically, and captures auth cookies. Do NOT tell the user to run this manually — run it yourself.
 
 ## Tips
 
 - Keep posts under 280 characters
+- All `screenName` arguments should be without the `@` prefix
+- All commands return JSON with an `ok` field

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -90,8 +90,45 @@ vellum x refresh
 
 This opens Chrome, navigates through x.com automatically, and captures auth cookies. Do NOT tell the user to run this manually — run it yourself.
 
+## Workflows
+
+### Check Mentions
+
+When the user asks to check mentions, check X, or see what's happening:
+
+1. Fetch notifications: `vellum x notifications --count 20 --json`
+2. Fetch their recent tweets to see replies: `vellum x timeline <theirScreenName> --count 10 --json`
+3. Summarize what needs attention:
+   - Group by type: replies to their tweets, likes, new followers, mentions
+   - For anything that looks like it needs a reply, fetch the full thread with `vellum x tweet <tweetId>` to understand context
+   - Prioritize: direct questions > mentions > engagement notifications
+4. For items that need replies, draft a response and ask the user to approve before sending with `vellum x reply`
+
+Present the summary as a scannable list, not a wall of text. Lead with action items.
+
+### Research a Topic
+
+When the user wants to understand what people are saying about something:
+
+1. Search: `vellum x search "topic" --count 20 --json`
+2. For the most interesting tweets, fetch threads: `vellum x tweet <tweetId>`
+3. Summarize: key themes, notable voices, sentiment, and any emerging consensus
+4. If the user wants to engage, draft a post or reply that adds to the conversation
+
+### Engagement Check
+
+When the user wants to see how their posts are performing:
+
+1. Fetch their recent tweets: `vellum x timeline <screenName> --count 20 --json`
+2. For each tweet, note engagement signals from the text/metadata
+3. Fetch notifications to see who's interacting: `vellum x notifications --count 20 --json`
+4. Summarize: which posts got traction, who's engaging, any conversations worth continuing
+
 ## Tips
 
 - Keep posts under 280 characters
 - All `screenName` arguments should be without the `@` prefix
 - All commands return JSON with an `ok` field
+- When drafting replies, match the tone of the conversation — casual threads get casual replies
+- Always show the user what you're about to post and get approval before sending
+- If a session is expired, refresh it silently with `vellum x refresh` before retrying

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -15,6 +15,24 @@ vellum x post "The post text here"
 
 The command returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share the URL with the user so they can verify the post.
 
+## Replying
+
+```bash
+vellum x reply <tweetUrl> "The reply text here"
+```
+
+The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID. The command returns the same JSON fields as `post`, plus `inReplyToTweetId`.
+
+## Fetching Tweets
+
+```bash
+vellum x timeline <screenName> [--count N]
+```
+
+The `screenName` argument is **required** (without the `@` prefix). To find the user's own screen name, check `vellum x status` or ask them.
+
+Returns JSON with `user` (userId, screenName, name) and `tweets` (array of tweetId, text, url, createdAt). Use this to look up a user's recent posts — e.g. to find the latest tweet before replying to it.
+
 ## Session Management
 
 Before posting, check if a session exists:

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -982,6 +982,9 @@ function buildDynamicSkillWorkflowSection(): string {
     '',
     '### Browser Skill Prerequisite',
     'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
+    '',
+    '### X (Twitter) Skill',
+    'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the X skill provides CLI commands (`vellum x post`, `vellum x reply`) that are faster and more reliable.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -15,6 +15,7 @@ import { getLogger } from '../util/logger.js';
 import { NetworkRecorder } from '../tools/browser/network-recorder.js';
 import { saveRecording } from '../tools/browser/recording-store.js';
 import type { SessionRecording } from '../tools/browser/network-recording-types.js';
+import { navigateXPages } from '../tools/browser/x-auto-navigate.js';
 
 const log = getLogger('ride-shotgun-handler');
 
@@ -130,13 +131,39 @@ export async function handleRideShotgunStart(
             await recorder.stop();
             return;
           }
-          // Auto-stop when login is detected
-          recorder.onLoginDetected = () => {
-            log.info({ watchId }, 'Login detected — auto-stopping learn session');
-            completeSession(session);
-          };
           activeRecorders.set(watchId, recorder);
           log.info({ watchId, targetDomain, attempt }, 'Network recording started for learn session');
+
+          // For x.com, auto-navigate Chrome through key pages to capture the full API surface.
+          // Skip login detection — auto-navigation will complete the session when done.
+          if (targetDomain === 'x.com' || targetDomain === 'twitter.com') {
+            // Don't set onLoginDetected — it would kill the session after the first
+            // GraphQL call (5s grace), before auto-navigation finishes.
+            const abortSignal = { aborted: false };
+            const checkInterval = setInterval(() => {
+              if (session.status !== 'active') {
+                abortSignal.aborted = true;
+                clearInterval(checkInterval);
+              }
+            }, 1000);
+            navigateXPages(abortSignal).then(completed => {
+              clearInterval(checkInterval);
+              log.info({ watchId, completedSteps: completed.length }, 'X auto-navigation finished');
+              if (session.status === 'active') {
+                completeSession(session);
+              }
+            }).catch(err => {
+              clearInterval(checkInterval);
+              log.warn({ err, watchId }, 'X auto-navigation failed');
+            });
+          } else {
+            // Non-X domains: use login detection as before
+            recorder.onLoginDetected = () => {
+              log.info({ watchId }, 'Login detected — auto-stopping learn session');
+              completeSession(session);
+            };
+          }
+
           return;
         } catch (err) {
           if (attempt < 9) {

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -155,6 +155,9 @@ export async function handleRideShotgunStart(
             }).catch(err => {
               clearInterval(checkInterval);
               log.warn({ err, watchId }, 'X auto-navigation failed');
+              if (session.status === 'active') {
+                completeSession(session);
+              }
             });
           } else {
             // Non-X domains: use login detection as before

--- a/assistant/src/tools/browser/x-auto-navigate.ts
+++ b/assistant/src/tools/browser/x-auto-navigate.ts
@@ -1,0 +1,207 @@
+/**
+ * CDP-based auto-navigation for X.com.
+ *
+ * Drives Chrome through key X.com pages to trigger GraphQL API calls,
+ * so the NetworkRecorder captures the full API surface without manual browsing.
+ */
+
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('x-auto-navigate');
+
+const CDP_BASE = 'http://localhost:9222';
+
+interface NavStep {
+  label: string;
+  url?: string;
+  clickSelector?: string;
+}
+
+/** Minimal CDP client — connects to one page tab. */
+class MiniCDP {
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private callbacks = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+  async connect(wsUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(wsUrl);
+      ws.onopen = () => { this.ws = ws; resolve(); };
+      ws.onerror = (e) => reject(new Error(`CDP error: ${e}`));
+      ws.onclose = () => { this.ws = null; };
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(String(event.data));
+        if (msg.id != null) {
+          const cb = this.callbacks.get(msg.id);
+          if (cb) {
+            this.callbacks.delete(msg.id);
+            msg.error ? cb.reject(new Error(msg.error.message)) : cb.resolve(msg.result);
+          }
+        }
+      };
+    });
+  }
+
+  async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!this.ws) throw new Error('Not connected');
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.callbacks.set(id, { resolve, reject });
+      this.ws!.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() { this.ws?.close(); }
+}
+
+/**
+ * Navigate Chrome through X.com pages to trigger GraphQL calls.
+ * The NetworkRecorder should already be attached and capturing.
+ *
+ * @param abortSignal Optional signal to stop navigation early.
+ * @returns List of step labels that completed successfully.
+ */
+export async function navigateXPages(abortSignal?: { aborted: boolean }): Promise<string[]> {
+  let wsUrl: string | null = null;
+  try {
+    const res = await fetch(`${CDP_BASE}/json/list`);
+    if (!res.ok) {
+      log.warn('CDP not available for auto-navigation');
+      return [];
+    }
+    const targets = (await res.json()) as Array<{ type: string; url: string; webSocketDebuggerUrl: string }>;
+    const xTab = targets.find(
+      t => t.type === 'page' && (t.url.includes('x.com') || t.url.includes('twitter.com')),
+    );
+    wsUrl = xTab?.webSocketDebuggerUrl ?? targets.find(t => t.type === 'page')?.webSocketDebuggerUrl ?? null;
+  } catch (err) {
+    log.warn({ err }, 'Failed to discover Chrome tabs');
+    return [];
+  }
+
+  if (!wsUrl) {
+    log.warn('No Chrome tab found for auto-navigation');
+    return [];
+  }
+
+  const cdp = new MiniCDP();
+  try {
+    await cdp.connect(wsUrl);
+  } catch (err) {
+    log.warn({ err }, 'Failed to connect CDP for auto-navigation');
+    return [];
+  }
+
+  await cdp.send('Page.enable').catch(() => {});
+  const completed: string[] = [];
+
+  // Navigate to home first to discover the screen name
+  try {
+    await cdp.send('Page.navigate', { url: 'https://x.com/home' });
+    await sleep(3000);
+  } catch (err) {
+    log.warn({ err }, 'Failed to navigate to home');
+    cdp.close();
+    return [];
+  }
+
+  // Resolve screen name for profile-based URLs
+  let screenName: string | null = null;
+  try {
+    const result = await cdp.send('Runtime.evaluate', {
+      expression: `
+        (function() {
+          const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
+          if (link) return link.getAttribute('href')?.replace('/', '') ?? null;
+          return null;
+        })()
+      `,
+      awaitPromise: false,
+      returnByValue: true,
+    }) as { result?: { value?: string | null } };
+    screenName = result?.result?.value ?? null;
+  } catch { /* ignore */ }
+
+  log.info({ screenName }, 'Detected screen name');
+
+  // Build steps with resolved URLs
+  const steps: NavStep[] = [
+    { label: 'Home timeline', url: 'https://x.com/home' },
+    { label: 'Profile', clickSelector: 'a[data-testid="AppTabBar_Profile_Link"]' },
+    { label: 'Tweet detail', clickSelector: 'article[data-testid="tweet"] a[href*="/status/"]' },
+    { label: 'Search', url: 'https://x.com/search?q=hello&src=typed_query' },
+    { label: 'Bookmarks', url: 'https://x.com/i/bookmarks' },
+    { label: 'Notifications', url: 'https://x.com/notifications' },
+  ];
+
+  // Add profile-based URLs if we have the screen name
+  if (screenName) {
+    steps.push(
+      { label: 'Likes', url: `https://x.com/${screenName}/likes` },
+      { label: 'Followers', url: `https://x.com/${screenName}/followers` },
+      { label: 'Following', url: `https://x.com/${screenName}/following` },
+      { label: 'Media', url: `https://x.com/${screenName}/media` },
+    );
+  }
+
+  for (const step of steps) {
+    if (abortSignal?.aborted) break;
+
+    log.info({ step: step.label }, 'Auto-navigate step starting');
+
+    try {
+      if (step.url) {
+        await cdp.send('Page.navigate', { url: step.url });
+        await sleep(3000);
+      }
+
+      if (step.clickSelector) {
+        await sleep(1500);
+        await clickInPage(cdp, step.clickSelector);
+        await sleep(2000);
+      }
+
+      // Scroll to trigger lazy-loaded content
+      await cdp.send('Runtime.evaluate', {
+        expression: 'window.scrollBy(0, 800)',
+        awaitPromise: false,
+      }).catch(() => {});
+
+      await sleep(2000);
+
+      completed.push(step.label);
+      log.info({ step: step.label }, 'Auto-navigate step completed');
+    } catch (err) {
+      log.warn({ err, step: step.label }, 'Auto-navigate step failed');
+    }
+  }
+
+  cdp.close();
+  log.info({ completed: completed.length, total: steps.length }, 'Auto-navigation finished');
+  return completed;
+}
+
+async function clickInPage(cdp: MiniCDP, selector: string): Promise<boolean> {
+  try {
+    const result = await cdp.send('Runtime.evaluate', {
+      expression: `
+        (function() {
+          const el = document.querySelector(${JSON.stringify(selector)});
+          if (!el) return false;
+          el.scrollIntoView({ block: 'center' });
+          el.click();
+          return true;
+        })()
+      `,
+      awaitPromise: false,
+      returnByValue: true,
+    }) as { result?: { value?: boolean } };
+    return result?.result?.value === true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}

--- a/assistant/src/twitter/client.ts
+++ b/assistant/src/twitter/client.ts
@@ -1,6 +1,6 @@
 /**
  * Twitter API client.
- * Executes GraphQL mutations through Chrome's CDP (Runtime.evaluate) so requests
+ * Executes GraphQL queries through Chrome's CDP (Runtime.evaluate) so requests
  * go through the browser's authenticated session.
  */
 
@@ -15,17 +15,33 @@ const CDP_BASE = 'http://localhost:9222';
 const BEARER_TOKEN =
   'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 
-/** Query ID for CreateTweet persisted query. */
-const CREATE_TWEET_QUERY_ID = 'Ah3G_byjEDs_HSlgU0PyZw';
+// ─── Query IDs (captured from x.com) ─────────────────────────────────────────
 
-/** Query ID for UserByScreenName persisted query. */
-const USER_BY_SCREEN_NAME_QUERY_ID = 'AWbeRIdkLtqTRN7yL_H8yw';
+const QUERY_IDS = {
+  CreateTweet: 'Ah3G_byjEDs_HSlgU0PyZw',
+  UserByScreenName: 'AWbeRIdkLtqTRN7yL_H8yw',
+  UserTweets: 'N2tFDY-MlrLxXJ9F_ZxJGA',
+  TweetDetail: 'YCNdW_ZytXfV9YR3cJK9kw',
+  SearchTimeline: 'ML-n2SfAxx5S_9QMqNejbg',
+  Bookmarks: 'toTC7lB_mQm5fuBE5yyEJw',
+  HomeTimeline: 'nn16KxqX3E1OdE7WlHB5LA',
+  NotificationsTimeline: 'saZw4lppu6QzMEiRUCYurg',
+  Likes: 'Pcw-j9lrSeDMmkgnIejJiQ',
+  Followers: 'P7m4Qr-rJEB8KUluOenU6A',
+  Following: 'T5wihsMTYHncY7BB4YxHSg',
+  UserMedia: 'xLCC9bG_VqHfXXgq8jPoCg',
+} as const;
 
-/** Query ID for UserTweets persisted query. */
-const USER_TWEETS_QUERY_ID = 'eApPT8jppbYXlweF_ByTyA';
-
-/** Feature flags required by the CreateTweet mutation. */
-const CREATE_TWEET_FEATURES: Record<string, boolean> = {
+/** Feature flags shared by all GraphQL endpoints. */
+const FEATURES: Record<string, boolean> = {
+  rweb_video_screen_enabled: false,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: false,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
   premium_content_api_read_enabled: false,
   communities_web_enable_tweet_community_results_fetch: true,
   c9s_tweet_anatomy_moderator_badge_enabled: true,
@@ -34,6 +50,7 @@ const CREATE_TWEET_FEATURES: Record<string, boolean> = {
   responsive_web_jetfuel_frame: true,
   responsive_web_grok_share_attachment_enabled: true,
   responsive_web_grok_annotations_enabled: true,
+  articles_preview_enabled: true,
   responsive_web_edit_tweet_api_enabled: true,
   graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
   view_counts_everywhere_api_enabled: true,
@@ -43,23 +60,18 @@ const CREATE_TWEET_FEATURES: Record<string, boolean> = {
   responsive_web_grok_show_grok_translated_post: true,
   responsive_web_grok_analysis_button_from_backend: true,
   post_ctas_fetch_enabled: true,
-  longform_notetweets_rich_text_read_enabled: true,
-  longform_notetweets_inline_media_enabled: true,
-  profile_label_improvements_pcf_label_in_post_enabled: true,
-  responsive_web_profile_redirect_enabled: false,
-  rweb_tipjar_consumption_enabled: false,
-  verified_phone_label_enabled: false,
-  articles_preview_enabled: true,
-  responsive_web_grok_community_note_auto_translation_is_enabled: false,
-  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
   freedom_of_speech_not_reach_fetch_enabled: true,
   standardized_nudges_misinfo: true,
   tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
   responsive_web_grok_image_annotation_enabled: true,
   responsive_web_grok_imagine_annotation_enabled: true,
-  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_grok_community_note_auto_translation_is_enabled: false,
   responsive_web_enhance_cards_enabled: false,
 };
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
 
 /** Thrown when the session is missing or expired. */
 export class SessionExpiredError extends Error {
@@ -77,9 +89,8 @@ function requireSession(): TwitterSession {
   return session;
 }
 
-/**
- * Find a Chrome tab on x.com and return its WebSocket debugger URL.
- */
+// ─── CDP transport ───────────────────────────────────────────────────────────
+
 async function findTwitterTab(): Promise<string> {
   const res = await fetch(`${CDP_BASE}/json/list`).catch(() => null);
   if (!res?.ok) {
@@ -95,104 +106,149 @@ async function findTwitterTab(): Promise<string> {
   return tab.webSocketDebuggerUrl;
 }
 
-/**
- * Execute a fetch() call inside Chrome's page context via CDP Runtime.evaluate.
- */
+/** Standard headers for X API requests (as a JS expression for Runtime.evaluate). */
+const API_HEADERS_GET = `{
+      'authorization': 'Bearer ${BEARER_TOKEN}',
+      'x-csrf-token': csrf,
+      'x-twitter-auth-type': 'OAuth2Session',
+      'x-twitter-active-user': 'yes',
+      'x-twitter-client-language': 'en',
+    }`;
+
+const API_HEADERS_POST = `{
+      'Content-Type': 'application/json',
+      'authorization': 'Bearer ${BEARER_TOKEN}',
+      'x-csrf-token': csrf,
+      'x-twitter-auth-type': 'OAuth2Session',
+      'x-twitter-active-user': 'yes',
+      'x-twitter-client-language': 'en',
+    }`;
+
+/** Execute a POST fetch inside Chrome via CDP Runtime.evaluate. */
 async function cdpFetch(wsUrl: string, url: string, body: string): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(wsUrl);
-    const id = 1;
+  return cdpEval(wsUrl, `
+    (function() {
+      var csrf = (document.cookie.match(/ct0=([^;]+)/) || [])[1] || '';
+      return fetch(${JSON.stringify(url)}, {
+        method: 'POST',
+        headers: ${API_HEADERS_POST},
+        body: ${JSON.stringify(body)},
+        credentials: 'include',
+      })
+      .then(function(r) {
+        if (!r.ok) return r.text().then(function(t) {
+          return JSON.stringify({ __status: r.status, __error: true, __body: t.substring(0, 500) });
+        });
+        return r.text();
+      })
+      .catch(function(e) { return JSON.stringify({ __error: true, __message: e.message }); });
+    })()
+  `);
+}
 
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error('CDP fetch timed out after 30s'));
-    }, 30000);
-
-    ws.onopen = () => {
-      const fetchScript = `
-        (function() {
-          var csrf = (document.cookie.match(/ct0=([^;]+)/) || [])[1] || '';
-          return fetch(${JSON.stringify(url)}, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'authorization': 'Bearer ${BEARER_TOKEN}',
-              'x-csrf-token': csrf,
-              'x-twitter-auth-type': 'OAuth2Session',
-              'x-twitter-active-user': 'yes',
-              'x-twitter-client-language': 'en',
-            },
-            body: ${JSON.stringify(body)},
-            credentials: 'include',
-          })
-          .then(function(r) {
-            if (!r.ok) return r.text().then(function(t) {
-              return JSON.stringify({ __status: r.status, __error: true, __body: t.substring(0, 500) });
-            });
-            return r.text();
-          })
-          .catch(function(e) { return JSON.stringify({ __error: true, __message: e.message }); });
-        })()
-      `;
-
-      ws.send(JSON.stringify({
-        id,
-        method: 'Runtime.evaluate',
-        params: {
-          expression: fetchScript,
-          awaitPromise: true,
-          returnByValue: true,
-        },
-      }));
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
-        if (msg.id === id) {
-          clearTimeout(timeout);
-          ws.close();
-
-          if (msg.error) {
-            reject(new Error(`CDP error: ${msg.error.message}`));
-            return;
-          }
-
-          const value = msg.result?.result?.value;
-          if (!value) {
-            reject(new Error('Empty CDP response'));
-            return;
-          }
-
-          const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-          if (parsed.__error) {
-            if (parsed.__status === 403 || parsed.__status === 401) {
-              reject(new SessionExpiredError('Twitter session has expired.'));
-            } else {
-              reject(new Error(parsed.__message ?? `HTTP ${parsed.__status}: ${parsed.__body ?? ''}`));
-            }
-            return;
-          }
-          resolve(parsed);
-        }
-      } catch (err) {
-        clearTimeout(timeout);
-        ws.close();
-        reject(err);
-      }
-    };
-
-    ws.onerror = () => {
-      clearTimeout(timeout);
-      reject(new SessionExpiredError('CDP connection failed.'));
-    };
-  });
+/** Execute a GET fetch inside Chrome via CDP Runtime.evaluate. */
+async function cdpGet(wsUrl: string, url: string): Promise<unknown> {
+  return cdpEval(wsUrl, `
+    (function() {
+      var csrf = (document.cookie.match(/ct0=([^;]+)/) || [])[1] || '';
+      return fetch(${JSON.stringify(url)}, {
+        method: 'GET',
+        headers: ${API_HEADERS_GET},
+        credentials: 'include',
+      })
+      .then(function(r) {
+        if (!r.ok) return r.text().then(function(t) {
+          return JSON.stringify({ __status: r.status, __error: true, __body: t.substring(0, 500) });
+        });
+        return r.text();
+      })
+      .catch(function(e) { return JSON.stringify({ __error: true, __message: e.message }); });
+    })()
+  `);
 }
 
 /**
- * Execute a GET fetch() inside Chrome's page context via CDP Runtime.evaluate.
+ * Navigate Chrome to a URL and capture the response body of a specific GraphQL query.
+ * This works for endpoints that require X's client-generated transaction ID (e.g. Search, Followers)
+ * because the browser's own JavaScript generates the correct headers.
  */
-async function cdpGet(wsUrl: string, url: string): Promise<unknown> {
+async function cdpNavigateAndCapture(wsUrl: string, pageUrl: string, queryName: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    let nextId = 1;
+    const callbacks = new Map<number, (v: unknown) => void>();
+    const pendingRequestIds = new Set<string>();
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`CDP navigate+capture timed out waiting for ${queryName}`));
+    }, 30000);
+
+    function send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+      const id = nextId++;
+      return new Promise(r => {
+        callbacks.set(id, r);
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+    }
+
+    ws.onmessage = (event) => {
+      const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
+
+      // Handle command responses
+      if (msg.id != null && callbacks.has(msg.id)) {
+        callbacks.get(msg.id)!(msg.result ?? msg.error);
+        callbacks.delete(msg.id);
+        return;
+      }
+
+      // Track GraphQL requests matching our query name
+      if (msg.method === 'Network.requestWillBeSent') {
+        const req = msg.params?.request;
+        const url = req?.url as string | undefined;
+        if (url?.includes(`/graphql/`) && url?.includes(`/${queryName}`)) {
+          pendingRequestIds.add(msg.params.requestId as string);
+        }
+      }
+
+      // Capture response when loading finishes
+      if (msg.method === 'Network.loadingFinished') {
+        const requestId = msg.params?.requestId as string;
+        if (!pendingRequestIds.has(requestId)) return;
+        pendingRequestIds.delete(requestId);
+
+        send('Network.getResponseBody', { requestId }).then(result => {
+          const body = (result as Record<string, unknown>)?.body as string;
+          if (!body) return;
+          try {
+            const json = JSON.parse(body);
+            clearTimeout(timeout);
+            ws.close();
+            if (json.errors?.length) {
+              reject(new Error(`X API errors: ${json.errors.map((e: { message: string }) => e.message).join('; ')}`));
+            } else {
+              resolve(json);
+            }
+          } catch { /* not JSON, skip */ }
+        }).catch(() => { /* ignore */ });
+      }
+    };
+
+    ws.onerror = () => {
+      clearTimeout(timeout);
+      reject(new SessionExpiredError('CDP connection failed.'));
+    };
+
+    ws.onopen = async () => {
+      await send('Network.enable');
+      await send('Page.enable');
+      await send('Page.navigate', { url: pageUrl });
+    };
+  });
+}
+
+/** Shared CDP evaluate helper. */
+async function cdpEval(wsUrl: string, expression: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(wsUrl);
     const id = 1;
@@ -203,38 +259,10 @@ async function cdpGet(wsUrl: string, url: string): Promise<unknown> {
     }, 30000);
 
     ws.onopen = () => {
-      const fetchScript = `
-        (function() {
-          var csrf = (document.cookie.match(/ct0=([^;]+)/) || [])[1] || '';
-          return fetch(${JSON.stringify(url)}, {
-            method: 'GET',
-            headers: {
-              'authorization': 'Bearer ${BEARER_TOKEN}',
-              'x-csrf-token': csrf,
-              'x-twitter-auth-type': 'OAuth2Session',
-              'x-twitter-active-user': 'yes',
-              'x-twitter-client-language': 'en',
-            },
-            credentials: 'include',
-          })
-          .then(function(r) {
-            if (!r.ok) return r.text().then(function(t) {
-              return JSON.stringify({ __status: r.status, __error: true, __body: t.substring(0, 500) });
-            });
-            return r.text();
-          })
-          .catch(function(e) { return JSON.stringify({ __error: true, __message: e.message }); });
-        })()
-      `;
-
       ws.send(JSON.stringify({
         id,
         method: 'Runtime.evaluate',
-        params: {
-          expression: fetchScript,
-          awaitPromise: true,
-          returnByValue: true,
-        },
+        params: { expression, awaitPromise: true, returnByValue: true },
       }));
     };
 
@@ -281,9 +309,101 @@ async function cdpGet(wsUrl: string, url: string): Promise<unknown> {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+// ─── GraphQL helpers ─────────────────────────────────────────────────────────
+
+/** Build a GraphQL GET URL with encoded variables and features. */
+function graphqlUrl(queryId: string, queryName: string, variables: Record<string, unknown>): string {
+  const v = encodeURIComponent(JSON.stringify(variables));
+  const f = encodeURIComponent(JSON.stringify(FEATURES));
+  return `https://x.com/i/api/graphql/${queryId}/${queryName}?variables=${v}&features=${f}`;
+}
+
+/** Execute a GraphQL GET query and return the parsed response. */
+async function graphqlGet(queryId: string, queryName: string, variables: Record<string, unknown>): Promise<unknown> {
+  requireSession();
+  const wsUrl = await findTwitterTab();
+  const url = graphqlUrl(queryId, queryName, variables);
+  const json = await cdpGet(wsUrl, url) as { errors?: Array<{ message: string }> };
+  if (json.errors?.length) {
+    throw new Error(`X API errors: ${json.errors.map(e => e.message).join('; ')}`);
+  }
+  return json;
+}
+
+// ─── Tweet extraction helpers ────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyJson = any;
+
+function extractScreenName(tweetResult: AnyJson): string {
+  return (
+    tweetResult?.core?.user_results?.result?.legacy?.screen_name ??
+    tweetResult?.core?.user_results?.result?.core?.screen_name ??
+    'i'
+  );
+}
+
+/** Extract tweets from a timeline instructions array (shared by most endpoints). */
+function extractTweetsFromInstructions(instructions: AnyJson[]): TweetEntry[] {
+  const tweets: TweetEntry[] = [];
+  for (const instruction of instructions) {
+    // Handle both array-style entries and direct entries
+    const entries = instruction.entries ?? [];
+    for (const entry of entries) {
+      // Standard tweet entry
+      let tweetResult = entry.content?.itemContent?.tweet_results?.result;
+      // Some results wrap in __typename: "TweetWithVisibilityResults"
+      if (tweetResult?.__typename === 'TweetWithVisibilityResults') {
+        tweetResult = tweetResult.tweet;
+      }
+      if (tweetResult?.rest_id) {
+        tweets.push({
+          tweetId: tweetResult.rest_id,
+          text: tweetResult.legacy?.full_text ?? '',
+          url: `https://x.com/${extractScreenName(tweetResult)}/status/${tweetResult.rest_id}`,
+          createdAt: tweetResult.legacy?.created_at ?? '',
+        });
+      }
+
+      // Search results can have TimelineTimelineModule with nested items
+      if (entry.content?.items) {
+        for (const item of entry.content.items) {
+          let tr = item.item?.itemContent?.tweet_results?.result;
+          if (tr?.__typename === 'TweetWithVisibilityResults') tr = tr.tweet;
+          if (tr?.rest_id) {
+            tweets.push({
+              tweetId: tr.rest_id,
+              text: tr.legacy?.full_text ?? '',
+              url: `https://x.com/${extractScreenName(tr)}/status/${tr.rest_id}`,
+              createdAt: tr.legacy?.created_at ?? '',
+            });
+          }
+        }
+      }
+    }
+  }
+  return tweets;
+}
+
+/** Extract users from a timeline instructions array (Followers/Following). */
+function extractUsersFromInstructions(instructions: AnyJson[]): UserInfo[] {
+  const users: UserInfo[] = [];
+  for (const instruction of instructions) {
+    for (const entry of instruction.entries ?? []) {
+      const userResult = entry.content?.itemContent?.user_results?.result;
+      if (userResult?.rest_id) {
+        users.push({
+          userId: userResult.rest_id,
+          screenName: userResult.legacy?.screen_name ?? userResult.core?.screen_name ?? '',
+          name: userResult.legacy?.name ?? userResult.core?.name ?? '',
+        });
+      }
+    }
+  }
+  return users;
+}
+
+// ─── Public types ────────────────────────────────────────────────────────────
 
 export interface PostTweetResult {
   tweetId: string;
@@ -291,11 +411,33 @@ export interface PostTweetResult {
   url: string;
 }
 
+export interface UserInfo {
+  userId: string;
+  screenName: string;
+  name: string;
+}
+
+export interface TweetEntry {
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}
+
+export interface NotificationEntry {
+  id: string;
+  message: string;
+  timestamp: string;
+  url?: string;
+}
+
+// ─── Write operations ────────────────────────────────────────────────────────
+
 export async function postTweet(text: string, opts?: { inReplyToTweetId?: string }): Promise<PostTweetResult> {
   requireSession();
 
   const wsUrl = await findTwitterTab();
-  const url = `https://x.com/i/api/graphql/${CREATE_TWEET_QUERY_ID}/CreateTweet`;
+  const url = `https://x.com/i/api/graphql/${QUERY_IDS.CreateTweet}/CreateTweet`;
   const variables: Record<string, unknown> = {
     tweet_text: text,
     dark_request: false,
@@ -314,96 +456,39 @@ export async function postTweet(text: string, opts?: { inReplyToTweetId?: string
   }
   const body = JSON.stringify({
     variables,
-    features: CREATE_TWEET_FEATURES,
-    queryId: CREATE_TWEET_QUERY_ID,
+    features: FEATURES,
+    queryId: QUERY_IDS.CreateTweet,
   });
 
-  const json = (await cdpFetch(wsUrl, url, body)) as {
-    data?: {
-      create_tweet?: {
-        tweet_results?: {
-          result?: {
-            rest_id?: string;
-            core?: {
-              user_results?: {
-                result?: {
-                  core?: {
-                    screen_name?: string;
-                  };
-                  legacy?: {
-                    screen_name?: string;
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
-    errors?: Array<{ message: string }>;
-  };
+  const json = (await cdpFetch(wsUrl, url, body)) as AnyJson;
 
   if (json.errors?.length) {
-    const msgs = json.errors.map(e => e.message).join('; ');
-    throw new Error(`Twitter API errors: ${msgs}`);
+    throw new Error(`X API errors: ${json.errors.map((e: AnyJson) => e.message).join('; ')}`);
   }
 
   const tweetResults = json.data?.create_tweet?.tweet_results;
   const result = tweetResults?.result;
   if (!result?.rest_id) {
-    // Empty tweet_results (no result key) typically means X rejected a duplicate tweet
     if (tweetResults && !result) {
       throw new Error('X rejected this post — it may be a duplicate of a recent post. Try different text.');
     }
     throw new Error(`Unexpected response from X API. Response: ${JSON.stringify(json).slice(0, 500)}`);
   }
 
-  const screenName =
-    result.core?.user_results?.result?.legacy?.screen_name ??
-    result.core?.user_results?.result?.core?.screen_name ??
-    'i';
-
   return {
     tweetId: result.rest_id,
     text,
-    url: `https://x.com/${screenName}/status/${result.rest_id}`,
+    url: `https://x.com/${extractScreenName(result)}/status/${result.rest_id}`,
   };
 }
 
-// ---------------------------------------------------------------------------
-// User lookup
-// ---------------------------------------------------------------------------
-
-export interface UserInfo {
-  userId: string;
-  screenName: string;
-  name: string;
-}
+// ─── User lookup ─────────────────────────────────────────────────────────────
 
 export async function getUserByScreenName(screenName: string): Promise<UserInfo> {
-  requireSession();
-  const wsUrl = await findTwitterTab();
-
-  const variables = JSON.stringify({ screen_name: screenName, withGrokTranslatedBio: true });
-  const features = JSON.stringify(CREATE_TWEET_FEATURES);
-  const url = `https://x.com/i/api/graphql/${USER_BY_SCREEN_NAME_QUERY_ID}/UserByScreenName?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(features)}`;
-
-  const json = (await cdpGet(wsUrl, url)) as {
-    data?: {
-      user?: {
-        result?: {
-          rest_id?: string;
-          legacy?: { screen_name?: string; name?: string };
-        };
-      };
-    };
-    errors?: Array<{ message: string }>;
-  };
-
-  if (json.errors?.length) {
-    const msgs = json.errors.map(e => e.message).join('; ');
-    throw new Error(`Twitter API errors: ${msgs}`);
-  }
+  const json = await graphqlGet(QUERY_IDS.UserByScreenName, 'UserByScreenName', {
+    screen_name: screenName,
+    withGrokTranslatedBio: true,
+  }) as AnyJson;
 
   const user = json.data?.user?.result;
   if (!user?.rest_id) {
@@ -417,99 +502,191 @@ export async function getUserByScreenName(screenName: string): Promise<UserInfo>
   };
 }
 
-// ---------------------------------------------------------------------------
-// User tweets (timeline)
-// ---------------------------------------------------------------------------
-
-export interface TweetEntry {
-  tweetId: string;
-  text: string;
-  url: string;
-  createdAt: string;
-}
+// ─── User tweets ─────────────────────────────────────────────────────────────
 
 export async function getUserTweets(userId: string, count = 20): Promise<TweetEntry[]> {
-  requireSession();
-  const wsUrl = await findTwitterTab();
-
-  const variables = JSON.stringify({
+  const json = await graphqlGet(QUERY_IDS.UserTweets, 'UserTweets', {
     userId,
     count,
     includePromotedContent: true,
     withQuickPromoteEligibilityTweetFields: true,
     withVoice: true,
-  });
-  const features = JSON.stringify(CREATE_TWEET_FEATURES);
-  const url = `https://x.com/i/api/graphql/${USER_TWEETS_QUERY_ID}/UserTweets?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(features)}`;
+  }) as AnyJson;
 
-  const json = (await cdpGet(wsUrl, url)) as {
-    data?: {
-      user?: {
-        result?: {
-          timeline_v2?: {
-            timeline?: {
-              instructions?: Array<{
-                type: string;
-                entries?: Array<{
-                  content?: {
-                    entryType?: string;
-                    itemContent?: {
-                      tweet_results?: {
-                        result?: {
-                          rest_id?: string;
-                          core?: {
-                            user_results?: {
-                              result?: {
-                                legacy?: { screen_name?: string };
-                              };
-                            };
-                          };
-                          legacy?: {
-                            full_text?: string;
-                            created_at?: string;
-                          };
-                        };
-                      };
-                    };
-                  };
-                }>;
-              }>;
-            };
-          };
-        };
-      };
-    };
-    errors?: Array<{ message: string }>;
-  };
-
-  if (json.errors?.length) {
-    const msgs = json.errors.map(e => e.message).join('; ');
-    throw new Error(`Twitter API errors: ${msgs}`);
-  }
-
+  // Response path: data.user.result.timeline_v2.timeline.instructions[]
+  // Fallback to data.user.result.timeline.timeline.instructions[]
   const timelineData = json.data?.user?.result?.timeline_v2 ?? json.data?.user?.result?.timeline;
   const instructions = timelineData?.timeline?.instructions ?? [];
-  const tweets: TweetEntry[] = [];
+  return extractTweetsFromInstructions(instructions);
+}
 
+// ─── Tweet detail ────────────────────────────────────────────────────────────
+
+export async function getTweetDetail(tweetId: string): Promise<TweetEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.TweetDetail, 'TweetDetail', {
+    focalTweetId: tweetId,
+    referrer: 'tweet',
+    with_rux_injections: false,
+    rankingMode: 'Relevance',
+    includePromotedContent: true,
+    withCommunity: true,
+    withQuickPromoteEligibilityTweetFields: true,
+    withBirdwatchNotes: true,
+    withVoice: true,
+  }) as AnyJson;
+
+  // Response path: data.threaded_conversation_with_injections_v2.instructions[]
+  const instructions = json.data?.threaded_conversation_with_injections_v2?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
+}
+
+// ─── Search ──────────────────────────────────────────────────────────────────
+
+export async function searchTweets(
+  query: string,
+  count = 20,
+  product: 'Top' | 'Latest' | 'People' | 'Media' = 'Top',
+): Promise<TweetEntry[]> {
+  requireSession();
+  const wsUrl = await findTwitterTab();
+
+  // Search requires X's client-generated transaction ID, so we navigate Chrome
+  // to the search page and capture the response from network events.
+  const productParam = product === 'Top' ? '' : `&f=${product.toLowerCase()}`;
+  const pageUrl = `https://x.com/search?q=${encodeURIComponent(query)}&src=typed_query${productParam}`;
+  const json = await cdpNavigateAndCapture(wsUrl, pageUrl, 'SearchTimeline') as AnyJson;
+
+  const instructions = json.data?.search_by_raw_query?.search_timeline?.timeline?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
+}
+
+// ─── Bookmarks ───────────────────────────────────────────────────────────────
+
+export async function getBookmarks(count = 20): Promise<TweetEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.Bookmarks, 'Bookmarks', {
+    count,
+    includePromotedContent: true,
+  }) as AnyJson;
+
+  // Response path: data.bookmark_timeline_v2.timeline.instructions[]
+  const instructions = json.data?.bookmark_timeline_v2?.timeline?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
+}
+
+// ─── Home timeline ───────────────────────────────────────────────────────────
+
+export async function getHomeTimeline(count = 20): Promise<TweetEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.HomeTimeline, 'HomeTimeline', {
+    count,
+    includePromotedContent: true,
+    requestContext: 'launch',
+    withCommunity: true,
+  }) as AnyJson;
+
+  // Response path: data.home.home_timeline_urt.instructions[]
+  const instructions = json.data?.home?.home_timeline_urt?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
+}
+
+// ─── Notifications ───────────────────────────────────────────────────────────
+
+export async function getNotifications(count = 20): Promise<NotificationEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.NotificationsTimeline, 'NotificationsTimeline', {
+    timeline_type: 'All',
+    count,
+  }) as AnyJson;
+
+  // Response path: data.viewer_v2.user_results.result.notification_timeline.timeline.instructions[]
+  const instructions =
+    json.data?.viewer_v2?.user_results?.result?.notification_timeline?.timeline?.instructions ?? [];
+
+  const notifications: NotificationEntry[] = [];
   for (const instruction of instructions) {
-    if (instruction.type !== 'TimelineAddEntries') continue;
     for (const entry of instruction.entries ?? []) {
-      const tweetResult = entry.content?.itemContent?.tweet_results?.result;
-      if (!tweetResult?.rest_id) continue;
-
-      const screenName =
-        tweetResult.core?.user_results?.result?.legacy?.screen_name ??
-        tweetResult.core?.user_results?.result?.core?.screen_name ??
-        'i';
-
-      tweets.push({
-        tweetId: tweetResult.rest_id,
-        text: tweetResult.legacy?.full_text ?? '',
-        url: `https://x.com/${screenName}/status/${tweetResult.rest_id}`,
-        createdAt: tweetResult.legacy?.created_at ?? '',
+      const ic = entry.content?.itemContent;
+      if (ic?.__typename !== 'TimelineNotification') continue;
+      notifications.push({
+        id: ic.id ?? entry.entryId ?? '',
+        message: ic.rich_message?.text ?? ic.notification_text?.text ?? '',
+        timestamp: ic.timestamp_ms ?? '',
+        url: ic.notification_url?.url,
       });
     }
   }
+  return notifications;
+}
 
-  return tweets;
+// ─── Likes ───────────────────────────────────────────────────────────────────
+
+export async function getLikes(userId: string, count = 20): Promise<TweetEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.Likes, 'Likes', {
+    userId,
+    count,
+    includePromotedContent: false,
+    withClientEventToken: false,
+    withBirdwatchNotes: false,
+    withVoice: true,
+  }) as AnyJson;
+
+  // Response path: data.user.result.timeline.timeline.instructions[]
+  const instructions = json.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
+}
+
+// ─── Followers ───────────────────────────────────────────────────────────────
+
+export async function getFollowers(userId: string, count = 20, screenName?: string): Promise<UserInfo[]> {
+  // Followers requires X's client-generated transaction ID.
+  // If we have a screenName, navigate to the followers page and capture.
+  // Otherwise fall back to graphqlGet (may 404 on some sessions).
+  if (screenName) {
+    requireSession();
+    const wsUrl = await findTwitterTab();
+    const json = await cdpNavigateAndCapture(wsUrl, `https://x.com/${screenName}/followers`, 'Followers') as AnyJson;
+    const instructions = json.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+    return extractUsersFromInstructions(instructions);
+  }
+
+  const json = await graphqlGet(QUERY_IDS.Followers, 'Followers', {
+    userId,
+    count,
+    includePromotedContent: false,
+    withGrokTranslatedBio: false,
+  }) as AnyJson;
+
+  const instructions = json.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+  return extractUsersFromInstructions(instructions);
+}
+
+// ─── Following ───────────────────────────────────────────────────────────────
+
+export async function getFollowing(userId: string, count = 20): Promise<UserInfo[]> {
+  const json = await graphqlGet(QUERY_IDS.Following, 'Following', {
+    userId,
+    count,
+    includePromotedContent: false,
+    withGrokTranslatedBio: false,
+  }) as AnyJson;
+
+  // Response path: data.user.result.timeline.timeline.instructions[]
+  const instructions = json.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+  return extractUsersFromInstructions(instructions);
+}
+
+// ─── User media ──────────────────────────────────────────────────────────────
+
+export async function getUserMedia(userId: string, count = 20): Promise<TweetEntry[]> {
+  const json = await graphqlGet(QUERY_IDS.UserMedia, 'UserMedia', {
+    userId,
+    count,
+    includePromotedContent: false,
+    withClientEventToken: false,
+    withBirdwatchNotes: false,
+    withVoice: true,
+  }) as AnyJson;
+
+  // Response path: data.user.result.timeline.timeline.instructions[]
+  // (same as Likes — contains tweets that have media)
+  const instructions = json.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+  return extractTweetsFromInstructions(instructions);
 }

--- a/assistant/src/twitter/client.ts
+++ b/assistant/src/twitter/client.ts
@@ -18,6 +18,12 @@ const BEARER_TOKEN =
 /** Query ID for CreateTweet persisted query. */
 const CREATE_TWEET_QUERY_ID = 'Ah3G_byjEDs_HSlgU0PyZw';
 
+/** Query ID for UserByScreenName persisted query. */
+const USER_BY_SCREEN_NAME_QUERY_ID = 'AWbeRIdkLtqTRN7yL_H8yw';
+
+/** Query ID for UserTweets persisted query. */
+const USER_TWEETS_QUERY_ID = 'eApPT8jppbYXlweF_ByTyA';
+
 /** Feature flags required by the CreateTweet mutation. */
 const CREATE_TWEET_FEATURES: Record<string, boolean> = {
   premium_content_api_read_enabled: false,
@@ -183,6 +189,98 @@ async function cdpFetch(wsUrl: string, url: string, body: string): Promise<unkno
   });
 }
 
+/**
+ * Execute a GET fetch() inside Chrome's page context via CDP Runtime.evaluate.
+ */
+async function cdpGet(wsUrl: string, url: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const id = 1;
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('CDP fetch timed out after 30s'));
+    }, 30000);
+
+    ws.onopen = () => {
+      const fetchScript = `
+        (function() {
+          var csrf = (document.cookie.match(/ct0=([^;]+)/) || [])[1] || '';
+          return fetch(${JSON.stringify(url)}, {
+            method: 'GET',
+            headers: {
+              'authorization': 'Bearer ${BEARER_TOKEN}',
+              'x-csrf-token': csrf,
+              'x-twitter-auth-type': 'OAuth2Session',
+              'x-twitter-active-user': 'yes',
+              'x-twitter-client-language': 'en',
+            },
+            credentials: 'include',
+          })
+          .then(function(r) {
+            if (!r.ok) return r.text().then(function(t) {
+              return JSON.stringify({ __status: r.status, __error: true, __body: t.substring(0, 500) });
+            });
+            return r.text();
+          })
+          .catch(function(e) { return JSON.stringify({ __error: true, __message: e.message }); });
+        })()
+      `;
+
+      ws.send(JSON.stringify({
+        id,
+        method: 'Runtime.evaluate',
+        params: {
+          expression: fetchScript,
+          awaitPromise: true,
+          returnByValue: true,
+        },
+      }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
+        if (msg.id === id) {
+          clearTimeout(timeout);
+          ws.close();
+
+          if (msg.error) {
+            reject(new Error(`CDP error: ${msg.error.message}`));
+            return;
+          }
+
+          const value = msg.result?.result?.value;
+          if (!value) {
+            reject(new Error('Empty CDP response'));
+            return;
+          }
+
+          const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+          if (parsed.__error) {
+            if (parsed.__status === 403 || parsed.__status === 401) {
+              reject(new SessionExpiredError('Twitter session has expired.'));
+            } else {
+              reject(new Error(parsed.__message ?? `HTTP ${parsed.__status}: ${parsed.__body ?? ''}`));
+            }
+            return;
+          }
+          resolve(parsed);
+        }
+      } catch (err) {
+        clearTimeout(timeout);
+        ws.close();
+        reject(err);
+      }
+    };
+
+    ws.onerror = () => {
+      clearTimeout(timeout);
+      reject(new SessionExpiredError('CDP connection failed.'));
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -193,22 +291,29 @@ export interface PostTweetResult {
   url: string;
 }
 
-export async function postTweet(text: string): Promise<PostTweetResult> {
+export async function postTweet(text: string, opts?: { inReplyToTweetId?: string }): Promise<PostTweetResult> {
   requireSession();
 
   const wsUrl = await findTwitterTab();
   const url = `https://x.com/i/api/graphql/${CREATE_TWEET_QUERY_ID}/CreateTweet`;
-  const body = JSON.stringify({
-    variables: {
-      tweet_text: text,
-      dark_request: false,
-      media: {
-        media_entities: [],
-        possibly_sensitive: false,
-      },
-      semantic_annotation_ids: [],
-      disallowed_reply_options: null,
+  const variables: Record<string, unknown> = {
+    tweet_text: text,
+    dark_request: false,
+    media: {
+      media_entities: [],
+      possibly_sensitive: false,
     },
+    semantic_annotation_ids: [],
+    disallowed_reply_options: null,
+  };
+  if (opts?.inReplyToTweetId) {
+    variables.reply = {
+      in_reply_to_tweet_id: opts.inReplyToTweetId,
+      exclude_reply_user_ids: [],
+    };
+  }
+  const body = JSON.stringify({
+    variables,
     features: CREATE_TWEET_FEATURES,
     queryId: CREATE_TWEET_QUERY_ID,
   });
@@ -263,4 +368,148 @@ export async function postTweet(text: string): Promise<PostTweetResult> {
     text,
     url: `https://x.com/${screenName}/status/${result.rest_id}`,
   };
+}
+
+// ---------------------------------------------------------------------------
+// User lookup
+// ---------------------------------------------------------------------------
+
+export interface UserInfo {
+  userId: string;
+  screenName: string;
+  name: string;
+}
+
+export async function getUserByScreenName(screenName: string): Promise<UserInfo> {
+  requireSession();
+  const wsUrl = await findTwitterTab();
+
+  const variables = JSON.stringify({ screen_name: screenName, withGrokTranslatedBio: true });
+  const features = JSON.stringify(CREATE_TWEET_FEATURES);
+  const url = `https://x.com/i/api/graphql/${USER_BY_SCREEN_NAME_QUERY_ID}/UserByScreenName?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(features)}`;
+
+  const json = (await cdpGet(wsUrl, url)) as {
+    data?: {
+      user?: {
+        result?: {
+          rest_id?: string;
+          legacy?: { screen_name?: string; name?: string };
+        };
+      };
+    };
+    errors?: Array<{ message: string }>;
+  };
+
+  if (json.errors?.length) {
+    const msgs = json.errors.map(e => e.message).join('; ');
+    throw new Error(`Twitter API errors: ${msgs}`);
+  }
+
+  const user = json.data?.user?.result;
+  if (!user?.rest_id) {
+    throw new Error(`User @${screenName} not found`);
+  }
+
+  return {
+    userId: user.rest_id,
+    screenName: user.legacy?.screen_name ?? screenName,
+    name: user.legacy?.name ?? screenName,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// User tweets (timeline)
+// ---------------------------------------------------------------------------
+
+export interface TweetEntry {
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}
+
+export async function getUserTweets(userId: string, count = 20): Promise<TweetEntry[]> {
+  requireSession();
+  const wsUrl = await findTwitterTab();
+
+  const variables = JSON.stringify({
+    userId,
+    count,
+    includePromotedContent: true,
+    withQuickPromoteEligibilityTweetFields: true,
+    withVoice: true,
+  });
+  const features = JSON.stringify(CREATE_TWEET_FEATURES);
+  const url = `https://x.com/i/api/graphql/${USER_TWEETS_QUERY_ID}/UserTweets?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(features)}`;
+
+  const json = (await cdpGet(wsUrl, url)) as {
+    data?: {
+      user?: {
+        result?: {
+          timeline_v2?: {
+            timeline?: {
+              instructions?: Array<{
+                type: string;
+                entries?: Array<{
+                  content?: {
+                    entryType?: string;
+                    itemContent?: {
+                      tweet_results?: {
+                        result?: {
+                          rest_id?: string;
+                          core?: {
+                            user_results?: {
+                              result?: {
+                                legacy?: { screen_name?: string };
+                              };
+                            };
+                          };
+                          legacy?: {
+                            full_text?: string;
+                            created_at?: string;
+                          };
+                        };
+                      };
+                    };
+                  };
+                }>;
+              }>;
+            };
+          };
+        };
+      };
+    };
+    errors?: Array<{ message: string }>;
+  };
+
+  if (json.errors?.length) {
+    const msgs = json.errors.map(e => e.message).join('; ');
+    throw new Error(`Twitter API errors: ${msgs}`);
+  }
+
+  const timelineData = json.data?.user?.result?.timeline_v2 ?? json.data?.user?.result?.timeline;
+  const instructions = timelineData?.timeline?.instructions ?? [];
+  const tweets: TweetEntry[] = [];
+
+  for (const instruction of instructions) {
+    if (instruction.type !== 'TimelineAddEntries') continue;
+    for (const entry of instruction.entries ?? []) {
+      const tweetResult = entry.content?.itemContent?.tweet_results?.result;
+      if (!tweetResult?.rest_id) continue;
+
+      const screenName =
+        tweetResult.core?.user_results?.result?.legacy?.screen_name ??
+        tweetResult.core?.user_results?.result?.core?.screen_name ??
+        'i';
+
+      tweets.push({
+        tweetId: tweetResult.rest_id,
+        text: tweetResult.legacy?.full_text ?? '',
+        url: `https://x.com/${screenName}/status/${tweetResult.rest_id}`,
+        createdAt: tweetResult.legacy?.created_at ?? '',
+      });
+    }
+  }
+
+  return tweets;
 }

--- a/assistant/src/twitter/client.ts
+++ b/assistant/src/twitter/client.ts
@@ -544,7 +544,6 @@ export async function getTweetDetail(tweetId: string): Promise<TweetEntry[]> {
 
 export async function searchTweets(
   query: string,
-  count = 20,
   product: 'Top' | 'Latest' | 'People' | 'Media' = 'Top',
 ): Promise<TweetEntry[]> {
   requireSession();
@@ -635,10 +634,9 @@ export async function getLikes(userId: string, count = 20): Promise<TweetEntry[]
 
 // ─── Followers ───────────────────────────────────────────────────────────────
 
-export async function getFollowers(userId: string, count = 20, screenName?: string): Promise<UserInfo[]> {
+export async function getFollowers(userId: string, screenName?: string): Promise<UserInfo[]> {
   // Followers requires X's client-generated transaction ID.
-  // If we have a screenName, navigate to the followers page and capture.
-  // Otherwise fall back to graphqlGet (may 404 on some sessions).
+  // Navigate to the followers page and capture via CDP.
   if (screenName) {
     requireSession();
     const wsUrl = await findTwitterTab();
@@ -649,7 +647,7 @@ export async function getFollowers(userId: string, count = 20, screenName?: stri
 
   const json = await graphqlGet(QUERY_IDS.Followers, 'Followers', {
     userId,
-    count,
+    count: 20,
     includePromotedContent: false,
     withGrokTranslatedBio: false,
   }) as AnyJson;


### PR DESCRIPTION
## Summary
- Add 8 new read endpoints to the X client: search, tweet detail, home timeline, bookmarks, notifications, likes, followers, following, media
- Improve `capture-x-graphql.ts` with relevance filtering, full response bodies, `--auto` CDP navigation mode
- Hook auto-navigation into ride-shotgun learn mode for x.com — `vellum x refresh` now auto-captures the full API surface
- Add skill workflows: check mentions, research topics, engagement check
- Discovered X requires computed `x-client-transaction-id` for search/followers — solved via CDP navigate+capture

## Test plan
- [ ] `vellum x search "hello" --json` returns tweets
- [ ] `vellum x home --json` returns home timeline
- [ ] `vellum x notifications --json` returns notifications
- [ ] `vellum x tweet <tweetId> --json` returns thread
- [ ] `vellum x likes <user> --json` returns liked tweets
- [ ] `vellum x followers <user> --json` returns followers
- [ ] `vellum x following <user> --json` returns following
- [ ] `vellum x bookmarks --json` returns bookmarks
- [ ] `bun run scripts/capture-x-graphql.ts --auto` navigates Chrome and captures queries
- [ ] `vellum x refresh` auto-navigates through X.com pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
