### PR TITLE
M3: CLI command + ride-shotgun integration

### DIFF
--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -1,0 +1,245 @@
+/**
+ * CLI command: `vellum map <domain>`
+ *
+ * Launches Chrome with CDP, starts a Ride Shotgun learn session to auto-navigate
+ * the given domain, then analyzes captured network traffic into a deduplicated API map.
+ */
+
+import * as net from 'node:net';
+import { spawn as spawnChild } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+import { Command } from 'commander';
+import { getSocketPath, readSessionToken } from '../util/platform.js';
+import {
+  serialize,
+  createMessageParser,
+} from '../daemon/ipc-protocol.js';
+import { loadRecording } from '../tools/browser/recording-store.js';
+import { analyzeApiMap, saveApiMap, printApiMapTable } from '../tools/browser/api-map.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function output(data: unknown, json: boolean): void {
+  process.stdout.write(
+    json ? JSON.stringify(data) + '\n' : JSON.stringify(data, null, 2) + '\n',
+  );
+}
+
+function outputError(message: string, code = 1): void {
+  output({ ok: false, error: message }, true);
+  process.exitCode = code;
+}
+
+function getJson(cmd: Command): boolean {
+  let c: Command | null = cmd;
+  while (c) {
+    if ((c.opts() as { json?: boolean }).json) return true;
+    c = c.parent;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Chrome CDP helpers
+// ---------------------------------------------------------------------------
+
+const CDP_BASE = 'http://localhost:9222';
+const CHROME_DATA_DIR = pathJoin(
+  homedir(),
+  'Library/Application Support/Google/Chrome-CDP',
+);
+
+async function isCdpReady(): Promise<boolean> {
+  try {
+    const res = await fetch(`${CDP_BASE}/json/version`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureChromeWithCDP(domain: string): Promise<void> {
+  // Already running with CDP?
+  if (await isCdpReady()) return;
+
+  // Launch a separate Chrome instance with CDP flags alongside any existing Chrome.
+  const chromeApp =
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+  spawnChild(chromeApp, [
+    `--remote-debugging-port=9222`,
+    `--force-renderer-accessibility`,
+    `--user-data-dir=${CHROME_DATA_DIR}`,
+    `https://${domain}/`,
+  ], {
+    detached: true,
+    stdio: 'ignore',
+  }).unref();
+
+  // Wait for CDP to be ready
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    if (await isCdpReady()) return;
+  }
+  throw new Error('Chrome started but CDP endpoint not responding after 15s');
+}
+
+// ---------------------------------------------------------------------------
+// Ride Shotgun learn session helper
+// ---------------------------------------------------------------------------
+
+interface LearnResult {
+  recordingId?: string;
+  recordingPath?: string;
+}
+
+async function startLearnSession(domain: string, durationSeconds: number): Promise<LearnResult> {
+  await ensureChromeWithCDP(domain);
+
+  return new Promise((resolve, reject) => {
+    const socketPath = getSocketPath();
+    const sessionToken = readSessionToken();
+    const socket = net.createConnection(socketPath);
+    const parser = createMessageParser();
+
+    socket.on('error', (err) => {
+      reject(new Error(`Cannot connect to daemon: ${err.message}. Is the daemon running?`));
+    });
+
+    const timeoutHandle = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`Learn session timed out after ${durationSeconds + 30}s`));
+    }, (durationSeconds + 30) * 1000);
+    timeoutHandle.unref();
+
+    let authenticated = !sessionToken;
+
+    const sendStartCommand = () => {
+      socket.write(
+        serialize({
+          type: 'ride_shotgun_start',
+          durationSeconds,
+          intervalSeconds: 5,
+          mode: 'learn',
+          targetDomain: domain,
+        } as unknown as import('../daemon/ipc-protocol.js').ClientMessage),
+      );
+    };
+
+    socket.on('data', (chunk) => {
+      const messages = parser.feed(chunk.toString('utf-8'));
+      for (const msg of messages) {
+        const m = msg as unknown as Record<string, unknown>;
+
+        if (!authenticated && m.type === 'auth_result') {
+          if ((m as { success: boolean }).success) {
+            authenticated = true;
+            sendStartCommand();
+          } else {
+            clearTimeout(timeoutHandle);
+            socket.destroy();
+            reject(new Error('Daemon authentication failed'));
+          }
+          continue;
+        }
+
+        if (m.type === 'auth_result') {
+          continue;
+        }
+
+        if (m.type === 'ride_shotgun_result') {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          resolve({
+            recordingId: m.recordingId as string | undefined,
+            recordingPath: m.recordingPath as string | undefined,
+          });
+        }
+      }
+    });
+
+    socket.on('connect', () => {
+      if (sessionToken) {
+        socket.write(
+          serialize({
+            type: 'auth',
+            token: sessionToken,
+          } as unknown as import('../daemon/ipc-protocol.js').ClientMessage),
+        );
+      } else {
+        sendStartCommand();
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerMapCommand(program: Command): void {
+  program
+    .command('map')
+    .description(
+      'Auto-navigate a domain and produce a deduplicated API map. ' +
+      'Launches Chrome with CDP, starts a Ride Shotgun learn session, ' +
+      'then analyzes captured network traffic.',
+    )
+    .argument('<domain>', 'Domain to map (e.g., example.com)')
+    .option('--duration <seconds>', 'Recording duration in seconds', '120')
+    .option('--json', 'Machine-readable JSON output')
+    .action(async (domain: string, opts: { duration: string; json?: boolean }, cmd: Command) => {
+      const json = getJson(cmd);
+      const duration = parseInt(opts.duration, 10);
+
+      try {
+        // 1. Start learn session (launches Chrome + auto-navigates)
+        if (!json) {
+          console.log(`Starting API map session for ${domain} (${duration}s)...`);
+        }
+        const result = await startLearnSession(domain, duration);
+
+        if (!result.recordingId) {
+          outputError('Recording completed but no recording ID returned');
+          return;
+        }
+
+        // 2. Load the recording
+        const recording = loadRecording(result.recordingId);
+        if (!recording) {
+          outputError(`Failed to load recording ${result.recordingId}`);
+          return;
+        }
+
+        // 3. Analyze the API map
+        const apiMap = analyzeApiMap(recording.networkEntries, domain);
+
+        // 4. Save the API map
+        const savedPath = saveApiMap(domain, apiMap);
+
+        // 5. Display results
+        if (!json) {
+          printApiMapTable(apiMap);
+          console.log(`API map saved to: ${savedPath}`);
+        }
+
+        // 6. Output JSON result
+        output(
+          {
+            ok: true,
+            domain,
+            recordingId: result.recordingId,
+            savedPath,
+            totalRequests: apiMap.totalRequests,
+            endpointCount: apiMap.endpoints.length,
+            apiMap,
+          },
+          json,
+        );
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
+      }
+    });
+}

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -16,6 +16,7 @@ import { NetworkRecorder } from '../tools/browser/network-recorder.js';
 import { saveRecording } from '../tools/browser/recording-store.js';
 import type { SessionRecording } from '../tools/browser/network-recording-types.js';
 import { navigateXPages } from '../tools/browser/x-auto-navigate.js';
+import { autoNavigate } from '../tools/browser/auto-navigate.js';
 
 const log = getLogger('ride-shotgun-handler');
 
@@ -159,8 +160,29 @@ export async function handleRideShotgunStart(
                 completeSession(session);
               }
             });
+          } else if (targetDomain) {
+            const abortSignal = { aborted: false };
+            const checkInterval = setInterval(() => {
+              if (session.status !== 'active') {
+                abortSignal.aborted = true;
+                clearInterval(checkInterval);
+              }
+            }, 1000);
+            autoNavigate(targetDomain, abortSignal).then(visited => {
+              clearInterval(checkInterval);
+              log.info({ watchId, visitedPages: visited.length }, 'Generic auto-navigation finished');
+              if (session.status === 'active') {
+                completeSession(session);
+              }
+            }).catch(err => {
+              clearInterval(checkInterval);
+              log.warn({ err, watchId }, 'Generic auto-navigation failed');
+              if (session.status === 'active') {
+                completeSession(session);
+              }
+            });
           } else {
-            // Non-X domains: use login detection as before
+            // No targetDomain: use login detection as before
             recorder.onLoginDetected = () => {
               log.info({ watchId }, 'Login detected — auto-stopping learn session');
               completeSession(session);

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -29,6 +29,7 @@ import { registerContactsCommand } from './cli/contacts.js';
 import { registerAutonomyCommand } from './cli/autonomy.js';
 import { registerDoordashCommand } from './cli/doordash.js';
 import { registerTwitterCommand } from './cli/twitter.js';
+import { registerMapCommand } from './cli/map.js';
 
 const program = new Command();
 
@@ -55,6 +56,7 @@ registerDoordashCommand(program);
 registerCompletionsCommand(program);
 
 registerTwitterCommand(program);
+registerMapCommand(program);
 
 const knownCommands = new Set(program.commands.map(cmd => cmd.name()));
 const firstArg = process.argv[2];


### PR DESCRIPTION
Part of #5768. Adds `vellum map <domain>` CLI command that launches Chrome with CDP, starts a learn session, auto-navigates the domain, and produces a deduplicated API map. Also integrates generic auto-navigation into ride-shotgun-handler for non-X domains.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
