### PR TITLE
fix: replace close button with back button on avatar customization

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -32,7 +32,16 @@ struct AvatarCustomizationPanel: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 // Header
-                HStack(alignment: .center) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    Button(action: onClose) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Back to identity")
                     Text("Customize Avatar")
                         .font(VFont.panelTitle)
                         .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -340,7 +340,6 @@ extension MainWindowView {
                 .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
-                .overlay(alignment: .topTrailing) { panelDismissButton }
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
             // if we reach here, isDynamicExpanded is false — clear selection so


### PR DESCRIPTION
## Summary
- Replace the X close button with a `<` back chevron on the avatar customization panel
- Removes the overlay dismiss button since the inline back button handles navigation
- Back button navigates to the identity panel, making the navigation hierarchy clearer

## Test plan
- [ ] Open identity panel → click "Customize Avatar" → verify back chevron appears (no X)
- [ ] Click back chevron → returns to identity panel
- [ ] Verify no regression on other panel close buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
