### PR TITLE
fix: add timeout to AgentHeartbeatService.stop() to prevent blocking shutdown

### DIFF
--- a/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
+++ b/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
@@ -49,7 +49,8 @@ export class AgentHeartbeatService {
       this.timer = null;
     }
     if (this.activeRun) {
-      await this.activeRun;
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, 5_000));
+      await Promise.race([this.activeRun, timeout]);
     }
     log.info('Agent heartbeat service stopped');
   }


### PR DESCRIPTION
## Summary
- Race `this.activeRun` against a 5-second timeout in `stop()` so it doesn't block indefinitely
- Prevents forced `process.exit(1)` when a long-running heartbeat is in-flight during daemon shutdown
- Addresses unresolved feedback from #5755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
