### PR TITLE
fix: suppress thinking indicator flash between tool calls

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -500,7 +500,8 @@ struct ChatView: View {
                     let lastVisible = displayMessages.last
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
                     let hasActiveToolCall = lastVisible?.toolCalls.contains(where: { !$0.isComplete }) == true
-                    if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
+                    let hasAnyToolCalls = lastVisible?.toolCalls.isEmpty == false
+                    if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall && !hasAnyToolCalls {
                         RunningIndicator(
                             label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
                             showIcon: false


### PR DESCRIPTION
## Summary
- Suppress "Thinking" indicator when the last assistant message already has tool calls (even completed ones)
- Prevents a brief annoying flash of "Thinking" between consecutive tool executions

## Test plan
- [ ] Send a message that triggers multiple tool calls
- [ ] Verify "Thinking" does NOT flash between tool completions
- [ ] Verify "Thinking" still shows on initial send before any assistant content appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
