### PR TITLE
fix: prevent web fetch hang on large HTML pages

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -298,12 +298,17 @@ function extractFirstMatch(text: string, regex: RegExp, captureGroup = 1): strin
 }
 
 function extractHtmlMetadata(html: string): { title?: string; description?: string } {
-  const title = extractFirstMatch(html, /<title[^>]*>([\s\S]*?)<\/title>/i);
+  // Only search the <head> section (or first 50KB) to avoid catastrophic
+  // regex backtracking on large HTML documents.
+  const headEnd = html.search(/<\/head[\s>]/i);
+  const searchRegion = headEnd > 0 ? html.slice(0, headEnd + 10) : html.slice(0, 50_000);
+
+  const title = extractFirstMatch(searchRegion, /<title[^>]*>([\s\S]*?)<\/title>/i);
   const description =
-    extractFirstMatch(html, /<meta\s+[^>]*name=(['"])description\1[^>]*content=(['"])([\s\S]*?)\2[^>]*>/i, 3)
-    ?? extractFirstMatch(html, /<meta\s+[^>]*content=(['"])([\s\S]*?)\1[^>]*name=(['"])description\3[^>]*>/i, 2)
-    ?? extractFirstMatch(html, /<meta\s+[^>]*property=(['"])og:description\1[^>]*content=(['"])([\s\S]*?)\2[^>]*>/i, 3)
-    ?? extractFirstMatch(html, /<meta\s+[^>]*content=(['"])([\s\S]*?)\1[^>]*property=(['"])og:description\3[^>]*>/i, 2);
+    extractFirstMatch(searchRegion, /<meta\s+[^>]*name=(['"])description\1[^>]*content=(['"])([\s\S]*?)\2[^>]*>/i, 3)
+    ?? extractFirstMatch(searchRegion, /<meta\s+[^>]*content=(['"])([\s\S]*?)\1[^>]*name=(['"])description\3[^>]*>/i, 2)
+    ?? extractFirstMatch(searchRegion, /<meta\s+[^>]*property=(['"])og:description\1[^>]*content=(['"])([\s\S]*?)\2[^>]*>/i, 3)
+    ?? extractFirstMatch(searchRegion, /<meta\s+[^>]*content=(['"])([\s\S]*?)\1[^>]*property=(['"])og:description\3[^>]*>/i, 2);
 
   return { title, description };
 }
@@ -437,7 +442,10 @@ export async function executeWebFetch(
   const safeRequestedUrl = sanitizeUrlForOutput(parsedUrl);
 
   const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+  const timeoutHandle = setTimeout(() => {
+    log.warn({ url: safeRequestedUrl, timeoutSeconds }, 'Web fetch timeout fired, aborting');
+    controller.abort();
+  }, timeoutSeconds * 1000);
 
   try {
     log.debug({ url: safeRequestedUrl, timeoutSeconds, maxChars, startIndex, rawMode }, 'Fetching webpage');


### PR DESCRIPTION
## Summary
- `extractHtmlMetadata` ran complex regex patterns against entire HTML bodies (800KB+), causing catastrophic regex backtracking that hung the event loop indefinitely
- Now restricts metadata extraction to the `<head>` section (or first 50KB fallback) since `<title>` and `<meta>` tags only appear there
- Also logs a warning when the timeout fires for better debuggability

## Test plan
- [ ] Fetch a large HTML page (e.g. `https://docs.openclaw.ai/gateway/heartbeat` — 828KB) — should complete quickly instead of hanging
- [ ] Verify title/description metadata is still extracted correctly for normal pages
- [ ] Verify pages without `</head>` tag fall back to 50KB search region

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
