### PR TITLE
fix: clear heartbeat stop() timeout to avoid holding event loop

### DIFF
--- a/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
+++ b/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
@@ -49,8 +49,10 @@ export class AgentHeartbeatService {
       this.timer = null;
     }
     if (this.activeRun) {
-      const timeout = new Promise<void>((resolve) => setTimeout(resolve, 5_000));
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<void>((resolve) => { timerId = setTimeout(resolve, 5_000); });
       await Promise.race([this.activeRun, timeout]);
+      clearTimeout(timerId!);
     }
     log.info('Agent heartbeat service stopped');
   }


### PR DESCRIPTION
## Summary
- Clear the 5-second timeout in AgentHeartbeatService.stop() after Promise.race resolves
- Prevents the timer from unnecessarily holding the event loop alive when activeRun finishes quickly
- Addresses unresolved review feedback from #5776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
