### PR TITLE
fix: strip script blocks before searching for </head> in metadata extraction

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -300,8 +300,12 @@ function extractFirstMatch(text: string, regex: RegExp, captureGroup = 1): strin
 function extractHtmlMetadata(html: string): { title?: string; description?: string } {
   // Only search the <head> section (or first 50KB) to avoid catastrophic
   // regex backtracking on large HTML documents.
-  const headEnd = html.search(/<\/head[\s>]/i);
-  const searchRegion = headEnd > 0 ? html.slice(0, headEnd + 10) : html.slice(0, 50_000);
+  // Strip <script> blocks first so that a literal "</head>" inside a script
+  // doesn't cause a false match that truncates the search region prematurely.
+  const candidate = html.slice(0, 200_000);
+  const stripped = candidate.replace(/<script[\s>][\s\S]*?<\/script>/gi, '');
+  const headEnd = stripped.search(/<\/head[\s>]/i);
+  const searchRegion = headEnd > 0 ? stripped.slice(0, headEnd + 10) : stripped.slice(0, 50_000);
 
   const title = extractFirstMatch(searchRegion, /<title[^>]*>([\s\S]*?)<\/title>/i);
   const description =


### PR DESCRIPTION
## Summary
- Strip `<script>` blocks before searching for `</head>` to prevent false matches inside inline scripts (e.g., `const x = "</head>";`)
- Metadata extraction now operates on script-stripped HTML, avoiding both the false truncation issue and any regex backtracking from script content
- Addresses review feedback from #5778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
