### PR TITLE
fix: remove Tasks option from menu bar dropdown

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -135,11 +135,6 @@ extension AppDelegate {
         newChatItem.image = NSImage(systemSymbolName: "plus.message", accessibilityDescription: nil)
         menu.addItem(newChatItem)
 
-        let tasksItem = NSMenuItem(title: "Tasks", action: #selector(showTasksWindow), keyEquivalent: "t")
-        tasksItem.target = self
-        tasksItem.image = NSImage(systemSymbolName: "list.bullet.clipboard", accessibilityDescription: nil)
-        menu.addItem(tasksItem)
-
         // My Apps submenu
         let myAppsItem = NSMenuItem(title: "My Apps", action: nil, keyEquivalent: "")
         myAppsItem.image = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil)


### PR DESCRIPTION
## Summary
- Remove the "Tasks" menu item from the status bar dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
