### PR TITLE
fix: rename stale discoveredPaths reference to discoveredLinks

### DIFF
--- a/assistant/src/tools/browser/auto-navigate.ts
+++ b/assistant/src/tools/browser/auto-navigate.ts
@@ -171,7 +171,7 @@ export async function autoNavigate(domain: string, abortSignal?: { aborted: bool
   }
 
   cdp.close();
-  log.info({ visited: visitedUrls.length, total: discoveredPaths.length + 1 }, 'Auto-navigation finished');
+  log.info({ visited: visitedUrls.length, total: discoveredLinks.length + 1 }, 'Auto-navigation finished');
   return visitedUrls;
 }
 


### PR DESCRIPTION
One-liner fix: `discoveredPaths` was renamed to `discoveredLinks` in #5783 but one log statement was missed, causing a ReferenceError at runtime.

Addresses review feedback on #5783.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
