### PR TITLE
fix: tasks window UX polish — status chip, labels, see result link

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -11,30 +11,9 @@ struct TasksWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text("Tasks")
-                    .font(VFont.display)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                Text("\(viewModel.items.count)")
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.textMuted)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.top, VSpacing.lg)
-            .padding(.bottom, VSpacing.sm)
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
             // Column headers — fixed above the scrollable list
             HStack(alignment: .center, spacing: 0) {
-                Text("Task")
+                Text("Task Description")
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 Text("Priority")
@@ -48,7 +27,8 @@ struct TasksWindowView: View {
             }
             .font(VFont.captionMedium)
             .foregroundColor(VColor.textMuted)
-            .padding(.vertical, VSpacing.sm)
+            .padding(.top, VSpacing.lg)
+            .padding(.bottom, VSpacing.sm)
             .padding(.horizontal, VSpacing.lg)
             // Inner horizontal padding matches row padding so labels sit
             // directly above their respective columns.
@@ -257,35 +237,36 @@ private struct TasksWindowRow: View {
     private var statusColumn: some View {
         let status = WorkItemStatus(rawStatus: item.status)
         let style = TasksTableContract.statusStyle(for: status)
-        // When the status has output to show, use accent color persistently
-        // (not just on hover) so the badge looks clearly clickable.
-        let textColor = hasOutput ? VColor.accent : style.color
-        let bgColor = hasOutput
-            ? VColor.accent.opacity(isStatusHovered ? 0.24 : 0.14)
-            : style.color.opacity(0.12)
-        return HStack(spacing: VSpacing.xs) {
-            if status == .running {
-                ProgressView()
-                    .controlSize(.mini)
+        return VStack(spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.xs) {
+                if status == .running {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+                Circle()
+                    .fill(style.color)
+                    .frame(width: 6, height: 6)
+                Text(style.label)
+                    .font(VFont.caption)
+                    .foregroundColor(style.color)
             }
-            Text(style.label)
-                .font(VFont.caption)
-                .foregroundColor(textColor)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, 2)
+            .background(style.color.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+
             if hasOutput {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundColor(textColor.opacity(0.6))
+                Text("See result")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.accent)
+                    .underline()
+                    .onHover { hovering in isStatusHovered = hovering }
+                    .opacity(isStatusHovered ? 0.7 : 1.0)
+                    .onTapGesture { onTap() }
+                    .accessibilityLabel("View task output")
+                    .accessibilityAddTraits(.isButton)
             }
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, 2)
-        .background(bgColor)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-        .contentShape(Rectangle())
-        .onHover { hovering in isStatusHovered = hovering }
-        .onTapGesture { if hasOutput { onTap() } }
-        .accessibilityLabel(hasOutput ? "View output — \(style.label)" : "Status \(style.label)")
-        .accessibilityAddTraits(hasOutput ? .isButton : [])
     }
 
     // MARK: - Actions Column


### PR DESCRIPTION
## Summary
- Removed the redundant "Tasks" title header above the table since the window title already says "Tasks"
- Renamed the first column from "Task" to "Task Description" to reduce repetitive labeling
- Fixed the status chip for awaiting_review to use consistent color treatment (colored dot + styled text) instead of the accent-override approach that made it look greyed out
- Added a "See result" underlined link below the status chip when output is available, making it clearly discoverable that the task has viewable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
