### PR TITLE
fix: dismiss surface panel when file upload is canceled

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -92,6 +92,7 @@ struct SurfaceContainerView: View {
                     },
                     onCancel: {
                         viewModel.onAction("cancel", ["files": [Any]()])
+                        viewModel.onDismiss()
                     }
                 )
             case .table, .browserView, .documentPreview:


### PR DESCRIPTION
## Summary
- The file upload surface's `onCancel` handler was sending the cancel action but not calling `onDismiss()`, leaving the panel visible after cancellation
- Added the missing `viewModel.onDismiss()` call to match the expected dismiss behavior

## Test plan
- [ ] Open a file upload surface, click cancel, verify the panel dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
