### PR TITLE
fix: remove visible titlebar from floating surface panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -192,7 +192,10 @@ final class SurfaceManager: ObservableObject {
 
         let view = SurfaceContainerView(viewModel: viewModel)
 
-        let hostingController = NSHostingController(rootView: view)
+        let isDP = if case .dynamicPage = surface.data { true } else { false }
+        let hostingController = isDP
+            ? NSHostingController(rootView: AnyView(view))
+            : NSHostingController(rootView: AnyView(view.ignoresSafeArea(.all, edges: .top)))
 
         let surfacePanelWidth: CGFloat
         let surfacePanelHeight: CGFloat
@@ -215,7 +218,7 @@ final class SurfaceManager: ObservableObject {
             contentRect: NSRect(x: 0, y: 0, width: surfacePanelWidth, height: surfacePanelHeight),
             styleMask: isDynamicPage
                 ? [.titled, .closable, .miniaturizable, .resizable]
-                : [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow, .resizable],
+                : [.titled, .fullSizeContentView, .nonactivatingPanel, .utilityWindow, .hudWindow, .resizable],
             backing: .buffered,
             defer: false
         )


### PR DESCRIPTION
## Summary
- Add `.fullSizeContentView` to non-dynamic surface panel style mask so content extends under the titlebar (keeps rounded corners from `.titled`)
- Add `.ignoresSafeArea(.all, edges: .top)` so the invisible titlebar's safe area inset doesn't create uneven padding

## Test plan
- [ ] File upload surface panel has no visible dark titlebar at the top
- [ ] Panel still has rounded corners
- [ ] Padding is uniform on all four sides
- [ ] Dynamic page surfaces (apps) are unaffected — still show normal titlebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
