### PR TITLE
fix: restore symmetric composer padding for text field

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -133,7 +133,7 @@ struct ComposerView: View {
             .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.xs)
             .padding(.bottom, isComposerExpanded ? VSpacing.sm : VSpacing.xs)
             .padding(.leading, VSpacing.lg)
-            .padding(.trailing, 2)
+            .padding(.trailing, VSpacing.lg)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .fill(VColor.surface)
@@ -359,7 +359,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .padding(.trailing, VSpacing.xs)
+        .padding(.trailing, -(VSpacing.lg - 2))
         .animation(VAnimation.spring, value: canSend)
     }
 


### PR DESCRIPTION
## Summary
- Restore `VSpacing.lg` trailing padding on the composer VStack so the text field has symmetric left/right padding
- Use negative trailing margin on action buttons only to push them flush right (2pt from edge)
- Fixes the asymmetric text area caused by #5789

## Test plan
- [ ] Text field has equal padding on left and right sides
- [ ] Send button still sits flush against the right edge of the composer
- [ ] Attachment button spacing unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
