### PR TITLE
fix: match stop button shape to send button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -260,7 +260,7 @@ struct ComposerView: View {
             if isSending {
                 Button(action: onStop) {
                     ZStack {
-                        Circle()
+                        RoundedRectangle(cornerRadius: 10)
                             .fill(VColor.textPrimary)
                             .frame(width: 30, height: 30)
                         RoundedRectangle(cornerRadius: VRadius.xs)


### PR DESCRIPTION
## Summary
- Change stop button from `Circle()` to `RoundedRectangle(cornerRadius: 10)` to match the send button shape

## Test plan
- [ ] Stop button appears as rounded rectangle during generation
- [ ] Matches send button shape and positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
