### PR TITLE
fix: bump ephemeral task rule priority above defaults to prevent auto-deny

### DIFF
--- a/assistant/src/tasks/ephemeral-permissions.ts
+++ b/assistant/src/tasks/ephemeral-permissions.ts
@@ -22,11 +22,13 @@ export function clearTaskRunRules(taskRunId: string): void {
  * Build ephemeral TrustRule entries from a task's required_tools list.
  *
  * Each rule allows the specified tool with a wildcard pattern scoped to the
- * given working directory. Priority is set to 50 — lower than user rules (100)
- * so that user deny rules still take precedence. `allowHighRisk` is set because
- * task runs execute asynchronously without interactive confirmation — the client
- * pre-approves tools via the preflight flow before execution begins, so there
- * is no interactive prompt during the run itself.
+ * given working directory. Priority is set to 75 — above default rules (50)
+ * so pre-approved tools aren't shadowed by default `ask` rules (which would
+ * trigger prompting and auto-deny in non-interactive task runs), but below
+ * user rules (100) so user deny rules still take precedence. `allowHighRisk`
+ * is set because task runs execute asynchronously without interactive
+ * confirmation — the client pre-approves tools via the preflight flow before
+ * execution begins, so there is no interactive prompt during the run itself.
  */
 export function buildTaskRules(taskRunId: string, requiredTools: string[], workingDir: string): TrustRule[] {
   return requiredTools.map((tool) => ({
@@ -36,7 +38,7 @@ export function buildTaskRules(taskRunId: string, requiredTools: string[], worki
     scope: workingDir,
     decision: 'allow' as const,
     allowHighRisk: true,
-    priority: 50,
+    priority: 75,
     createdAt: Date.now(),
     principalKind: 'task',
     principalId: taskRunId,


### PR DESCRIPTION
## Summary
- Ephemeral task permission rules had priority 50, same as default `ask` rules
- `ruleOrder` tiebreaks same-priority rules with deny > ask > allow, so the default `ask` rule for `host_bash` always won over the ephemeral `allow` rule
- In non-interactive task runs (`isInteractive: false`), a `prompt` decision auto-denies — so pre-approved tools were blocked with "no interactive client connected"
- Bumped ephemeral rule priority from 50 → 75 (above defaults, below user rules at 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
