### PR TITLE
Fix composer text rendering outside the input box

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -11,7 +11,7 @@
         "@huggingface/transformers": "^3.8.1",
         "@qdrant/js-client-rest": "^1.16.2",
         "@sentry/node": "^10.38.0",
-        "@vellumai/cli": "0.1.6",
+        "@vellumai/cli": "0.1.7",
         "@vellumai/vellum-gateway": "^0.1.7",
         "agentmail": "^0.1.0",
         "archiver": "^7.0.1",
@@ -540,7 +540,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.55.0", "", { "dependencies": { "@typescript-eslint/types": "8.55.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA=="],
 
-    "@vellumai/cli": ["@vellumai/cli@0.1.6", "", { "dependencies": { "ink": "^6.7.0", "react": "^19.2.4" }, "bin": { "vellum-cli": "src/index.ts" } }, "sha512-KXCa/Fvy/6Y/S6kJqKo2t+I4/G1dRpmJ8c4IT+90m8F3JnV+enMUca0jUtk/XMtW6iNGBo4VTY8+P8cb7mtD2g=="],
+    "@vellumai/cli": ["@vellumai/cli@0.1.7", "", { "dependencies": { "ink": "^6.7.0", "react": "^19.2.4" }, "bin": { "vellum-cli": "src/index.ts" } }, "sha512-mrFDk4t2L0EK643A7plRZmZPiuu1+MRVimfKRJv38h4o4hVEOInD08Gh8eQJJznIIqobvHIZpgG1RxI/VCLQMg=="],
 
     "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.1.7", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "zod": "^4.3.6" } }, "sha512-JJhCqhsnZ99+dazCUWtOac24p92WyCr3/bxYkfmTgk6yYz9zqH7O1DpjxTLOtjAohQnki4WXNFUCzu48LCtFsg=="],
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -113,6 +113,7 @@ struct ComposerView: View {
                     composerTextField
                         .frame(height: clampedComposerHeight)
                         .frame(maxHeight: isComposerExpanded ? clampedComposerHeight : .infinity, alignment: .center)
+                        .clipped()
                     if !isComposerExpanded {
                         composerActionButtons
                             .frame(maxHeight: .infinity, alignment: .center)
@@ -130,8 +131,8 @@ struct ComposerView: View {
                     .padding(.top, VSpacing.xs)
                 }
             }
-            .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.xs)
-            .padding(.bottom, isComposerExpanded ? VSpacing.sm : VSpacing.xs)
+            .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.sm)
+            .padding(.bottom, isComposerExpanded ? VSpacing.sm : VSpacing.sm)
             .padding(.leading, VSpacing.lg)
             .padding(.trailing, VSpacing.lg)
             .background(
@@ -569,6 +570,10 @@ private struct ComposerTextView: NSViewRepresentable {
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
+        // Ensure text content is clipped to the scroll view frame so it
+        // never renders outside the composer box.
+        scrollView.wantsLayer = true
+        scrollView.layer?.masksToBounds = true
 
         // Use a centering clip view so text + cursor are vertically centered together
         let clipView = CenteringClipView()
@@ -876,8 +881,9 @@ private final class CenteringClipView: NSClipView {
             // centering accounts for the top/bottom padding the text view adds.
             let insetHeight = textView.textContainerInset.height * 2
             let contentHeight = usedHeight + insetHeight
-            if contentHeight < bounds.height {
-                rect.origin.y = (contentHeight - bounds.height) / 2
+            let visibleHeight = proposedBounds.height
+            if contentHeight < visibleHeight {
+                rect.origin.y = (contentHeight - visibleHeight) / 2
             }
         }
         return rect


### PR DESCRIPTION
## Summary
- Add `wantsLayer = true` and `masksToBounds = true` on the composer scroll view to ensure text content is clipped at the AppKit level
- Add `.clipped()` on the composer text field frame in SwiftUI to prevent NSView content from escaping layout bounds
- Increase compact vertical padding from `VSpacing.xs` (4pt) to `VSpacing.sm` (8pt) so text has more breathing room within the rounded border
- Fix `CenteringClipView` to use `proposedBounds.height` instead of `bounds.height` to avoid stale values during layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
