### PR TITLE
Fix composerReservedHeight compact padding to match ComposerView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -179,8 +179,8 @@ struct ChatView: View {
         let editorClamped = min(max(editorContentHeight, 34), 200)
         let contentHeight = max(editorClamped, 34)
         let expanded = isComposerExpanded
-        let topPad: CGFloat = expanded ? VSpacing.md : VSpacing.xs
-        let bottomPad: CGFloat = expanded ? VSpacing.sm : VSpacing.xs
+        let topPad: CGFloat = expanded ? VSpacing.md : VSpacing.sm
+        let bottomPad: CGFloat = expanded ? VSpacing.sm : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 34 + VSpacing.xs : 0
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48


### PR DESCRIPTION
## Summary
- Update `composerReservedHeight` in ChatView.swift to use `VSpacing.sm` (8pt) instead of `VSpacing.xs` (4pt) for compact-mode vertical padding
- Keeps the reserved height calculation in sync with the actual padding applied in ComposerView (changed in #5809)
- Prevents the last chat message from being partially hidden behind the composer

Addresses feedback from #5809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
