### PR TITLE
Fix vellum-gateway integrity hash in bun.lock

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -542,7 +542,7 @@
 
     "@vellumai/cli": ["@vellumai/cli@0.1.7", "", { "dependencies": { "ink": "^6.7.0", "react": "^19.2.4" }, "bin": { "vellum-cli": "src/index.ts" } }, "sha512-mrFDk4t2L0EK643A7plRZmZPiuu1+MRVimfKRJv38h4o4hVEOInD08Gh8eQJJznIIqobvHIZpgG1RxI/VCLQMg=="],
 
-    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.1.9", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "zod": "^4.3.6" } }, "sha512-kRHAeYCuQxkPQt5H4HiaWShnkHNFJO0sw00Z/CIlfmgGU3OyDNt3t9b2A0jHwsfcdjs1EyCIjfnznZ8ESocgog=="],
+    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.1.9", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "zod": "^4.3.6" } }, "sha512-LNE5ueTWvyi4jJxIb99qKyanOX2H9DftR2CliC4vfU6jjLQdvvD3vZccx/VS5uVhfQsIQK08HF1XF9MtCwoJHA=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 


### PR DESCRIPTION
## Summary
- Fix incorrect integrity hash for `@vellumai/vellum-gateway@0.1.9` in `bun.lock`
- The package was republished to npm after the lockfile was generated, causing an integrity mismatch
- This fixes CI failures from PR #5811 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22229357443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
