### PR TITLE
Fix noisy memory conflict prompting from unrelated queries (JARVIS-6)

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -949,7 +949,7 @@ describe('Memory regressions', () => {
         id: 'msg-conflicts-bg',
         conversationId: 'conv-conflicts-bg',
         role: 'user',
-        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new MySQL default instead.' }]),
         createdAt: now + 1,
       }).run();
 
@@ -1047,7 +1047,7 @@ describe('Memory regressions', () => {
         id: 'msg-conflicts-age',
         conversationId: 'conv-conflicts-age',
         role: 'user',
-        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new Bun runtime instead.' }]),
         createdAt: now + 1,
       }).run();
 
@@ -1105,6 +1105,104 @@ describe('Memory regressions', () => {
         .select()
         .from(memoryItems)
         .where(eq(memoryItems.id, 'item-conflict-candidate-age'))
+        .get();
+      const updatedConflict = getConflictById(conflict.id);
+
+      expect(existing?.status).toBe('active');
+      expect(existing?.invalidAt).toBeNull();
+      expect(candidate?.status).toBe('pending_clarification');
+      expect(updatedConflict?.status).toBe('pending_clarification');
+      expect(updatedConflict?.resolutionNote).toBeNull();
+    } finally {
+      TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
+    }
+  });
+
+  test('background conflict resolver ignores clarification-like replies with no topical overlap when conflict was never asked', async () => {
+    const db = getDb();
+    const now = 1_700_001_400_000;
+    const originalConflictsEnabled = TEST_CONFIG.memory.conflicts.enabled;
+    TEST_CONFIG.memory.conflicts.enabled = true;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-conflicts-unrelated',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values({
+        id: 'msg-conflicts-unrelated',
+        conversationId: 'conv-conflicts-unrelated',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        createdAt: now + 1,
+      }).run();
+
+      db.insert(memoryItems).values([
+        {
+          id: 'item-conflict-existing-unrelated',
+          kind: 'preference',
+          subject: 'database',
+          statement: 'Use Postgres by default.',
+          status: 'active',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-existing-unrelated',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-unrelated',
+          firstSeenAt: now - 10_000,
+          lastSeenAt: now - 5_000,
+          validFrom: now - 10_000,
+          invalidAt: null,
+        },
+        {
+          id: 'item-conflict-candidate-unrelated',
+          kind: 'preference',
+          subject: 'database',
+          statement: 'Use MySQL by default.',
+          status: 'pending_clarification',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-candidate-unrelated',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-unrelated',
+          firstSeenAt: now - 9_000,
+          lastSeenAt: now - 4_000,
+          validFrom: now - 9_000,
+          invalidAt: null,
+        },
+      ]).run();
+
+      const conflict = createOrUpdatePendingConflict({
+        scopeId: 'scope-conflicts-unrelated',
+        existingItemId: 'item-conflict-existing-unrelated',
+        candidateItemId: 'item-conflict-candidate-unrelated',
+        relationship: 'ambiguous_contradiction',
+      });
+      db.update(memoryItemConflicts)
+        .set({ createdAt: now, updatedAt: now, lastAskedAt: null })
+        .where(eq(memoryItemConflicts.id, conflict.id))
+        .run();
+
+      enqueueResolvePendingConflictsForMessageJob('msg-conflicts-unrelated', 'scope-conflicts-unrelated');
+      const processed = await runMemoryJobsOnce();
+      expect(processed).toBe(1);
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-existing-unrelated'))
+        .get();
+      const candidate = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-candidate-unrelated'))
         .get();
       const updatedConflict = getConflictById(conflict.id);
 

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -39,8 +39,18 @@ let resolverResult: {
 
 const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
 
+function makeMockLogger(): Record<string, unknown> {
+  const logger: Record<string, unknown> = {};
+  logger.child = () => logger;
+  logger.debug = () => {};
+  logger.info = () => {};
+  logger.warn = () => {};
+  logger.error = () => {};
+  return logger;
+}
+
 mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getLogger: () => makeMockLogger(),
 }));
 
 mock.module('../util/platform.js', () => ({
@@ -305,7 +315,7 @@ describe('Session conflict soft gate', () => {
     await session.processMessage('Should I use React or Vue here?', [], (event) => events.push(event));
 
     expect(runCalls).toHaveLength(0);
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-relevant']);
     const clarificationEvent = events.find((event) => event.type === 'assistant_text_delta');
     expect(clarificationEvent).toBeDefined();
@@ -315,7 +325,7 @@ describe('Session conflict soft gate', () => {
     expect(events.some((event) => event.type === 'message_complete')).toBe(true);
   });
 
-  test('irrelevant unresolved conflict asks once and continues with normal answer flow', async () => {
+  test('irrelevant unresolved conflict does not inject side-question into normal answer flow', async () => {
     pendingConflicts = [{
       id: 'conflict-irrelevant',
       scopeId: 'default',
@@ -332,13 +342,6 @@ describe('Session conflict soft gate', () => {
       existingStatement: 'Use Postgres as the default database.',
       candidateStatement: 'Use MySQL as the default database.',
     }];
-    resolverResult = {
-      resolution: 'keep_existing',
-      strategy: 'heuristic',
-      resolvedStatement: null,
-      explanation: 'Resolved by accident.',
-    };
-
     const session = makeSession();
     await session.loadFromDb();
 
@@ -349,10 +352,10 @@ describe('Session conflict soft gate', () => {
     const injectedUser = runCalls[0][runCalls[0].length - 1];
     expect(injectedUser.role).toBe('user');
     const injectedText = extractText(injectedUser);
-    expect(injectedText).toContain('Memory clarification request');
-    expect(injectedText).toContain('Should I assume Postgres or MySQL?');
+    expect(injectedText).not.toContain('Memory clarification request');
+    expect(injectedText).not.toContain('Should I assume Postgres or MySQL?');
     expect(resolverCallCount).toBe(0);
-    expect(markAskedCalls).toEqual(['conflict-irrelevant']);
+    expect(markAskedCalls).toEqual([]);
     expect(events.some((event) => event.type === 'message_complete')).toBe(true);
   });
 
@@ -379,7 +382,7 @@ describe('Session conflict soft gate', () => {
 
     // First turn asks the clarification and records it as asked.
     await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-followup']);
 
     resolverResult = {
@@ -392,7 +395,7 @@ describe('Session conflict soft gate', () => {
     // Follow-up reply does not overlap statement tokens but should still resolve.
     await session.processMessage('Keep the new one.', [], () => {});
 
-    expect(resolverCallCount).toBe(2);
+    expect(resolverCallCount).toBe(1);
     expect(markAskedCalls).toEqual(['conflict-followup']);
     expect(runCalls).toHaveLength(1);
   });
@@ -420,7 +423,7 @@ describe('Session conflict soft gate', () => {
 
     // First turn asks the clarification.
     await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-concise']);
 
     resolverResult = {
@@ -433,7 +436,7 @@ describe('Session conflict soft gate', () => {
     // Short directional reply with no action verb should still resolve.
     await session.processMessage('both', [], () => {});
 
-    expect(resolverCallCount).toBe(2);
+    expect(resolverCallCount).toBe(1);
     expect(runCalls).toHaveLength(1);
   });
 
@@ -460,7 +463,7 @@ describe('Session conflict soft gate', () => {
 
     // First turn: relevant question triggers clarification ask.
     await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-unrelated']);
 
     // Second turn: unrelated question containing the cue word "new" should NOT
@@ -473,8 +476,8 @@ describe('Session conflict soft gate', () => {
     };
     await session.processMessage("What's new in Bun?", [], () => {});
 
-    // The resolver should NOT have been called again for this unrelated question.
-    expect(resolverCallCount).toBe(1);
+    // The resolver should NOT have been called for this unrelated question.
+    expect(resolverCallCount).toBe(0);
     // Normal agent loop should still run.
     expect(runCalls).toHaveLength(1);
   });
@@ -502,7 +505,7 @@ describe('Session conflict soft gate', () => {
 
     // First turn: triggers clarification ask.
     await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-unrelated-no-qmark']);
 
     resolverResult = {
@@ -516,11 +519,11 @@ describe('Session conflict soft gate', () => {
     // Should NOT resolve the conflict.
     await session.processMessage('I started a new project today', [], () => {});
 
-    expect(resolverCallCount).toBe(1);
+    expect(resolverCallCount).toBe(0);
     expect(runCalls).toHaveLength(1);
   });
 
-  test('cooldown prevents repeated asks on subsequent turns', async () => {
+  test('irrelevant conflicts remain silent across subsequent turns', async () => {
     pendingConflicts = [{
       id: 'conflict-cooldown',
       scopeId: 'default',
@@ -547,9 +550,9 @@ describe('Session conflict soft gate', () => {
     expect(runCalls).toHaveLength(2);
     const firstUserText = extractText(runCalls[0][runCalls[0].length - 1]);
     const secondUserText = extractText(runCalls[1][runCalls[1].length - 1]);
-    expect(firstUserText).toContain('Memory clarification request');
+    expect(firstUserText).not.toContain('Memory clarification request');
     expect(secondUserText).not.toContain('Memory clarification request');
-    expect(markAskedCalls).toEqual(['conflict-cooldown']);
+    expect(markAskedCalls).toEqual([]);
   });
 
   test('passes session scopeId through to conflict store queries', async () => {

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -1,8 +1,8 @@
 /**
  * Conflict-gate logic extracted from Session.
  *
- * Decides whether to ask the user about a pending memory conflict (relevant gate),
- * inject a soft instruction (irrelevant gate), or skip entirely.
+ * Decides whether to ask the user about a pending memory conflict (relevant gate)
+ * or skip entirely.
  */
 
 import {
@@ -12,6 +12,11 @@ import {
 } from '../memory/conflict-store.js';
 import type { PendingConflictDetail } from '../memory/conflict-store.js';
 import { resolveConflictClarification } from '../memory/clarification-resolver.js';
+import {
+  computeConflictRelevance,
+  looksLikeClarificationReply,
+  shouldAttemptConflictResolution,
+} from '../memory/conflict-intent.js';
 
 export interface ConflictGateDecision {
   question: string;
@@ -39,14 +44,14 @@ export class ConflictGate {
     const threshold = conflictConfig.relevanceThreshold;
     const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
     const pendingBeforeResolve = listPendingConflictDetails(scopeId, 50);
+    const clarificationReply = looksLikeClarificationReply(userMessage);
     const candidatesBeforeResolve = pendingBeforeResolve.filter((conflict) => {
       const relevance = computeConflictRelevance(userMessage, conflict);
-      if (relevance >= threshold) return true;
-      // Only try to resolve recently-asked conflicts when the user message
-      // looks like a short clarification reply (e.g. "keep the new one"),
-      // not a full unrelated question that happens to contain cue words.
-      return this.wasRecentlyAsked(conflict.id, cooldownTurns)
-        && looksLikeClarificationReply(userMessage);
+      return shouldAttemptConflictResolution({
+        clarificationReply,
+        relevance,
+        wasRecentlyAsked: this.wasRecentlyAsked(conflict.id, cooldownTurns),
+      });
     });
     await this.resolvePendingConflicts(
       userMessage,
@@ -61,18 +66,16 @@ export class ConflictGate {
       conflict,
       relevance: computeConflictRelevance(userMessage, conflict),
     }));
-    const relevant = scored.filter((entry) => entry.relevance >= threshold);
-    const irrelevant = scored.filter((entry) => entry.relevance < threshold);
-    const ordered = [...relevant, ...irrelevant];
-
-    const askable = ordered.find((entry) => this.shouldAsk(entry.conflict.id, cooldownTurns));
+    const askable = scored
+      .filter((entry) => entry.relevance >= threshold)
+      .find((entry) => this.shouldAsk(entry.conflict.id, cooldownTurns));
     if (!askable) return null;
 
     this.lastAskedTurn.set(askable.conflict.id, this.turnCounter);
     markConflictAsked(askable.conflict.id);
     return {
       question: askable.conflict.clarificationQuestion ?? buildFallbackConflictQuestion(askable.conflict),
-      relevant: askable.relevance >= threshold,
+      relevant: true,
     };
   }
 
@@ -122,98 +125,4 @@ export function buildFallbackConflictQuestion(conflict: PendingConflictDetail): 
     'Which one should I keep?',
   ].join('\n');
 }
-
-export function computeConflictRelevance(
-  userMessage: string,
-  conflict: Pick<PendingConflictDetail, 'existingStatement' | 'candidateStatement'>,
-): number {
-  const queryTokens = tokenizeForConflictRelevance(userMessage);
-  if (queryTokens.size === 0) return 0;
-  const existingTokens = tokenizeForConflictRelevance(conflict.existingStatement);
-  const candidateTokens = tokenizeForConflictRelevance(conflict.candidateStatement);
-  return Math.max(
-    overlapRatio(queryTokens, existingTokens),
-    overlapRatio(queryTokens, candidateTokens),
-  );
-}
-
-function tokenizeForConflictRelevance(input: string): Set<string> {
-  const tokens = input
-    .toLowerCase()
-    .split(/[^a-z0-9]+/g)
-    .map((token) => token.trim())
-    .filter((token) => token.length >= 4);
-  return new Set(tokens);
-}
-
-function overlapRatio(left: Set<string>, right: Set<string>): number {
-  if (left.size === 0 || right.size === 0) return 0;
-  let overlap = 0;
-  for (const token of left) {
-    if (right.has(token)) overlap += 1;
-  }
-  return overlap / Math.max(left.size, right.size);
-}
-
-// Action verbs that signal the user is making a deliberate choice.
-const ACTION_CUES = new Set([
-  'keep', 'use', 'prefer', 'go', 'pick', 'choose', 'take', 'want', 'select',
-]);
-
-// Directional/merge cue words mirrored from clarification-resolver.ts heuristics.
-const DIRECTIONAL_CUES = new Set([
-  'existing', 'old', 'previous', 'first', 'earlier', 'original',
-  'candidate', 'new', 'latest', 'second', 'updated', 'instead', 'replace',
-  'both', 'merge', 'combine', 'together', 'either', 'mix',
-  'option', 'former', 'latter',
-]);
-
-const MAX_REPLY_WORD_COUNT = 12;
-
-// Direction-only matches (no action verb) must be very short to avoid
-// false positives from unrelated statements that happen to contain
-// common words like "new", "old", "option", etc.
-const MAX_DIRECTION_ONLY_WORD_COUNT = 4;
-
-// Messages starting with a question word are unlikely to be clarification
-// replies even when they lack a trailing question mark.
-const QUESTION_WORD_PREFIXES = new Set([
-  'what', 'how', 'why', 'where', 'when', 'which', 'who', 'whom', 'whose',
-]);
-
-/**
- * Determines whether a user message looks like a deliberate reply to a
- * recently asked conflict clarification (e.g. "keep the new one", "both",
- * "option B", "new one"). Requires at least one action or directional cue,
- * and the message must be short. Questions and longer statements are excluded
- * to prevent accidental resolution from unrelated messages.
- *
- * When only directional cues are present (no action verb), the message must
- * be very short (<= 4 words) to avoid false positives from unrelated messages
- * like "What's new in Bun" or "try the old approach".
- */
-export function looksLikeClarificationReply(userMessage: string): boolean {
-  const trimmed = userMessage.trim();
-  if (trimmed.endsWith('?')) return false;
-
-  const words = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
-  if (words.length === 0 || words.length > MAX_REPLY_WORD_COUNT) return false;
-
-  const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
-
-  // Reject messages that start with a question word (even without '?').
-  // Match exact question words or contractions (e.g. "what's", "where's"),
-  // but not words that merely share a prefix (e.g. "whichever", "however").
-  const firstWord = words[0];
-  const firstNorm = normalized[0];
-  for (const qw of QUESTION_WORD_PREFIXES) {
-    if (firstNorm === qw || (firstWord.startsWith(qw) && "'\u2018\u2019".includes(firstWord[qw.length]))) return false;
-  }
-
-  const hasAction = normalized.some((w) => ACTION_CUES.has(w));
-  const hasDirection = normalized.some((w) => DIRECTIONAL_CUES.has(w));
-
-  if (hasAction) return true;
-  if (hasDirection) return words.length <= MAX_DIRECTION_ONLY_WORD_COUNT;
-  return false;
-}
+export { computeConflictRelevance, looksLikeClarificationReply };

--- a/assistant/src/memory/conflict-intent.ts
+++ b/assistant/src/memory/conflict-intent.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared conflict intent helpers used by both interactive conflict gating and
+ * background conflict resolution jobs.
+ */
+
+export interface ConflictStatementPair {
+  existingStatement: string;
+  candidateStatement: string;
+}
+
+export function computeConflictRelevance(
+  userMessage: string,
+  conflict: ConflictStatementPair,
+): number {
+  const queryTokens = tokenizeForConflictRelevance(userMessage);
+  if (queryTokens.size === 0) return 0;
+  const existingTokens = tokenizeForConflictRelevance(conflict.existingStatement);
+  const candidateTokens = tokenizeForConflictRelevance(conflict.candidateStatement);
+  return Math.max(
+    overlapRatio(queryTokens, existingTokens),
+    overlapRatio(queryTokens, candidateTokens),
+  );
+}
+
+function tokenizeForConflictRelevance(input: string): Set<string> {
+  const tokens = input
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 4);
+  return new Set(tokens);
+}
+
+function overlapRatio(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 || right.size === 0) return 0;
+  let overlap = 0;
+  for (const token of left) {
+    if (right.has(token)) overlap += 1;
+  }
+  return overlap / Math.max(left.size, right.size);
+}
+
+// Action verbs that signal the user is making a deliberate choice.
+const ACTION_CUES = new Set([
+  'keep', 'use', 'prefer', 'go', 'pick', 'choose', 'take', 'want', 'select',
+]);
+
+// Directional/merge cue words mirrored from clarification-resolver.ts heuristics.
+const DIRECTIONAL_CUES = new Set([
+  'existing', 'old', 'previous', 'first', 'earlier', 'original',
+  'candidate', 'new', 'latest', 'second', 'updated', 'instead', 'replace',
+  'both', 'merge', 'combine', 'together', 'either', 'mix',
+  'option', 'former', 'latter',
+]);
+
+const MAX_REPLY_WORD_COUNT = 12;
+
+// Direction-only matches (no action verb) must be very short to avoid
+// false positives from unrelated statements that happen to contain
+// common words like "new", "old", "option", etc.
+const MAX_DIRECTION_ONLY_WORD_COUNT = 4;
+
+// Messages starting with a question word are unlikely to be clarification
+// replies even when they lack a trailing question mark.
+const QUESTION_WORD_PREFIXES = new Set([
+  'what', 'how', 'why', 'where', 'when', 'which', 'who', 'whom', 'whose',
+]);
+
+/**
+ * Determines whether a user message looks like a deliberate clarification
+ * reply (e.g. "keep the new one", "both", "option B").
+ */
+export function looksLikeClarificationReply(userMessage: string): boolean {
+  const trimmed = userMessage.trim();
+  if (trimmed.endsWith('?')) return false;
+
+  const words = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0 || words.length > MAX_REPLY_WORD_COUNT) return false;
+
+  const normalized = words.map((w) => w.replace(/[^a-z]/g, ''));
+
+  // Reject messages that start with a question word (even without '?').
+  // Match exact question words or contractions (e.g. "what's", "where's"),
+  // but not words that merely share a prefix (e.g. "whichever", "however").
+  const firstWord = words[0];
+  const firstNorm = normalized[0];
+  for (const qw of QUESTION_WORD_PREFIXES) {
+    if (firstNorm === qw || (firstWord.startsWith(qw) && "'\u2018\u2019".includes(firstWord[qw.length]))) return false;
+  }
+
+  const hasAction = normalized.some((w) => ACTION_CUES.has(w));
+  const hasDirection = normalized.some((w) => DIRECTIONAL_CUES.has(w));
+
+  if (hasAction) return true;
+  if (hasDirection) return words.length <= MAX_DIRECTION_ONLY_WORD_COUNT;
+  return false;
+}
+
+/**
+ * Conflict resolution should require explicit clarification intent and either:
+ * - non-zero topical overlap with the conflict statements, or
+ * - a very recent explicit ask from the assistant.
+ */
+export function shouldAttemptConflictResolution(
+  input: {
+    clarificationReply: boolean;
+    relevance: number;
+    wasRecentlyAsked: boolean;
+  },
+): boolean {
+  if (!input.clarificationReply) return false;
+  if (input.relevance > 0) return true;
+  return input.wasRecentlyAsked;
+}

--- a/assistant/src/memory/job-handlers/conflict.ts
+++ b/assistant/src/memory/job-handlers/conflict.ts
@@ -1,6 +1,11 @@
 import { and, asc, eq, inArray, lt, ne } from 'drizzle-orm';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
+import {
+  computeConflictRelevance,
+  looksLikeClarificationReply,
+  shouldAttemptConflictResolution,
+} from '../conflict-intent.js';
 import { getDb } from '../db.js';
 import { resolveConflictClarification } from '../clarification-resolver.js';
 import { applyConflictResolution, listPendingConflictDetails } from '../conflict-store.js';
@@ -12,6 +17,7 @@ import { memoryItemConflicts, messages } from '../schema.js';
 const log = getLogger('memory-jobs-worker');
 
 const CLEANUP_BATCH_LIMIT = 250;
+const BACKGROUND_RECENT_ASK_WINDOW_MS = 6 * 60 * 60 * 1000;
 
 export async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
   if (!config.memory.conflicts.enabled) return;
@@ -33,13 +39,28 @@ export async function resolvePendingConflictsForMessageJob(job: MemoryJob, confi
 
   const userMessage = extractTextFromStoredMessageContent(message.content).trim();
   if (userMessage.length === 0) return;
+  const clarificationReply = looksLikeClarificationReply(userMessage);
+  if (!clarificationReply) return;
 
   const pending = listPendingConflictDetails(scopeId, 25);
   const eligible = pending.filter((conflict) => conflict.createdAt <= message.createdAt);
   if (eligible.length === 0) return;
+  const candidates = eligible.filter((conflict) => {
+    const askedAt = conflict.lastAskedAt;
+    const wasRecentlyAsked = typeof askedAt === 'number'
+      && askedAt <= message.createdAt
+      && message.createdAt - askedAt <= BACKGROUND_RECENT_ASK_WINDOW_MS;
+    const relevance = computeConflictRelevance(userMessage, conflict);
+    return shouldAttemptConflictResolution({
+      clarificationReply,
+      relevance,
+      wasRecentlyAsked,
+    });
+  });
+  if (candidates.length === 0) return;
 
   let resolvedCount = 0;
-  for (const conflict of eligible) {
+  for (const conflict of candidates) {
     const resolution = await resolveConflictClarification(
       {
         existingStatement: conflict.existingStatement,
@@ -63,6 +84,7 @@ export async function resolvePendingConflictsForMessageJob(job: MemoryJob, confi
     scopeId,
     pendingConflicts: pending.length,
     eligibleConflicts: eligible.length,
+    candidateConflicts: candidates.length,
     resolvedConflicts: resolvedCount,
   }, 'Processed pending conflict resolution job');
 }


### PR DESCRIPTION
## Summary\n- stop in-band conflict questions for irrelevant turns (only ask when relevance threshold is met)\n- add shared conflict-intent gating so both interactive and background conflict resolution require explicit clarification intent\n- restrict background resolver to relevant or recently-asked conflicts instead of evaluating every user message\n- add regression coverage for unrelated clarification-like replies\n\n## Validation\n- cd assistant && bun test src/__tests__/session-conflict-gate.test.ts\n- cd assistant && bun test src/__tests__/memory-regressions.test.ts\n- cd assistant && bun test src/__tests__/memory-lifecycle-e2e.test.ts\n\nLinear: https://linear.app/vellum/issue/JARVIS-6/assistant-repeatedly-asks-to-update-identity-from-normal-queries\n\nCloses JARVIS-6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
