### PR TITLE
Fix assistant source tree resolution in bunx hatch layout

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -11,7 +11,7 @@
         "@huggingface/transformers": "^3.8.1",
         "@qdrant/js-client-rest": "^1.16.2",
         "@sentry/node": "^10.38.0",
-        "@vellumai/cli": "0.1.7",
+        "@vellumai/cli": "0.1.8",
         "@vellumai/vellum-gateway": "0.1.9",
         "agentmail": "^0.1.0",
         "archiver": "^7.0.1",
@@ -540,7 +540,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.55.0", "", { "dependencies": { "@typescript-eslint/types": "8.55.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA=="],
 
-    "@vellumai/cli": ["@vellumai/cli@0.1.7", "", { "dependencies": { "ink": "^6.7.0", "react": "^19.2.4" }, "bin": { "vellum-cli": "src/index.ts" } }, "sha512-mrFDk4t2L0EK643A7plRZmZPiuu1+MRVimfKRJv38h4o4hVEOInD08Gh8eQJJznIIqobvHIZpgG1RxI/VCLQMg=="],
+    "@vellumai/cli": ["@vellumai/cli@0.1.8", "", { "dependencies": { "ink": "^6.7.0", "react": "^19.2.4" }, "bin": { "vellum-cli": "src/index.ts" } }, "sha512-mrFDk4t2L0EK643A7plRZmZPiuu1+MRVimfKRJv38h4o4hVEOInD08Gh8eQJJznIIqobvHIZpgG1RxI/VCLQMg=="],
 
     "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.1.9", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "zod": "^4.3.6" } }, "sha512-LNE5ueTWvyi4jJxIb99qKyanOX2H9DftR2CliC4vfU6jjLQdvvD3vZccx/VS5uVhfQsIQK08HF1XF9MtCwoJHA=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "bin": {
     "vellum": "./src/index.ts"
@@ -28,7 +28,7 @@
     "@huggingface/transformers": "^3.8.1",
     "@qdrant/js-client-rest": "^1.16.2",
     "@sentry/node": "^10.38.0",
-    "@vellumai/cli": "0.1.7",
+    "@vellumai/cli": "0.1.8",
     "@vellumai/vellum-gateway": "0.1.9",
     "agentmail": "^0.1.0",
     "archiver": "^7.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "bin": {

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -805,8 +805,15 @@ async function hatchLocal(species: Species, name: string | null): Promise<void> 
       console.warn("⚠️  Daemon socket did not appear within 10s — continuing anyway");
     }
   } else {
+    // Source tree layout: cli/src/commands/ -> ../../.. -> repo root -> assistant/src/index.ts
     const sourceTreeIndex = join(import.meta.dir, "..", "..", "..", "assistant", "src", "index.ts");
+    // bunx layout: @vellumai/cli/src/commands/ -> ../../../.. -> node_modules/ -> vellum/src/index.ts
+    const bunxIndex = join(import.meta.dir, "..", "..", "..", "..", "vellum", "src", "index.ts");
     let assistantIndex = sourceTreeIndex;
+
+    if (!existsSync(assistantIndex)) {
+      assistantIndex = bunxIndex;
+    }
 
     if (!existsSync(assistantIndex)) {
       try {


### PR DESCRIPTION
## Summary
- When running `bunx vellum hatch` in cloud environments, the `@vellumai/cli` package is nested at `node_modules/@vellumai/cli/`, causing the relative path `../../../assistant/src/index.ts` to incorrectly resolve to `@vellumai/assistant/src/index.ts`
- Adds a second candidate path (`../../../../vellum/src/index.ts`) that correctly resolves in the bunx layout by going up to `node_modules/` and into the `vellum` package
- Bumps `@vellumai/cli` to 0.1.8 and `vellum` to 0.2.6

## Test plan
- [ ] Run `bunx vellum hatch` on a cloud instance and verify the daemon starts successfully
- [ ] Run `vel hatch` from the source tree and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
