### PR TITLE
Fix Twilio credential key mismatch with credential_store format

### DIFF
--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -12,14 +12,14 @@ export interface TwilioConfig {
 }
 
 export function getTwilioConfig(): TwilioConfig {
-  const accountSid = getSecureKey('twilio_account_sid');
-  const authToken = getSecureKey('twilio_auth_token');
-  const phoneNumber = process.env.TWILIO_PHONE_NUMBER || getSecureKey('twilio_phone_number') || '';
+  const accountSid = getSecureKey('credential:twilio:account_sid');
+  const authToken = getSecureKey('credential:twilio:auth_token');
+  const phoneNumber = process.env.TWILIO_PHONE_NUMBER || getSecureKey('credential:twilio:phone_number') || '';
   const webhookBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL || '';
   const wssBaseUrl = process.env.TWILIO_WSS_BASE_URL || '';
 
   if (!accountSid || !authToken) {
-    throw new Error('Twilio credentials not configured. Set twilio_account_sid and twilio_auth_token via the credential_store tool.');
+    throw new Error('Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.');
   }
   if (!phoneNumber) {
     throw new Error('TWILIO_PHONE_NUMBER not configured.');


### PR DESCRIPTION
## Summary
- Fix `getTwilioConfig()` to use `credential:twilio:account_sid` / `credential:twilio:auth_token` / `credential:twilio:phone_number` key format instead of flat `twilio_account_sid` etc.
- The `credential_store` tool saves secrets with the `credential:{service}:{field}` pattern, but `getTwilioConfig()` was looking up flat keys — they never matched.
- Also update the error message to reference the correct key names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
