### PR TITLE
Fix IPCRideShotgunStart convenience init missing autoNavigate param

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -201,8 +201,8 @@ extension IPCCuObservation {
 public typealias RideShotgunStartMessage = IPCRideShotgunStart
 
 extension IPCRideShotgunStart {
-    public init(durationSeconds: Double, intervalSeconds: Double, mode: String? = nil, targetDomain: String? = nil) {
-        self.init(type: "ride_shotgun_start", durationSeconds: durationSeconds, intervalSeconds: intervalSeconds, mode: mode, targetDomain: targetDomain)
+    public init(durationSeconds: Double, intervalSeconds: Double, mode: String? = nil, targetDomain: String? = nil, autoNavigate: Bool? = nil) {
+        self.init(type: "ride_shotgun_start", durationSeconds: durationSeconds, intervalSeconds: intervalSeconds, mode: mode, targetDomain: targetDomain, autoNavigate: autoNavigate)
     }
 }
 


### PR DESCRIPTION
## Summary
- The generated `IPCRideShotgunStart` struct gained a new `autoNavigate: Bool?` field, but the convenience initializer in `IPCMessages.swift` wasn't updated to include it.
- Add the `autoNavigate` parameter (defaulting to `nil`) to the convenience init and forward it to the memberwise init.
- Fixes a Swift compile error that prevented the macOS app from building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
