### PR TITLE
fix: attach .catch() before await to handle orphaned enrichment rejections

### DIFF
--- a/assistant/src/workspace/commit-message-enrichment-service.ts
+++ b/assistant/src/workspace/commit-message-enrichment-service.ts
@@ -183,6 +183,9 @@ export class CommitEnrichmentService {
       // has already settled with the timeout error, that rejection is orphaned.
       // The .catch() swallows it to prevent an unhandled promise rejection.
       const enrichmentPromise = this.doEnrichment(job, controller.signal);
+      enrichmentPromise.catch(() => {
+        // Intentionally swallowed — the timeout branch already handled the error
+      });
       await Promise.race([
         enrichmentPromise,
         new Promise<never>((_, reject) => {
@@ -192,9 +195,6 @@ export class CommitEnrichmentService {
           }, this.jobTimeoutMs);
         }),
       ]);
-      enrichmentPromise.catch(() => {
-        // Intentionally swallowed — the timeout branch already handled the error
-      });
       this.succeededCount++;
       log.debug(
         { commitHash: job.commitHash, attempts: job.attempts },


### PR DESCRIPTION
Moves the .catch() handler from after await Promise.race() to immediately after promise creation, ensuring it is unconditionally attached regardless of which branch wins the race. Previously the .catch() only ran on the success path, leaving orphaned rejections unhandled on timeout. Addresses feedback from PR #5720.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
