### PR TITLE
fix: restore previous client ID on secret storage failure instead of deleting

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -503,6 +503,7 @@ export function handleTwitterIntegrationConfig(
         });
         return;
       }
+      const previousClientId = getSecureKey('credential:integration:twitter:oauth_client_id');
       const storedId = setSecureKey('credential:integration:twitter:oauth_client_id', msg.clientId);
       if (!storedId) {
         ctx.send(socket, {
@@ -518,8 +519,12 @@ export function handleTwitterIntegrationConfig(
       if (msg.clientSecret) {
         const storedSecret = setSecureKey('credential:integration:twitter:oauth_client_secret', msg.clientSecret);
         if (!storedSecret) {
-          // Roll back the already-persisted client ID to avoid inconsistent OAuth state
-          deleteSecureKey('credential:integration:twitter:oauth_client_id');
+          // Roll back the client ID to its previous value to avoid inconsistent OAuth state
+          if (previousClientId) {
+            setSecureKey('credential:integration:twitter:oauth_client_id', previousClientId);
+          } else {
+            deleteSecureKey('credential:integration:twitter:oauth_client_id');
+          }
           ctx.send(socket, {
             type: 'twitter_integration_config_response',
             success: false,


### PR DESCRIPTION
When storing a new Twitter OAuth client secret fails, the rollback now restores the previous client ID instead of unconditionally deleting it. This preserves PKCE clientId-only configurations. Addresses feedback from PR #5714.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
