### PR TITLE
fix: migrate twilio-provider.ts to credential:twilio:* key format

### DIFF
--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -17,11 +17,11 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── Credential helpers ──────────────────────────────────────────────
 
   private getCredentials(): { accountSid: string; authToken: string } {
-    const accountSid = getSecureKey('twilio_account_sid');
-    const authToken = getSecureKey('twilio_auth_token');
+    const accountSid = getSecureKey('credential:twilio:account_sid');
+    const authToken = getSecureKey('credential:twilio:auth_token');
     if (!accountSid || !authToken) {
       throw new Error(
-        'Twilio credentials not configured. Set twilio_account_sid and twilio_auth_token via the credential_store tool.',
+        'Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.',
       );
     }
     return { accountSid, authToken };
@@ -134,7 +134,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
    * HTTP server webhook middleware) can check availability independently.
    */
   static getAuthToken(): string | null {
-    return getSecureKey('twilio_auth_token') ?? null;
+    return getSecureKey('credential:twilio:auth_token') ?? null;
   }
 
   /**


### PR DESCRIPTION
Updates twilio-provider.ts to use the credential:twilio:* key format, matching the change already made to twilio-config.ts in PR #5822. Without this, getCredentials() and getAuthToken() look up the old flat keys and fail to find credentials stored via the credential_store tool. Addresses feedback from PR #5822.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
