### PR TITLE
docs: align Twitter allowedTools with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2481,7 +2481,7 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
 ```
 {
   accountInfo: "@username",
-  allowedTools: ["twitter_post", "twitter_read"],
+  allowedTools: ["twitter_post"],
   allowedDomains: [],
   oauth2TokenUrl: "https://api.x.com/2/oauth2/token",
   oauth2ClientId: "<user's client ID>",
@@ -2501,7 +2501,7 @@ The `vellum x post` CLI command uses an alternative mechanism that does not requ
 |------|-----------|-------------|
 | `twitter_post` | OAuth2 or CDP | Post a tweet. Available via the `X` bundled skill (`vellum x post`). |
 
-Note: `twitter_read` is listed in `allowedTools` metadata but has no tool implementation. The `tweet.read` and `users.read` OAuth2 scopes are used for identity verification during the auth flow.
+Note: The `tweet.read` and `users.read` OAuth2 scopes are used for identity verification during the auth flow, but read functionality is not exposed as a tool.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ Connect via the Settings UI or `integration_connect` IPC message. OAuth2 tokens 
 
 Twitter integration supports posting to X via two mechanisms:
 
-1. **OAuth2 PKCE flow** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. Tokens are stored in the credential vault with `allowedTools: ["twitter_post", "twitter_read"]`. Connect via the Settings UI or `twitter_auth_start` IPC message.
+1. **OAuth2 PKCE flow** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. Tokens are stored in the credential vault with `allowedTools: ["twitter_post"]`. Connect via the Settings UI or `twitter_auth_start` IPC message.
 
 2. **Browser session** (CDP): The `vellum x post` CLI command posts via Chrome DevTools Protocol, executing GraphQL mutations through an authenticated x.com browser tab. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
 
-**Available tool**: `twitter_post` — posts a tweet. There is no `twitter_read` tool implementation; the OAuth2 scopes include `tweet.read` and `users.read` for identity verification, but read functionality is not currently exposed as a tool.
+**Available tool**: `twitter_post` — posts a tweet. The OAuth2 scopes include `tweet.read` and `users.read` for identity verification, but read functionality is not exposed as a tool.
 
 **Setup (OAuth2 mode)**: Store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`). Optionally store a Client Secret. Then initiate the OAuth2 flow from the Settings UI.
 


### PR DESCRIPTION
## Summary
- Update README.md and ARCHITECTURE.md to reflect that Twitter credential metadata `allowedTools` is `["twitter_post"]`, not `["twitter_post", "twitter_read"]`
- Remove incorrect claims that `twitter_read` is listed in `allowedTools`
- Retain accurate note that OAuth2 scopes include `tweet.read` and `users.read` for identity verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
