### PR TITLE
M1: Baseline test coverage for allow-always persistence

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -3854,3 +3854,107 @@ describe('computer-use tool permission defaults', () => {
     expect(risk).toBe(RiskLevel.Low);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Scope-matching behavior: project-scoped vs everywhere rules
+// ---------------------------------------------------------------------------
+
+describe('scope matching behavior', () => {
+  beforeEach(() => {
+    clearCache();
+    testConfig.permissions = { mode: 'legacy' };
+    try { rmSync(join(checkerTestDir, 'protected', 'trust.json')); } catch { /* may not exist */ }
+  });
+
+  test('project-scoped rule matches tool invocations from within that directory', async () => {
+    const projectDir = '/home/user/my-project';
+    // Use the pattern format that file tools produce: "toolName:path/**"
+    addRule('file_write', 'file_write:/home/user/my-project/**', projectDir);
+
+    // Invocation from within the project directory should match
+    const result = await check('file_write', { path: '/home/user/my-project/src/index.ts' }, projectDir);
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRule).toBeDefined();
+    expect(result.matchedRule!.scope).toBe(projectDir);
+  });
+
+  test('project-scoped rule matches tool invocations from subdirectory of project', async () => {
+    const projectDir = '/home/user/my-project';
+    addRule('file_write', 'file_write:/home/user/my-project/**', projectDir);
+
+    // Invocation from a subdirectory should also match (scope is a prefix match)
+    const result = await check('file_write', { path: '/home/user/my-project/src/index.ts' }, '/home/user/my-project/src');
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRule).toBeDefined();
+    expect(result.matchedRule!.scope).toBe(projectDir);
+  });
+
+  test('project-scoped rule does NOT match invocations from sibling directory', async () => {
+    const projectDir = '/home/user/my-project';
+    // Use a broad pattern that matches any file, scoped to the project
+    addRule('file_write', 'file_write:*', projectDir);
+
+    // Invocation from a sibling directory should NOT match the project-scoped rule
+    const result = await check('file_write', { path: '/home/user/other-project/file.ts' }, '/home/user/other-project');
+    expect(result.decision).toBe('prompt');
+  });
+
+  test('project-scoped rule does NOT match invocations from parent directory', async () => {
+    const projectDir = '/home/user/my-project';
+    addRule('file_write', 'file_write:*', projectDir);
+
+    // Invocation from a parent directory should NOT match
+    const result = await check('file_write', { path: '/home/user/file.txt' }, '/home/user');
+    expect(result.decision).toBe('prompt');
+  });
+
+  test('project-scoped rule does NOT match directory with shared prefix', async () => {
+    // A rule for /home/user/project should NOT match /home/user/project-evil
+    // (directory-boundary enforcement in matchesScope)
+    const projectDir = '/home/user/project';
+    addRule('file_write', 'file_write:*', projectDir);
+
+    const result = await check('file_write', { path: '/home/user/project-evil/malicious.ts' }, '/home/user/project-evil');
+    expect(result.decision).toBe('prompt');
+  });
+
+  test('everywhere-scoped rule matches invocations from any directory', async () => {
+    addRule('file_write', 'file_write:*', 'everywhere');
+
+    // Should match from various directories
+    const r1 = await check('file_write', { path: 'file.ts' }, '/home/user/project-a');
+    expect(r1.decision).toBe('allow');
+    expect(r1.matchedRule).toBeDefined();
+    expect(r1.matchedRule!.scope).toBe('everywhere');
+
+    const r2 = await check('file_write', { path: 'output.txt' }, '/var/tmp');
+    expect(r2.decision).toBe('allow');
+    expect(r2.matchedRule!.scope).toBe('everywhere');
+
+    const r3 = await check('file_write', { path: 'file.json' }, '/opt/data');
+    expect(r3.decision).toBe('allow');
+    expect(r3.matchedRule!.scope).toBe('everywhere');
+  });
+
+  test('bash rule scoped to project matches commands within that project', async () => {
+    const projectDir = '/home/user/my-project';
+    addRule('bash', 'npm *', projectDir);
+
+    const result = await check('bash', { command: 'npm install' }, projectDir);
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRule).toBeDefined();
+  });
+
+  test('bash rule scoped to project does NOT match commands from different project', async () => {
+    const projectDir = '/home/user/my-project';
+    addRule('bash', 'npm *', projectDir);
+
+    const result = await check('bash', { command: 'npm install' }, '/home/user/other-project');
+    // npm install is Low risk, so it falls through to auto-allow via the
+    // default sandbox bash rule, not via the project-scoped rule.
+    // The key assertion is that the project-scoped rule is NOT the matched rule.
+    if (result.matchedRule) {
+      expect(result.matchedRule.scope).not.toBe(projectDir);
+    }
+  });
+});

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1965,3 +1965,91 @@ describe('buildSanitizedEnv — baseline: credential exclusion', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Persistent-allow lifecycle: roundtrip and auto-allow on subsequent invocation
+// ---------------------------------------------------------------------------
+
+describe('ToolExecutor persistent-allow lifecycle', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+    lastCheckArgs = undefined;
+    getToolOverride = undefined;
+    checkResultOverride = undefined;
+    checkFnOverride = undefined;
+    if (addRuleSpy) { addRuleSpy.mockRestore(); addRuleSpy = undefined; }
+  });
+
+  function setupAddRuleSpy() {
+    addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      },
+    );
+    return addRuleSpy;
+  }
+
+  test('persistent-allow roundtrip: always_allow saves rule and allows tool', async () => {
+    // Simulate check() returning 'prompt' so the executor asks the user
+    checkResultOverride = { decision: 'prompt', reason: 'Medium risk: requires approval' };
+    const spy = setupAddRuleSpy();
+
+    // User responds with always_allow, selecting a pattern and scope
+    const prompter = makePrompterWithDecision('always_allow', 'git *', '/tmp/project');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('bash', { command: 'git status' }, makeContext());
+
+    // The tool should have been allowed to proceed
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+
+    // addRule should have been called with the correct arguments
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [tool, pattern, scope, decision] = spy.mock.calls[0];
+    expect(tool).toBe('bash');
+    expect(pattern).toBe('git *');
+    expect(scope).toBe('/tmp/project');
+    expect(decision).toBe('allow');
+  });
+
+  test('auto-allow on subsequent invocation: matching rule skips prompt', async () => {
+    // Simulate a previously saved rule by making check() return 'allow'
+    // with a matched rule (as findHighestPriorityRule would).
+    checkResultOverride = { decision: 'allow', reason: 'Matched trust rule: git *' };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => { promptCalled = true; return { decision: 'allow' as const }; },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    const result = await executor.execute('bash', { command: 'git status' }, makeContext());
+
+    // The tool should be auto-allowed
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+
+    // The prompter should NOT have been called — the rule auto-allowed
+    expect(promptCalled).toBe(false);
+  });
+
+  test('always_allow with everywhere scope saves rule and allows tool', async () => {
+    checkResultOverride = { decision: 'prompt', reason: 'Medium risk: requires approval' };
+    const spy = setupAddRuleSpy();
+
+    const prompter = makePrompterWithDecision('always_allow', 'file_write:*', 'everywhere');
+    const executor = new ToolExecutor(prompter);
+    const result = await executor.execute('file_write', { path: '/tmp/test.txt', content: 'hello' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [tool, pattern, scope, decision] = spy.mock.calls[0];
+    expect(tool).toBe('file_write');
+    expect(pattern).toBe('file_write:*');
+    expect(scope).toBe('everywhere');
+    expect(decision).toBe('allow');
+  });
+});


### PR DESCRIPTION
Part of #5831. Adds backend tests for persistent-allow lifecycle roundtrip, auto-allow on subsequent invocations, guard clauses, and scope matching behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
