### PR TITLE
M2: Unify confirmation persistence on always_allow

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -67,8 +67,8 @@ struct ChatContentView: View {
                                         viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
                                     },
                                     onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
-                                    onAddTrustRule: { toolName, pattern, scope, decision in
-                                        viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision)
+                                    onAlwaysAllow: { requestId, selectedPattern, selectedScope in
+                                        viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope)
                                     }
                                 )
                                 .id(message.id)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -33,7 +33,7 @@ struct ChatView: View {
     var configuredProviders: Set<String> = []
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
-    let onAddTrustRule: (String, String, String, String) -> Bool
+    let onAlwaysAllow: (String, String, String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onRegenerate: () -> Void
     let sessionError: SessionError?
@@ -387,7 +387,7 @@ struct ChatView: View {
                                     confirmation: confirmation,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                    onAddTrustRule: onAddTrustRule
+                                    onAlwaysAllow: onAlwaysAllow
                                 )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -407,7 +407,7 @@ struct ChatView: View {
                                         confirmation: confirmation,
                                         onAllow: { onConfirmationAllow(confirmation.requestId) },
                                         onDeny: { onConfirmationDeny(confirmation.requestId) },
-                                        onAddTrustRule: onAddTrustRule
+                                        onAlwaysAllow: onAlwaysAllow
                                     )
                                     .id(message.id)
                                     .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -642,7 +642,7 @@ private struct ChatViewPreviewWrapper: View {
                 onMicrophoneToggle: {},
                 onConfirmationAllow: { _ in },
                 onConfirmationDeny: { _ in },
-                onAddTrustRule: { _, _, _, _ in true },
+                onAlwaysAllow: { _, _, _ in },
                 onSurfaceAction: { _, _, _ in },
                 onRegenerate: {},
                 sessionError: nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -506,7 +506,7 @@ struct ActiveChatViewWrapper: View {
             configuredProviders: settingsStore.configuredProviders,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
-            onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
+            onAlwaysAllow: { requestId, selectedPattern, selectedScope in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
             onRegenerate: { viewModel.regenerateLastMessage() },
             sessionError: viewModel.sessionError,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1075,6 +1075,28 @@ public final class ChatViewModel: ObservableObject {
         onInlineConfirmationResponse?(requestId, decision)
     }
 
+    /// Respond to a tool confirmation with "always_allow", sending the selected pattern and scope
+    /// so the backend atomically persists the trust rule alongside the confirmation response.
+    public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String) {
+        guard daemonClient.isConnected else {
+            errorText = "Failed to send confirmation response."
+            return
+        }
+        do {
+            try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: "always_allow", selectedPattern: selectedPattern, selectedScope: selectedScope))
+        } catch {
+            log.error("Failed to send always_allow confirmation response: \(error.localizedDescription)")
+            errorText = "Failed to send confirmation response."
+            return
+        }
+        // IPC send succeeded — update the message state
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            messages[index].confirmation?.state = .approved
+        }
+        // Dismiss the corresponding floating panel / native notification if one exists
+        onInlineConfirmationResponse?(requestId, "allow")
+    }
+
     /// Update the inline confirmation message state without sending a response to the daemon.
     /// Used when the floating panel handles the response.
     public func updateConfirmationState(requestId: String, decision: String) {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -13,20 +13,20 @@ public struct MessageBubbleView: View {
     /// When non-nil, a "Regenerate" option appears in the long-press context menu
     /// for the last assistant message. Pass nil when generation is in-flight.
     public let onRegenerate: (() -> Void)?
-    public let onAddTrustRule: ((String, String, String, String) -> Bool)?
+    public let onAlwaysAllow: ((String, String, String) -> Void)?
 
     public init(
         message: ChatMessage,
         onConfirmationResponse: ((String, String) -> Void)?,
         onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?,
         onRegenerate: (() -> Void)?,
-        onAddTrustRule: ((String, String, String, String) -> Bool)? = nil
+        onAlwaysAllow: ((String, String, String) -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
         self.onSurfaceAction = onSurfaceAction
         self.onRegenerate = onRegenerate
-        self.onAddTrustRule = onAddTrustRule
+        self.onAlwaysAllow = onAlwaysAllow
     }
 
     public var body: some View {
@@ -46,8 +46,8 @@ public struct MessageBubbleView: View {
                         onDeny: {
                             onConfirmationResponse?(confirmation.requestId, "deny")
                         },
-                        onAddTrustRule: { toolName, pattern, scope, decision in
-                            onAddTrustRule?(toolName, pattern, scope, decision) ?? false
+                        onAlwaysAllow: { requestId, pattern, scope in
+                            onAlwaysAllow?(requestId, pattern, scope)
                         }
                     )
                 } else if message.role == .assistant && hasInterleavedContent {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -7,17 +7,17 @@ public struct ToolConfirmationBubble: View {
     public let confirmation: ToolConfirmationData
     public let onAllow: () -> Void
     public let onDeny: () -> Void
-    public let onAddTrustRule: (String, String, String, String) -> Bool
+    public let onAlwaysAllow: (String, String, String) -> Void
 
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
     @State private var showTechnicalDetails = true
 
-    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAddTrustRule: @escaping (String, String, String, String) -> Bool) {
+    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String) -> Void) {
         self.confirmation = confirmation
         self.onAllow = onAllow
         self.onDeny = onDeny
-        self.onAddTrustRule = onAddTrustRule
+        self.onAlwaysAllow = onAlwaysAllow
     }
 
     private var hasRuleOptions: Bool {
@@ -348,9 +348,10 @@ public struct ToolConfirmationBubble: View {
                 let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
                 let scope = confirmation.scopeOptions.first?.scope ?? ""
                 if !pattern.isEmpty && !scope.isEmpty {
-                    _ = onAddTrustRule(confirmation.toolName, pattern, scope, "allow")
+                    onAlwaysAllow(confirmation.requestId, pattern, scope)
+                } else {
+                    onAllow()
                 }
-                onAllow()
             }
             .help(patternDesc.isEmpty ? "Always allow this action" : patternDesc)
         }
@@ -372,9 +373,10 @@ public struct ToolConfirmationBubble: View {
                         showAlwaysAllowMenu = false
                         let scope = confirmation.scopeOptions.first?.scope ?? ""
                         if !option.pattern.isEmpty && !scope.isEmpty {
-                            _ = onAddTrustRule(confirmation.toolName, option.pattern, scope, "allow")
+                            onAlwaysAllow(confirmation.requestId, option.pattern, scope)
+                        } else {
+                            onAllow()
                         }
-                        onAllow()
                     }
 
                     if index < confirmation.allowlistOptions.count - 1 {
@@ -479,7 +481,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // File write — high risk, pending
@@ -493,7 +495,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // Bash — low risk, pending
@@ -507,7 +509,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // Always-allow dropdown — medium risk
@@ -529,7 +531,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // Collapsed — approved
@@ -543,7 +545,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // Collapsed — denied
@@ -557,7 +559,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // Unknown tool fallback
@@ -570,7 +572,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
 
         // System permission request (pending)
@@ -586,7 +588,7 @@ private struct AlwaysAllowRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in true }
+            onAlwaysAllow: { _, _, _ in }
         )
     }
     .padding(VSpacing.xl)


### PR DESCRIPTION
Part of #5831. Replaces the fire-and-forget dual-path (AddTrustRule + allow) with a single ConfirmationResponse(decision: always_allow) that the backend handles atomically. Removes onAddTrustRule from ToolConfirmationBubble in favor of onAlwaysAllow callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
