### PR TITLE
M4: User-visible failure handling + diagnostics

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -164,9 +164,9 @@ export function handleAddTrustRule(
 ): void {
   try {
     addRule(msg.toolName, msg.pattern, msg.scope, msg.decision);
-    log.info({ tool: msg.toolName, pattern: msg.pattern, scope: msg.scope, decision: msg.decision }, 'Trust rule added via client');
+    log.info({ toolName: msg.toolName, pattern: msg.pattern, scope: msg.scope, decision: msg.decision }, 'Trust rule added via client');
   } catch (err) {
-    log.error({ err }, 'Failed to add trust rule');
+    log.error({ err, toolName: msg.toolName, pattern: msg.pattern, scope: msg.scope }, 'Failed to add trust rule via client');
   }
 }
 

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -14,6 +14,9 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } from '../permissions/checker.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('session-tool-setup');
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { coreAppProxyTools } from '../tools/apps/definitions.js';
@@ -248,10 +251,12 @@ export function createToolExecutor(
           req.principal,
         );
         if ((response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') && response.selectedPattern && response.selectedScope) {
+          log.info({ toolName: 'cc:' + req.toolName, pattern: response.selectedPattern, scope: response.selectedScope, highRisk: response.decision === 'always_allow_high_risk' }, 'Persisting always-allow trust rule');
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'allow', 100,
             response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined);
         }
         if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
+          log.info({ toolName: 'cc:' + req.toolName, pattern: response.selectedPattern, scope: response.selectedScope }, 'Persisting always-deny trust rule');
           addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'deny');
         }
         return {
@@ -440,10 +445,12 @@ export function createProxyApprovalCallback(
 
     // Persist trust rule if the user chose "always allow" or "always deny"
     if ((response.decision === 'always_allow' || response.decision === 'always_allow_high_risk') && response.selectedPattern && response.selectedScope) {
+      log.info({ toolName, pattern: response.selectedPattern, scope: response.selectedScope, highRisk: response.decision === 'always_allow_high_risk' }, 'Persisting always-allow trust rule (proxy)');
       addRule(toolName, response.selectedPattern, response.selectedScope, 'allow', 100,
         response.decision === 'always_allow_high_risk' ? { allowHighRisk: true } : undefined);
     }
     if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
+      log.info({ toolName, pattern: response.selectedPattern, scope: response.selectedScope }, 'Persisting always-deny trust rule (proxy)');
       addRule(toolName, response.selectedPattern, response.selectedScope, 'deny');
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1077,16 +1077,23 @@ public final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation with "always_allow", sending the selected pattern and scope
     /// so the backend atomically persists the trust rule alongside the confirmation response.
+    /// On failure (daemon disconnected or IPC error), falls back to a one-time allow so the
+    /// current action isn't blocked, and shows a warning that the persistent preference wasn't saved.
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String) {
         guard daemonClient.isConnected else {
-            errorText = "Failed to send confirmation response."
+            // Fallback: try one-time allow so the current action isn't blocked
+            respondToConfirmation(requestId: requestId, decision: "allow")
+            log.warning("Always-allow failed (daemon disconnected) — fell back to one-time allow")
+            errorText = "Preference could not be saved (daemon disconnected). This action was allowed once."
             return
         }
         do {
             try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: "always_allow", selectedPattern: selectedPattern, selectedScope: selectedScope))
         } catch {
-            log.error("Failed to send always_allow confirmation response: \(error.localizedDescription)")
-            errorText = "Failed to send confirmation response."
+            // Fallback: try one-time allow so the current action isn't blocked
+            respondToConfirmation(requestId: requestId, decision: "allow")
+            log.warning("Always-allow IPC failed — fell back to one-time allow: \(error.localizedDescription)")
+            errorText = "Preference could not be saved. This action was allowed once."
             return
         }
         // IPC send succeeded — update the message state


### PR DESCRIPTION
Part of #5831. Falls back to one-time allow when always-allow persistence fails (daemon disconnect or IPC error), with a user-visible warning. Adds structured logging around trust rule persistence for diagnostics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
