### PR TITLE
Fix misleading fallback message when daemon disconnected

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1077,23 +1077,26 @@ public final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation with "always_allow", sending the selected pattern and scope
     /// so the backend atomically persists the trust rule alongside the confirmation response.
-    /// On failure (daemon disconnected or IPC error), falls back to a one-time allow so the
-    /// current action isn't blocked, and shows a warning that the persistent preference wasn't saved.
+    /// If the daemon is disconnected, shows an error without attempting a fallback (since
+    /// respondToConfirmation would also fail). On IPC send errors, attempts a one-time allow
+    /// fallback and only claims success if the fallback actually went through.
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String) {
         guard daemonClient.isConnected else {
-            // Fallback: try one-time allow so the current action isn't blocked
-            respondToConfirmation(requestId: requestId, decision: "allow")
-            log.warning("Always-allow failed (daemon disconnected) — fell back to one-time allow")
-            errorText = "Preference could not be saved (daemon disconnected). This action was allowed once."
+            log.warning("Cannot persist always-allow: daemon not connected")
+            errorText = "Cannot send confirmation — daemon is not connected."
             return
         }
         do {
             try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: "always_allow", selectedPattern: selectedPattern, selectedScope: selectedScope))
         } catch {
-            // Fallback: try one-time allow so the current action isn't blocked
+            log.warning("Always-allow IPC failed: \(error.localizedDescription)")
+            // Try one-time allow as fallback (daemon may still be connected)
             respondToConfirmation(requestId: requestId, decision: "allow")
-            log.warning("Always-allow IPC failed — fell back to one-time allow: \(error.localizedDescription)")
-            errorText = "Preference could not be saved. This action was allowed once."
+            // respondToConfirmation sets errorText on failure; override with more context if it succeeded
+            if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }),
+               messages[index].confirmation?.state == .approved {
+                errorText = "Preference could not be saved. This action was allowed once."
+            }
             return
         }
         // IPC send succeeded — update the message state


### PR DESCRIPTION
Addresses review feedback on #5846. When daemon is disconnected, don't falsely claim the action was allowed once — the fallback respondToConfirmation also fails. In the catch path, only claim one-time allow if the fallback actually succeeded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
