### PR TITLE
M1: Config schema + Twilio URL helper + runtime refactor

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -646,6 +646,7 @@ describe('AssistantConfigSchema', () => {
     expect(result.calls).toEqual({
       enabled: true,
       provider: 'twilio',
+      webhookBaseUrl: '',
       maxDurationSeconds: 3600,
       userConsultTimeoutSeconds: 120,
       disclosure: {
@@ -656,6 +657,11 @@ describe('AssistantConfigSchema', () => {
         denyCategories: [],
       },
     });
+  });
+
+  test('calls.webhookBaseUrl defaults to empty string', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.calls.webhookBaseUrl).toBe('');
   });
 
   test('accepts valid calls config overrides', () => {

--- a/assistant/src/calls/__tests__/twilio-webhook-urls.test.ts
+++ b/assistant/src/calls/__tests__/twilio-webhook-urls.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mocks — silence logger output during tests
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of ['info', 'warn', 'error', 'debug', 'trace', 'fatal', 'silent', 'child']) {
+    stub[m] = m === 'child' ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module('../../util/logger.js', () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+import {
+  normalizeBaseUrl,
+  buildTwilioVoiceWebhookUrl,
+  buildTwilioStatusCallbackUrl,
+  getWebhookBaseUrl,
+} from '../twilio-webhook-urls.js';
+
+// ---------------------------------------------------------------------------
+// normalizeBaseUrl
+// ---------------------------------------------------------------------------
+
+describe('normalizeBaseUrl', () => {
+  test('returns already-clean URL unchanged', () => {
+    expect(normalizeBaseUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  test('strips trailing slash', () => {
+    expect(normalizeBaseUrl('https://example.com/')).toBe('https://example.com');
+  });
+
+  test('strips multiple trailing slashes', () => {
+    expect(normalizeBaseUrl('https://example.com///')).toBe('https://example.com');
+  });
+
+  test('trims leading and trailing whitespace', () => {
+    expect(normalizeBaseUrl('  https://example.com  ')).toBe('https://example.com');
+  });
+
+  test('trims whitespace and strips trailing slash together', () => {
+    expect(normalizeBaseUrl('  https://example.com/  ')).toBe('https://example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTwilioVoiceWebhookUrl
+// ---------------------------------------------------------------------------
+
+describe('buildTwilioVoiceWebhookUrl', () => {
+  test('returns correct URL with callSessionId', () => {
+    const url = buildTwilioVoiceWebhookUrl('https://example.com', 'session-123');
+    expect(url).toBe('https://example.com/webhooks/twilio/voice?callSessionId=session-123');
+  });
+
+  test('normalizes base URL before composing', () => {
+    const url = buildTwilioVoiceWebhookUrl('https://example.com/', 'abc');
+    expect(url).toBe('https://example.com/webhooks/twilio/voice?callSessionId=abc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTwilioStatusCallbackUrl
+// ---------------------------------------------------------------------------
+
+describe('buildTwilioStatusCallbackUrl', () => {
+  test('returns correct URL', () => {
+    const url = buildTwilioStatusCallbackUrl('https://example.com');
+    expect(url).toBe('https://example.com/webhooks/twilio/status');
+  });
+
+  test('normalizes base URL before composing', () => {
+    const url = buildTwilioStatusCallbackUrl('https://example.com/');
+    expect(url).toBe('https://example.com/webhooks/twilio/status');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWebhookBaseUrl
+// ---------------------------------------------------------------------------
+
+describe('getWebhookBaseUrl', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.TWILIO_WEBHOOK_BASE_URL;
+    delete process.env.TWILIO_WEBHOOK_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.TWILIO_WEBHOOK_BASE_URL = savedEnv;
+    } else {
+      delete process.env.TWILIO_WEBHOOK_BASE_URL;
+    }
+  });
+
+  test('uses config value when set', () => {
+    const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: 'https://config.example.com/' } });
+    expect(result).toBe('https://config.example.com');
+  });
+
+  test('falls back to env var when config value is empty', () => {
+    process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com/';
+    const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: '' } });
+    expect(result).toBe('https://env.example.com');
+  });
+
+  test('falls back to env var when config value is undefined', () => {
+    process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com';
+    const result = getWebhookBaseUrl({ calls: {} });
+    expect(result).toBe('https://env.example.com');
+  });
+
+  test('throws when neither config nor env var is set', () => {
+    expect(() => getWebhookBaseUrl({ calls: { webhookBaseUrl: '' } })).toThrow(
+      /No webhook base URL configured/,
+    );
+  });
+
+  test('throws when config is undefined and env var is unset', () => {
+    expect(() => getWebhookBaseUrl({ calls: {} })).toThrow(
+      /No webhook base URL configured/,
+    );
+  });
+
+  test('normalizes the returned URL', () => {
+    const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: '  https://example.com/  ' } });
+    expect(result).toBe('https://example.com');
+  });
+});

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -20,6 +20,7 @@ import { getCallOrchestrator, unregisterCallOrchestrator } from './call-state.js
 import { activeRelayConnections } from './relay-server.js';
 import { TwilioConversationRelayProvider } from './twilio-provider.js';
 import { getTwilioConfig } from './twilio-config.js';
+import { buildTwilioVoiceWebhookUrl, buildTwilioStatusCallbackUrl } from './twilio-webhook-urls.js';
 import type { CallSession } from './types.js';
 
 const log = getLogger('call-domain');
@@ -102,12 +103,11 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
 
     log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
 
-    const baseUrl = config.webhookBaseUrl.replace(/\/$/, '');
     const { callSid } = await provider.initiateCall({
       from: config.phoneNumber,
       to: phoneNumber,
-      webhookUrl: `${baseUrl}/webhooks/twilio/voice?callSessionId=${session.id}`,
-      statusCallbackUrl: `${baseUrl}/webhooks/twilio/status`,
+      webhookUrl: buildTwilioVoiceWebhookUrl(config.webhookBaseUrl, session.id),
+      statusCallbackUrl: buildTwilioStatusCallbackUrl(config.webhookBaseUrl),
     });
 
     updateCallSession(session.id, { providerCallSid: callSid });

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,5 +1,7 @@
 import { getSecureKey } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
+import { loadConfig } from '../config/loader.js';
+import { getWebhookBaseUrl } from './twilio-webhook-urls.js';
 
 const log = getLogger('twilio-config');
 
@@ -15,7 +17,8 @@ export function getTwilioConfig(): TwilioConfig {
   const accountSid = getSecureKey('credential:twilio:account_sid');
   const authToken = getSecureKey('credential:twilio:auth_token');
   const phoneNumber = process.env.TWILIO_PHONE_NUMBER || getSecureKey('credential:twilio:phone_number') || '';
-  const webhookBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL || '';
+  const config = loadConfig();
+  const webhookBaseUrl = getWebhookBaseUrl(config);
   const wssBaseUrl = process.env.TWILIO_WSS_BASE_URL || '';
 
   if (!accountSid || !authToken) {
@@ -23,9 +26,6 @@ export function getTwilioConfig(): TwilioConfig {
   }
   if (!phoneNumber) {
     throw new Error('TWILIO_PHONE_NUMBER not configured.');
-  }
-  if (!webhookBaseUrl) {
-    throw new Error('TWILIO_WEBHOOK_BASE_URL not configured.');
   }
 
   log.debug('Twilio config loaded successfully');

--- a/assistant/src/calls/twilio-webhook-urls.ts
+++ b/assistant/src/calls/twilio-webhook-urls.ts
@@ -1,0 +1,48 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('twilio-webhook-urls');
+
+/**
+ * Resolve the webhook base URL from config, falling back to the
+ * TWILIO_WEBHOOK_BASE_URL environment variable with a deprecation warning.
+ * Throws if neither source provides a value.
+ */
+export function getWebhookBaseUrl(config: { calls: { webhookBaseUrl?: string } }): string {
+  const configValue = config.calls.webhookBaseUrl;
+  if (configValue) {
+    return normalizeBaseUrl(configValue);
+  }
+
+  const envValue = process.env.TWILIO_WEBHOOK_BASE_URL;
+  if (envValue) {
+    log.warn(
+      'TWILIO_WEBHOOK_BASE_URL env var is deprecated — set calls.webhookBaseUrl in config instead.',
+    );
+    return normalizeBaseUrl(envValue);
+  }
+
+  throw new Error(
+    'No webhook base URL configured. Set calls.webhookBaseUrl in config or TWILIO_WEBHOOK_BASE_URL env var.',
+  );
+}
+
+/**
+ * Trim whitespace and strip trailing slash from a URL string.
+ */
+export function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Build the Twilio voice webhook URL for a given call session.
+ */
+export function buildTwilioVoiceWebhookUrl(baseUrl: string, callSessionId: string): string {
+  return `${normalizeBaseUrl(baseUrl)}/webhooks/twilio/voice?callSessionId=${callSessionId}`;
+}
+
+/**
+ * Build the Twilio status callback URL.
+ */
+export function buildTwilioStatusCallbackUrl(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}/webhooks/twilio/status`;
+}

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -217,6 +217,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   calls: {
     enabled: true,
     provider: 'twilio' as const,
+    webhookBaseUrl: '',
     maxDurationSeconds: 3600,
     userConsultTimeoutSeconds: 120,
     disclosure: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -883,6 +883,9 @@ export const CallsConfigSchema = z.object({
       error: `calls.provider must be one of: ${VALID_CALL_PROVIDERS.join(', ')}`,
     })
     .default('twilio'),
+  webhookBaseUrl: z
+    .string({ error: 'calls.webhookBaseUrl must be a string' })
+    .default(''),
   maxDurationSeconds: z
     .number({ error: 'calls.maxDurationSeconds must be a number' })
     .int('calls.maxDurationSeconds must be an integer')
@@ -1149,6 +1152,7 @@ export const AssistantConfigSchema = z.object({
   calls: CallsConfigSchema.default({
     enabled: true,
     provider: 'twilio',
+    webhookBaseUrl: '',
     maxDurationSeconds: 3600,
     userConsultTimeoutSeconds: 120,
     disclosure: {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -11,6 +11,8 @@ import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
+import { loadConfig } from '../config/loader.js';
+import { getWebhookBaseUrl } from '../calls/twilio-webhook-urls.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 
 // Route handlers — grouped by domain
@@ -182,10 +184,15 @@ async function validateTwilioWebhook(
   // Behind proxies/gateways, req.url is the local server URL (e.g.
   // http://127.0.0.1:7821/...) which differs from the public URL Twilio
   // used to compute the HMAC-SHA1 signature.
-  const publicBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL;
+  let publicBaseUrl: string | undefined;
+  try {
+    publicBaseUrl = getWebhookBaseUrl(loadConfig());
+  } catch {
+    // No webhook base URL configured — fall back to using req.url as-is
+  }
   const parsedUrl = new URL(req.url);
   const publicUrl = publicBaseUrl
-    ? publicBaseUrl.replace(/\/$/, '') + parsedUrl.pathname + parsedUrl.search
+    ? publicBaseUrl + parsedUrl.pathname + parsedUrl.search
     : req.url;
 
   const isValid = TwilioConversationRelayProvider.verifyWebhookSignature(


### PR DESCRIPTION
Adds calls.webhookBaseUrl to config schema, creates twilio-webhook-urls.ts helper for centralized URL composition with env fallback + deprecation warning, refactors call-domain.ts and http-server.ts to use config-backed URL. Part of #5839.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
