### PR TITLE
M3: macOS Settings UI for Twilio webhook base URL

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -24,6 +24,7 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
+    @State private var twilioWebhookUrlText: String = ""
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
     @State private var integrationError: (id: String, message: String)?
@@ -85,6 +86,8 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
+            store.refreshTwilioWebhookConfig()
+            twilioWebhookUrlText = store.twilioWebhookBaseUrl
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }
@@ -510,6 +513,50 @@ struct SettingsPanel: View {
 
             // TWITTER / X section
             twitterSection
+
+            // TWILIO WEBHOOK section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Twilio")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack(spacing: VSpacing.xs) {
+                    Text("Base Webhook URL")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                TextField("https://abc123.ngrok-free.app", text: $twilioWebhookUrlText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Setting a public base URL may expose this computer to the public internet. Use with caution.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                Text("Twilio webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+
+                VButton(label: "Save", style: .primary) {
+                    store.saveTwilioWebhookBaseUrl(twilioWebhookUrlText)
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -75,6 +75,10 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthError: String?
 
+    // MARK: - Twilio Webhook State
+
+    @Published var twilioWebhookBaseUrl: String = ""
+
     // MARK: - Trust Rules Coordination
 
     /// Whether any settings surface currently has a trust rules sheet open.
@@ -175,6 +179,14 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
+        // Wire up Twilio webhook config IPC response
+        daemonClient?.onTwilioWebhookConfigResponse = { [weak self] response in
+            guard let self else { return }
+            if response.success {
+                self.twilioWebhookBaseUrl = response.webhookBaseUrl
+            }
+        }
+
         // Wire up Twitter auth result IPC response
         daemonClient?.onTwitterAuthResult = { [weak self] response in
             guard let self else { return }
@@ -197,6 +209,9 @@ public final class SettingsStore: ObservableObject {
 
         // Refresh Twitter integration status on init
         refreshTwitterStatus()
+
+        // Refresh Twilio webhook config on init
+        refreshTwilioWebhookConfig()
     }
 
     // MARK: - API Key Actions
@@ -351,6 +366,18 @@ public final class SettingsStore: ObservableObject {
     func disconnectTwitter() {
         twitterAuthInProgress = false
         try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
+    }
+
+    // MARK: - Twilio Webhook Actions
+
+    func refreshTwilioWebhookConfig() {
+        try? daemonClient?.send(TwilioWebhookConfigRequestMessage(action: "get"))
+    }
+
+    func saveTwilioWebhookBaseUrl(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        try? daemonClient?.send(TwilioWebhookConfigRequestMessage(action: "set", webhookBaseUrl: trimmed))
+        twilioWebhookBaseUrl = trimmed
     }
 
     // MARK: - Model Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -11,6 +11,7 @@ public struct SettingsView: View {
     @State private var vercelKeyText = ""
     @State private var twitterClientId = ""
     @State private var twitterClientSecret = ""
+    @State private var twilioWebhookUrlText = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
@@ -323,6 +324,31 @@ public struct SettingsView: View {
                 }
             }
 
+            Section("Twilio") {
+                TextField("Base Webhook URL (e.g. https://abc123.ngrok-free.app)", text: $twilioWebhookUrlText)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.system(size: 12))
+                    Text("Setting a public base URL may expose this computer to the public internet. Use with caution.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Twilio webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Spacer()
+                    Button("Save") {
+                        store.saveTwilioWebhookBaseUrl(twilioWebhookUrlText)
+                    }
+                }
+            }
+
             Section("Computer Use") {
                 HStack {
                     Text("Max steps per session")
@@ -523,6 +549,8 @@ public struct SettingsView: View {
             store.refreshAPIKeyState()
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
+            store.refreshTwilioWebhookConfig()
+            twilioWebhookUrlText = store.twilioWebhookBaseUrl
             checkPermissions()
         }
         .onDisappear {


### PR DESCRIPTION
Add Base Webhook URL text input to both SettingsView and SettingsPanel with amber warning about public internet exposure. Wired through SettingsStore using existing daemon IPC (twilio_webhook_config).\n\nPart of #5839.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
