### PR TITLE
Fix getWebhookBaseUrl empty string edge case

### DIFF
--- a/assistant/src/calls/__tests__/twilio-webhook-urls.test.ts
+++ b/assistant/src/calls/__tests__/twilio-webhook-urls.test.ts
@@ -134,4 +134,29 @@ describe('getWebhookBaseUrl', () => {
     const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: '  https://example.com/  ' } });
     expect(result).toBe('https://example.com');
   });
+
+  test('falls through when config value is whitespace-only', () => {
+    process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com';
+    const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: '   ' } });
+    expect(result).toBe('https://env.example.com');
+  });
+
+  test('falls through when config value is slash-only', () => {
+    process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com';
+    const result = getWebhookBaseUrl({ calls: { webhookBaseUrl: '///' } });
+    expect(result).toBe('https://env.example.com');
+  });
+
+  test('throws when config is whitespace-only and env var is unset', () => {
+    expect(() => getWebhookBaseUrl({ calls: { webhookBaseUrl: '   ' } })).toThrow(
+      /No webhook base URL configured/,
+    );
+  });
+
+  test('throws when env var is whitespace-only and config is empty', () => {
+    process.env.TWILIO_WEBHOOK_BASE_URL = '   ';
+    expect(() => getWebhookBaseUrl({ calls: {} })).toThrow(
+      /No webhook base URL configured/,
+    );
+  });
 });

--- a/assistant/src/calls/twilio-webhook-urls.ts
+++ b/assistant/src/calls/twilio-webhook-urls.ts
@@ -10,7 +10,8 @@ const log = getLogger('twilio-webhook-urls');
 export function getWebhookBaseUrl(config: { calls: { webhookBaseUrl?: string } }): string {
   const configValue = config.calls.webhookBaseUrl;
   if (configValue) {
-    return normalizeBaseUrl(configValue);
+    const normalized = normalizeBaseUrl(configValue);
+    if (normalized) return normalized;
   }
 
   const envValue = process.env.TWILIO_WEBHOOK_BASE_URL;
@@ -18,7 +19,8 @@ export function getWebhookBaseUrl(config: { calls: { webhookBaseUrl?: string } }
     log.warn(
       'TWILIO_WEBHOOK_BASE_URL env var is deprecated — set calls.webhookBaseUrl in config instead.',
     );
-    return normalizeBaseUrl(envValue);
+    const normalized = normalizeBaseUrl(envValue);
+    if (normalized) return normalized;
   }
 
   throw new Error(


### PR DESCRIPTION
Check normalized result is non-empty before returning from getWebhookBaseUrl. Whitespace-only or slash-only config/env values now correctly fall through to the next source or throw.\n\nAddresses review feedback from #5853.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
