### PR TITLE
Fix config reload suppression race in Twilio webhook handler

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -412,8 +412,13 @@ export function handleTwilioWebhookConfig(
       const raw = loadRawConfig();
       const calls = (raw?.calls ?? {}) as Record<string, unknown>;
       calls.webhookBaseUrl = value || undefined;
-      saveRawConfig({ ...raw, calls });
       ctx.setSuppressConfigReload(true);
+      try {
+        saveRawConfig({ ...raw, calls });
+      } catch (err) {
+        ctx.setSuppressConfigReload(false);
+        throw err;
+      }
       const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
       if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
       const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);


### PR DESCRIPTION
Move setSuppressConfigReload(true) before saveRawConfig to prevent file watcher race condition. Follows the established pattern from handleModelSet.\n\nAddresses review feedback from #5856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
