### PR TITLE
M2: Turn commit context quality without blocking

### DIFF
--- a/assistant/src/__tests__/turn-commit.test.ts
+++ b/assistant/src/__tests__/turn-commit.test.ts
@@ -487,4 +487,68 @@ describe('LLM commit message integration', () => {
 
     expect(fullMessage).toContain('Turn:');
   });
+
+  test('changed files from preStatus are passed to generator', async () => {
+    let capturedContext: { changedFiles: string[] } | undefined;
+    let capturedOptions: { changedFiles: string[] } | undefined;
+
+    const llmResult: GenerateCommitMessageResult = {
+      message: 'feat: captured context test',
+      source: 'llm',
+    };
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async (ctx: { changedFiles: string[] }, opts: { changedFiles: string[] }) => {
+          capturedContext = ctx;
+          capturedOptions = opts;
+          return llmResult;
+        },
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    writeFileSync(join(testDir, 'alpha.ts'), 'export const a = 1;');
+    writeFileSync(join(testDir, 'beta.ts'), 'export const b = 2;');
+
+    await commit(testDir, 'sess_files', 1);
+
+    // The generator should have received the actual file list, not empty arrays
+    expect(capturedContext).toBeDefined();
+    expect(capturedContext!.changedFiles.length).toBeGreaterThan(0);
+    expect(capturedContext!.changedFiles).toContain('alpha.ts');
+    expect(capturedContext!.changedFiles).toContain('beta.ts');
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions!.changedFiles.length).toBeGreaterThan(0);
+    expect(capturedOptions!.changedFiles).toContain('alpha.ts');
+    expect(capturedOptions!.changedFiles).toContain('beta.ts');
+  });
+
+  test('clean workspace skips LLM generator call', async () => {
+    let generatorCalled = false;
+
+    mock.module('../workspace/provider-commit-message-generator.js', () => ({
+      getCommitMessageGenerator: () => ({
+        generateCommitMessage: async () => {
+          generatorCalled = true;
+          return { message: 'should not be called', source: 'llm' as const };
+        },
+      }),
+    }));
+
+    const { commitTurnChanges: commit } = await import('../workspace/turn-commit.js');
+
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // No file changes — workspace is clean
+    await commit(testDir, 'sess_clean', 1);
+
+    expect(generatorCalled).toBe(false);
+  });
 });

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -72,10 +72,14 @@ export async function commitTurnChanges(
     if (!provider) {
       // Guard: skip pre-check if deadline already elapsed to avoid unnecessary mutex contention
       let preClean = false;
+      let candidateChangedFiles: string[] = [];
       if (!deadlineMs || Date.now() < deadlineMs) {
         try {
           const preStatus = await gitService.getStatus();
           preClean = preStatus.clean;
+          if (!preClean) {
+            candidateChangedFiles = [...new Set([...preStatus.staged, ...preStatus.modified, ...preStatus.untracked])];
+          }
         } catch {
           // If we can't determine status, assume dirty so we don't skip the commit
         }
@@ -90,10 +94,10 @@ export async function commitTurnChanges(
               trigger: 'turn',
               sessionId,
               turnNumber,
-              changedFiles: [], // File list unavailable outside the git mutex; generator handles empty arrays
+              changedFiles: candidateChangedFiles,
               timestampMs: Date.now(),
             },
-            { deadlineMs, changedFiles: [] },
+            { deadlineMs, changedFiles: candidateChangedFiles },
           );
           commitMessageSource = result.source;
           llmFallbackReason = result.reason;


### PR DESCRIPTION
Closes #5851. Part of #5849.

## Changes
- Extract candidate file list from pre-status check in turn-commit
- Pass real changed files to LLM generator instead of empty arrays
- Keep lock discipline: getStatus() and LLM call remain outside git mutex
- Add tests verifying file context is passed when workspace is dirty

## Test plan
- `bun test assistant/src/__tests__/turn-commit.test.ts` — all green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
