### PR TITLE
Sync Twilio URL field with async IPC response

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -100,6 +100,9 @@ struct SettingsPanel: View {
                 mouseDownMonitor = nil
             }
         }
+        .onChange(of: store.twilioWebhookBaseUrl) { _, newValue in
+            twilioWebhookUrlText = newValue
+        }
         .onChange(of: showModelDropdown) { _, isOpen in
             if let monitor = mouseDownMonitor {
                 NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -561,6 +561,9 @@ public struct SettingsView: View {
         .onReceive(permissionTimer) { _ in
             checkPermissions()
         }
+        .onChange(of: store.twilioWebhookBaseUrl) { _, newValue in
+            twilioWebhookUrlText = newValue
+        }
         .sheet(isPresented: $showingSkills, onDismiss: {
             skillsViewModel = nil
         }) {


### PR DESCRIPTION
Add .onChange(of: store.twilioWebhookBaseUrl) handlers to SettingsView and SettingsPanel so the text field updates when the daemon responds with the saved webhook URL.\n\nAddresses review feedback from #5857.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
