### PR TITLE
Fix provider key + keyless provider handling

### DIFF
--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -40,8 +40,11 @@ Rules:
 const PROVIDER_DEFAULT_FAST_MODELS: Record<string, string> = {
   anthropic: 'claude-haiku-4-5-20251001',
   openai: 'gpt-4o-mini',
-  google: 'gemini-2.0-flash',
+  gemini: 'gemini-2.0-flash',
 };
+
+// Providers that can be initialized without an API key (e.g., Ollama runs locally)
+const KEYLESS_PROVIDERS = new Set(['ollama']);
 
 const deterministicProvider = new DefaultCommitMessageProvider();
 
@@ -110,11 +113,13 @@ export class ProviderCommitMessageGenerator {
       return buildDeterministicResult(context, 'disabled');
     }
 
-    // Step 2.5: API key preflight
-    const providerApiKey = config.apiKeys[config.provider];
-    if (!providerApiKey || providerApiKey === '') {
-      log.debug('Provider API key missing; falling back to deterministic');
-      return buildDeterministicResult(context, 'missing_provider_api_key');
+    // Step 2.5: API key preflight (skip for providers that run without a key)
+    if (!KEYLESS_PROVIDERS.has(config.provider)) {
+      const providerApiKey = config.apiKeys[config.provider];
+      if (!providerApiKey || providerApiKey === '') {
+        log.debug('Provider API key missing; falling back to deterministic');
+        return buildDeterministicResult(context, 'missing_provider_api_key');
+      }
     }
 
     // Step 3: Circuit breaker


### PR DESCRIPTION
Fix 'google' → 'gemini' key in PROVIDER_DEFAULT_FAST_MODELS and skip API key preflight for keyless providers like Ollama.\n\nAddresses review feedback from #5861.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
