### PR TITLE
Sync Twilio URL field with async config responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -124,7 +124,12 @@ final class AvatarAppearanceManager {
 
         let path = looksPath
         let fd = open(path, O_EVTONLY)
-        guard fd >= 0 else { return }
+
+        if fd < 0 {
+            // File doesn't exist yet — watch the parent directory for creation
+            watchDirectory()
+            return
+        }
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
@@ -133,12 +138,42 @@ final class AvatarAppearanceManager {
         )
 
         source.setEventHandler { [weak self] in
+            let flags = source.data
             Task { @MainActor [weak self] in
                 self?.reload()
                 // Re-watch in case of delete+recreate
-                let flags = source.data
                 if flags.contains(.delete) || flags.contains(.rename) {
                     self?.watchFile()
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        fileMonitor = source
+        source.resume()
+    }
+
+    /// Watches the workspace directory for LOOKS.md creation, then switches to file-level watching.
+    private func watchDirectory() {
+        let dirPath = (looksPath as NSString).deletingLastPathComponent
+        let fd = open(dirPath, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: .write,
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if FileManager.default.fileExists(atPath: self.looksPath) {
+                    self.reload()
+                    self.watchFile()
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Avatar/DinoPalette.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/DinoPalette.swift
@@ -53,7 +53,7 @@ struct DinoOutfit: Equatable {
 enum BodyColorScale {
     static let scales: [String: (outline: UInt32, dark: UInt32, mid: UInt32, light: UInt32, belly: UInt32)] = [
         // From ColorTokens.swift
-        "violet":  (0x5C2FB2, 0x7240CC, 0x8A5BE0, 0x9878EA, 0xD4C8F7),
+        "violet":  (0x5C2FB2, 0x7240CC, 0x8A5BE0, 0x9878EA, 0xB8A6F1),
         "emerald": (0x0C7356, 0x10906A, 0x18B07A, 0x38CF93, 0xA6F2D1),
         "rose":    (0xA8183E, 0xD02050, 0xE84060, 0xF06A86, 0xFCBFC9),
         "amber":   (0xA35E0C, 0xC97C10, 0xE8A020, 0xFAC426, 0xFEEC94),

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -87,7 +87,6 @@ struct SettingsPanel: View {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
             store.refreshTwilioWebhookConfig()
-            twilioWebhookUrlText = store.twilioWebhookBaseUrl
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -550,7 +550,6 @@ public struct SettingsView: View {
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
             store.refreshTwilioWebhookConfig()
-            twilioWebhookUrlText = store.twilioWebhookBaseUrl
             checkPermissions()
         }
         .onDisappear {


### PR DESCRIPTION
Addresses Codex/Devin feedback on #5857. Removes dead synchronous assignments of twilioWebhookUrlText in onAppear that always read the empty default value before the async IPC response arrives. The .onChange(of: store.twilioWebhookBaseUrl) handlers (added in #5864) already correctly sync the @State text field when the daemon responds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
