### PR TITLE
Bump assistant package to 0.2.7

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "bin": {
     "vellum": "./src/index.ts"


### PR DESCRIPTION
## Summary
- Bumps `vellum` (assistant) package version from 0.2.6 to 0.2.7
- Verified `@vellumai/cli` (0.1.8) and `@vellumai/vellum-gateway` (0.1.9) are already on latest

## Test plan
- [ ] `bun install` in `assistant/` succeeds
- [ ] `bunx vellum hatch` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
