### PR TITLE
Fix fast model fallback for non-default providers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1135,13 +1135,13 @@ graph TB
     4. `breaker_open` — the generator's internal circuit breaker is open after consecutive LLM failures (exponential backoff)
     5. `insufficient_budget` — the remaining turn budget (`deadlineMs - Date.now()`) is below `minRemainingTurnBudgetMs`
     6. `timeout` — the LLM call exceeded `timeoutMs` (AbortController fires)
-    7. `provider_error` — the provider threw an exception or no fast model is available for the provider
+    7. `provider_error` — the provider threw an exception during the LLM call
     8. `invalid_output` — the LLM returned empty text, the literal string "FALLBACK", total output > 500 chars, or subject line > 72 chars
 
     **Fast model resolution**: The LLM call uses a small/fast model to minimize latency and cost. The model is resolved as follows:
     - If `commitMessageLLM.providerFastModelOverrides[provider]` is set, that model is used.
     - Otherwise, a built-in default is used: `anthropic` -> `claude-haiku-4-5-20251001`, `openai` -> `gpt-4o-mini`, `gemini` -> `gemini-2.0-flash`.
-    - If the configured provider has no override and no built-in default, the generator returns deterministic with reason `provider_error` without calling sendMessage.
+    - If the configured provider has no override and no built-in default (e.g., `ollama`, `fireworks`, `openrouter`), the `model` field is omitted from the sendMessage config and the provider uses its own configured model.
 
     **Pre-mutex LLM attempt**: The LLM generation runs BEFORE entering `commitIfDirty()` (outside the git mutex). Changed files are captured from a read-only `getStatus()` call (the "pre-status") outside the mutex. This avoids holding the mutex during network calls. The `commitIfDirty` callback uses its own mutex-protected status for the actual commit, so the file list used for commit and for the LLM prompt may differ slightly if files change between the two status calls — this is accepted as a tradeoff for not blocking concurrent git operations on LLM latency.
 

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -274,16 +274,39 @@ describe('ProviderCommitMessageGenerator', () => {
     expect(result.reason).toBe('invalid_output');
   });
 
-  // 12. No default fast model for unknown provider
-  test('No default fast model for unknown provider → returns deterministic fallback', async () => {
+  // 12. Unknown provider without fast model default → uses provider's configured model
+  test('Unknown provider without fast model default → LLM call succeeds without model in config', async () => {
     (currentConfig as Record<string, unknown>).provider = 'exotic-provider';
     currentConfig.apiKeys = { 'exotic-provider': 'sk-exotic' } as Record<string, string>;
+    const commitMsg = 'chore: update dependencies';
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
     });
-    expect(result.source).toBe('deterministic');
-    expect(result.reason).toBe('provider_error');
-    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(result.source).toBe('llm');
+    expect(result.message).toBe(commitMsg);
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  // 13. Omits model from config when no fast model available
+  test('omits model from config when no fast model available', async () => {
+    (currentConfig as Record<string, unknown>).provider = 'ollama';
+    currentConfig.apiKeys = {} as Record<string, string>; // Ollama is keyless
+    const commitMsg = 'fix: local model commit';
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe('llm');
+    expect(result.message).toBe(commitMsg);
+
+    // Verify model is NOT set in the config
+    const callArgs = mockSendMessage.mock.calls[0];
+    const options = callArgs[3] as { config: Record<string, unknown> };
+    expect(options.config.model).toBeUndefined();
+    expect(options.config.max_tokens).toBe(120);
+    expect(options.config.temperature).toBe(0.2);
   });
 });

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -179,13 +179,9 @@ export class ProviderCommitMessageGenerator {
         },
       ];
 
-      // Resolve fast model
+      // Resolve fast model — if no override or default, the provider will use its configured model
       const fastModel = llmConfig.providerFastModelOverrides[config.provider]
         ?? PROVIDER_DEFAULT_FAST_MODELS[config.provider];
-      if (!fastModel) {
-        log.debug({ provider: config.provider }, 'No default fast model for provider; falling back to deterministic');
-        return buildDeterministicResult(context, 'provider_error');
-      }
 
       // AbortController with timeout
       const ac = new AbortController();
@@ -199,7 +195,11 @@ export class ProviderCommitMessageGenerator {
           SYSTEM_PROMPT,
           {
             signal: ac.signal,
-            config: { model: fastModel, max_tokens: llmConfig.maxTokens, temperature: llmConfig.temperature },
+            config: {
+              ...(fastModel ? { model: fastModel } : {}),
+              max_tokens: llmConfig.maxTokens,
+              temperature: llmConfig.temperature,
+            },
           },
         );
       } catch (err: unknown) {


### PR DESCRIPTION
Addresses review feedback from #5872.

## Changes
- Remove hard-fail when no fast model default exists for a provider
- Unknown providers (ollama, fireworks, openrouter) now proceed with LLM call using their configured model
- Conditionally include model in sendMessage config only when a fast model is resolved
- Update tests and ARCHITECTURE.md

## Test plan
- `bun test assistant/src/__tests__/provider-commit-message-generator.test.ts` — all green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
