### PR TITLE
fix: remove Tasks option from Control Center drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -478,10 +478,6 @@ struct MainWindowView: View {
                     // Control center drawer rendered at top level so it floats above all content
                     if showControlCenterDrawer {
                         DrawerMenuView(
-                            onTaskQueue: {
-                                showControlCenterDrawer = false
-                                (NSApp.delegate as? AppDelegate)?.showTasksWindow()
-                            },
                             onSettings: {
                                 showControlCenterDrawer = false
                                 windowState.togglePanel(.settings)
@@ -1156,14 +1152,12 @@ private struct ControlCenterRow: View {
 }
 
 private struct DrawerMenuView: View {
-    let onTaskQueue: () -> Void
     let onSettings: () -> Void
     let onDebug: () -> Void
     let onDoctor: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DrawerMenuItem(icon: "list.bullet.clipboard", label: "Tasks", action: onTaskQueue)
             DrawerMenuItem(icon: "gearshape", label: "Settings", action: onSettings)
 
             VColor.surfaceBorder.frame(height: 1)


### PR DESCRIPTION
## Summary
- Remove the "Tasks" menu item from the sidebar Control Center drawer
- Remove the `onTaskQueue` callback from `DrawerMenuView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
