### PR TITLE
feat: smart chat scroll — stop forcing scroll-to-bottom during streaming

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -892,6 +892,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     title: 'Urgent email from Alice',
     body: 'Meeting rescheduled to 3pm today.',
   },
+  agent_heartbeat_alert: {
+    type: 'agent_heartbeat_alert',
+    title: 'Agent heartbeat stalled',
+    body: 'No activity detected in the last 60 minutes.',
+  },
   watch_started: {
     type: 'watch_started',
     sessionId: 'sess-001',
@@ -1407,6 +1412,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   open_tasks_window: {
     type: 'open_tasks_window',
+  },
+  task_run_thread_created: {
+    type: 'task_run_thread_created',
+    conversationId: 'conv-task-run-001',
+    workItemId: 'wi-001',
+    title: 'Process report',
   },
   subagent_spawned: {
     type: 'subagent_spawned',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -780,8 +780,19 @@ export const WorkspaceGitConfigSchema = z.object({
         .int().positive().default(2000),
       backoffMaxMs: z.number({ error: 'workspaceGit.commitMessageLLM.breaker.backoffMaxMs must be a number' })
         .int().positive().default(60000),
-    }).default({}),
-  }).default({}),
+    }).default({ openAfterFailures: 3, backoffBaseMs: 2000, backoffMaxMs: 60000 }),
+  }).default({
+    enabled: false,
+    useConfiguredProvider: true,
+    providerFastModelOverrides: {},
+    timeoutMs: 600,
+    maxTokens: 120,
+    temperature: 0.2,
+    maxFilesInPrompt: 30,
+    maxDiffBytes: 12000,
+    minRemainingTurnBudgetMs: 1000,
+    breaker: { openAfterFailures: 3, backoffBaseMs: 2000, backoffMaxMs: 60000 },
+  }),
 });
 
 export const AgentHeartbeatConfigSchema = z.object({

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -426,8 +426,8 @@ export async function handleWorkItemRunTask(
   // Execute task asynchronously — lazily create a session inside the callback
   // using the conversationId provided by runTask, so the session references
   // the conversation that was actually inserted into the database.
+  let session: Awaited<ReturnType<typeof ctx.getOrCreateSession>> | null = null;
   try {
-    let session: Awaited<ReturnType<typeof ctx.getOrCreateSession>> | null = null;
     const result = await runTask(
       { taskId: workItem.taskId, workingDir: process.cwd(), approvedTools },
       async (conversationId, message, taskRunId) => {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2015,7 +2015,7 @@ export interface WorkItemDeleteResponse {
   success: boolean;
 }
 
-export type WorkItemRunTaskErrorCode = 'not_found' | 'already_running' | 'invalid_status' | 'no_task';
+export type WorkItemRunTaskErrorCode = 'not_found' | 'already_running' | 'invalid_status' | 'no_task' | 'permission_required';
 
 export interface WorkItemRunTaskResponse {
   type: 'work_item_run_task_response';

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -67,6 +67,7 @@ struct ChatView: View {
         return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 
+    @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
     @State private var isComposerExpanded = false
@@ -514,6 +515,9 @@ struct ChatView: View {
                     // Invisible anchor at the very bottom of all content
                     Color.clear.frame(height: 1)
                         .id("scroll-bottom-anchor")
+                        .onAppear {
+                            isNearBottom = true
+                        }
                 }
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
@@ -523,12 +527,43 @@ struct ChatView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
+            .background {
+                ScrollWheelDetector {
+                    isNearBottom = false
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if !isNearBottom {
+                    Button(action: {
+                        isNearBottom = true
+                        withAnimation(VAnimation.fast) {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
+                    }) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "arrow.down")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Scroll to latest")
+                                .font(VFont.monoSmall)
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.bottom, VSpacing.lg)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
             .onAppear {
                 // Scroll to bottom on initial load
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
             .onChange(of: isSending) {
                 if isSending {
+                    isNearBottom = true
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
@@ -543,13 +578,17 @@ struct ChatView: View {
                 }
             }
             .onChange(of: streamingScrollTrigger) {
-                withAnimation(VAnimation.fast) {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                if isNearBottom {
+                    withAnimation(VAnimation.fast) {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
                 }
             }
             .onChange(of: messages.count) {
-                withAnimation(VAnimation.fast) {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                if isNearBottom {
+                    withAnimation(VAnimation.fast) {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
                 }
             }
         }
@@ -584,6 +623,48 @@ struct ChatView: View {
             .foregroundColor(.white)
             .background(VColor.warning)
         }
+    }
+}
+
+// MARK: - Scroll Wheel Detection
+
+/// Detects user-initiated scroll-up events via NSEvent monitoring.
+/// Used to untether auto-scroll when the user scrolls away from the bottom during streaming.
+private struct ScrollWheelDetector: NSViewRepresentable {
+    let onScrollUp: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        let coordinator = context.coordinator
+        coordinator.onScrollUp = onScrollUp
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+            // Only act on direct user scroll gestures (not momentum),
+            // and only when scrolling up (positive deltaY = toward older content).
+            if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
+                coordinator.onScrollUp?()
+            }
+            return event
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onScrollUp = onScrollUp
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        if let monitor = coordinator.monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
+    class Coordinator {
+        var onScrollUp: (() -> Void)?
+        var monitor: Any?
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -528,9 +528,10 @@ struct ChatView: View {
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
             .background {
-                ScrollWheelDetector {
-                    isNearBottom = false
-                }
+                ScrollWheelDetector(
+                    onScrollUp: { isNearBottom = false },
+                    onScrollToBottom: { isNearBottom = true }
+                )
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom {
@@ -628,10 +629,12 @@ struct ChatView: View {
 
 // MARK: - Scroll Wheel Detection
 
-/// Detects user-initiated scroll-up events via NSEvent monitoring.
-/// Used to untether auto-scroll when the user scrolls away from the bottom during streaming.
+/// Detects user-initiated scroll events scoped to the chat scroll view.
+/// Fires `onScrollUp` when the user scrolls toward older content (untethers auto-scroll),
+/// and `onScrollToBottom` when the user manually scrolls back to the bottom (re-tethers).
 private struct ScrollWheelDetector: NSViewRepresentable {
     let onScrollUp: () -> Void
+    let onScrollToBottom: () -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -640,12 +643,32 @@ private struct ScrollWheelDetector: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         let coordinator = context.coordinator
+        coordinator.view = view
         coordinator.onScrollUp = onScrollUp
+        coordinator.onScrollToBottom = onScrollToBottom
         coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
-            // Only act on direct user scroll gestures (not momentum),
-            // and only when scrolling up (positive deltaY = toward older content).
-            if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
+            // Only process events within this view's bounds (scoped to the chat scroll area)
+            guard let view = coordinator.view,
+                  let window = view.window,
+                  event.window == window else { return event }
+            let locationInView = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.width > 0, view.bounds.contains(locationInView) else { return event }
+
+            // Only act on direct user gestures, not momentum
+            guard event.momentumPhase.isEmpty else { return event }
+
+            if event.scrollingDeltaY > 3 {
+                // Scrolling up (toward older content) — untether
                 coordinator.onScrollUp?()
+            } else if event.scrollingDeltaY < -1 {
+                // Scrolling down — check if the underlying NSScrollView is at the bottom
+                if let scrollView = coordinator.findEnclosingScrollView() {
+                    let clipBounds = scrollView.contentView.bounds
+                    let docHeight = scrollView.documentView?.frame.height ?? 0
+                    if docHeight - clipBounds.maxY < 50 {
+                        coordinator.onScrollToBottom?()
+                    }
+                }
             }
             return event
         }
@@ -654,6 +677,7 @@ private struct ScrollWheelDetector: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         context.coordinator.onScrollUp = onScrollUp
+        context.coordinator.onScrollToBottom = onScrollToBottom
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
@@ -663,8 +687,19 @@ private struct ScrollWheelDetector: NSViewRepresentable {
     }
 
     class Coordinator {
+        weak var view: NSView?
         var onScrollUp: (() -> Void)?
+        var onScrollToBottom: (() -> Void)?
         var monitor: Any?
+
+        func findEnclosingScrollView() -> NSScrollView? {
+            var current = view?.superview
+            while let v = current {
+                if let sv = v as? NSScrollView { return sv }
+                current = v.superview
+            }
+            return nil
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -654,13 +654,12 @@ private struct ScrollWheelDetector: NSViewRepresentable {
             let locationInView = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.width > 0, view.bounds.contains(locationInView) else { return event }
 
-            // Only act on direct user gestures, not momentum
-            guard event.momentumPhase.isEmpty else { return event }
-
-            if event.scrollingDeltaY > 3 {
-                // Scrolling up (toward older content) — untether
+            if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
+                // Direct user scroll up (toward older content) — untether.
+                // Momentum events are excluded so a flick doesn't accidentally untether.
                 coordinator.onScrollUp?()
             } else if event.scrollingDeltaY < -1 {
+                // Scrolling down (direct or momentum) — re-tether if at bottom.
                 // Scrolling down — check if the underlying NSScrollView is at the bottom
                 if let scrollView = coordinator.findEnclosingScrollView() {
                     let clipBounds = scrollView.contentView.bounds

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -201,8 +201,8 @@ extension IPCCuObservation {
 public typealias RideShotgunStartMessage = IPCRideShotgunStart
 
 extension IPCRideShotgunStart {
-    public init(durationSeconds: Double, intervalSeconds: Double, mode: String? = nil, targetDomain: String? = nil, autoNavigate: Bool? = nil) {
-        self.init(type: "ride_shotgun_start", durationSeconds: durationSeconds, intervalSeconds: intervalSeconds, mode: mode, targetDomain: targetDomain, autoNavigate: autoNavigate)
+    public init(durationSeconds: Double, intervalSeconds: Double, mode: String? = nil, targetDomain: String? = nil, navigateDomain: String? = nil, autoNavigate: Bool? = nil) {
+        self.init(type: "ride_shotgun_start", durationSeconds: durationSeconds, intervalSeconds: intervalSeconds, mode: mode, targetDomain: targetDomain, navigateDomain: navigateDomain, autoNavigate: autoNavigate)
     }
 }
 


### PR DESCRIPTION
## Summary

- Detect user scroll-up intent via NSEvent scroll wheel monitoring to untether auto-scroll during streaming, so users can read earlier messages without being forced back to the bottom
- Add a floating "Scroll to latest" capsule button that appears when scrolled away from the bottom
- Gate streaming and message-count scroll triggers on `isNearBottom`; sending a new message always re-tethers and scrolls to bottom

## Test plan

- [ ] Send a message and let the response stream — should auto-scroll as before
- [ ] Scroll up during streaming — should stop forcing scroll, and "Scroll to latest" button appears
- [ ] Click the button — should jump to bottom and resume auto-scrolling
- [ ] Send a new message — should auto-scroll to bottom regardless of previous scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
