### PR TITLE
Enforce strict fast-model preflight in commit message generator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1131,17 +1131,18 @@ graph TB
 
     1. `disabled` — `commitMessageLLM.enabled` is `false` or `useConfiguredProvider` is `false`
     2. `missing_provider_api_key` — the configured provider's API key is not set in `config.apiKeys` (skipped for keyless providers like Ollama that run without an API key)
-    3. `provider_not_initialized` — the configured provider is not registered/bootstrapped (e.g., `getProvider()` throws)
-    4. `breaker_open` — the generator's internal circuit breaker is open after consecutive LLM failures (exponential backoff)
-    5. `insufficient_budget` — the remaining turn budget (`deadlineMs - Date.now()`) is below `minRemainingTurnBudgetMs`
-    6. `timeout` — the LLM call exceeded `timeoutMs` (AbortController fires)
-    7. `provider_error` — the provider threw an exception during the LLM call
-    8. `invalid_output` — the LLM returned empty text, the literal string "FALLBACK", total output > 500 chars, or subject line > 72 chars
+    3. `breaker_open` — the generator's internal circuit breaker is open after consecutive LLM failures (exponential backoff)
+    4. `insufficient_budget` — the remaining turn budget (`deadlineMs - Date.now()`) is below `minRemainingTurnBudgetMs`
+    5. `missing_fast_model` — no fast model could be resolved for the configured provider (see below); the provider is **not** called
+    6. `provider_not_initialized` — the configured provider is not registered/bootstrapped (e.g., `getProvider()` throws)
+    7. `timeout` — the LLM call exceeded `timeoutMs` (AbortController fires)
+    8. `provider_error` — the provider threw an exception during the LLM call
+    9. `invalid_output` — the LLM returned empty text, the literal string "FALLBACK", total output > 500 chars, or subject line > 72 chars
 
-    **Fast model resolution**: The LLM call uses a small/fast model to minimize latency and cost. The model is resolved as follows:
+    **Fast model resolution**: The LLM call uses a small/fast model to minimize latency and cost. The model is resolved **before** any provider call as a pre-flight check:
     - If `commitMessageLLM.providerFastModelOverrides[provider]` is set, that model is used.
     - Otherwise, a built-in default is used: `anthropic` -> `claude-haiku-4-5-20251001`, `openai` -> `gpt-4o-mini`, `gemini` -> `gemini-2.0-flash`.
-    - If the configured provider has no override and no built-in default (e.g., `ollama`, `fireworks`, `openrouter`), the `model` field is omitted from the sendMessage config and the provider uses its own configured model.
+    - If the configured provider has no override and no built-in default (e.g., `ollama`, `fireworks`, `openrouter`), the generator returns a deterministic fallback with reason `missing_fast_model` and the provider is never called. To enable LLM commit messages for such providers, set `providerFastModelOverrides[provider]` to the desired model.
 
     **Pre-mutex LLM attempt**: The LLM generation runs BEFORE entering `commitIfDirty()` (outside the git mutex). Changed files are captured from a read-only `getStatus()` call (the "pre-status") outside the mutex. This avoids holding the mutex during network calls. The `commitIfDirty` callback uses its own mutex-protected status for the actual commit, so the file list used for commit and for the LLM prompt may differ slightly if files change between the two status calls — this is accepted as a tradeoff for not blocking concurrent git operations on LLM latency.
 

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -274,39 +274,40 @@ describe('ProviderCommitMessageGenerator', () => {
     expect(result.reason).toBe('invalid_output');
   });
 
-  // 12. Keyless provider (Ollama) skips API key preflight
-  test('Ollama without API key → does not return missing_provider_api_key', async () => {
+  // 12. Keyless provider (Ollama) without fast model → missing_fast_model (skips API key check)
+  test('Ollama without API key or fast model → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = 'ollama';
     currentConfig.apiKeys = {} as Record<string, string>;
-    const commitMsg = 'fix: local model commit';
-    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
     });
-    expect(result.source).toBe('llm');
+    expect(result.source).toBe('deterministic');
+    expect(result.reason).toBe('missing_fast_model');
     expect(result.reason).not.toBe('missing_provider_api_key');
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
-  // 13. Unknown provider without fast model default → uses provider's configured model
-  test('Unknown provider without fast model default → LLM call succeeds without model in config', async () => {
+  // 13. Unknown provider without fast model default → missing_fast_model, no provider call
+  test('Unknown provider without fast model default → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = 'exotic-provider';
     currentConfig.apiKeys = { 'exotic-provider': 'sk-exotic' } as Record<string, string>;
-    const commitMsg = 'chore: update dependencies';
-    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
     });
-    expect(result.source).toBe('llm');
-    expect(result.message).toBe(commitMsg);
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe('deterministic');
+    expect(result.reason).toBe('missing_fast_model');
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
-  // 14. Omits model from config when no fast model available
-  test('omits model from config when no fast model available', async () => {
+  // 14. Fast-model override enables LLM path for provider without built-in default
+  test('fast-model override enables LLM path for provider without built-in default', async () => {
     (currentConfig as Record<string, unknown>).provider = 'ollama';
     currentConfig.apiKeys = {} as Record<string, string>; // Ollama is keyless
+    currentConfig.workspaceGit.commitMessageLLM.providerFastModelOverrides = {
+      ollama: 'llama3.2:3b',
+    };
     const commitMsg = 'fix: local model commit';
     mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
     const gen = getCommitMessageGenerator();
@@ -316,11 +317,9 @@ describe('ProviderCommitMessageGenerator', () => {
     expect(result.source).toBe('llm');
     expect(result.message).toBe(commitMsg);
 
-    // Verify model is NOT set in the config
+    // Verify the override model was passed
     const callArgs = mockSendMessage.mock.calls[0];
-    const options = callArgs[3] as { config: Record<string, unknown> };
-    expect(options.config.model).toBeUndefined();
-    expect(options.config.max_tokens).toBe(120);
-    expect(options.config.temperature).toBe(0.2);
+    const options = callArgs[3] as { config: { model: string } };
+    expect(options.config.model).toBe('llama3.2:3b');
   });
 });

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -10,9 +10,10 @@ export type CommitMessageSource = 'llm' | 'deterministic';
 export type LLMFallbackReason =
   | 'disabled'
   | 'missing_provider_api_key'
-  | 'provider_not_initialized'
   | 'breaker_open'
   | 'insufficient_budget'
+  | 'missing_fast_model'
+  | 'provider_not_initialized'
   | 'timeout'
   | 'provider_error'
   | 'invalid_output';
@@ -103,17 +104,25 @@ export class ProviderCommitMessageGenerator {
     const config = getConfig();
     const llmConfig = config.workspaceGit.commitMessageLLM;
 
+    // ── Fallback check order (canonical) ──────────────────────────────
+    // 1. disabled
+    // 2. missing_provider_api_key  (except keyless providers like ollama)
+    // 3. breaker_open
+    // 4. insufficient_budget
+    // 5. missing_fast_model
+    // 6. provider_not_initialized
+    // 7. call provider → timeout / provider_error / invalid_output
+    // ──────────────────────────────────────────────────────────────────
+
     // Step 1: Feature gate
     if (!llmConfig.enabled) {
       return buildDeterministicResult(context, 'disabled');
     }
-
-    // Step 2: Provider gate
     if (!llmConfig.useConfiguredProvider) {
       return buildDeterministicResult(context, 'disabled');
     }
 
-    // Step 2.5: API key preflight (skip for providers that run without a key)
+    // Step 2: API key preflight (skip for providers that run without a key)
     if (!KEYLESS_PROVIDERS.has(config.provider)) {
       const providerApiKey = config.apiKeys[config.provider];
       if (!providerApiKey || providerApiKey === '') {
@@ -143,7 +152,19 @@ export class ProviderCommitMessageGenerator {
       }
     }
 
-    // Step 5: Call the provider
+    // Step 5: Fast model preflight — resolve before any provider call
+    const fastModel = llmConfig.providerFastModelOverrides[config.provider]
+      ?? PROVIDER_DEFAULT_FAST_MODELS[config.provider];
+
+    if (!fastModel) {
+      log.debug(
+        { provider: config.provider },
+        'No fast model resolvable for provider; falling back to deterministic',
+      );
+      return buildDeterministicResult(context, 'missing_fast_model');
+    }
+
+    // Step 6 + 7: Call the provider
     try {
       const { getProvider } = await import('../providers/registry.js');
 
@@ -179,10 +200,6 @@ export class ProviderCommitMessageGenerator {
         },
       ];
 
-      // Resolve fast model — if no override or default, the provider will use its configured model
-      const fastModel = llmConfig.providerFastModelOverrides[config.provider]
-        ?? PROVIDER_DEFAULT_FAST_MODELS[config.provider];
-
       // AbortController with timeout
       const ac = new AbortController();
       const timer = setTimeout(() => ac.abort(), llmConfig.timeoutMs);
@@ -196,7 +213,7 @@ export class ProviderCommitMessageGenerator {
           {
             signal: ac.signal,
             config: {
-              ...(fastModel ? { model: fastModel } : {}),
+              model: fastModel,
               max_tokens: llmConfig.maxTokens,
               temperature: llmConfig.temperature,
             },
@@ -244,7 +261,6 @@ export class ProviderCommitMessageGenerator {
       this.recordSuccess();
       return { message: text, source: 'llm' };
     } catch (err: unknown) {
-      // Step 6: Any error -> deterministic fallback
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
         'Commit message LLM provider error; falling back to deterministic',


### PR DESCRIPTION
## Summary
- Add `missing_fast_model` fallback reason: when no fast model resolves (no override, no built-in default), return deterministic immediately without calling the provider
- Reorder fallback checks to canonical order: disabled → missing_provider_api_key → breaker_open → insufficient_budget → missing_fast_model → provider_not_initialized → provider call
- Update ARCHITECTURE.md fallback chain and fast-model resolution docs to match runtime exactly
- Update tests to assert no provider call occurs for unresolvable fast models, and that overrides enable the LLM path for providers without built-in defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
