### PR TITLE
Fix always-allow high-risk decision plumbing and pattern picker threshold

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -145,7 +145,7 @@ export function handleConfirmationResponse(
       ctx.touchSession(sessionId);
       session.handleConfirmationResponse(
         msg.requestId,
-        msg.decision as 'allow' | 'always_allow' | 'deny',
+        msg.decision,
         msg.selectedPattern,
         msg.selectedScope,
       );
@@ -158,7 +158,7 @@ export function handleConfirmationResponse(
     if (cuSession.hasPendingConfirmation(msg.requestId)) {
       cuSession.handleConfirmationResponse(
         msg.requestId,
-        msg.decision as 'allow' | 'always_allow' | 'deny',
+        msg.decision,
         msg.selectedPattern,
         msg.selectedScope,
       );

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -382,4 +382,57 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         XCTAssertEqual(viewModel.messages.count, 0, "Deltas should be suppressed when cancelling")
     }
+
+    // MARK: - Always Allow Decision Plumbing
+
+    func testRespondToAlwaysAllowSendsHighRiskDecision() {
+        viewModel.sessionId = "sess-hr"
+
+        viewModel.respondToAlwaysAllow(
+            requestId: "req-1",
+            selectedPattern: "rm -rf *",
+            selectedScope: "project",
+            decision: "always_allow_high_risk"
+        )
+
+        // Verify the sent message carries the high-risk decision
+        let confirmations = mockClient.sentMessages.compactMap { $0 as? ConfirmationResponseMessage }
+        XCTAssertEqual(confirmations.count, 1)
+        XCTAssertEqual(confirmations[0].decision, "always_allow_high_risk")
+        XCTAssertEqual(confirmations[0].selectedPattern, "rm -rf *")
+        XCTAssertEqual(confirmations[0].selectedScope, "project")
+    }
+
+    func testRespondToAlwaysAllowSendsDefaultDecision() {
+        viewModel.sessionId = "sess-default"
+
+        viewModel.respondToAlwaysAllow(
+            requestId: "req-2",
+            selectedPattern: "npm test",
+            selectedScope: "project"
+        )
+
+        // Default decision should be "always_allow"
+        let confirmations = mockClient.sentMessages.compactMap { $0 as? ConfirmationResponseMessage }
+        XCTAssertEqual(confirmations.count, 1)
+        XCTAssertEqual(confirmations[0].decision, "always_allow")
+    }
+
+    func testRespondToAlwaysAllowFailsWhenDisconnected() {
+        viewModel.sessionId = "sess-fallback"
+        mockClient.isConnected = false
+
+        viewModel.respondToAlwaysAllow(
+            requestId: "req-3",
+            selectedPattern: "npm install",
+            selectedScope: "project",
+            decision: "always_allow_high_risk"
+        )
+
+        // Should set error text when daemon is not connected
+        XCTAssertNotNil(viewModel.errorText)
+        // No IPC messages should have been sent
+        let confirmations = mockClient.sentMessages.compactMap { $0 as? ConfirmationResponseMessage }
+        XCTAssertTrue(confirmations.isEmpty)
+    }
 }

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -67,8 +67,8 @@ struct ChatContentView: View {
                                         viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
                                     },
                                     onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
-                                    onAlwaysAllow: { requestId, selectedPattern, selectedScope in
-                                        viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope)
+                                    onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in
+                                        viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision)
                                     }
                                 )
                                 .id(message.id)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -33,7 +33,7 @@ struct ChatView: View {
     var configuredProviders: Set<String> = []
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
-    let onAlwaysAllow: (String, String, String) -> Void
+    let onAlwaysAllow: (String, String, String, String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onRegenerate: () -> Void
     let sessionError: SessionError?
@@ -642,7 +642,7 @@ private struct ChatViewPreviewWrapper: View {
                 onMicrophoneToggle: {},
                 onConfirmationAllow: { _ in },
                 onConfirmationDeny: { _ in },
-                onAlwaysAllow: { _, _, _ in },
+                onAlwaysAllow: { _, _, _, _ in },
                 onSurfaceAction: { _, _, _ in },
                 onRegenerate: {},
                 sessionError: nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -506,7 +506,7 @@ struct ActiveChatViewWrapper: View {
             configuredProviders: settingsStore.configuredProviders,
             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
-            onAlwaysAllow: { requestId, selectedPattern, selectedScope in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope) },
+            onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
             onRegenerate: { viewModel.regenerateLastMessage() },
             sessionError: viewModel.sessionError,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1080,14 +1080,14 @@ public final class ChatViewModel: ObservableObject {
     /// If the daemon is disconnected, shows an error without attempting a fallback (since
     /// respondToConfirmation would also fail). On IPC send errors, attempts a one-time allow
     /// fallback and only claims success if the fallback actually went through.
-    public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String) {
+    public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String, decision: String = "always_allow") {
         guard daemonClient.isConnected else {
             log.warning("Cannot persist always-allow: daemon not connected")
             errorText = "Cannot send confirmation — daemon is not connected."
             return
         }
         do {
-            try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: "always_allow", selectedPattern: selectedPattern, selectedScope: selectedScope))
+            try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope))
         } catch {
             log.warning("Always-allow IPC failed: \(error.localizedDescription)")
             // Try one-time allow as fallback (daemon may still be connected)

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -13,14 +13,14 @@ public struct MessageBubbleView: View {
     /// When non-nil, a "Regenerate" option appears in the long-press context menu
     /// for the last assistant message. Pass nil when generation is in-flight.
     public let onRegenerate: (() -> Void)?
-    public let onAlwaysAllow: ((String, String, String) -> Void)?
+    public let onAlwaysAllow: ((String, String, String, String) -> Void)?
 
     public init(
         message: ChatMessage,
         onConfirmationResponse: ((String, String) -> Void)?,
         onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?,
         onRegenerate: (() -> Void)?,
-        onAlwaysAllow: ((String, String, String) -> Void)? = nil
+        onAlwaysAllow: ((String, String, String, String) -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
@@ -46,8 +46,8 @@ public struct MessageBubbleView: View {
                         onDeny: {
                             onConfirmationResponse?(confirmation.requestId, "deny")
                         },
-                        onAlwaysAllow: { requestId, pattern, scope in
-                            onAlwaysAllow?(requestId, pattern, scope)
+                        onAlwaysAllow: { requestId, pattern, scope, decision in
+                            onAlwaysAllow?(requestId, pattern, scope, decision)
                         }
                     )
                 } else if message.role == .assistant && hasInterleavedContent {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -7,7 +7,7 @@ public struct ToolConfirmationBubble: View {
     public let confirmation: ToolConfirmationData
     public let onAllow: () -> Void
     public let onDeny: () -> Void
-    public let onAlwaysAllow: (String, String, String) -> Void
+    public let onAlwaysAllow: (String, String, String, String) -> Void
 
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
@@ -16,7 +16,7 @@ public struct ToolConfirmationBubble: View {
     @State private var pendingPattern: String?
     @State private var showScopePickerMenu = false
 
-    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String) -> Void) {
+    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
         self.confirmation = confirmation
         self.onAllow = onAllow
         self.onDeny = onDeny
@@ -33,6 +33,13 @@ public struct ToolConfirmationBubble: View {
 
     private var isDecided: Bool {
         confirmation.state != .pending
+    }
+
+    /// The decision value to send when "Always Allow" is clicked.
+    /// High-risk prompts use `always_allow_high_risk` so the daemon persists
+    /// a rule with `allowHighRisk: true`.
+    private var alwaysAllowDecision: String {
+        confirmation.riskLevel.lowercased() == "high" ? "always_allow_high_risk" : "always_allow"
     }
 
     /// The raw command/path preview for the inline display.
@@ -347,7 +354,7 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowInlineButton: some View {
-        if hasRuleOptions && confirmation.allowlistOptions.count > 2 {
+        if hasRuleOptions && confirmation.allowlistOptions.count > 1 {
             alwaysAllowDropdown
         } else {
             let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
@@ -363,7 +370,7 @@ public struct ToolConfirmationBubble: View {
                 } else {
                     let scope = confirmation.scopeOptions.first?.scope ?? ""
                     if !scope.isEmpty {
-                        onAlwaysAllow(confirmation.requestId, pattern, scope)
+                        onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
                     } else {
                         onAllow()
                     }
@@ -414,7 +421,7 @@ public struct ToolConfirmationBubble: View {
                         ScopePickerRow(label: scopeOption.label) {
                             showAlwaysAllowMenu = false
                             pendingPattern = nil
-                            onAlwaysAllow(confirmation.requestId, pending, scopeOption.scope)
+                            onAlwaysAllow(confirmation.requestId, pending, scopeOption.scope, alwaysAllowDecision)
                         }
 
                         if index < confirmation.scopeOptions.count - 1 {
@@ -435,7 +442,7 @@ public struct ToolConfirmationBubble: View {
                                 showAlwaysAllowMenu = false
                                 let scope = confirmation.scopeOptions.first?.scope ?? ""
                                 if !scope.isEmpty {
-                                    onAlwaysAllow(confirmation.requestId, option.pattern, scope)
+                                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, alwaysAllowDecision)
                                 } else {
                                     onAllow()
                                 }
@@ -472,7 +479,7 @@ public struct ToolConfirmationBubble: View {
                 ScopePickerRow(label: scopeOption.label) {
                     showScopePickerMenu = false
                     if let pattern = pendingPattern {
-                        onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope)
+                        onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
                         pendingPattern = nil
                     }
                 }
@@ -613,7 +620,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // File write — high risk, pending
@@ -627,7 +634,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Bash — low risk, pending
@@ -641,7 +648,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Always-allow dropdown — medium risk
@@ -663,7 +670,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Collapsed — approved
@@ -677,7 +684,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Collapsed — denied
@@ -691,7 +698,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Unknown tool fallback
@@ -704,7 +711,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // System permission request (pending)
@@ -720,7 +727,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Inline always-allow with multiple scopes (scope picker on click)
@@ -741,7 +748,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
 
         // Dropdown always-allow with multiple scopes (two-step selection)
@@ -764,7 +771,7 @@ private struct ScopePickerRow: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAlwaysAllow: { _, _, _ in }
+            onAlwaysAllow: { _, _, _, _ in }
         )
     }
     .padding(VSpacing.xl)


### PR DESCRIPTION
## Summary
- Plumb `always_allow_high_risk` decision from ToolConfirmationBubble through the full callback chain (MessageBubbleView → ChatView → PanelCoordinator → ChatContentView → ChatViewModel) to the daemon, choosing decision based on `riskLevel == "high"`.
- Fix pattern picker visibility: show dropdown when `allowlistOptions.count > 1` (was `> 2`), so exactly 2 options get a picker instead of auto-selecting the first.
- Remove narrow `as 'allow' | 'always_allow' | 'deny'` cast in `sessions.ts` handler, passing the full `UserDecision` union through to session handlers.
- Add 3 regression tests in `ChatViewModelIOSTests` covering high-risk decision, default decision, and disconnected fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
