### PR TITLE
Cap LLM commit subject lines to 72 chars instead of falling back

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1137,7 +1137,8 @@ graph TB
     6. `provider_not_initialized` — the configured provider is not registered/bootstrapped (e.g., `getProvider()` throws)
     7. `timeout` — the LLM call exceeded `timeoutMs` (AbortController fires)
     8. `provider_error` — the provider threw an exception during the LLM call
-    9. `invalid_output` — the LLM returned empty text, the literal string "FALLBACK", total output > 500 chars, or subject line > 72 chars
+    9. `invalid_output` — the LLM returned empty text, the literal string "FALLBACK", or total output > 500 chars
+    - **Subject line capping**: If the LLM subject line exceeds 72 chars it is deterministically truncated to 72 chars. This is NOT treated as a failure (no breaker penalty, no deterministic fallback).
 
     **Fast model resolution**: The LLM call uses a small/fast model to minimize latency and cost. The model is resolved **before** any provider call as a pre-flight check:
     - If `commitMessageLLM.providerFastModelOverrides[provider]` is set, that model is used.

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -262,16 +262,33 @@ describe('ProviderCommitMessageGenerator', () => {
     expect(result.reason).toBe('invalid_output');
   });
 
-  // 11. LLM output too long (subject > 72 chars)
-  test('LLM output too long (subject > 72 chars) → returns deterministic, reason "invalid_output"', async () => {
-    const longSubject = 'a'.repeat(73);
+  // 11. LLM subject > 72 chars → truncated to 72, still source "llm"
+  test('LLM subject > 72 chars → truncated to 72, source "llm"', async () => {
+    const longSubject = 'a'.repeat(100);
     mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(longSubject));
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
     });
-    expect(result.source).toBe('deterministic');
-    expect(result.reason).toBe('invalid_output');
+    expect(result.source).toBe('llm');
+    expect(result.reason).toBeUndefined();
+    expect(result.message.split('\n')[0].length).toBeLessThanOrEqual(72);
+    expect(result.message).toBe('a'.repeat(72));
+  });
+
+  // 11b. LLM subject > 72 chars with body → subject truncated, body preserved
+  test('LLM subject > 72 chars with body → subject truncated, body preserved', async () => {
+    const longSubject = 'b'.repeat(80);
+    const body = '\n\n- bullet one\n- bullet two';
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(longSubject + body));
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe('llm');
+    expect(result.reason).toBeUndefined();
+    expect(result.message.split('\n')[0].length).toBeLessThanOrEqual(72);
+    expect(result.message).toBe('b'.repeat(72) + body);
   });
 
   // 12. Keyless provider (Ollama) without fast model → missing_fast_model (skips API key check)

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -247,19 +247,19 @@ export class ProviderCommitMessageGenerator {
         return buildDeterministicResult(context, 'invalid_output');
       }
 
-      // Validate single-line subject: first line must be <= 72 chars
-      const firstLine = text.split('\n')[0];
-      if (firstLine.length > 72) {
+      // Cap subject line to 72 chars deterministically (no fallback, no breaker failure)
+      const lines = text.split('\n');
+      if (lines[0].length > 72) {
         log.debug(
-          { subjectLength: firstLine.length },
-          'LLM subject line too long; falling back to deterministic',
+          { originalLength: lines[0].length },
+          'Capping LLM subject line to 72 chars',
         );
-        this.recordFailure();
-        return buildDeterministicResult(context, 'invalid_output');
+        lines[0] = lines[0].slice(0, 72);
       }
+      const finalMessage = lines.join('\n');
 
       this.recordSuccess();
-      return { message: text, source: 'llm' };
+      return { message: finalMessage, source: 'llm' };
     } catch (err: unknown) {
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
## Summary
- LLM-generated commit message subject lines > 72 chars are now deterministically truncated to 72 chars instead of triggering a full deterministic fallback
- This avoids penalizing the circuit breaker and discarding a valid LLM body just because the subject was slightly long
- Updated ARCHITECTURE.md to reflect the new capping behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
