### PR TITLE
feat: show task list inline in chat alongside Tasks window

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -218,7 +218,7 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '',
     'You can create ad-hoc work items by providing just a `title` to `task_list_add` — no existing task template is needed. A lightweight template is auto-created behind the scenes. For reusable task definitions with templates and input schemas, use `task_save` first.',
     '',
-    '**IMPORTANT:** When you call `task_list_show`, the Tasks window opens automatically on the client. Do NOT also create a separate surface/UI (via `ui_show` or `app_create`) to display the task queue. Doing so causes duplicate Task Queue windows. Just call `task_list_show` and let the native window handle the presentation.',
+    '**IMPORTANT:** When you call `task_list_show`, the Tasks window opens automatically on the client AND the tool returns the current task list. Present a brief summary of the tasks in your chat response so the user can see them inline. Do NOT also create a separate surface/UI (via `ui_show` or `app_create`) to display the task queue — that causes duplicate windows.',
     '',
     '### Schedules (schedule_create / schedule_list / schedule_update / schedule_delete)',
     'For recurring automated jobs that run on a recurrence schedule (cron or RRULE). Use ONLY when the user explicitly wants:',

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -1,5 +1,17 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
-import { listWorkItems, type WorkItemStatus } from '../../work-items/work-item-store.js';
+import { listWorkItems, type WorkItem, type WorkItemStatus } from '../../work-items/work-item-store.js';
+
+const PRIORITY_LABELS: Record<number, string> = { 0: 'High', 1: 'Medium', 2: 'Low' };
+
+function formatTaskList(items: WorkItem[]): string {
+  const lines: string[] = [];
+  for (const item of items) {
+    const priority = PRIORITY_LABELS[item.priorityTier] ?? 'Medium';
+    const status = item.status.replace(/_/g, ' ');
+    lines.push(`- [${priority}] ${item.title} (${status})`);
+  }
+  return lines.join('\n');
+}
 
 export async function executeTaskListShow(
   input: Record<string, unknown>,
@@ -33,7 +45,9 @@ export async function executeTaskListShow(
       ? `${count} ${Array.isArray(statusFilter) ? 'matching' : statusFilter} item${count === 1 ? '' : 's'}`
       : `${count} item${count === 1 ? '' : 's'}`;
 
-    return { content: `Opened Tasks window (${label}).`, isError: false };
+    const taskList = formatTaskList(items);
+
+    return { content: `Opened Tasks window (${label}).\n\nCurrent tasks:\n${taskList}`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: ${msg}`, isError: true };


### PR DESCRIPTION
## Summary
- `task_list_show` tool now returns a formatted task list (priority + title + status) in its text response, so the model can present tasks inline in chat
- Updated system prompt to instruct the model to summarize tasks in chat rather than just saying "Opened Tasks window"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
