### PR TITLE
Gateway OAuth callback route + runtime internal plumbing (#5884)

### DIFF
--- a/assistant/src/__tests__/oauth-callback-registry.test.ts
+++ b/assistant/src/__tests__/oauth-callback-registry.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import {
+  registerPendingCallback,
+  consumeCallback,
+  consumeCallbackError,
+  clearAllCallbacks,
+} from '../security/oauth-callback-registry.js';
+
+afterEach(() => {
+  clearAllCallbacks();
+});
+
+describe('OAuth callback registry', () => {
+  test('registerPendingCallback + consumeCallback resolves with code', async () => {
+    const promise = new Promise<string>((resolve, reject) => {
+      registerPendingCallback('state-1', resolve, reject);
+    });
+
+    const consumed = consumeCallback('state-1', 'auth-code-123');
+    expect(consumed).toBe(true);
+
+    const code = await promise;
+    expect(code).toBe('auth-code-123');
+  });
+
+  test('consumeCallback with unknown state returns false', () => {
+    const consumed = consumeCallback('nonexistent', 'code');
+    expect(consumed).toBe(false);
+  });
+
+  test('consumeCallbackError rejects the pending callback', async () => {
+    const promise = new Promise<string>((resolve, reject) => {
+      registerPendingCallback('state-err', resolve, reject);
+    });
+
+    const consumed = consumeCallbackError('state-err', 'access_denied');
+    expect(consumed).toBe(true);
+
+    await expect(promise).rejects.toThrow('access_denied');
+  });
+
+  test('consumeCallbackError with unknown state returns false', () => {
+    const consumed = consumeCallbackError('nonexistent', 'some error');
+    expect(consumed).toBe(false);
+  });
+
+  test('duplicate consumeCallback returns false on second call', async () => {
+    const promise = new Promise<string>((resolve, reject) => {
+      registerPendingCallback('state-dup', resolve, reject);
+    });
+
+    const first = consumeCallback('state-dup', 'code-1');
+    expect(first).toBe(true);
+
+    const second = consumeCallback('state-dup', 'code-2');
+    expect(second).toBe(false);
+
+    const code = await promise;
+    expect(code).toBe('code-1');
+  });
+
+  test('TTL expiry rejects callback with timeout error', async () => {
+    const promise = new Promise<string>((resolve, reject) => {
+      registerPendingCallback('state-ttl', resolve, reject, 50);
+    });
+
+    // Wait for the TTL to expire
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(promise).rejects.toThrow('OAuth callback timed out');
+
+    // After expiry, consume should return false
+    const consumed = consumeCallback('state-ttl', 'late-code');
+    expect(consumed).toBe(false);
+  });
+
+  test('clearAllCallbacks cleans up all pending entries', () => {
+    registerPendingCallback('s1', () => {}, () => {});
+    registerPendingCallback('s2', () => {}, () => {});
+    clearAllCallbacks();
+
+    expect(consumeCallback('s1', 'code')).toBe(false);
+    expect(consumeCallback('s2', 'code')).toBe(false);
+  });
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -65,6 +65,7 @@ import {
 } from '../calls/twilio-routes.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
+import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
 
 // Re-export shared types so existing consumers don't need to update imports
 export type {
@@ -626,6 +627,27 @@ export class RuntimeHttpServer {
           body: formBody,
         });
         return await handleConnectAction(fakeReq);
+      }
+
+      // ── Internal OAuth callback endpoint (gateway → runtime) ──
+      if (endpoint === 'internal/oauth/callback' && req.method === 'POST') {
+        const json = await req.json() as { state: string; code?: string; error?: string };
+        if (!json.state) {
+          return Response.json({ error: 'Missing state parameter' }, { status: 400 });
+        }
+        if (json.error) {
+          const consumed = consumeCallbackError(json.state, json.error);
+          return consumed
+            ? Response.json({ ok: true })
+            : Response.json({ error: 'Unknown state' }, { status: 404 });
+        }
+        if (json.code) {
+          const consumed = consumeCallback(json.state, json.code);
+          return consumed
+            ? Response.json({ ok: true })
+            : Response.json({ error: 'Unknown state' }, { status: 404 });
+        }
+        return Response.json({ error: 'Missing code or error parameter' }, { status: 400 });
       }
 
       return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });

--- a/assistant/src/security/oauth-callback-registry.ts
+++ b/assistant/src/security/oauth-callback-registry.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory registry for pending OAuth callback states.
+ * Used by the gateway-routed OAuth flow to resolve authorization codes
+ * back to the runtime code that initiated the OAuth handshake.
+ */
+
+interface PendingCallback {
+  resolve: (code: string) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingCallbacks = new Map<string, PendingCallback>();
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export function registerPendingCallback(
+  state: string,
+  resolve: (code: string) => void,
+  reject: (error: Error) => void,
+  ttlMs = DEFAULT_TTL_MS,
+): void {
+  const timer = setTimeout(() => {
+    const entry = pendingCallbacks.get(state);
+    if (entry) {
+      pendingCallbacks.delete(state);
+      entry.reject(new Error('OAuth callback timed out'));
+    }
+  }, ttlMs);
+
+  pendingCallbacks.set(state, { resolve, reject, timer });
+}
+
+export function consumeCallback(state: string, code: string): boolean {
+  const entry = pendingCallbacks.get(state);
+  if (!entry) return false;
+  clearTimeout(entry.timer);
+  pendingCallbacks.delete(state);
+  entry.resolve(code);
+  return true;
+}
+
+export function consumeCallbackError(state: string, error: string): boolean {
+  const entry = pendingCallbacks.get(state);
+  if (!entry) return false;
+  clearTimeout(entry.timer);
+  pendingCallbacks.delete(state);
+  entry.reject(new Error(error));
+  return true;
+}
+
+export function clearAllCallbacks(): void {
+  for (const entry of pendingCallbacks.values()) {
+    clearTimeout(entry.timer);
+  }
+  pendingCallbacks.clear();
+}

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { createOAuthCallbackHandler } from "../http/routes/oauth-callback.js";
+
+const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
+  telegramBotToken: "tok",
+  telegramWebhookSecret: "wh-ver",
+  telegramApiBaseUrl: "https://api.telegram.org",
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  routingEntries: [],
+  defaultAssistantId: undefined,
+  unmappedPolicy: "reject",
+  port: 7830,
+  runtimeBearerToken: "rt-token",
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeProxyBearerToken: undefined,
+  shutdownDrainMs: 5000,
+  runtimeTimeoutMs: 30000,
+  runtimeMaxRetries: 2,
+  runtimeInitialBackoffMs: 500,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
+  telegramTimeoutMs: 15000,
+  maxWebhookPayloadBytes: 1048576,
+  logFile: { dir: undefined, retentionDays: 30 },
+  maxAttachmentBytes: 20971520,
+  maxAttachmentConcurrency: 3,
+  twilioAuthToken: undefined,
+  twilioWebhookBaseUrl: undefined,
+  ingressPublicBaseUrl: undefined,
+  ...overrides,
+});
+
+function mockFetch(fn: () => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
+
+describe("OAuth callback handler", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("forwards valid state+code to runtime and returns success page", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    );
+
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?state=abc123&code=authcode456",
+      { method: "GET" },
+    );
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.text();
+    expect(body).toContain("Authorization Successful");
+    expect(body).toContain("close this tab");
+
+    // Verify fetch was called with the runtime internal endpoint
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toBe("http://localhost:7821/v1/internal/oauth/callback");
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const sentBody = JSON.parse(calledInit.body as string);
+    expect(sentBody.state).toBe("abc123");
+    expect(sentBody.code).toBe("authcode456");
+    expect(sentBody.error).toBeUndefined();
+
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer rt-token");
+  });
+
+  test("missing state parameter returns 400 error page", async () => {
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?code=authcode456",
+      { method: "GET" },
+    );
+
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.text();
+    expect(body).toContain("Authorization Failed");
+    expect(body).toContain("Missing state parameter");
+  });
+
+  test("error param is forwarded to runtime", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    );
+
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?state=abc123&error=access_denied",
+      { method: "GET" },
+    );
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const sentBody = JSON.parse(calledInit.body as string);
+    expect(sentBody.state).toBe("abc123");
+    expect(sentBody.error).toBe("access_denied");
+    expect(sentBody.code).toBeUndefined();
+  });
+
+  test("runtime returning 404 (unknown state) shows error page", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        Response.json({ error: "Unknown state" }, { status: 404 }),
+      ),
+    );
+
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?state=expired123&code=code",
+      { method: "GET" },
+    );
+
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.text();
+    expect(body).toContain("Authorization Failed");
+  });
+
+  test("runtime unreachable returns 502 error page", async () => {
+    mockFetch(() => Promise.reject(new Error("Connection refused")));
+
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?state=abc123&code=code",
+      { method: "GET" },
+    );
+
+    const res = await handler(req);
+    expect(res.status).toBe(502);
+
+    const body = await res.text();
+    expect(body).toContain("Authorization Failed");
+  });
+
+  test("omits Authorization header when runtimeBearerToken is undefined", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    );
+
+    const handler = createOAuthCallbackHandler(
+      makeConfig({ runtimeBearerToken: undefined }),
+    );
+    const req = new Request(
+      "http://localhost:7830/webhooks/oauth/callback?state=s1&code=c1",
+      { method: "GET" },
+    );
+
+    await handler(req);
+
+    const calledInit = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+});

--- a/gateway/src/http/routes/oauth-callback.ts
+++ b/gateway/src/http/routes/oauth-callback.ts
@@ -1,0 +1,56 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { forwardOAuthCallback } from "../../runtime/client.js";
+
+const log = getLogger("oauth-callback");
+
+export function createOAuthCallbackHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const state = url.searchParams.get("state");
+    const code = url.searchParams.get("code");
+    const error = url.searchParams.get("error");
+
+    if (!state) {
+      return new Response(renderErrorPage("Missing state parameter"), {
+        status: 400,
+        headers: { "Content-Type": "text/html" },
+      });
+    }
+
+    try {
+      const response = await forwardOAuthCallback(
+        config,
+        state,
+        code || undefined,
+        error || undefined,
+      );
+
+      if (response.status >= 200 && response.status < 300) {
+        return new Response(renderSuccessPage(), {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+
+      return new Response(
+        renderErrorPage("Authorization failed. Please try again."),
+        { status: 400, headers: { "Content-Type": "text/html" } },
+      );
+    } catch (err) {
+      log.error({ err }, "Failed to forward OAuth callback to runtime");
+      return new Response(
+        renderErrorPage("Authorization failed. Please try again."),
+        { status: 502, headers: { "Content-Type": "text/html" } },
+      );
+    }
+  };
+}
+
+function renderSuccessPage(): string {
+  return `<!DOCTYPE html><html><head><title>Authorization Successful</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}</style></head><body><div><h1>Authorization Successful</h1><p>You can close this tab and return to the app.</p></div></body></html>`;
+}
+
+function renderErrorPage(message: string): string {
+  return `<!DOCTYPE html><html><head><title>Authorization Failed</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}</style></head><body><div><h1>Authorization Failed</h1><p>${message}</p></div></body></html>`;
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -7,6 +7,7 @@ import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webh
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
 import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
 import { createTwilioRelayWebsocketHandler, getRelayWebsocketHandlers } from "./http/routes/twilio-relay-websocket.js";
+import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { getLogger, initLogger } from "./logger.js";
 import { buildSchema } from "./schema.js";
 import { callTelegramApi } from "./telegram/api.js";
@@ -31,6 +32,7 @@ function main() {
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
+  const handleOAuthCallback = createOAuthCallbackHandler(config);
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
@@ -103,6 +105,10 @@ function main() {
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
         return undefined as unknown as Response;
+      }
+
+      if (url.pathname === "/webhooks/oauth/callback" && req.method === "GET") {
+        return handleOAuthCallback(req);
       }
 
       if (handleRuntimeProxy) {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -294,3 +294,34 @@ export async function uploadAttachment(
 
   return (await response.json()) as UploadAttachmentResponse;
 }
+
+// ── OAuth callback forwarding ────────────────────────────────────────
+
+export type OAuthCallbackResponse = {
+  status: number;
+  body: string;
+};
+
+/**
+ * Forward an OAuth callback to the runtime's internal endpoint.
+ * This is a one-shot operation — no retries, since the state token
+ * can only be consumed once.
+ */
+export async function forwardOAuthCallback(
+  config: GatewayConfig,
+  state: string,
+  code?: string,
+  error?: string,
+): Promise<OAuthCallbackResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/internal/oauth/callback`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ state, code, error }),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  const body = await response.text();
+  return { status: response.status, body };
+}


### PR DESCRIPTION
## Summary
- Create OAuth callback registry in runtime (register/consume pending states with TTL)
- Add POST /v1/internal/oauth/callback runtime endpoint for gateway forwarding
- Add GET /webhooks/oauth/callback gateway route with HTML success/error pages
- Tests for callback registry and gateway route

Part of #5881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
