### PR TITLE
Settings UX for public ingress URL + local gateway target (#5883)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -24,7 +24,9 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
-    @State private var twilioWebhookUrlText: String = ""
+    @State private var ingressUrlText: String = ""
+    @State private var gatewayReachable: Bool? = nil
+    @State private var checkingGateway: Bool = false
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
     @State private var integrationError: (id: String, message: String)?
@@ -86,7 +88,7 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
-            store.refreshTwilioWebhookConfig()
+            store.refreshIngressConfig()
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }
@@ -99,8 +101,8 @@ struct SettingsPanel: View {
                 mouseDownMonitor = nil
             }
         }
-        .onChange(of: store.twilioWebhookBaseUrl) { _, newValue in
-            twilioWebhookUrlText = newValue
+        .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
+            ingressUrlText = newValue
         }
         .onChange(of: showModelDropdown) { _, isOpen in
             if let monitor = mouseDownMonitor {
@@ -516,19 +518,20 @@ struct SettingsPanel: View {
             // TWITTER / X section
             twitterSection
 
-            // TWILIO WEBHOOK section
+            // PUBLIC INGRESS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Twilio")
+                Text("Public Ingress")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
+                // Public Ingress URL field
                 HStack(spacing: VSpacing.xs) {
-                    Text("Base Webhook URL")
+                    Text("Public Ingress URL")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                TextField("https://abc123.ngrok-free.app", text: $twilioWebhookUrlText)
+                TextField("https://abc123.ngrok-free.app", text: $ingressUrlText)
                     .textFieldStyle(.plain)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
@@ -549,13 +552,79 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                Text("Twilio webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
+                Text("Webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
 
                 VButton(label: "Save", style: .primary) {
-                    store.saveTwilioWebhookBaseUrl(twilioWebhookUrlText)
+                    store.saveIngressPublicBaseUrl(ingressUrlText)
                 }
+
+                Divider()
+                    .background(VColor.surfaceBorder)
+
+                // Local Gateway Target (read-only)
+                HStack(spacing: VSpacing.xs) {
+                    Text("Local Gateway Target")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                HStack(spacing: VSpacing.sm) {
+                    Text("http://127.0.0.1:7830")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .textSelection(.enabled)
+                        .padding(VSpacing.md)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(VColor.surface.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                        )
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString("http://127.0.0.1:7830", forType: .string)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Copy gateway address")
+
+                    // Check Gateway button
+                    Button {
+                        checkGatewayHealth()
+                    } label: {
+                        if checkingGateway {
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(width: 28, height: 28)
+                        } else if let reachable = gatewayReachable {
+                            Image(systemName: reachable ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .font(.system(size: 14))
+                                .foregroundColor(reachable ? VColor.success : VColor.error)
+                                .frame(width: 28, height: 28)
+                        } else {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(width: 28, height: 28)
+                                .contentShape(Rectangle())
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Check gateway health")
+                }
+
+                Text("Point your tunnel service at this local address.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
@@ -963,6 +1032,36 @@ struct SettingsPanel: View {
 
         // Close the settings panel so the user sees the chat
         onClose()
+    }
+
+    // MARK: - Gateway Health Check
+
+    private func checkGatewayHealth() {
+        gatewayReachable = nil
+        checkingGateway = true
+
+        Task {
+            defer { checkingGateway = false }
+
+            guard let url = URL(string: "http://127.0.0.1:7830/healthz") else {
+                gatewayReachable = false
+                return
+            }
+
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 3
+
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse {
+                    gatewayReachable = (200..<300).contains(httpResponse.statusCode)
+                } else {
+                    gatewayReachable = false
+                }
+            } catch {
+                gatewayReachable = false
+            }
+        }
     }
 
     // MARK: - Permission Row

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -75,7 +75,11 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthError: String?
 
-    // MARK: - Twilio Webhook State
+    // MARK: - Ingress Config State
+
+    @Published var ingressPublicBaseUrl: String = ""
+
+    // MARK: - Twilio Webhook State (legacy)
 
     @Published var twilioWebhookBaseUrl: String = ""
 
@@ -179,7 +183,15 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Wire up Twilio webhook config IPC response
+        // Wire up ingress config IPC response
+        daemonClient?.onIngressConfigResponse = { [weak self] response in
+            guard let self else { return }
+            if response.success {
+                self.ingressPublicBaseUrl = response.publicBaseUrl
+            }
+        }
+
+        // Wire up Twilio webhook config IPC response (legacy)
         daemonClient?.onTwilioWebhookConfigResponse = { [weak self] response in
             guard let self else { return }
             if response.success {
@@ -210,7 +222,10 @@ public final class SettingsStore: ObservableObject {
         // Refresh Twitter integration status on init
         refreshTwitterStatus()
 
-        // Refresh Twilio webhook config on init
+        // Refresh ingress config on init
+        refreshIngressConfig()
+
+        // Refresh Twilio webhook config on init (legacy)
         refreshTwilioWebhookConfig()
     }
 
@@ -368,7 +383,19 @@ public final class SettingsStore: ObservableObject {
         try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
     }
 
-    // MARK: - Twilio Webhook Actions
+    // MARK: - Ingress Config Actions
+
+    func refreshIngressConfig() {
+        try? daemonClient?.send(IngressConfigRequestMessage(action: "get"))
+    }
+
+    func saveIngressPublicBaseUrl(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed))
+        ingressPublicBaseUrl = trimmed
+    }
+
+    // MARK: - Twilio Webhook Actions (legacy)
 
     func refreshTwilioWebhookConfig() {
         try? daemonClient?.send(TwilioWebhookConfigRequestMessage(action: "get"))

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -11,7 +11,7 @@ public struct SettingsView: View {
     @State private var vercelKeyText = ""
     @State private var twitterClientId = ""
     @State private var twitterClientSecret = ""
-    @State private var twilioWebhookUrlText = ""
+    @State private var ingressUrlText = ""
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
@@ -324,8 +324,8 @@ public struct SettingsView: View {
                 }
             }
 
-            Section("Twilio") {
-                TextField("Base Webhook URL (e.g. https://abc123.ngrok-free.app)", text: $twilioWebhookUrlText)
+            Section("Public Ingress") {
+                TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
                     .textFieldStyle(.roundedBorder)
 
                 HStack(alignment: .top, spacing: 6) {
@@ -337,16 +337,45 @@ public struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Text("Twilio webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
+                Text("Webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 HStack {
                     Spacer()
                     Button("Save") {
-                        store.saveTwilioWebhookBaseUrl(twilioWebhookUrlText)
+                        store.saveIngressPublicBaseUrl(ingressUrlText)
                     }
                 }
+
+                Divider()
+
+                HStack {
+                    Text("Local Gateway Target")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+
+                HStack(spacing: 6) {
+                    Text("http://127.0.0.1:7830")
+                        .font(.body.monospaced())
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString("http://127.0.0.1:7830", forType: .string)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("Copy gateway address")
+                }
+
+                Text("Point your tunnel service at this local address.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Computer Use") {
@@ -549,7 +578,7 @@ public struct SettingsView: View {
             store.refreshAPIKeyState()
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
-            store.refreshTwilioWebhookConfig()
+            store.refreshIngressConfig()
             checkPermissions()
         }
         .onDisappear {
@@ -560,8 +589,8 @@ public struct SettingsView: View {
         .onReceive(permissionTimer) { _ in
             checkPermissions()
         }
-        .onChange(of: store.twilioWebhookBaseUrl) { _, newValue in
-            twilioWebhookUrlText = newValue
+        .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
+            ingressUrlText = newValue
         }
         .sheet(isPresented: $showingSkills, onDismiss: {
             skillsViewModel = nil

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -233,6 +233,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `twilio_webhook_config_response` message.
     public var onTwilioWebhookConfigResponse: ((TwilioWebhookConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `ingress_config_response` message.
+    public var onIngressConfigResponse: ((IngressConfigResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `vercel_api_config_response` message.
     public var onVercelApiConfigResponse: ((VercelApiConfigResponseMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -119,6 +119,8 @@ extension DaemonClient {
             onSlackWebhookConfigResponse?(msg)
         case .twilioWebhookConfigResponse(let msg):
             onTwilioWebhookConfigResponse?(msg)
+        case .ingressConfigResponse(let msg):
+            onIngressConfigResponse?(msg)
         case .vercelApiConfigResponse(let msg):
             onVercelApiConfigResponse?(msg)
         case .twitterIntegrationConfigResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1637,6 +1637,26 @@ public struct TwilioWebhookConfigResponseMessage: Decodable, Sendable {
     public let error: String?
 }
 
+// MARK: - Ingress Config Messages
+
+public struct IngressConfigRequestMessage: Encodable, Sendable {
+    public let type = "ingress_config"
+    public let action: String
+    public let publicBaseUrl: String?
+
+    public init(action: String, publicBaseUrl: String? = nil) {
+        self.action = action
+        self.publicBaseUrl = publicBaseUrl
+    }
+}
+
+public struct IngressConfigResponseMessage: Decodable, Sendable {
+    public let type: String
+    public let publicBaseUrl: String
+    public let success: Bool
+    public let error: String?
+}
+
 // MARK: - Model Config Messages
 
 /// Request the current model/provider configuration.
@@ -1877,6 +1897,7 @@ public enum ServerMessage: Decodable, Sendable {
     case shareToSlackResponse(ShareToSlackResponseMessage)
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
     case twilioWebhookConfigResponse(TwilioWebhookConfigResponseMessage)
+    case ingressConfigResponse(IngressConfigResponseMessage)
     case vercelApiConfigResponse(VercelApiConfigResponseMessage)
     case twitterIntegrationConfigResponse(TwitterIntegrationConfigResponseMessage)
     case twitterAuthResult(TwitterAuthResultMessage)
@@ -2127,6 +2148,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "twilio_webhook_config_response":
             let message = try TwilioWebhookConfigResponseMessage(from: decoder)
             self = .twilioWebhookConfigResponse(message)
+        case "ingress_config_response":
+            let message = try IngressConfigResponseMessage(from: decoder)
+            self = .ingressConfigResponse(message)
         case "vercel_api_config_response":
             let message = try VercelApiConfigResponseMessage(from: decoder)
             self = .vercelApiConfigResponse(message)


### PR DESCRIPTION
## Summary
- Rename Twilio Base Webhook URL to Public Ingress URL
- Switch IPC from twilio_webhook_config to ingress_config
- Add read-only Local Gateway Target field with copy support
- Add helper text for tunnel setup guidance

Part of #5881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
