### PR TITLE
OAuth flow gateway transport refactor (#5885)

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -1,0 +1,298 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockPublicBaseUrl = '';
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => ({
+    ingress: { publicBaseUrl: mockPublicBaseUrl },
+  }),
+  getConfig: () => ({
+    ingress: { publicBaseUrl: mockPublicBaseUrl },
+  }),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+// Track registerPendingCallback calls
+let pendingCallbacks: Map<string, { resolve: (code: string) => void; reject: (error: Error) => void }> = new Map();
+
+mock.module('../security/oauth-callback-registry.js', () => ({
+  registerPendingCallback: (state: string, resolve: (code: string) => void, reject: (error: Error) => void) => {
+    pendingCallbacks.set(state, { resolve, reject });
+  },
+  consumeCallback: () => true,
+  consumeCallbackError: () => true,
+  clearAllCallbacks: () => { pendingCallbacks.clear(); },
+}));
+
+let mockOAuthCallbackUrl = '';
+
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getOAuthCallbackUrl: () => mockOAuthCallbackUrl,
+  getPublicBaseUrl: () => 'https://gw.example.com',
+}));
+
+// Mock fetch for token exchange
+let mockTokenResponse: { ok: boolean; status: number; body: Record<string, unknown> } = {
+  ok: true,
+  status: 200,
+  body: {
+    access_token: 'test-access-token',
+    refresh_token: 'test-refresh-token',
+    expires_in: 3600,
+    scope: 'read write',
+    token_type: 'Bearer',
+  },
+};
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  if (url.includes('token')) {
+    if (!mockTokenResponse.ok) {
+      return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+        status: mockTokenResponse.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(mockTokenResponse.body), {
+      status: mockTokenResponse.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return originalFetch(input, init);
+}) as typeof fetch;
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER mocks are in place
+// ---------------------------------------------------------------------------
+
+import { startOAuth2Flow, type OAuth2Config } from '../security/oauth2.js';
+
+const BASE_OAUTH_CONFIG: OAuth2Config = {
+  authUrl: 'https://provider.example.com/authorize',
+  tokenUrl: 'https://provider.example.com/token',
+  scopes: ['read', 'write'],
+  clientId: 'test-client-id',
+};
+
+beforeEach(() => {
+  mockPublicBaseUrl = '';
+  mockOAuthCallbackUrl = 'https://gw.example.com/webhooks/oauth/callback';
+  pendingCallbacks.clear();
+  mockTokenResponse = {
+    ok: true,
+    status: 200,
+    body: {
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_in: 3600,
+      scope: 'read write',
+      token_type: 'Bearer',
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OAuth2 gateway transport', () => {
+  describe('auto-detection', () => {
+    test('selects gateway transport when ingress.publicBaseUrl is configured', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(BASE_OAUTH_CONFIG, {
+        openUrl: (url) => { capturedAuthUrl = url; },
+      });
+
+      // Give the flow a tick to register the callback and open the browser
+      await new Promise((r) => setTimeout(r, 10));
+
+      // The auth URL should contain the gateway redirect_uri, not a loopback one
+      expect(capturedAuthUrl).toContain('redirect_uri=');
+      expect(capturedAuthUrl).not.toContain('127.0.0.1');
+      expect(capturedAuthUrl).toContain(encodeURIComponent('https://gw.example.com'));
+
+      // Resolve the pending callback to complete the flow
+      const entries = Array.from(pendingCallbacks.entries());
+      expect(entries.length).toBe(1);
+      const [, { resolve }] = entries[0];
+      resolve('auth-code-from-gateway');
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+
+    test('selects loopback transport when ingress.publicBaseUrl is empty', async () => {
+      mockPublicBaseUrl = '';
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(BASE_OAUTH_CONFIG, {
+        openUrl: (url) => { capturedAuthUrl = url; },
+      });
+
+      // Give the flow a tick
+      await new Promise((r) => setTimeout(r, 10));
+
+      // The auth URL should contain a loopback redirect_uri
+      expect(capturedAuthUrl).toContain('redirect_uri=');
+      expect(capturedAuthUrl).toContain('127.0.0.1');
+
+      // Extract the redirect_uri to send the callback
+      const authUrlParsed = new URL(capturedAuthUrl);
+      const redirectUri = authUrlParsed.searchParams.get('redirect_uri')!;
+      const stateParam = authUrlParsed.searchParams.get('state')!;
+
+      // Simulate the OAuth provider callback to the loopback server
+      const callbackUrl = `${redirectUri}?code=loopback-code&state=${stateParam}`;
+      await fetch(callbackUrl);
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+  });
+
+  describe('explicit transport', () => {
+    test('uses gateway transport when explicitly specified', async () => {
+      // Even with no publicBaseUrl, explicit gateway should work
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'gateway' },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(capturedAuthUrl).toContain(encodeURIComponent('https://gw.example.com'));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      expect(entries.length).toBe(1);
+      entries[0][1].resolve('explicit-gateway-code');
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+
+    test('uses loopback transport when explicitly specified', async () => {
+      // Even with publicBaseUrl configured, explicit loopback should work
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'loopback' },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(capturedAuthUrl).toContain('127.0.0.1');
+
+      const authUrlParsed = new URL(capturedAuthUrl);
+      const redirectUri = authUrlParsed.searchParams.get('redirect_uri')!;
+      const stateParam = authUrlParsed.searchParams.get('state')!;
+
+      await fetch(`${redirectUri}?code=loopback-code&state=${stateParam}`);
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+  });
+
+  describe('gateway transport flow', () => {
+    test('success: register callback, consume with code, exchange for tokens', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: 'gateway' },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // A callback should be registered
+      const entries = Array.from(pendingCallbacks.entries());
+      expect(entries.length).toBe(1);
+
+      // Simulate gateway delivering the authorization code
+      const [state, { resolve }] = entries[0];
+      expect(typeof state).toBe('string');
+      expect(state.length).toBeGreaterThan(0);
+
+      resolve('gateway-auth-code');
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+      expect(result.tokens.refreshToken).toBe('test-refresh-token');
+      expect(result.tokens.expiresIn).toBe(3600);
+      expect(result.grantedScopes).toEqual(['read', 'write']);
+    });
+
+    test('error: register callback, consume with error, rejects', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: 'gateway' },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      expect(entries.length).toBe(1);
+
+      // Simulate the gateway delivering an error (e.g. user denied access)
+      const [, { reject }] = entries[0];
+      reject(new Error('OAuth2 authorization denied: access_denied'));
+
+      await expect(flowPromise).rejects.toThrow('OAuth2 authorization denied: access_denied');
+    });
+
+    test('token exchange failure propagates error', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+      mockTokenResponse = { ok: false, status: 400, body: { error: 'invalid_grant' } };
+
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: 'gateway' },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve('code-that-fails-exchange');
+
+      await expect(flowPromise).rejects.toThrow('OAuth2 token exchange failed');
+    });
+  });
+});

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -1,6 +1,10 @@
 /**
  * General-purpose OAuth2 Authorization Code flow with PKCE.
  *
+ * Supports two callback transports:
+ *   - loopback: spins up a local HTTP server on 127.0.0.1 (default when no public URL configured)
+ *   - gateway:  uses the gateway's OAuth callback route + in-memory registry (when ingress.publicBaseUrl is set)
+ *
  * Moved from integrations/oauth2.ts. Types that were in integrations/types.ts
  * are now inlined here since the integration framework is removed.
  */
@@ -39,6 +43,11 @@ export interface OAuth2FlowCallbacks {
   openUrl: (url: string) => void;
 }
 
+export interface OAuth2FlowOptions {
+  /** Which callback transport to use. When omitted, auto-detected from config. */
+  callbackTransport?: 'loopback' | 'gateway';
+}
+
 export interface OAuth2FlowResult {
   tokens: OAuth2TokenResult;
   grantedScopes: string[];
@@ -62,20 +71,107 @@ function generateState(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Token exchange (shared between transports)
+// ---------------------------------------------------------------------------
+
+async function exchangeCodeForTokens(
+  config: OAuth2Config,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+): Promise<OAuth2FlowResult> {
+  const usePKCE = !config.clientSecret;
+
+  const tokenBody: Record<string, string> = {
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: config.clientId,
+  };
+  if (usePKCE) {
+    tokenBody.code_verifier = codeVerifier;
+  }
+  if (config.clientSecret) {
+    tokenBody.client_secret = config.clientSecret;
+  }
+
+  const tokenResp = await fetch(config.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(tokenBody),
+  });
+
+  if (!tokenResp.ok) {
+    const rawBody = await tokenResp.text().catch(() => '');
+    let safeDetail: Record<string, unknown> = {};
+    let errorCode = '';
+    try {
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+      if (parsed.error) { safeDetail.error = String(parsed.error); errorCode = String(parsed.error); }
+      if (parsed.error_description) safeDetail.error_description = String(parsed.error_description);
+    } catch {
+      safeDetail.error = '[non-JSON response]';
+    }
+    log.error({ status: tokenResp.status, ...safeDetail }, 'OAuth2 token exchange failed');
+    const detail = errorCode ? `HTTP ${tokenResp.status}: ${errorCode}` : `HTTP ${tokenResp.status}`;
+    throw new Error(`OAuth2 token exchange failed (${detail})`);
+  }
+
+  const tokenData = await tokenResp.json() as Record<string, unknown>;
+
+  // Slack V2 OAuth returns user tokens nested under `authed_user`
+  const authedUser = tokenData.authed_user as Record<string, unknown> | undefined;
+  const tokenSource = authedUser?.access_token ? authedUser : tokenData;
+
+  const tokens: OAuth2TokenResult = {
+    accessToken: (tokenSource.access_token as string) ?? (tokenData.access_token as string),
+    refreshToken: (tokenSource.refresh_token as string | undefined) ?? (tokenData.refresh_token as string | undefined),
+    expiresIn: (tokenSource.expires_in as number | undefined) ?? (tokenData.expires_in as number | undefined),
+    scope: (tokenSource.scope as string | undefined) ?? (tokenData.scope as string | undefined),
+    tokenType: (tokenSource.token_type as string | undefined) ?? (tokenData.token_type as string | undefined),
+  };
+
+  const grantedScopes = typeof tokens.scope === 'string'
+    ? tokens.scope.split(/[ ,]/).filter(Boolean)
+    : [...config.scopes];
+
+  return { tokens, grantedScopes, rawTokenResponse: tokenData };
+}
+
+// ---------------------------------------------------------------------------
+// Transport auto-detection
 // ---------------------------------------------------------------------------
 
 /**
- * Run a full OAuth2 PKCE authorization code flow using a loopback redirect.
+ * Determine which callback transport to use when not explicitly specified.
+ * Uses gateway if ingress.publicBaseUrl is configured, otherwise loopback.
  */
-export async function startOAuth2Flow(
+function detectTransport(): 'loopback' | 'gateway' {
+  try {
+    // Dynamic import avoided — loadConfig is synchronous and already used elsewhere.
+    const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
+    const appConfig = loadConfig();
+    if (appConfig.ingress?.publicBaseUrl) {
+      return 'gateway';
+    }
+  } catch {
+    // Config loading failed — fall back to loopback
+    log.debug('Config not available for transport auto-detection, defaulting to loopback');
+  }
+  return 'loopback';
+}
+
+// ---------------------------------------------------------------------------
+// Loopback transport
+// ---------------------------------------------------------------------------
+
+async function runLoopbackFlow(
   config: OAuth2Config,
   callbacks: OAuth2FlowCallbacks,
+  codeVerifier: string,
+  codeChallenge: string,
+  state: string,
 ): Promise<OAuth2FlowResult> {
-  const codeVerifier = generateCodeVerifier();
-  const codeChallenge = generateCodeChallenge(codeVerifier);
-  const state = generateState();
-
   let resolveCode: (value: { code: string; returnedState: string }) => void;
   let rejectCode: (reason: Error) => void;
 
@@ -84,7 +180,6 @@ export async function startOAuth2Flow(
     rejectCode = reject;
   });
 
-  /** How long to wait for the user to complete the OAuth consent flow. */
   const FLOW_TIMEOUT_MS = 120_000;
 
   const timeout = setTimeout(() => {
@@ -153,64 +248,85 @@ export async function startOAuth2Flow(
       throw new Error('OAuth2 state mismatch — possible CSRF attack');
     }
 
-    const tokenBody: Record<string, string> = {
-      grant_type: 'authorization_code',
-      code,
-      redirect_uri: redirectUri,
-      client_id: config.clientId,
-    };
-    if (usePKCE) {
-      tokenBody.code_verifier = codeVerifier;
-    }
-    if (config.clientSecret) {
-      tokenBody.client_secret = config.clientSecret;
-    }
-
-    const tokenResp = await fetch(config.tokenUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams(tokenBody),
-    });
-
-    if (!tokenResp.ok) {
-      const rawBody = await tokenResp.text().catch(() => '');
-      let safeDetail: Record<string, unknown> = {};
-      let errorCode = '';
-      try {
-        const parsed = JSON.parse(rawBody) as Record<string, unknown>;
-        if (parsed.error) { safeDetail.error = String(parsed.error); errorCode = String(parsed.error); }
-        if (parsed.error_description) safeDetail.error_description = String(parsed.error_description);
-      } catch {
-        safeDetail.error = '[non-JSON response]';
-      }
-      log.error({ status: tokenResp.status, ...safeDetail }, 'OAuth2 token exchange failed');
-      const detail = errorCode ? `HTTP ${tokenResp.status}: ${errorCode}` : `HTTP ${tokenResp.status}`;
-      throw new Error(`OAuth2 token exchange failed (${detail})`);
-    }
-
-    const tokenData = await tokenResp.json() as Record<string, unknown>;
-
-    // Slack V2 OAuth returns user tokens nested under `authed_user`
-    const authedUser = tokenData.authed_user as Record<string, unknown> | undefined;
-    const tokenSource = authedUser?.access_token ? authedUser : tokenData;
-
-    const tokens: OAuth2TokenResult = {
-      accessToken: (tokenSource.access_token as string) ?? (tokenData.access_token as string),
-      refreshToken: (tokenSource.refresh_token as string | undefined) ?? (tokenData.refresh_token as string | undefined),
-      expiresIn: (tokenSource.expires_in as number | undefined) ?? (tokenData.expires_in as number | undefined),
-      scope: (tokenSource.scope as string | undefined) ?? (tokenData.scope as string | undefined),
-      tokenType: (tokenSource.token_type as string | undefined) ?? (tokenData.token_type as string | undefined),
-    };
-
-    const grantedScopes = typeof tokens.scope === 'string'
-      ? tokens.scope.split(/[ ,]/).filter(Boolean)
-      : [...config.scopes];
-
-    return { tokens, grantedScopes, rawTokenResponse: tokenData };
+    return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
   } finally {
     clearTimeout(timeout);
     server.stop(true);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Gateway transport
+// ---------------------------------------------------------------------------
+
+async function runGatewayFlow(
+  config: OAuth2Config,
+  callbacks: OAuth2FlowCallbacks,
+  codeVerifier: string,
+  codeChallenge: string,
+  state: string,
+): Promise<OAuth2FlowResult> {
+  const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
+  const { getOAuthCallbackUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
+  const { registerPendingCallback } = require('./oauth-callback-registry.js') as typeof import('./oauth-callback-registry.js');
+
+  const appConfig = loadConfig();
+  const redirectUri = getOAuthCallbackUrl(appConfig);
+
+  const codePromise = new Promise<string>((resolve, reject) => {
+    registerPendingCallback(state, resolve, reject);
+  });
+
+  const usePKCE = !config.clientSecret;
+  const authParams = new URLSearchParams({
+    ...config.extraParams,
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: config.scopes.join(' '),
+    state,
+    ...(usePKCE ? { code_challenge: codeChallenge, code_challenge_method: 'S256' } : {}),
+  });
+
+  const authUrl = `${config.authUrl}?${authParams}`;
+  callbacks.openUrl(authUrl);
+
+  const code = await codePromise;
+
+  return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a full OAuth2 authorization code flow with PKCE support.
+ *
+ * Supports two callback transports:
+ *   - loopback (default): local HTTP server on 127.0.0.1
+ *   - gateway: callback via the gateway's OAuth route + in-memory registry
+ *
+ * Transport is auto-detected based on ingress.publicBaseUrl config unless
+ * explicitly specified via options.callbackTransport.
+ */
+export async function startOAuth2Flow(
+  config: OAuth2Config,
+  callbacks: OAuth2FlowCallbacks,
+  options?: OAuth2FlowOptions,
+): Promise<OAuth2FlowResult> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const transport = options?.callbackTransport ?? detectTransport();
+  log.debug({ transport }, 'OAuth2 flow starting');
+
+  if (transport === 'gateway') {
+    return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  }
+
+  return runLoopbackFlow(config, callbacks, codeVerifier, codeChallenge, state);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add gateway callback transport mode to OAuth2 flow
- Auto-detect transport based on ingress.publicBaseUrl config
- Gateway mode uses callback registry + gateway route instead of loopback server
- Loopback mode preserved as fallback when no public URL configured
- Tests for transport auto-detection and gateway flow

Part of #5881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
