### PR TITLE
Runtime gateway-only ingress enforcement (#5886)

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for gateway-only ingress mode enforcement in the runtime HTTP server.
+ *
+ * Verifies:
+ * - Direct Twilio webhook routes return 410 in gateway_only mode
+ * - Internal forwarding routes (gateway→runtime) still work in gateway_only mode
+ * - Relay WebSocket upgrade blocked for non-localhost origins in gateway_only mode
+ * - Relay WebSocket upgrade allowed from localhost in gateway_only mode
+ * - All routes work normally in compat mode
+ * - Startup warning when RUNTIME_HTTP_HOST is not loopback in gateway_only mode
+ */
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'gw-only-enforcement-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getWorkspaceConfigPath: () => join(testDir, 'config.json'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+// Configurable ingress mode — tests toggle this between 'gateway_only' and 'compat'
+let mockIngressMode: 'gateway_only' | 'compat' = 'compat';
+
+const logMessages: { level: string; msg: string; args?: unknown }[] = [];
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: (_target, prop: string) => {
+      if (prop === 'child') return () => new Proxy({} as Record<string, unknown>, {
+        get: () => () => {},
+      });
+      return (...args: unknown[]) => {
+        if (typeof args[0] === 'string') {
+          logMessages.push({ level: prop, msg: args[0] });
+        } else if (typeof args[1] === 'string') {
+          logMessages.push({ level: prop, msg: args[1], args: args[0] });
+        }
+      };
+    },
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    calls: {
+      enabled: true,
+      provider: 'twilio',
+      webhookBaseUrl: 'https://test.example.com',
+      maxDurationSeconds: 3600,
+      userConsultTimeoutSeconds: 120,
+      disclosure: { enabled: false, text: '' },
+      safety: { denyCategories: [] },
+    },
+    ingress: {
+      publicBaseUrl: 'https://test.example.com',
+      mode: mockIngressMode,
+    },
+  }),
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    ingress: {
+      publicBaseUrl: 'https://test.example.com',
+      mode: mockIngressMode,
+    },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+// Mock Twilio provider
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    static getAuthToken() { return 'mock-auth-token'; }
+    static verifyWebhookSignature() { return true; }
+    async initiateCall() { return { callSid: 'CA_mock_sid' }; }
+    async endCall() { return; }
+  },
+}));
+
+// Mock Twilio config
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test_token',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => null,
+  setSecureKey: () => true,
+  deleteSecureKey: () => {},
+}));
+
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getPublicBaseUrl: () => 'https://test.example.com',
+  getTwilioRelayUrl: () => 'wss://test.example.com/webhooks/twilio/relay',
+  getTwilioVoiceWebhookUrl: (_cfg: unknown, id: string) => `https://test.example.com/webhooks/twilio/voice?callSessionId=${id}`,
+  getTwilioStatusCallbackUrl: () => 'https://test.example.com/webhooks/twilio/status',
+  getTwilioConnectActionUrl: () => 'https://test.example.com/webhooks/twilio/connect-action',
+  getOAuthCallbackUrl: () => 'https://test.example.com/webhooks/oauth/callback',
+}));
+
+// Mock the oauth callback registry
+mock.module('../security/oauth-callback-registry.js', () => ({
+  consumeCallback: () => true,
+  consumeCallbackError: () => true,
+}));
+
+import { RuntimeHttpServer } from '../runtime/http-server.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_TOKEN = 'test-bearer-token-gw';
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
+function makeFormBody(params: Record<string, string>): string {
+  return new URLSearchParams(params).toString();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('gateway-only ingress enforcement', () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(async () => {
+    logMessages.length = 0;
+    port = 17800 + Math.floor(Math.random() * 1000);
+    server = new RuntimeHttpServer({
+      port,
+      hostname: '127.0.0.1',
+      bearerToken: TEST_TOKEN,
+    });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  // ── Direct Twilio webhook routes blocked in gateway_only mode ──────
+
+  describe('gateway_only mode — direct webhook routes', () => {
+    beforeEach(() => { mockIngressMode = 'gateway_only'; });
+    afterEach(() => { mockIngressMode = 'compat'; });
+
+    test('POST /webhooks/twilio/voice returns 410', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ CallSid: 'CA123', AccountSid: 'AC_test' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+      expect(body.error).toContain('gateway-only mode');
+    });
+
+    test('POST /webhooks/twilio/status returns 410', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ CallSid: 'CA123', CallStatus: 'completed' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+
+    test('POST /webhooks/twilio/connect-action returns 410', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/connect-action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ CallSid: 'CA123' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+
+    test('POST /v1/calls/twilio/voice-webhook returns 410', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/voice-webhook`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ CallSid: 'CA123' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+
+    test('POST /v1/calls/twilio/status returns 410', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ CallSid: 'CA123', CallStatus: 'completed' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+  });
+
+  // ── Internal forwarding routes still work in gateway_only mode ─────
+
+  describe('gateway_only mode — internal forwarding routes', () => {
+    beforeEach(() => { mockIngressMode = 'gateway_only'; });
+    afterEach(() => { mockIngressMode = 'compat'; });
+
+    test('POST /v1/internal/twilio/voice-webhook is NOT blocked', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/internal/twilio/voice-webhook`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          params: { CallSid: 'CA123', AccountSid: 'AC_test' },
+          originalUrl: `http://127.0.0.1:${port}/v1/internal/twilio/voice-webhook?callSessionId=sess-123`,
+        }),
+      });
+      // Should NOT be 410 — it may 404 or 400 because the call session
+      // doesn't exist, but the gateway-only guard should NOT block it.
+      expect(res.status).not.toBe(410);
+    });
+
+    test('POST /v1/internal/twilio/status is NOT blocked', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/internal/twilio/status`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          params: { CallSid: 'CA123', CallStatus: 'completed' },
+        }),
+      });
+      expect(res.status).not.toBe(410);
+    });
+
+    test('POST /v1/internal/twilio/connect-action is NOT blocked', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/internal/twilio/connect-action`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          params: { CallSid: 'CA123' },
+        }),
+      });
+      expect(res.status).not.toBe(410);
+    });
+
+    test('POST /v1/internal/oauth/callback is NOT blocked', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/internal/oauth/callback`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: 'test-state',
+          code: 'test-code',
+        }),
+      });
+      // Should succeed or return a non-410 status
+      expect(res.status).not.toBe(410);
+    });
+  });
+
+  // ── Relay WebSocket upgrade in gateway_only mode ───────────────────
+
+  describe('gateway_only mode — relay WebSocket upgrade', () => {
+    beforeEach(() => { mockIngressMode = 'gateway_only'; });
+    afterEach(() => { mockIngressMode = 'compat'; });
+
+    test('blocks non-localhost origin', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
+        headers: {
+          'Upgrade': 'websocket',
+          'Connection': 'Upgrade',
+          'Origin': 'https://external.example.com',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+        },
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+      expect(body.error).toContain('gateway-only mode');
+    });
+
+    test('allows request with no origin header (localhost)', async () => {
+      // Without an origin header, isLoopbackOrigin returns true
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
+        headers: {
+          'Upgrade': 'websocket',
+          'Connection': 'Upgrade',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+        },
+      });
+      // Should NOT be 403 — WebSocket upgrade may or may not succeed
+      // depending on test environment, but the gateway guard should pass.
+      expect(res.status).not.toBe(403);
+    });
+
+    test('allows localhost origin', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
+        headers: {
+          'Upgrade': 'websocket',
+          'Connection': 'Upgrade',
+          'Origin': 'http://127.0.0.1:3000',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+        },
+      });
+      // Should NOT be 403
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  // ── Compat mode — everything works as before ───────────────────────
+
+  describe('compat mode — no enforcement', () => {
+    beforeEach(() => { mockIngressMode = 'compat'; });
+
+    test('POST /webhooks/twilio/voice is NOT blocked', async () => {
+      // In compat mode, disable webhook validation to focus on the ingress check
+      const savedDisable = process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice?callSessionId=test-compat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: makeFormBody({ CallSid: 'CA_compat', AccountSid: 'AC_test' }),
+        });
+        // Should NOT be 410 (gateway-only)
+        expect(res.status).not.toBe(410);
+      } finally {
+        if (savedDisable !== undefined) {
+          process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = savedDisable;
+        } else {
+          delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+        }
+      }
+    });
+
+    test('POST /webhooks/twilio/status is NOT blocked', async () => {
+      const savedDisable = process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/status`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: makeFormBody({ CallSid: 'CA_compat', CallStatus: 'completed' }),
+        });
+        expect(res.status).not.toBe(410);
+      } finally {
+        if (savedDisable !== undefined) {
+          process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = savedDisable;
+        } else {
+          delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+        }
+      }
+    });
+
+    test('relay WebSocket upgrade is NOT blocked for external origin', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-compat`, {
+        headers: {
+          'Upgrade': 'websocket',
+          'Connection': 'Upgrade',
+          'Origin': 'https://external.example.com',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+        },
+      });
+      // In compat mode, the gateway-only guard should not activate
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  // ── Startup warning for non-loopback host ──────────────────────────
+
+  describe('startup guard — non-loopback host warning', () => {
+    test('logs warning when hostname is not loopback in gateway_only mode', async () => {
+      mockIngressMode = 'gateway_only';
+      logMessages.length = 0;
+
+      const warnServer = new RuntimeHttpServer({
+        port: port + 100,
+        hostname: '0.0.0.0',
+        bearerToken: TEST_TOKEN,
+      });
+      await warnServer.start();
+
+      const infoMsg = logMessages.find(
+        m => m.level === 'info' && m.msg.includes('gateway-only ingress mode'),
+      );
+      expect(infoMsg).toBeDefined();
+
+      const warnMsg = logMessages.find(
+        m => m.level === 'warn' && m.msg.includes('not bound to loopback'),
+      );
+      expect(warnMsg).toBeDefined();
+
+      await warnServer.stop();
+      mockIngressMode = 'compat';
+    });
+
+    test('does NOT log warning when hostname is loopback in gateway_only mode', async () => {
+      mockIngressMode = 'gateway_only';
+      logMessages.length = 0;
+
+      // The main test server already uses 127.0.0.1, so restart with
+      // a fresh server and capture logs
+      const loopbackServer = new RuntimeHttpServer({
+        port: port + 200,
+        hostname: '127.0.0.1',
+        bearerToken: TEST_TOKEN,
+      });
+      await loopbackServer.start();
+
+      const infoMsg = logMessages.find(
+        m => m.level === 'info' && m.msg.includes('gateway-only ingress mode'),
+      );
+      expect(infoMsg).toBeDefined();
+
+      const warnMsg = logMessages.find(
+        m => m.level === 'warn' && m.msg.includes('not bound to loopback'),
+      );
+      expect(warnMsg).toBeUndefined();
+
+      await loopbackServer.stop();
+      mockIngressMode = 'compat';
+    });
+  });
+});

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -2,6 +2,7 @@ import { getSecureKey } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
 import { loadConfig } from '../config/loader.js';
 import { getWebhookBaseUrl } from './twilio-webhook-urls.js';
+import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 
 const log = getLogger('twilio-config');
 
@@ -19,7 +20,22 @@ export function getTwilioConfig(): TwilioConfig {
   const phoneNumber = process.env.TWILIO_PHONE_NUMBER || getSecureKey('credential:twilio:phone_number') || '';
   const config = loadConfig();
   const webhookBaseUrl = getWebhookBaseUrl(config);
-  const wssBaseUrl = process.env.TWILIO_WSS_BASE_URL || '';
+
+  // In gateway_only mode, ignore TWILIO_WSS_BASE_URL and always use the
+  // centralized relay URL derived from the public ingress base URL.
+  let wssBaseUrl: string;
+  if (config.ingress.mode === 'gateway_only') {
+    if (process.env.TWILIO_WSS_BASE_URL) {
+      log.warn('TWILIO_WSS_BASE_URL env var is ignored in gateway-only mode. Relay URL is derived from ingress.publicBaseUrl.');
+    }
+    try {
+      wssBaseUrl = getTwilioRelayUrl(config);
+    } catch {
+      wssBaseUrl = '';
+    }
+  } else {
+    wssBaseUrl = process.env.TWILIO_WSS_BASE_URL || '';
+  }
 
   if (!accountSid || !authToken) {
     throw new Error('Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.');

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,6 +139,35 @@ const GATEWAY_SUBPATH_MAP: Record<string, string> = {
 };
 
 /**
+ * Direct Twilio webhook subpaths that are blocked in gateway_only mode.
+ * Internal forwarding endpoints (gateway→runtime) are unaffected.
+ */
+const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set(['voice-webhook', 'status', 'connect-action']);
+
+/**
+ * Check if a request origin is from localhost / loopback.
+ */
+function isLoopbackOrigin(req: Request): boolean {
+  const origin = req.headers.get('origin');
+  // No origin header (e.g., server-initiated or same-origin) — allow
+  if (!origin) return true;
+  try {
+    const url = new URL(origin);
+    const host = url.hostname;
+    return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a hostname is a loopback address.
+ */
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === '::1' || hostname === 'localhost';
+}
+
+/**
  * Validate a Twilio webhook request's X-Twilio-Signature header.
  *
  * Returns the raw body text on success so callers can reconstruct the Request
@@ -290,6 +319,19 @@ export class RuntimeHttpServer {
       }, 30_000);
     }
 
+    // Startup guard: log gateway-only mode warnings
+    try {
+      const config = loadConfig();
+      if (config.ingress.mode === 'gateway_only') {
+        log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');
+        if (!isLoopbackHost(this.hostname)) {
+          log.warn('gateway-only mode is enabled but RUNTIME_HTTP_HOST is not bound to loopback. This may expose the runtime to direct public access.');
+        }
+      }
+    } catch {
+      // Config loading may fail during startup — don't block server start
+    }
+
     log.info({ port: this.port, hostname: this.hostname, auth: !!this.bearerToken }, 'Runtime HTTP server listening');
   }
 
@@ -328,6 +370,15 @@ export class RuntimeHttpServer {
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
     if (path.startsWith('/v1/calls/relay') && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+      // In gateway_only mode, only allow relay connections from localhost
+      const config = loadConfig();
+      if (config.ingress.mode === 'gateway_only' && !isLoopbackOrigin(req)) {
+        return Response.json(
+          { error: 'Direct relay access disabled in gateway-only mode', code: 'GATEWAY_ONLY' },
+          { status: 403 },
+        );
+      }
+
       const wsUrl = new URL(req.url);
       const callSessionId = wsUrl.searchParams.get('callSessionId');
       if (!callSessionId) {
@@ -356,6 +407,15 @@ export class RuntimeHttpServer {
         : null;
     if (resolvedTwilioSubpath && req.method === 'POST') {
       const twilioSubpath = resolvedTwilioSubpath;
+
+      // In gateway_only mode, block direct Twilio webhook routes
+      const ingressConfig = loadConfig();
+      if (ingressConfig.ingress.mode === 'gateway_only' && GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
+        return Response.json(
+          { error: 'Direct webhook access disabled in gateway-only mode. Use the gateway.', code: 'GATEWAY_ONLY' },
+          { status: 410 },
+        );
+      }
 
       // Validate Twilio request signature before dispatching
       const validation = await validateTwilioWebhook(req);


### PR DESCRIPTION
## Summary
- Enforce gateway-only mode in runtime HTTP server (disable direct Twilio webhook routes)
- Keep internal forwarding routes (gateway→runtime) working
- Block direct relay WebSocket access for non-localhost origins
- Startup guard warnings for non-loopback binding
- Ignore TWILIO_WSS_BASE_URL env in gateway_only mode
- Tests for enforcement behavior

Part of #5881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
