### PR TITLE
fix: align CU confirmation types with UserDecision and add fallback test

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -15,6 +15,7 @@ import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
+import type { UserDecision } from '../permissions/types.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { registerSkillTools } from '../tools/registry.js';
@@ -893,7 +894,7 @@ export class ComputerUseSession {
 
   handleConfirmationResponse(
     requestId: string,
-    decision: 'allow' | 'always_allow' | 'deny',
+    decision: UserDecision,
     selectedPattern?: string,
     selectedScope?: string,
   ): void {

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -435,4 +435,89 @@ final class ChatViewModelIOSTests: XCTestCase {
         let confirmations = mockClient.sentMessages.compactMap { $0 as? ConfirmationResponseMessage }
         XCTAssertTrue(confirmations.isEmpty)
     }
+
+    func testRespondToAlwaysAllowConnectedSendFailureFallsBackToAllow() {
+        // Use a test double that fails the first send but succeeds on the second.
+        let failOnceClient = FailOnceDaemonClient()
+        failOnceClient.isConnected = true
+        let vm = ChatViewModel(daemonClient: failOnceClient)
+        vm.sessionId = "sess-fail-once"
+
+        // Seed a confirmation message so the fallback path can update its state
+        let confirmation = ToolConfirmationData(
+            requestId: "req-fail",
+            toolName: "bash",
+            input: ["command": AnyCodable("rm -rf *")],
+            riskLevel: "high",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: nil,
+            persistentDecisionsAllowed: true
+        )
+        let msg = ChatMessage(role: .assistant, text: "Run rm -rf?", confirmation: confirmation)
+        vm.messages.append(msg)
+
+        vm.respondToAlwaysAllow(
+            requestId: "req-fail",
+            selectedPattern: "rm -rf *",
+            selectedScope: "project",
+            decision: "always_allow_high_risk"
+        )
+
+        // First attempted decision should be always_allow_high_risk (the one that failed)
+        XCTAssertEqual(failOnceClient.allAttemptedMessages.count, 2)
+        let first = failOnceClient.allAttemptedMessages[0] as? ConfirmationResponseMessage
+        XCTAssertEqual(first?.decision, "always_allow_high_risk")
+
+        // Fallback should be a one-time "allow"
+        let second = failOnceClient.allAttemptedMessages[1] as? ConfirmationResponseMessage
+        XCTAssertEqual(second?.decision, "allow")
+
+        // The fallback succeeded, so errorText should reflect the preference-not-saved message
+        XCTAssertEqual(vm.errorText, "Preference could not be saved. This action was allowed once.")
+
+        // The client was connected the whole time — no disconnected error
+        XCTAssertTrue(failOnceClient.isConnected)
+    }
+}
+
+// MARK: - Test Doubles
+
+/// A `DaemonClientProtocol` implementation that throws on the first `send` call
+/// and succeeds on subsequent calls. Used to test the connected send-failure
+/// fallback path in `respondToAlwaysAllow`.
+@MainActor
+private final class FailOnceDaemonClient: DaemonClientProtocol {
+    var isConnected: Bool = false
+    var isBlobTransportAvailable: Bool = false
+
+    /// All messages attempted (including failed ones).
+    private(set) var allAttemptedMessages: [Any] = []
+
+    /// Messages that were successfully sent (after the first failure).
+    private(set) var sentMessages: [Any] = []
+
+    private var sendCount = 0
+
+    func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { _ in }
+    }
+
+    func send<T: Encodable>(_ message: T) throws {
+        allAttemptedMessages.append(message)
+        sendCount += 1
+        if sendCount == 1 {
+            throw NSError(domain: "TestSendFailure", code: 1, userInfo: [NSLocalizedDescriptionKey: "Simulated first-send failure"])
+        }
+        sentMessages.append(message)
+    }
+
+    func connect() async throws {
+        isConnected = true
+    }
+
+    func disconnect() {
+        isConnected = false
+    }
 }


### PR DESCRIPTION
## Summary
- Widens `ComputerUseSession.handleConfirmationResponse` decision type from `'allow' | 'always_allow' | 'deny'` to `UserDecision`, so `sessions.ts` can pass `msg.decision` directly without casts (supports `always_allow_high_risk` and `always_deny`)
- Adds iOS regression test for the connected send-failure fallback in `respondToAlwaysAllow`: verifies the first attempt uses the passed decision, the fallback sends one-time `allow`, and no disconnected error is reported
- Introduces `FailOnceDaemonClient` test double that throws on the first `send` call, enabling deterministic testing of the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
