### PR TITLE
feat: add task_queue_run tool for running tasks from Telegram/chat

### DIFF
--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -251,6 +251,31 @@
       },
       "executor": "tools/task-list-remove.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "task_queue_run",
+      "description": "Run a task from the Task Queue in the background. Use this when the user says \"run this task\", \"execute this task\", \"start this task\", or wants to kick off a queued work item. The task runs asynchronously — the user can continue chatting while it executes. Required tool permissions are auto-approved since the user is explicitly requesting execution.",
+      "category": "tasks",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "work_item_id": {
+            "type": "string",
+            "description": "Direct work item ID (most precise selector)"
+          },
+          "task_name": {
+            "type": "string",
+            "description": "Task name/title to search for (case-insensitive substring match)"
+          },
+          "title": {
+            "type": "string",
+            "description": "Work item title to search for (case-insensitive substring match)"
+          }
+        }
+      },
+      "executor": "tools/task-queue-run.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/tasks/tools/task-queue-run.ts
+++ b/assistant/src/config/bundled-skills/tasks/tools/task-queue-run.ts
@@ -1,0 +1,9 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { executeTaskQueueRun } from '../../../../tools/tasks/work-item-run.js';
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeTaskQueueRun(input, context);
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -39,6 +39,7 @@ import { getSubagentManager } from '../subagent/index.js';
 import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
 import { resolveSlash } from './session-slash.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
+import { registerDaemonCallbacks } from '../work-items/work-item-runner.js';
 
 const log = getLogger('server');
 
@@ -183,6 +184,12 @@ export class DaemonServer {
     }
 
     this.evictor.start();
+
+    // Register daemon callbacks so tools can trigger work item execution
+    registerDaemonCallbacks({
+      getOrCreateSession: (conversationId) => this.getOrCreateSession(conversationId),
+      broadcast: (msg) => this.broadcast(msg),
+    });
 
     ensureBlobDir();
     this.blobSweepTimer = setInterval(() => {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -282,7 +282,7 @@ export function createToolExecutor(
 
     // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
     // auto-refresh when the LLM mutates the task queue via tools
-    if ((name === 'task_list_add' || name === 'task_list_update' || name === 'task_list_remove') && !result.isError) {
+    if ((name === 'task_list_add' || name === 'task_list_update' || name === 'task_list_remove' || name === 'task_queue_run') && !result.isError) {
       broadcastToAllClients?.({ type: 'tasks_changed' });
     }
 

--- a/assistant/src/tools/tasks/work-item-run.ts
+++ b/assistant/src/tools/tasks/work-item-run.ts
@@ -1,0 +1,78 @@
+import type { ToolContext, ToolExecutionResult } from '../types.js';
+import { getWorkItem, listWorkItems, identifyEntityById, buildWorkItemMismatchError } from '../../work-items/work-item-store.js';
+import { runWorkItemInBackground } from '../../work-items/work-item-runner.js';
+import { getTask } from '../../tasks/task-store.js';
+
+export async function executeTaskQueueRun(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const workItemId = input.work_item_id as string | undefined;
+  const taskName = input.task_name as string | undefined;
+  const title = input.title as string | undefined;
+
+  if (!workItemId && !taskName && !title) {
+    return {
+      content: 'Error: Provide work_item_id, task_name, or title to identify the task to run.',
+      isError: true,
+    };
+  }
+
+  try {
+    let resolvedId: string | undefined;
+
+    if (workItemId) {
+      const item = getWorkItem(workItemId);
+      if (!item) {
+        const entity = identifyEntityById(workItemId);
+        if (entity.type === 'task') {
+          return {
+            content: `Error: "${workItemId}" is a task template ID, not a work item. Use task_list_show to find the work item ID.`,
+            isError: true,
+          };
+        }
+        return { content: `Error: No work item found with ID "${workItemId}".`, isError: true };
+      }
+      resolvedId = item.id;
+    } else {
+      // Search by task_name or title among active work items
+      const needle = (taskName ?? title)!.toLowerCase();
+      const allItems = listWorkItems();
+      const activeItems = allItems.filter((i) => !['archived', 'done'].includes(i.status));
+      const matches = activeItems.filter((i) => i.title.toLowerCase().includes(needle));
+
+      if (matches.length === 0) {
+        return {
+          content: `Error: No active work item matching "${taskName ?? title}". Use task_list_show to see your task queue.`,
+          isError: true,
+        };
+      }
+
+      if (matches.length > 1) {
+        const lines = [`Multiple work items match "${taskName ?? title}". Please specify by ID:`, ''];
+        for (const m of matches) {
+          lines.push(`- ${m.title} (ID: ${m.id}, status: ${m.status})`);
+        }
+        return { content: lines.join('\n'), isError: true };
+      }
+
+      resolvedId = matches[0].id;
+    }
+
+    const result = runWorkItemInBackground(resolvedId);
+
+    if (!result.success) {
+      return { content: `Error: ${result.error}`, isError: true };
+    }
+
+    const item = getWorkItem(resolvedId)!;
+    const task = getTask(item.taskId);
+    return {
+      content: `Started running task "${item.title}"${task ? ` (template: ${task.title})` : ''}. It will execute in the background. Use task_list_show to check progress.`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -1,0 +1,171 @@
+/**
+ * Module-level registry for running work items from tool context.
+ *
+ * The daemon server registers its `getOrCreateSession` and `broadcast`
+ * callbacks at startup. Tool implementations can then trigger async
+ * work item execution without needing direct access to HandlerContext.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { getWorkItem, updateWorkItem, type WorkItemStatus } from './work-item-store.js';
+import { getTask } from '../tasks/task-store.js';
+import { runTask } from '../tasks/task-runner.js';
+import { sanitizeToolList, getRegisteredToolNames } from '../tasks/tool-sanitizer.js';
+import type { Session } from '../daemon/session.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+const log = getLogger('work-item-runner');
+
+// ── Daemon callback registry ─────────────────────────────────────────
+
+interface DaemonCallbacks {
+  getOrCreateSession: (conversationId: string) => Promise<Session>;
+  broadcast: (msg: ServerMessage) => void;
+}
+
+let _callbacks: DaemonCallbacks | null = null;
+
+export function registerDaemonCallbacks(callbacks: DaemonCallbacks): void {
+  _callbacks = callbacks;
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+function broadcastWorkItemStatus(broadcast: (msg: ServerMessage) => void, id: string): void {
+  const item = getWorkItem(id);
+  if (item) {
+    broadcast({
+      type: 'work_item_status_changed',
+      item: {
+        id: item.id,
+        taskId: item.taskId,
+        title: item.title,
+        status: item.status,
+        lastRunId: item.lastRunId,
+        lastRunConversationId: item.lastRunConversationId,
+        lastRunStatus: item.lastRunStatus,
+        updatedAt: item.updatedAt,
+      },
+    } as ServerMessage);
+  }
+}
+
+export interface RunWorkItemResult {
+  success: boolean;
+  error?: string;
+  errorCode?: string;
+}
+
+/**
+ * Run a work item in the background. Returns immediately after validation.
+ * The actual execution happens asynchronously.
+ *
+ * When called from a chat tool (e.g. Telegram), required tools are
+ * auto-approved since the user explicitly requested execution.
+ */
+export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
+  if (!_callbacks) {
+    return { success: false, error: 'Daemon callbacks not registered', errorCode: 'not_initialized' };
+  }
+
+  const workItem = getWorkItem(workItemId);
+  if (!workItem) {
+    return { success: false, error: 'Work item not found', errorCode: 'not_found' };
+  }
+
+  if (workItem.status === 'running') {
+    return { success: false, error: 'Work item is already running', errorCode: 'already_running' };
+  }
+
+  const NON_RUNNABLE_STATUSES: readonly string[] = ['archived'];
+  if (NON_RUNNABLE_STATUSES.includes(workItem.status)) {
+    return { success: false, error: `Work item has status '${workItem.status}' and cannot be run`, errorCode: 'invalid_status' };
+  }
+
+  const task = getTask(workItem.taskId);
+  if (!task) {
+    return { success: false, error: `Associated task not found: ${workItem.taskId}`, errorCode: 'no_task' };
+  }
+
+  // Resolve required tools
+  let requiredTools: string[];
+  if (workItem.requiredTools !== null && workItem.requiredTools !== undefined) {
+    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+  } else {
+    requiredTools = task.requiredTools
+      ? sanitizeToolList(JSON.parse(task.requiredTools))
+      : getRegisteredToolNames();
+  }
+
+  // Auto-approve all required tools for chat-initiated runs.
+  // The user explicitly asked to run the task, so we treat that as consent.
+  const approvedTools = requiredTools;
+
+  // Set status to running
+  updateWorkItem(workItemId, { status: 'running' });
+
+  const { getOrCreateSession, broadcast } = _callbacks;
+
+  // Broadcast the running state
+  broadcastWorkItemStatus(broadcast, workItemId);
+  broadcast({ type: 'tasks_changed' } as ServerMessage);
+
+  // Execute asynchronously
+  let session: Awaited<ReturnType<typeof getOrCreateSession>> | null = null;
+  void (async () => {
+    try {
+      const result = await runTask(
+        { taskId: workItem.taskId, workingDir: process.cwd(), approvedTools },
+        async (conversationId, message, taskRunId) => {
+          if (!session) {
+            updateWorkItem(workItemId, { lastRunConversationId: conversationId });
+            session = await getOrCreateSession(conversationId);
+
+            broadcast({
+              type: 'task_run_thread_created',
+              conversationId,
+              workItemId,
+              title: workItem.title,
+            } as ServerMessage);
+            (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
+            (session as unknown as { headlessLock: boolean }).headlessLock = true;
+          }
+          await session.processMessage(message, [], (event) => {
+            broadcast(event);
+          });
+        },
+      );
+
+      if (session) {
+        (session as unknown as { headlessLock: boolean }).headlessLock = false;
+      }
+
+      const current = getWorkItem(workItemId);
+      if (current?.status !== 'cancelled') {
+        const finalStatus: WorkItemStatus = result.status === 'completed' ? 'awaiting_review' : 'failed';
+        updateWorkItem(workItemId, {
+          status: finalStatus,
+          lastRunId: result.taskRunId,
+          lastRunConversationId: result.conversationId,
+          lastRunStatus: result.status,
+        });
+      }
+
+      broadcastWorkItemStatus(broadcast, workItemId);
+      broadcast({ type: 'tasks_changed' } as ServerMessage);
+    } catch (err) {
+      if (session) {
+        (session as unknown as { headlessLock: boolean }).headlessLock = false;
+      }
+      log.error({ err, workItemId }, 'work item background run failed');
+      updateWorkItem(workItemId, {
+        status: 'failed',
+        lastRunStatus: 'failed',
+      });
+      broadcastWorkItemStatus(broadcast, workItemId);
+      broadcast({ type: 'tasks_changed' } as ServerMessage);
+    }
+  })();
+
+  return { success: true };
+}


### PR DESCRIPTION
## Summary
- Add `task_queue_run` tool to the tasks skill so users can run queued tasks from any chat client (Telegram, web, etc.)
- Create module-level daemon callback registry (`work-item-runner.ts`) that bridges the gap between tool context and session management
- Auto-approve required tool permissions for chat-initiated runs since the user explicitly requests execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
