### PR TITLE
Telegram ingress convergence with centralized URL builders (#5905)

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -23,6 +23,7 @@ import {
   getTwilioConnectActionUrl,
   getTwilioRelayUrl,
   getOAuthCallbackUrl,
+  getTelegramWebhookUrl,
 } from '../inbound/public-ingress-urls.js';
 
 // ---------------------------------------------------------------------------
@@ -202,5 +203,26 @@ describe('getOAuthCallbackUrl', () => {
       ingress: { publicBaseUrl: 'https://example.com' },
     });
     expect(url).toBe('https://example.com/webhooks/oauth/callback');
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// getTelegramWebhookUrl
+// ---------------------------------------------------------------------------
+
+describe('getTelegramWebhookUrl', () => {
+  test('builds correct URL', () => {
+    const url = getTelegramWebhookUrl({
+      ingress: { publicBaseUrl: 'https://example.com' },
+    });
+    expect(url).toBe('https://example.com/webhooks/telegram');
+  });
+
+  test('normalizes trailing slash before composing', () => {
+    const url = getTelegramWebhookUrl({
+      ingress: { publicBaseUrl: 'https://example.com/' },
+    });
+    expect(url).toBe('https://example.com/webhooks/telegram');
   });
 });

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -10,9 +10,9 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 ## What You Need
 
 1. **Bot token** from Telegram's @BotFather (the user provides this)
-2. **Gateway webhook URL** where the gateway receives webhooks (e.g. `https://their-domain/webhooks/telegram`)
+2. **Gateway webhook URL** where the gateway receives webhooks — this should be `${ingress.publicBaseUrl}/webhooks/telegram`. If `ingress.publicBaseUrl` is configured, use it to auto-derive the webhook URL. If it is not configured, ask the user to either set `ingress.publicBaseUrl` in the assistant config or provide the webhook URL manually as a fallback.
 
-If the user has already provided the bot token in the conversation, use it directly. Otherwise, ask for it. Always confirm the gateway webhook URL if not provided.
+If the user has already provided the bot token in the conversation, use it directly. Otherwise, ask for it.
 
 ## Setup Steps
 

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -104,3 +104,11 @@ export function getOAuthCallbackUrl(config: IngressConfig): string {
   const base = getPublicBaseUrl(config);
   return `${base}/webhooks/oauth/callback`;
 }
+
+/**
+ * Build the Telegram webhook URL.
+ */
+export function getTelegramWebhookUrl(config: IngressConfig): string {
+  const base = getPublicBaseUrl(config);
+  return `${base}/webhooks/telegram`;
+}


### PR DESCRIPTION
## Summary
- Added `getTelegramWebhookUrl(config)` to the centralized URL builder module (`assistant/src/inbound/public-ingress-urls.ts`), following the same pattern as existing builders like `getTwilioStatusCallbackUrl` and `getOAuthCallbackUrl`.
- Added tests for the new function in `assistant/src/__tests__/public-ingress-urls.test.ts` (correct URL construction and trailing-slash normalization).
- Updated the Telegram Setup skill (`SKILL.md`) to auto-derive the webhook URL from `ingress.publicBaseUrl` when configured, with a manual fallback for backward compatibility.

## Test plan
- [x] `bun test src/__tests__/public-ingress-urls.test.ts` passes (20/20 tests, including 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
