### PR TITLE
M1: Unify CC artifact discovery across commands + skills

### DIFF
--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -30,6 +30,15 @@ function createCommandsDir(base: string, files: Record<string, string>): void {
   }
 }
 
+/** Helper to create a .claude/skills/ directory with markdown files. */
+function createSkillsDir(base: string, files: Record<string, string>): void {
+  const skillsDir = join(base, '.claude', 'skills');
+  mkdirSync(skillsDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(skillsDir, name), content, 'utf-8');
+  }
+}
+
 describe('discoverCCCommands', () => {
   test('discovers commands in .claude/commands/', () => {
     createCommandsDir(tmpDir, {
@@ -45,11 +54,13 @@ describe('discoverCCCommands', () => {
     expect(hello!.name).toBe('hello');
     expect(hello!.summary).toBe('Hello World');
     expect(hello!.source).toBe(tmpDir);
+    expect(hello!.artifactType).toBe('command');
 
     const deploy = registry.entries.get('deploy');
     expect(deploy).toBeDefined();
     expect(deploy!.name).toBe('deploy');
     expect(deploy!.summary).toBe('Deploy the application to production.');
+    expect(deploy!.artifactType).toBe('command');
   });
 
   test('child directory commands override parent on name collisions', () => {
@@ -129,6 +140,107 @@ describe('discoverCCCommands', () => {
     expect(registry.entries.has('parent-only')).toBe(true);
     expect(registry.entries.has('child-only')).toBe(true);
   });
+
+  test('discovers skills in .claude/skills/', () => {
+    createSkillsDir(tmpDir, {
+      'summarize.md': '# Summarize\nSummarize any document.',
+      'translate.md': 'Translate text between languages.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    expect(registry.entries.size).toBe(2);
+
+    const summarize = registry.entries.get('summarize');
+    expect(summarize).toBeDefined();
+    expect(summarize!.name).toBe('summarize');
+    expect(summarize!.summary).toBe('Summarize');
+    expect(summarize!.source).toBe(tmpDir);
+    expect(summarize!.artifactType).toBe('skill');
+
+    const translate = registry.entries.get('translate');
+    expect(translate).toBeDefined();
+    expect(translate!.name).toBe('translate');
+    expect(translate!.summary).toBe('Translate text between languages.');
+    expect(translate!.artifactType).toBe('skill');
+  });
+
+  test('commands take precedence over skills at the same directory level', () => {
+    createCommandsDir(tmpDir, {
+      'shared.md': 'Command version of shared.',
+    });
+    createSkillsDir(tmpDir, {
+      'shared.md': 'Skill version of shared.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const shared = registry.entries.get('shared');
+    expect(shared).toBeDefined();
+    expect(shared!.summary).toBe('Command version of shared.');
+    expect(shared!.artifactType).toBe('command');
+  });
+
+  test('child skill overrides parent command (child wins across levels)', () => {
+    // Parent has a command
+    createCommandsDir(tmpDir, {
+      'analyze.md': 'Parent command version.',
+    });
+
+    // Child has a skill with the same name
+    const childDir = join(tmpDir, 'project');
+    mkdirSync(childDir, { recursive: true });
+    createSkillsDir(childDir, {
+      'analyze.md': 'Child skill version.',
+    });
+
+    const registry = discoverCCCommands(childDir);
+    const analyze = registry.entries.get('analyze');
+    expect(analyze).toBeDefined();
+    expect(analyze!.summary).toBe('Child skill version.');
+    expect(analyze!.artifactType).toBe('skill');
+    expect(analyze!.source).toBe(childDir);
+  });
+
+  test('mixed hierarchy: commands at child, skills at parent', () => {
+    // Parent has skills
+    createSkillsDir(tmpDir, {
+      'parent-skill.md': 'A parent skill.',
+    });
+
+    // Child has commands
+    const childDir = join(tmpDir, 'project');
+    mkdirSync(childDir, { recursive: true });
+    createCommandsDir(childDir, {
+      'child-cmd.md': 'A child command.',
+    });
+
+    const registry = discoverCCCommands(childDir);
+    expect(registry.entries.size).toBe(2);
+
+    const parentSkill = registry.entries.get('parent-skill');
+    expect(parentSkill).toBeDefined();
+    expect(parentSkill!.artifactType).toBe('skill');
+    expect(parentSkill!.source).toBe(tmpDir);
+
+    const childCmd = registry.entries.get('child-cmd');
+    expect(childCmd).toBeDefined();
+    expect(childCmd!.artifactType).toBe('command');
+    expect(childCmd!.source).toBe(childDir);
+  });
+
+  test('skills and commands with different names are both discovered', () => {
+    createCommandsDir(tmpDir, {
+      'deploy.md': 'Deploy command.',
+    });
+    createSkillsDir(tmpDir, {
+      'summarize.md': 'Summarize skill.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    expect(registry.entries.size).toBe(2);
+
+    expect(registry.entries.get('deploy')!.artifactType).toBe('command');
+    expect(registry.entries.get('summarize')!.artifactType).toBe('skill');
+  });
 });
 
 describe('caching', () => {
@@ -165,6 +277,25 @@ describe('caching', () => {
     const first = discoverCCCommands(tmpDir, 0);
     const second = discoverCCCommands(tmpDir, 0);
     expect(first).not.toBe(second); // different object reference due to expired TTL
+  });
+
+  test('cache covers both commands and skills', () => {
+    createCommandsDir(tmpDir, {
+      'cmd.md': 'A command.',
+    });
+    createSkillsDir(tmpDir, {
+      'skl.md': 'A skill.',
+    });
+
+    const first = discoverCCCommands(tmpDir);
+    expect(first.entries.size).toBe(2);
+    expect(first.entries.get('cmd')!.artifactType).toBe('command');
+    expect(first.entries.get('skl')!.artifactType).toBe('skill');
+
+    // Second call returns cached instance with both entries
+    const second = discoverCCCommands(tmpDir);
+    expect(first).toBe(second);
+    expect(second.entries.size).toBe(2);
   });
 });
 

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -13,8 +13,10 @@ export interface CCCommandEntry {
   summary: string;
   /** Absolute path to the .md file. */
   filePath: string;
-  /** Directory containing the `.claude/commands/` folder. */
+  /** Directory containing the `.claude/commands/` or `.claude/skills/` folder. */
   source: string;
+  /** Whether this entry was discovered from a `commands/` or `skills/` directory. */
+  artifactType: 'command' | 'skill';
 }
 
 export interface CCCommandRegistry {
@@ -102,11 +104,73 @@ function extractSummary(content: string): string {
   return '';
 }
 
+// ─── Artifact scanning ───────────────────────────────────────────────────────
+
+/**
+ * Scan a single `.claude/commands/` or `.claude/skills/` directory and add
+ * discovered entries to `entries`. Entries that already exist in the map are
+ * skipped (child-level / higher-precedence entries win).
+ */
+function scanArtifactDir(
+  dir: string,
+  artifactType: 'command' | 'skill',
+  source: string,
+  entries: Map<string, CCCommandEntry>,
+): void {
+  if (!existsSync(dir)) return;
+
+  try {
+    const files = readdirSync(dir, { withFileTypes: true });
+    for (const file of files) {
+      if (!file.isFile()) continue;
+      if (!file.name.endsWith('.md')) continue;
+
+      const nameWithoutExt = basename(file.name, '.md');
+
+      // Validate command name
+      if (!COMMAND_NAME_REGEX.test(nameWithoutExt) || nameWithoutExt.includes('..')) {
+        log.warn({ fileName: file.name, dir }, 'Skipping invalid CC artifact filename');
+        continue;
+      }
+
+      const key = nameWithoutExt.toLowerCase();
+
+      // Skip if already discovered from a closer ancestor or higher-precedence source
+      if (entries.has(key)) continue;
+
+      const filePath = join(dir, file.name);
+
+      let summary = '';
+      try {
+        const head = readFileHead(filePath, SUMMARY_READ_BYTES);
+        summary = extractSummary(head);
+      } catch (err) {
+        log.warn({ err, filePath }, 'Failed to read CC artifact file for summary extraction');
+      }
+
+      entries.set(key, {
+        name: nameWithoutExt,
+        summary,
+        filePath,
+        source,
+        artifactType,
+      });
+    }
+  } catch (err) {
+    log.warn({ err, dir }, 'Failed to read CC artifact directory');
+  }
+}
+
 // ─── Discovery ───────────────────────────────────────────────────────────────
 
 /**
- * Discover `.claude/commands/*.md` files by walking up from `cwd`.
- * Nearest directory wins on name collisions (child overrides parent).
+ * Discover `.claude/commands/*.md` and `.claude/skills/*.md` files by walking
+ * up from `cwd`.
+ *
+ * Precedence rules:
+ * - Child directories win over parent directories (unchanged).
+ * - Within the same directory level, commands take precedence over skills.
+ *
  * Results are cached per cwd with a 30-second TTL.
  */
 export function discoverCCCommands(cwd: string, ttlMs: number = DEFAULT_CACHE_TTL_MS): CCCommandRegistry {
@@ -124,53 +188,16 @@ export function discoverCCCommands(cwd: string, ttlMs: number = DEFAULT_CACHE_TT
   const entries = new Map<string, CCCommandEntry>();
   let current = resolvedCwd;
 
-  // Walk up the directory tree; collect commands from each level.
+  // Walk up the directory tree; collect entries from each level.
   // Since child directories should win on name collisions, we only add entries
   // that haven't been seen yet (first occurrence = nearest ancestor).
+  // At each level, commands are scanned before skills so commands take
+  // precedence over skills with the same name at the same level.
   while (true) {
-    const commandsDir = join(current, '.claude', 'commands');
+    const claudeDir = join(current, '.claude');
 
-    if (existsSync(commandsDir)) {
-      try {
-        const files = readdirSync(commandsDir, { withFileTypes: true });
-        for (const file of files) {
-          if (!file.isFile()) continue;
-          if (!file.name.endsWith('.md')) continue;
-
-          const nameWithoutExt = basename(file.name, '.md');
-
-          // Validate command name
-          if (!COMMAND_NAME_REGEX.test(nameWithoutExt) || nameWithoutExt.includes('..')) {
-            log.warn({ fileName: file.name, dir: commandsDir }, 'Skipping invalid CC command filename');
-            continue;
-          }
-
-          const key = nameWithoutExt.toLowerCase();
-
-          // Child directories win — skip if already discovered from a closer ancestor
-          if (entries.has(key)) continue;
-
-          const filePath = join(commandsDir, file.name);
-
-          let summary = '';
-          try {
-            const head = readFileHead(filePath, SUMMARY_READ_BYTES);
-            summary = extractSummary(head);
-          } catch (err) {
-            log.warn({ err, filePath }, 'Failed to read CC command file for summary extraction');
-          }
-
-          entries.set(key, {
-            name: nameWithoutExt,
-            summary,
-            filePath,
-            source: current,
-          });
-        }
-      } catch (err) {
-        log.warn({ err, commandsDir }, 'Failed to read CC commands directory');
-      }
-    }
+    scanArtifactDir(join(claudeDir, 'commands'), 'command', current, entries);
+    scanArtifactDir(join(claudeDir, 'skills'), 'skill', current, entries);
 
     const parent = dirname(current);
     if (parent === current) break; // reached filesystem root


### PR DESCRIPTION
Part of #5900. Extends cc-command-registry to discover both .claude/commands/*.md and .claude/skills/*.md with same walk-up/collision/cache semantics. Adds artifactType discriminator to CCCommandEntry. Closes #5901.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
