### PR TITLE
Docs, skills, and migration messaging (#5887)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,7 +147,7 @@ graph TB
 
         subgraph "Integrations"
             INT_REGISTRY["IntegrationRegistry<br/>in-memory definitions"]
-            INT_OAUTH["OAuth2 PKCE Flow<br/>Bun.serve loopback"]
+            INT_OAUTH["OAuth2 PKCE Flow<br/>gateway callback transport"]
             INT_TOKEN["TokenManager<br/>auto-refresh + retry"]
             GMAIL_CLIENT["GmailClient<br/>REST API wrapper"]
             GMAIL_TOOLS["Gmail Tools<br/>(bundled skill: gmail)"]
@@ -2528,7 +2528,7 @@ Note: The `tweet.read` and `users.read` OAuth2 scopes are used for identity veri
 | Decision | Rationale |
 |----------|-----------|
 | PKCE by default, optional client_secret | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh |
-| `127.0.0.1` not `localhost` | Google OAuth requires IP literal for loopback redirect URIs |
+| Gateway callback transport | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments. |
 | Unified `MessagingProvider` interface | All platforms implement the same contract; generic tools work immediately for new providers |
 | Twitter outside unified messaging | Twitter is a broadcast platform (post-only), not a conversation platform — it doesn't fit the `MessagingProvider` contract |
 | Provider auto-selection | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX |
@@ -3363,6 +3363,58 @@ The avatar evolves during onboarding based on conversation and identity choices.
 
 **Persistence:** Evolution state in UserDefaults, resolved appearance in LOOKS.md
 
+## Ingress Boundary Architecture — Gateway-Only Public Ingress
+
+All public-facing HTTP callbacks (Twilio webhooks, OAuth authorization callbacks, Telegram webhooks) terminate at the gateway, which validates and forwards them to the assistant runtime. The runtime HTTP server is not directly exposed to the internet.
+
+```
+Internet
+  |
+  +-- Twilio ----------> Gateway POST /webhooks/twilio/*    --> Runtime /v1/calls/*
+  +-- OAuth Provider ---> Gateway GET  /webhooks/oauth/callback --> Runtime /v1/oauth/callback
+  +-- Telegram --------> Gateway POST /webhooks/telegram    --> Runtime /v1/assistants/:id/channels/inbound
+  |
+  +-- Tunnel (ngrok, Cloudflare, etc.)
+       |
+       v
+     Gateway (http://127.0.0.1:7830)
+```
+
+### Configuration
+
+The public URL where the gateway is reachable is configured via:
+
+| Source | Priority | Description |
+|--------|----------|-------------|
+| `ingress.publicBaseUrl` (workspace config) | 1 (preferred) | Set via Settings UI > Public Ingress, or directly in workspace `config.json` |
+| `INGRESS_PUBLIC_BASE_URL` (env var) | 1 | Environment variable equivalent of `ingress.publicBaseUrl` |
+| `calls.webhookBaseUrl` (workspace config) | 2 (deprecated) | Legacy Twilio-specific setting, still honored as fallback |
+| `TWILIO_WEBHOOK_BASE_URL` (env var) | 3 (deprecated) | Legacy env var, still honored as fallback |
+
+### Tunnel-Agnostic Setup
+
+To expose the gateway for external callbacks during local development:
+
+1. **Start your tunnel** service (ngrok, Cloudflare Tunnel, or any similar tool), pointing it at the local gateway: `http://127.0.0.1:7830`
+2. **Set the public URL** provided by the tunnel as `ingress.publicBaseUrl` in the Settings UI (Public Ingress section) or as the `INGRESS_PUBLIC_BASE_URL` environment variable
+
+The assistant runtime reads this URL via the centralized `public-ingress-urls.ts` module and uses it to construct all webhook and callback URLs automatically (Twilio voice/status/relay webhooks, OAuth redirect URIs, etc.).
+
+### URL Builders
+
+All public-facing URLs are constructed by `assistant/src/inbound/public-ingress-urls.ts`:
+
+| Function | URL Pattern |
+|----------|-------------|
+| `getPublicBaseUrl()` | Resolves the base URL via the fallback chain above |
+| `getTwilioVoiceWebhookUrl()` | `${base}/webhooks/twilio/voice?callSessionId=...` |
+| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status` |
+| `getTwilioConnectActionUrl()` | `${base}/webhooks/twilio/connect-action` |
+| `getTwilioRelayUrl()` | `ws(s)://.../webhooks/twilio/relay` |
+| `getOAuthCallbackUrl()` | `${base}/webhooks/oauth/callback` |
+
+---
+
 ## Outgoing AI Phone Calls — Twilio ConversationRelay
 
 The Calls subsystem enables the assistant to place outgoing phone calls on behalf of the user via Twilio's ConversationRelay protocol. The assistant uses an LLM-driven conversation loop to speak with the callee in real time, and can pause to consult the user (in the chat UI) when it encounters questions it cannot answer on its own.
@@ -3529,9 +3581,15 @@ In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice w
 
 Signature validation is **fail-closed**: if the Twilio auth token is not configured, all webhook requests are rejected with `403`. Missing or invalid `X-Twilio-Signature` headers are also rejected with `403`. Payload size is capped by `maxWebhookPayloadBytes` (checked via both `Content-Length` header and actual body size).
 
-**Webhook base URL resolution:** The base URL used when constructing Twilio webhook URLs (passed to the Twilio REST API during call initiation) is read from `calls.webhookBaseUrl` in workspace config. If not set, the system falls back to the `TWILIO_WEBHOOK_BASE_URL` environment variable (deprecated — see below). Setting the base URL via workspace config (or the Settings UI) is the recommended approach. Twilio-specific paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, etc.) are appended automatically.
+**Webhook base URL resolution:** The base URL used when constructing all public ingress URLs (Twilio webhooks, OAuth callbacks, etc.) is resolved via a three-level fallback chain managed by `public-ingress-urls.ts`:
 
-> **Deprecation:** The `TWILIO_WEBHOOK_BASE_URL` environment variable is deprecated. Use `calls.webhookBaseUrl` in workspace config instead. The env var will continue to work as a fallback during the compatibility window, but a deprecation warning is logged when it is used.
+1. `ingress.publicBaseUrl` in workspace config (preferred)
+2. `calls.webhookBaseUrl` in workspace config (backward compat, deprecated)
+3. `TWILIO_WEBHOOK_BASE_URL` environment variable (legacy, deprecated)
+
+Setting `ingress.publicBaseUrl` via the Settings UI (Public Ingress section) or the `INGRESS_PUBLIC_BASE_URL` environment variable is the recommended approach. All webhook paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhooks/oauth/callback`, etc.) are appended automatically.
+
+> **Deprecation:** Both `calls.webhookBaseUrl` and the `TWILIO_WEBHOOK_BASE_URL` environment variable are deprecated in favor of `ingress.publicBaseUrl` / `INGRESS_PUBLIC_BASE_URL`. They continue to work as fallbacks during the compatibility window, but deprecation warnings are logged when they are used.
 
 ### Runtime HTTP Endpoints
 
@@ -3584,7 +3642,7 @@ Call behavior is controlled via the `calls` config block in the assistant config
 |-------|------|---------|-------------|
 | `calls.enabled` | boolean | `true` | Master toggle for the calls feature. When `false`, call routes return 403 and tools return errors. |
 | `calls.provider` | enum | `'twilio'` | Voice provider to use (currently only Twilio is supported). |
-| `calls.webhookBaseUrl` | string | `""` | Base URL for Twilio webhooks (e.g., `https://abc123.ngrok-free.app`). Twilio-specific paths like `/webhooks/twilio/voice` and `/webhooks/twilio/status` are appended automatically. Falls back to `TWILIO_WEBHOOK_BASE_URL` env var if not set (deprecated). |
+| `calls.webhookBaseUrl` | string | `""` | **Deprecated** — use `ingress.publicBaseUrl` instead. Legacy base URL for Twilio webhooks. Falls back to `TWILIO_WEBHOOK_BASE_URL` env var if not set (also deprecated). See `ingress.publicBaseUrl` for the preferred configuration. |
 | `calls.maxDurationSeconds` | int | `3600` | Maximum allowed duration per call. |
 | `calls.userConsultTimeoutSeconds` | int | `120` | How long to wait for a user answer before timing out a pending question. |
 | `calls.disclosure.enabled` | boolean | `true` | Whether the AI should disclose it is an AI at the start of the call. |

--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -124,7 +124,7 @@ Tell the user: "Consent screen is configured! Almost there — just need to crea
 
 > **Create OAuth Credentials**
 >
-> I'm about to create OAuth Desktop credentials for Vellum Assistant. This generates a client ID that Vellum uses to initiate the authorization flow. No secret keys are involved — we use the secure PKCE method.
+> I'm about to create OAuth Web Application credentials for Vellum Assistant. This generates a client ID that Vellum uses to initiate the authorization flow. The redirect URI will point to the gateway's OAuth callback endpoint.
 
 Wait for the user to approve. If they decline, explain that credentials are the final step needed and offer to try again or cancel.
 
@@ -133,8 +133,9 @@ Once approved, navigate to `https://console.cloud.google.com/apis/credentials?pr
 Use `browser_click` on "+ Create Credentials" at the top, then select "OAuth client ID" from the dropdown.
 
 Take a `browser_snapshot` and fill in:
-1. **Application type:** Select "Desktop app" from the dropdown
-2. **Name:** "Vellum Assistant Desktop"
+1. **Application type:** Select "Web application" from the dropdown
+2. **Name:** "Vellum Assistant"
+3. **Authorized redirect URIs:** Click "Add URI" and enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable.
 
 Use `browser_click` on the "Create" button.
 
@@ -179,7 +180,7 @@ Summarize what was accomplished:
 - Created a Google Cloud project (or used an existing one)
 - Enabled the Gmail API and Google Calendar API
 - Configured the OAuth consent screen with appropriate scopes (including calendar)
-- Created OAuth Desktop credentials using secure PKCE
+- Created OAuth Web Application credentials with gateway callback redirect URI
 - Connected your Gmail and Google Calendar accounts
 
 ## Error Handling

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -85,14 +85,16 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
+The redirect URL must point to the gateway's OAuth callback endpoint. Determine the URL by reading the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable. The callback path is `/webhooks/oauth/callback`.
+
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `http://127.0.0.1:0/callback` — Vellum will use a random port on localhost
+2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`)
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured."
+Tell the user: "Redirect URL configured. Make sure your tunnel is running and `ingress.publicBaseUrl` is set in Settings so the callback can reach the gateway."
 
 ## Step 5: Extract Client ID and Client Secret
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,6 +1,6 @@
 # Vellum Gateway
 
-Standalone service that owns Telegram integration end-to-end and optionally acts as an authenticated reverse proxy for the assistant runtime.
+Standalone service that serves as the public ingress boundary for all external webhooks and callbacks. It owns Telegram integration end-to-end, routes Twilio voice webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime.
 
 ## Architecture
 
@@ -34,6 +34,7 @@ bun run dev
 | `GATEWAY_DEFAULT_ASSISTANT_ID` | No | — | Default assistant ID for unmapped users |
 | `GATEWAY_UNMAPPED_POLICY` | No | `reject` | Policy for unmapped users: `reject` or `default` |
 | `GATEWAY_PORT` | No | `7830` | Port for the gateway HTTP server |
+| `INGRESS_PUBLIC_BASE_URL` | No | — | Public URL where the gateway is reachable (e.g. `https://abc123.ngrok-free.app`). Used by the assistant runtime to construct webhook and OAuth callback URLs. Set this to your tunnel's public URL. |
 | `GATEWAY_RUNTIME_PROXY_ENABLED` | No | `false` | Enable runtime proxy for non-Telegram requests |
 | `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
 | `RUNTIME_PROXY_BEARER_TOKEN` | Conditional | — | Bearer token for proxy auth (required when proxy + auth enabled) |
@@ -71,6 +72,31 @@ After deploying the gateway, register the webhook with Telegram using the `setWe
 - `allowed_updates` — `["message", "edited_message"]`
 
 See the [Telegram Bot API docs](https://core.telegram.org/bots/api#setwebhook) for the full API reference.
+
+## Public Ingress Routes
+
+The gateway serves as the single public ingress point for all external callbacks. The following routes are handled directly by the gateway before any proxy forwarding:
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/webhooks/telegram` | POST | Telegram bot webhook (validated via `TELEGRAM_WEBHOOK_SECRET`) |
+| `/webhooks/twilio/voice` | POST | Twilio voice webhook (validated via HMAC-SHA1 signature) |
+| `/webhooks/twilio/status` | POST | Twilio status callback (validated via HMAC-SHA1 signature) |
+| `/webhooks/twilio/connect-action` | POST | Twilio connect-action callback (validated via HMAC-SHA1 signature) |
+| `/webhooks/twilio/relay` | WS | Twilio ConversationRelay WebSocket (bidirectional proxy) |
+| `/webhooks/oauth/callback` | GET | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime |
+| `/healthz` | GET | Liveness probe |
+| `/readyz` | GET | Readiness probe |
+
+### Tunnel Setup
+
+To receive external callbacks during local development, point a tunnel service at the local gateway (default `http://127.0.0.1:7830`) and configure the resulting public URL:
+
+1. Start your tunnel (e.g. ngrok, Cloudflare Tunnel, or similar) targeting `http://127.0.0.1:7830`
+2. Copy the public URL provided by the tunnel service (e.g. `https://abc123.ngrok-free.app`)
+3. Set the URL as `ingress.publicBaseUrl` in the Settings UI (Public Ingress section) **or** as the `INGRESS_PUBLIC_BASE_URL` environment variable
+
+The assistant runtime uses this URL to construct all webhook and OAuth callback URLs automatically.
 
 ## Default Mode: Telegram-Only
 


### PR DESCRIPTION
## Summary
- **ARCHITECTURE.md**: Added "Ingress Boundary Architecture" section documenting gateway-only public ingress pattern, tunnel-agnostic setup steps, URL builder reference table, and the `ingress.publicBaseUrl` fallback chain. Updated OAuth flow diagram label from loopback to gateway callback transport. Updated Twilio webhook base URL resolution docs to reflect the three-level fallback chain. Added deprecation notes for `calls.webhookBaseUrl` and `TWILIO_WEBHOOK_BASE_URL`.
- **gateway/README.md**: Updated description to reflect public ingress role. Added `INGRESS_PUBLIC_BASE_URL` env var to configuration table. Added "Public Ingress Routes" section documenting all webhook/callback routes and "Tunnel Setup" guidance.
- **Slack OAuth skill (SKILL.md)**: Replaced loopback redirect URI (`http://127.0.0.1:0/callback`) with gateway callback URL (`${ingress.publicBaseUrl}/webhooks/oauth/callback`).
- **Google OAuth skill (SKILL.md)**: Changed credential type from "Desktop app" to "Web application" with gateway callback redirect URI. Updated confirmation messaging and celebration summary.

## Test plan
- [ ] Verify ARCHITECTURE.md renders correctly with new ingress boundary section and updated deprecation notes
- [ ] Verify gateway/README.md configuration table and public ingress routes section
- [ ] Verify Slack OAuth skill redirect URL guidance references gateway callback
- [ ] Verify Google OAuth skill credential type changed to Web application with redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
