### PR TITLE
M4: Fix subprocess tool access policy for real workflows

### DIFF
--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -3,7 +3,7 @@ import type { SwarmRole } from './types.js';
 /**
  * Profile names that scope tool access for worker tasks.
  */
-export type WorkerProfile = 'general' | 'researcher' | 'coder' | 'reviewer';
+export type WorkerProfile = 'general' | 'researcher' | 'coder' | 'reviewer' | 'worker';
 
 /**
  * Maps swarm roles to worker profiles.
@@ -70,6 +70,13 @@ export function getProfilePolicy(profile: WorkerProfile): ProfilePolicy {
       return {
         allow: new Set(READ_ONLY_TOOLS),
         deny: new Set([...WRITE_TOOLS, 'Bash']),
+        approvalRequired: new Set(),
+      };
+
+    case 'worker':
+      return {
+        allow: new Set([...READ_ONLY_TOOLS, 'Bash', ...WRITE_TOOLS, 'Task']),
+        deny: new Set(),
         approvalRequired: new Set(),
       };
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -15,7 +15,7 @@ const ALLOWED_TOOLS = new Set([
   'LS', 'Task', 'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
 ]);
 
-const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
+const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer', 'worker'];
 
 // Maximum nesting depth for Claude Code subprocesses.
 // Depth 0 = top-level assistant, depth 1 = first subprocess, etc.
@@ -90,7 +90,7 @@ export const claudeCodeTool: Tool = {
           },
           profile: {
             type: 'string',
-            enum: ['general', 'researcher', 'coder', 'reviewer'],
+            enum: ['general', 'researcher', 'coder', 'reviewer', 'worker'],
             description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
           },
         },


### PR DESCRIPTION
Part of #5900. Adds worker profile that auto-allows Bash, Write, Edit, Task tools for autonomous workflows (swarm, safe-blitz). Adds Task to ALLOWED_TOOLS for subagent spawning. Closes #5904.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
