### PR TITLE
M5: Wire all consumers of unified discovery + permissions

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -201,12 +201,28 @@ export const claudeCodeTool: Tool = {
       resolvedPrompt = prompt!;
     }
 
-    // If the project has .claude/commands/, hint the subprocess so it can discover them
+    // If the project has .claude/commands/ or .claude/skills/, hint the subprocess
     try {
       const { discoverCCCommands } = await import('../../commands/cc-command-registry.js');
       const registry = discoverCCCommands(workingDir);
       if (registry.entries.size > 0) {
-        resolvedPrompt += '\n\nNote: Custom project commands are available in .claude/commands/. Use Glob to list them and Read to view their instructions.';
+        let hasCommands = false;
+        let hasSkills = false;
+        for (const [, entry] of registry.entries) {
+          if (entry.artifactType === 'skill') hasSkills = true;
+          else hasCommands = true;
+          if (hasCommands && hasSkills) break;
+        }
+
+        let hint: string;
+        if (hasCommands && hasSkills) {
+          hint = 'Custom project commands are available in .claude/commands/ and skills in .claude/skills/.';
+        } else if (hasSkills) {
+          hint = 'Custom project skills are available in .claude/skills/.';
+        } else {
+          hint = 'Custom project commands are available in .claude/commands/.';
+        }
+        resolvedPrompt += `\n\nNote: ${hint} Use Glob to list them and Read to view their instructions.`;
       }
     } catch {
       // Non-fatal — skip hint if discovery fails

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -8,6 +8,7 @@ import { indexCatalogById, validateIncludes } from '../../skills/include-graph.j
 import { computeSkillVersionHash } from '../../skills/version-hash.js';
 import { getLogger } from '../../util/logger.js';
 import { discoverCCCommands } from '../../commands/cc-command-registry.js';
+import type { CCCommandEntry } from '../../commands/cc-command-registry.js';
 
 const log = getLogger('skill-load');
 
@@ -118,18 +119,37 @@ export class SkillLoadTool implements Tool {
       }
     }
 
-    // When loading the claude-code skill, append available CC commands
+    // When loading the claude-code skill, append available CC commands and skills
     let ccCommandsSection = '';
     if (skill.id === 'claude-code' && context.workingDir) {
       const ccRegistry = discoverCCCommands(context.workingDir);
       if (ccRegistry.entries.size > 0) {
-        const lines = ['Available Claude Code Commands (from .claude/commands/):'];
+        const commands: CCCommandEntry[] = [];
+        const skills: CCCommandEntry[] = [];
         for (const [, entry] of ccRegistry.entries) {
-          lines.push(`- /${entry.name}: ${entry.summary}`);
+          if (entry.artifactType === 'skill') {
+            skills.push(entry);
+          } else {
+            commands.push(entry);
+          }
         }
-        lines.push('');
-        lines.push('Users can invoke these with /command-name. You can execute them using the claude_code tool with the `command` parameter.');
-        ccCommandsSection = '\n\n' + lines.join('\n');
+
+        const sections: string[] = [];
+        if (commands.length > 0) {
+          sections.push('Available Claude Code Commands (from .claude/commands/):');
+          for (const entry of commands) {
+            sections.push(`- /${entry.name}: ${entry.summary}`);
+          }
+        }
+        if (skills.length > 0) {
+          sections.push('Available Claude Code Skills (from .claude/skills/):');
+          for (const entry of skills) {
+            sections.push(`- /${entry.name}: ${entry.summary}`);
+          }
+        }
+        sections.push('');
+        sections.push('Users can invoke these with /command-name. You can execute them using the claude_code tool with the `command` parameter.');
+        ccCommandsSection = '\n\n' + sections.join('\n');
       }
     }
 


### PR DESCRIPTION
Part of #5900. Updates skill_load CC section and claude_code subprocess hint to use unified artifact types. Verifies context threading for requestConfirmation and isInteractive. Closes #5906.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
