### PR TITLE
fix: align OAuth transport detection with public URL fallback chain

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -51,7 +51,13 @@ let mockOAuthCallbackUrl = '';
 
 mock.module('../inbound/public-ingress-urls.js', () => ({
   getOAuthCallbackUrl: () => mockOAuthCallbackUrl,
-  getPublicBaseUrl: () => 'https://gw.example.com',
+  getPublicBaseUrl: (config?: { ingress?: { publicBaseUrl?: string } }) => {
+    const url = config?.ingress?.publicBaseUrl ?? mockPublicBaseUrl;
+    if (!url) {
+      throw new Error('No public base URL configured.');
+    }
+    return url;
+  },
 }));
 
 // Mock fetch for token exchange

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -144,19 +144,18 @@ async function exchangeCodeForTokens(
 
 /**
  * Determine which callback transport to use when not explicitly specified.
- * Uses gateway if ingress.publicBaseUrl is configured, otherwise loopback.
+ * Uses gateway if any public base URL source is configured (ingress.publicBaseUrl,
+ * calls.webhookBaseUrl, or TWILIO_WEBHOOK_BASE_URL), otherwise loopback.
  */
 function detectTransport(): 'loopback' | 'gateway' {
   try {
-    // Dynamic import avoided — loadConfig is synchronous and already used elsewhere.
     const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
+    const { getPublicBaseUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
     const appConfig = loadConfig();
-    if (appConfig.ingress?.publicBaseUrl) {
-      return 'gateway';
-    }
+    getPublicBaseUrl(appConfig); // throws if no public URL configured
+    return 'gateway';
   } catch {
-    // Config loading failed — fall back to loopback
-    log.debug('Config not available for transport auto-detection, defaulting to loopback');
+    log.debug('No public base URL configured for transport auto-detection, defaulting to loopback');
   }
   return 'loopback';
 }


### PR DESCRIPTION
## Summary
- Updates `detectTransport()` in `assistant/src/security/oauth2.ts` to use `getPublicBaseUrl()` instead of directly checking `appConfig.ingress?.publicBaseUrl`, so that the fallback chain (`calls.webhookBaseUrl`, `TWILIO_WEBHOOK_BASE_URL`) is respected during auto-detection.
- Updates the `getPublicBaseUrl` mock in `assistant/src/__tests__/oauth2-gateway-transport.test.ts` to throw when no public URL is configured, matching the real function's behavior.
- Addresses review feedback on PR #5895.

## Test plan
- [x] Ran `bun test src/__tests__/oauth2-gateway-transport.test.ts` — all 5 gateway transport tests pass (2 pre-existing loopback ECONNRESET failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
