### PR TITLE
fix: add INGRESS_PUBLIC_BASE_URL env var support to assistant runtime URL resolution

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -31,18 +31,26 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('getPublicBaseUrl', () => {
-  let savedEnv: string | undefined;
+  let savedTwilioEnv: string | undefined;
+  let savedIngressEnv: string | undefined;
 
   beforeEach(() => {
-    savedEnv = process.env.TWILIO_WEBHOOK_BASE_URL;
+    savedTwilioEnv = process.env.TWILIO_WEBHOOK_BASE_URL;
+    savedIngressEnv = process.env.INGRESS_PUBLIC_BASE_URL;
     delete process.env.TWILIO_WEBHOOK_BASE_URL;
+    delete process.env.INGRESS_PUBLIC_BASE_URL;
   });
 
   afterEach(() => {
-    if (savedEnv !== undefined) {
-      process.env.TWILIO_WEBHOOK_BASE_URL = savedEnv;
+    if (savedTwilioEnv !== undefined) {
+      process.env.TWILIO_WEBHOOK_BASE_URL = savedTwilioEnv;
     } else {
       delete process.env.TWILIO_WEBHOOK_BASE_URL;
+    }
+    if (savedIngressEnv !== undefined) {
+      process.env.INGRESS_PUBLIC_BASE_URL = savedIngressEnv;
+    } else {
+      delete process.env.INGRESS_PUBLIC_BASE_URL;
     }
   });
 
@@ -69,7 +77,29 @@ describe('getPublicBaseUrl', () => {
     expect(result).toBe('https://calls.example.com');
   });
 
-  test('falls back to TWILIO_WEBHOOK_BASE_URL env var when both config fields are empty', () => {
+  test('falls back to INGRESS_PUBLIC_BASE_URL env var when both config fields are empty', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://ingress-env.example.com/';
+    const result = getPublicBaseUrl({
+      ingress: { publicBaseUrl: '' },
+      calls: { webhookBaseUrl: '' },
+    });
+    expect(result).toBe('https://ingress-env.example.com');
+  });
+
+  test('falls back to INGRESS_PUBLIC_BASE_URL env var when config fields are undefined', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://ingress-env.example.com';
+    const result = getPublicBaseUrl({});
+    expect(result).toBe('https://ingress-env.example.com');
+  });
+
+  test('prefers INGRESS_PUBLIC_BASE_URL over TWILIO_WEBHOOK_BASE_URL', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://ingress-env.example.com';
+    process.env.TWILIO_WEBHOOK_BASE_URL = 'https://twilio-env.example.com';
+    const result = getPublicBaseUrl({});
+    expect(result).toBe('https://ingress-env.example.com');
+  });
+
+  test('falls back to TWILIO_WEBHOOK_BASE_URL env var when both config fields and INGRESS_PUBLIC_BASE_URL are empty', () => {
     process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com/';
     const result = getPublicBaseUrl({
       ingress: { publicBaseUrl: '' },
@@ -78,7 +108,7 @@ describe('getPublicBaseUrl', () => {
     expect(result).toBe('https://env.example.com');
   });
 
-  test('falls back to env var when config fields are undefined', () => {
+  test('falls back to TWILIO_WEBHOOK_BASE_URL env var when config fields are undefined', () => {
     process.env.TWILIO_WEBHOOK_BASE_URL = 'https://env.example.com';
     const result = getPublicBaseUrl({});
     expect(result).toBe('https://env.example.com');
@@ -115,6 +145,18 @@ describe('getPublicBaseUrl', () => {
       calls: { webhookBaseUrl: 'https://calls.example.com' },
     });
     expect(result).toBe('https://calls.example.com');
+  });
+
+  test('normalizes trailing slashes from INGRESS_PUBLIC_BASE_URL', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://ingress-env.example.com///';
+    const result = getPublicBaseUrl({});
+    expect(result).toBe('https://ingress-env.example.com');
+  });
+
+  test('trims whitespace from INGRESS_PUBLIC_BASE_URL', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = '  https://ingress-env.example.com  ';
+    const result = getPublicBaseUrl({});
+    expect(result).toBe('https://ingress-env.example.com');
   });
 });
 

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -2,7 +2,7 @@
  * Centralized URL builders for all public-facing ingress endpoints.
  *
  * Resolves the canonical public base URL via a fallback chain:
- *   ingress.publicBaseUrl → calls.webhookBaseUrl → env TWILIO_WEBHOOK_BASE_URL
+ *   ingress.publicBaseUrl → calls.webhookBaseUrl → env INGRESS_PUBLIC_BASE_URL → env TWILIO_WEBHOOK_BASE_URL
  *
  * Supersedes the per-domain URL helpers in calls/twilio-webhook-urls.ts.
  */
@@ -24,10 +24,11 @@ function normalizeUrl(url: string): string {
 }
 
 /**
- * Resolve the canonical public base URL with a three-level fallback chain:
- *   1. ingress.publicBaseUrl (preferred)
- *   2. calls.webhookBaseUrl (backward compat)
- *   3. TWILIO_WEBHOOK_BASE_URL env var (legacy, deprecated)
+ * Resolve the canonical public base URL with a four-level fallback chain:
+ *   1. ingress.publicBaseUrl (preferred, workspace config)
+ *   2. calls.webhookBaseUrl (workspace config, deprecated)
+ *   3. INGRESS_PUBLIC_BASE_URL env var (gateway-compatible)
+ *   4. TWILIO_WEBHOOK_BASE_URL env var (legacy, deprecated)
  *
  * Throws if no source provides a non-empty value.
  */
@@ -49,17 +50,23 @@ export function getPublicBaseUrl(config: IngressConfig): string {
     }
   }
 
+  const ingressEnvValue = process.env.INGRESS_PUBLIC_BASE_URL;
+  if (ingressEnvValue) {
+    const normalized = normalizeUrl(ingressEnvValue);
+    if (normalized) return normalized;
+  }
+
   const envValue = process.env.TWILIO_WEBHOOK_BASE_URL;
   if (envValue) {
     log.warn(
-      'TWILIO_WEBHOOK_BASE_URL env var is deprecated — set ingress.publicBaseUrl in config instead.',
+      'TWILIO_WEBHOOK_BASE_URL env var is deprecated — set ingress.publicBaseUrl in config or INGRESS_PUBLIC_BASE_URL env var instead.',
     );
     const normalized = normalizeUrl(envValue);
     if (normalized) return normalized;
   }
 
   throw new Error(
-    'No public base URL configured. Set ingress.publicBaseUrl in config, calls.webhookBaseUrl, or TWILIO_WEBHOOK_BASE_URL env var.',
+    'No public base URL configured. Set ingress.publicBaseUrl in config, INGRESS_PUBLIC_BASE_URL env var, or TWILIO_WEBHOOK_BASE_URL env var.',
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds `INGRESS_PUBLIC_BASE_URL` env var as a fallback in the assistant runtime's `getPublicBaseUrl()` function, checked after workspace config fields but before the deprecated `TWILIO_WEBHOOK_BASE_URL`
- Updates JSDoc comments to reflect the four-level fallback chain: `ingress.publicBaseUrl` -> `calls.webhookBaseUrl` -> `INGRESS_PUBLIC_BASE_URL` -> `TWILIO_WEBHOOK_BASE_URL`
- Adds tests for the new env var fallback step, including normalization and priority over `TWILIO_WEBHOOK_BASE_URL`

## Context
Addresses review feedback on PR #5911 where docs referenced `INGRESS_PUBLIC_BASE_URL` as supported by the assistant runtime, but it was only read by the gateway. This aligns the assistant runtime behavior with the documentation.

## Test plan
- [x] `bun test src/__tests__/public-ingress-urls.test.ts` — all 25 tests pass
- [x] Verified `INGRESS_PUBLIC_BASE_URL` is preferred over `TWILIO_WEBHOOK_BASE_URL`
- [x] Verified config fields still take priority over env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
