### PR TITLE
fix: use peer address for relay WebSocket enforcement in gateway-only mode

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -168,6 +168,18 @@ function isLoopbackHost(hostname: string): boolean {
 }
 
 /**
+ * Check if the actual peer/remote address of a connection is loopback.
+ * Uses Bun's server.requestIP() to get the real peer address,
+ * which cannot be spoofed unlike the Origin header.
+ */
+function isLoopbackPeer(server: { requestIP(req: Request): { address: string; family: string; port: number } | null }, req: Request): boolean {
+  const ip = server.requestIP(req);
+  if (!ip) return false;
+  const addr = ip.address;
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
+/**
  * Validate a Twilio webhook request's X-Twilio-Signature header.
  *
  * Returns the raw body text on success so callers can reconstruct the Request
@@ -370,9 +382,11 @@ export class RuntimeHttpServer {
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
     if (path.startsWith('/v1/calls/relay') && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
-      // In gateway_only mode, only allow relay connections from localhost
+      // In gateway_only mode, only allow relay connections from loopback peers.
+      // Primary check: actual peer address (cannot be spoofed).
+      // Secondary check: Origin header (defense in depth).
       const config = loadConfig();
-      if (config.ingress.mode === 'gateway_only' && !isLoopbackOrigin(req)) {
+      if (config.ingress.mode === 'gateway_only' && (!isLoopbackPeer(server, req) || !isLoopbackOrigin(req))) {
         return Response.json(
           { error: 'Direct relay access disabled in gateway-only mode', code: 'GATEWAY_ONLY' },
           { status: 403 },


### PR DESCRIPTION
## Summary
- Adds `isLoopbackPeer()` helper that uses `server.requestIP(req)` to check the actual peer/remote address of WebSocket connections, which cannot be spoofed unlike the `Origin` header
- Updates the relay WebSocket guard in gateway-only mode to require both a loopback peer address (primary check) and a loopback origin (secondary defense-in-depth check)
- Fixes a bypass where non-browser clients could omit or spoof the `Origin` header to access `/v1/calls/relay` when the runtime is reachable off-loopback

## Test plan
- [x] Verified `bun test src/__tests__/gateway-only-enforcement.test.ts` passes (14/14 relevant tests pass; 3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
