### PR TITLE
Fix: command-not-found error distinguishes commands from skills

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -163,12 +163,28 @@ export const claudeCodeTool: Tool = {
       const entry = getCCCommand(workingDir, command);
       if (!entry) {
         const registry = discoverCCCommands(workingDir);
-        const available = Array.from(registry.entries.values()).map(e => e.name).sort();
-        const availableList = available.length > 0
-          ? `\nAvailable commands: ${available.join(', ')}`
-          : '\nNo commands found in .claude/commands/';
+        const commands = Array.from(registry.entries.values())
+          .filter(e => e.artifactType === 'command')
+          .map(e => e.name)
+          .sort();
+        const skills = Array.from(registry.entries.values())
+          .filter(e => e.artifactType === 'skill')
+          .map(e => e.name)
+          .sort();
+
+        const parts: string[] = [];
+        if (commands.length > 0) {
+          parts.push(`Available commands: ${commands.join(', ')}`);
+        }
+        if (skills.length > 0) {
+          parts.push(`Available skills: ${skills.join(', ')}`);
+        }
+        const availableList = parts.length > 0
+          ? '\n' + parts.join('\n')
+          : '\nNo commands or skills found in .claude/';
+
         return {
-          content: `Error: Command "${command}" not found in .claude/commands/.${availableList}`,
+          content: `Error: "${command}" not found in .claude/commands/ or .claude/skills/.${availableList}`,
           isError: true,
         };
       }


### PR DESCRIPTION
Addresses Devin review feedback on #5910. Updates the claude_code tool error message to list available commands and skills separately. Part of #5900.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
