### PR TITLE
fix: polish subagent detail panel — abort button, event cards, status badge

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -273,6 +273,8 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
+                        subagentInfo: viewModel.activeSubagents.first(where: { $0.id == subagentId }),
+                        onAbort: { try? daemonClient.sendSubagentAbort(subagentId: subagentId) },
                         onClose: { windowState.selectedSubagentId = nil }
                     )
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -5,26 +5,48 @@ struct SubagentDetailPanel: View {
     let subagentId: String
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var detailStore: SubagentDetailStore
+    let subagentInfo: SubagentInfo?
+    var onAbort: (() -> Void)?
     var onClose: () -> Void
 
-    private var subagentInfo: SubagentInfo? { viewModel.activeSubagents.first(where: { $0.id == subagentId }) }
     private var objective: String? { detailStore.objectives[subagentId] }
     private var usage: SubagentUsageStats? { detailStore.usageStats[subagentId] }
     private var events: [SubagentEventItem] { detailStore.eventsBySubagent[subagentId] ?? [] }
+    private var isRunning: Bool { subagentInfo?.status == .running || subagentInfo?.status == .pending }
 
     var body: some View {
-        VSidePanel(title: subagentInfo?.label ?? "Subagent", onClose: onClose, pinnedContent: {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                // Status badge
-                if let info = subagentInfo {
-                    statusBadge(info)
+        VSidePanel(title: subagentInfo?.label ?? "Subagent", titleFont: VFont.sectionTitle, onClose: onClose, pinnedContent: {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Status + abort row
+                HStack {
+                    statusBadge
+                    Spacer()
+                    if isRunning {
+                        Button(action: { onAbort?() }) {
+                            HStack(spacing: VSpacing.xxs) {
+                                Image(systemName: "stop.fill")
+                                    .font(.system(size: 8))
+                                Text("Abort")
+                                    .font(VFont.captionMedium)
+                            }
+                            .foregroundColor(Rose._400)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xxs)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.pill)
+                                    .fill(Rose._500.opacity(0.12))
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Abort subagent")
+                    }
                 }
 
                 // Objective
                 if let objective, !objective.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Text("Objective")
-                            .font(VFont.captionMedium)
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("OBJECTIVE")
+                            .font(VFont.small)
                             .foregroundColor(VColor.textMuted)
                         Text(objective)
                             .font(VFont.caption)
@@ -33,26 +55,35 @@ struct SubagentDetailPanel: View {
                     }
                 }
 
-                // Usage metrics
+                // Usage metrics row
                 if let usage {
                     usageMetrics(usage)
                 }
 
-                // Error
+                // Error banner
                 if let error = subagentInfo?.error, !error.isEmpty {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(Rose._400)
-                        .padding(VSpacing.xs)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .fill(Rose._500.opacity(0.1))
-                        )
+                    HStack(alignment: .top, spacing: VSpacing.xs) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(Rose._500)
+                        Text(error)
+                            .font(VFont.caption)
+                            .foregroundColor(Rose._400)
+                    }
+                    .padding(VSpacing.sm)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(Rose._500.opacity(0.08))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .strokeBorder(Rose._500.opacity(0.2), lineWidth: 1)
+                            )
+                    )
                 }
             }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
 
             Divider().background(VColor.surfaceBorder)
         }) {
@@ -63,12 +94,11 @@ struct SubagentDetailPanel: View {
                     icon: "waveform.path"
                 )
             } else {
-                LazyVStack(alignment: .leading, spacing: VSpacing.xs) {
+                LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
                     ForEach(events) { event in
                         eventRow(event)
                     }
                 }
-                .padding(.horizontal, VSpacing.sm)
             }
         }
     }
@@ -76,14 +106,22 @@ struct SubagentDetailPanel: View {
     // MARK: - Status Badge
 
     @ViewBuilder
-    private func statusBadge(_ info: SubagentInfo) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            Circle()
-                .fill(statusColor(info.status))
-                .frame(width: 8, height: 8)
-            Text(info.status.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.textSecondary)
+    private var statusBadge: some View {
+        if let info = subagentInfo {
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(statusColor(info.status))
+                    .frame(width: 8, height: 8)
+                Text(info.status.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(statusColor(info.status))
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xxs)
+            .background(
+                Capsule()
+                    .fill(statusColor(info.status).opacity(0.12))
+            )
         }
     }
 
@@ -100,11 +138,14 @@ struct SubagentDetailPanel: View {
 
     @ViewBuilder
     private func usageMetrics(_ usage: SubagentUsageStats) -> some View {
-        HStack(spacing: VSpacing.lg) {
+        HStack(spacing: 0) {
             metricItem(icon: "arrow.down.circle", label: "Input", value: "\(formatNumber(usage.inputTokens)) tokens")
+            Spacer()
             metricItem(icon: "arrow.up.circle", label: "Output", value: "\(formatNumber(usage.outputTokens)) tokens")
+            Spacer()
             metricItem(icon: "dollarsign.circle", label: "Cost", value: formatCost(usage.estimatedCost))
         }
+        .padding(.vertical, VSpacing.xs)
     }
 
     @ViewBuilder
@@ -128,76 +169,107 @@ struct SubagentDetailPanel: View {
 
     @ViewBuilder
     private func eventRow(_ event: SubagentEventItem) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            // Label above the card
+            eventLabel(for: event.kind)
+
+            // Content card
+            eventContent(event)
+        }
+    }
+
+    @ViewBuilder
+    private func eventLabel(for kind: SubagentEventItem.Kind) -> some View {
+        switch kind {
+        case .text:
+            label(icon: "text.bubble.fill", text: "RESPONSE", color: Indigo._400)
+        case .toolUse:
+            label(icon: "wrench.fill", text: "TOOL CALL", color: Violet._400)
+        case .toolResult(let isError):
+            label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Rose._400 : Emerald._400)
+        case .error:
+            label(icon: "exclamationmark.triangle.fill", text: "ERROR", color: Rose._500)
+        }
+    }
+
+    @ViewBuilder
+    private func label(icon: String, text: String, color: Color) -> some View {
+        HStack(spacing: VSpacing.xxs) {
+            Image(systemName: icon)
+                .font(.system(size: 8))
+            Text(text)
+                .font(VFont.small)
+        }
+        .foregroundColor(color)
+    }
+
+    @ViewBuilder
+    private func eventContent(_ event: SubagentEventItem) -> some View {
         switch event.kind {
         case .text:
             Text(event.content)
-                .font(VFont.mono)
+                .font(VFont.monoSmall)
                 .foregroundColor(VColor.textPrimary)
                 .textSelection(.enabled)
-                .padding(VSpacing.xs)
+                .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(VColor.backgroundSubtle.opacity(0.3))
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.surface.opacity(0.4))
                 )
 
         case .toolUse(let name):
             HStack(spacing: VSpacing.xs) {
-                Image(systemName: "wrench.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(Violet._400)
                 Text(name)
                     .font(VFont.captionMedium)
-                    .foregroundColor(Violet._400)
+                    .foregroundColor(Violet._300)
                 if !event.content.isEmpty {
                     Text(event.content)
-                        .font(VFont.caption)
+                        .font(VFont.monoSmall)
                         .foregroundColor(VColor.textMuted)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
             }
-            .padding(VSpacing.xs)
+            .padding(VSpacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(Violet._500.opacity(0.08))
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(Violet._500.opacity(0.06))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .strokeBorder(Violet._500.opacity(0.12), lineWidth: 1)
+                    )
             )
 
-        case .toolResult(let isError):
-            HStack(alignment: .top, spacing: VSpacing.xs) {
-                Image(systemName: isError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(isError ? Rose._400 : Emerald._400)
-                Text(event.content)
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.textSecondary)
-                    .lineLimit(6)
-                    .textSelection(.enabled)
-            }
-            .padding(VSpacing.xs)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(VColor.backgroundSubtle.opacity(0.2))
-            )
+        case .toolResult:
+            Text(event.content)
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.textSecondary)
+                .lineLimit(6)
+                .textSelection(.enabled)
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.surface.opacity(0.3))
+                )
 
         case .error:
-            HStack(alignment: .top, spacing: VSpacing.xs) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 10))
-                    .foregroundColor(Rose._500)
-                Text(event.content)
-                    .font(VFont.caption)
-                    .foregroundColor(Rose._400)
-                    .textSelection(.enabled)
-            }
-            .padding(VSpacing.xs)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(Rose._500.opacity(0.1))
-            )
+            Text(event.content)
+                .font(VFont.caption)
+                .foregroundColor(Rose._400)
+                .textSelection(.enabled)
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(Rose._500.opacity(0.08))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .strokeBorder(Rose._500.opacity(0.15), lineWidth: 1)
+                        )
+                )
         }
     }
 


### PR DESCRIPTION
## Summary
- Add abort button for running/pending subagents in the detail panel
- Redesign status badge as a colored capsule with tinted background
- Improve error banner with icon and subtle border
- Refactor event rows into labeled cards (Response, Tool Call, Tool Result, Error) with distinct colors and styles
- Adjust spacing, fonts, and layout for better visual hierarchy

## Test plan
- [ ] Open a subagent detail panel while a subagent is running — verify abort button appears
- [ ] Tap abort — verify subagent stops
- [ ] Check completed/failed subagent panels — verify no abort button shown
- [ ] Verify event cards display correctly for text, tool use, tool result, and error events
- [ ] Confirm error banner renders with icon and border styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
