### PR TITLE
fix: accept private network peers for relay WebSocket in gateway-only mode

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -4,8 +4,8 @@
  * Verifies:
  * - Direct Twilio webhook routes return 410 in gateway_only mode
  * - Internal forwarding routes (gateway→runtime) still work in gateway_only mode
- * - Relay WebSocket upgrade blocked for non-localhost origins in gateway_only mode
- * - Relay WebSocket upgrade allowed from localhost in gateway_only mode
+ * - Relay WebSocket upgrade blocked for non-private-network origins in gateway_only mode
+ * - Relay WebSocket upgrade allowed from private network peers in gateway_only mode
  * - All routes work normally in compat mode
  * - Startup warning when RUNTIME_HTTP_HOST is not loopback in gateway_only mode
  */
@@ -133,7 +133,7 @@ mock.module('../security/oauth-callback-registry.js', () => ({
   consumeCallbackError: () => true,
 }));
 
-import { RuntimeHttpServer } from '../runtime/http-server.js';
+import { RuntimeHttpServer, isPrivateAddress } from '../runtime/http-server.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -294,7 +294,9 @@ describe('gateway-only ingress enforcement', () => {
     beforeEach(() => { mockIngressMode = 'gateway_only'; });
     afterEach(() => { mockIngressMode = 'compat'; });
 
-    test('blocks non-localhost origin', async () => {
+    test('blocks non-private-network origin', async () => {
+      // The peer address (127.0.0.1) passes the private network check,
+      // but the external Origin header triggers the secondary defense-in-depth block.
       const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
         headers: {
           'Upgrade': 'websocket',
@@ -310,8 +312,9 @@ describe('gateway-only ingress enforcement', () => {
       expect(body.error).toContain('gateway-only mode');
     });
 
-    test('allows request with no origin header (localhost)', async () => {
-      // Without an origin header, isLoopbackOrigin returns true
+    test('allows request with no origin header (private network peer)', async () => {
+      // Without an origin header, isLoopbackOrigin returns true.
+      // The peer address (127.0.0.1) passes the private network peer check.
       const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
         headers: {
           'Upgrade': 'websocket',
@@ -325,7 +328,7 @@ describe('gateway-only ingress enforcement', () => {
       expect(res.status).not.toBe(403);
     });
 
-    test('allows localhost origin', async () => {
+    test('allows localhost origin from loopback peer', async () => {
       const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
         headers: {
           'Upgrade': 'websocket',
@@ -397,6 +400,83 @@ describe('gateway-only ingress enforcement', () => {
       });
       // In compat mode, the gateway-only guard should not activate
       expect(res.status).not.toBe(403);
+    });
+  });
+
+  // ── isPrivateAddress unit tests ─────────────────────────────────────
+
+  describe('isPrivateAddress', () => {
+    // Loopback
+    test.each([
+      '127.0.0.1',
+      '127.0.0.2',
+      '127.255.255.255',
+      '::1',
+      '::ffff:127.0.0.1',
+    ])('accepts loopback address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // RFC 1918 private ranges
+    test.each([
+      '10.0.0.1',
+      '10.255.255.255',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '192.168.1.100',
+    ])('accepts RFC 1918 private address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // Link-local
+    test.each([
+      '169.254.0.1',
+      '169.254.255.255',
+    ])('accepts link-local address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // IPv6 unique local (fc00::/7)
+    test.each([
+      'fc00::1',
+      'fd12:3456:789a::1',
+      'fdff::1',
+    ])('accepts IPv6 unique local address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // IPv6 link-local (fe80::/10)
+    test.each([
+      'fe80::1',
+      'fe80::abcd:1234',
+    ])('accepts IPv6 link-local address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // IPv4-mapped IPv6 private addresses
+    test.each([
+      '::ffff:10.0.0.1',
+      '::ffff:172.16.0.1',
+      '::ffff:192.168.1.1',
+      '::ffff:169.254.0.1',
+    ])('accepts IPv4-mapped IPv6 private address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+
+    // Public addresses — should be rejected
+    test.each([
+      '8.8.8.8',
+      '1.1.1.1',
+      '203.0.113.1',
+      '172.32.0.1',
+      '172.15.255.255',
+      '11.0.0.1',
+      '192.169.0.1',
+      '::ffff:8.8.8.8',
+      '2001:db8::1',
+    ])('rejects public address %s', (addr) => {
+      expect(isPrivateAddress(addr)).toBe(false);
     });
   });
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -168,15 +168,66 @@ function isLoopbackHost(hostname: string): boolean {
 }
 
 /**
- * Check if the actual peer/remote address of a connection is loopback.
- * Uses Bun's server.requestIP() to get the real peer address,
- * which cannot be spoofed unlike the Origin header.
+ * Check if the actual peer/remote address of a connection is from a
+ * private/internal network. Uses Bun's server.requestIP() to get the
+ * real peer address, which cannot be spoofed unlike the Origin header.
+ *
+ * Accepts loopback, RFC 1918 private IPv4, link-local, and RFC 4193
+ * unique-local IPv6 — including their IPv4-mapped IPv6 forms. This
+ * supports container/pod deployments (e.g. Kubernetes sidecars) where
+ * gateway and runtime communicate over pod-internal private IPs.
  */
-function isLoopbackPeer(server: { requestIP(req: Request): { address: string; family: string; port: number } | null }, req: Request): boolean {
+function isPrivateNetworkPeer(server: { requestIP(req: Request): { address: string; family: string; port: number } | null }, req: Request): boolean {
   const ip = server.requestIP(req);
   if (!ip) return false;
-  const addr = ip.address;
-  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+  return isPrivateAddress(ip.address);
+}
+
+/**
+ * @internal Exported for testing.
+ *
+ * Determine whether an IP address string belongs to a private/internal
+ * network range:
+ *   - Loopback: 127.0.0.0/8, ::1
+ *   - RFC 1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+ *   - Link-local: 169.254.0.0/16
+ *   - IPv6 unique local: fc00::/7 (fc00::–fdff::)
+ *   - IPv4-mapped IPv6 variants of all of the above (::ffff:x.x.x.x)
+ */
+export function isPrivateAddress(addr: string): boolean {
+  // Handle IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1) — extract the IPv4 part
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : addr;
+
+  // IPv4 checks
+  if (normalized.includes('.')) {
+    const parts = normalized.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(p => isNaN(p) || p < 0 || p > 255)) return false;
+
+    // Loopback: 127.0.0.0/8
+    if (parts[0] === 127) return true;
+    // 10.0.0.0/8
+    if (parts[0] === 10) return true;
+    // 172.16.0.0/12 (172.16.x.x – 172.31.x.x)
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+    // 192.168.0.0/16
+    if (parts[0] === 192 && parts[1] === 168) return true;
+    // Link-local: 169.254.0.0/16
+    if (parts[0] === 169 && parts[1] === 254) return true;
+
+    return false;
+  }
+
+  // IPv6 checks
+  const lower = normalized.toLowerCase();
+  // Loopback
+  if (lower === '::1') return true;
+  // Unique local: fc00::/7 (fc00:: through fdff::)
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+  // Link-local: fe80::/10
+  if (lower.startsWith('fe80')) return true;
+
+  return false;
 }
 
 /**
@@ -382,11 +433,12 @@ export class RuntimeHttpServer {
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
     if (path.startsWith('/v1/calls/relay') && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
-      // In gateway_only mode, only allow relay connections from loopback peers.
-      // Primary check: actual peer address (cannot be spoofed).
+      // In gateway_only mode, only allow relay connections from private network peers.
+      // Primary check: actual peer address (cannot be spoofed) — accepts loopback
+      // and RFC 1918/4193 private addresses to support container deployments.
       // Secondary check: Origin header (defense in depth).
       const config = loadConfig();
-      if (config.ingress.mode === 'gateway_only' && (!isLoopbackPeer(server, req) || !isLoopbackOrigin(req))) {
+      if (config.ingress.mode === 'gateway_only' && (!isPrivateNetworkPeer(server, req) || !isLoopbackOrigin(req))) {
         return Response.json(
           { error: 'Direct relay access disabled in gateway-only mode', code: 'GATEWAY_ONLY' },
           { status: 403 },


### PR DESCRIPTION
Addresses feedback from PR #5918.\n\nExpands the relay WebSocket peer check from loopback-only to also accept private/internal network addresses (RFC 1918, RFC 4193, link-local). This supports container/pod deployments where gateway and runtime communicate over private network IPs while still blocking public internet access.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
