### PR TITLE
fix: guard ingress URL sync against edit clobber and fix config reload suppression

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -90,11 +90,12 @@ export function handleModelSet(
     // Suppress the file watcher callback — handleModelSet already does
     // the full reload sequence; a redundant watcher-triggered reload
     // would incorrectly evict sessions created after this method returns.
+    const wasSuppressed = ctx.suppressConfigReload;
     ctx.setSuppressConfigReload(true);
     try {
       saveRawConfig(raw);
     } catch (err) {
-      ctx.setSuppressConfigReload(false);
+      ctx.setSuppressConfigReload(wasSuppressed);
       throw err;
     }
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
@@ -139,11 +140,12 @@ export function handleImageGenModelSet(
     const raw = loadRawConfig();
     raw.imageGenModel = msg.model;
 
+    const wasSuppressed = ctx.suppressConfigReload;
     ctx.setSuppressConfigReload(true);
     try {
       saveRawConfig(raw);
     } catch (err) {
-      ctx.setSuppressConfigReload(false);
+      ctx.setSuppressConfigReload(wasSuppressed);
       throw err;
     }
     const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,6 +25,7 @@ struct SettingsPanel: View {
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
     @State private var ingressUrlText: String = ""
+    @FocusState private var isIngressUrlFocused: Bool
     @State private var gatewayReachable: Bool? = nil
     @State private var checkingGateway: Bool = false
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
@@ -89,6 +90,7 @@ struct SettingsPanel: View {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
             store.refreshIngressConfig()
+            ingressUrlText = store.ingressPublicBaseUrl
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
         }
@@ -102,7 +104,11 @@ struct SettingsPanel: View {
             }
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            ingressUrlText = newValue
+            // Only sync from store when the field is not focused, so
+            // background IPC responses don't overwrite in-progress edits.
+            if !isIngressUrlFocused {
+                ingressUrlText = newValue
+            }
         }
         .onChange(of: showModelDropdown) { _, isOpen in
             if let monitor = mouseDownMonitor {
@@ -532,6 +538,7 @@ struct SettingsPanel: View {
                 }
 
                 TextField("https://abc123.ngrok-free.app", text: $ingressUrlText)
+                    .focused($isIngressUrlFocused)
                     .textFieldStyle(.plain)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -391,8 +391,10 @@ public final class SettingsStore: ObservableObject {
 
     func saveIngressPublicBaseUrl(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Don't update local state optimistically — wait for the daemon's
+        // success response (handled by onIngressConfigResponse) so the UI
+        // reverts automatically if the save fails.
         try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed))
-        ingressPublicBaseUrl = trimmed
     }
 
     // MARK: - Twilio Webhook Actions (legacy)
@@ -403,8 +405,10 @@ public final class SettingsStore: ObservableObject {
 
     func saveTwilioWebhookBaseUrl(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Don't update local state optimistically — wait for the daemon's
+        // success response (handled by onTwilioWebhookConfigResponse) so the
+        // UI reverts automatically if the save fails.
         try? daemonClient?.send(TwilioWebhookConfigRequestMessage(action: "set", webhookBaseUrl: trimmed))
-        twilioWebhookBaseUrl = trimmed
     }
 
     // MARK: - Model Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ public struct SettingsView: View {
     @State private var twitterClientId = ""
     @State private var twitterClientSecret = ""
     @State private var ingressUrlText = ""
+    @FocusState private var isIngressUrlFocused: Bool
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
@@ -326,6 +327,7 @@ public struct SettingsView: View {
 
             Section("Public Ingress") {
                 TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
+                    .focused($isIngressUrlFocused)
                     .textFieldStyle(.roundedBorder)
 
                 HStack(alignment: .top, spacing: 6) {
@@ -579,6 +581,7 @@ public struct SettingsView: View {
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
             store.refreshIngressConfig()
+            ingressUrlText = store.ingressPublicBaseUrl
             checkPermissions()
         }
         .onDisappear {
@@ -590,7 +593,11 @@ public struct SettingsView: View {
             checkPermissions()
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            ingressUrlText = newValue
+            // Only sync from store when the field is not focused, so
+            // background IPC responses don't overwrite in-progress edits.
+            if !isIngressUrlFocused {
+                ingressUrlText = newValue
+            }
         }
         .sheet(isPresented: $showingSkills, onDismiss: {
             skillsViewModel = nil


### PR DESCRIPTION
Addresses feedback from PRs #5864, #5868, and #5869.

- Gate .onChange ingress URL sync behind @FocusState to prevent overwriting in-progress edits
- Restore initial ingressUrlText assignment in onAppear for correct population on reopen
- Fix handleModelSet and handleImageGenModelSet to save/restore suppressConfigReload state on failure
- Make saveTwilioWebhookBaseUrl and saveIngressPublicBaseUrl only commit state after successful daemon response
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
