### PR TITLE
fix: update Origin check to accept private network origins for relay WebSocket

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -4,8 +4,8 @@
  * Verifies:
  * - Direct Twilio webhook routes return 410 in gateway_only mode
  * - Internal forwarding routes (gateway→runtime) still work in gateway_only mode
- * - Relay WebSocket upgrade blocked for non-private-network origins in gateway_only mode
- * - Relay WebSocket upgrade allowed from private network peers in gateway_only mode
+ * - Relay WebSocket upgrade blocked for non-private-network origins (isPrivateNetworkOrigin) in gateway_only mode
+ * - Relay WebSocket upgrade allowed from private network peers/origins in gateway_only mode
  * - All routes work normally in compat mode
  * - Startup warning when RUNTIME_HTTP_HOST is not loopback in gateway_only mode
  */
@@ -313,7 +313,7 @@ describe('gateway-only ingress enforcement', () => {
     });
 
     test('allows request with no origin header (private network peer)', async () => {
-      // Without an origin header, isLoopbackOrigin returns true.
+      // Without an origin header, isPrivateNetworkOrigin returns true.
       // The peer address (127.0.0.1) passes the private network peer check.
       const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-123`, {
         headers: {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,16 +145,20 @@ const GATEWAY_SUBPATH_MAP: Record<string, string> = {
 const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set(['voice-webhook', 'status', 'connect-action']);
 
 /**
- * Check if a request origin is from localhost / loopback.
+ * Check if a request origin is from a private/internal network address.
+ * Extracts the hostname from the Origin header and validates it against
+ * isPrivateAddress(), consistent with the isPrivateNetworkPeer check.
  */
-function isLoopbackOrigin(req: Request): boolean {
+function isPrivateNetworkOrigin(req: Request): boolean {
   const origin = req.headers.get('origin');
   // No origin header (e.g., server-initiated or same-origin) — allow
   if (!origin) return true;
   try {
     const url = new URL(origin);
     const host = url.hostname;
-    return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+    // "localhost" is not a raw IP, so check it explicitly
+    if (host === 'localhost') return true;
+    return isPrivateAddress(host);
   } catch {
     return false;
   }
@@ -438,7 +442,7 @@ export class RuntimeHttpServer {
       // and RFC 1918/4193 private addresses to support container deployments.
       // Secondary check: Origin header (defense in depth).
       const config = loadConfig();
-      if (config.ingress.mode === 'gateway_only' && (!isPrivateNetworkPeer(server, req) || !isLoopbackOrigin(req))) {
+      if (config.ingress.mode === 'gateway_only' && (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req))) {
         return Response.json(
           { error: 'Direct relay access disabled in gateway-only mode', code: 'GATEWAY_ONLY' },
           { status: 403 },


### PR DESCRIPTION
Addresses feedback from PR #5922.\n\nRenames isLoopbackOrigin to isPrivateNetworkOrigin and uses isPrivateAddress() to validate the Origin header hostname. This makes the secondary Origin check consistent with the primary isPrivateNetworkPeer check, preventing false rejections when a private-network gateway sends an Origin header with its private IP.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
