### PR TITLE
fix: derive subagentInfo reactively in SubagentDetailPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -273,7 +273,6 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
-                        subagentInfo: viewModel.activeSubagents.first(where: { $0.id == subagentId }),
                         onAbort: { try? daemonClient.sendSubagentAbort(subagentId: subagentId) },
                         onClose: { windowState.selectedSubagentId = nil }
                     )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -5,10 +5,10 @@ struct SubagentDetailPanel: View {
     let subagentId: String
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var detailStore: SubagentDetailStore
-    let subagentInfo: SubagentInfo?
     var onAbort: (() -> Void)?
     var onClose: () -> Void
 
+    private var subagentInfo: SubagentInfo? { viewModel.activeSubagents.first(where: { $0.id == subagentId }) }
     private var objective: String? { detailStore.objectives[subagentId] }
     private var usage: SubagentUsageStats? { detailStore.usageStats[subagentId] }
     private var events: [SubagentEventItem] { detailStore.eventsBySubagent[subagentId] ?? [] }


### PR DESCRIPTION
## Summary
- Change `subagentInfo` from a `let` snapshot back to a computed property derived from `viewModel.activeSubagents`
- Ensures status transitions update the panel reactively (abort button hides when subagent finishes, status badge updates)
- Addresses review feedback from #5920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
