### PR TITLE
fix: prevent sidebar pin/archive buttons from overlapping thread title

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -691,7 +691,7 @@ struct MainWindowView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.md)
-            .padding(.trailing, VSpacing.sm)
+            .padding(.trailing, isHovered ? (VSpacing.xs + 20 + VSpacing.xs + 20 + VSpacing.xs) : VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected || isHovered {


### PR DESCRIPTION
## Summary
- Expand trailing padding on hovered sidebar thread rows to reserve space for the pin and archive action buttons, preventing them from overlapping the title text when the sidebar is narrow.

## Test plan
- [ ] Hover a thread in the sidebar — pin/archive buttons should not overlap the title
- [ ] Resize sidebar to be narrow — title should truncate before the buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
