### PR TITLE
feat: include baseDataDir when hatching local assistants

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -916,7 +916,7 @@ async function hatchLocal(species: Species, name: string | null): Promise<void> 
   console.log("✅ Gateway started\n");
 
   const runtimeUrl = `http://localhost:${GATEWAY_PORT}`;
-  const baseDataDir = join(process.env.HOME ?? userInfo().homedir, ".vellum");
+  const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -916,9 +916,11 @@ async function hatchLocal(species: Species, name: string | null): Promise<void> 
   console.log("✅ Gateway started\n");
 
   const runtimeUrl = `http://localhost:${GATEWAY_PORT}`;
+  const baseDataDir = join(process.env.HOME ?? userInfo().homedir, ".vellum");
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,
+    baseDataDir,
     cloud: "local",
     species,
     hatchedAt: new Date().toISOString(),

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 export interface AssistantEntry {
   assistantId: string;
   runtimeUrl: string;
+  baseDataDir?: string;
   bearerToken?: string;
   cloud: string;
   instanceId?: string;


### PR DESCRIPTION
## Summary
- Adds `baseDataDir` field to `AssistantEntry` interface
- Sets `baseDataDir` to `~/.vellum` when hatching local assistants, so `vel ps` in vellum-assistant-platform can display the data directory path instead of just "local"

Companion to https://github.com/vellum-ai/vellum-assistant-platform/pull/548

## Test plan
- [ ] Hatch a local assistant and verify `~/.vellum.lock.json` entry includes `baseDataDir`
- [ ] Run `vel ps` and confirm the `.vellum` path appears in the info column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
