### PR TITLE
fix: populate subagent detail panel after app reload

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -30,6 +30,7 @@ import {
   renderHistoryContent,
   mergeToolResults,
   pendingStandaloneSecrets,
+  isRecord,
   type HandlerContext,
   defineHandlers,
   type HistoryToolCall,
@@ -412,6 +413,71 @@ export function handleHistoryRequest(
       ...(m.subagentNotification ? { subagentNotification: m.subagentNotification } : {}),
     };
   });
+  // Enrich subagent notifications with detail data (objective, events, usage)
+  // so the client can populate the detail panel without separate IPC messages.
+  for (const hm of historyMessages) {
+    if (!hm.subagentNotification?.conversationId) continue;
+    const { conversationId } = hm.subagentNotification;
+    const subagentMsgs = conversationStore.getMessages(conversationId);
+
+    // Extract objective from the first user message
+    const firstUser = subagentMsgs.find(m => m.role === 'user');
+    if (firstUser) {
+      try {
+        const parsed = JSON.parse(firstUser.content);
+        if (Array.isArray(parsed)) {
+          const textBlock = parsed.find((b: Record<string, unknown>) => isRecord(b) && b.type === 'text');
+          if (textBlock && typeof textBlock.text === 'string') {
+            hm.subagentNotification.objective = textBlock.text;
+          }
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Extract events from assistant messages
+    const events: Array<{ type: string; content: string; toolName?: string; isError?: boolean }> = [];
+    for (const m of subagentMsgs) {
+      if (m.role !== 'assistant') continue;
+      let content: unknown[];
+      try {
+        const parsed = JSON.parse(m.content);
+        content = Array.isArray(parsed) ? parsed : [];
+      } catch { continue; }
+
+      const textParts: string[] = [];
+      for (const block of content) {
+        if (isRecord(block) && block.type === 'text' && typeof block.text === 'string') {
+          textParts.push(block.text);
+        }
+      }
+      if (textParts.length > 0) {
+        events.push({ type: 'text', content: textParts.join('') });
+      }
+
+      const pendingTools = new Map<string, string>();
+      for (const block of content) {
+        if (!isRecord(block) || typeof block.type !== 'string') continue;
+        if (block.type === 'tool_use') {
+          const name = typeof block.name === 'string' ? block.name : 'unknown';
+          const input = isRecord(block.input) ? block.input as Record<string, unknown> : {};
+          const id = typeof block.id === 'string' ? block.id : '';
+          events.push({ type: 'tool_use', content: JSON.stringify(input), toolName: name });
+          if (id) pendingTools.set(id, name);
+        }
+        if (block.type === 'tool_result') {
+          const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
+          const resultContent = typeof block.content === 'string' ? block.content : '';
+          const isError = block.is_error === true;
+          const toolName = toolUseId ? pendingTools.get(toolUseId) : undefined;
+          events.push({ type: 'tool_result', content: resultContent, toolName: toolName ?? 'unknown', isError });
+        }
+      }
+    }
+    if (events.length > 0) {
+      hm.subagentNotification.events = events;
+    }
+  }
+
   ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });
 
   // Surfaces are now included directly in the history_response message (in the surfaces array),

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -75,6 +75,11 @@ export interface SubagentNotificationData {
   label: string;
   status: 'completed' | 'failed' | 'aborted';
   error?: string;
+  conversationId?: string;
+  /** Populated during history enrichment from the subagent's conversation. */
+  objective?: string;
+  /** Populated during history enrichment from the subagent's conversation. */
+  events?: Array<{ type: string; content: string; toolName?: string; isError?: boolean }>;
 }
 
 export interface ParsedHistoryMessage {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1234,6 +1234,16 @@ export interface HistoryResponse {
       label: string;
       status: 'completed' | 'failed' | 'aborted';
       error?: string;
+      conversationId?: string;
+      /** Subagent objective text, populated from DB on history load. */
+      objective?: string;
+      /** Subagent events (text, tool_use, tool_result), populated from DB on history load. */
+      events?: Array<{
+        type: string;
+        content: string;
+        toolName?: string;
+        isError?: boolean;
+      }>;
     };
   }>;
 }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -57,6 +57,7 @@ export interface SubagentNotificationInfo {
   label: string;
   status: 'completed' | 'failed' | 'aborted';
   error?: string;
+  conversationId?: string;
 }
 
 export type ParentNotifyCallback = (
@@ -299,7 +300,7 @@ export class SubagentManager {
             managed.state.config.parentSessionId,
             message,
             managed.parentSendToClient,
-            { subagentId, label, status: 'aborted' },
+            { subagentId, label, status: 'aborted', conversationId: managed.state.conversationId },
           );
         } catch (err) {
           log.error({ subagentId, err }, 'Failed to notify parent about abort');
@@ -497,6 +498,7 @@ export class SubagentManager {
       subagentId: config.id,
       label: config.label,
       status: outcome,
+      conversationId: managed.state.conversationId,
       ...(outcome === 'failed' ? { error: managed.state.error ?? 'Unknown error' } : {}),
     };
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1323,6 +1323,41 @@ public final class ChatViewModel: ObservableObject {
                 info.error = notification.error
                 reconstructedSubagents.append(info)
                 chatMsg.isSubagentNotification = true
+
+                // Populate detail store from embedded data so the side panel works after reload
+                if let objective = notification.objective {
+                    subagentDetailStore.recordSpawned(subagentId: notification.subagentId, objective: objective)
+                }
+                if let events = notification.events {
+                    for event in events {
+                        switch event.type {
+                        case "text":
+                            subagentDetailStore.handleEvent(
+                                subagentId: notification.subagentId,
+                                event: .assistantTextDelta(IPCAssistantTextDelta(type: "assistant_text_delta", text: event.content, sessionId: nil))
+                            )
+                        case "tool_use":
+                            let input: [String: AnyCodable]
+                            if let data = event.content.data(using: .utf8),
+                               let parsed = try? JSONDecoder().decode([String: AnyCodable].self, from: data) {
+                                input = parsed
+                            } else {
+                                input = [:]
+                            }
+                            subagentDetailStore.handleEvent(
+                                subagentId: notification.subagentId,
+                                event: .toolUseStart(IPCToolUseStart(type: "tool_use_start", toolName: event.toolName ?? "unknown", input: input, sessionId: nil))
+                            )
+                        case "tool_result":
+                            subagentDetailStore.handleEvent(
+                                subagentId: notification.subagentId,
+                                event: .toolResult(IPCToolResult(type: "tool_result", toolName: event.toolName ?? "unknown", result: event.content, isError: event.isError, diff: nil, status: nil, sessionId: nil, imageData: nil))
+                            )
+                        default:
+                            break
+                        }
+                    }
+                }
             }
 
             chatMessages.append(chatMsg)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -718,6 +718,18 @@ public struct IPCHistoryResponseMessageSubagentNotification: Codable, Sendable {
     public let label: String
     public let status: String
     public let error: String?
+    public let conversationId: String?
+    /// Subagent objective text, populated from DB on history load.
+    public let objective: String?
+    /// Subagent events (text, tool_use, tool_result), populated from DB on history load.
+    public let events: [SubagentHistoryEvent]?
+
+    public struct SubagentHistoryEvent: Codable, Sendable {
+        public let type: String
+        public let content: String
+        public let toolName: String?
+        public let isError: Bool?
+    }
 }
 
 public struct IPCHistoryResponseSurface: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Store `conversationId` in subagent notification metadata so we can look up the subagent's messages from DB on history load
- Enrich `history_response` with subagent objective + events data, avoiding a timing issue where separate `subagent_event` IPC messages arrived before the ChatViewModel's message loop was started
- Client processes embedded events in `populateFromHistory` to populate `SubagentDetailStore` directly

## Test plan
- [ ] Spawn subagents, wait for completion
- [ ] Quit and relaunch the macOS app
- [ ] Click a completed subagent chip — events and objective should appear in the side panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
