### PR TITLE
Show typing indicator while macOS assistant is busy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -486,15 +486,8 @@ struct ChatView: View {
                         && !(lastVisible?.isStreaming == true)
                         && !hasPendingConfirmation
                         && !hasActiveToolCall
-                    let isWakeUpTurn = !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
                     if shouldShowTypingIndicator {
-                        RunningIndicator(
-                            label: isWakeUpTurn ? "Waking up..." : "Typing",
-                            showIcon: false,
-                            progressiveLabels: isWakeUpTurn ? [] : ["Typing", "Still working", "Almost ready"],
-                            labelInterval: 8
-                        )
-                        .frame(maxWidth: 520, alignment: .leading)
+                        TypingBubbleIndicator()
                         .id("typing-indicator")
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -478,13 +478,24 @@ struct ChatView: View {
                     let lastVisible = displayMessages.last
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
                     let hasActiveToolCall = lastVisible?.toolCalls.contains(where: { !$0.isComplete }) == true
-                    if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
+                    // Keep a lightweight "typing" indicator visible whenever the model is
+                    // still working but there is no explicit in-message progress surface.
+                    // We intentionally do not suppress this for completed historical tools,
+                    // because that can otherwise look idle between queue handoffs.
+                    let shouldShowTypingIndicator = (isSending || isThinking)
+                        && !(lastVisible?.isStreaming == true)
+                        && !hasPendingConfirmation
+                        && !hasActiveToolCall
+                    let isWakeUpTurn = !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                    if shouldShowTypingIndicator {
                         RunningIndicator(
-                            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
-                            showIcon: false
+                            label: isWakeUpTurn ? "Waking up..." : "Typing",
+                            showIcon: false,
+                            progressiveLabels: isWakeUpTurn ? [] : ["Typing", "Still working", "Almost ready"],
+                            labelInterval: 8
                         )
                         .frame(maxWidth: 520, alignment: .leading)
-                        .id("thinking-indicator")
+                        .id("typing-indicator")
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -108,6 +108,51 @@ struct RunningIndicator: View {
     }
 }
 
+struct TypingBubbleIndicator: View {
+    @State private var isGlowing = false
+    @State private var appearance = AvatarAppearanceManager.shared
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(nsImage: appearance.chatAvatarImage)
+                .interpolation(.none)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 28, height: 28)
+                .clipShape(Circle())
+                .padding(.top, 2)
+
+            Text("...")
+                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                .foregroundColor(VColor.textPrimary.opacity(isGlowing ? 1.0 : 0.75))
+                .shadow(
+                    color: VColor.accent.opacity(isGlowing ? 0.5 : 0.15),
+                    radius: isGlowing ? 9 : 3
+                )
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .fill(VColor.surface)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .strokeBorder(VColor.surfaceBorder.opacity(0.85), lineWidth: 0.5)
+                }
+                .frame(maxWidth: 520, alignment: .leading)
+
+            Spacer(minLength: 0)
+        }
+        .onAppear {
+            withAnimation(
+                .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+            ) {
+                isGlowing = true
+            }
+        }
+    }
+}
+
 struct CodePreviewView: View {
     let code: String
 


### PR DESCRIPTION
This updates the macOS chat feed to keep a visible typing indicator whenever the agent is still processing but no explicit in-message progress UI is present. The indicator is no longer suppressed just because the latest message contains completed historical tool calls, which avoids idle-looking gaps between queue handoffs. It also renames the visible state from "Thinking" to "Typing" (while preserving "Waking up..." for first-turn startup) and adds progressive typing labels for long waits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
