### PR TITLE
Fix permission UI state after denied macOS permission

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1954,6 +1954,109 @@ final class ChatViewModelTests: XCTestCase {
                         "Retried message should not be tracked when no other send is in progress")
     }
 
+    // MARK: - Confirmation State Reconciliation
+
+    func testToolResultPermissionDeniedDowngradesApprovedConfirmation() {
+        viewModel.isSending = true
+
+        // Build an assistant turn with one pending tool call.
+        viewModel.handleServerMessage(
+            .toolUseStart(
+                ToolUseStartMessage(
+                    type: "tool_use_start",
+                    toolName: "computer_use_click",
+                    input: ["x": AnyCodable(100), "y": AnyCodable(200)],
+                    sessionId: nil
+                )
+            )
+        )
+
+        var confirmation = ToolConfirmationData(
+            requestId: "req-accessibility",
+            toolName: "computer_use_click",
+            input: ["x": AnyCodable(100), "y": AnyCodable(200)],
+            riskLevel: "high",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: nil,
+            persistentDecisionsAllowed: true
+        )
+        confirmation.state = .approved
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmation))
+
+        viewModel.handleServerMessage(
+            .toolResult(
+                ToolResultMessage(
+                    type: "tool_result",
+                    toolName: "computer_use_click",
+                    result: "Accessibility permission not granted",
+                    isError: true,
+                    diff: nil,
+                    status: nil,
+                    sessionId: nil,
+                    imageData: nil
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            viewModel.messages.last?.confirmation?.state,
+            .denied,
+            "Permission-denied execution errors should not leave confirmation in approved state"
+        )
+    }
+
+    func testToolResultNonPermissionErrorKeepsApprovedConfirmation() {
+        viewModel.isSending = true
+
+        viewModel.handleServerMessage(
+            .toolUseStart(
+                ToolUseStartMessage(
+                    type: "tool_use_start",
+                    toolName: "computer_use_click",
+                    input: ["x": AnyCodable(100), "y": AnyCodable(200)],
+                    sessionId: nil
+                )
+            )
+        )
+
+        var confirmation = ToolConfirmationData(
+            requestId: "req-non-permission",
+            toolName: "computer_use_click",
+            input: ["x": AnyCodable(100), "y": AnyCodable(200)],
+            riskLevel: "high",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: nil,
+            persistentDecisionsAllowed: true
+        )
+        confirmation.state = .approved
+        viewModel.messages.append(ChatMessage(role: .assistant, text: "", confirmation: confirmation))
+
+        viewModel.handleServerMessage(
+            .toolResult(
+                ToolResultMessage(
+                    type: "tool_result",
+                    toolName: "computer_use_click",
+                    result: "Action failed: target element disappeared",
+                    isError: true,
+                    diff: nil,
+                    status: nil,
+                    sessionId: nil,
+                    imageData: nil
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            viewModel.messages.last?.confirmation?.state,
+            .approved,
+            "Non-permission failures should preserve the user's approval decision"
+        )
+    }
+
     // MARK: - Thinking Indicator During Tool Execution
 
     func testToolResultRestoresThinkingState() {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -201,8 +201,8 @@ final class ChatViewModelTests: XCTestCase {
     func testGenerationCancelledWithoutStreamingMessage() {
         viewModel.isSending = true
         viewModel.isThinking = true
-        viewModel.isCancelling = true
 
+        viewModel.isCancelling = true
         viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
 
         XCTAssertFalse(viewModel.isSending)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -32,6 +32,20 @@ extension ChatViewModel {
         "command", "file_path", "path", "query", "url", "pattern", "glob"
     ]
 
+    /// Substrings that indicate a tool failed because the OS denied permission.
+    /// This lets the UI reconcile "allowed" confirmations that still fail at
+    /// execution time (for example: user clicked Always Allow, then denied the
+    /// macOS Accessibility prompt).
+    private static let osPermissionDeniedIndicators: [String] = [
+        "accessibility permission not granted",
+        "accessibility permission denied",
+        "screen recording permission denied",
+        "full disk access",
+        "operation not permitted",
+        "permission denied",
+        "not authorized"
+    ]
+
     /// Extract the most relevant tool input value as a full string (no truncation).
     /// Redacts values for sensitive keys to prevent credential leakage into inputSummary.
     func extractToolInput(_ input: [String: AnyCodable]) -> String {
@@ -329,6 +343,39 @@ extension ChatViewModel {
             let msg = ChatMessage(role: .assistant, text: "", attachments: chatAttachments)
             currentAssistantMessageId = msg.id
             messages.append(msg)
+        }
+    }
+
+    /// Returns true when a tool error string looks like a macOS/TCC permission denial.
+    private static func isOSPermissionDeniedError(_ result: String) -> Bool {
+        let normalized = result.lowercased()
+        return osPermissionDeniedIndicators.contains { normalized.contains($0) }
+    }
+
+    /// If the user approved a confirmation but execution still failed due OS
+    /// permission denial, update the nearby confirmation so the UI does not
+    /// incorrectly show it as approved.
+    private func downgradeAdjacentApprovedConfirmationForPermissionDeniedError(
+        assistantMessageIndex: Int,
+        toolResult: String,
+        isError: Bool
+    ) {
+        guard isError, Self.isOSPermissionDeniedError(toolResult) else { return }
+
+        var index = assistantMessageIndex + 1
+        while index < messages.count {
+            // Stay within this turn.
+            if messages[index].role == .user { break }
+
+            guard messages[index].confirmation != nil else {
+                index += 1
+                continue
+            }
+
+            if messages[index].confirmation?.state == .approved {
+                messages[index].confirmation?.state = .denied
+            }
+            return
         }
     }
 
@@ -959,6 +1006,11 @@ extension ChatViewModel {
                 // When a claude_code tool completes, mark any remaining in-progress sub-steps
                 // as done. This handles timeouts, crashes, and lost tool_complete events.
                 let toolErrored = msg.isError ?? false
+                downgradeAdjacentApprovedConfirmationForPermissionDeniedError(
+                    assistantMessageIndex: msgIndex,
+                    toolResult: truncatedResult,
+                    isError: toolErrored
+                )
                 for stepIdx in messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.indices {
                     if !messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete {
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete = true


### PR DESCRIPTION
This PR fixes a chat confirmation state bug where the UI could remain approved even when tool execution failed due macOS permission denial. In ChatViewModel message handling, we now detect permission-denied tool errors and downgrade an adjacent approved confirmation to denied so the chip reflects the real outcome. It adds two regression tests covering both paths: permission-denied errors flip approved to denied, while unrelated tool errors keep approved state unchanged. The workspace diff includes only these logic and test updates in shared chat handling and macOS ChatViewModel tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
