### PR TITLE
Hide queue UI and support rapid multi-send in macOS chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -9,9 +9,6 @@ struct ChatBubble: View {
     let hideToolCalls: Bool
     /// Decided confirmation from the next message, rendered as a compact chip at the bottom.
     let decidedConfirmation: ToolConfirmationData?
-    /// Whether to show the regenerate button on this message.
-    let showRegenerate: Bool
-    let onRegenerate: () -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onDismissDocumentWidget: (String) -> Void
     let dismissedDocumentSurfaceIds: Set<String>
@@ -21,8 +18,6 @@ struct ChatBubble: View {
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
-    @State private var isRegenerateHovered = false
-    @State private var isCopyHovered = false
 
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
@@ -33,6 +28,15 @@ struct ChatBubble: View {
     private var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
         !isUser && onReportMessage != nil
+    }
+    private var hasCopyableText: Bool {
+        !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    private var hasOverflowActions: Bool {
+        hasCopyableText || canReportMessage
+    }
+    private var showOverflowMenu: Bool {
+        hasOverflowActions && (isHovered || showCopyConfirmation)
     }
 
     /// Composite identity for the `.task` modifier so it re-runs when either
@@ -171,47 +175,6 @@ struct ChatBubble: View {
                 if !isUser {
                     trailingStatus
                 }
-
-                HStack(spacing: VSpacing.xs) {
-                    if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        copyButton
-                    }
-
-                    if showRegenerate {
-                        regenerateButton
-                    }
-
-                    if canReportMessage {
-                        // Use ZStack + conditional rendering so the NSPopUpButton is only
-                        // in the view hierarchy while hovered — avoiding per-message SF
-                        // Symbol and accessibility-string lookups on every scroll frame
-                        // that cause the scroll crash (see #4809).
-                        ZStack {
-                            Color.clear.frame(width: 24, height: 24)
-                            if isHovered {
-                                Menu {
-                                    if let onReportMessage {
-                                        Button("Export response for diagnostics") {
-                                            onReportMessage(message.daemonMessageId)
-                                        }
-                                    }
-                                } label: {
-                                    Image(systemName: "ellipsis")
-                                        .font(.system(size: 11, weight: .medium))
-                                        .foregroundColor(VColor.textMuted)
-                                        .frame(width: 24, height: 24)
-                                        .contentShape(Rectangle())
-                                }
-                                .menuStyle(.borderlessButton)
-                                .menuIndicator(.hidden)
-                                .tint(VColor.textMuted)
-                                .frame(width: 24, height: 24)
-                                .accessibilityLabel("Message actions")
-                                .transition(.opacity.animation(VAnimation.fast))
-                            }
-                        }
-                    }
-                }
             }
             // Prevent LazyVStack from compressing the bubble height, which causes the
             // trailing tool-chip to overlap long text content.
@@ -223,6 +186,12 @@ struct ChatBubble: View {
         .contentShape(Rectangle())
         .onHover { hovering in
             isHovered = hovering
+        }
+        .overlay(alignment: isUser ? .leading : .trailing) {
+            if showOverflowMenu {
+                overflowMenuButton
+                    .transition(.opacity)
+            }
         }
         .task(id: mediaEmbedTaskID) {
             guard !message.isStreaming else { return }
@@ -243,93 +212,41 @@ struct ChatBubble: View {
         !message.toolCalls.isEmpty && message.toolCalls.allSatisfy { $0.isComplete } && !message.isStreaming
     }
 
-    private var copyButton: some View {
-        Button {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(message.text, forType: .string)
-            copyConfirmationTimer?.cancel()
-            showCopyConfirmation = true
-            let timer = DispatchWorkItem { showCopyConfirmation = false }
-            copyConfirmationTimer = timer
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+    private func copyMessageText() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(message.text, forType: .string)
+        copyConfirmationTimer?.cancel()
+        showCopyConfirmation = true
+        let timer = DispatchWorkItem { showCopyConfirmation = false }
+        copyConfirmationTimer = timer
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+    }
+
+    private var overflowMenuButton: some View {
+        Menu {
+            if hasCopyableText {
+                Button("Copy message") {
+                    copyMessageText()
+                }
+            }
+            if let onReportMessage, !isUser {
+                Button("Export response for diagnostics") {
+                    onReportMessage(message.daemonMessageId)
+                }
+            }
         } label: {
-            Image(systemName: showCopyConfirmation ? "checkmark" : "doc.on.doc")
+            Image(systemName: showCopyConfirmation ? "checkmark" : "ellipsis")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
                 .frame(width: 24, height: 24)
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Copy message")
-        .onHover { hovering in
-            isCopyHovered = hovering
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
-        .overlay(alignment: .bottom) {
-            if isCopyHovered && !showCopyConfirmation {
-                Text("Copy")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(VColor.surface)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .vShadow(VShadow.sm)
-                    .fixedSize()
-                    .offset(y: 28)
-                    .transition(.opacity)
-                    .allowsHitTesting(false)
-            }
-        }
-        .opacity(isUser ? (isHovered ? 1 : 0) : 1)
-        .allowsHitTesting(isUser ? isHovered : true)
-        .animation(VAnimation.fast, value: isHovered)
-    }
-
-    private var regenerateButton: some View {
-        Button(action: onRegenerate) {
-            Image(systemName: "arrow.trianglehead.counterclockwise")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Try again")
-        .onHover { isRegenerateHovered = $0 }
-        .overlay(alignment: .bottom) {
-            if isRegenerateHovered {
-                Text("Try again")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(VColor.surface)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .vShadow(VShadow.sm)
-                    .fixedSize()
-                    .offset(y: 28)
-                    .transition(.opacity)
-                    .allowsHitTesting(false)
-            }
-        }
-        .animation(VAnimation.fast, value: isRegenerateHovered)
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .tint(showCopyConfirmation ? VColor.success : VColor.textMuted)
+        .frame(width: 24, height: 24)
+        .accessibilityLabel("Message actions")
+        .animation(VAnimation.fast, value: showCopyConfirmation)
     }
 
     /// Whether the permission was denied, meaning incomplete tools were blocked (not running).

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -124,74 +124,85 @@ struct ChatBubble: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
+        // Outer HStack: Spacer pushes the content group to the correct side.
+        HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }
 
-            if !isUser {
-                Image(nsImage: appearance.chatAvatarImage)
-                    .interpolation(.none)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 28, height: 28)
-                    .clipShape(Circle())
-                    .padding(.top, 2)
-            }
+            // Inner HStack: avatar/button and bubble are grouped so the button
+            // is always immediately adjacent to the bubble, not the screen edge.
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                if !isUser {
+                    Image(nsImage: appearance.chatAvatarImage)
+                        .interpolation(.none)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 28, height: 28)
+                        .clipShape(Circle())
+                        .padding(.top, 2)
+                }
 
-            VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                if !isUser && hasInterleavedContent {
-                    interleavedContent
-                } else {
-                    if shouldShowBubble {
-                        bubbleContent
-                    }
+                if isUser && hasOverflowActions {
+                    overflowMenuButton
+                        .opacity(showOverflowMenu ? 1 : 0)
+                        .animation(VAnimation.fast, value: showOverflowMenu)
+                }
 
-                    // Inline surfaces render below the bubble as full-width cards
-                    // Skip surfaces that are currently shown in the floating overlay
-                    if !message.inlineSurfaces.isEmpty {
-                        ForEach(message.inlineSurfaces.filter { $0.id != taskProgressOverlay.activeSurfaceId }) { surface in
-                            InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
+                    if !isUser && hasInterleavedContent {
+                        interleavedContent
+                    } else {
+                        if shouldShowBubble {
+                            bubbleContent
+                        }
+
+                        // Inline surfaces render below the bubble as full-width cards
+                        // Skip surfaces that are currently shown in the floating overlay
+                        if !message.inlineSurfaces.isEmpty {
+                            ForEach(message.inlineSurfaces.filter { $0.id != taskProgressOverlay.activeSurfaceId }) { surface in
+                                InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                            }
+                        }
+
+                        // Document widget for document_create tool calls
+                        if let documentToolCall = message.toolCalls.first(where: { $0.toolName == "document_create" && $0.isComplete }) {
+                            documentWidget(for: documentToolCall)
                         }
                     }
 
-                    // Document widget for document_create tool calls
-                    if let documentToolCall = message.toolCalls.first(where: { $0.toolName == "document_create" && $0.isComplete }) {
-                        documentWidget(for: documentToolCall)
+                    // Media embeds rendered below the text, preserving source order
+                    ForEach(mediaEmbedIntents.indices, id: \.self) { idx in
+                        switch mediaEmbedIntents[idx] {
+                        case .image(let url):
+                            InlineImageEmbedView(url: url)
+                        case .video(let provider, let videoID, let embedURL):
+                            InlineVideoEmbedCard(provider: provider, videoID: videoID, embedURL: embedURL)
+                        }
+                    }
+
+                    // Single unified status area at the bottom of the message:
+                    // - In-progress: shows "Running a terminal command ..."
+                    // - Complete: shows compact chips ("Ran a terminal command" + "Permission granted")
+                    if !isUser {
+                        trailingStatus
                     }
                 }
+                // Prevent LazyVStack from compressing the bubble height, which causes the
+                // trailing tool-chip to overlap long text content.
+                .fixedSize(horizontal: false, vertical: true)
+                .contextMenu {}
 
-                // Media embeds rendered below the text, preserving source order
-                ForEach(mediaEmbedIntents.indices, id: \.self) { idx in
-                    switch mediaEmbedIntents[idx] {
-                    case .image(let url):
-                        InlineImageEmbedView(url: url)
-                    case .video(let provider, let videoID, let embedURL):
-                        InlineVideoEmbedCard(provider: provider, videoID: videoID, embedURL: embedURL)
-                    }
-                }
-
-                // Single unified status area at the bottom of the message:
-                // - In-progress: shows "Running a terminal command ..."
-                // - Complete: shows compact chips ("Ran a terminal command" + "Permission granted")
-                if !isUser {
-                    trailingStatus
+                if !isUser && hasOverflowActions {
+                    overflowMenuButton
+                        .opacity(showOverflowMenu ? 1 : 0)
+                        .animation(VAnimation.fast, value: showOverflowMenu)
                 }
             }
-            // Prevent LazyVStack from compressing the bubble height, which causes the
-            // trailing tool-chip to overlap long text content.
-            .fixedSize(horizontal: false, vertical: true)
-            .contextMenu {}
 
             if !isUser { Spacer(minLength: 0) }
         }
         .contentShape(Rectangle())
         .onHover { hovering in
             isHovered = hovering
-        }
-        .overlay(alignment: isUser ? .leading : .trailing) {
-            if showOverflowMenu {
-                overflowMenuButton
-                    .transition(.opacity)
-            }
         }
         .task(id: mediaEmbedTaskID) {
             guard !message.isStreaming else { return }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -43,8 +43,6 @@ struct ChatView: View {
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
-    var onDeleteQueuedMessage: ((UUID) -> Void)?
-    var onSendDirectQueuedMessage: ((UUID) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var isTemporaryChat: Bool = false
     var activeSubagents: [SubagentInfo] = []
@@ -71,7 +69,6 @@ struct ChatView: View {
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
     @State private var isComposerExpanded = false
-    @State private var isQueueExpanded = true
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
@@ -186,9 +183,7 @@ struct ChatView: View {
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
-        let queueCount = CGFloat(queuedMessages.count)
-        let queue: CGFloat = queueCount > 0 ? (28 + (isQueueExpanded ? queueCount * 24 : 0) + VSpacing.xs) : 0
-        return base + attachments + error + queue
+        return base + attachments + error
     }
 
     private func modelPickerView(for message: ChatMessage) -> some View {
@@ -226,12 +221,6 @@ struct ChatView: View {
                     onDismissError: onDismissError
                 )
             }
-            ChatQueueSummaryView(
-                queuedMessages: queuedMessages,
-                onDeleteQueuedMessage: onDeleteQueuedMessage,
-                onSendDirectQueuedMessage: onSendDirectQueuedMessage,
-                isExpanded: $isQueueExpanded
-            )
             ComposerView(
                 inputText: $inputText,
                 hasAPIKey: hasAPIKey,
@@ -370,9 +359,8 @@ struct ChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
-                    // Filter out queued messages — they're shown above the composer instead
+                    // Render all chat messages inline except subagent notification placeholders.
                     let displayMessages = messages.filter { msg in
-                        if case .queued = msg.status { return false }
                         if msg.isSubagentNotification { return false }
                         return true
                     }
@@ -591,17 +579,6 @@ struct ChatView: View {
                     }
                 }
             }
-        }
-    }
-
-    // MARK: - Queued Messages (above composer)
-
-    /// Messages waiting in the queue, shown stacked above the input field
-    /// so they don't break chronological order in the chat feed.
-    private var queuedMessages: [ChatMessage] {
-        messages.filter { msg in
-            if case .queued = msg.status { return true }
-            return false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -35,7 +35,6 @@ struct ChatView: View {
     let onConfirmationDeny: (String) -> Void
     let onAlwaysAllow: (String, String, String, String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
-    let onRegenerate: () -> Void
     let sessionError: SessionError?
     let onRetry: () -> Void
     let onDismissSessionError: () -> Void
@@ -358,7 +357,7 @@ struct ChatView: View {
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
+                LazyVStack(alignment: .leading, spacing: VSpacing.md) {
                     // Render all chat messages inline except subagent notification placeholders.
                     let displayMessages = messages.filter { msg in
                         if msg.isSubagentNotification { return false }
@@ -431,20 +430,10 @@ struct ChatView: View {
                                 return conf
                             }()
 
-                            let isLastAssistant = message.role == .assistant
-                                && !message.isStreaming
-                                && (index == displayMessages.count - 1
-                                    || (index == displayMessages.count - 2
-                                        && displayMessages[displayMessages.count - 1].confirmation != nil && displayMessages[displayMessages.count - 1].confirmation?.state != .pending))
-                                && !isSending
-                                && !isThinking
-
                             ChatBubble(
                                 message: message,
                                 hideToolCalls: nextIsPendingConfirmation,
                                 decidedConfirmation: nextDecidedConfirmation,
-                                showRegenerate: isLastAssistant,
-                                onRegenerate: onRegenerate,
                                 onSurfaceAction: onSurfaceAction,
                                 onDismissDocumentWidget: { surfaceId in
                                     onDismissDocumentWidget?(surfaceId)
@@ -735,7 +724,6 @@ private struct ChatViewPreviewWrapper: View {
                 onConfirmationDeny: { _ in },
                 onAlwaysAllow: { _, _, _, _ in },
                 onSurfaceAction: { _, _, _ in },
-                onRegenerate: {},
                 sessionError: nil,
                 onRetry: {},
                 onDismissSessionError: {},

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -517,7 +517,6 @@ struct ActiveChatViewWrapper: View {
             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
             onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
-            onRegenerate: { viewModel.regenerateLastMessage() },
             sessionError: viewModel.sessionError,
             onRetry: { viewModel.retryAfterSessionError() },
             onDismissSessionError: { viewModel.dismissSessionError() },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -538,8 +538,6 @@ struct ActiveChatViewWrapper: View {
                     )
                 }
             },
-            onDeleteQueuedMessage: { messageId in viewModel.deleteQueuedMessage(messageId: messageId) },
-            onSendDirectQueuedMessage: { messageId in viewModel.sendDirectQueuedMessage(messageId: messageId) },
             mediaEmbedSettings: MediaEmbedResolverSettings(
                 enabled: settingsStore.mediaEmbedsEnabled,
                 enabledSince: settingsStore.mediaEmbedsEnabledSince,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -684,6 +684,29 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].status, .processing)
     }
 
+    func testMessageDequeuedKeepsMessagePositionInTranscript() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+
+        let indexBeforeDequeue = viewModel.messages.firstIndex(where: { $0.text == "Message B" })
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        let indexAfterDequeue = viewModel.messages.firstIndex(where: { $0.text == "Message B" })
+
+        XCTAssertEqual(indexBeforeDequeue, indexAfterDequeue, "Dequeued message should stay in place in the transcript")
+        if let indexAfterDequeue {
+            XCTAssertEqual(viewModel.messages[indexAfterDequeue].status, .processing)
+        } else {
+            XCTFail("Expected dequeued message to remain in transcript")
+        }
+    }
+
     func testMessageDequeuedRestoresSendingAndThinkingState() {
         // Simulate: message A completes, then queued message B is dequeued
         viewModel.sessionId = "sess-1"
@@ -728,7 +751,6 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         // Daemon dequeues B — status becomes .processing
-        // Note: messageDequeued moves the message to the end of the array for chronological ordering
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterDequeue.status, .processing, "Message B should be processing after dequeue")
@@ -912,7 +934,7 @@ final class ChatViewModelTests: XCTestCase {
         // Assistant message for A should be finalized
         XCTAssertFalse(viewModel.messages[3].isStreaming, "First assistant message should be finalized")
 
-        // 6. Daemon dequeues B (messageDequeued moves B to the end for chronological ordering)
+        // 6. Daemon dequeues B (status transitions to .processing)
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBStatus = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBStatus.status, .processing, "Message B should be processing")
@@ -928,7 +950,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[4].isStreaming, "Second assistant message should be finalized")
         XCTAssertTrue(viewModel.isSending, "isSending stays true — C is still queued")
 
-        // 8. Daemon dequeues C (messageDequeued moves C to the end for chronological ordering)
+        // 8. Daemon dequeues C (status transitions to .processing)
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-C")))
         let messageCStatus = viewModel.messages.first(where: { $0.text == "Message C" })!
         XCTAssertEqual(messageCStatus.status, .processing, "Message C should be processing")
@@ -1009,7 +1031,6 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.pendingQueuedCount, 2)
 
         // Simulate messageDequeued for B — first queued goes to .processing
-        // (messageDequeued moves B to the end for chronological ordering)
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBStatus = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBStatus.status, .processing, "Message B should now be processing")
@@ -1023,7 +1044,6 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isSending, "isSending stays true — C is still queued")
 
         // Simulate messageDequeued for C
-        // (messageDequeued moves C to the end for chronological ordering)
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-C")))
         let messageCStatus = viewModel.messages.first(where: { $0.text == "Message C" })!
         XCTAssertEqual(messageCStatus.status, .processing, "Message C should now be processing")

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -666,13 +666,8 @@ extension ChatViewModel {
             // so assistantTextDelta tags the response correctly.
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
                let index = messages.firstIndex(where: { $0.id == messageId }) {
-                // Move the dequeued message to the end so it appears after the
-                // agent's response to the previous message, preserving chronological order.
-                var message = messages.remove(at: index)
-                message.status = .processing
-                message.timestamp = Date()
-                messages.append(message)
-                currentTurnUserText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                messages[index].status = .processing
+                currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             // Recompute positions for remaining queued messages
             for i in messages.indices {


### PR DESCRIPTION
This removes the separate queued-message summary UI in macOS chat and renders queued user messages inline so multi-send looks like a normal text thread. It also updates shared dequeue handling to keep messages in place and only transition status to processing, while daemon queueing behavior remains unchanged. The wrapper wiring for queue-only actions is removed, and ChatViewModel tests now cover the no-reorder dequeue behavior with updated queue transition comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
