### PR TITLE
fix: preserve event order and include tool results in subagent history enrichment

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -434,37 +434,28 @@ export function handleHistoryRequest(
       } catch { /* ignore */ }
     }
 
-    // Extract events from assistant messages
+    // Extract events from conversation messages (both assistant and user roles)
     const events: Array<{ type: string; content: string; toolName?: string; isError?: boolean }> = [];
+    const pendingTools = new Map<string, string>();
     for (const m of subagentMsgs) {
-      if (m.role !== 'assistant') continue;
+      if (m.role !== 'assistant' && m.role !== 'user') continue;
       let content: unknown[];
       try {
         const parsed = JSON.parse(m.content);
         content = Array.isArray(parsed) ? parsed : [];
       } catch { continue; }
 
-      const textParts: string[] = [];
-      for (const block of content) {
-        if (isRecord(block) && block.type === 'text' && typeof block.text === 'string') {
-          textParts.push(block.text);
-        }
-      }
-      if (textParts.length > 0) {
-        events.push({ type: 'text', content: textParts.join('') });
-      }
-
-      const pendingTools = new Map<string, string>();
       for (const block of content) {
         if (!isRecord(block) || typeof block.type !== 'string') continue;
-        if (block.type === 'tool_use') {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          events.push({ type: 'text', content: block.text });
+        } else if (block.type === 'tool_use') {
           const name = typeof block.name === 'string' ? block.name : 'unknown';
           const input = isRecord(block.input) ? block.input as Record<string, unknown> : {};
           const id = typeof block.id === 'string' ? block.id : '';
           events.push({ type: 'tool_use', content: JSON.stringify(input), toolName: name });
           if (id) pendingTools.set(id, name);
-        }
-        if (block.type === 'tool_result') {
+        } else if (block.type === 'tool_result') {
           const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
           const resultContent = typeof block.content === 'string' ? block.content : '';
           const isError = block.is_error === true;


### PR DESCRIPTION
## Summary
- Replace two-pass extraction (text first, then tools) with single-pass to preserve interleaved chronological order
- Process both `assistant` and `user` role messages so tool results (stored as user messages) are included after reload
- Addresses review feedback from #5940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
