### PR TITLE
fix: exclude user-role text blocks from subagent history events

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -447,7 +447,7 @@ export function handleHistoryRequest(
 
       for (const block of content) {
         if (!isRecord(block) || typeof block.type !== 'string') continue;
-        if (block.type === 'text' && typeof block.text === 'string') {
+        if (m.role === 'assistant' && block.type === 'text' && typeof block.text === 'string') {
           events.push({ type: 'text', content: block.text });
         } else if (block.type === 'tool_use') {
           const name = typeof block.name === 'string' ? block.name : 'unknown';


### PR DESCRIPTION
## Summary
- Restrict text event emission to assistant-role messages only, preventing user-role text (objective, nudge prompts) from leaking into the event timeline
- Tool results from user messages are still correctly included
- Addresses review feedback from #5944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
