### PR TITLE
fix: match send button right-edge spacing to composer padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -360,7 +360,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .padding(.trailing, -(VSpacing.lg - 2))
+        .padding(.trailing, -(VSpacing.lg - VSpacing.sm))
         .animation(VAnimation.spring, value: canSend)
     }
 


### PR DESCRIPTION
## Summary
- Change the action buttons' negative trailing margin from `-(VSpacing.lg - 2)` (2pt from edge) to `-(VSpacing.lg - VSpacing.sm)` (8pt from edge) so the send button's right-edge spacing matches the composer's top/bottom padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
