### PR TITLE
M1: Canonical ingress cleanup — remove legacy keys and env fallbacks

### DIFF
--- a/assistant/src/calls/twilio-webhook-urls.ts
+++ b/assistant/src/calls/twilio-webhook-urls.ts
@@ -11,13 +11,12 @@ import {
 } from '../inbound/public-ingress-urls.js';
 
 /**
- * Resolve the webhook base URL from config, falling back to the
- * TWILIO_WEBHOOK_BASE_URL environment variable with a deprecation warning.
- * Throws if neither source provides a value.
+ * Resolve the webhook base URL from config via ingress.publicBaseUrl
+ * or INGRESS_PUBLIC_BASE_URL env var. Throws if no value is configured.
  *
  * @deprecated Use `getPublicBaseUrl` from `inbound/public-ingress-urls.ts` instead.
  */
-export function getWebhookBaseUrl(config: { calls: { webhookBaseUrl?: string }; ingress?: { publicBaseUrl?: string } }): string {
+export function getWebhookBaseUrl(config: { ingress?: { publicBaseUrl?: string } }): string {
   return getPublicBaseUrl(config as IngressConfig);
 }
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -217,7 +217,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   calls: {
     enabled: true,
     provider: 'twilio' as const,
-    webhookBaseUrl: '',
     maxDurationSeconds: 3600,
     userConsultTimeoutSeconds: 120,
     disclosure: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -895,9 +895,6 @@ export const CallsConfigSchema = z.object({
       error: `calls.provider must be one of: ${VALID_CALL_PROVIDERS.join(', ')}`,
     })
     .default('twilio'),
-  webhookBaseUrl: z
-    .string({ error: 'calls.webhookBaseUrl must be a string' })
-    .default(''),
   maxDurationSeconds: z
     .number({ error: 'calls.maxDurationSeconds must be a number' })
     .int('calls.maxDurationSeconds must be an integer')
@@ -1175,7 +1172,6 @@ export const AssistantConfigSchema = z.object({
   calls: CallsConfigSchema.default({
     enabled: true,
     provider: 'twilio',
-    webhookBaseUrl: '',
     maxDurationSeconds: 3600,
     userConsultTimeoutSeconds: 120,
     disclosure: {

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -408,17 +408,18 @@ export function handleTwilioWebhookConfig(
   try {
     if (msg.action === 'get') {
       const raw = loadRawConfig();
-      const webhookBaseUrl = (raw?.calls as Record<string, unknown>)?.webhookBaseUrl as string ?? '';
+      const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+      const webhookBaseUrl = (ingress.publicBaseUrl as string) ?? '';
       ctx.send(socket, { type: 'twilio_webhook_config_response', webhookBaseUrl, success: true });
     } else if (msg.action === 'set') {
       const value = (msg.webhookBaseUrl ?? '').trim().replace(/\/+$/, '');
       const raw = loadRawConfig();
-      const calls = (raw?.calls ?? {}) as Record<string, unknown>;
-      calls.webhookBaseUrl = value || undefined;
+      const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+      ingress.publicBaseUrl = value || undefined;
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
       try {
-        saveRawConfig({ ...raw, calls });
+        saveRawConfig({ ...raw, ingress });
       } catch (err) {
         ctx.setSuppressConfigReload(wasSuppressed);
         throw err;
@@ -456,14 +457,10 @@ export function handleIngressConfig(
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       ingress.publicBaseUrl = value || undefined;
 
-      // Also update calls.webhookBaseUrl for backward compat
-      const calls = (raw?.calls ?? {}) as Record<string, unknown>;
-      calls.webhookBaseUrl = value || undefined;
-
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
       try {
-        saveRawConfig({ ...raw, ingress, calls });
+        saveRawConfig({ ...raw, ingress });
       } catch (err) {
         ctx.setSuppressConfigReload(wasSuppressed);
         throw err;

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -1,19 +1,14 @@
 /**
  * Centralized URL builders for all public-facing ingress endpoints.
  *
- * Resolves the canonical public base URL via a fallback chain:
- *   ingress.publicBaseUrl → calls.webhookBaseUrl → env INGRESS_PUBLIC_BASE_URL → env TWILIO_WEBHOOK_BASE_URL
+ * Resolves the canonical public base URL via:
+ *   ingress.publicBaseUrl → env INGRESS_PUBLIC_BASE_URL
  *
  * Supersedes the per-domain URL helpers in calls/twilio-webhook-urls.ts.
  */
 
-import { getLogger } from '../util/logger.js';
-
-const log = getLogger('public-ingress-urls');
-
 export interface IngressConfig {
   ingress?: { publicBaseUrl?: string };
-  calls?: { webhookBaseUrl?: string };
 }
 
 /**
@@ -24,11 +19,9 @@ function normalizeUrl(url: string): string {
 }
 
 /**
- * Resolve the canonical public base URL with a four-level fallback chain:
+ * Resolve the canonical public base URL:
  *   1. ingress.publicBaseUrl (preferred, workspace config)
- *   2. calls.webhookBaseUrl (workspace config, deprecated)
- *   3. INGRESS_PUBLIC_BASE_URL env var (gateway-compatible)
- *   4. TWILIO_WEBHOOK_BASE_URL env var (legacy, deprecated)
+ *   2. INGRESS_PUBLIC_BASE_URL env var
  *
  * Throws if no source provides a non-empty value.
  */
@@ -39,34 +32,14 @@ export function getPublicBaseUrl(config: IngressConfig): string {
     if (normalized) return normalized;
   }
 
-  const callsValue = config.calls?.webhookBaseUrl;
-  if (callsValue) {
-    const normalized = normalizeUrl(callsValue);
-    if (normalized) {
-      log.warn(
-        'Using calls.webhookBaseUrl as public base URL — set ingress.publicBaseUrl instead.',
-      );
-      return normalized;
-    }
-  }
-
   const ingressEnvValue = process.env.INGRESS_PUBLIC_BASE_URL;
   if (ingressEnvValue) {
     const normalized = normalizeUrl(ingressEnvValue);
     if (normalized) return normalized;
   }
 
-  const envValue = process.env.TWILIO_WEBHOOK_BASE_URL;
-  if (envValue) {
-    log.warn(
-      'TWILIO_WEBHOOK_BASE_URL env var is deprecated — set ingress.publicBaseUrl in config or INGRESS_PUBLIC_BASE_URL env var instead.',
-    );
-    const normalized = normalizeUrl(envValue);
-    if (normalized) return normalized;
-  }
-
   throw new Error(
-    'No public base URL configured. Set ingress.publicBaseUrl in config, INGRESS_PUBLIC_BASE_URL env var, or TWILIO_WEBHOOK_BASE_URL env var.',
+    'No public base URL configured. Set ingress.publicBaseUrl in config or INGRESS_PUBLIC_BASE_URL env var.',
   );
 }
 

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -144,8 +144,8 @@ async function exchangeCodeForTokens(
 
 /**
  * Determine which callback transport to use when not explicitly specified.
- * Uses gateway if any public base URL source is configured (ingress.publicBaseUrl,
- * calls.webhookBaseUrl, or TWILIO_WEBHOOK_BASE_URL), otherwise loopback.
+ * Uses gateway if a public base URL is configured (ingress.publicBaseUrl or
+ * INGRESS_PUBLIC_BASE_URL), otherwise loopback.
  */
 function detectTransport(): 'loopback' | 'gateway' {
   try {

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -37,9 +37,7 @@ export type GatewayConfig = {
   telegramWebhookSecret: string | undefined;
   /** Twilio auth token for validating webhook signatures at the gateway boundary. */
   twilioAuthToken: string | undefined;
-  /** Public base URL that Twilio uses when computing webhook signatures. */
-  twilioWebhookBaseUrl: string | undefined;
-  /** Canonical public ingress base URL, used for webhook signature reconstruction. Falls back to twilioWebhookBaseUrl. */
+  /** Canonical public ingress base URL, used for webhook signature reconstruction. */
   ingressPublicBaseUrl: string | undefined;
   unmappedPolicy: "reject" | "default";
   /** The gateway's own public-facing URL (e.g. http://<external-ip>:7830). */
@@ -209,9 +207,8 @@ export function loadConfig(): GatewayConfig {
   }
 
   const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || undefined;
-  const twilioWebhookBaseUrl = process.env.TWILIO_WEBHOOK_BASE_URL || undefined;
   const publicUrl = process.env.GATEWAY_PUBLIC_URL || undefined;
-  const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || twilioWebhookBaseUrl || undefined;
+  const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
 
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;
 
@@ -266,7 +263,6 @@ export function loadConfig(): GatewayConfig {
     telegramWebhookSecret,
     publicUrl,
     twilioAuthToken,
-    twilioWebhookBaseUrl,
     ingressPublicBaseUrl,
     unmappedPolicy,
   };

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -67,10 +67,10 @@ export async function validateTwilioWebhookRequest(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Reconstruct the public-facing URL that Twilio signed against.
-  // Prefer ingressPublicBaseUrl (which already falls back to twilioWebhookBaseUrl at config load).
+  // Reconstruct the public-facing URL that Twilio signed against
+  // using the canonical ingress base URL.
   const parsedUrl = new URL(req.url);
-  const effectiveBaseUrl = config.ingressPublicBaseUrl ?? config.twilioWebhookBaseUrl;
+  const effectiveBaseUrl = config.ingressPublicBaseUrl;
   const publicUrl = effectiveBaseUrl
     ? effectiveBaseUrl.replace(/\/$/, "") + parsedUrl.pathname + parsedUrl.search
     : req.url;


### PR DESCRIPTION
## Summary
- Remove `calls.webhookBaseUrl` from config schema and defaults
- Remove `TWILIO_WEBHOOK_BASE_URL` / `twilioWebhookBaseUrl` fallbacks from assistant URL resolution and gateway config
- Use only `ingress.publicBaseUrl` / `INGRESS_PUBLIC_BASE_URL` for callback URL derivation and Twilio signature reconstruction
- Update error/warning messages to reference canonical ingress settings only

Part of #5948 (Gateway Ingress Remediation). Closes #5949.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
