### PR TITLE
M4: Enforce gateway_only default + OAuth loopback restrictions

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -229,6 +229,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   ingress: {
     publicBaseUrl: '',
-    mode: 'compat' as const,
+    mode: 'gateway_only' as const,
   },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -931,7 +931,7 @@ export const IngressConfigSchema = z.object({
     .enum(VALID_INGRESS_MODES, {
       error: `ingress.mode must be one of: ${VALID_INGRESS_MODES.join(', ')}`,
     })
-    .default('compat'),
+    .default('gateway_only'),
 });
 
 export const AssistantConfigSchema = z.object({
@@ -1184,7 +1184,7 @@ export const AssistantConfigSchema = z.object({
   }),
   ingress: IngressConfigSchema.default({
     publicBaseUrl: '',
-    mode: 'compat',
+    mode: 'gateway_only',
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -318,6 +318,38 @@ export async function startOAuth2Flow(
   const codeChallenge = generateCodeChallenge(codeVerifier);
   const state = generateState();
 
+  // In gateway_only mode, enforce gateway transport and require a public ingress URL
+  let ingressMode: string | undefined;
+  try {
+    const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
+    ingressMode = loadConfig().ingress.mode;
+  } catch {
+    // Config unavailable — proceed with default transport detection
+  }
+
+  if (ingressMode === 'gateway_only') {
+    // Verify a public ingress URL is configured; fail fast with actionable error if not
+    let hasPublicUrl = false;
+    try {
+      const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
+      const { getPublicBaseUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
+      getPublicBaseUrl(loadConfig());
+      hasPublicUrl = true;
+    } catch {
+      // No public URL configured
+    }
+
+    if (!hasPublicUrl) {
+      throw new Error(
+        'OAuth requires a public ingress URL in gateway-only mode. Set ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL so OAuth callbacks can route through the gateway.',
+      );
+    }
+
+    // In gateway_only mode, always use gateway transport — never fall back to loopback
+    log.debug({ transport: 'gateway' }, 'OAuth2 flow starting (gateway_only mode)');
+    return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  }
+
   const transport = options?.callbackTransport ?? detectTransport();
   log.debug({ transport }, 'OAuth2 flow starting');
 


### PR DESCRIPTION
## Summary
- Default ingress.mode to gateway_only (was compat)
- In gateway_only mode, OAuth fails fast with actionable error if no public ingress URL configured
- OAuth loopback transport disabled in gateway_only mode — always routes through gateway
- compat mode preserved as explicit emergency override

Part of #5948 (Gateway Ingress Remediation). Closes #5952.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
