### PR TITLE
ci: bump @vellumai/cli in vellum-assistant-platform on publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -119,9 +119,66 @@ jobs:
           sleep 10
           gh pr merge "$PR_URL" --auto --squash
 
+  update-platform:
+    needs: [publish]
+    if: needs.publish.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+          owner: vellum-ai
+          repositories: vellum-assistant-platform
+
+      - name: Checkout platform repo
+        uses: actions/checkout@v4
+        with:
+          repository: vellum-ai/vellum-assistant-platform
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: Update vel dependency
+        env:
+          NEW_VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          cd vel
+          jq --arg v "$NEW_VERSION" '.dependencies["@vellumai/cli"] = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+          bun install
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW_VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          BRANCH="auto/bump-cli-${NEW_VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add vel/package.json vel/bun.lock
+          git commit -m "Bump @vellumai/cli to ${NEW_VERSION} in vel"
+          git push origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --repo vellum-ai/vellum-assistant-platform \
+            --title "Bump @vellumai/cli to ${NEW_VERSION} in vel" \
+            --body "Auto-generated PR to update @vellumai/cli to ${NEW_VERSION}." \
+            --base main \
+            --head "$BRANCH")
+          sleep 10
+          gh pr merge "$PR_URL" --auto --squash
+
   notify-failure:
     if: failure()
-    needs: [publish, update-assistant]
+    needs: [publish, update-assistant, update-platform]
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack of publish failure


### PR DESCRIPTION
## Summary
- Adds a new `update-platform` job to the publish-cli workflow
- When @vellumai/cli is published, it now also creates a PR in `vellum-ai/vellum-assistant-platform` to update `vel/package.json` with the new version
- Uses the GitHub App token scoped to the platform repo for cross-repo access
- Added to notify-failure dependencies

## Test plan
- [ ] Trigger a CLI version bump and verify PRs are created in both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
