### PR TITLE
refactor: drive onboarding from lockfile assistants instead of UserDefaults flag

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -157,6 +157,7 @@ interface HatchArgs {
   detached: boolean;
   name: string | null;
   remote: RemoteHost;
+  daemonOnly: boolean;
 }
 
 function parseArgs(): HatchArgs {
@@ -165,11 +166,14 @@ function parseArgs(): HatchArgs {
   let detached = false;
   let name: string | null = null;
   let remote: RemoteHost = DEFAULT_REMOTE;
+  let daemonOnly = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "-d") {
       detached = true;
+    } else if (arg === "--daemon-only") {
+      daemonOnly = true;
     } else if (arg === "--name") {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
@@ -192,13 +196,13 @@ function parseArgs(): HatchArgs {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --daemon-only, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>`,
       );
       process.exit(1);
     }
   }
 
-  return { species, detached, name, remote };
+  return { species, detached, name, remote, daemonOnly };
 }
 
 export interface PollResult {
@@ -815,7 +819,7 @@ async function discoverPublicUrl(): Promise<string | undefined> {
   return undefined;
 }
 
-async function hatchLocal(species: Species, name: string | null): Promise<void> {
+async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false): Promise<void> {
   const instanceName =
     name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
 
@@ -1011,15 +1015,17 @@ async function hatchLocal(species: Species, name: string | null): Promise<void> 
     species,
     hatchedAt: new Date().toISOString(),
   };
-  saveAssistantEntry(localEntry);
+  if (!daemonOnly) {
+    saveAssistantEntry(localEntry);
 
-  console.log("");
-  console.log(`✅ Local assistant hatched!`);
-  console.log("");
-  console.log("Instance details:");
-  console.log(`  Name: ${instanceName}`);
-  console.log(`  Runtime: ${runtimeUrl}`);
-  console.log("");
+    console.log("");
+    console.log(`✅ Local assistant hatched!`);
+    console.log("");
+    console.log("Instance details:");
+    console.log(`  Name: ${instanceName}`);
+    console.log(`  Runtime: ${runtimeUrl}`);
+    console.log("");
+  }
 }
 
 function getCliVersion(): string {
@@ -1036,10 +1042,10 @@ export async function hatch(): Promise<void> {
   const cliVersion = getCliVersion();
   console.log(`@vellumai/cli v${cliVersion}`);
 
-  const { species, detached, name, remote } = parseArgs();
+  const { species, detached, name, remote, daemonOnly } = parseArgs();
 
   if (remote === "local") {
-    await hatchLocal(species, name);
+    await hatchLocal(species, name, daemonOnly);
     return;
   }
 

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -354,6 +354,7 @@ export async function retireInstance(
       name,
       `--project=${project}`,
       `--zone=${zone}`,
+      "--quiet",
     ],
     { stdio: "inherit" },
   );

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -197,7 +197,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // (setupDaemonClient already started connecting — don't interfere).
         guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
         Task {
-            try? await assistantCli.hatch()
+            try? await assistantCli.hatch(daemonOnly: true)
             assistantCli.startMonitoring()
             // Only connect if setupDaemonClient's connect hasn't already started
             guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
@@ -310,6 +310,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Switches the app to a different lockfile assistant: stops the current
+    /// daemon, updates persisted state, and restarts with the new assistant.
+    func performSwitchAssistant(to assistant: LockfileAssistant) {
+        assistantCli.stop()
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        assistant.writeToWorkspaceConfig()
+
+        hasSetupDaemon = false
+        setupDaemonClient()
+    }
+
     @objc func performRetire() {
         let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
@@ -324,6 +335,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 assistantCli.stop()
             }
 
+            // Check if other assistants remain in the lockfile
+            let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
+            if let next = remaining.first {
+                // Auto-switch to the next available assistant
+                settingsWindow?.close()
+                settingsWindow = nil
+                performSwitchAssistant(to: next)
+                return
+            }
+
+            // No assistants left — tear down fully and show onboarding
             OnboardingState.clearPersistedState()
 
             mainWindow?.close()
@@ -390,9 +412,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Reads `connectedAssistantId` from UserDefaults, looks it up in the lockfile
+    /// (falling back to the latest entry), and writes its config so the daemon connects
+    /// to the correct assistant.
+    private func loadAssistantFromLockfile() {
+        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant: LockfileAssistant?
+
+        if let storedId, let found = LockfileAssistant.loadByName(storedId) {
+            assistant = found
+        } else {
+            assistant = LockfileAssistant.loadLatest()
+        }
+
+        guard let assistant else { return }
+
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        assistant.writeToWorkspaceConfig()
+    }
+
     func setupDaemonClient() {
         guard !hasSetupDaemon else { return }
         hasSetupDaemon = true
+
+        loadAssistantFromLockfile()
 
         // Show macOS notification when a reminder fires
         daemonClient.onReminderFired = { msg in
@@ -526,8 +569,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         Task {
-            // Hatch the assistant via CLI (spawns daemon in release builds)
-            try? await assistantCli.hatch()
+            // Hatch the assistant via CLI (spawns daemon in release builds).
+            // daemonOnly: true prevents creating a new lockfile entry on every launch.
+            try? await assistantCli.hatch(daemonOnly: true)
             assistantCli.startMonitoring()
             try? await daemonClient.connect()
             // Once connected, start ambient agent if it was waiting for daemon

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -139,18 +139,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let skipOnboarding = false
         #endif
 
-        if !skipOnboarding && !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-            // If the user already has an API key and model configured,
-            // skip onboarding entirely — they're a returning user whose
-            // hasCompletedOnboarding flag was cleared (e.g. by Retire).
-            // Provider is not checked because the daemon defaults to 'anthropic'.
-            let config = WorkspaceConfigIO.read()
-            if APIKeyManager.hasAnyKey(), config["model"] != nil {
-                UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-            } else {
-                showOnboarding()
-                return
-            }
+        if !skipOnboarding && !lockfileHasAssistants() {
+            showOnboarding()
+            return
         }
 
         startAuthenticatedFlow()
@@ -333,7 +324,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 assistantCli.stop()
             }
 
-            UserDefaults.standard.set(false, forKey: "hasCompletedOnboarding")
             OnboardingState.clearPersistedState()
 
             mainWindow?.close()
@@ -945,13 +935,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Onboarding
 
+    /// Returns `true` when `~/.vellum.lock.json` contains at least one assistant entry.
+    private func lockfileHasAssistants() -> Bool {
+        let lockfilePath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum.lock.json").path
+        guard let data = FileManager.default.contents(atPath: lockfilePath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let assistants = json["assistants"] as? [[String: Any]] else {
+            return false
+        }
+        return !assistants.isEmpty
+    }
+
     private func showOnboarding() {
         setupDaemonClient()
 
         let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
-            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
             UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
             writeVellumIdentityFile(name: state.assistantName)

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -87,7 +87,7 @@ final class AssistantCli {
     /// waits for the socket, and registers the assistant entry.
     ///
     /// - Parameter name: Optional assistant name to reuse (for health monitor restarts).
-    func hatch(name: String? = nil) async throws {
+    func hatch(name: String? = nil, daemonOnly: Bool = false) async throws {
         guard let binaryURL = cliBinaryURL else {
             log.info("No bundled CLI binary found — skipping hatch (dev mode)")
             return
@@ -96,6 +96,9 @@ final class AssistantCli {
         log.info("Running hatch via CLI at \(binaryURL.path)")
 
         var arguments = ["hatch", "-d"]
+        if daemonOnly {
+            arguments.append("--daemon-only")
+        }
         if let name {
             arguments += ["--name", name]
         }
@@ -111,8 +114,17 @@ final class AssistantCli {
         log.info("CLI hatch completed successfully")
     }
 
+    /// How long to wait for the retire CLI command before giving up.
+    private static let retireTimeout: TimeInterval = 60.0
+
     /// Retire an assistant via the CLI. Stops the daemon, deregisters the
     /// assistant entry. Does NOT delete ~/.vellum (macOS app manages its data).
+    ///
+    /// Uses `terminationHandler` + `DispatchQueue` instead of `waitUntilExit()`
+    /// inside `Task.detached` to avoid blocking a cooperative thread pool thread,
+    /// which can cause hangs when the pool is saturated.
+    ///
+    /// Times out after 60 seconds; on timeout the CLI process is terminated.
     func retire(name: String) async throws {
         isStopping = true
         stopMonitoring()
@@ -124,7 +136,72 @@ final class AssistantCli {
 
         log.info("Running retire via CLI at \(binaryURL.path) for '\(name)'")
 
-        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: ["retire", name])
+        let (stderr, status) = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(String, Int32), Error>) in
+            let proc = Process()
+            proc.executableURL = binaryURL
+            proc.arguments = ["retire", name]
+
+            let stderrPipe = Pipe()
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = stderrPipe
+
+            let fullEnv = ProcessInfo.processInfo.environment
+            var env: [String: String] = [
+                "HOME": NSHomeDirectory(),
+                "PATH": fullEnv["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+                "VELLUM_DESKTOP_APP": "1",
+            ]
+            for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
+                        "SENTRY_DSN", "TMPDIR", "USER", "LANG"] {
+                if let val = fullEnv[key] { env[key] = val }
+            }
+            proc.environment = env
+
+            var resumed = false
+            let lock = NSLock()
+
+            // Timeout: terminate the process if it takes too long
+            let timeoutItem = DispatchWorkItem { [weak proc] in
+                lock.lock()
+                let alreadyResumed = resumed
+                if !alreadyResumed { resumed = true }
+                lock.unlock()
+
+                if !alreadyResumed {
+                    proc?.terminate()
+                    continuation.resume(throwing: CLIError.executionFailed("Retire timed out after 60 seconds"))
+                }
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + Self.retireTimeout, execute: timeoutItem)
+
+            proc.terminationHandler = { finished in
+                timeoutItem.cancel()
+                lock.lock()
+                let alreadyResumed = resumed
+                if !alreadyResumed { resumed = true }
+                lock.unlock()
+
+                guard !alreadyResumed else { return }
+
+                let stderrData = stderrPipe.fileHandleForReading.availableData
+                let stderrStr = String(data: stderrData, encoding: .utf8) ?? ""
+                continuation.resume(returning: (stderrStr, finished.terminationStatus))
+            }
+
+            do {
+                try proc.run()
+            } catch {
+                timeoutItem.cancel()
+                lock.lock()
+                let alreadyResumed = resumed
+                if !alreadyResumed { resumed = true }
+                lock.unlock()
+
+                if !alreadyResumed {
+                    continuation.resume(throwing: CLIError.executionFailed("Failed to launch retire: \(error.localizedDescription)"))
+                }
+            }
+        }
 
         if status != 0 {
             log.error("CLI retire failed with exit code \(status): \(stderr)")
@@ -371,7 +448,7 @@ final class AssistantCli {
         do {
             // Pass the existing assistant name so the CLI reuses it
             let existingName = UserDefaults.standard.string(forKey: "connectedAssistantId")
-            try await hatch(name: existingName)
+            try await hatch(name: existingName, daemonOnly: true)
             log.info("Daemon restarted successfully via CLI")
             onDaemonRestarted?()
         } catch {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -241,6 +241,11 @@ struct LockfileAssistant {
     }
 
     static func loadLatest() -> LockfileAssistant? {
+        loadAll().first
+    }
+
+    /// Returns all assistant entries from the lockfile, sorted newest first.
+    static func loadAll() -> [LockfileAssistant] {
         let home = NSHomeDirectory()
         let candidatePaths = [
             home + "/.vellum.lock.json",
@@ -262,24 +267,44 @@ struct LockfileAssistant {
                 return dateA > dateB
             }
 
-            guard let latest = sorted.first,
-                  let assistantId = latest["assistantId"] as? String else {
-                continue
+            return sorted.compactMap { entry -> LockfileAssistant? in
+                guard let assistantId = entry["assistantId"] as? String else { return nil }
+                return LockfileAssistant(
+                    assistantId: assistantId,
+                    runtimeUrl: entry["runtimeUrl"] as? String,
+                    cloud: entry["cloud"] as? String ?? "local",
+                    project: entry["project"] as? String,
+                    region: entry["region"] as? String,
+                    zone: entry["zone"] as? String,
+                    instanceId: entry["instanceId"] as? String,
+                    hatchedAt: entry["hatchedAt"] as? String
+                )
             }
-
-            return LockfileAssistant(
-                assistantId: assistantId,
-                runtimeUrl: latest["runtimeUrl"] as? String,
-                cloud: latest["cloud"] as? String ?? "local",
-                project: latest["project"] as? String,
-                region: latest["region"] as? String,
-                zone: latest["zone"] as? String,
-                instanceId: latest["instanceId"] as? String,
-                hatchedAt: latest["hatchedAt"] as? String
-            )
         }
 
-        return nil
+        return []
+    }
+
+    /// Find an assistant by its ID in the lockfile.
+    static func loadByName(_ name: String) -> LockfileAssistant? {
+        loadAll().first { $0.assistantId == name }
+    }
+
+    /// Writes this assistant's config to `~/.vellum/workspace/config.json`
+    /// via `WorkspaceConfigIO.merge()`.
+    func writeToWorkspaceConfig() {
+        var homeConfig: [String: Any] = ["cloud": cloud]
+        if let runtimeUrl { homeConfig["runtimeUrl"] = runtimeUrl }
+        if let project { homeConfig["project"] = project }
+        if let region { homeConfig["region"] = region }
+        if let zone { homeConfig["zone"] = zone }
+        if let instanceId { homeConfig["instanceId"] = instanceId }
+
+        let existing = WorkspaceConfigIO.read()
+        var assistantConfig = existing["assistant"] as? [String: Any] ?? [:]
+        assistantConfig["id"] = assistantId
+        assistantConfig["home"] = homeConfig
+        try? WorkspaceConfigIO.merge(["assistant": assistantConfig])
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -14,6 +14,8 @@ struct SettingsAdvancedTab: View {
     @State private var tokenCopied: Bool = false
     @State private var showingRetireConfirmation: Bool = false
     @State private var isRetiring: Bool = false
+    @State private var lockfileAssistants: [LockfileAssistant] = []
+    @State private var selectedAssistantId: String = ""
     #if DEBUG
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
@@ -26,6 +28,7 @@ struct SettingsAdvancedTab: View {
             privateThreadSection
             archivedThreadsSection
             iosDeviceSection
+            switchAssistantSection
             retireAssistantSection
 
             #if DEBUG
@@ -35,6 +38,8 @@ struct SettingsAdvancedTab: View {
         .onAppear {
             let tokenPath = NSHomeDirectory() + "/.vellum/session-token"
             sessionToken = (try? String(contentsOfFile: tokenPath, encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            lockfileAssistants = LockfileAssistant.loadAll()
+            selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -43,7 +48,11 @@ struct SettingsAdvancedTab: View {
                 NSApp.sendAction(#selector(AppDelegate.performRetire), to: nil, from: nil)
             }
         } message: {
-            Text("This will stop the assistant daemon, remove local data, and return to initial setup. This action cannot be undone.")
+            if lockfileAssistants.count > 1 {
+                Text("This will stop the current assistant and switch to another. The retired assistant's lockfile entry will be removed.")
+            } else {
+                Text("This will stop the assistant daemon, remove local data, and return to initial setup. This action cannot be undone.")
+            }
         }
         .sheet(isPresented: $isRetiring) {
             VStack(spacing: VSpacing.lg) {
@@ -205,6 +214,58 @@ struct SettingsAdvancedTab: View {
         }
     }
 
+    // MARK: - Switch Assistant
+
+    @ViewBuilder
+    private var switchAssistantSection: some View {
+        if lockfileAssistants.count > 1 {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Switch Assistant")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                ForEach(lockfileAssistants, id: \.assistantId) { assistant in
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: assistant.assistantId == selectedAssistantId
+                              ? "checkmark.circle.fill" : "circle")
+                            .foregroundColor(assistant.assistantId == selectedAssistantId
+                                             ? VColor.accent : VColor.textMuted)
+                            .font(.system(size: 16))
+
+                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                            Text(assistant.assistantId)
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textPrimary)
+                            Text(assistant.home.displayLabel)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+
+                        Spacer()
+
+                        if assistant.assistantId != selectedAssistantId {
+                            VButton(label: "Switch", style: .primary) {
+                                switchToAssistant(assistant)
+                            }
+                        } else {
+                            Text("Active")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                    .padding(.vertical, VSpacing.xs)
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+        }
+    }
+
+    private func switchToAssistant(_ assistant: LockfileAssistant) {
+        (NSApp.delegate as? AppDelegate)?.performSwitchAssistant(to: assistant)
+        onClose()
+    }
+
     // MARK: - Retire Assistant
 
     private var retireAssistantSection: some View {
@@ -218,9 +279,15 @@ struct SettingsAdvancedTab: View {
                     Text("Retire this assistant")
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
-                    Text("Stops the daemon, removes local data, and returns to initial setup.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                    if lockfileAssistants.count > 1 {
+                        Text("Stops the current assistant and switches to another.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    } else {
+                        Text("Stops the daemon, removes local data, and returns to initial setup.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
                 }
                 Spacer()
                 VButton(label: "Retire...", style: .danger) {


### PR DESCRIPTION
## Summary
- Replace the `hasCompletedOnboarding` UserDefaults boolean with a lockfile check (`~/.vellum.lock.json` has assistants)
- Remove all reads/writes of the `hasCompletedOnboarding` flag from `applicationDidFinishLaunching`, `showOnboarding` completion, and `performRetire`
- Add `lockfileHasAssistants()` helper that reads the lockfile and checks for a non-empty assistants array

## Test plan
- [ ] Fresh install (no lockfile) → onboarding shown
- [ ] After hatching (lockfile has assistant) → app proceeds past onboarding
- [ ] Retire → lockfile assistant removed → next launch shows onboarding again
- [ ] `--skip-onboarding` debug flag still bypasses the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
