### PR TITLE
M3: Gateway target diagnostics — config-derived local target in Settings

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -399,17 +399,23 @@ export function handleSlackWebhookConfig(
   }
 }
 
+function computeLocalGatewayTarget(): string {
+  const port = process.env.GATEWAY_PORT || '7830';
+  return `http://127.0.0.1:${port}`;
+}
+
 export function handleIngressConfig(
   msg: IngressConfigRequest,
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  const localGatewayTarget = computeLocalGatewayTarget();
   try {
     if (msg.action === 'get') {
       const raw = loadRawConfig();
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       const publicBaseUrl = (ingress.publicBaseUrl as string) ?? '';
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl, success: true });
+      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl, localGatewayTarget, success: true });
     } else if (msg.action === 'set') {
       const value = (msg.publicBaseUrl ?? '').trim().replace(/\/+$/, '');
       const raw = loadRawConfig();
@@ -430,13 +436,13 @@ export function handleIngressConfig(
       if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
       const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
       ctx.debounceTimers.set('__suppress_reset__', resetTimer);
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, success: true });
+      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, localGatewayTarget, success: true });
     } else {
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', success: false, error: message });
+    ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', localGatewayTarget, success: false, error: message });
   }
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1703,6 +1703,8 @@ export interface SlackWebhookConfigResponse {
 export interface IngressConfigResponse {
   type: 'ingress_config_response';
   publicBaseUrl: string;
+  /** Read-only gateway target computed from GATEWAY_PORT env var (default 7830) + loopback host. */
+  localGatewayTarget: string;
   success: boolean;
   error?: string;
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -578,7 +578,7 @@ struct SettingsPanel: View {
                 }
 
                 HStack(spacing: VSpacing.sm) {
-                    Text("http://127.0.0.1:7830")
+                    Text(store.localGatewayTarget)
                         .font(VFont.mono)
                         .foregroundColor(VColor.textPrimary)
                         .textSelection(.enabled)
@@ -593,7 +593,7 @@ struct SettingsPanel: View {
 
                     Button {
                         NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString("http://127.0.0.1:7830", forType: .string)
+                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
                     } label: {
                         Image(systemName: "doc.on.doc")
                             .font(.system(size: 12, weight: .medium))
@@ -1050,7 +1050,7 @@ struct SettingsPanel: View {
         Task {
             defer { checkingGateway = false }
 
-            guard let url = URL(string: "http://127.0.0.1:7830/healthz") else {
+            guard let url = URL(string: "\(store.localGatewayTarget)/healthz") else {
                 gatewayReachable = false
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -78,6 +78,8 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Ingress Config State
 
     @Published var ingressPublicBaseUrl: String = ""
+    /// Read-only gateway target derived from daemon config (GATEWAY_PORT env var, default 7830).
+    @Published var localGatewayTarget: String = "http://127.0.0.1:7830"
 
     // MARK: - Trust Rules Coordination
 
@@ -182,6 +184,7 @@ public final class SettingsStore: ObservableObject {
         // Wire up ingress config IPC response
         daemonClient?.onIngressConfigResponse = { [weak self] response in
             guard let self else { return }
+            self.localGatewayTarget = response.localGatewayTarget
             if response.success {
                 self.ingressPublicBaseUrl = response.publicBaseUrl
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -360,13 +360,13 @@ public struct SettingsView: View {
                 }
 
                 HStack(spacing: 6) {
-                    Text("http://127.0.0.1:7830")
+                    Text(store.localGatewayTarget)
                         .font(.body.monospaced())
                         .textSelection(.enabled)
                     Spacer()
                     Button {
                         NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString("http://127.0.0.1:7830", forType: .string)
+                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
                     } label: {
                         Image(systemName: "doc.on.doc")
                             .font(.system(size: 12))

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -802,6 +802,8 @@ public struct IPCIngressConfigRequest: Codable, Sendable {
 public struct IPCIngressConfigResponse: Codable, Sendable {
     public let type: String
     public let publicBaseUrl: String
+    /// Read-only gateway target computed from GATEWAY_PORT env var (default 7830) + loopback host.
+    public let localGatewayTarget: String
     public let success: Bool
     public let error: String?
 }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1635,6 +1635,7 @@ public struct IngressConfigRequestMessage: Encodable, Sendable {
 public struct IngressConfigResponseMessage: Decodable, Sendable {
     public let type: String
     public let publicBaseUrl: String
+    public let localGatewayTarget: String
     public let success: Bool
     public let error: String?
 }


### PR DESCRIPTION
## Summary
- Add read-only localGatewayTarget to ingress_config IPC response
- Compute from GATEWAY_PORT env var (default 7830) + loopback host
- Replace hardcoded http://127.0.0.1:7830 in Settings UI with config-derived value
- Regenerate IPC bindings

Part of #5948 (Gateway Ingress Remediation). Closes #5951.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
