### PR TITLE
Fix: OAuth config loading fails closed to gateway_only

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -324,7 +324,10 @@ export async function startOAuth2Flow(
     const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
     ingressMode = loadConfig().ingress.mode;
   } catch {
-    // Config unavailable — proceed with default transport detection
+    // Fail closed: if config can't be loaded (e.g., malformed config.json), default to the
+    // most restrictive mode to prevent loopback fallback from creating a fail-open path.
+    log.warn('Failed to load config for OAuth ingress mode detection; defaulting to gateway_only (fail closed)');
+    ingressMode = 'gateway_only';
   }
 
   if (ingressMode === 'gateway_only') {


### PR DESCRIPTION
## Summary
- When loadConfig() fails in OAuth transport detection, default to gateway_only instead of leaving ingressMode undefined
- Prevents fail-open path to loopback transport when config is malformed
- Log warning about config load failure

Addresses feedback on #5957.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
