### PR TITLE
fix: re-sync ingress URL text on focus leave

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -110,6 +110,13 @@ struct SettingsPanel: View {
                 ingressUrlText = newValue
             }
         }
+        .onChange(of: isIngressUrlFocused) { _, focused in
+            // Re-sync when focus leaves so any updates skipped while the
+            // user was editing are applied once they're done.
+            if !focused {
+                ingressUrlText = store.ingressPublicBaseUrl
+            }
+        }
         .onChange(of: showModelDropdown) { _, isOpen in
             if let monitor = mouseDownMonitor {
                 NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -599,6 +599,13 @@ public struct SettingsView: View {
                 ingressUrlText = newValue
             }
         }
+        .onChange(of: isIngressUrlFocused) { _, focused in
+            // Re-sync when focus leaves so any updates skipped while the
+            // user was editing are applied once they're done.
+            if !focused {
+                ingressUrlText = store.ingressPublicBaseUrl
+            }
+        }
         .sheet(isPresented: $showingSkills, onDismiss: {
             skillsViewModel = nil
         }) {


### PR DESCRIPTION
Addresses review feedback on #5924. When the ingress URL text field loses focus, re-sync from store.ingressPublicBaseUrl to ensure any updates skipped during editing are applied.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
