### PR TITLE
fix: strip IPv6 brackets in isPrivateNetworkOrigin

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -156,9 +156,10 @@ function isPrivateNetworkOrigin(req: Request): boolean {
   try {
     const url = new URL(origin);
     const host = url.hostname;
-    // "localhost" is not a raw IP, so check it explicitly
     if (host === 'localhost') return true;
-    return isPrivateAddress(host);
+    // URL.hostname wraps IPv6 addresses in brackets (e.g. "[::1]") — strip them
+    const rawHost = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+    return isPrivateAddress(rawHost);
   } catch {
     return false;
   }


### PR DESCRIPTION
Addresses review feedback on #5926. URL.hostname wraps IPv6 addresses in brackets (e.g. [::1]), but isPrivateAddress expects unbracketed IPs. Strip brackets before the check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
