### PR TITLE
fix: duplicate config property + forbidden-symbols repo root

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -12,7 +12,7 @@ import { resolve } from 'node:path';
  */
 describe('forbidden legacy symbols', () => {
   test('no production code references removed Twilio ingress symbols', () => {
-    const repoRoot = resolve(__dirname, '..', '..', '..', '..');
+    const repoRoot = resolve(__dirname, '..', '..', '..');
     let matches = '';
     try {
       matches = execSync(

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -28,7 +28,6 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
-  ingressPublicBaseUrl: undefined,
   ...overrides,
 });
 


### PR DESCRIPTION
Addresses review feedback on #5965. Removes duplicate ingressPublicBaseUrl in oauth-callback test, and fixes repoRoot in forbidden-legacy-symbols test to use 3 levels up instead of 4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
