### PR TITLE
fix: normalize gateway port + resilient IPC decode for localGatewayTarget

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -400,7 +400,8 @@ export function handleSlackWebhookConfig(
 }
 
 function computeLocalGatewayTarget(): string {
-  const port = process.env.GATEWAY_PORT || '7830';
+  const portRaw = process.env.GATEWAY_PORT || '7830';
+  const port = Number(portRaw) || 7830;
   return `http://127.0.0.1:${port}`;
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1632,12 +1632,27 @@ public struct IngressConfigRequestMessage: Encodable, Sendable {
     }
 }
 
-public struct IngressConfigResponseMessage: Decodable, Sendable {
+public struct IngressConfigResponseMessage: Sendable {
     public let type: String
     public let publicBaseUrl: String
     public let localGatewayTarget: String
     public let success: Bool
     public let error: String?
+}
+
+extension IngressConfigResponseMessage: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(String.self, forKey: .type)
+        publicBaseUrl = try container.decode(String.self, forKey: .publicBaseUrl)
+        localGatewayTarget = try container.decodeIfPresent(String.self, forKey: .localGatewayTarget) ?? "http://127.0.0.1:7830"
+        success = try container.decode(Bool.self, forKey: .success)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, publicBaseUrl, localGatewayTarget, success, error
+    }
 }
 
 // MARK: - Model Config Messages


### PR DESCRIPTION
Addresses review feedback on #5964. Normalizes GATEWAY_PORT to a number before URL construction, and uses decodeIfPresent with fallback in Swift to handle daemon/client version skew.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
