### PR TITLE
fix: report correct localClientConfigured state after secret storage rollback

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -580,7 +580,7 @@ export function handleTwitterIntegrationConfig(
             type: 'twitter_integration_config_response',
             success: false,
             managedAvailable: false,
-            localClientConfigured: false,
+            localClientConfigured: !!previousClientId,
             connected: false,
             error: 'Failed to store client secret in secure storage',
           });


### PR DESCRIPTION
When storing a client secret fails and the previous client ID is restored, the error response was hardcoding `localClientConfigured: false` regardless of whether a previous client ID existed. This caused the UI to show the client as unconfigured even though the previous PKCE client ID was successfully preserved.

Now uses `!!previousClientId` to accurately reflect whether a client ID is still configured after rollback.

Addresses feedback from #5714 (via #5825).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
