### PR TITLE
fix: correct Twitter docs to clarify posting is CDP-only, not OAuth2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2444,7 +2444,7 @@ sequenceDiagram
 
 ### Twitter Integration Architecture
 
-Twitter uses a standalone OAuth2 flow separate from the unified messaging layer. It supports two posting mechanisms: an OAuth2 PKCE flow for API-based access, and a browser-session (CDP) approach for posting via Chrome.
+Twitter uses a standalone OAuth2 flow separate from the unified messaging layer. The OAuth2 flow handles identity verification only (confirming the user's Twitter account). Posting is done exclusively via Chrome DevTools Protocol (CDP).
 
 #### Twitter OAuth2 Flow
 
@@ -2489,7 +2489,7 @@ sequenceDiagram
 | Auth URL | `https://twitter.com/i/oauth2/authorize` |
 | Token URL | `https://api.x.com/2/oauth2/token` |
 | Flow | PKCE (S256), optional client secret |
-| Requested scopes | `tweet.read`, `users.read`, `offline.access` |
+| Requested scopes | `tweet.read`, `tweet.write`, `users.read`, `offline.access` |
 | Identity verification | `GET https://api.x.com/2/users/me` with Bearer token, before persisting tokens |
 | Integration mode | `local_byo` — user provides their own Twitter app Client ID |
 | IPC messages | `twitter_auth_start`, `twitter_auth_status` / `twitter_auth_result`, `twitter_auth_status_response` |
@@ -2506,22 +2506,22 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
   oauth2TokenUrl: "https://api.x.com/2/oauth2/token",
   oauth2ClientId: "<user's client ID>",
   oauth2ClientSecret: "<optional>",
-  grantedScopes: ["tweet.read", "users.read", "offline.access"],
+  grantedScopes: ["tweet.read", "tweet.write", "users.read", "offline.access"],
   expiresAt: <epoch ms>
 }
 ```
 
 #### Twitter CDP Posting Path
 
-The `vellum x post` CLI command uses an alternative mechanism that does not require OAuth2 credentials. It connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes a `CreateTweet` GraphQL mutation through the browser's session cookies. Session management is handled by Ride Shotgun recordings (`vellum x refresh`).
+The `vellum x post` CLI command is the sole posting mechanism. It connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes a `CreateTweet` GraphQL mutation through the browser's session cookies. It does not use OAuth2 tokens for posting. Session management is handled by Ride Shotgun recordings (`vellum x refresh`).
 
 #### Available Twitter Tools
 
 | Tool | Mechanism | Description |
 |------|-----------|-------------|
-| `twitter_post` | OAuth2 or CDP | Post a tweet. Available via the `X` bundled skill (`vellum x post`). |
+| `twitter_post` | CDP | Post a tweet. Available via the `X` bundled skill (`vellum x post`). |
 
-Note: The `tweet.read` and `users.read` OAuth2 scopes are used for identity verification during the auth flow, but read functionality is not exposed as a tool.
+Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow for identity verification. Posting is handled exclusively via CDP, not through the OAuth2 tokens.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -211,15 +211,15 @@ Connect via the Settings UI or `integration_connect` IPC message. OAuth2 tokens 
 
 ### Twitter (X)
 
-Twitter integration supports posting to X via two mechanisms:
+Twitter integration has two components: an OAuth2 identity flow and a CDP-based posting path.
 
-1. **OAuth2 PKCE flow** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. Tokens are stored in the credential vault with `allowedTools: ["twitter_post"]`. Connect via the Settings UI or `twitter_auth_start` IPC message.
+- **OAuth2 PKCE flow** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. This flow is used for **identity verification only** (`GET /2/users/me`) — it confirms the user's Twitter account and stores credentials in the vault, but is not used for posting. Connect via the Settings UI or `twitter_auth_start` IPC message.
 
-2. **Browser session** (CDP): The `vellum x post` CLI command posts via Chrome DevTools Protocol, executing GraphQL mutations through an authenticated x.com browser tab. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
+- **Browser session posting** (CDP): The `vellum x post` CLI command posts via Chrome DevTools Protocol, executing GraphQL mutations through an authenticated x.com browser tab. This is the **only posting mechanism**. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
 
-**Available tool**: `twitter_post` — posts a tweet. The OAuth2 scopes include `tweet.read` and `users.read` for identity verification, but read functionality is not exposed as a tool.
+**Available tool**: `twitter_post` — posts a tweet via CDP. OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow, but posting is handled exclusively through the browser session.
 
-**Setup (OAuth2 mode)**: Store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`). Optionally store a Client Secret. Then initiate the OAuth2 flow from the Settings UI.
+**Setup**: Store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`). Optionally store a Client Secret. Initiate the OAuth2 flow from the Settings UI to verify your identity. For posting, ensure Chrome is running with remote debugging enabled and an authenticated x.com tab.
 
 ## Dynamic Skill Authoring
 


### PR DESCRIPTION
Address review feedback from #5732: both Codex and Devin flagged that the Twitter integration documentation incorrectly stated that `twitter_post` supports OAuth2-based posting. In reality, posting is done exclusively via Chrome DevTools Protocol (CDP). The OAuth2 flow is used only for identity verification.

Changes:
- README.md: Rewrite Twitter section to clearly separate the OAuth2 identity flow from the CDP posting path
- ARCHITECTURE.md: Change `twitter_post` mechanism from "OAuth2 or CDP" to "CDP"
- ARCHITECTURE.md: Update intro paragraph to state OAuth2 is for identity verification only
- ARCHITECTURE.md: Clarify CDP posting path is the sole posting mechanism, not an alternative
- ARCHITECTURE.md: Update OAuth2 scopes to match current code (`tweet.write` was added)
- ARCHITECTURE.md: Update credential metadata example to match current scopes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
