### PR TITLE
fix: restore --frozen-lockfile in publish-assistant workflow

### DIFF
--- a/.github/workflows/publish-assistant.yml
+++ b/.github/workflows/publish-assistant.yml
@@ -41,12 +41,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
-        run: |
-          for i in 1 2 3 4 5; do
-            bun install && break
-            echo "bun install attempt $i failed, retrying in 30s..."
-            sleep 30
-          done
+        run: bun install --frozen-lockfile
 
       - name: Setup Node
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
Fixes CI failures from #5811 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22229357443). PR #5811 introduced a bump script that manually edited bun.lock via string replacement, leaving stale integrity hashes. This caused `bun install --frozen-lockfile` to fail with IntegrityCheckFailed in the publish-assistant CI. As a workaround, PR #5812 removed `--frozen-lockfile` from the workflow, and PR #5829 replaced the bump scripts with a proper auto-PR workflow that runs `bun install` to regenerate the lockfile. Now that the root cause is fixed, this restores `--frozen-lockfile` to match the publish-gateway workflow and catch future integrity mismatches early.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
