### PR TITLE
fix: add stale lockfile fallback to publish-cli and publish-gateway workflows

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -41,7 +41,13 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
-        run: bun install --frozen-lockfile
+        run: |
+          if ! bun install --frozen-lockfile; then
+            echo "bun install failed (likely stale lockfile integrity hash), retrying without lockfile..."
+            rm -f bun.lock
+            rm -rf node_modules
+            bun install
+          fi
 
       - name: Setup Node
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/publish-gateway.yml
+++ b/.github/workflows/publish-gateway.yml
@@ -41,7 +41,13 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
-        run: bun install --frozen-lockfile
+        run: |
+          if ! bun install --frozen-lockfile; then
+            echo "bun install failed (likely stale lockfile integrity hash), retrying without lockfile..."
+            rm -f bun.lock
+            rm -rf node_modules
+            bun install
+          fi
 
       - name: Setup Node
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Applies the same stale lockfile integrity hash fallback from publish-assistant.yml (PR #5979) to publish-cli.yml and publish-gateway.yml
- When `bun install --frozen-lockfile` fails, the workflow removes the lockfile and node_modules, then retries without --frozen-lockfile
- Prevents the same class of CI failure seen in https://github.com/vellum-ai/vellum-assistant/actions/runs/22227696755 (from PR #5805) from recurring in CLI or Gateway publish workflows

Fixes CI failures from #5805.
Failed run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22227696755
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
