### PR TITLE
fix: force view recreation when switching subagent detail panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -281,6 +281,7 @@ extension MainWindowView {
                         },
                         onClose: { windowState.selectedSubagentId = nil }
                     )
+                    .id(subagentId)
                 } else {
                     slotView(for: config.right.content)
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -108,13 +108,6 @@ struct SubagentDetailPanel: View {
                 onRequestDetail?()
             }
         }
-        .onChange(of: subagentId) { _ in
-            // When switching between subagents, onAppear doesn't fire since the panel
-            // stays on screen — trigger lazy load for the newly selected subagent.
-            if events.isEmpty, subagentInfo?.conversationId != nil {
-                onRequestDetail?()
-            }
-        }
     }
 
     // MARK: - Status Badge


### PR DESCRIPTION
## Summary
- Add `.id(subagentId)` to `SubagentDetailPanel` in `PanelCoordinator` to force SwiftUI to destroy and recreate the view when switching between subagents
- Remove the `.onChange(of: subagentId)` workaround (no longer needed since `.onAppear` fires naturally on recreation)
- Fixes: when multiple subagents exist, only the first one clicked would show events — the second would show "No events yet" because `onAppear` doesn't re-fire for reused views

## Test plan
- [ ] Spawn 2+ subagents, wait for completion
- [ ] Click first subagent chip — events should load
- [ ] Click second subagent chip — events should also load (not empty)
- [ ] Re-click first subagent — events still shown (cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
