### PR TITLE
ci: add compile check to CLI CI to catch bun build --compile failures

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -31,3 +31,8 @@ jobs:
 
       - name: Type check
         run: bun run typecheck
+
+      - name: Compile check
+        run: |
+          bun build --compile src/index.ts --outfile /tmp/vellum-cli-compile-check
+          rm -f /tmp/vellum-cli-compile-check


### PR DESCRIPTION
## Summary
- Adds a `bun build --compile` step to the CLI CI workflow (`ci-cli.yml`)
- This catches compilation failures that lint/typecheck miss (e.g. Bun text imports that don't work in compiled binaries)

## Context
The CI failure from [PR #5500](https://github.com/vellum-ai/vellum-assistant/pull/5500) ([run 22202052052](https://github.com/vellum-ai/vellum-assistant/actions/runs/22202052052)) was caused by a pre-existing bug in `cli/src/lib/interfaces-seed.ts` that used `import ... with { type: "text" }` — a pattern incompatible with `bun build --compile`. The bug was introduced in PR #5720 and fixed in PR #5796, but the CLI CI only ran lint and type-check, so it was never caught at PR time. The macOS build workflow (`build-and-release-macos.yml`) was the first to run `bun build --compile` and it failed.

## Test plan
- [ ] Verify the new compile check step runs in CI on PRs that touch `cli/`
- [ ] Confirm it would have caught the original `with { type: "text" }` import error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
