### PR TITLE
fix: add --no-provenance to npm publish for private repo compatibility

### DIFF
--- a/.github/workflows/publish-assistant.yml
+++ b/.github/workflows/publish-assistant.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
-        run: npm publish --access public
+        # --no-provenance: sigstore provenance signing fails for private repos (see PR #1660)
+        run: npm publish --access public --no-provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -52,7 +52,8 @@ jobs:
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
-        run: npm publish --access public
+        # --no-provenance: sigstore provenance signing fails for private repos (see PR #1660)
+        run: npm publish --access public --no-provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-gateway.yml
+++ b/.github/workflows/publish-gateway.yml
@@ -52,7 +52,8 @@ jobs:
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
-        run: npm publish --access public
+        # --no-provenance: sigstore provenance signing fails for private repos (see PR #1660)
+        run: npm publish --access public --no-provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

Adds `--no-provenance` to `npm publish` in all three publish workflows (`publish-assistant.yml`, `publish-cli.yml`, `publish-gateway.yml`) to prevent sigstore provenance signing failures in this private repository.

**Root cause:** PR #1660 introduced `npm publish --provenance` which fails with a 422 error because sigstore provenance only supports public repositories. While the original workflow (`publish-velly.yml`) was subsequently removed, the successor workflows (`publish-assistant.yml`, `publish-cli.yml`, `publish-gateway.yml`) should explicitly opt out of provenance to guard against npm versions that may enable it by default when `id-token: write` permissions are present.

**Failed run:** https://github.com/vellum-ai/vellum-assistant/actions/runs/22004477714
**Original PR:** https://github.com/vellum-ai/vellum-assistant/pull/1660

## Changes
- `.github/workflows/publish-assistant.yml`: Added `--no-provenance` flag
- `.github/workflows/publish-cli.yml`: Added `--no-provenance` flag  
- `.github/workflows/publish-gateway.yml`: Added `--no-provenance` flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
