### PR TITLE
fix: add stale lockfile fallback to publish-cli and publish-gateway workflows

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -41,7 +41,13 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
-        run: bun install --frozen-lockfile
+        run: |
+          if ! bun install --frozen-lockfile; then
+            echo "bun install failed (likely stale lockfile integrity hash), retrying without lockfile..."
+            rm -f bun.lock
+            rm -rf node_modules
+            bun install
+          fi
 
       - name: Setup Node
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/publish-gateway.yml
+++ b/.github/workflows/publish-gateway.yml
@@ -41,7 +41,13 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
-        run: bun install --frozen-lockfile
+        run: |
+          if ! bun install --frozen-lockfile; then
+            echo "bun install failed (likely stale lockfile integrity hash), retrying without lockfile..."
+            rm -f bun.lock
+            rm -rf node_modules
+            bun install
+          fi
 
       - name: Setup Node
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Applies the same stale lockfile fallback from publish-assistant.yml (PR #5979) to the publish-cli and publish-gateway workflows. These workflows were still using bare `bun install --frozen-lockfile` which can fail when the lockfile integrity hash is stale after dependency version bumps.

**Root cause**: PR #5801 bumped `@vellumai/cli` version in both `cli/package.json` and `assistant/package.json` without regenerating the lockfile, causing the [Publish Assistant to npm](https://github.com/vellum-ai/vellum-assistant/actions/runs/22224735295) workflow to fail with `lockfile had changes, but lockfile is frozen`. PRs #5978/#5979 fixed publish-assistant.yml, but the same vulnerability existed in publish-cli.yml and publish-gateway.yml.

**Fix**: When `bun install --frozen-lockfile` fails, fall back to removing the stale lockfile and running a fresh `bun install`. This matches the pattern already in publish-assistant.yml.

References:
- Original PR: #5801
- Failed run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22224735295
- Prior fixes: #5978, #5979
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
