### PR TITLE
fix: render subagent response events with MarkdownRenderer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -221,10 +221,8 @@ struct SubagentDetailPanel: View {
     private func eventContent(_ event: SubagentEventItem) -> some View {
         switch event.kind {
         case .text:
-            Text(event.content)
+            MarkdownRenderer(text: event.content)
                 .font(VFont.monoSmall)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
                 .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(


### PR DESCRIPTION
## Summary
- Use the shared `MarkdownRenderer` instead of plain `Text` for subagent response events in the detail panel
- Headings, code blocks, lists, bold/italic, and links now render properly

## Test plan
- [ ] Open a completed subagent detail panel with markdown content (headings, code blocks, lists)
- [ ] Verify markdown renders correctly instead of showing raw markdown syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
