### PR TITLE
Fix port-flaky gateway tests

### DIFF
--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterAll } from "bun:test";
 import { buildSchema } from "../schema.js";
 
-const PORT = 19836;
+const PORT = 19836 + Math.floor(Math.random() * 1000);
 
 const server = Bun.serve({
   port: PORT,

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -7,7 +7,7 @@ import { describe, test, expect, afterAll } from "bun:test";
  * enabling the proxy by default) will be caught by this test.
  */
 
-const PORT = 19830; // ephemeral port for test
+const PORT = 19830 + Math.floor(Math.random() * 1000);
 
 // Minimal env for loadConfig
 const env: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Replaced fixed port `19836` in `schema.test.ts` with random offset (19836 + random 0-999)
- Replaced fixed port `19830` in `telegram-only-default.test.ts` with random offset (19830 + random 0-999)
- Prevents intermittent `EADDRINUSE` failures during parallel or repeated test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
