### PR TITLE
fix: optimistically update ingressPublicBaseUrl to prevent focus-leave revert

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -379,9 +379,11 @@ public final class SettingsStore: ObservableObject {
 
     func saveIngressPublicBaseUrl(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Don't update local state optimistically — wait for the daemon's
-        // success response (handled by onIngressConfigResponse) so the UI
-        // reverts automatically if the save fails.
+        // Update local state optimistically so the focus-leave onChange handler
+        // in SettingsPanel/SettingsView reads the new value instead of reverting
+        // the text field to a stale URL. The daemon's success response
+        // (handled by onIngressConfigResponse) will confirm or correct.
+        ingressPublicBaseUrl = trimmed
         try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed))
     }
 


### PR DESCRIPTION
## Summary
- Update ingressPublicBaseUrl optimistically in saveIngressPublicBaseUrl() before sending IPC
- Prevents the focus-leave onChange handler from reverting the text field to the stale value when Save is clicked
- Fixes visual flash where the URL briefly reverts to old value after clicking Save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
