### PR TITLE
fix: add missing file extensions to forbidden-legacy-symbols guard

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -15,7 +15,7 @@ describe('forbidden legacy symbols', () => {
     try {
       matches = execSync(
         'grep -rn -E "TWILIO_WEBHOOK_BASE_URL|twilioWebhookBaseUrl|twilio_webhook_config|calls\\.webhookBaseUrl"' +
-        ' --include="*.ts" --include="*.js" --include="*.swift" --include="*.json"' +
+        ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift" --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
         ' --exclude-dir=node_modules --exclude-dir=__tests__ --exclude-dir=.private' +
         ' .',
         { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },


### PR DESCRIPTION
## Summary
- Add *.tsx, *.mjs, *.md, *.yml, *.yaml to the --include globs in the forbidden-legacy-symbols guard test
- Prevents legacy Twilio ingress symbols from being reintroduced in TSX, MJS, Markdown, or YAML files without detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
