### PR TITLE
fix: use port 0 in gateway tests to eliminate port collisions

### DIFF
--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -1,12 +1,10 @@
 import { describe, test, expect, afterAll } from "bun:test";
 
-const PORT = 19831;
-
 const env: Record<string, string> = {
   TELEGRAM_BOT_TOKEN: "test-tok",
   TELEGRAM_WEBHOOK_SECRET: "wh-sec",
   ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
-  GATEWAY_PORT: String(PORT),
+  GATEWAY_PORT: "7830",
 };
 
 const saved: Record<string, string | undefined> = {};
@@ -29,7 +27,7 @@ const handleTelegramWebhook = createTelegramWebhookHandler(config);
 let draining = false;
 
 const server = Bun.serve({
-  port: PORT,
+  port: 0,
   async fetch(req) {
     const url = new URL(req.url);
 
@@ -62,7 +60,7 @@ afterAll(() => {
 
 describe("/healthz", () => {
   test("returns 200 with ok status", async () => {
-    const res = await fetch(`http://localhost:${PORT}/healthz`);
+    const res = await fetch(`http://localhost:${server.port}/healthz`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
@@ -71,7 +69,7 @@ describe("/healthz", () => {
 
 describe("/readyz", () => {
   test("returns 200 when not draining", async () => {
-    const res = await fetch(`http://localhost:${PORT}/readyz`);
+    const res = await fetch(`http://localhost:${server.port}/readyz`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
@@ -80,7 +78,7 @@ describe("/readyz", () => {
   test("returns 503 when draining", async () => {
     draining = true;
     try {
-      const res = await fetch(`http://localhost:${PORT}/readyz`);
+      const res = await fetch(`http://localhost:${server.port}/readyz`);
       expect(res.status).toBe(503);
       const body = await res.json();
       expect(body.status).toBe("draining");

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -1,10 +1,8 @@
 import { describe, test, expect, afterAll } from "bun:test";
 import { buildSchema } from "../schema.js";
 
-const PORT = 19836 + Math.floor(Math.random() * 1000);
-
 const server = Bun.serve({
-  port: PORT,
+  port: 0,
   fetch(req) {
     const url = new URL(req.url);
 
@@ -30,7 +28,7 @@ describe("/schema route", () => {
     // GIVEN a running gateway server
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${PORT}/schema`);
+    const res = await fetch(`http://localhost:${server.port}/schema`);
 
     // THEN we receive a 200 with valid JSON
     expect(res.status).toBe(200);
@@ -56,7 +54,7 @@ describe("/schema route", () => {
     // GIVEN a running gateway server
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${PORT}/schema`);
+    const res = await fetch(`http://localhost:${server.port}/schema`);
     const body = await res.json();
 
     // THEN the paths include every gateway endpoint
@@ -76,7 +74,7 @@ describe("/schema route", () => {
     const pkg = (await import("../../package.json")).default;
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${PORT}/schema`);
+    const res = await fetch(`http://localhost:${server.port}/schema`);
     const body = await res.json();
 
     // THEN the schema version matches the package version

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -7,14 +7,12 @@ import { describe, test, expect, afterAll } from "bun:test";
  * enabling the proxy by default) will be caught by this test.
  */
 
-const PORT = 19830 + Math.floor(Math.random() * 1000);
-
 // Minimal env for loadConfig
 const env: Record<string, string> = {
   TELEGRAM_BOT_TOKEN: "test-tok",
   TELEGRAM_WEBHOOK_SECRET: "wh-sec",
   ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
-  GATEWAY_PORT: String(PORT),
+  GATEWAY_PORT: "7830",
   // GATEWAY_RUNTIME_PROXY_ENABLED intentionally unset → defaults to false
 };
 
@@ -48,7 +46,7 @@ const handleRuntimeProxy = config.runtimeProxyEnabled
   : null;
 
 const server = Bun.serve({
-  port: PORT,
+  port: 0,
   async fetch(req) {
     const url = new URL(req.url);
 
@@ -82,19 +80,19 @@ afterAll(() => {
 
 describe("Telegram-only default: non-Telegram requests return 404", () => {
   test("GET / returns 404", async () => {
-    const res = await fetch(`http://localhost:${PORT}/`);
+    const res = await fetch(`http://localhost:${server.port}/`);
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("Not found");
   });
 
   test("GET /v1/health returns 404", async () => {
-    const res = await fetch(`http://localhost:${PORT}/v1/health`);
+    const res = await fetch(`http://localhost:${server.port}/v1/health`);
     expect(res.status).toBe(404);
   });
 
   test("POST /v1/assistants/foo/chat returns 404", async () => {
-    const res = await fetch(`http://localhost:${PORT}/v1/assistants/foo/chat`, {
+    const res = await fetch(`http://localhost:${server.port}/v1/assistants/foo/chat`, {
       method: "POST",
       body: "{}",
       headers: { "content-type": "application/json" },
@@ -103,7 +101,7 @@ describe("Telegram-only default: non-Telegram requests return 404", () => {
   });
 
   test("GET /random-path returns 404", async () => {
-    const res = await fetch(`http://localhost:${PORT}/random-path`);
+    const res = await fetch(`http://localhost:${server.port}/random-path`);
     expect(res.status).toBe(404);
   });
 
@@ -116,14 +114,14 @@ describe("Telegram-only default: non-Telegram requests return 404", () => {
   });
 
   test("GET /healthz returns 200 (infrastructure routes still work)", async () => {
-    const res = await fetch(`http://localhost:${PORT}/healthz`);
+    const res = await fetch(`http://localhost:${server.port}/healthz`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
   });
 
   test("GET /readyz returns 200 (infrastructure routes still work)", async () => {
-    const res = await fetch(`http://localhost:${PORT}/readyz`);
+    const res = await fetch(`http://localhost:${server.port}/readyz`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");


### PR DESCRIPTION
## Summary
- Replace random/fixed port assignments with port: 0 in Bun.serve() across gateway tests
- Read actual assigned port from server.port after startup
- Eliminates all port collision possibilities between parallel test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
