### PR TITLE
feat: reorder tool confirmation buttons and add keyboard navigation

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -15,6 +15,7 @@ public struct ToolConfirmationBubble: View {
     /// Tracks a selected pattern while waiting for the user to pick a scope.
     @State private var pendingPattern: String?
     @State private var showScopePickerMenu = false
+    @State private var keyboardModel: ToolConfirmationKeyboardModel?
 
     public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
         self.confirmation = confirmation
@@ -322,18 +323,77 @@ public struct ToolConfirmationBubble: View {
 
     // MARK: - Button Row
 
+    /// Build the ordered list of top-level actions based on current confirmation state.
+    private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
+        var actions: [ToolConfirmationKeyboardModel.Action] = [.allowOnce]
+        if hasRuleOptions && confirmation.persistentDecisionsAllowed {
+            actions.append(.alwaysAllow)
+        }
+        actions.append(.dontAllow)
+        return actions
+    }
+
     @ViewBuilder
     private var buttonRow: some View {
+        let actions = topLevelActions
         HStack(spacing: VSpacing.xs) {
+            confirmationButton(
+                "Allow Once",
+                isPrimary: true,
+                isDanger: false,
+                isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
+            ) { onAllow() }
             if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
-            confirmationButton("Allow Once", isPrimary: false, isDanger: false) { onAllow() }
-            confirmationButton("Don\u{2019}t Allow", isPrimary: false, isDanger: false) { onDeny() }
+            confirmationButton(
+                "Don\u{2019}t Allow",
+                isPrimary: false,
+                isDanger: false,
+                isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
+            ) { onDeny() }
             Spacer()
+        }
+        .onAppear {
+            keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+        }
+        .focusable()
+        #if os(macOS)
+        .onKeyPress(.leftArrow) {
+            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
+            keyboardModel?.moveLeft()
+            return .handled
+        }
+        .onKeyPress(.rightArrow) {
+            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
+            keyboardModel?.moveRight()
+            return .handled
+        }
+        .onKeyPress(.return) {
+            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
+            if let action = keyboardModel?.selectedAction {
+                activateAction(action)
+            }
+            return .handled
+        }
+        #endif
+    }
+
+    /// Trigger the callback for a given top-level action.
+    private func activateAction(_ action: ToolConfirmationKeyboardModel.Action) {
+        switch action {
+        case .allowOnce:
+            onAllow()
+        case .alwaysAllow:
+            withAnimation(VAnimation.fast) {
+                pendingPattern = nil
+                showAlwaysAllowMenu.toggle()
+            }
+        case .dontAllow:
+            onDeny()
         }
     }
 
     @ViewBuilder
-    private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, action: @escaping () -> Void) -> some View {
+    private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, isKeyboardSelected: Bool = false, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
                 .font(VFont.caption)
@@ -344,7 +404,10 @@ public struct ToolConfirmationBubble: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(isPrimary || isDanger ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
+                        .stroke(
+                            isKeyboardSelected ? VColor.accent : (isPrimary || isDanger ? Color.clear : VColor.surfaceBorder),
+                            lineWidth: isKeyboardSelected ? 2 : 1
+                        )
                 )
         }
         .buttonStyle(.plain)
@@ -358,7 +421,7 @@ public struct ToolConfirmationBubble: View {
             alwaysAllowDropdown
         } else {
             let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
-            confirmationButton("Always Allow", isPrimary: true, isDanger: false) {
+            confirmationButton("Always Allow", isPrimary: false, isDanger: false, isKeyboardSelected: keyboardModel?.selectedAction == .alwaysAllow) {
                 let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
                 if pattern.isEmpty {
                     onAllow()
@@ -387,7 +450,7 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowDropdown: some View {
-        confirmationButton("Always Allow", isPrimary: true, isDanger: false) {
+        confirmationButton("Always Allow", isPrimary: false, isDanger: false, isKeyboardSelected: keyboardModel?.selectedAction == .alwaysAllow) {
             withAnimation(VAnimation.fast) {
                 pendingPattern = nil
                 showAlwaysAllowMenu.toggle()

--- a/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Lightweight state machine for keyboard navigation across the top-level
+/// tool-confirmation action buttons (Allow Once, Always Allow, Don't Allow).
+///
+/// macOS-only at runtime, but the model itself is platform-agnostic so it
+/// can be unit-tested without a host app.
+struct ToolConfirmationKeyboardModel {
+
+    /// The logical actions that can appear in the button row.
+    enum Action: Equatable {
+        case allowOnce
+        case alwaysAllow
+        case dontAllow
+    }
+
+    /// Ordered list of currently visible actions.
+    private(set) var actions: [Action]
+
+    /// Index of the currently selected action.
+    private(set) var selectedIndex: Int
+
+    /// Creates a model with the given ordered list of actions.
+    /// Selection defaults to the first action (Allow Once).
+    init(actions: [Action]) {
+        precondition(!actions.isEmpty, "Must have at least one action")
+        self.actions = actions
+        self.selectedIndex = 0
+    }
+
+    /// The currently selected action.
+    var selectedAction: Action {
+        actions[selectedIndex]
+    }
+
+    /// Move selection one step to the right, clamped at the end.
+    mutating func moveRight() {
+        selectedIndex = min(selectedIndex + 1, actions.count - 1)
+    }
+
+    /// Move selection one step to the left, clamped at the start.
+    mutating func moveLeft() {
+        selectedIndex = max(selectedIndex - 1, 0)
+    }
+}

--- a/clients/shared/Tests/ToolConfirmationKeyboardModelTests.swift
+++ b/clients/shared/Tests/ToolConfirmationKeyboardModelTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class ToolConfirmationKeyboardModelTests: XCTestCase {
+
+    // MARK: - Default selection
+
+    func testDefaultSelectionIsFirstAction() {
+        let model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    func testDefaultSelectionWithTwoActions() {
+        let model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .dontAllow])
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Right movement
+
+    func testMoveRightAdvancesSelection() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveRight()
+        XCTAssertEqual(model.selectedAction, .alwaysAllow)
+        XCTAssertEqual(model.selectedIndex, 1)
+    }
+
+    func testMoveRightTwiceReachesEnd() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveRight()
+        model.moveRight()
+        XCTAssertEqual(model.selectedAction, .dontAllow)
+        XCTAssertEqual(model.selectedIndex, 2)
+    }
+
+    func testMoveRightClampsAtEnd() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveRight()
+        model.moveRight()
+        model.moveRight() // should stay clamped
+        model.moveRight() // should still be clamped
+        XCTAssertEqual(model.selectedAction, .dontAllow)
+        XCTAssertEqual(model.selectedIndex, 2)
+    }
+
+    // MARK: - Left movement
+
+    func testMoveLeftClampsAtStart() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveLeft() // already at 0, should stay
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    func testMoveLeftFromMiddle() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveRight() // index 1
+        model.moveLeft()  // back to 0
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Two-action row (no Always Allow)
+
+    func testTwoActionRowNavigation() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .dontAllow])
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+
+        model.moveRight()
+        XCTAssertEqual(model.selectedAction, .dontAllow)
+
+        model.moveRight() // clamp
+        XCTAssertEqual(model.selectedAction, .dontAllow)
+
+        model.moveLeft()
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+
+        model.moveLeft() // clamp
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripNavigation() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        model.moveRight() // 1
+        model.moveRight() // 2
+        model.moveLeft()  // 1
+        model.moveLeft()  // 0
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Swaps button order so Allow Once appears first as the green primary action, with Always Allow as a non-primary outline button
- Adds `ToolConfirmationKeyboardModel` for left/right arrow key navigation across top-level actions with Enter to activate
- Keyboard navigation is gated when nested Always Allow popovers are open to prevent conflicts
- 9 new unit tests for keyboard state transitions (default selection, boundary clamping, round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
