### PR TITLE
fix: replicate single-option Always Allow logic in keyboard activation

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -383,12 +383,37 @@ public struct ToolConfirmationBubble: View {
         case .allowOnce:
             onAllow()
         case .alwaysAllow:
-            withAnimation(VAnimation.fast) {
-                pendingPattern = nil
-                showAlwaysAllowMenu.toggle()
+            if confirmation.allowlistOptions.count > 1 {
+                withAnimation(VAnimation.fast) {
+                    pendingPattern = nil
+                    showAlwaysAllowMenu.toggle()
+                }
+            } else {
+                handleSingleOptionAlwaysAllow()
             }
         case .dontAllow:
             onDeny()
+        }
+    }
+
+    /// Shared logic for the single-option Always Allow action, used by both the
+    /// inline button click handler and keyboard Enter activation.
+    private func handleSingleOptionAlwaysAllow() {
+        let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+        if pattern.isEmpty {
+            onAllow()
+            return
+        }
+        if needsScopeChoice {
+            pendingPattern = pattern
+            showScopePickerMenu = true
+        } else {
+            let scope = confirmation.scopeOptions.first?.scope ?? ""
+            if !scope.isEmpty {
+                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
+            } else {
+                onAllow()
+            }
         }
     }
 
@@ -422,22 +447,7 @@ public struct ToolConfirmationBubble: View {
         } else {
             let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
             confirmationButton("Always Allow", isPrimary: false, isDanger: false, isKeyboardSelected: keyboardModel?.selectedAction == .alwaysAllow) {
-                let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-                if pattern.isEmpty {
-                    onAllow()
-                    return
-                }
-                if needsScopeChoice {
-                    pendingPattern = pattern
-                    showScopePickerMenu = true
-                } else {
-                    let scope = confirmation.scopeOptions.first?.scope ?? ""
-                    if !scope.isEmpty {
-                        onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
-                    } else {
-                        onAllow()
-                    }
-                }
+                handleSingleOptionAlwaysAllow()
             }
             .help(patternDesc.isEmpty ? "Always allow this action" : patternDesc)
             .popover(isPresented: $showScopePickerMenu, arrowEdge: .bottom) {


### PR DESCRIPTION
Fixes keyboard Enter on Always Allow when there is a single allowlist option. The activateAction(.alwaysAllow) handler now replicates the same branching logic as the button click handler for the single-option case, instead of always toggling the dropdown menu.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
