### PR TITLE
feat: replace focus-based keyboard nav with NSEvent local monitor

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -16,6 +16,9 @@ public struct ToolConfirmationBubble: View {
     @State private var pendingPattern: String?
     @State private var showScopePickerMenu = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
+    #if os(macOS)
+    @State private var keyMonitor: Any?
+    #endif
 
     public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
         self.confirmation = confirmation
@@ -353,29 +356,62 @@ public struct ToolConfirmationBubble: View {
             Spacer()
         }
         .onAppear {
+            #if os(macOS)
+            installKeyMonitor(actions: actions)
+            #else
             keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+            #endif
         }
-        .focusable()
-        #if os(macOS)
-        .onKeyPress(.leftArrow) {
-            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
-            keyboardModel?.moveLeft()
-            return .handled
+        .onDisappear {
+            #if os(macOS)
+            removeKeyMonitor()
+            #endif
         }
-        .onKeyPress(.rightArrow) {
-            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
-            keyboardModel?.moveRight()
-            return .handled
-        }
-        .onKeyPress(.return) {
-            guard !showAlwaysAllowMenu && !showScopePickerMenu else { return .ignored }
-            if let action = keyboardModel?.selectedAction {
-                activateAction(action)
-            }
-            return .handled
-        }
-        #endif
     }
+
+    // MARK: - Key Monitor (macOS)
+
+    #if os(macOS)
+    private func installKeyMonitor(actions: [ToolConfirmationKeyboardModel.Action]) {
+        removeKeyMonitor()
+        keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Pass through when a popover menu is open
+            if showAlwaysAllowMenu || showScopePickerMenu {
+                return event
+            }
+            switch event.keyCode {
+            case 48 where event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .shift:
+                // Shift+Tab — move left
+                keyboardModel?.moveLeft()
+                return nil
+            case 48:
+                // Tab — move right
+                keyboardModel?.moveRight()
+                return nil
+            case 36, 76:
+                // Return / numpad Enter — activate
+                if let action = keyboardModel?.selectedAction {
+                    activateAction(action)
+                }
+                return nil
+            case 53:
+                // Escape — deny
+                activateAction(.dontAllow)
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyMonitor = nil
+        }
+    }
+    #endif
 
     /// Trigger the callback for a given top-level action.
     private func activateAction(_ action: ToolConfirmationKeyboardModel.Action) {

--- a/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
@@ -33,13 +33,13 @@ struct ToolConfirmationKeyboardModel {
         actions[selectedIndex]
     }
 
-    /// Move selection one step to the right, clamped at the end.
+    /// Move selection one step to the right, wrapping around to the start.
     mutating func moveRight() {
-        selectedIndex = min(selectedIndex + 1, actions.count - 1)
+        selectedIndex = (selectedIndex + 1) % actions.count
     }
 
-    /// Move selection one step to the left, clamped at the start.
+    /// Move selection one step to the left, wrapping around to the end.
     mutating func moveLeft() {
-        selectedIndex = max(selectedIndex - 1, 0)
+        selectedIndex = (selectedIndex - 1 + actions.count) % actions.count
     }
 }

--- a/clients/shared/Tests/ToolConfirmationKeyboardModelTests.swift
+++ b/clients/shared/Tests/ToolConfirmationKeyboardModelTests.swift
@@ -34,23 +34,22 @@ final class ToolConfirmationKeyboardModelTests: XCTestCase {
         XCTAssertEqual(model.selectedIndex, 2)
     }
 
-    func testMoveRightClampsAtEnd() {
+    func testMoveRightWrapsToStart() {
         var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
-        model.moveRight()
-        model.moveRight()
-        model.moveRight() // should stay clamped
-        model.moveRight() // should still be clamped
-        XCTAssertEqual(model.selectedAction, .dontAllow)
-        XCTAssertEqual(model.selectedIndex, 2)
+        model.moveRight() // 1
+        model.moveRight() // 2
+        model.moveRight() // wraps to 0
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+        XCTAssertEqual(model.selectedIndex, 0)
     }
 
     // MARK: - Left movement
 
-    func testMoveLeftClampsAtStart() {
+    func testMoveLeftWrapsToEnd() {
         var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
-        model.moveLeft() // already at 0, should stay
-        XCTAssertEqual(model.selectedAction, .allowOnce)
-        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveLeft() // wraps to 2
+        XCTAssertEqual(model.selectedAction, .dontAllow)
+        XCTAssertEqual(model.selectedIndex, 2)
     }
 
     func testMoveLeftFromMiddle() {
@@ -70,14 +69,11 @@ final class ToolConfirmationKeyboardModelTests: XCTestCase {
         model.moveRight()
         XCTAssertEqual(model.selectedAction, .dontAllow)
 
-        model.moveRight() // clamp
+        model.moveRight() // wraps to 0
+        XCTAssertEqual(model.selectedAction, .allowOnce)
+
+        model.moveLeft() // wraps to 1
         XCTAssertEqual(model.selectedAction, .dontAllow)
-
-        model.moveLeft()
-        XCTAssertEqual(model.selectedAction, .allowOnce)
-
-        model.moveLeft() // clamp
-        XCTAssertEqual(model.selectedAction, .allowOnce)
     }
 
     // MARK: - Round-trip
@@ -90,5 +86,33 @@ final class ToolConfirmationKeyboardModelTests: XCTestCase {
         model.moveLeft()  // 0
         XCTAssertEqual(model.selectedAction, .allowOnce)
         XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Full cycle
+
+    func testFullCycleForward() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveRight() // 1
+        XCTAssertEqual(model.selectedIndex, 1)
+        model.moveRight() // 2
+        XCTAssertEqual(model.selectedIndex, 2)
+        model.moveRight() // wraps to 0
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveRight() // 1
+        XCTAssertEqual(model.selectedIndex, 1)
+    }
+
+    func testFullCycleBackward() {
+        var model = ToolConfirmationKeyboardModel(actions: [.allowOnce, .alwaysAllow, .dontAllow])
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveLeft() // wraps to 2
+        XCTAssertEqual(model.selectedIndex, 2)
+        model.moveLeft() // 1
+        XCTAssertEqual(model.selectedIndex, 1)
+        model.moveLeft() // 0
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveLeft() // wraps to 2
+        XCTAssertEqual(model.selectedIndex, 2)
     }
 }


### PR DESCRIPTION
## Summary
- Replace `.focusable()` + `.onKeyPress()` with `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` so keyboard navigation works when composer holds first responder
- Tab/Shift+Tab cycle through buttons with wrap-around, Enter activates, Escape denies
- Update `ToolConfirmationKeyboardModel` from clamp to wrap-around navigation and add full-cycle tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/5999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
