### PR TITLE
M4: Preserve and re-assert no-legacy-Twilio policy

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -4,9 +4,26 @@ import { resolve } from 'node:path';
 
 /**
  * Guard test: fail if any legacy Twilio ingress symbols reappear in
- * production source code. These were removed as part of the Gateway
- * Ingress Remediation (#5948). Test files, node_modules, changelogs,
- * and .private/ are excluded.
+ * production source code, docs, configs, or scripts.
+ *
+ * Context: As part of the gateway-only ingress migration (#5948, #6000),
+ * all Twilio webhook configuration was consolidated into the gateway service.
+ * The assistant no longer manages its own Twilio webhook URLs — the gateway
+ * is the single ingress point for all telephony webhooks. Re-introducing
+ * these symbols in the assistant would bypass that architecture and create
+ * a split-brain ingress problem.
+ *
+ * Forbidden symbols:
+ *   - TWILIO_WEBHOOK_BASE_URL  — legacy env var for direct Twilio webhook base
+ *   - twilioWebhookBaseUrl     — camelCase variant used in runtime config
+ *   - twilio_webhook_config    — legacy config object key
+ *   - calls.webhookBaseUrl     — nested config path for call webhook URL
+ *
+ * Excluded directories:
+ *   - node_modules  — third-party code, not under our control
+ *   - __tests__     — test files (including this guard test) reference the
+ *                     symbols in grep patterns and assertions
+ *   - .private      — local-only developer notes and scratch files
  */
 describe('forbidden legacy symbols', () => {
   test('no production code references removed Twilio ingress symbols', () => {
@@ -15,7 +32,9 @@ describe('forbidden legacy symbols', () => {
     try {
       matches = execSync(
         'grep -rn -E "TWILIO_WEBHOOK_BASE_URL|twilioWebhookBaseUrl|twilio_webhook_config|calls\\.webhookBaseUrl"' +
-        ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift" --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
+        ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift"' +
+        ' --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
+        ' --include="*.sh" --include="*.env" --include="*.env.*"' +
         ' --exclude-dir=node_modules --exclude-dir=__tests__ --exclude-dir=.private' +
         ' .',
         { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },


### PR DESCRIPTION
Part of #6000. Strengthens the forbidden legacy Twilio symbols guard test with better documentation and coverage verification. Closes #6004.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
