### PR TITLE
M3: Gateway schema/docs consistency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,12 @@ graph TB
         GW_FORWARD["Runtime Client<br/>POST /channels/inbound"]
         GW_REPLY["Send Reply<br/>Telegram sendMessage"]
         GW_ATTACH["Send Attachments<br/>sendPhoto / sendDocument"]
+        GW_TG_DELIVER["Telegram Deliver<br/>/deliver/telegram<br/>(internal, from runtime)"]
+        GW_TWILIO_VOICE["Twilio Voice Webhook<br/>/webhooks/twilio/voice"]
+        GW_TWILIO_STATUS["Twilio Status Webhook<br/>/webhooks/twilio/status"]
+        GW_TWILIO_CONNECT["Twilio Connect-Action<br/>/webhooks/twilio/connect-action"]
+        GW_TWILIO_RELAY["Twilio Relay WS<br/>/webhooks/twilio/relay<br/>(bidirectional proxy)"]
+        GW_OAUTH["OAuth Callback<br/>/webhooks/oauth/callback"]
         GW_PROXY["Runtime Proxy<br/>(optional, bearer auth)"]
         GW_PROBES["/healthz + /readyz<br/>k8s liveness/readiness"]
     end
@@ -303,6 +309,20 @@ graph TB
     HTTP_SERVER -->|"channels/inbound transport<br/>channelId + hints + uxBrief"| PLAYBOOK_MGR
     GW_REPLY -->|"Telegram API"| GW_WEBHOOK
     GW_ATTACH -->|"download from runtime<br/>+ upload to Telegram"| GW_WEBHOOK
+
+    %% Gateway flow — Telegram deliver (runtime → gateway → Telegram)
+    HTTP_SERVER -->|"POST /deliver/telegram"| GW_TG_DELIVER
+    GW_TG_DELIVER --> GW_REPLY
+    GW_TG_DELIVER --> GW_ATTACH
+
+    %% Gateway flow — Twilio webhooks
+    GW_TWILIO_VOICE -->|"HTTP"| HTTP_SERVER
+    GW_TWILIO_STATUS -->|"HTTP"| HTTP_SERVER
+    GW_TWILIO_CONNECT -->|"HTTP"| HTTP_SERVER
+    GW_TWILIO_RELAY -->|"WebSocket proxy"| HTTP_SERVER
+
+    %% Gateway flow — OAuth callback
+    GW_OAUTH -->|"forward code + state"| HTTP_SERVER
 
     %% Gateway flow — Runtime proxy path (optional)
     GW_PROXY -->|"HTTP (forwarded)"| HTTP_SERVER

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -80,13 +80,26 @@ The gateway serves as the single public ingress point for all external callbacks
 | Route | Method | Description |
 |-------|--------|-------------|
 | `/webhooks/telegram` | POST | Telegram bot webhook (validated via `TELEGRAM_WEBHOOK_SECRET`) |
+| `/deliver/telegram` | POST | Internal endpoint for the assistant runtime to deliver outbound messages/attachments to Telegram chats |
 | `/webhooks/twilio/voice` | POST | Twilio voice webhook (validated via HMAC-SHA1 signature) |
 | `/webhooks/twilio/status` | POST | Twilio status callback (validated via HMAC-SHA1 signature) |
 | `/webhooks/twilio/connect-action` | POST | Twilio connect-action callback (validated via HMAC-SHA1 signature) |
-| `/webhooks/twilio/relay` | WS | Twilio ConversationRelay WebSocket (bidirectional proxy) |
+| `/webhooks/twilio/relay` | WS | Twilio ConversationRelay WebSocket (bidirectional proxy to runtime, requires `callSessionId` query param) |
 | `/webhooks/oauth/callback` | GET | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe |
+| `/schema` | GET | Returns the OpenAPI 3.1 schema for this gateway |
+
+#### Backward-Compatibility Paths
+
+The following legacy paths are aliases that map to their canonical equivalents above:
+
+| Legacy Path | Canonical Path |
+|-------------|---------------|
+| `/v1/calls/twilio/voice-webhook` | `/webhooks/twilio/voice` |
+| `/v1/calls/twilio/status` | `/webhooks/twilio/status` |
+| `/v1/calls/twilio/connect-action` | `/webhooks/twilio/connect-action` |
+| `/v1/calls/relay` | `/webhooks/twilio/relay` |
 
 ### Tunnel Setup
 

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -62,6 +62,12 @@ describe("/schema route", () => {
     expect(body.paths["/readyz"]).toBeDefined();
     expect(body.paths["/schema"]).toBeDefined();
     expect(body.paths["/webhooks/telegram"]).toBeDefined();
+    expect(body.paths["/webhooks/twilio/voice"]).toBeDefined();
+    expect(body.paths["/webhooks/twilio/status"]).toBeDefined();
+    expect(body.paths["/webhooks/twilio/connect-action"]).toBeDefined();
+    expect(body.paths["/webhooks/twilio/relay"]).toBeDefined();
+    expect(body.paths["/webhooks/oauth/callback"]).toBeDefined();
+    expect(body.paths["/deliver/telegram"]).toBeDefined();
     expect(body.paths["/{path}"]).toBeDefined();
   });
 
@@ -106,6 +112,8 @@ describe("buildSchema()", () => {
     expect(schemaNames).toContain("TelegramMessage");
     expect(schemaNames).toContain("TelegramPhotoSize");
     expect(schemaNames).toContain("TelegramDocument");
+    expect(schemaNames).toContain("TelegramDeliverRequest");
+    expect(schemaNames).toContain("RuntimeAttachmentMeta");
   });
 
   test("returns a JSON-serializable object", () => {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -307,6 +307,159 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/webhooks/twilio/relay": {
+        get: {
+          summary: "Twilio ConversationRelay WebSocket",
+          description:
+            "Accepts a WebSocket upgrade from Twilio ConversationRelay and bidirectionally proxies frames to the assistant runtime's /v1/calls/relay endpoint. Requires a callSessionId query parameter. Also available at /v1/calls/relay for backward compatibility.",
+          operationId: "twilioRelayWebsocket",
+          parameters: [
+            {
+              name: "callSessionId",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "Call session identifier used to correlate the WebSocket connection with the runtime relay session.",
+            },
+          ],
+          responses: {
+            "101": {
+              description: "WebSocket upgrade successful — bidirectional frame proxying begins.",
+            },
+            "400": {
+              description: "Missing callSessionId query parameter",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/webhooks/oauth/callback": {
+        get: {
+          summary: "OAuth2 callback",
+          description:
+            "Receives OAuth2 authorization code callbacks from external providers (Google, Slack, etc.). Forwards the authorization code and state parameter to the assistant runtime for token exchange. Returns an HTML success or error page to the user's browser.",
+          operationId: "oauthCallback",
+          parameters: [
+            {
+              name: "state",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "Opaque state parameter used to correlate the callback with the original OAuth flow.",
+            },
+            {
+              name: "code",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Authorization code returned by the OAuth provider on success.",
+            },
+            {
+              name: "error",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Error code returned by the OAuth provider on failure.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Authorization successful — HTML page rendered",
+              content: {
+                "text/html": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "400": {
+              description: "Missing state parameter or authorization failed — HTML error page rendered",
+              content: {
+                "text/html": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to forward callback to assistant runtime — HTML error page rendered",
+              content: {
+                "text/html": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/deliver/telegram": {
+        post: {
+          summary: "Telegram delivery (internal)",
+          description:
+            "Internal endpoint called by the assistant runtime to deliver outbound messages and attachments to a Telegram chat. Not intended for external use.",
+          operationId: "telegramDeliver",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TelegramDeliverRequest" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Message delivered",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/TelegramOk" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid JSON or missing required fields",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed (only POST accepted)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to deliver message via Telegram API",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "Telegram integration not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",
@@ -526,6 +679,29 @@ export function buildSchema(): Record<string, unknown> {
             file_name: { type: "string" },
             mime_type: { type: "string" },
             file_size: { type: "integer" },
+          },
+        },
+        TelegramDeliverRequest: {
+          type: "object",
+          required: ["chatId"],
+          properties: {
+            chatId: { type: "string", description: "Telegram chat ID to deliver the message to" },
+            text: { type: "string", description: "Text content to send" },
+            assistantId: { type: "string", description: "Assistant ID (required when sending attachments)" },
+            attachments: {
+              type: "array",
+              description: "Attachments to deliver (images sent via sendPhoto, others via sendDocument)",
+              items: { $ref: "#/components/schemas/RuntimeAttachmentMeta" },
+            },
+          },
+        },
+        RuntimeAttachmentMeta: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            filename: { type: "string" },
+            mimeType: { type: "string" },
+            sizeBytes: { type: "integer" },
           },
         },
       },


### PR DESCRIPTION
Part of #6000. Updates the OpenAPI schema, README route table, and architecture docs to accurately reflect all active gateway ingress routes including OAuth callback and Twilio relay WebSocket. Closes #6003.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
