### PR TITLE
M1: Canonical ingress source unification (assistant + gateway)

### DIFF
--- a/assistant/src/__tests__/ingress-url-consistency.test.ts
+++ b/assistant/src/__tests__/ingress-url-consistency.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mocks — silence logger output during tests
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of ['info', 'warn', 'error', 'debug', 'trace', 'fatal', 'silent', 'child']) {
+    stub[m] = m === 'child' ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+import {
+  getPublicBaseUrl,
+  getTwilioVoiceWebhookUrl,
+  getTwilioStatusCallbackUrl,
+  type IngressConfig,
+} from '../inbound/public-ingress-urls.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — simulate Twilio signature validation the same way the gateway does
+// ---------------------------------------------------------------------------
+
+/**
+ * Reproduce the gateway's canonical URL reconstruction logic from
+ * gateway/src/twilio/validate-webhook.ts (lines 72-76).
+ */
+function reconstructGatewayCanonicalUrl(
+  ingressPublicBaseUrl: string | undefined,
+  requestUrl: string,
+): string {
+  const parsedUrl = new URL(requestUrl);
+  if (ingressPublicBaseUrl) {
+    return ingressPublicBaseUrl.replace(/\/$/, '') + parsedUrl.pathname + parsedUrl.search;
+  }
+  return requestUrl;
+}
+
+/**
+ * Reproduce Twilio's HMAC-SHA1 signature algorithm (same as
+ * gateway/src/twilio/verify.ts).
+ */
+function computeTwilioSignature(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+  return createHmac('sha1', authToken).update(data).digest('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Ingress URL consistency between assistant and gateway', () => {
+  let savedIngressEnv: string | undefined;
+
+  beforeEach(() => {
+    savedIngressEnv = process.env.INGRESS_PUBLIC_BASE_URL;
+    delete process.env.INGRESS_PUBLIC_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedIngressEnv !== undefined) {
+      process.env.INGRESS_PUBLIC_BASE_URL = savedIngressEnv;
+    } else {
+      delete process.env.INGRESS_PUBLIC_BASE_URL;
+    }
+  });
+
+  test('assistant callback URL and gateway signature reconstruction use same base when config is set', () => {
+    const config: IngressConfig = {
+      ingress: { publicBaseUrl: 'https://my-tunnel.ngrok.io' },
+    };
+
+    // What the assistant would generate as the Twilio voice webhook callback
+    const assistantCallbackUrl = getTwilioVoiceWebhookUrl(config, 'session-abc');
+
+    // Simulate: when hatch.ts spawns the gateway, it reads config.ingress.publicBaseUrl
+    // and passes it as INGRESS_PUBLIC_BASE_URL. The gateway stores this as
+    // config.ingressPublicBaseUrl.
+    const gatewayIngressPublicBaseUrl = getPublicBaseUrl(config);
+
+    // When Twilio calls the gateway, the gateway reconstructs the canonical URL
+    // from the inbound request URL (which is localhost) + the configured base.
+    const inboundRequestUrl = 'http://127.0.0.1:7830/webhooks/twilio/voice?callSessionId=session-abc';
+    const gatewayCanonicalUrl = reconstructGatewayCanonicalUrl(
+      gatewayIngressPublicBaseUrl,
+      inboundRequestUrl,
+    );
+
+    // Both must resolve to the same URL for Twilio signatures to validate
+    expect(gatewayCanonicalUrl).toBe(assistantCallbackUrl);
+  });
+
+  test('Twilio signature computed against assistant URL validates at gateway', () => {
+    const publicBase = 'https://my-tunnel.ngrok.io';
+    const authToken = 'test-twilio-auth-token-12345';
+    const config: IngressConfig = {
+      ingress: { publicBaseUrl: publicBase },
+    };
+
+    // Assistant generates the callback URL and registers it with Twilio
+    const callbackUrl = getTwilioStatusCallbackUrl(config);
+    expect(callbackUrl).toBe('https://my-tunnel.ngrok.io/webhooks/twilio/status');
+
+    // Twilio signs the request using the callback URL
+    const params = { CallSid: 'CA123', CallStatus: 'completed' };
+    const twilioSignature = computeTwilioSignature(callbackUrl, params, authToken);
+
+    // Gateway receives the request on its local address
+    const localRequestUrl = 'http://127.0.0.1:7830/webhooks/twilio/status';
+
+    // Gateway reconstructs the canonical URL using its configured base
+    // (which was passed from the assistant's config via INGRESS_PUBLIC_BASE_URL)
+    const gatewayIngressPublicBaseUrl = getPublicBaseUrl(config);
+    const canonicalUrl = reconstructGatewayCanonicalUrl(
+      gatewayIngressPublicBaseUrl,
+      localRequestUrl,
+    );
+
+    // Verify the signature matches
+    const recomputedSignature = computeTwilioSignature(canonicalUrl, params, authToken);
+    expect(recomputedSignature).toBe(twilioSignature);
+  });
+
+  test('mismatch scenario: gateway without config creates signature validation failure', () => {
+    const authToken = 'test-twilio-auth-token-12345';
+
+    // Assistant uses config-based URL
+    const assistantConfig: IngressConfig = {
+      ingress: { publicBaseUrl: 'https://my-tunnel.ngrok.io' },
+    };
+    const callbackUrl = getTwilioStatusCallbackUrl(assistantConfig);
+
+    // Twilio signs against the callback URL the assistant registered
+    const params = { CallSid: 'CA123', CallStatus: 'completed' };
+    const twilioSignature = computeTwilioSignature(callbackUrl, params, authToken);
+
+    // Gateway does NOT have the ingress URL configured (simulating the bug)
+    const localRequestUrl = 'http://127.0.0.1:7830/webhooks/twilio/status';
+    const canonicalUrlWithout = reconstructGatewayCanonicalUrl(undefined, localRequestUrl);
+
+    // Signature should NOT match — this proves the mismatch bug
+    const recomputedWithout = computeTwilioSignature(canonicalUrlWithout, params, authToken);
+    expect(recomputedWithout).not.toBe(twilioSignature);
+
+    // Now simulate the fix: gateway has the same ingress URL
+    const canonicalUrlWith = reconstructGatewayCanonicalUrl(
+      'https://my-tunnel.ngrok.io',
+      localRequestUrl,
+    );
+    const recomputedWith = computeTwilioSignature(canonicalUrlWith, params, authToken);
+    expect(recomputedWith).toBe(twilioSignature);
+  });
+
+  test('env var fallback produces consistent URLs across assistant and gateway', () => {
+    // When no config.ingress.publicBaseUrl is set, both assistant and gateway
+    // fall back to the INGRESS_PUBLIC_BASE_URL env var.
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://env-tunnel.example.com';
+
+    const config: IngressConfig = {};
+
+    // Assistant resolves the base URL from env
+    const assistantBase = getPublicBaseUrl(config);
+    expect(assistantBase).toBe('https://env-tunnel.example.com');
+
+    // Gateway would also read the same env var (process.env.INGRESS_PUBLIC_BASE_URL)
+    // and store it as config.ingressPublicBaseUrl.
+    const gatewayIngressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL;
+
+    // Callback URL generated by assistant
+    const callbackUrl = getTwilioVoiceWebhookUrl(config, 'session-xyz');
+
+    // Gateway canonical URL reconstruction
+    const localUrl = 'http://127.0.0.1:7830/webhooks/twilio/voice?callSessionId=session-xyz';
+    const gatewayCanonical = reconstructGatewayCanonicalUrl(
+      gatewayIngressPublicBaseUrl,
+      localUrl,
+    );
+
+    expect(gatewayCanonical).toBe(callbackUrl);
+  });
+
+  test('trailing slashes are normalized consistently', () => {
+    const config: IngressConfig = {
+      ingress: { publicBaseUrl: 'https://my-tunnel.ngrok.io///' },
+    };
+
+    const assistantBase = getPublicBaseUrl(config);
+    expect(assistantBase).toBe('https://my-tunnel.ngrok.io');
+
+    const callbackUrl = getTwilioVoiceWebhookUrl(config, 'session-1');
+
+    // Gateway would receive the normalized value (hatch.ts trims trailing slashes)
+    const gatewayBase = 'https://my-tunnel.ngrok.io';
+    const localUrl = 'http://127.0.0.1:7830/webhooks/twilio/voice?callSessionId=session-1';
+    const gatewayCanonical = reconstructGatewayCanonicalUrl(gatewayBase, localUrl);
+
+    expect(gatewayCanonical).toBe(callbackUrl);
+  });
+});

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -421,7 +421,11 @@ export function handleIngressConfig(
       const value = (msg.publicBaseUrl ?? '').trim().replace(/\/+$/, '');
       const raw = loadRawConfig();
 
-      // Update ingress.publicBaseUrl
+      // Update ingress.publicBaseUrl — this is the single source of truth for
+      // the canonical public ingress URL. The gateway receives this value via
+      // the INGRESS_PUBLIC_BASE_URL env var at spawn time (see hatch.ts).
+      // A gateway restart is required for the new value to take effect in
+      // inbound Twilio signature validation.
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       ingress.publicBaseUrl = value || undefined;
 
@@ -437,6 +441,19 @@ export function handleIngressConfig(
       if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
       const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
       ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+
+      // Propagate to the gateway's process environment so it picks up the
+      // new URL on its next config load. For the local-deployment path the
+      // gateway runs as a child process that inherited the assistant's env,
+      // so updating process.env here ensures the value is visible when the
+      // gateway is restarted (e.g. by the self-upgrade skill or a manual
+      // `pkill -f gateway`).
+      if (value) {
+        process.env.INGRESS_PUBLIC_BASE_URL = value;
+      } else {
+        delete process.env.INGRESS_PUBLIC_BASE_URL;
+      }
+
       ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, localGatewayTarget, success: true });
     } else {
       ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -1,8 +1,27 @@
 /**
  * Centralized URL builders for all public-facing ingress endpoints.
  *
- * Resolves the canonical public base URL via:
- *   ingress.publicBaseUrl → env INGRESS_PUBLIC_BASE_URL
+ * ## Source-of-truth precedence
+ *
+ * The canonical public base URL is resolved through a two-level chain:
+ *
+ *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via the
+ *      Settings UI or `config set ingress.publicBaseUrl`. This is the
+ *      primary source of truth. When the assistant spawns or restarts
+ *      the gateway, this value is forwarded as the `INGRESS_PUBLIC_BASE_URL`
+ *      environment variable so both processes agree on the same URL.
+ *
+ *   2. **Environment variable** (`INGRESS_PUBLIC_BASE_URL`) — serves as a
+ *      fallback for operational use (e.g. direct gateway-only deployments
+ *      without the assistant, or CI overrides). When the assistant is
+ *      managing the gateway, the env var is set automatically from (1).
+ *
+ * This chain ensures that:
+ *   - The assistant's outbound callback URLs (Twilio webhooks, OAuth
+ *     redirect URIs, etc.) match the gateway's inbound signature
+ *     reconstruction URL.
+ *   - Changing the URL in Settings propagates to the gateway on restart,
+ *     eliminating Twilio signature mismatch risk.
  *
  * All public-facing ingress URL construction is centralized here.
  */
@@ -19,9 +38,8 @@ function normalizeUrl(url: string): string {
 }
 
 /**
- * Resolve the canonical public base URL:
- *   1. ingress.publicBaseUrl (preferred, workspace config)
- *   2. INGRESS_PUBLIC_BASE_URL env var
+ * Resolve the canonical public base URL using the precedence chain
+ * documented at the top of this module.
  *
  * Throws if no source provides a non-empty value.
  */

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -763,6 +763,28 @@ async function hatchCustom(
   }
 }
 
+/**
+ * Read `ingress.publicBaseUrl` from the assistant's workspace config file
+ * (~/.vellum/workspace/config.json). Returns undefined if the file doesn't
+ * exist or the value isn't set. This is intentionally a best-effort read
+ * — the CLI should not fail if the config file is absent.
+ */
+function readIngressPublicBaseUrl(): string | undefined {
+  try {
+    const baseDataDir = process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir());
+    const configPath = join(baseDataDir, ".vellum", "workspace", "config.json");
+    if (!existsSync(configPath)) return undefined;
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const value = raw?.ingress?.publicBaseUrl;
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().replace(/\/+$/, "");
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveGatewayDir(): string {
   const sourceDir = join(import.meta.dir, "..", "..", "..", "gateway");
   if (existsSync(sourceDir)) {
@@ -995,6 +1017,13 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
       GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
     };
     if (publicUrl) gatewayEnv.GATEWAY_PUBLIC_URL = publicUrl;
+
+    // Forward ingress.publicBaseUrl from the assistant's workspace config to
+    // the gateway so Twilio signature validation reconstructs the same
+    // canonical URL the assistant uses for outbound callback generation.
+    const ingressUrl = readIngressPublicBaseUrl();
+    if (ingressUrl) gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressUrl;
+
     const gateway = spawn("bun", ["run", "src/index.ts"], {
       cwd: gatewayDir,
       detached: true,

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -209,6 +209,10 @@ export function loadConfig(): GatewayConfig {
   const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || undefined;
   const publicUrl = process.env.GATEWAY_PUBLIC_URL || undefined;
 
+  // In the default local deployment, the assistant's hatch process sets this
+  // env var from config.ingress.publicBaseUrl when spawning the gateway.
+  // This ensures the gateway reconstructs the same canonical URL that the
+  // assistant used to register Twilio webhooks, preventing signature mismatch.
   const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
 
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;


### PR DESCRIPTION
Part of #6000. Ensures gateway receives the same ingress public base URL that the assistant uses for callback generation, eliminating signature mismatch risk. Closes #6001.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
