### PR TITLE
M2: Lock down /deliver/telegram boundary

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -15,10 +15,16 @@ export interface ChannelReplyPayload {
 export async function deliverChannelReply(
   callbackUrl: string,
   payload: ChannelReplyPayload,
+  bearerToken?: string,
 ): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (bearerToken) {
+    headers['Authorization'] = `Bearer ${bearerToken}`;
+  }
+
   const response = await fetch(callbackUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
   });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -684,7 +684,7 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        return await handleChannelInbound(req, this.processMessage);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {
@@ -909,7 +909,7 @@ export class RuntimeHttpServer {
             chatId: externalChatId,
             text: rendered.text || undefined,
             attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
-          });
+          }, this.bearerToken);
         }
         break;
       }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -42,6 +42,7 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
 export async function handleChannelInbound(
   req: Request,
   processMessage?: MessageProcessor,
+  bearerToken?: string,
 ): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
@@ -229,6 +230,7 @@ export async function handleChannelInbound(
       metadataHints,
       metadataUxBrief,
       replyCallbackUrl,
+      bearerToken,
     });
   }
 
@@ -250,6 +252,7 @@ interface BackgroundProcessingParams {
   metadataHints: string[];
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
+  bearerToken?: string;
 }
 
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
@@ -264,6 +267,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     metadataHints,
     metadataUxBrief,
     replyCallbackUrl,
+    bearerToken,
   } = params;
 
   (async () => {
@@ -285,7 +289,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
       channelDeliveryStore.markProcessed(eventId);
 
       if (replyCallbackUrl) {
-        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl);
+        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
       }
     } catch (err) {
       log.error({ err, conversationId }, 'Background channel message processing failed');
@@ -298,6 +302,7 @@ async function deliverReplyViaCallback(
   conversationId: string,
   externalChatId: string,
   callbackUrl: string,
+  bearerToken?: string,
 ): Promise<void> {
   const msgs = conversationStore.getMessages(conversationId);
   for (let i = msgs.length - 1; i >= 0; i--) {
@@ -320,7 +325,7 @@ async function deliverReplyViaCallback(
           chatId: externalChatId,
           text: rendered.text || undefined,
           attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
-        });
+        }, bearerToken);
       }
       break;
     }

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { createTelegramDeliverHandler } from "../http/routes/telegram-deliver.js";
+import type { GatewayConfig } from "../config.js";
+
+const TOKEN = "test-deliver-token";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-sec",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeProxyBearerToken: TOKEN,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    ingressPublicBaseUrl: undefined,
+    publicUrl: undefined,
+    ...overrides,
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockTelegramApi() {
+  globalThis.fetch = mock(async () => {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as any;
+}
+
+describe("/deliver/telegram bearer auth enforcement", () => {
+  test("rejects request without Authorization header with 401", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatId: "123", text: "hello" }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("rejects request with wrong bearer token with 401", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer wrong-token",
+      },
+      body: JSON.stringify({ chatId: "123", text: "hello" }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("rejects request with empty bearer token with 401", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer ",
+      },
+      body: JSON.stringify({ chatId: "123", text: "hello" }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(401);
+  });
+
+  test("accepts request with correct bearer token", async () => {
+    mockTelegramApi();
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({ chatId: "123", text: "hello" }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("allows unauthenticated access when no token is configured", async () => {
+    mockTelegramApi();
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatId: "123", text: "hello" }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("still rejects non-POST methods before auth check", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "GET",
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(405);
+  });
+
+  test("still validates request body after successful auth", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({}),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("chatId is required");
+  });
+});

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../../config.js";
+import { validateBearerToken } from "../auth/bearer.js";
 import { getLogger } from "../../logger.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
 import { sendTelegramAttachments, sendTelegramReply } from "../../telegram/send.js";
@@ -9,6 +10,18 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     if (req.method !== "POST") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    // Require bearer auth when a token is configured, preventing unauthenticated
+    // public access to the delivery endpoint.
+    if (config.runtimeProxyBearerToken) {
+      const authResult = validateBearerToken(
+        req.headers.get("authorization"),
+        config.runtimeProxyBearerToken,
+      );
+      if (!authResult.authorized) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
     }
 
     let body: {


### PR DESCRIPTION
Part of #6000. Adds bearer token authentication to the /deliver/telegram gateway endpoint, preventing unauthenticated public access while preserving the internal delivery flow. Closes #6002.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
