### PR TITLE
M5: Stabilize port-flaky tests

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -156,13 +156,13 @@ describe('gateway-only ingress enforcement', () => {
 
   beforeEach(async () => {
     logMessages.length = 0;
-    port = 17800 + Math.floor(Math.random() * 1000);
     server = new RuntimeHttpServer({
-      port,
+      port: 0,
       hostname: '127.0.0.1',
       bearerToken: TEST_TOKEN,
     });
     await server.start();
+    port = server.actualPort;
   });
 
   afterEach(async () => {
@@ -488,7 +488,7 @@ describe('gateway-only ingress enforcement', () => {
       logMessages.length = 0;
 
       const warnServer = new RuntimeHttpServer({
-        port: port + 100,
+        port: 0,
         hostname: '0.0.0.0',
         bearerToken: TEST_TOKEN,
       });
@@ -515,7 +515,7 @@ describe('gateway-only ingress enforcement', () => {
       // The main test server already uses 127.0.0.1, so restart with
       // a fresh server and capture logs
       const loopbackServer = new RuntimeHttpServer({
-        port: port + 200,
+        port: 0,
         hostname: '127.0.0.1',
         bearerToken: TEST_TOKEN,
       });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -205,9 +205,9 @@ describe('twilio webhook routes', () => {
   });
 
   async function startServer(): Promise<void> {
-    port = 20000 + Math.floor(Math.random() * 1000);
-    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
+    server = new RuntimeHttpServer({ port: 0, bearerToken: TEST_TOKEN });
     await server.start();
+    port = server.actualPort;
   }
 
   async function stopServer(): Promise<void> {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -345,6 +345,11 @@ export class RuntimeHttpServer {
     this.interfacesDir = options.interfacesDir ?? null;
   }
 
+  /** The port the server is actually listening on (resolved after start). */
+  get actualPort(): number {
+    return this.server?.port ?? this.port;
+  }
+
   async start(): Promise<void> {
     this.server = Bun.serve<RelayWebSocketData>({
       port: this.port,


### PR DESCRIPTION
Part of #6000. Replaces hardcoded and random-range port allocation with ephemeral port 0 allocation across all ingress-related test files, eliminating EADDRINUSE flakiness. Closes #6005.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
