### PR TITLE
Fix: Remove .env scan from legacy symbol guard (PR #6006 feedback)

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -34,7 +34,7 @@ describe('forbidden legacy symbols', () => {
         'grep -rn -E "TWILIO_WEBHOOK_BASE_URL|twilioWebhookBaseUrl|twilio_webhook_config|calls\\.webhookBaseUrl"' +
         ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift"' +
         ' --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
-        ' --include="*.sh" --include="*.env" --include="*.env.*"' +
+        ' --include="*.sh"' +
         ' --exclude-dir=node_modules --exclude-dir=__tests__ --exclude-dir=.private' +
         ' .',
         { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },


### PR DESCRIPTION
Addresses Codex feedback on #6006. Removes .env file patterns from the guard test grep to prevent nondeterministic failures on local .env files that are gitignored.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
