### PR TITLE
Fix: Preserve env fallback on config clear (PR #6008 feedback)

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -450,9 +450,9 @@ export function handleIngressConfig(
       // `pkill -f gateway`).
       if (value) {
         process.env.INGRESS_PUBLIC_BASE_URL = value;
-      } else {
-        delete process.env.INGRESS_PUBLIC_BASE_URL;
       }
+      // When cleared, do NOT delete the env var — the original env-provided
+      // value (if any) serves as a fallback per the documented precedence model.
 
       ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, localGatewayTarget, success: true });
     } else {


### PR DESCRIPTION
Addresses Codex feedback on #6008. When the user clears ingress.publicBaseUrl in Settings, the original INGRESS_PUBLIC_BASE_URL env var is now preserved as a fallback instead of being deleted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
