### PR TITLE
Fix: Encode deliver invariant in schema (PR #6007 feedback)

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -684,6 +684,8 @@ export function buildSchema(): Record<string, unknown> {
         TelegramDeliverRequest: {
           type: "object",
           required: ["chatId"],
+          description:
+            "Request to deliver a message to a Telegram chat. At least one of `text` or `attachments` must be provided.",
           properties: {
             chatId: { type: "string", description: "Telegram chat ID to deliver the message to" },
             text: { type: "string", description: "Text content to send" },
@@ -694,6 +696,10 @@ export function buildSchema(): Record<string, unknown> {
               items: { $ref: "#/components/schemas/RuntimeAttachmentMeta" },
             },
           },
+          anyOf: [
+            { required: ["text"] },
+            { required: ["attachments"] },
+          ],
         },
         RuntimeAttachmentMeta: {
           type: "object",


### PR DESCRIPTION
Addresses Codex feedback on #6007. Updates the TelegramDeliverRequest OpenAPI schema to express that either text or attachments must be provided.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
