### PR TITLE
feat: add HTTP transport for remote assistant communication

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -196,9 +196,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Skip if already connected or if a connection attempt is in progress
         // (setupDaemonClient already started connecting — don't interfere).
         guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
+
+        let isRemoteTransport: Bool
+        if case .http = daemonClient.config.transport {
+            isRemoteTransport = true
+        } else {
+            isRemoteTransport = false
+        }
+
         Task {
-            try? await assistantCli.hatch(daemonOnly: true)
-            assistantCli.startMonitoring()
+            if !isRemoteTransport {
+                try? await assistantCli.hatch(daemonOnly: true)
+                assistantCli.startMonitoring()
+            }
             // Only connect if setupDaemonClient's connect hasn't already started
             guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
             try? await daemonClient.connect()
@@ -415,7 +425,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Reads `connectedAssistantId` from UserDefaults, looks it up in the lockfile
     /// (falling back to the latest entry), and writes its config so the daemon connects
     /// to the correct assistant.
-    private func loadAssistantFromLockfile() {
+    ///
+    /// Returns the loaded assistant for transport selection, or nil if none found.
+    @discardableResult
+    private func loadAssistantFromLockfile() -> LockfileAssistant? {
         let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         let assistant: LockfileAssistant?
 
@@ -425,17 +438,42 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             assistant = LockfileAssistant.loadLatest()
         }
 
-        guard let assistant else { return }
+        guard let assistant else { return nil }
 
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
         assistant.writeToWorkspaceConfig()
+        return assistant
+    }
+
+    /// Configure the daemon client's transport based on the lockfile assistant.
+    /// For remote assistants (cloud != "local"), uses HTTP+SSE transport via the gateway URL.
+    /// For local assistants, uses the default Unix domain socket.
+    private func configureDaemonTransport(for assistant: LockfileAssistant?) {
+        guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
+            // Local assistant or no assistant — use default socket transport
+            return
+        }
+
+        let config = DaemonConfig(transport: .http(
+            baseURL: runtimeUrl,
+            bearerToken: assistant.bearerToken,
+            conversationKey: assistant.assistantId
+        ))
+
+        // Replace the daemon client's config. Since DaemonClient.config is let,
+        // we need to create a new DaemonClient with the HTTP config.
+        // The services property is mutable for this purpose.
+        services.reconfigureDaemonClient(config: config)
+
+        log.info("Configured HTTP transport for remote assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
     }
 
     func setupDaemonClient() {
         guard !hasSetupDaemon else { return }
         hasSetupDaemon = true
 
-        loadAssistantFromLockfile()
+        let assistant = loadAssistantFromLockfile()
+        configureDaemonTransport(for: assistant)
 
         // Show macOS notification when a reminder fires
         daemonClient.onReminderFired = { msg in
@@ -568,11 +606,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // For remote assistants (HTTP transport), skip local daemon hatching
+        // and connect directly via the gateway URL.
+        let isRemoteTransport: Bool
+        if case .http = daemonClient.config.transport {
+            isRemoteTransport = true
+        } else {
+            isRemoteTransport = false
+        }
+
         Task {
-            // Hatch the assistant via CLI (spawns daemon in release builds).
-            // daemonOnly: true prevents creating a new lockfile entry on every launch.
-            try? await assistantCli.hatch(daemonOnly: true)
-            assistantCli.startMonitoring()
+            if !isRemoteTransport {
+                // Hatch the assistant via CLI (spawns daemon in release builds).
+                // daemonOnly: true prevents creating a new lockfile entry on every launch.
+                try? await assistantCli.hatch(daemonOnly: true)
+                assistantCli.startMonitoring()
+            }
             try? await daemonClient.connect()
             // Once connected, start ambient agent if it was waiting for daemon
             if daemonClient.isConnected {

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 /// that were previously declared directly on `AppDelegate`.
 @MainActor
 public final class AppServices {
-    public let daemonClient = DaemonClient()
+    public private(set) var daemonClient: DaemonClient
     public let ambientAgent = AmbientAgent()
     let surfaceManager = SurfaceManager()
     let browserPiPManager = BrowserPiPManager()
@@ -22,4 +22,15 @@ public final class AppServices {
     public lazy var activityNotificationService: ActivityNotificationService = ActivityNotificationService(
         settingsStore: settingsStore
     )
+
+    init() {
+        self.daemonClient = DaemonClient()
+    }
+
+    /// Reconfigure the daemon client with a new config (e.g., for HTTP transport).
+    /// This replaces the daemon client instance. Must be called before any callbacks
+    /// are wired or connections are established.
+    func reconfigureDaemonClient(config: DaemonConfig) {
+        daemonClient = DaemonClient(config: config)
+    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -206,12 +206,18 @@ struct AssistantMetadata {
 struct LockfileAssistant {
     let assistantId: String
     let runtimeUrl: String?
+    let bearerToken: String?
     let cloud: String
     let project: String?
     let region: String?
     let zone: String?
     let instanceId: String?
     let hatchedAt: String?
+
+    /// Whether this assistant is running remotely (not on the local machine).
+    var isRemote: Bool {
+        cloud.lowercased() != "local"
+    }
 
     var home: AssistantHome {
         switch cloud.lowercased() {
@@ -272,6 +278,7 @@ struct LockfileAssistant {
                 return LockfileAssistant(
                     assistantId: assistantId,
                     runtimeUrl: entry["runtimeUrl"] as? String,
+                    bearerToken: entry["bearerToken"] as? String,
                     cloud: entry["cloud"] as? String ?? "local",
                     project: entry["project"] as? String,
                     region: entry["region"] as? String,

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -399,10 +399,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Internal (not private) for testability via @testable import.
     var pendingProbeId: String?
 
+    /// HTTP transport used when connecting to a remote assistant via gateway.
+    /// Non-nil when `config.transport` is `.http`.
+    #if os(macOS)
+    var httpTransport: HTTPTransport?
+    #endif
+
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()
 
-    let config: DaemonConfig
+    public let config: DaemonConfig
 
     // MARK: - Init
 
@@ -429,6 +435,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         blobProbeTask?.cancel()
         pathMonitor?.cancel()
         connection?.cancel()
+        // httpTransport is cleaned up via disconnectInternal() before dealloc;
     }
 
     // MARK: - Socket Path
@@ -487,6 +494,17 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             try override(message)
             return
         }
+
+        #if os(macOS)
+        // Route through HTTP transport when active (remote assistants).
+        if let httpTransport {
+            guard httpTransport.isConnected else {
+                throw SendError.notConnected
+            }
+            try httpTransport.send(message)
+            return
+        }
+        #endif
 
         guard let conn = connection else {
             log.warning("Cannot send: not connected")

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -2,15 +2,39 @@ import Foundation
 
 public struct DaemonConfig {
     #if os(macOS)
-    public let socketPath: String
+    /// Transport mode for communicating with the assistant daemon.
+    public enum Transport {
+        /// Local Unix domain socket (default for local assistants).
+        case socket(path: String)
+        /// HTTP + SSE via a remote gateway URL (for cloud/custom assistants).
+        case http(baseURL: String, bearerToken: String?, conversationKey: String)
+    }
 
+    public let transport: Transport
+
+    /// Socket path, for backwards compatibility.
+    /// Returns the socket path if using socket transport, otherwise the default path.
+    public var socketPath: String {
+        switch transport {
+        case .socket(let path):
+            return path
+        case .http:
+            return resolveSocketPath()
+        }
+    }
+
+    public init(transport: Transport) {
+        self.transport = transport
+    }
+
+    /// Convenience initializer for socket transport (backwards compatible).
     public init(socketPath: String) {
-        self.socketPath = socketPath
+        self.transport = .socket(path: socketPath)
     }
 
     public static var `default`: DaemonConfig {
         // Delegate to resolveSocketPath() to avoid duplication
-        return DaemonConfig(socketPath: resolveSocketPath())
+        return DaemonConfig(transport: .socket(path: resolveSocketPath()))
     }
     #elseif os(iOS)
     public let hostname: String

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -15,7 +15,8 @@ extension DaemonClient {
     static let authTimeout: TimeInterval = 5.0
 
     /// Connect to the daemon. If already connected, disconnects first.
-    /// - macOS: Connects to Unix domain socket at `~/.vellum/vellum.sock`
+    /// - macOS (socket): Connects to Unix domain socket at `~/.vellum/vellum.sock`
+    /// - macOS (http): Connects to remote assistant via HTTP REST + SSE
     /// - iOS: Connects to TCP endpoint (hostname from UserDefaults or localhost:8765)
     public func connect() async throws {
         // Disconnect any existing connection without triggering reconnect.
@@ -25,6 +26,12 @@ extension DaemonClient {
         shouldReconnect = true
 
         #if os(macOS)
+        // Check if we should use HTTP transport for a remote assistant.
+        if case .http(let baseURL, let bearerToken, let conversationKey) = config.transport {
+            try await connectHTTP(baseURL: baseURL, bearerToken: bearerToken, conversationKey: conversationKey)
+            return
+        }
+
         log.info("Connecting to daemon socket at \(self.config.socketPath, privacy: .public)")
         let endpoint = NWEndpoint.unix(path: self.config.socketPath)
         let parameters = NWParameters()
@@ -257,6 +264,49 @@ extension DaemonClient {
     }
     #endif
 
+    // MARK: - HTTP Transport (macOS only)
+
+    #if os(macOS)
+    /// Connect to a remote assistant via HTTP REST + SSE.
+    /// Used when `config.transport` is `.http`.
+    func connectHTTP(baseURL: String, bearerToken: String?, conversationKey: String) async throws {
+        let transport = HTTPTransport(
+            baseURL: baseURL,
+            bearerToken: bearerToken,
+            conversationKey: conversationKey
+        )
+
+        // Wire incoming SSE messages through the existing handleServerMessage infrastructure.
+        transport.onMessage = { [weak self] message in
+            self?.handleServerMessage(message)
+        }
+
+        // Bridge HTTP transport connection state to DaemonClient's @Published isConnected.
+        transport.onConnectionStateChanged = { [weak self] connected in
+            guard let self else { return }
+            self.isConnected = connected
+            self.isConnecting = false
+            if connected {
+                NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
+            }
+        }
+
+        self.httpTransport = transport
+
+        do {
+            try await transport.connect()
+            // isConnected is set by the onConnectionStateChanged callback
+            // when the SSE stream establishes.
+            isAuthenticated = true  // HTTP transport uses bearer token, no IPC auth needed
+            isConnecting = false
+        } catch {
+            isConnecting = false
+            httpTransport = nil
+            throw error
+        }
+    }
+    #endif
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -287,6 +337,11 @@ extension DaemonClient {
         pendingProbeId = nil
         isBlobTransportAvailable = false
         isAuthenticated = false
+
+        #if os(macOS)
+        httpTransport?.disconnect()
+        httpTransport = nil
+        #endif
 
         if let conn = connection {
             conn.stateUpdateHandler = nil

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1,0 +1,437 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - AssistantEvent Envelope
+
+/// Envelope around `ServerMessage` for SSE events from the runtime HTTP server.
+struct AssistantEvent: Decodable {
+    let id: String
+    let assistantId: String
+    let sessionId: String?
+    let emittedAt: String
+    let message: ServerMessage
+}
+
+// MARK: - HTTP Transport
+
+/// Internal helper that handles HTTP REST + SSE communication with a remote
+/// Vellum assistant runtime. Used by `DaemonClient` when configured with
+/// `.http` transport via `DaemonConfig`.
+///
+/// Responsibilities:
+/// - SSE stream connection to `GET /v1/events?conversationKey=...`
+/// - Translating IPC message types to HTTP API calls
+/// - Health check via `GET /healthz`
+/// - Auto-reconnect with exponential backoff
+@MainActor
+final class HTTPTransport {
+
+    let baseURL: String
+    let bearerToken: String?
+    private let conversationKey: String
+
+    /// Currently active SSE task.
+    private var sseTask: Task<Void, Never>?
+
+    /// Currently active run ID, tracked for decision/secret endpoints.
+    private(set) var activeRunId: String?
+
+    /// Whether the SSE stream is connected.
+    private(set) var isConnected: Bool = false
+
+    /// Whether we should attempt to reconnect on disconnect.
+    private var shouldReconnect = true
+
+    /// Current reconnect backoff delay in seconds.
+    private var reconnectDelay: TimeInterval = 1.0
+
+    /// Maximum reconnect backoff delay.
+    private let maxReconnectDelay: TimeInterval = 30.0
+
+    /// Reconnect task handle.
+    private var reconnectTask: Task<Void, Never>?
+
+    /// Callback for incoming server messages (called on main actor).
+    var onMessage: ((ServerMessage) -> Void)?
+
+    /// Callback for connection state changes.
+    var onConnectionStateChanged: ((Bool) -> Void)?
+
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    // MARK: - Init
+
+    init(baseURL: String, bearerToken: String?, conversationKey: String) {
+        // Strip trailing slash for clean URL construction
+        self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+        self.bearerToken = bearerToken
+        self.conversationKey = conversationKey
+    }
+
+    // MARK: - Connect
+
+    /// Verify reachability via health check, then open SSE stream.
+    func connect() async throws {
+        shouldReconnect = true
+
+        // 1. Health check
+        let healthURL = URL(string: "\(baseURL)/healthz")!
+        var healthReq = URLRequest(url: healthURL)
+        healthReq.timeoutInterval = 10
+        applyAuth(&healthReq)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: healthReq)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                throw HTTPTransportError.healthCheckFailed
+            }
+            log.info("Health check passed for \(self.baseURL, privacy: .public)")
+        } catch let error as HTTPTransportError {
+            throw error
+        } catch {
+            log.error("Health check failed: \(error.localizedDescription)")
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        // 2. Open SSE stream
+        startSSEStream()
+    }
+
+    // MARK: - SSE Stream
+
+    private func startSSEStream() {
+        sseTask?.cancel()
+
+        let urlString = "\(baseURL)/v1/events?conversationKey=\(conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey)"
+        guard let url = URL(string: urlString) else {
+            log.error("Invalid SSE URL: \(urlString)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = .infinity
+        applyAuth(&request)
+
+        sseTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                    log.error("SSE connection failed with status \(statusCode)")
+                    self.handleDisconnect()
+                    return
+                }
+
+                self.setConnected(true)
+                log.info("SSE stream connected to \(urlString, privacy: .public)")
+
+                var dataBuffer = ""
+
+                for try await line in bytes.lines {
+                    if Task.isCancelled { break }
+
+                    if line.hasPrefix("data: ") {
+                        dataBuffer += String(line.dropFirst(6))
+                    } else if line.isEmpty && !dataBuffer.isEmpty {
+                        // End of SSE event — parse accumulated data
+                        self.parseSSEData(dataBuffer)
+                        dataBuffer = ""
+                    }
+                    // Skip event:, id:, retry: lines — we only need data:
+                }
+            } catch {
+                if !Task.isCancelled {
+                    log.error("SSE stream error: \(error.localizedDescription)")
+                }
+            }
+
+            if !Task.isCancelled {
+                self.handleDisconnect()
+            }
+        }
+    }
+
+    private func parseSSEData(_ data: String) {
+        guard let jsonData = data.data(using: .utf8) else { return }
+
+        do {
+            let event = try decoder.decode(AssistantEvent.self, from: jsonData)
+            onMessage?(event.message)
+        } catch {
+            // Try decoding as a bare ServerMessage (some endpoints may send unwrapped)
+            do {
+                let message = try decoder.decode(ServerMessage.self, from: jsonData)
+                onMessage?(message)
+            } catch {
+                let byteCount = jsonData.count
+                log.error("Failed to decode SSE event: \(error.localizedDescription), bytes: \(byteCount)")
+            }
+        }
+    }
+
+    // MARK: - Send (HTTP API Calls)
+
+    /// Translate an IPC message to the appropriate HTTP API call.
+    func send<T: Encodable>(_ message: T) throws {
+        if let msg = message as? UserMessageMessage {
+            Task { await self.createRun(content: msg.content, sessionId: msg.sessionId) }
+        } else if let msg = message as? ConfirmationResponseMessage {
+            Task { await self.sendDecision(requestId: msg.requestId, decision: msg.decision) }
+        } else if let msg = message as? SecretResponseMessage {
+            Task { await self.sendSecret(requestId: msg.requestId, value: msg.value) }
+        } else if let msg = message as? CancelMessage {
+            // Best-effort cancel — no dedicated endpoint yet
+            log.info("Cancel requested for session \(msg.sessionId ?? "unknown") (no-op over HTTP)")
+        } else if let msg = message as? SessionCreateMessage {
+            // For HTTP transport, session creation is implicit — the conversationKey
+            // acts as the session. Emit a synthetic session_info so ChatViewModel
+            // records the session ID.
+            let sessionId = msg.correlationId ?? UUID().uuidString
+            let info = ServerMessage.sessionInfo(
+                SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
+            )
+            onMessage?(info)
+        } else if message is HistoryRequestMessage {
+            Task { await self.fetchHistory() }
+        } else if message is PingMessage {
+            // No-op for HTTP transport — SSE keepalive is handled by the connection
+        } else {
+            // For unhandled message types, log and skip
+            log.debug("HTTPTransport: unhandled send message type \(String(describing: type(of: message)))")
+        }
+    }
+
+    // MARK: - HTTP Endpoints
+
+    private func createRun(content: String?, sessionId: String) async {
+        guard let url = URL(string: "\(baseURL)/v1/runs") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = ["conversationKey": conversationKey]
+        if let content, !content.isEmpty {
+            body["content"] = content
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse else { return }
+
+            if http.statusCode == 201 || http.statusCode == 200 {
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let runId = json["id"] as? String {
+                    self.activeRunId = runId
+                    log.info("Run created: \(runId)")
+                }
+            } else {
+                let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+                log.error("Create run failed (\(http.statusCode)): \(errorBody)")
+                onMessage?(.sessionError(SessionErrorMessage(
+                    sessionId: sessionId,
+                    code: .providerApi,
+                    userMessage: "Failed to send message (HTTP \(http.statusCode))",
+                    retryable: true
+                )))
+            }
+        } catch {
+            log.error("Create run error: \(error.localizedDescription)")
+            onMessage?(.sessionError(SessionErrorMessage(
+                sessionId: sessionId,
+                code: .providerApi,
+                userMessage: error.localizedDescription,
+                retryable: true
+            )))
+        }
+    }
+
+    private func sendDecision(requestId: String, decision: String) async {
+        guard let runId = activeRunId else {
+            log.warning("No active run ID for decision response")
+            return
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/runs/\(runId)/decision") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["decision": decision]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                log.error("Decision response failed (\(http.statusCode))")
+            }
+        } catch {
+            log.error("Decision response error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendSecret(requestId: String, value: String?) async {
+        // Secrets can be delivered via the /v1/secrets endpoint for persistence,
+        // or via the run's decision flow. Use the secrets endpoint.
+        guard let url = URL(string: "\(baseURL)/v1/secrets") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        // The secret_request includes service/field info but we receive it via
+        // the SecretResponseMessage which only has requestId and value.
+        // For now, send as a credential with the requestId as name.
+        let body: [String: Any] = [
+            "type": "credential",
+            "name": requestId,
+            "value": value ?? ""
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse, http.statusCode != 201 {
+                log.error("Secret response failed (\(http.statusCode))")
+            }
+        } catch {
+            log.error("Secret response error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchHistory() async {
+        let urlString = "\(baseURL)/v1/messages?conversationKey=\(conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey)"
+        guard let url = URL(string: urlString) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                log.error("Fetch history failed")
+                return
+            }
+
+            // The /v1/messages endpoint returns { messages: [...] } which doesn't
+            // directly map to a HistoryResponseMessage. We need to construct one.
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let messages = json["messages"] as? [[String: Any]] {
+                // Convert REST messages to IPC history format
+                var historyMessages: [[String: Any]] = []
+                for msg in messages {
+                    historyMessages.append(msg)
+                }
+
+                // Emit as raw JSON that the history response decoder can handle
+                var historyPayload: [String: Any] = [
+                    "type": "history_response",
+                    "sessionId": conversationKey,
+                    "messages": historyMessages
+                ]
+                _ = historyPayload.removeValue(forKey: "")
+
+                if let historyData = try? JSONSerialization.data(withJSONObject: historyPayload),
+                   let historyResponse = try? decoder.decode(ServerMessage.self, from: historyData) {
+                    onMessage?(historyResponse)
+                }
+            }
+        } catch {
+            log.error("Fetch history error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Disconnect
+
+    func disconnect() {
+        shouldReconnect = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        sseTask?.cancel()
+        sseTask = nil
+        setConnected(false)
+        activeRunId = nil
+    }
+
+    // MARK: - Reconnect
+
+    private func handleDisconnect() {
+        setConnected(false)
+        guard shouldReconnect else { return }
+        scheduleReconnect()
+    }
+
+    private func scheduleReconnect() {
+        reconnectTask?.cancel()
+
+        let delay = reconnectDelay
+        log.info("HTTP transport: scheduling reconnect in \(delay)s")
+
+        reconnectTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                return
+            }
+
+            guard let self, self.shouldReconnect else { return }
+            self.reconnectDelay = min(self.reconnectDelay * 2, self.maxReconnectDelay)
+
+            do {
+                try await self.connect()
+            } catch {
+                log.error("HTTP reconnect failed: \(error.localizedDescription)")
+                if self.shouldReconnect {
+                    self.scheduleReconnect()
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func applyAuth(_ request: inout URLRequest) {
+        if let token = bearerToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    private func setConnected(_ connected: Bool) {
+        guard isConnected != connected else { return }
+        isConnected = connected
+        reconnectDelay = connected ? 1.0 : reconnectDelay
+        onConnectionStateChanged?(connected)
+    }
+
+    // MARK: - Errors
+
+    enum HTTPTransportError: Error, LocalizedError {
+        case healthCheckFailed
+        case invalidURL
+
+        var errorDescription: String? {
+            switch self {
+            case .healthCheckFailed:
+                return "Remote assistant health check failed"
+            case .invalidURL:
+                return "Invalid remote assistant URL"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When the lockfile indicates a remote assistant (`cloud != "local"`), the desktop app now connects via HTTP REST + SSE through the gateway URL instead of Unix domain socket IPC
- Adds `HTTPTransport` helper class integrated into `DaemonClient` to avoid breaking downstream consumers that depend on the concrete type
- Parses `bearerToken` from the lockfile and configures transport automatically in `AppDelegate`

## Test plan
- [ ] Verify local assistant still works identically (socket transport unchanged)
- [ ] Hatch a remote assistant (GCP/AWS), connect desktop app, verify SSE stream connects and receives real-time events
- [ ] Verify sending messages creates runs via HTTP
- [ ] Verify confirmation and secret prompt flows work via HTTP endpoints
- [ ] Verify message history loads on connect
- [ ] Kill and restart remote daemon, verify HTTP client reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
