### PR TITLE
Use source gateway by default in local workflows

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -4,12 +4,14 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
 
 ## Steps
 
-1. Kill any running Vellum and daemon processes:
+1. Kill app + daemon processes only (do **not** kill a manually run source gateway):
    ```bash
    pkill -x "Vellum" || true
    pkill -x "vellum-assistant" || true
    vellum daemon stop || true
    ```
+
+   If a source gateway is already running (for example `cd gateway && bun run dev:proxy`), leave it running.
 
 2. Switch to main and pull latest:
    ```bash
@@ -27,9 +29,15 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
    cd assistant && bun run src/index.ts daemon start && cd ..
    ```
 
-5. Build and launch the macOS app. Run this in the background since `build.sh run` enters a watch loop:
+5. Build and launch the macOS app from source. Pin gateway resolution to the repo `gateway/` directory so local gateway changes are used instead of a packaged fallback. Run this in the background since `build.sh run` enters a watch loop:
    ```bash
-   cd clients/macos && ./build.sh run &
+   REPO_ROOT="$(pwd)"
+   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-Report what was pulled (new commits) and confirm both the daemon and app are running.
+6. If no gateway is running yet and you need ingress/webhook testing, start gateway from source in a separate terminal:
+   ```bash
+   cd gateway && bun run dev:proxy
+   ```
+
+Report what was pulled (new commits), whether an existing source gateway was preserved or started, and confirm daemon + app are running.

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
+| `/update` | Pull latest from `main`, restart daemon/app, preserve any source-run gateway process, and launch app with `VELLUM_GATEWAY_DIR` pinned to local `gateway/`. |
 
 
 ### Review

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
+    "daemon:restart:http": "RUNTIME_HTTP_PORT=7821 bun run src/index.ts daemon restart",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "ipc:inventory": "bun run scripts/ipc/check-contract-inventory.ts",

--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -14,10 +14,10 @@ import { resolve } from 'node:path';
  * a split-brain ingress problem.
  *
  * Forbidden symbols:
- *   - TWILIO_WEBHOOK_BASE_URL  — legacy env var for direct Twilio webhook base
- *   - twilioWebhookBaseUrl     — camelCase variant used in runtime config
- *   - twilio_webhook_config    — legacy config object key
- *   - calls.webhookBaseUrl     — nested config path for call webhook URL
+ *   - legacy uppercase Twilio webhook base env var
+ *   - twilioWebhookBaseUrl
+ *   - twilio_webhook_config
+ *   - calls.webhookBaseUrl
  *
  * Excluded directories:
  *   - node_modules  — third-party code, not under our control
@@ -27,11 +27,22 @@ import { resolve } from 'node:path';
  */
 describe('forbidden legacy symbols', () => {
   test('no production code references removed Twilio ingress symbols', () => {
+    const legacyEnvVar = ['TWILIO', 'WEBHOOK', 'BASE', 'URL'].join('_');
+    const forbiddenSymbols = [
+      legacyEnvVar,
+      'twilioWebhookBaseUrl',
+      'twilio_webhook_config',
+      'calls.webhookBaseUrl',
+    ];
+    const escapedPattern = forbiddenSymbols
+      .map((symbol) => symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .join('|');
+
     const repoRoot = resolve(__dirname, '..', '..', '..');
     let matches = '';
     try {
       matches = execSync(
-        'grep -rn -E "TWILIO_WEBHOOK_BASE_URL|twilioWebhookBaseUrl|twilio_webhook_config|calls\\.webhookBaseUrl"' +
+        `grep -rn -E "${escapedPattern}"` +
         ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift"' +
         ' --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
         ' --include="*.sh" --include="*.env" --include="*.env.*"' +

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,7 +39,7 @@ vellum-cli hatch [species] [options]
 
 #### Remote Targets
 
-- **`local`** -- Starts a local daemon on your machine via `bunx vellum daemon start`.
+- **`local`** -- Starts the local daemon and local gateway. Gateway source resolution order is: `VELLUM_GATEWAY_DIR` override, repo source tree, then installed `@vellumai/vellum-gateway` package.
 - **`gcp`** -- Creates a GCP Compute Engine VM (`e2-standard-4`: 4 vCPUs, 16 GB) with a startup script that bootstraps the assistant. Requires `gcloud` authentication and `GCP_PROJECT` / `GCP_DEFAULT_ZONE` environment variables.
 - **`aws`** -- Provisions an AWS instance.
 - **`custom`** -- Provisions on an arbitrary SSH host. Set `VELLUM_CUSTOM_HOST` (e.g. `user@hostname`) to specify the target.
@@ -52,6 +52,8 @@ vellum-cli hatch [species] [options]
 | `GCP_PROJECT`         | `gcp`        | GCP project ID. Falls back to the active `gcloud` project. |
 | `GCP_DEFAULT_ZONE`    | `gcp`        | GCP zone for the compute instance. |
 | `VELLUM_CUSTOM_HOST`  | `custom`     | SSH host in `user@hostname` format. |
+| `VELLUM_GATEWAY_DIR`  | `local`      | Optional absolute path to a local gateway source directory to run instead of the packaged gateway. |
+| `INGRESS_PUBLIC_BASE_URL` | `local` | Optional fallback public ingress URL when `ingress.publicBaseUrl` is not set in workspace config. |
 
 #### Examples
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -763,32 +763,47 @@ async function hatchCustom(
   }
 }
 
-/**
- * Read `ingress.publicBaseUrl` from the assistant's workspace config file
- * (~/.vellum/workspace/config.json). Returns undefined if the file doesn't
- * exist or the value isn't set. This is intentionally a best-effort read
- * — the CLI should not fail if the config file is absent.
- */
-function readIngressPublicBaseUrl(): string | undefined {
-  try {
-    const baseDataDir = process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir());
-    const configPath = join(baseDataDir, ".vellum", "workspace", "config.json");
-    if (!existsSync(configPath)) return undefined;
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    const value = raw?.ingress?.publicBaseUrl;
-    if (typeof value === "string" && value.trim()) {
-      return value.trim().replace(/\/+$/, "");
+function isGatewaySourceDir(dir: string): boolean {
+  return existsSync(join(dir, "package.json")) && existsSync(join(dir, "src", "index.ts"));
+}
+
+function findGatewaySourceFromCwd(): string | undefined {
+  let current = process.cwd();
+  while (true) {
+    if (isGatewaySourceDir(current)) {
+      return current;
     }
-    return undefined;
-  } catch {
-    return undefined;
+    const nestedCandidate = join(current, "gateway");
+    if (isGatewaySourceDir(nestedCandidate)) {
+      return nestedCandidate;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
   }
 }
 
 function resolveGatewayDir(): string {
+  const override = process.env.VELLUM_GATEWAY_DIR?.trim();
+  if (override) {
+    if (!isGatewaySourceDir(override)) {
+      throw new Error(
+        `VELLUM_GATEWAY_DIR is set to "${override}", but it is not a valid gateway source directory.`,
+      );
+    }
+    return override;
+  }
+
   const sourceDir = join(import.meta.dir, "..", "..", "..", "gateway");
-  if (existsSync(sourceDir)) {
+  if (isGatewaySourceDir(sourceDir)) {
     return sourceDir;
+  }
+
+  const cwdSourceDir = findGatewaySourceFromCwd();
+  if (cwdSourceDir) {
+    return cwdSourceDir;
   }
 
   try {
@@ -796,8 +811,26 @@ function resolveGatewayDir(): string {
     return dirname(pkgPath);
   } catch {
     throw new Error(
-      "Gateway not found. Ensure @vellumai/vellum-gateway is installed or run from the source tree.",
+      "Gateway not found. Ensure @vellumai/vellum-gateway is installed, run from the source tree, or set VELLUM_GATEWAY_DIR.",
     );
+  }
+}
+
+function normalizeIngressUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+function readWorkspaceIngressPublicBaseUrl(): string | undefined {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir());
+  const workspaceConfigPath = join(baseDataDir, ".vellum", "workspace", "config.json");
+  try {
+    const raw = JSON.parse(readFileSync(workspaceConfigPath, "utf-8")) as Record<string, unknown>;
+    const ingress = raw.ingress as Record<string, unknown> | undefined;
+    return normalizeIngressUrl(ingress?.publicBaseUrl);
+  } catch {
+    return undefined;
   }
 }
 
@@ -1016,13 +1049,18 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
       GATEWAY_RUNTIME_PROXY_ENABLED: "true",
       GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
     };
+    const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
+    const ingressPublicBaseUrl =
+      workspaceIngressPublicBaseUrl
+      ?? normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL);
+    if (ingressPublicBaseUrl) {
+      gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressPublicBaseUrl;
+      console.log(`   Ingress URL: ${ingressPublicBaseUrl}`);
+      if (!workspaceIngressPublicBaseUrl) {
+        console.log("   (using INGRESS_PUBLIC_BASE_URL env fallback)");
+      }
+    }
     if (publicUrl) gatewayEnv.GATEWAY_PUBLIC_URL = publicUrl;
-
-    // Forward ingress.publicBaseUrl from the assistant's workspace config to
-    // the gateway so Twilio signature validation reconstructs the same
-    // canonical URL the assistant uses for outbound callback generation.
-    const ingressUrl = readIngressPublicBaseUrl();
-    if (ingressUrl) gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressUrl;
 
     const gateway = spawn("bun", ["run", "src/index.ts"], {
       cwd: gatewayDir,

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -105,9 +105,33 @@ The following legacy paths are aliases that map to their canonical equivalents a
 
 To receive external callbacks during local development, point a tunnel service at the local gateway (default `http://127.0.0.1:7830`) and configure the resulting public URL:
 
+#### Test Gateway Source Changes Locally (No Release Needed)
+
+Use this flow when you are changing files under `gateway/` and need to validate immediately without publishing `@vellumai/vellum-gateway`.
+
+```bash
+# Terminal 1: restart assistant runtime HTTP server
+cd assistant
+bun run daemon:restart:http
+
+# Terminal 2: run gateway from local source with runtime proxy enabled
+cd gateway
+bun run dev:proxy
+```
+
+If `7830` is already in use, start the gateway on another port:
+
+```bash
+cd gateway
+GATEWAY_PORT=7840 bun run dev:proxy
+```
+
+Then point your tunnel to that same local target (for example `http://127.0.0.1:7840`).
+
 1. Start your tunnel (e.g. ngrok, Cloudflare Tunnel, or similar) targeting `http://127.0.0.1:7830`
 2. Copy the public URL provided by the tunnel service (e.g. `https://abc123.ngrok-free.app`)
-3. Set the URL as `ingress.publicBaseUrl` in the Settings UI (Public Ingress section) **or** as the `INGRESS_PUBLIC_BASE_URL` environment variable
+3. Set the URL as `ingress.publicBaseUrl` in the Settings UI (Public Ingress section) **or** as the `INGRESS_PUBLIC_BASE_URL` environment variable.
+4. Use the Settings UI "Local Gateway Target" value as the source of truth for tunnel destination (it reflects `GATEWAY_PORT`).
 
 The assistant runtime uses this URL to construct all webhook and OAuth callback URLs automatically.
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",
+    "dev:proxy": "GATEWAY_RUNTIME_PROXY_ENABLED=true GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun",
     "schema": "bun run src/cli/schema.ts",
     "start": "bun run src/index.ts",


### PR DESCRIPTION
## Summary
- make local hatch prefer source gateway via `VELLUM_GATEWAY_DIR`, repo/cwd source discovery, then package fallback
- propagate ingress public base URL through a single normalized path and remove duplicate hatch logic
- add local dev scripts/docs for immediate source-gateway testing (`daemon:restart:http`, `dev:proxy`)
- update `/update` command to preserve source-run gateway and launch app with `VELLUM_GATEWAY_DIR` pinned to repo gateway
- remove literal `TWILIO_WEBHOOK_BASE_URL` references while preserving guard coverage

## Validation
- `cd cli && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/forbidden-legacy-symbols.test.ts`
- manual local run: `bun run daemon:restart:http`, `GATEWAY_PORT=7840 bun run dev:proxy`, `curl http://127.0.0.1:7840/healthz`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
