### PR TITLE
feat: support secret prompts over HTTP runtime API

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -241,6 +241,7 @@ export function initializeDb(): void {
       message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
       status TEXT NOT NULL DEFAULT 'running',
       pending_confirmation TEXT,
+      pending_secret TEXT,
       input_tokens INTEGER NOT NULL DEFAULT 0,
       output_tokens INTEGER NOT NULL DEFAULT 0,
       estimated_cost REAL NOT NULL DEFAULT 0,
@@ -249,6 +250,8 @@ export function initializeDb(): void {
       updated_at INTEGER NOT NULL
     )
   `);
+
+  try { database.run(/*sql*/ `ALTER TABLE message_runs ADD COLUMN pending_secret TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE message_runs ADD COLUMN pending_secret (likely already exists)'); }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS reminders (

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -3,6 +3,7 @@
  *
  * Runs track the lifecycle of an agent loop triggered by a user message:
  *   running → needs_confirmation → running → completed | failed
+ *   running → needs_secret       → running → completed | failed
  */
 
 import { eq, inArray } from 'drizzle-orm';
@@ -14,7 +15,7 @@ import { messageRuns } from './schema.js';
 // Types
 // ---------------------------------------------------------------------------
 
-export type RunStatus = 'running' | 'needs_confirmation' | 'completed' | 'failed';
+export type RunStatus = 'running' | 'needs_confirmation' | 'needs_secret' | 'completed' | 'failed';
 
 export interface PendingConfirmation {
   toolName: string;
@@ -34,12 +35,24 @@ export interface PendingConfirmation {
   persistentDecisionsAllowed?: boolean;
 }
 
+export interface PendingSecret {
+  requestId: string;
+  service: string;
+  field: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  purpose?: string;
+  allowOneTimeSend?: boolean;
+}
+
 export interface Run {
   id: string;
   conversationId: string;
   messageId: string | null;
   status: RunStatus;
   pendingConfirmation: PendingConfirmation | null;
+  pendingSecret: PendingSecret | null;
   inputTokens: number;
   outputTokens: number;
   estimatedCost: number;
@@ -63,12 +76,17 @@ function rowToRun(row: typeof messageRuns.$inferSelect): Run {
   if (row.pendingConfirmation) {
     try { pendingConfirmation = JSON.parse(row.pendingConfirmation); } catch { /* malformed */ }
   }
+  let pendingSecret: PendingSecret | null = null;
+  if (row.pendingSecret) {
+    try { pendingSecret = JSON.parse(row.pendingSecret); } catch { /* malformed */ }
+  }
   return {
     id: row.id,
     conversationId: row.conversationId,
     messageId: row.messageId,
     status: row.status as RunStatus,
     pendingConfirmation,
+    pendingSecret,
     inputTokens: row.inputTokens,
     outputTokens: row.outputTokens,
     estimatedCost: row.estimatedCost,
@@ -96,6 +114,7 @@ export function createRun(
     messageId: messageId ?? null,
     status: 'running' as const,
     pendingConfirmation: null,
+    pendingSecret: null,
     inputTokens: 0,
     outputTokens: 0,
     estimatedCost: 0,
@@ -144,6 +163,35 @@ export function clearRunConfirmation(runId: string): void {
     .run();
 }
 
+export function setRunSecret(
+  runId: string,
+  secret: PendingSecret,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'needs_secret',
+      pendingSecret: JSON.stringify(secret),
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
+export function clearRunSecret(runId: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'running',
+      pendingSecret: null,
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
 export function completeRun(runId: string, usage?: RunUsage): void {
   const db = getDb();
   const now = Date.now();
@@ -177,13 +225,13 @@ export function failRun(runId: string, error: string): void {
 /**
  * Mark all non-terminal runs as failed.
  * Called on startup to recover from daemon restarts that left runs
- * in running/needs_confirmation with no in-memory state to resolve them.
+ * in running/needs_confirmation/needs_secret with no in-memory state to resolve them.
  * Returns the number of rows affected.
  */
 export function failOrphanedRuns(): number {
   const db = getDb();
   const now = Date.now();
-  const activeStatuses = ['running', 'needs_confirmation'];
+  const activeStatuses = ['running', 'needs_confirmation', 'needs_secret'];
 
   // Count first so we can report how many were recovered.
   const active = db.select({ id: messageRuns.id })

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -209,8 +209,9 @@ export const messageRuns = sqliteTable('message_runs', {
     .references(() => conversations.id, { onDelete: 'cascade' }),
   messageId: text('message_id')
     .references(() => messages.id, { onDelete: 'cascade' }),
-  status: text('status').notNull().default('running'),          // running | needs_confirmation | completed | failed
+  status: text('status').notNull().default('running'),          // running | needs_confirmation | needs_secret | completed | failed
   pendingConfirmation: text('pending_confirmation'),            // JSON when status=needs_confirmation
+  pendingSecret: text('pending_secret'),                        // JSON when status=needs_secret
   inputTokens: integer('input_tokens').notNull().default(0),
   outputTokens: integer('output_tokens').notNull().default(0),
   estimatedCost: real('estimated_cost').notNull().default(0),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -30,6 +30,7 @@ import {
   handleCreateRun,
   handleGetRun,
   handleRunDecision,
+  handleRunSecret,
   handleAddTrustRule,
 } from './routes/run-routes.js';
 import {
@@ -657,8 +658,8 @@ export class RuntimeHttpServer {
         return await handleCreateRun(req, this.runOrchestrator);
       }
 
-      // Match runs/:runId, runs/:runId/decision, runs/:runId/trust-rule
-      const runsMatch = endpoint.match(/^runs\/([^/]+)(\/decision|\/trust-rule)?$/);
+      // Match runs/:runId, runs/:runId/decision, runs/:runId/trust-rule, runs/:runId/secret
+      const runsMatch = endpoint.match(/^runs\/([^/]+)(\/decision|\/trust-rule|\/secret)?$/);
       if (runsMatch) {
         if (!this.runOrchestrator) {
           return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
@@ -666,6 +667,9 @@ export class RuntimeHttpServer {
         const runId = runsMatch[1];
         if (runsMatch[2] === '/decision' && req.method === 'POST') {
           return await handleRunDecision(runId, req, this.runOrchestrator);
+        }
+        if (runsMatch[2] === '/secret' && req.method === 'POST') {
+          return await handleRunSecret(runId, req, this.runOrchestrator);
         }
         if (runsMatch[2] === '/trust-rule' && req.method === 'POST') {
           const run = this.runOrchestrator.getRun(runId);

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -88,6 +88,7 @@ export function handleGetRun(
     status: run.status,
     messageId: run.messageId,
     pendingConfirmation: run.pendingConfirmation,
+    pendingSecret: run.pendingSecret,
     error: run.error,
     createdAt: new Date(run.createdAt).toISOString(),
     updatedAt: new Date(run.updatedAt).toISOString(),
@@ -216,4 +217,46 @@ export async function handleAddTrustRule(
     log.error({ err }, 'Failed to add trust rule');
     return Response.json({ error: 'Failed to add trust rule' }, { status: 500 });
   }
+}
+
+export async function handleRunSecret(
+  runId: string,
+  req: Request,
+  runOrchestrator: RunOrchestrator,
+): Promise<Response> {
+  const run = runOrchestrator.getRun(runId);
+  if (!run) {
+    return Response.json({ error: 'Run not found' }, { status: 404 });
+  }
+
+  const body = await req.json() as {
+    value?: string;
+    delivery?: string;
+  };
+
+  const { value, delivery } = body;
+
+  if (delivery !== undefined && delivery !== 'store' && delivery !== 'transient_send') {
+    return Response.json(
+      { error: 'delivery must be "store" or "transient_send"' },
+      { status: 400 },
+    );
+  }
+
+  const result = runOrchestrator.submitSecret(
+    runId,
+    value,
+    delivery as 'store' | 'transient_send' | undefined,
+  );
+  if (result === 'run_not_found') {
+    return Response.json({ error: 'Run not found' }, { status: 404 });
+  }
+  if (result === 'no_pending_secret') {
+    return Response.json(
+      { error: 'No secret pending for this run' },
+      { status: 409 },
+    );
+  }
+
+  return Response.json({ accepted: true });
 }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -3,11 +3,14 @@
  *
  * A "run" wraps a single agent-loop execution, tracking its state through:
  *   running → needs_confirmation → running → completed | failed
+ *   running → needs_secret       → running → completed | failed
  *
  * When a tool needs permission, the orchestrator intercepts the
  * confirmation_request from the session's prompter and records it in
- * the run store.  The web UI can then poll the run status and submit
- * a decision via the /decision endpoint.
+ * the run store.  Similarly, when a tool needs a secret (e.g.
+ * credential_store prompt), the orchestrator intercepts the
+ * secret_request and records it.  The client can then poll the run
+ * status and submit a decision or secret via the respective endpoints.
  */
 
 import * as runsStore from '../memory/runs-store.js';
@@ -113,11 +116,10 @@ export class RunOrchestrator {
     };
 
 
-    // Hook into session to intercept confirmation_request events.
-    // When the prompter sends a confirmation_request, we record it in the
-    // run store so the web UI can poll and submit a decision.
-    // Do NOT set hasNoClient — run sessions have a client (the HTTP caller)
-    // and confirmations are handled via the /runs/:id/decision endpoint.
+    // Hook into session to intercept confirmation_request and secret_request events.
+    // When the prompter sends one of these, we record it in the run store so
+    // the client can poll and submit a decision/secret via the respective endpoint.
+    // Do NOT set hasNoClient — run sessions have a client (the HTTP caller).
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
@@ -133,6 +135,21 @@ export class RunOrchestrator {
           principalId: msg.principalId,
           principalVersion: msg.principalVersion,
           persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
+        });
+        this.pending.set(run.id, {
+          prompterRequestId: msg.requestId,
+          session,
+        });
+      } else if (msg.type === 'secret_request') {
+        runsStore.setRunSecret(run.id, {
+          requestId: msg.requestId,
+          service: msg.service,
+          field: msg.field,
+          label: msg.label,
+          description: msg.description,
+          placeholder: msg.placeholder,
+          purpose: msg.purpose,
+          allowOneTimeSend: msg.allowOneTimeSend,
         });
         this.pending.set(run.id, {
           prompterRequestId: msg.requestId,
@@ -235,5 +252,45 @@ export class RunOrchestrator {
     // agent loop hasn't reached a confirmation point yet. Reject so
     // the client doesn't mistakenly treat the decision as accepted.
     return 'no_pending_decision';
+  }
+
+  /**
+   * Submit a secret value for a pending secret request.
+   *
+   * Returns:
+   * - `'applied'`           – secret was forwarded to the session
+   * - `'run_not_found'`     – no run exists with the given ID
+   * - `'no_pending_secret'` – run exists but is not awaiting a secret
+   */
+  submitSecret(
+    runId: string,
+    value?: string,
+    delivery?: 'store' | 'transient_send',
+  ): 'applied' | 'run_not_found' | 'no_pending_secret' {
+    const pendingState = this.pending.get(runId);
+    if (pendingState) {
+      runsStore.clearRunSecret(runId);
+      pendingState.session.handleSecretResponse(
+        pendingState.prompterRequestId,
+        value,
+        delivery,
+      );
+      this.pending.delete(runId);
+      return 'applied';
+    }
+
+    const run = runsStore.getRun(runId);
+    if (!run) return 'run_not_found';
+
+    if (run.status === 'needs_secret') {
+      runsStore.failRun(runId, 'Secret prompter timed out (no active handler)');
+      return 'applied';
+    }
+
+    if (run.status === 'completed' || run.status === 'failed') {
+      return 'applied';
+    }
+
+    return 'no_pending_secret';
   }
 }


### PR DESCRIPTION
## Summary
- Mirrors the existing `confirmation_request` → `needs_confirmation` flow for `secret_request` → `needs_secret`
- The `RunOrchestrator` now intercepts `secret_request` messages from the session's `SecretPrompter` and records them in the run store, so HTTP clients can poll and submit secrets
- Adds `POST /runs/:id/secret` endpoint for submitting secret values with optional delivery mode (`store` or `transient_send`)
- Includes `pendingSecret` in the `GET /runs/:id` response

## Context
The `credential_store` tool's `prompt` action sends a `secret_request` through the session's `updateClient` callback — the same path as `confirmation_request`. But the `RunOrchestrator` only handled `confirmation_request`, so secret requests fell through silently. This caused HTTP clients (vel client, web UI) to hang on "Working..." when the assistant needed a credential.

## Test plan
- [x] `run-orchestrator.test.ts` — 5/5 pass
- [x] `runtime-runs.test.ts` — 8/8 pass
- [x] `runtime-runs-http.test.ts` — 14/14 pass
- [x] `secret-response-routing.test.ts` — 8/8 pass
- [x] TypeScript type check passes (excluding pre-existing snapshot issues)
- [x] ESLint passes on all changed files
- [ ] Manual test: `vel client` → trigger credential_store prompt → verify secret input UI appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
