### PR TITLE
fix(macos): stabilize composer scroll during multi-line transitions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -113,7 +113,6 @@ struct ComposerView: View {
                     composerTextField
                         .frame(height: clampedComposerHeight)
                         .frame(maxHeight: isComposerExpanded ? clampedComposerHeight : .infinity, alignment: .center)
-                        .clipped()
                     if !isComposerExpanded {
                         composerActionButtons
                             .frame(maxHeight: .infinity, alignment: .center)
@@ -247,9 +246,11 @@ struct ComposerView: View {
             }
         }
         .onChange(of: editorContentHeight) {
-            if editorContentHeight > composerCompactHeight && !isComposerExpanded {
+            // Hysteresis buffer (4pt) prevents oscillation when height
+            // hovers right at the compact threshold during typing.
+            if editorContentHeight > composerCompactHeight + 4 && !isComposerExpanded {
                 withAnimation(VAnimation.fast) { isComposerExpanded = true }
-            } else if editorContentHeight <= composerCompactHeight && isComposerExpanded {
+            } else if editorContentHeight < composerCompactHeight - 4 && isComposerExpanded {
                 withAnimation(VAnimation.fast) { isComposerExpanded = false }
             }
         }
@@ -709,10 +710,12 @@ private struct ComposerTextView: NSViewRepresentable {
             parent.onOverflowChange?(rawHeight > parent.maxHeight)
 
             if abs(lastReportedHeight - clampedHeight) > 0.5 {
-                // When content shrinks (e.g. deleting from 2 lines back to 1),
-                // reset the scroll position so text isn't clipped at the top.
-                if clampedHeight < lastReportedHeight {
-                    textView.scrollToBeginningOfDocument(nil)
+                // Only reset scroll when returning to true single-line height.
+                // Deferring to next runloop avoids fighting the current layout pass.
+                if clampedHeight < lastReportedHeight && clampedHeight <= parent.minHeight {
+                    DispatchQueue.main.async { [weak textView] in
+                        textView?.scrollToBeginningOfDocument(nil)
+                    }
                 }
                 lastReportedHeight = clampedHeight
                 parent.onHeightChange(clampedHeight)
@@ -882,8 +885,11 @@ private final class CenteringClipView: NSClipView {
             let insetHeight = textView.textContainerInset.height * 2
             let contentHeight = usedHeight + insetHeight
             let visibleHeight = proposedBounds.height
-            if contentHeight < visibleHeight {
-                rect.origin.y = (contentHeight - visibleHeight) / 2
+            // Only center when content is meaningfully shorter (4pt dead zone)
+            // to prevent jitter at the transition boundary. Round to avoid
+            // subpixel positioning that causes scrollbar flicker.
+            if contentHeight < visibleHeight - 4 {
+                rect.origin.y = round((contentHeight - visibleHeight) / 2)
             }
         }
         return rect


### PR DESCRIPTION
## Summary
- Add hysteresis buffer (4pt) to the expansion/collapse threshold so the composer doesn't oscillate when editor height hovers near the boundary
- Remove inner `.clipped()` on the text field (outer `.clipShape` already handles clipping) to prevent transient second-line cutoff during height animation
- Harden `CenteringClipView.constrainBoundsRect` with a 4pt dead zone and pixel rounding to eliminate scrollbar jitter at the centering threshold
- Change scroll reset policy: only reset to top when returning to true single-line height, deferred to next runloop to avoid fighting the current layout pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
