### PR TITLE
fix: unify task queue status chip colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksTableContract.swift
@@ -96,13 +96,13 @@ enum TasksTableContract {
     static func statusStyle(for status: WorkItemStatus) -> StatusStyle {
         switch status {
         case .queued:          return StatusStyle(label: "Queued",    color: VColor.textSecondary)
-        case .running:         return StatusStyle(label: "Running",   color: VColor.warning)
-        case .awaitingReview:  return StatusStyle(label: "Awaiting Review", color: VColor.accent)
-        case .failed:          return StatusStyle(label: "Failed",    color: VColor.error)
-        case .cancelled:       return StatusStyle(label: "Cancelled", color: VColor.textMuted)
-        case .done:            return StatusStyle(label: "Done",      color: VColor.success)
-        case .archived:        return StatusStyle(label: "Archived",  color: VColor.textMuted)
-        case .unknown(let raw): return StatusStyle(label: raw,        color: VColor.textMuted)
+        case .running:         return StatusStyle(label: "Running",   color: VColor.textSecondary)
+        case .awaitingReview:  return StatusStyle(label: "Awaiting Review", color: VColor.textSecondary)
+        case .failed:          return StatusStyle(label: "Failed",    color: VColor.textSecondary)
+        case .cancelled:       return StatusStyle(label: "Cancelled", color: VColor.textSecondary)
+        case .done:            return StatusStyle(label: "Done",      color: VColor.textSecondary)
+        case .archived:        return StatusStyle(label: "Archived",  color: VColor.textSecondary)
+        case .unknown(let raw): return StatusStyle(label: raw,        color: VColor.textSecondary)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change all task status chips to use the same `VColor.textSecondary` color for visual consistency
- Previously, awaiting review used `VColor.accent` which was much darker than other statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
