### PR TITLE
fix: app cards unclickable after restart

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1222,13 +1222,28 @@ public final class ChatViewModel: ObservableObject {
                     // Use sessionId from the view model (assumes history is for current session)
                     if let sessionId = self.sessionId,
                        let surface = Surface.from(surf, sessionId: sessionId) {
+                        // Reconstruct a UiSurfaceShowMessage so the card remains
+                        // clickable after the app restarts (history restore).
+                        let reconstructedActions: [SurfaceActionData]? = surf.actions?.map { action in
+                            SurfaceActionData(id: action.id, label: action.label, style: action.style)
+                        }
+                        let reconstructedMessage = UiSurfaceShowMessage(
+                            sessionId: sessionId,
+                            surfaceId: surf.surfaceId,
+                            surfaceType: surf.surfaceType,
+                            title: surf.title,
+                            data: AnyCodable(surf.data.mapValues { $0.value }),
+                            actions: reconstructedActions,
+                            display: surf.display,
+                            messageId: item.id
+                        )
                         let inlineSurface = InlineSurfaceData(
                             id: surface.id,
                             surfaceType: surface.type,
                             title: surface.title,
                             data: surface.data,
                             actions: surface.actions,
-                            surfaceMessage: nil  // No IPC message for history surfaces
+                            surfaceMessage: reconstructedMessage
                         )
                         inlineSurfaces.append(inlineSurface)
                     }


### PR DESCRIPTION
## Summary
- When chat history was restored on app restart, inline app cards (dynamic page previews like the flight map) became unclickable because `surfaceMessage` was `nil`
- The click handler in `InlineSurfaceRouter` requires a non-nil `UiSurfaceShowMessage` to post the `openDynamicWorkspace` notification
- Fix reconstructs the `UiSurfaceShowMessage` from history surface data (`IPCHistoryResponseSurface`) during `populateFromHistory`, so cards work identically to live sessions

## Test plan
- [ ] Build an app via chat (e.g. a flight map)
- [ ] Click the app card arrow to verify it opens normally
- [ ] Restart the macOS app
- [ ] Verify the app card in history is still clickable and opens the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
