### PR TITLE
feat: add keyboard nav for Always Allow nested popovers

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -16,6 +16,7 @@ public struct ToolConfirmationBubble: View {
     @State private var pendingPattern: String?
     @State private var showScopePickerMenu = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
+    @State private var popoverKeyboardModel: ToolConfirmationPopoverKeyboardModel?
     #if os(macOS)
     @State private var keyMonitor: Any?
     #endif
@@ -363,6 +364,7 @@ public struct ToolConfirmationBubble: View {
             #endif
         }
         .onDisappear {
+            popoverKeyboardModel = nil
             #if os(macOS)
             removeKeyMonitor()
             #endif
@@ -376,10 +378,11 @@ public struct ToolConfirmationBubble: View {
         removeKeyMonitor()
         keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            // Pass through when a popover menu is open
+            // Nested popover is open — handle up/down/enter/escape within it
             if showAlwaysAllowMenu || showScopePickerMenu {
-                return event
+                return handlePopoverKey(event)
             }
+            // Top-level button row navigation
             switch event.keyCode {
             case 48 where event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .shift:
                 // Shift+Tab — move left
@@ -405,6 +408,105 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
+    /// Handle key events when a nested popover (Always Allow dropdown or
+    /// scope picker) is open.
+    private func handlePopoverKey(_ event: NSEvent) -> NSEvent? {
+        switch event.keyCode {
+        case 126:
+            // Up arrow
+            popoverKeyboardModel?.moveUp()
+            return nil
+        case 125:
+            // Down arrow
+            popoverKeyboardModel?.moveDown()
+            return nil
+        case 36, 76:
+            // Return / numpad Enter — activate selected row
+            activatePopoverSelection()
+            return nil
+        case 53:
+            // Escape — back or close
+            handlePopoverEscape()
+            return nil
+        default:
+            return event
+        }
+    }
+
+    /// Activate the currently selected row in the nested popover.
+    private func activatePopoverSelection() {
+        guard let model = popoverKeyboardModel else { return }
+        let index = model.selectedIndex
+
+        if showAlwaysAllowMenu {
+            if pendingPattern != nil && needsScopeChoice {
+                // We're in the scope step of the dropdown
+                guard index < confirmation.scopeOptions.count else { return }
+                let scopeOption = confirmation.scopeOptions[index]
+                showAlwaysAllowMenu = false
+                let pattern = pendingPattern!
+                pendingPattern = nil
+                popoverKeyboardModel = nil
+                onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
+            } else {
+                // We're in the pattern step of the dropdown
+                guard index < confirmation.allowlistOptions.count else { return }
+                let option = confirmation.allowlistOptions[index]
+                if option.pattern.isEmpty {
+                    showAlwaysAllowMenu = false
+                    popoverKeyboardModel = nil
+                    onAllow()
+                } else if needsScopeChoice {
+                    pendingPattern = option.pattern
+                    popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                        mode: .scopes,
+                        itemCount: confirmation.scopeOptions.count
+                    )
+                } else {
+                    showAlwaysAllowMenu = false
+                    popoverKeyboardModel = nil
+                    let scope = confirmation.scopeOptions.first?.scope ?? ""
+                    if !scope.isEmpty {
+                        onAlwaysAllow(confirmation.requestId, option.pattern, scope, alwaysAllowDecision)
+                    } else {
+                        onAllow()
+                    }
+                }
+            }
+        } else if showScopePickerMenu {
+            // Inline scope picker
+            guard index < confirmation.scopeOptions.count else { return }
+            let scopeOption = confirmation.scopeOptions[index]
+            showScopePickerMenu = false
+            popoverKeyboardModel = nil
+            if let pattern = pendingPattern {
+                onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
+                pendingPattern = nil
+            }
+        }
+    }
+
+    /// Handle Escape in a nested popover.
+    private func handlePopoverEscape() {
+        guard let model = popoverKeyboardModel else { return }
+        switch model.handleEscape() {
+        case .backToPatterns:
+            pendingPattern = nil
+            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                mode: .patterns,
+                itemCount: confirmation.allowlistOptions.count
+            )
+        case .closePopover:
+            if showAlwaysAllowMenu {
+                showAlwaysAllowMenu = false
+            }
+            if showScopePickerMenu {
+                showScopePickerMenu = false
+            }
+            popoverKeyboardModel = nil
+        }
+    }
+
     private func removeKeyMonitor() {
         if let monitor = keyMonitor {
             NSEvent.removeMonitor(monitor)
@@ -423,6 +525,14 @@ public struct ToolConfirmationBubble: View {
                 withAnimation(VAnimation.fast) {
                     pendingPattern = nil
                     showAlwaysAllowMenu.toggle()
+                }
+                if showAlwaysAllowMenu {
+                    popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                        mode: .patterns,
+                        itemCount: confirmation.allowlistOptions.count
+                    )
+                } else {
+                    popoverKeyboardModel = nil
                 }
             } else {
                 handleSingleOptionAlwaysAllow()
@@ -443,6 +553,10 @@ public struct ToolConfirmationBubble: View {
         if needsScopeChoice {
             pendingPattern = pattern
             showScopePickerMenu = true
+            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                mode: .scopes,
+                itemCount: confirmation.scopeOptions.count
+            )
         } else {
             let scope = confirmation.scopeOptions.first?.scope ?? ""
             if !scope.isEmpty {
@@ -501,6 +615,14 @@ public struct ToolConfirmationBubble: View {
                 pendingPattern = nil
                 showAlwaysAllowMenu.toggle()
             }
+            if showAlwaysAllowMenu {
+                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                    mode: .patterns,
+                    itemCount: confirmation.allowlistOptions.count
+                )
+            } else {
+                popoverKeyboardModel = nil
+            }
         }
         .popover(isPresented: $showAlwaysAllowMenu, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
@@ -509,6 +631,10 @@ public struct ToolConfirmationBubble: View {
                     HStack(spacing: VSpacing.xs) {
                         Button {
                             pendingPattern = nil
+                            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                                mode: .patterns,
+                                itemCount: confirmation.allowlistOptions.count
+                            )
                         } label: {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 10, weight: .semibold))
@@ -527,9 +653,13 @@ public struct ToolConfirmationBubble: View {
                         .background(VColor.divider)
 
                     ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { index, scopeOption in
-                        ScopePickerRow(label: scopeOption.label) {
+                        ScopePickerRow(
+                            label: scopeOption.label,
+                            isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
+                        ) {
                             showAlwaysAllowMenu = false
                             pendingPattern = nil
+                            popoverKeyboardModel = nil
                             onAlwaysAllow(confirmation.requestId, pending, scopeOption.scope, alwaysAllowDecision)
                         }
 
@@ -541,14 +671,23 @@ public struct ToolConfirmationBubble: View {
                 } else {
                     // Pattern selection step
                     ForEach(Array(confirmation.allowlistOptions.enumerated()), id: \.element.pattern) { index, option in
-                        AlwaysAllowRow(label: option.description) {
+                        AlwaysAllowRow(
+                            label: option.description,
+                            isKeyboardSelected: popoverKeyboardModel?.mode == .patterns && popoverKeyboardModel?.selectedIndex == index
+                        ) {
                             if option.pattern.isEmpty {
                                 showAlwaysAllowMenu = false
+                                popoverKeyboardModel = nil
                                 onAllow()
                             } else if needsScopeChoice {
                                 pendingPattern = option.pattern
+                                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                                    mode: .scopes,
+                                    itemCount: confirmation.scopeOptions.count
+                                )
                             } else {
                                 showAlwaysAllowMenu = false
+                                popoverKeyboardModel = nil
                                 let scope = confirmation.scopeOptions.first?.scope ?? ""
                                 if !scope.isEmpty {
                                     onAlwaysAllow(confirmation.requestId, option.pattern, scope, alwaysAllowDecision)
@@ -585,8 +724,12 @@ public struct ToolConfirmationBubble: View {
                 .background(VColor.divider)
 
             ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { index, scopeOption in
-                ScopePickerRow(label: scopeOption.label) {
+                ScopePickerRow(
+                    label: scopeOption.label,
+                    isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
+                ) {
                     showScopePickerMenu = false
+                    popoverKeyboardModel = nil
                     if let pattern = pendingPattern {
                         onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
                         pendingPattern = nil
@@ -643,6 +786,7 @@ public struct ToolConfirmationBubble: View {
 
 private struct AlwaysAllowRow: View {
     let label: String
+    var isKeyboardSelected: Bool = false
     let action: () -> Void
 
     @State private var isHovered = false
@@ -657,7 +801,11 @@ private struct AlwaysAllowRow: View {
                 .padding(.horizontal, VSpacing.sm)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+                        .fill(isHovered || isKeyboardSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(isKeyboardSelected ? VColor.accent : .clear, lineWidth: 2)
                 )
                 .contentShape(Rectangle())
         }
@@ -678,6 +826,7 @@ private struct AlwaysAllowRow: View {
 
 private struct ScopePickerRow: View {
     let label: String
+    var isKeyboardSelected: Bool = false
     let action: () -> Void
 
     @State private var isHovered = false
@@ -692,7 +841,11 @@ private struct ScopePickerRow: View {
                 .padding(.horizontal, VSpacing.sm)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+                        .fill(isHovered || isKeyboardSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(isKeyboardSelected ? VColor.accent : .clear, lineWidth: 2)
                 )
                 .contentShape(Rectangle())
         }

--- a/clients/shared/Features/Chat/ToolConfirmationPopoverKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationPopoverKeyboardModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// State machine for keyboard navigation within the Always Allow nested
+/// popover menus (pattern list and scope list).
+///
+/// Platform-agnostic so it can be unit-tested without a host app.
+struct ToolConfirmationPopoverKeyboardModel {
+
+    /// Which step of the Always Allow flow is currently showing.
+    enum Mode: Equatable {
+        case patterns
+        case scopes
+    }
+
+    /// Result of handling an Escape key press.
+    enum EscapeResult: Equatable {
+        /// Navigated back from scopes to patterns.
+        case backToPatterns
+        /// Popover should be closed entirely.
+        case closePopover
+    }
+
+    private(set) var mode: Mode
+    private(set) var selectedIndex: Int
+    private let itemCount: Int
+
+    /// Creates a model for a given mode and item count.
+    /// Selection defaults to the first item.
+    init(mode: Mode, itemCount: Int) {
+        precondition(itemCount > 0, "Must have at least one item")
+        self.mode = mode
+        self.selectedIndex = 0
+        self.itemCount = itemCount
+    }
+
+    /// Move selection up (wrapping around).
+    mutating func moveUp() {
+        selectedIndex = (selectedIndex - 1 + itemCount) % itemCount
+    }
+
+    /// Move selection down (wrapping around).
+    mutating func moveDown() {
+        selectedIndex = (selectedIndex + 1) % itemCount
+    }
+
+    /// Handle Escape: in scopes mode, go back to patterns; in patterns mode, close.
+    func handleEscape() -> EscapeResult {
+        switch mode {
+        case .scopes:
+            return .backToPatterns
+        case .patterns:
+            return .closePopover
+        }
+    }
+}

--- a/clients/shared/Tests/ToolConfirmationPopoverKeyboardModelTests.swift
+++ b/clients/shared/Tests/ToolConfirmationPopoverKeyboardModelTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class ToolConfirmationPopoverKeyboardModelTests: XCTestCase {
+
+    // MARK: - Default selection
+
+    func testDefaultSelectionIsFirstItem() {
+        let model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        XCTAssertEqual(model.selectedIndex, 0)
+        XCTAssertEqual(model.mode, .patterns)
+    }
+
+    func testDefaultSelectionInScopesMode() {
+        let model = ToolConfirmationPopoverKeyboardModel(mode: .scopes, itemCount: 2)
+        XCTAssertEqual(model.selectedIndex, 0)
+        XCTAssertEqual(model.mode, .scopes)
+    }
+
+    // MARK: - Down movement
+
+    func testMoveDownAdvancesSelection() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        model.moveDown()
+        XCTAssertEqual(model.selectedIndex, 1)
+    }
+
+    func testMoveDownWrapsToStart() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        model.moveDown() // 1
+        model.moveDown() // 2
+        model.moveDown() // wraps to 0
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Up movement
+
+    func testMoveUpWrapsToEnd() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        model.moveUp() // wraps to 2
+        XCTAssertEqual(model.selectedIndex, 2)
+    }
+
+    func testMoveUpFromMiddle() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        model.moveDown() // 1
+        model.moveUp()   // 0
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Full cycle
+
+    func testFullCycleDown() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveDown()
+        XCTAssertEqual(model.selectedIndex, 1)
+        model.moveDown()
+        XCTAssertEqual(model.selectedIndex, 2)
+        model.moveDown()
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    func testFullCycleUp() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .scopes, itemCount: 2)
+        XCTAssertEqual(model.selectedIndex, 0)
+        model.moveUp()
+        XCTAssertEqual(model.selectedIndex, 1)
+        model.moveUp()
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Single item
+
+    func testSingleItemMoveDownStaysAtZero() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 1)
+        model.moveDown()
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    func testSingleItemMoveUpStaysAtZero() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 1)
+        model.moveUp()
+        XCTAssertEqual(model.selectedIndex, 0)
+    }
+
+    // MARK: - Escape handling
+
+    func testEscapeFromPatternsClosesPopover() {
+        let model = ToolConfirmationPopoverKeyboardModel(mode: .patterns, itemCount: 3)
+        XCTAssertEqual(model.handleEscape(), .closePopover)
+    }
+
+    func testEscapeFromScopesGoesBackToPatterns() {
+        let model = ToolConfirmationPopoverKeyboardModel(mode: .scopes, itemCount: 2)
+        XCTAssertEqual(model.handleEscape(), .backToPatterns)
+    }
+
+    // MARK: - Mode preservation
+
+    func testMovementPreservesMode() {
+        var model = ToolConfirmationPopoverKeyboardModel(mode: .scopes, itemCount: 3)
+        model.moveDown()
+        XCTAssertEqual(model.mode, .scopes)
+        model.moveUp()
+        XCTAssertEqual(model.mode, .scopes)
+    }
+}


### PR DESCRIPTION
## Summary
- Add up/down arrow navigation, Enter activation, and Escape back/close for nested Always Allow pattern list and scope picker popovers
- New `ToolConfirmationPopoverKeyboardModel` state machine tracks nested menu selection with wraparound
- Keyboard-selected rows show accent border highlight; mouse click behavior unchanged

## Test plan
- [x] 13 new unit tests for popover keyboard model (up/down wrap, escape semantics, mode transitions)
- [ ] Manual: trigger confirmation with multiple allowlist options, navigate pattern list with up/down, press Enter
- [ ] Manual: in scope list, navigate with up/down, press Enter to confirm
- [ ] Manual: Escape in scope list returns to pattern list; Escape in pattern list closes popover
- [ ] Manual: click behavior still works identically
- [ ] Manual: top-level Tab/Enter/Escape still work when popover is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
