### PR TITLE
fix: gracefully handle missing source files in compiled CLI binary

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -26,8 +26,18 @@ import { exec, execOutput } from "../lib/step-runner";
 const _require = createRequire(import.meta.url);
 
 const INSTALL_SCRIPT_REMOTE_PATH = "/tmp/vellum-install.sh";
-const INSTALL_SCRIPT_PATH = join(import.meta.dir, "..", "adapters", "install.sh");
 const MACHINE_TYPE = "e2-standard-4"; // 4 vCPUs, 16 GB memory
+
+// Resolve the install script path. In source tree, use the file directly.
+// In compiled binary ($bunfs), the file may not be available.
+async function resolveInstallScriptPath(): Promise<string | null> {
+  const sourcePath = join(import.meta.dir, "..", "adapters", "install.sh");
+  if (existsSync(sourcePath)) {
+    return sourcePath;
+  }
+  console.warn("⚠️  Install script not found at", sourcePath, "(expected in compiled binary)");
+  return null;
+}
 const HATCH_TIMEOUT_MS: Record<Species, number> = {
   vellum: 2 * 60 * 1000,
   openclaw: 10 * 60 * 1000,
@@ -103,7 +113,7 @@ export async function buildStartupScript(
     );
   }
 
-  const interfacesSeed = buildInterfacesSeed();
+  const interfacesSeed = await buildInterfacesSeed();
 
   return `#!/bin/bash
 set -e
@@ -311,14 +321,16 @@ async function recoverFromCurlFailure(
   sshUser: string,
   account?: string,
 ): Promise<void> {
-  if (!existsSync(INSTALL_SCRIPT_PATH)) {
-    throw new Error(`Install script not found at ${INSTALL_SCRIPT_PATH}`);
+  const installScriptPath = await resolveInstallScriptPath();
+  if (!installScriptPath) {
+    console.warn("⚠️  Skipping install script upload (not available in compiled binary)");
+    return;
   }
 
   const scpArgs = [
     "compute",
     "scp",
-    INSTALL_SCRIPT_PATH,
+    installScriptPath,
     `${instanceName}:${INSTALL_SCRIPT_REMOTE_PATH}`,
     `--zone=${zone}`,
     `--project=${project}`,
@@ -703,14 +715,19 @@ async function hatchCustom(
     writeFileSync(startupScriptPath, startupScript);
 
     try {
-      console.log("📋 Uploading install script to instance...");
-      await exec("scp", [
-        "-o", "StrictHostKeyChecking=no",
-        "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR",
-        INSTALL_SCRIPT_PATH,
-        `${host}:${INSTALL_SCRIPT_REMOTE_PATH}`,
-      ]);
+      const installScriptPath = await resolveInstallScriptPath();
+      if (installScriptPath) {
+        console.log("📋 Uploading install script to instance...");
+        await exec("scp", [
+          "-o", "StrictHostKeyChecking=no",
+          "-o", "UserKnownHostsFile=/dev/null",
+          "-o", "LogLevel=ERROR",
+          installScriptPath,
+          `${host}:${INSTALL_SCRIPT_REMOTE_PATH}`,
+        ]);
+      } else {
+        console.warn("⚠️  Skipping install script upload (not available in compiled binary)");
+      }
 
       console.log("📋 Uploading startup script to instance...");
       const remoteStartupPath = `/tmp/${instanceName}-startup.sh`;
@@ -1097,8 +1114,9 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
 
 function getCliVersion(): string {
   try {
-    const pkgPath = join(import.meta.dir, "..", "..", "package.json");
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    // Use createRequire for JSON import — works in both Bun dev and compiled binary.
+    const require = createRequire(import.meta.url);
+    const pkg = require("../../package.json") as { version?: string };
     return pkg.version ?? "unknown";
   } catch {
     return "unknown";

--- a/cli/src/lib/interfaces-seed.ts
+++ b/cli/src/lib/interfaces-seed.ts
@@ -1,5 +1,7 @@
-import { readFileSync } from "fs";
-import { join } from "path";
+// Read source files using Bun.file() with string concatenation (not join())
+// so Bun's bundler can statically analyze the paths and embed the files
+// in the compiled binary ($bunfs). Files must also be passed via --embed
+// in the bun build --compile invocation.
 
 function inlineLocalImports(source: string, constantsSource: string): string {
   return source
@@ -7,15 +9,20 @@ function inlineLocalImports(source: string, constantsSource: string): string {
     .replace(/import\s*\{[^}]*\}\s*from\s*["']path["'];?\s*\n/, "");
 }
 
-export function buildInterfacesSeed(): string {
-  const constantsSource = readFileSync(join(import.meta.dir, "constants.ts"), "utf-8");
-  const defaultMainScreenSource = readFileSync(join(import.meta.dir, "..", "components", "DefaultMainScreen.tsx"), "utf-8");
-  const mainWindowSource = inlineLocalImports(defaultMainScreenSource, constantsSource);
+export async function buildInterfacesSeed(): Promise<string> {
+  try {
+    const constantsSource = await Bun.file(import.meta.dir + "/constants.ts").text();
+    const defaultMainScreenSource = await Bun.file(import.meta.dir + "/../components/DefaultMainScreen.tsx").text();
+    const mainWindowSource = inlineLocalImports(defaultMainScreenSource, constantsSource);
 
-  return `
+    return `
 INTERFACES_SEED_DIR="/tmp/interfaces-seed"
 mkdir -p "\$INTERFACES_SEED_DIR/tui"
 cat > "\$INTERFACES_SEED_DIR/tui/main-window.tsx" << 'INTERFACES_SEED_EOF'
 ${mainWindowSource}INTERFACES_SEED_EOF
 `;
+  } catch (err) {
+    console.warn("⚠️  Could not embed interfaces seed files (expected in compiled binary without --embed):", (err as Error).message);
+    return "# interfaces-seed: skipped (source files not available in compiled binary)";
+  }
 }

--- a/cli/src/lib/openclaw-runtime-server.ts
+++ b/cli/src/lib/openclaw-runtime-server.ts
@@ -1,9 +1,13 @@
-import { join } from "path";
+// Read source file using Bun.file() with string concatenation (not join())
+// so Bun's bundler can statically analyze the path and embed the file
+// in the compiled binary ($bunfs). The file must also be passed via --embed
+// in the bun build --compile invocation.
 
 export async function buildOpenclawRuntimeServer(): Promise<string> {
-  const serverSource = await Bun.file(join(import.meta.dir, "..", "adapters", "openclaw-http-server.ts")).text();
+  try {
+    const serverSource = await Bun.file(import.meta.dir + "/../adapters/openclaw-http-server.ts").text();
 
-  return `
+    return `
 cat > /opt/openclaw-runtime-server.ts << 'RUNTIME_SERVER_EOF'
 ${serverSource}
 RUNTIME_SERVER_EOF
@@ -12,4 +16,8 @@ mkdir -p "\$HOME/.vellum"
 nohup bun run /opt/openclaw-runtime-server.ts >> "\$HOME/.vellum/http-gateway.log" 2>&1 &
 echo "OpenClaw runtime server started (PID: \$!)"
 `;
+  } catch (err) {
+    console.warn("⚠️  Could not embed openclaw runtime server (expected in compiled binary without --embed):", (err as Error).message);
+    return "# openclaw-runtime-server: skipped (source files not available in compiled binary)";
+  }
 }

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-let appVersion = "0.2.4"
+let appVersion = "0.2.5"
 
 let package = Package(
     name: "vellum-assistant",


### PR DESCRIPTION
When the CLI is compiled with `bun build --compile`, source .ts files are not available in the $bunfs virtual filesystem. This adds try/catch around all runtime file reads so the hatch proceeds with warnings instead of crashing with ENOENT.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
