### PR TITLE
fix: use daemon:restart:http in update command

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -24,9 +24,9 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
    cd assistant && bun install && cd ..
    ```
 
-4. Start the daemon fresh:
+4. Start the daemon fresh with runtime HTTP enabled (required for gateway/Twilio/OAuth ingress):
    ```bash
-   cd assistant && bun run src/index.ts daemon start && cd ..
+   cd assistant && bun run daemon:restart:http && cd ..
    ```
 
 5. Build and launch the macOS app from source. Pin gateway resolution to the repo `gateway/` directory so local gateway changes are used instead of a packaged fallback. Run this in the background since `build.sh run` enters a watch loop:


### PR DESCRIPTION
## Summary
- Update the `/update` slash command to start the daemon with `bun run daemon:restart:http` instead of `bun run src/index.ts daemon start`, ensuring the runtime HTTP server is enabled for gateway/Twilio/OAuth ingress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
