### PR TITLE
chore: bump @vellumai/cli to 0.1.9

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Patch version bump for `@vellumai/cli` from 0.1.8 to 0.1.9

## Test plan
- [ ] CI passes
- [ ] Publish to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
