### PR TITLE
fix(macos): stabilize composer width during multi-line transitions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -179,11 +179,11 @@ struct ChatView: View {
     private var composerReservedHeight: CGFloat {
         let editorClamped = min(max(editorContentHeight, 34), 200)
         let contentHeight = max(editorClamped, 34)
-        let expanded = isComposerExpanded
-        let topPad: CGFloat = expanded ? VSpacing.md : VSpacing.sm
-        let bottomPad: CGFloat = expanded ? VSpacing.sm : VSpacing.sm
-        let buttonRow: CGFloat = expanded ? 34 + VSpacing.xs : 0
-        let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
+        let topPad: CGFloat = VSpacing.sm
+        let bottomPad: CGFloat = VSpacing.sm
+        // Action buttons now always live inline in the same HStack as the
+        // text field (no separate button row), so no extra buttonRow height.
+        let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
         let queueCount = CGFloat(queuedMessages.count)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -104,35 +104,24 @@ struct ComposerView: View {
                     attachmentStrip
                 }
 
-                // Text field always lives at the same structural position
-                // so that the NSViewRepresentable is never destroyed and
-                // recreated when toggling between compact/expanded layouts.
-                // In compact mode, buttons are overlaid at trailing edge;
-                // in expanded mode, they sit on a separate row below.
-                HStack(alignment: .center, spacing: VSpacing.md) {
+                // Text field and action buttons always live in the same
+                // HStack so the text container width stays constant when
+                // toggling between compact/expanded layouts. In compact mode
+                // buttons are vertically centered; in expanded mode they
+                // anchor to the bottom so they sit near the last line of text.
+                HStack(alignment: isComposerExpanded ? .bottom : .center, spacing: VSpacing.md) {
                     composerTextField
                         .frame(height: clampedComposerHeight)
                         .frame(maxHeight: isComposerExpanded ? clampedComposerHeight : .infinity, alignment: .center)
                         .clipped()
-                    if !isComposerExpanded {
-                        composerActionButtons
-                            .frame(maxHeight: .infinity, alignment: .center)
-                            .offset(y: compactActionOpticalYOffset)
-                    }
+                    composerActionButtons
+                        .frame(maxHeight: .infinity, alignment: isComposerExpanded ? .bottom : .center)
+                        .offset(y: isComposerExpanded ? 0 : compactActionOpticalYOffset)
                 }
                 .frame(height: isComposerExpanded ? clampedComposerHeight : compactRowHeight, alignment: .center)
-
-                if isComposerExpanded {
-                    // Expanded: buttons on a separate row below the text area
-                    HStack(spacing: VSpacing.md) {
-                        Spacer()
-                        composerActionButtons
-                    }
-                    .padding(.top, VSpacing.xs)
-                }
             }
-            .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.sm)
-            .padding(.bottom, isComposerExpanded ? VSpacing.sm : VSpacing.sm)
+            .padding(.top, VSpacing.sm)
+            .padding(.bottom, VSpacing.sm)
             .padding(.leading, VSpacing.lg)
             .padding(.trailing, VSpacing.lg)
             .background(
@@ -569,6 +558,11 @@ private struct ComposerTextView: NSViewRepresentable {
         scrollView.borderType = .noBorder
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
+        // Use overlay scrollers so the scroller draws on top of the
+        // content rather than reserving horizontal space. This prevents
+        // the text container width from shifting when the scroller
+        // appears or disappears during multi-line transitions.
+        scrollView.scrollerStyle = .overlay
         scrollView.autohidesScrollers = true
         // Ensure text content is clipped to the scroll view frame so it
         // never renders outside the composer box.


### PR DESCRIPTION
## Summary
- Keep action buttons always in the same HStack as the text field so the text container width stays constant when toggling between compact/expanded layouts
- Force overlay scroller style on the NSScrollView so the scrollbar draws on top of content rather than reserving horizontal space
- Remove the separate button row in expanded mode and simplify padding/reserved height calculations

🚀 Generated with [Vellum](https://vellum.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
