### PR TITLE
fix: use automatic code signing for iOS release archives

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -48,7 +48,6 @@ Environment variables for CI:
 | `DEVELOPMENT_TEAM` | *(required for release)* | Apple team ID |
 | `DISPLAY_VERSION` | from `Package.swift` | CFBundleShortVersionString |
 | `BUILD_VERSION` | `1` | CFBundleVersion |
-| `SIGN_IDENTITY` | `Apple Distribution` | Code signing identity |
 
 ### Building with Xcode (development)
 

--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 #   DEVELOPMENT_TEAM  Apple team ID (required for release)
 #   DISPLAY_VERSION   Override CFBundleShortVersionString (default: from Package.swift)
 #   BUILD_VERSION     Override CFBundleVersion (default: 1)
-#   SIGN_IDENTITY     Override code signing identity (default: Apple Distribution)
 #
 # Migration notes:
 #   - Use `open clients/ios/vellum-assistant-ios.xcodeproj` (not Package.swift)
@@ -52,7 +51,6 @@ fi
 BUILD_VERSION="${BUILD_VERSION:-1}"
 
 # Signing
-SIGN_IDENTITY="${SIGN_IDENTITY:-Apple Distribution}"
 DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-}"
 
 CMD="${1:-build}"
@@ -118,7 +116,6 @@ EXPORT_PATH="$DIST_DIR/export"
 echo "Building release archive..."
 echo "  Version: $DISPLAY_VERSION ($BUILD_VERSION)"
 echo "  Team: $DEVELOPMENT_TEAM"
-echo "  Identity: $SIGN_IDENTITY"
 
 # Clean previous artifacts
 rm -rf "$ARCHIVE_PATH" "$EXPORT_PATH"
@@ -132,7 +129,7 @@ xcodebuild archive \
     -archivePath "$ARCHIVE_PATH" \
     -configuration Release \
     DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-    CODE_SIGN_IDENTITY="$SIGN_IDENTITY" \
+    CODE_SIGN_STYLE=Automatic \
     MARKETING_VERSION="$DISPLAY_VERSION" \
     CURRENT_PROJECT_VERSION="$BUILD_VERSION"
 


### PR DESCRIPTION
## Summary

The archive command in `build.sh` used `CODE_SIGN_IDENTITY="Apple Distribution"` (manual signing), which requires explicitly specifying a provisioning profile. This breaks the build because no profile is provided.

Switches to `CODE_SIGN_STYLE=Automatic` so Xcode automatically selects the correct signing identity and provisioning profile based on `DEVELOPMENT_TEAM`.

## Changes

- Replace `CODE_SIGN_IDENTITY="$SIGN_IDENTITY"` with `CODE_SIGN_STYLE=Automatic` in the archive command
- Remove `SIGN_IDENTITY` variable and its env var handling
- Remove `SIGN_IDENTITY` from header docs and README env var table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
