### PR TITLE
Fix Twilio webhook forwarding auth in gateway

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -37,6 +37,7 @@ bun run dev
 | `INGRESS_PUBLIC_BASE_URL` | No | — | Public URL where the gateway is reachable (e.g. `https://abc123.ngrok-free.app`). Used by the assistant runtime to construct webhook and OAuth callback URLs. Set this to your tunnel's public URL. |
 | `GATEWAY_RUNTIME_PROXY_ENABLED` | No | `false` | Enable runtime proxy for non-Telegram requests |
 | `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
+| `RUNTIME_BEARER_TOKEN` | No | `~/.vellum/http-token` (if present) | Bearer token used by gateway when forwarding requests to assistant runtime internal endpoints (Twilio/OAuth/proxy upstream). |
 | `RUNTIME_PROXY_BEARER_TOKEN` | Conditional | — | Bearer token for proxy auth (required when proxy + auth enabled) |
 | `GATEWAY_SHUTDOWN_DRAIN_MS` | No | `5000` | Graceful shutdown drain window in milliseconds |
 | `GATEWAY_RUNTIME_TIMEOUT_MS` | No | `30000` | Timeout for runtime HTTP calls (ms) |

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -220,17 +220,41 @@ describe("config: runtime proxy flags", () => {
 });
 
 describe("config: runtime bearer token", () => {
-  test("runtimeBearerToken is undefined when RUNTIME_BEARER_TOKEN is unset", () => {
-    withEnv({}, () => {
+  test("runtimeBearerToken is undefined when env is unset and http-token file is missing", () => {
+    withEnv({ VELLUM_HTTP_TOKEN_PATH: "/nonexistent/http-token" }, () => {
       const config = loadConfig();
       expect(config.runtimeBearerToken).toBeUndefined();
     });
   });
 
   test("runtimeBearerToken is set from RUNTIME_BEARER_TOKEN env var", () => {
-    withEnv({ RUNTIME_BEARER_TOKEN: "rt-secret" }, () => {
+    withEnv({ RUNTIME_BEARER_TOKEN: "rt-secret", VELLUM_HTTP_TOKEN_PATH: "/nonexistent/http-token" }, () => {
       const config = loadConfig();
       expect(config.runtimeBearerToken).toBe("rt-secret");
     });
+  });
+
+  test("runtimeBearerToken is read from http-token file when env var is unset", () => {
+    withEnv({ VELLUM_HTTP_TOKEN_PATH: "/tmp/test-runtime-http-token" }, () => {
+      writeFileSync("/tmp/test-runtime-http-token", "runtime-file-token\n");
+      const config = loadConfig();
+      expect(config.runtimeBearerToken).toBe("runtime-file-token");
+      unlinkSync("/tmp/test-runtime-http-token");
+    });
+  });
+
+  test("RUNTIME_BEARER_TOKEN env var takes precedence over http-token file", () => {
+    withEnv(
+      {
+        RUNTIME_BEARER_TOKEN: "runtime-env-token",
+        VELLUM_HTTP_TOKEN_PATH: "/tmp/test-runtime-http-token-priority",
+      },
+      () => {
+        writeFileSync("/tmp/test-runtime-http-token-priority", "runtime-file-token");
+        const config = loadConfig();
+        expect(config.runtimeBearerToken).toBe("runtime-env-token");
+        unlinkSync("/tmp/test-runtime-http-token-priority");
+      },
+    );
   });
 });

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -136,11 +136,14 @@ export function loadConfig(): GatewayConfig {
   }
   const runtimeProxyRequireAuth = proxyRequireAuthRaw !== "false";
 
+  // Gateway -> runtime auth should use the same daemon-issued token source as
+  // runtime-proxy auth, unless explicitly overridden by env vars.
+  const runtimeTokenFromFile = readHttpTokenFile() || undefined;
   const runtimeBearerToken =
-    process.env.RUNTIME_BEARER_TOKEN || undefined;
+    process.env.RUNTIME_BEARER_TOKEN || runtimeTokenFromFile;
 
   const runtimeProxyBearerToken =
-    process.env.RUNTIME_PROXY_BEARER_TOKEN || readHttpTokenFile() || undefined;
+    process.env.RUNTIME_PROXY_BEARER_TOKEN || runtimeTokenFromFile;
 
   const MAX_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1, max safe setTimeout delay
 


### PR DESCRIPTION
## Summary
- fix gateway runtime auth token resolution so Twilio/OAuth/internal forwards use daemon token file fallback (`~/.vellum/http-token`) when `RUNTIME_BEARER_TOKEN` is unset
- keep explicit env var precedence for both `RUNTIME_BEARER_TOKEN` and `RUNTIME_PROXY_BEARER_TOKEN`
- add config tests for runtime bearer token file fallback + precedence
- document `RUNTIME_BEARER_TOKEN` behavior in gateway README

## Why
Twilio voice webhook requests were reaching gateway and passing signature validation, but gateway->runtime forwarding returned `401 Unauthorized` because runtime auth token was not set in gateway env. This fix aligns runtime forwarding auth with existing proxy token fallback behavior.

## Validation
- `cd gateway && bun test src/__tests__/config.test.ts`
- manual signed webhook probe now returns runtime response (`404 Call session not found` for fake session) instead of `401 Unauthorized`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
