### PR TITLE
Fix: restrict Return to unmodified Enter (PR #5999 feedback)

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -392,8 +392,8 @@ public struct ToolConfirmationBubble: View {
                 // Tab — move right
                 keyboardModel?.moveRight()
                 return nil
-            case 36, 76:
-                // Return / numpad Enter — activate
+            case 36, 76 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
+                // Plain Return / numpad Enter — activate (modified Enter passes through, e.g. Shift+Enter for newline)
                 if let action = keyboardModel?.selectedAction {
                     activateAction(action)
                 }


### PR DESCRIPTION
## Summary
- Restrict the NSEvent key monitor's Return/Enter handling to only fire when no modifier flags are held
- Shift+Enter and other modified Enter presses now pass through to the composer for newline insertion

Addresses feedback on #5999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
