### PR TITLE
Fix: scope legacy guard to tracked files (PR #6011 feedback)

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -41,13 +41,15 @@ describe('forbidden legacy symbols', () => {
     const repoRoot = resolve(__dirname, '..', '..', '..');
     let matches = '';
     try {
+      // Use git grep so only tracked files are searched. This automatically
+      // excludes untracked local .env files while still scanning committed
+      // environment templates like .env.example.
       matches = execSync(
-        `grep -rn -E "${escapedPattern}"` +
-        ' --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.swift"' +
-        ' --include="*.json" --include="*.md" --include="*.yml" --include="*.yaml"' +
-        ' --include="*.sh"' +
-        ' --exclude-dir=node_modules --exclude-dir=__tests__ --exclude-dir=.private' +
-        ' .',
+        `git grep -rn -E "${escapedPattern}" --` +
+        ' "*.ts" "*.tsx" "*.js" "*.mjs" "*.swift"' +
+        ' "*.json" "*.md" "*.yml" "*.yaml"' +
+        ' "*.sh" "*.env" "*.env.*"' +
+        ' ":!node_modules" ":!*/__tests__/*" ":!.private"',
         { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
       );
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Replace raw grep with git grep in the forbidden legacy symbols test
- This scans only tracked files, so committed .env.example files are checked while untracked local .env files are excluded
- Re-adds .env and .env.* patterns that were previously removed

Addresses feedback on #6011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
