### PR TITLE
Fix: restore original env fallback on config clear (PR #6012 feedback)

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -26,6 +26,10 @@ import type {
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
+// Snapshot the env-provided value at module load time so we can restore it
+// when the user clears a Settings-set override.
+const ORIGINAL_INGRESS_ENV = process.env.INGRESS_PUBLIC_BASE_URL;
+
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
   const configured = Object.keys(config.apiKeys).filter((k) => !!config.apiKeys[k]);
@@ -450,9 +454,11 @@ export function handleIngressConfig(
       // `pkill -f gateway`).
       if (value) {
         process.env.INGRESS_PUBLIC_BASE_URL = value;
+      } else if (ORIGINAL_INGRESS_ENV !== undefined) {
+        process.env.INGRESS_PUBLIC_BASE_URL = ORIGINAL_INGRESS_ENV;
+      } else {
+        delete process.env.INGRESS_PUBLIC_BASE_URL;
       }
-      // When cleared, do NOT delete the env var — the original env-provided
-      // value (if any) serves as a fallback per the documented precedence model.
 
       ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, localGatewayTarget, success: true });
     } else {


### PR DESCRIPTION
## Summary
- Capture original INGRESS_PUBLIC_BASE_URL at module load time
- When user clears ingress config in Settings, restore the original env value instead of leaving a stale Settings-set value
- If no original env value existed, properly delete the env var

Addresses feedback on #6012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
