### PR TITLE
Fix: enforce non-empty text/attachments in schema (PR #6013 feedback)

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -688,12 +688,13 @@ export function buildSchema(): Record<string, unknown> {
             "Request to deliver a message to a Telegram chat. At least one of `text` or `attachments` must be provided.",
           properties: {
             chatId: { type: "string", description: "Telegram chat ID to deliver the message to" },
-            text: { type: "string", description: "Text content to send" },
+            text: { type: "string", description: "Text content to send", minLength: 1 },
             assistantId: { type: "string", description: "Assistant ID (required when sending attachments)" },
             attachments: {
               type: "array",
               description: "Attachments to deliver (images sent via sendPhoto, others via sendDocument)",
               items: { $ref: "#/components/schemas/RuntimeAttachmentMeta" },
+              minItems: 1,
             },
           },
           anyOf: [


### PR DESCRIPTION
## Summary
- Add minLength: 1 to the text field in TelegramDeliverRequest schema
- Add minItems: 1 to the attachments array field
- Ensures the OpenAPI schema matches the runtime validation that rejects empty text/attachments

Addresses feedback on #6013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
