### PR TITLE
Fix: validate gateway package name in source dir check (PR #6017 feedback)

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -781,7 +781,14 @@ async function hatchCustom(
 }
 
 function isGatewaySourceDir(dir: string): boolean {
-  return existsSync(join(dir, "package.json")) && existsSync(join(dir, "src", "index.ts"));
+  const pkgPath = join(dir, "package.json");
+  if (!existsSync(pkgPath) || !existsSync(join(dir, "src", "index.ts"))) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return pkg.name === "@vellumai/vellum-gateway";
+  } catch {
+    return false;
+  }
 }
 
 function findGatewaySourceFromCwd(): string | undefined {


### PR DESCRIPTION
## Summary
- Update isGatewaySourceDir() to read package.json and verify the name field is @vellumai/vellum-gateway
- Prevents assistant/ and cli/ directories from being misidentified as gateway source

Addresses feedback on #6017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
