### PR TITLE
fix: add -allowProvisioningUpdates to iOS archive command

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -128,6 +128,7 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$ARCHIVE_PATH" \
     -configuration Release \
+    -allowProvisioningUpdates \
     DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
     CODE_SIGN_STYLE=Automatic \
     MARKETING_VERSION="$DISPLAY_VERSION" \


### PR DESCRIPTION
## Summary

The `xcodebuild archive` command fails with: *"Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass -allowProvisioningUpdates to xcodebuild."*

Adds `-allowProvisioningUpdates` so xcodebuild can create and download provisioning profiles automatically when using `CODE_SIGN_STYLE=Automatic`.

## Changes

One-line addition to the archive command in `clients/ios/build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
