### PR TITLE
Fix Twilio call status updates and live transcript handoff

### DIFF
--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -92,6 +92,9 @@ import {
 import {
   registerCallQuestionNotifier,
   unregisterCallQuestionNotifier,
+  registerCallTranscriptNotifier,
+  unregisterCallTranscriptNotifier,
+  fireCallTranscriptNotifier,
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
   fireCallQuestionNotifier,
@@ -333,6 +336,43 @@ describe('call-bridge', () => {
     expect(emittedEvents[1].type).toBe('message_complete');
 
     unregisterCallQuestionNotifier('conv-notifier-q');
+  });
+
+  // ── Call transcript notifier ─────────────────────────────────────
+
+  test('call transcript notifier persists transcript line and emits events', () => {
+    ensureConversation('conv-notifier-t');
+
+    const emittedEvents: Array<{ type: string; text?: string }> = [];
+    const sendToClient = (msg: { type: string; text?: string }) => {
+      emittedEvents.push(msg);
+    };
+
+    registerCallTranscriptNotifier('conv-notifier-t', (_callSessionId: string, speaker: 'caller' | 'assistant', text: string) => {
+      const speakerLabel = speaker === 'caller' ? 'Caller' : 'Assistant';
+      const transcriptText = `**Live call transcript**\n${speakerLabel}: ${text}`;
+      conversationStore.addMessage(
+        'conv-notifier-t',
+        'assistant',
+        JSON.stringify([{ type: 'text', text: transcriptText }]),
+      );
+      sendToClient({ type: 'assistant_text_delta', text: transcriptText });
+      sendToClient({ type: 'message_complete' });
+    });
+
+    fireCallTranscriptNotifier('conv-notifier-t', 'call-session-1', 'caller', 'Can you confirm the appointment?');
+
+    const msgs = getMessagesForConversation('conv-notifier-t');
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].role).toBe('assistant');
+    expect(msgs[0].content).toContain('Caller: Can you confirm the appointment?');
+
+    expect(emittedEvents.length).toBe(2);
+    expect(emittedEvents[0].type).toBe('assistant_text_delta');
+    expect(emittedEvents[0].text).toContain('Live call transcript');
+    expect(emittedEvents[1].type).toBe('message_complete');
+
+    unregisterCallTranscriptNotifier('conv-notifier-t');
   });
 
   // ── Call completion notifier ────────────────────────────────────

--- a/assistant/src/__tests__/call-state.test.ts
+++ b/assistant/src/__tests__/call-state.test.ts
@@ -10,6 +10,9 @@ import {
   registerCallQuestionNotifier,
   unregisterCallQuestionNotifier,
   fireCallQuestionNotifier,
+  registerCallTranscriptNotifier,
+  unregisterCallTranscriptNotifier,
+  fireCallTranscriptNotifier,
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
   fireCallCompletionNotifier,
@@ -23,6 +26,7 @@ describe('call-state', () => {
   // Clean up notifiers between tests
   beforeEach(() => {
     unregisterCallQuestionNotifier('test-conv');
+    unregisterCallTranscriptNotifier('test-conv');
     unregisterCallCompletionNotifier('test-conv');
     unregisterCallOrchestrator('test-session');
   });
@@ -60,6 +64,43 @@ describe('call-state', () => {
   test('fireCallQuestionNotifier does nothing when no notifier is registered', () => {
     // Should not throw
     fireCallQuestionNotifier('unregistered-conv', 'session-1', 'question');
+  });
+
+  // ── Transcript notifiers ──────────────────────────────────────────
+
+  test('registerCallTranscriptNotifier + fireCallTranscriptNotifier: callback receives args', () => {
+    let receivedSessionId = '';
+    let receivedSpeaker = '';
+    let receivedText = '';
+
+    registerCallTranscriptNotifier('test-conv', (callSessionId, speaker, text) => {
+      receivedSessionId = callSessionId;
+      receivedSpeaker = speaker;
+      receivedText = text;
+    });
+
+    fireCallTranscriptNotifier('test-conv', 'session-321', 'caller', 'Hello from caller');
+
+    expect(receivedSessionId).toBe('session-321');
+    expect(receivedSpeaker).toBe('caller');
+    expect(receivedText).toBe('Hello from caller');
+  });
+
+  test('unregisterCallTranscriptNotifier: fire after unregister does nothing', () => {
+    let called = false;
+
+    registerCallTranscriptNotifier('test-conv', () => {
+      called = true;
+    });
+
+    unregisterCallTranscriptNotifier('test-conv');
+    fireCallTranscriptNotifier('test-conv', 'session-321', 'assistant', 'Test');
+
+    expect(called).toBe(false);
+  });
+
+  test('fireCallTranscriptNotifier does nothing when no notifier is registered', () => {
+    fireCallTranscriptNotifier('unregistered-conv', 'session-1', 'caller', 'text');
   });
 
   // ── Completion notifiers ──────────────────────────────────────────

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -119,6 +119,7 @@ import { RuntimeHttpServer } from '../runtime/http-server.js';
 import * as callStore from '../calls/call-store.js';
 import {
   createCallSession,
+  getCallSession,
   updateCallSession,
   getCallEvents,
   buildCallbackDedupeKey,
@@ -126,6 +127,7 @@ import {
   releaseCallbackClaim,
 } from '../calls/call-store.js';
 import { resolveRelayUrl, handleStatusCallback } from '../calls/twilio-routes.js';
+import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from '../calls/call-state.js';
 
 initializeDb();
 
@@ -532,6 +534,112 @@ describe('twilio webhook routes', () => {
       expect(res.status).toBe(200);
 
       await stopServer();
+    });
+  });
+
+  describe('status mapping and completion notifications', () => {
+    test('initiated status callback is accepted and recorded as call_started', async () => {
+      const session = createTestSession('conv-status-init-1', 'CA_status_init_1');
+      const params = new URLSearchParams({
+        CallSid: 'CA_status_init_1',
+        CallStatus: 'initiated',
+        Timestamp: '2025-01-21T10:00:00Z',
+      });
+
+      const req = new Request('http://127.0.0.1/v1/calls/twilio/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      const res = await handleStatusCallback(req);
+      expect(res.status).toBe(200);
+
+      const updated = getCallSession(session.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('initiated');
+      const events = getCallEvents(session.id);
+      expect(events.filter((e) => e.eventType === 'call_started').length).toBe(1);
+    });
+
+    test('answered status callback transitions to in_progress', async () => {
+      const session = createTestSession('conv-status-answered-1', 'CA_status_answered_1');
+      const params = new URLSearchParams({
+        CallSid: 'CA_status_answered_1',
+        CallStatus: 'answered',
+        Timestamp: '2025-01-21T10:05:00Z',
+      });
+
+      const req = new Request('http://127.0.0.1/v1/calls/twilio/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      const res = await handleStatusCallback(req);
+      expect(res.status).toBe(200);
+
+      const updated = getCallSession(session.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('in_progress');
+      expect(updated!.startedAt).not.toBeNull();
+      const events = getCallEvents(session.id);
+      expect(events.filter((e) => e.eventType === 'call_connected').length).toBe(1);
+    });
+
+    test('completed status callback fires completion notifier when first entering terminal state', async () => {
+      const session = createTestSession('conv-status-complete-1', 'CA_status_complete_1');
+      updateCallSession(session.id, { status: 'in_progress', startedAt: Date.now() - 20_000 });
+      const params = new URLSearchParams({
+        CallSid: 'CA_status_complete_1',
+        CallStatus: 'completed',
+        Timestamp: '2025-01-21T10:10:00Z',
+      });
+
+      let fired = 0;
+      registerCallCompletionNotifier('conv-status-complete-1', () => {
+        fired += 1;
+      });
+
+      const req = new Request('http://127.0.0.1/v1/calls/twilio/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      const res = await handleStatusCallback(req);
+      expect(res.status).toBe(200);
+
+      const updated = getCallSession(session.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('completed');
+      expect(updated!.endedAt).not.toBeNull();
+      expect(fired).toBe(1);
+
+      unregisterCallCompletionNotifier('conv-status-complete-1');
+    });
+
+    test('completed callback does not re-fire completion notifier for already terminal call', async () => {
+      const session = createTestSession('conv-status-complete-2', 'CA_status_complete_2');
+      updateCallSession(session.id, { status: 'completed', startedAt: Date.now() - 20_000, endedAt: Date.now() - 5_000 });
+      const params = new URLSearchParams({
+        CallSid: 'CA_status_complete_2',
+        CallStatus: 'completed',
+        Timestamp: '2025-01-21T10:15:00Z',
+      });
+
+      let fired = 0;
+      registerCallCompletionNotifier('conv-status-complete-2', () => {
+        fired += 1;
+      });
+
+      const req = new Request('http://127.0.0.1/v1/calls/twilio/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      const res = await handleStatusCallback(req);
+      expect(res.status).toBe(200);
+      expect(fired).toBe(0);
+
+      unregisterCallCompletionNotifier('conv-status-complete-2');
     });
   });
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -18,7 +18,7 @@ import {
 } from './call-store.js';
 import { getMaxCallDurationMs, getUserConsultationTimeoutMs, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import type { RelayConnection } from './relay-server.js';
-import { registerCallOrchestrator, unregisterCallOrchestrator, fireCallQuestionNotifier, fireCallCompletionNotifier } from './call-state.js';
+import { registerCallOrchestrator, unregisterCallOrchestrator, fireCallQuestionNotifier, fireCallCompletionNotifier, fireCallTranscriptNotifier } from './call-state.js';
 import type { PromptSpeakerContext } from './speaker-identification.js';
 
 const log = getLogger('call-orchestrator');
@@ -290,6 +290,13 @@ export class CallOrchestrator {
       // Record the assistant response
       this.conversationHistory.push({ role: 'assistant', content: responseText });
       recordCallEvent(this.callSessionId, 'assistant_spoke', { text: responseText });
+      const spokenText = responseText.replace(ASK_USER_REGEX, '').replace(END_CALL_MARKER, '').trim();
+      if (spokenText.length > 0) {
+        const session = getCallSession(this.callSessionId);
+        if (session) {
+          fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', spokenText);
+        }
+      }
 
       // Check for ASK_USER pattern
       const askMatch = responseText.match(ASK_USER_REGEX);
@@ -324,14 +331,19 @@ export class CallOrchestrator {
 
       // Check for END_CALL marker
       if (responseText.includes(END_CALL_MARKER)) {
+        const currentSession = getCallSession(this.callSessionId);
+        const shouldNotifyCompletion = currentSession
+          ? currentSession.status !== 'completed' && currentSession.status !== 'failed' && currentSession.status !== 'cancelled'
+          : false;
+
         this.relay.endSession('Call completed');
         updateCallSession(this.callSessionId, { status: 'completed', endedAt: Date.now() });
         recordCallEvent(this.callSessionId, 'call_ended', { reason: 'completed' });
 
-        // Notify the conversation that the call completed
-        const endSession = getCallSession(this.callSessionId);
-        if (endSession) {
-          fireCallCompletionNotifier(endSession.conversationId, this.callSessionId);
+        // Notify the conversation when this is the first transition
+        // into a terminal call state.
+        if (shouldNotifyCompletion && currentSession) {
+          fireCallCompletionNotifier(currentSession.conversationId, this.callSessionId);
         }
         this.state = 'idle';
         return;
@@ -373,9 +385,17 @@ export class CallOrchestrator {
       );
       // Give TTS a moment to play, then end
       this.durationEndTimer = setTimeout(() => {
+        const currentSession = getCallSession(this.callSessionId);
+        const shouldNotifyCompletion = currentSession
+          ? currentSession.status !== 'completed' && currentSession.status !== 'failed' && currentSession.status !== 'cancelled'
+          : false;
+
         this.relay.endSession('Maximum call duration reached');
         updateCallSession(this.callSessionId, { status: 'completed', endedAt: Date.now() });
         recordCallEvent(this.callSessionId, 'call_ended', { reason: 'max_duration' });
+        if (shouldNotifyCompletion && currentSession) {
+          fireCallCompletionNotifier(currentSession.conversationId, this.callSessionId);
+        }
       }, 3000);
     }, maxDurationMs);
   }

--- a/assistant/src/calls/call-state.ts
+++ b/assistant/src/calls/call-state.ts
@@ -28,6 +28,29 @@ export function fireCallQuestionNotifier(conversationId: string, callSessionId: 
   questionNotifiers.get(conversationId)?.(callSessionId, question);
 }
 
+// ── Transcript notifiers ────────────────────────────────────────────
+const transcriptNotifiers = new Map<string, (callSessionId: string, speaker: 'caller' | 'assistant', text: string) => void>();
+
+export function registerCallTranscriptNotifier(
+  conversationId: string,
+  callback: (callSessionId: string, speaker: 'caller' | 'assistant', text: string) => void,
+): void {
+  transcriptNotifiers.set(conversationId, callback);
+}
+
+export function unregisterCallTranscriptNotifier(conversationId: string): void {
+  transcriptNotifiers.delete(conversationId);
+}
+
+export function fireCallTranscriptNotifier(
+  conversationId: string,
+  callSessionId: string,
+  speaker: 'caller' | 'assistant',
+  text: string,
+): void {
+  transcriptNotifiers.get(conversationId)?.(callSessionId, speaker, text);
+}
+
 // ── Completion notifiers ────────────────────────────────────────────
 const completionNotifiers = new Map<string, (callSessionId: string) => void>();
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -14,6 +14,7 @@ import {
   recordCallEvent,
 } from './call-store.js';
 import { CallOrchestrator } from './call-orchestrator.js';
+import { fireCallTranscriptNotifier } from './call-state.js';
 import {
   extractPromptSpeakerMetadata,
   SpeakerIdentityTracker,
@@ -285,6 +286,11 @@ export class RelayConnection {
       speakerConfidence: speaker.speakerConfidence,
       speakerSource: speaker.source,
     });
+
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'caller', msg.voicePrompt);
+    }
 
     // Route to orchestrator for LLM-driven response
     if (this.orchestrator) {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -24,6 +24,7 @@ import { isTerminalState } from './call-state-machine.js';
 import { getTwilioConfig } from './twilio-config.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
+import { fireCallCompletionNotifier } from './call-state.js';
 
 const log = getLogger('twilio-routes');
 
@@ -74,9 +75,12 @@ export function resolveRelayUrl(wssBaseUrl: string, webhookBaseUrl: string): str
  */
 function mapTwilioStatus(twilioStatus: string): CallStatus | null {
   switch (twilioStatus) {
+    case 'initiated':
     case 'queued':
+      return 'initiated';
     case 'ringing':
       return 'ringing';
+    case 'answered':
     case 'in-progress':
       return 'in_progress';
     case 'completed':
@@ -189,6 +193,8 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
   }
 
   try {
+    const wasTerminal = isTerminalState(session.status);
+
     // Build updates
     const updates: Parameters<typeof updateCallSession>[1] = {
       status: mappedStatus,
@@ -218,6 +224,10 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     // Expire pending questions on terminal status
     if (isTerminal) {
       expirePendingQuestions(session.id);
+
+      if (!wasTerminal) {
+        fireCallCompletionNotifier(session.conversationId, session.id);
+      }
     }
 
     // Mark the claim as permanently processed so it never expires.
@@ -255,4 +265,3 @@ export async function handleConnectAction(_req: Request): Promise<Response> {
     },
   );
 }
-

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -25,6 +25,8 @@ import { lastCommentaryBySession, lastSummaryBySession } from './watch-handler.j
 import {
   registerCallQuestionNotifier,
   unregisterCallQuestionNotifier,
+  registerCallTranscriptNotifier,
+  unregisterCallTranscriptNotifier,
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
 } from '../calls/call-state.js';
@@ -114,6 +116,32 @@ export function registerSessionNotifiers(
     });
   });
 
+  registerCallTranscriptNotifier(
+    conversationId,
+    (_callSessionId: string, speaker: 'caller' | 'assistant', text: string) => {
+      const speakerLabel = speaker === 'caller' ? 'Caller' : 'Assistant';
+      const transcriptText = `**Live call transcript**\n${speakerLabel}: ${text}`;
+
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: transcriptText }]),
+      );
+
+      ctx.messages.push(createAssistantMessage(transcriptText));
+
+      ctx.sendToClient({
+        type: 'assistant_text_delta',
+        text: transcriptText,
+        sessionId: conversationId,
+      });
+      ctx.sendToClient({
+        type: 'message_complete',
+        sessionId: conversationId,
+      });
+    },
+  );
+
   registerCallCompletionNotifier(conversationId, (callSessionId: string) => {
     const callSession = getCallSession(callSessionId);
     const events = getCallEvents(callSessionId);
@@ -160,5 +188,6 @@ export function unregisterWatchNotifiers(conversationId: string): void {
  */
 export function unregisterCallNotifiers(conversationId: string): void {
   unregisterCallQuestionNotifier(conversationId);
+  unregisterCallTranscriptNotifier(conversationId);
   unregisterCallCompletionNotifier(conversationId);
 }


### PR DESCRIPTION
## Summary
- map Twilio status callbacks to include initiated and answered so sessions no longer get stuck as initiated
- fire call completion notifications from status callback terminal transitions with duplicate suppression
- add live call transcript notifier plumbing and stream caller and assistant utterances into the conversation thread
- keep completion notifications idempotent when both orchestrator and callback paths can end a call

## Validation
- bun test src/__tests__/call-state.test.ts src/__tests__/call-bridge.test.ts src/__tests__/relay-server.test.ts
- bun test src/__tests__/twilio-routes.test.ts --filter status mapping and completion notifications (new direct handler tests passed; existing server-start tests in this file fail in this environment with Bun port-0 EADDRINUSE before test logic)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
