### PR TITLE
fix: use manual code signing for iOS release archives

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -128,9 +128,10 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$ARCHIVE_PATH" \
     -configuration Release \
-    -allowProvisioningUpdates \
     DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-    CODE_SIGN_STYLE=Automatic \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="Apple Distribution" \
+    PROVISIONING_PROFILE_SPECIFIER="Vellum Assistant iOS Distribution" \
     MARKETING_VERSION="$DISPLAY_VERSION" \
     CURRENT_PROJECT_VERSION="$BUILD_VERSION"
 


### PR DESCRIPTION
## Summary

Automatic signing (`CODE_SIGN_STYLE=Automatic`) tries to generate a development provisioning profile, which fails without a registered device. Switch release/archive builds to manual signing with an explicit distribution identity and profile.

## Changes

In the `xcodebuild archive` command:
- `CODE_SIGN_STYLE=Automatic` → `CODE_SIGN_STYLE=Manual`
- Added `CODE_SIGN_IDENTITY="Apple Distribution"`
- Added `PROVISIONING_PROFILE_SPECIFIER="Vellum Assistant iOS Distribution"`
- Removed `-allowProvisioningUpdates` (not needed for manual signing)

Debug/simulator builds are unaffected (`CODE_SIGNING_ALLOWED=NO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
