### PR TITLE
fix: update exportOptions for manual signing and app-store-connect

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -165,11 +165,16 @@ cat > "$EXPORT_OPTIONS" <<PLIST
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>app-store</string>
+    <string>app-store-connect</string>
     <key>teamID</key>
     <string>$DEVELOPMENT_TEAM</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.vellum.vellum-assistant-ios</key>
+        <string>Vellum Assistant iOS Distribution</string>
+    </dict>
     <key>uploadSymbols</key>
     <true/>
     <key>uploadBitcode</key>


### PR DESCRIPTION
## Summary

Export step fails after a successful archive because the exportOptions.plist has the wrong method and signing style.

## Changes

- `method`: `app-store` → `app-store-connect`
- `signingStyle`: `automatic` → `manual` (matches the archive's manual signing)
- Added `provisioningProfiles` dict mapping the bundle ID to the distribution profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
