### PR TITLE
Fix Twilio call status stuck at initiated

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,0 +1,4 @@
+
+https://github.com/vellum-ai/vellum-assistant/pull/5992
+
+https://github.com/vellum-ai/vellum-assistant/pull/6044

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -104,6 +104,7 @@ import {
   getCallSession,
   getCallEvents,
 } from '../calls/call-store.js';
+import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from '../calls/call-state.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
 
@@ -196,6 +197,8 @@ describe('relay-server', () => {
     const updated = getCallSession(session.id);
     expect(updated).not.toBeNull();
     expect(updated!.providerCallSid).toBe('CA_relay_setup_123');
+    expect(updated!.status).toBe('in_progress');
+    expect(updated!.startedAt).not.toBeNull();
 
     // Verify event was recorded
     const events = getCallEvents(session.id);
@@ -204,6 +207,58 @@ describe('relay-server', () => {
 
     // Verify orchestrator was created
     expect(relay.getOrchestrator()).not.toBeNull();
+
+    relay.destroy();
+  });
+
+  test('handleTransportClosed: normal close marks call completed and notifies completion', () => {
+    ensureConversation('conv-relay-close-normal');
+    const session = createCallSession({
+      conversationId: 'conv-relay-close-normal',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const { relay } = createMockWs(session.id);
+    let completionCount = 0;
+    registerCallCompletionNotifier('conv-relay-close-normal', () => {
+      completionCount += 1;
+    });
+
+    relay.handleTransportClosed(1000, 'Closing websocket session');
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('completed');
+    expect(updated!.endedAt).not.toBeNull();
+    const endedEvents = getCallEvents(session.id).filter((e) => e.eventType === 'call_ended');
+    expect(endedEvents.length).toBe(1);
+    expect(completionCount).toBe(1);
+
+    unregisterCallCompletionNotifier('conv-relay-close-normal');
+    relay.destroy();
+  });
+
+  test('handleTransportClosed: abnormal close marks call failed', () => {
+    ensureConversation('conv-relay-close-abnormal');
+    const session = createCallSession({
+      conversationId: 'conv-relay-close-abnormal',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const { relay } = createMockWs(session.id);
+    relay.handleTransportClosed(1006, 'abnormal closure');
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.endedAt).not.toBeNull();
+    expect(updated!.lastError).toContain('abnormal closure');
+    const failEvents = getCallEvents(session.id).filter((e) => e.eventType === 'call_failed');
+    expect(failEvents.length).toBe(1);
 
     relay.destroy();
   });

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -30,10 +30,12 @@ mock.module('../util/logger.js', () => ({
 
 // Start with a configured auth token
 let mockAuthToken: string | undefined = 'test-auth-token-secret';
+let mockAccountSid: string | undefined = 'AC_test_account';
 
 mock.module('../security/secure-keys.js', () => ({
   getSecureKey: (account: string) => {
     if (account === 'credential:twilio:auth_token') return mockAuthToken;
+    if (account === 'credential:twilio:account_sid') return mockAccountSid;
     return undefined;
   },
 }));
@@ -60,6 +62,7 @@ function computeValidSignature(
 describe('TwilioConversationRelayProvider', () => {
   beforeEach(() => {
     mockAuthToken = 'test-auth-token-secret';
+    mockAccountSid = 'AC_test_account';
   });
 
   describe('verifyWebhookSignature', () => {
@@ -138,6 +141,39 @@ describe('TwilioConversationRelayProvider', () => {
       mockAuthToken = undefined;
       const token = TwilioConversationRelayProvider.getAuthToken();
       expect(token).toBeNull();
+    });
+  });
+
+  describe('initiateCall', () => {
+    test('sends repeated StatusCallbackEvent parameters', async () => {
+      const provider = new TwilioConversationRelayProvider();
+      const originalFetch = globalThis.fetch;
+      let capturedBody = '';
+
+      globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        capturedBody = String(init?.body ?? '');
+        return new Response(JSON.stringify({ sid: 'CA_test_123' }), { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        const result = await provider.initiateCall({
+          from: '+15550001111',
+          to: '+15550002222',
+          webhookUrl: 'https://example.com/webhooks/twilio/voice?callSessionId=s1',
+          statusCallbackUrl: 'https://example.com/webhooks/twilio/status',
+        });
+
+        expect(result.callSid).toBe('CA_test_123');
+        const params = new URLSearchParams(capturedBody);
+        expect(params.getAll('StatusCallbackEvent')).toEqual([
+          'initiated',
+          'ringing',
+          'answered',
+          'completed',
+        ]);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,14 +12,16 @@ import {
   getCallSession,
   updateCallSession,
   recordCallEvent,
+  expirePendingQuestions,
 } from './call-store.js';
 import { CallOrchestrator } from './call-orchestrator.js';
-import { fireCallTranscriptNotifier } from './call-state.js';
+import { fireCallTranscriptNotifier, fireCallCompletionNotifier } from './call-state.js';
 import {
   extractPromptSpeakerMetadata,
   SpeakerIdentityTracker,
   type PromptSpeakerContext,
 } from './speaker-identification.js';
+import { isTerminalState } from './call-state-machine.js';
 
 const log = getLogger('relay-server');
 
@@ -229,6 +231,44 @@ export class RelayConnection {
     log.info({ callSessionId: this.callSessionId }, 'RelayConnection destroyed');
   }
 
+  /**
+   * Handle transport-level close from the relay websocket.
+   *
+   * Twilio status callbacks are best-effort; if they are delayed or absent,
+   * we still finalize the call lifecycle from the relay close signal.
+   */
+  handleTransportClosed(code?: number, reason?: string): void {
+    const session = getCallSession(this.callSessionId);
+    if (!session) return;
+    if (isTerminalState(session.status)) return;
+
+    const isNormalClose = code === 1000;
+    if (isNormalClose) {
+      updateCallSession(this.callSessionId, {
+        status: 'completed',
+        endedAt: Date.now(),
+      });
+      recordCallEvent(this.callSessionId, 'call_ended', {
+        reason: reason || 'relay_closed',
+        closeCode: code,
+      });
+    } else {
+      const detail = reason || (code ? `relay_closed_${code}` : 'relay_closed_abnormal');
+      updateCallSession(this.callSessionId, {
+        status: 'failed',
+        endedAt: Date.now(),
+        lastError: `Relay websocket closed unexpectedly: ${detail}`,
+      });
+      recordCallEvent(this.callSessionId, 'call_failed', {
+        reason: detail,
+        closeCode: code,
+      });
+    }
+
+    expirePendingQuestions(this.callSessionId);
+    fireCallCompletionNotifier(session.conversationId, this.callSessionId);
+  }
+
   // ── Private handlers ─────────────────────────────────────────────
 
   private async handleSetup(msg: RelaySetupMessage): Promise<void> {
@@ -240,7 +280,16 @@ export class RelayConnection {
     // Store the callSid association on the call session
     const session = getCallSession(this.callSessionId);
     if (session) {
-      updateCallSession(this.callSessionId, { providerCallSid: msg.callSid });
+      const updates: Parameters<typeof updateCallSession>[1] = {
+        providerCallSid: msg.callSid,
+      };
+      if (!isTerminalState(session.status) && session.status !== 'in_progress' && session.status !== 'waiting_on_user') {
+        updates.status = 'in_progress';
+        if (!session.startedAt) {
+          updates.startedAt = Date.now();
+        }
+      }
+      updateCallSession(this.callSessionId, updates);
     }
 
     recordCallEvent(this.callSessionId, 'call_connected', {

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -45,8 +45,13 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       To: opts.to,
       Url: opts.webhookUrl,
       StatusCallback: opts.statusCallbackUrl,
-      StatusCallbackEvent: 'initiated ringing answered completed',
     });
+    // Twilio expects repeated StatusCallbackEvent params, not a single
+    // space-delimited string.
+    body.append('StatusCallbackEvent', 'initiated');
+    body.append('StatusCallbackEvent', 'ringing');
+    body.append('StatusCallbackEvent', 'answered');
+    body.append('StatusCallbackEvent', 'completed');
 
     const reservedKeys = new Set(['From', 'To', 'Url', 'StatusCallback', 'StatusCallbackEvent']);
     if (opts.customParams) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -378,6 +378,7 @@ export class RuntimeHttpServer {
           log.info({ callSessionId, code, reason: reason?.toString() }, 'ConversationRelay WebSocket closed');
           if (callSessionId) {
             const connection = activeRelayConnections.get(callSessionId);
+            connection?.handleTransportClosed(code, reason?.toString());
             connection?.destroy();
             activeRelayConnections.delete(callSessionId);
           }


### PR DESCRIPTION
## Summary
- send Twilio StatusCallbackEvent as repeated parameters initiated/ringing/answered/completed instead of a single space-delimited field
- mark calls in_progress on relay setup when status callbacks are delayed
- finalize call status from relay transport close as fallback (completed on normal close, failed on abnormal close), including completion notifications and pending-question expiry
- wire runtime websocket close path to invoke relay transport-close finalization
- add tests for repeated callback event params and relay-close status finalization

## Validation
- bun test src/__tests__/relay-server.test.ts src/__tests__/twilio-provider.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
