### PR TITLE
feat: fetch identity info for GCP-hosted assistants

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -6,10 +6,12 @@
  */
 
 import { existsSync, readFileSync, statfsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
+import { getWorkspacePromptPath } from '../util/platform.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl } from '../inbound/public-ingress-urls.js';
@@ -770,6 +772,10 @@ export class RuntimeHttpServer {
         return await handleConnectAction(fakeReq);
       }
 
+      if (endpoint === 'identity' && req.method === 'GET') {
+        return this.handleGetIdentity();
+      }
+
       if (endpoint === 'events' && req.method === 'GET') {
         return handleSubscribeAssistantEvents(req, url);
       }
@@ -923,6 +929,54 @@ export class RuntimeHttpServer {
         break;
       }
     }
+  }
+
+  private handleGetIdentity(): Response {
+    const identityPath = getWorkspacePromptPath('IDENTITY.md');
+    if (!existsSync(identityPath)) {
+      return Response.json({ error: 'IDENTITY.md not found' }, { status: 404 });
+    }
+
+    const content = readFileSync(identityPath, 'utf-8');
+    const fields: Record<string, string> = {};
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      const lower = trimmed.toLowerCase();
+      const extract = (prefix: string): string | null => {
+        if (!lower.startsWith(prefix)) return null;
+        return trimmed.split(':**').pop()?.trim() ?? null;
+      };
+
+      const name = extract('- **name:**');
+      if (name) { fields.name = name; continue; }
+      const role = extract('- **role:**');
+      if (role) { fields.role = role; continue; }
+      const personality = extract('- **personality:**') ?? extract('- **vibe:**');
+      if (personality) { fields.personality = personality; continue; }
+      const emoji = extract('- **emoji:**');
+      if (emoji) { fields.emoji = emoji; continue; }
+      const home = extract('- **home:**');
+      if (home) { fields.home = home; continue; }
+    }
+
+    // Read version from package.json
+    let version: string | undefined;
+    try {
+      const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      version = pkg.version;
+    } catch {
+      // ignore
+    }
+
+    return Response.json({
+      name: fields.name ?? '',
+      role: fields.role ?? '',
+      personality: fields.personality ?? '',
+      emoji: fields.emoji ?? '',
+      home: fields.home ?? '',
+      version,
+    });
   }
 
   private handleHealth(): Response {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -8,6 +8,7 @@ struct IdentityPanel: View {
     @State private var appearance = AvatarAppearanceManager.shared
 
     @State private var identity: IdentityInfo?
+    @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var metadata: AssistantMetadata?
     @State private var lockfileAssistant: LockfileAssistant?
     @State private var workspaceFiles: [WorkspaceFileNode] = []
@@ -34,13 +35,11 @@ struct IdentityPanel: View {
 
                 // Avatar + ID card + CTA
                 HStack(alignment: .center, spacing: VSpacing.lg) {
-                    DinoSceneView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                    DinoSceneView(seed: identity?.name ?? remoteIdentity?.name ?? lockfileAssistant?.assistantId ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                         .frame(width: 180, height: 200)
 
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        if let identity {
-                            idCardSection(identity: identity)
-                        }
+                        idCardSection(identity: identity, remoteIdentity: remoteIdentity)
 
                         // Customize Avatar CTA
                         Button(action: onCustomizeAvatar) {
@@ -101,6 +100,13 @@ struct IdentityPanel: View {
             lockfileAssistant = LockfileAssistant.loadLatest()
             workspaceFiles = WorkspaceFileNode.scan()
             fetchSkills()
+
+            // For remote assistants without local IDENTITY.md, fetch from daemon
+            if identity == nil, lockfileAssistant?.isRemote == true {
+                Task {
+                    remoteIdentity = await daemonClient.fetchRemoteIdentity()
+                }
+            }
         }
     }
 
@@ -128,24 +134,38 @@ struct IdentityPanel: View {
     // MARK: - ID Card
 
     @ViewBuilder
-    private func idCardSection(identity: IdentityInfo) -> some View {
+    private func idCardSection(identity: IdentityInfo?, remoteIdentity: RemoteIdentityInfo?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             if let assistantId = lockfileAssistant?.assistantId {
                 idRow(label: "Assistant ID", value: assistantId, mono: true)
             }
 
-            idRow(label: "Agent ID", value: identity.agentID, mono: true)
-            idRow(label: "Given name", value: identity.name)
-
-            if !identity.role.isEmpty {
-                idRow(label: "Role", value: identity.role)
+            // Agent ID (only available from local identity)
+            if let identity {
+                idRow(label: "Agent ID", value: identity.agentID, mono: true)
             }
 
-            if !identity.personality.isEmpty {
-                idRow(label: "Personality", value: identity.personality)
+            // Given name: remote > local > assistantId
+            let name = remoteIdentity?.name.nilIfEmpty ?? identity?.name ?? lockfileAssistant?.assistantId
+            if let name {
+                idRow(label: "Given name", value: name)
             }
 
-            idRow(label: "Version", value: daemonClient.daemonVersion ?? metadata?.version ?? "—")
+            // Role: remote > local
+            let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
+            if let role, !role.isEmpty {
+                idRow(label: "Role", value: role)
+            }
+
+            // Personality: remote > local
+            let personality = remoteIdentity?.personality.nilIfEmpty ?? identity?.personality
+            if let personality, !personality.isEmpty {
+                idRow(label: "Personality", value: personality)
+            }
+
+            // Version: remote > daemon > metadata
+            let version = remoteIdentity?.version ?? daemonClient.daemonVersion ?? metadata?.version
+            idRow(label: "Version", value: version ?? "—")
 
             if let date = metadata?.createdAt {
                 idRow(label: "Created at", value: formatDate(date))
@@ -153,7 +173,7 @@ struct IdentityPanel: View {
 
             idRow(label: "Origin system", value: metadata?.originSystem ?? "local")
 
-            let home = lockfileAssistant?.home ?? identity.home ?? .local(workspacePath: NSHomeDirectory() + "/.vellum/workspace")
+            let home = lockfileAssistant?.home ?? identity?.home ?? .local(workspacePath: NSHomeDirectory() + "/.vellum/workspace")
             homeRow(home: home)
         }
     }
@@ -210,6 +230,10 @@ struct IdentityPanel: View {
         formatter.timeStyle = .short
         return formatter.string(from: date)
     }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }
 
 // MARK: - Workspace File Sheet

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -926,6 +926,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(LinkOpenRequestMessage(url: url, metadata: metadata))
     }
 
+    // MARK: - Remote Identity
+
+    /// Fetch identity info from the remote daemon. Returns nil for local (socket) transports.
+    #if os(macOS)
+    public func fetchRemoteIdentity() async -> RemoteIdentityInfo? {
+        return await httpTransport?.fetchRemoteIdentity()
+    }
+    #endif
+
     // MARK: - Document Persistence
 
     public func sendDocumentSave(surfaceId: String, conversationId: String, title: String, content: String, wordCount: Int) throws {

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Identity fields fetched from a remote assistant's `GET /v1/identity` endpoint.
+public struct RemoteIdentityInfo: Decodable {
+    public let name: String
+    public let role: String
+    public let personality: String
+    public let emoji: String
+    public let version: String?
+}
+
 public struct DaemonConfig {
     #if os(macOS)
     /// Transport mode for communicating with the assistant daemon.

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -357,6 +357,26 @@ final class HTTPTransport {
         }
     }
 
+    // MARK: - Remote Identity
+
+    /// Fetch identity info from the remote daemon's `GET /v1/identity` endpoint.
+    func fetchRemoteIdentity() async -> RemoteIdentityInfo? {
+        guard let url = URL(string: "\(baseURL)/v1/identity") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return try? JSONDecoder().decode(RemoteIdentityInfo.self, from: data)
+        } catch {
+            log.error("fetchRemoteIdentity failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
     // MARK: - Disconnect
 
     func disconnect() {


### PR DESCRIPTION
## Summary
- Adds `GET /v1/identity` endpoint to the runtime HTTP server that reads and returns parsed IDENTITY.md fields (name, role, personality, emoji) plus the daemon version
- Adds `RemoteIdentityInfo` struct and `fetchRemoteIdentity()` on `HTTPTransport` / `DaemonClient` to call this endpoint from the macOS client
- Updates `IdentityPanel` to always show the ID card section, using remote identity data as fallback when local IDENTITY.md is unavailable (GCP/AWS/custom assistants)

## Test plan
- [ ] Local assistant: Identity panel continues to work as before (local IDENTITY.md takes priority)
- [ ] GCP assistant in lockfile: Identity panel shows Assistant ID, Home (GCP with project/zone/instance), Version
- [ ] If remote daemon is reachable: panel also shows Given name, Role, Personality fetched from remote IDENTITY.md
- [ ] If remote daemon is unreachable: panel gracefully shows lockfile-derived fallbacks without errors
- [ ] `./build.sh` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
