### PR TITLE
fix: dismiss retiring assistant modal after operation completes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -332,72 +332,76 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func performRetire() {
+        Task { await performRetireAsync() }
+    }
+
+    /// Async retire implementation callable from SwiftUI so callers can
+    /// await completion and dismiss their loading UI.
+    func performRetireAsync() async {
         let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
         if assistantName == nil {
             log.error("No stored connected assistant ID found — skipping retire")
         }
 
-        Task {
-            if let name = assistantName {
-                try? await assistantCli.retire(name: name)
-            } else {
-                assistantCli.stop()
-            }
+        if let name = assistantName {
+            try? await assistantCli.retire(name: name)
+        } else {
+            assistantCli.stop()
+        }
 
-            // Check if other assistants remain in the lockfile
-            let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
-            if let next = remaining.first {
-                // Auto-switch to the next available assistant
-                settingsWindow?.close()
-                settingsWindow = nil
-                performSwitchAssistant(to: next)
-                return
-            }
-
-            // No assistants left — tear down fully and show onboarding
-            OnboardingState.clearPersistedState()
-
-            mainWindow?.close()
-            mainWindow = nil
+        // Check if other assistants remain in the lockfile
+        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
+        if let next = remaining.first {
+            // Auto-switch to the next available assistant
             settingsWindow?.close()
             settingsWindow = nil
-
-            if let hotKeyMonitor {
-                NSEvent.removeMonitor(hotKeyMonitor)
-                self.hotKeyMonitor = nil
-            }
-            if let escapeMonitor {
-                NSEvent.removeMonitor(escapeMonitor)
-                self.escapeMonitor = nil
-            }
-            voiceInput?.stop()
-            voiceInput = nil
-            ambientAgent.teardown()
-
-            if let observer = windowObserver {
-                NotificationCenter.default.removeObserver(observer)
-                windowObserver = nil
-            }
-            statusIconCancellable?.cancel()
-            statusIconCancellable = nil
-
-            if let item = statusItem {
-                NSStatusBar.system.removeStatusItem(item)
-                statusItem = nil
-            }
-
-            if let mainMenu = NSApp.mainMenu {
-                for title in ["File", "View"] {
-                    let idx = mainMenu.indexOfItem(withTitle: title)
-                    if idx >= 0 { mainMenu.removeItem(at: idx) }
-                }
-            }
-
-            hasSetupApp = false
-            hasSetupDaemon = false
-            showOnboarding()
+            performSwitchAssistant(to: next)
+            return
         }
+
+        // No assistants left — tear down fully and show onboarding
+        OnboardingState.clearPersistedState()
+
+        mainWindow?.close()
+        mainWindow = nil
+        settingsWindow?.close()
+        settingsWindow = nil
+
+        if let hotKeyMonitor {
+            NSEvent.removeMonitor(hotKeyMonitor)
+            self.hotKeyMonitor = nil
+        }
+        if let escapeMonitor {
+            NSEvent.removeMonitor(escapeMonitor)
+            self.escapeMonitor = nil
+        }
+        voiceInput?.stop()
+        voiceInput = nil
+        ambientAgent.teardown()
+
+        if let observer = windowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowObserver = nil
+        }
+        statusIconCancellable?.cancel()
+        statusIconCancellable = nil
+
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+            statusItem = nil
+        }
+
+        if let mainMenu = NSApp.mainMenu {
+            for title in ["File", "View"] {
+                let idx = mainMenu.indexOfItem(withTitle: title)
+                if idx >= 0 { mainMenu.removeItem(at: idx) }
+            }
+        }
+
+        hasSetupApp = false
+        hasSetupDaemon = false
+        showOnboarding()
     }
 
     /// Applies the user's theme preference to the app appearance.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -45,7 +45,10 @@ struct SettingsAdvancedTab: View {
             Button("Cancel", role: .cancel) {}
             Button("Retire", role: .destructive) {
                 isRetiring = true
-                NSApp.sendAction(#selector(AppDelegate.performRetire), to: nil, from: nil)
+                Task {
+                    await (NSApp.delegate as? AppDelegate)?.performRetireAsync()
+                    isRetiring = false
+                }
             }
         } message: {
             if lockfileAssistants.count > 1 {


### PR DESCRIPTION
## Summary
- The "Retiring assistant..." loading modal would hang indefinitely because `isRetiring` was set to `true` but never reset to `false`
- The fire-and-forget `NSApp.sendAction` pattern had no way to signal completion back to the SwiftUI view
- Extracted `performRetireAsync()` so `SettingsAdvancedTab` can `await` it and dismiss the modal when done

## Test plan
- [ ] Open Settings > Advanced, click Retire, confirm — verify the modal dismisses after the operation completes
- [ ] With multiple assistants: verify retire switches to the next assistant and modal dismisses
- [ ] With one assistant: verify retire tears down and shows onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
