### PR TITLE
fix: add CFBundlePackageType APPL to iOS Info.plist

### DIFF
--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -8,6 +8,8 @@
     <string>com.vellum.vellum-assistant-ios</string>
     <key>CFBundleExecutable</key>
     <string>vellum-assistant-ios</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary

Transporter validation requires `CFBundlePackageType` set to `APPL` for App Store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
