### PR TITLE
Make ingress URL updates apply smoothly for Twilio webhooks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3607,6 +3607,13 @@ Signature validation is **fail-closed**: if the Twilio auth token is not configu
 
 All webhook paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhooks/telegram`, `/webhooks/oauth/callback`, etc.) are appended automatically.
 
+For **inbound Twilio signature validation** at the gateway, URL reconstruction now supports multiple candidates in order:
+1. `config.ingressPublicBaseUrl` (if configured)
+2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`, with `X-Original-*`/`Host` fallbacks)
+3. Raw request URL fallback when no public candidates are available
+
+This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating even before a gateway restart.
+
 ### Runtime HTTP Endpoints
 
 | Method | Path | Description |

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -428,8 +428,8 @@ export function handleIngressConfig(
       // Update ingress.publicBaseUrl — this is the single source of truth for
       // the canonical public ingress URL. The gateway receives this value via
       // the INGRESS_PUBLIC_BASE_URL env var at spawn time (see hatch.ts).
-      // A gateway restart is required for the new value to take effect in
-      // inbound Twilio signature validation.
+      // The gateway also validates Twilio signatures against forwarded public
+      // URL headers, so local tunnel updates generally apply without restarts.
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       ingress.publicBaseUrl = value || undefined;
 
@@ -447,7 +447,7 @@ export function handleIngressConfig(
       ctx.debounceTimers.set('__suppress_reset__', resetTimer);
 
       // Propagate to the gateway's process environment so it picks up the
-      // new URL on its next config load. For the local-deployment path the
+      // new URL when it is restarted. For the local-deployment path the
       // gateway runs as a child process that inherited the assistant's env,
       // so updating process.env here ensures the value is visible when the
       // gateway is restarted (e.g. by the self-upgrade skill or a manual

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -20,8 +20,9 @@
  *   - The assistant's outbound callback URLs (Twilio webhooks, OAuth
  *     redirect URIs, etc.) match the gateway's inbound signature
  *     reconstruction URL.
- *   - Changing the URL in Settings propagates to the gateway on restart,
- *     eliminating Twilio signature mismatch risk.
+ *   - Changing the URL in Settings immediately updates outbound callback
+ *     registration, while the gateway can validate inbound Twilio signatures
+ *     using forwarded public URL headers from tunnels/proxies.
  *
  * All public-facing ingress URL construction is centralized here.
  */

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -134,6 +134,8 @@ Then point your tunnel to that same local target (for example `http://127.0.0.1:
 3. Set the URL as `ingress.publicBaseUrl` in the Settings UI (Public Ingress section) **or** as the `INGRESS_PUBLIC_BASE_URL` environment variable.
 4. Use the Settings UI "Local Gateway Target" value as the source of truth for tunnel destination (it reflects `GATEWAY_PORT`).
 
+In local tunnel setups, updating `ingress.publicBaseUrl` in Settings is typically live for Twilio inbound validation (no manual gateway restart required) because the gateway also validates signatures against forwarded public URL headers.
+
 The assistant runtime uses this URL to construct all webhook and OAuth callback URLs automatically.
 
 ## Default Mode: Telegram-Only

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -60,6 +60,7 @@ function buildSignedRequest(
   url: string,
   params: Record<string, string>,
   authToken: string,
+  extraHeaders: Record<string, string> = {},
 ): Request {
   const body = new URLSearchParams(params).toString();
   const signature = computeSignature(url, params, authToken);
@@ -68,6 +69,7 @@ function buildSignedRequest(
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       "X-Twilio-Signature": signature,
+      ...extraHeaders,
     },
     body,
   });
@@ -378,5 +380,45 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 
     const res = await handler(req);
     expect(res.status).toBe(403);
+  });
+
+  test("accepts signature from forwarded public URL headers when configured URL is stale", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+      ),
+    );
+
+    const staleConfiguredBase = "https://stale.example.com";
+    const config = makeConfig({ ingressPublicBaseUrl: staleConfiguredBase });
+    const handler = createTwilioVoiceWebhookHandler(config);
+
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
+    const forwardedBase = "https://fresh-tunnel.example.com";
+    const signedPublicUrl = `${forwardedBase}/webhooks/twilio/voice`;
+    const params = { CallSid: "CA123" };
+    const req = buildSignedRequest(
+      signedPublicUrl,
+      params,
+      AUTH_TOKEN,
+      {
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "fresh-tunnel.example.com",
+      },
+    );
+
+    // Gateway receives the local URL from the tunnel, but should still
+    // validate against the forwarded public URL headers.
+    const tunneledReq = new Request(localUrl, {
+      method: req.method,
+      headers: req.headers,
+      body: await req.text(),
+    });
+
+    const res = await handler(tunneledReq);
+    expect(res.status).toBe(200);
   });
 });

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -4,6 +4,55 @@ import { verifyTwilioSignature } from "./verify.js";
 
 const log = getLogger("twilio-validate");
 
+function firstHeaderValue(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const first = value.split(",")[0]?.trim();
+  return first ? first : undefined;
+}
+
+/**
+ * Build URL candidates Twilio may have used when computing the webhook signature.
+ *
+ * Precedence:
+ * 1) Canonical configured ingress URL (when present)
+ * 2) Forwarded public URL headers from tunnel/proxy
+ * 3) Raw request URL (last-resort fallback)
+ */
+function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): string[] {
+  const parsedUrl = new URL(req.url);
+  const pathAndQuery = parsedUrl.pathname + parsedUrl.search;
+  const candidates: string[] = [];
+
+  const addBase = (base: string | undefined): void => {
+    if (!base) return;
+    const normalized = base.trim().replace(/\/+$/, "");
+    if (!normalized) return;
+    const candidate = `${normalized}${pathAndQuery}`;
+    if (!candidates.includes(candidate)) {
+      candidates.push(candidate);
+    }
+  };
+
+  addBase(config.ingressPublicBaseUrl);
+
+  const forwardedProto =
+    firstHeaderValue(req.headers.get("x-forwarded-proto")) ??
+    firstHeaderValue(req.headers.get("x-original-proto"));
+  const forwardedHost =
+    firstHeaderValue(req.headers.get("x-forwarded-host")) ??
+    firstHeaderValue(req.headers.get("x-original-host")) ??
+    firstHeaderValue(req.headers.get("host"));
+  if (forwardedProto && forwardedHost) {
+    addBase(`${forwardedProto}://${forwardedHost}`);
+  }
+
+  if (candidates.length === 0) {
+    candidates.push(req.url);
+  }
+
+  return candidates;
+}
+
 export type TwilioValidationSuccess = {
   /** Raw form-urlencoded body as a string. */
   rawBody: string;
@@ -67,23 +116,16 @@ export async function validateTwilioWebhookRequest(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Reconstruct the public-facing URL that Twilio signed against
-  // using the canonical ingress base URL.
-  const parsedUrl = new URL(req.url);
-  const effectiveBaseUrl = config.ingressPublicBaseUrl;
-  const publicUrl = effectiveBaseUrl
-    ? effectiveBaseUrl.replace(/\/$/, "") + parsedUrl.pathname + parsedUrl.search
-    : req.url;
-
-  const isValid = verifyTwilioSignature(
-    publicUrl,
-    params,
-    signature,
-    config.twilioAuthToken,
+  const signatureUrlCandidates = buildSignatureUrlCandidates(req, config);
+  const isValid = signatureUrlCandidates.some((candidate) =>
+    verifyTwilioSignature(candidate, params, signature, config.twilioAuthToken!),
   );
 
   if (!isValid) {
-    log.warn("Twilio webhook signature validation failed");
+    log.warn(
+      { candidateCount: signatureUrlCandidates.length },
+      "Twilio webhook signature validation failed",
+    );
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 


### PR DESCRIPTION
## Summary
- make gateway Twilio signature validation accept multiple URL candidates (configured ingress URL, forwarded public URL headers, then raw request URL fallback)
- add coverage for stale configured ingress URL + fresh forwarded public tunnel URL
- update ingress/Twilio docs and inline comments to reflect smoother no-restart behavior in tunnel setups

## Validation
- cd gateway && bun test src/__tests__/twilio-webhooks.test.ts
- cd gateway && bunx tsc --noEmit (fails due pre-existing twilio-relay-websocket typing issues unrelated to this PR)