### PR TITLE
feat: add bundled public-ingress skill for ngrok tunnel management

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -538,6 +538,89 @@ describe('bundled browser skill', () => {
   });
 });
 
+describe('bundled public-ingress skill', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('public-ingress skill appears in full catalog (including bundled)', () => {
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'public-ingress');
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe('Public Ingress');
+    expect(skill!.bundled).toBe(true);
+  });
+
+  test('public-ingress skill has correct description', () => {
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'public-ingress');
+    expect(skill).toBeDefined();
+    expect(skill!.description).toContain('ngrok');
+    expect(skill!.description).toContain('ingress.publicBaseUrl');
+  });
+
+  test('public-ingress skill is user-invocable', () => {
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'public-ingress');
+    expect(skill).toBeDefined();
+    expect(skill!.userInvocable).toBe(true);
+  });
+
+  test('public-ingress skill has no tool manifest (instructions-only)', () => {
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === 'public-ingress');
+    expect(skill).toBeDefined();
+    expect(skill!.toolManifest).toBeUndefined();
+  });
+});
+
+describe('ingress-dependent setup skills declare public-ingress', () => {
+  const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+  const VELLUM_SKILLS_DIR = join(import.meta.dir, '..', 'config', 'vellum-skills');
+
+  function readVellumSkillIncludes(skillId: string): string[] | undefined {
+    const content = require('node:fs').readFileSync(join(VELLUM_SKILLS_DIR, skillId, 'SKILL.md'), 'utf-8');
+    const match = content.match(FRONTMATTER_REGEX);
+    if (!match) return undefined;
+    for (const line of match[1].split(/\r?\n/)) {
+      const sep = line.indexOf(':');
+      if (sep === -1) continue;
+      const key = line.slice(0, sep).trim();
+      if (key !== 'includes') continue;
+      const val = line.slice(sep + 1).trim();
+      try {
+        const parsed = JSON.parse(val);
+        if (Array.isArray(parsed)) return parsed as string[];
+      } catch { /* ignore */ }
+    }
+    return undefined;
+  }
+
+  test('telegram-setup includes public-ingress', () => {
+    const includes = readVellumSkillIncludes('telegram-setup');
+    expect(includes).toBeDefined();
+    expect(includes).toContain('public-ingress');
+  });
+
+  test('google-oauth-setup includes public-ingress', () => {
+    const includes = readVellumSkillIncludes('google-oauth-setup');
+    expect(includes).toBeDefined();
+    expect(includes).toContain('public-ingress');
+  });
+
+  test('slack-oauth-setup includes public-ingress', () => {
+    const includes = readVellumSkillIncludes('slack-oauth-setup');
+    expect(includes).toBeDefined();
+    expect(includes).toContain('public-ingress');
+  });
+});
+
 describe('bundled computer-use skill', () => {
   beforeEach(() => {
     mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -11,9 +11,13 @@ You are a unified messaging assistant with access to multiple platforms (Slack, 
 
 Before using any messaging tool, verify that the platform is connected by calling `messaging_auth_test` with the appropriate `platform` parameter. If the call fails with a token/authorization error, follow the steps below.
 
+### Public Ingress (required for all platforms)
+
+Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth callbacks or webhook delivery. The **public-ingress** skill handles ngrok tunnel setup and persists the URL as `ingress.publicBaseUrl`. Each setup skill below declares `public-ingress` as a dependency and will prompt you to run it if `ingress.publicBaseUrl` is not configured.
+
 ### Gmail
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials — so this single call may be all that's needed.
-2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Install and load the **google-oauth-setup** skill:
+2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Install and load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
    - Then call `skill_load` with `skill: "google-oauth-setup"`.
    - Tell the user: *"Gmail isn't connected yet. I've loaded a setup guide that will walk you through creating Google credentials and connecting your account."*
@@ -21,14 +25,14 @@ Before using any messaging tool, verify that the platform is connected by callin
 
 ### Slack
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "slack"`. The tool auto-fills Slack's OAuth endpoints and looks up any previously stored client credentials.
-2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill:
+2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "slack-oauth-setup"`.
    - Then call `skill_load` with `skill: "slack-oauth-setup"`.
    - Tell the user: *"Slack isn't connected yet. I've loaded a setup guide that will walk you through creating a Slack App and connecting your workspace."*
 3. **If the user provides client_id and client_secret directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "slack"`, `client_id`, and `client_secret`. Everything else is auto-filled. Note: Slack always requires a client_secret.
 
 ### Telegram
-Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** skill which automates the full setup:
+Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** skill (which depends on **public-ingress** for the webhook URL) which automates the full setup:
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "telegram-setup"`.
    - Then call `skill_load` with `skill: "telegram-setup"`.
    - Tell the user: *"I've loaded a setup guide for Telegram. It will walk you through connecting a Telegram bot to your assistant."*

--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: "Public Ingress"
+description: "Set up and manage ngrok-based public ingress for webhooks and OAuth callbacks via ingress.publicBaseUrl"
+user-invocable: true
+metadata: {"vellum": {"emoji": "🌍"}}
+---
+
+You are setting up and managing a public ingress tunnel so that external services (Telegram webhooks, OAuth callbacks, etc.) can reach the local Vellum gateway. This skill uses ngrok to create a secure tunnel and persists the public URL as `ingress.publicBaseUrl`.
+
+## Overview
+
+The Vellum gateway listens locally and needs a publicly reachable URL for:
+- Telegram webhook delivery
+- Google/Slack OAuth redirect callbacks
+- Any other inbound webhook traffic
+
+This skill installs ngrok, configures authentication, starts a tunnel, discovers the public URL, and saves it to the assistant's ingress config.
+
+## Step 1: Check Current Ingress Status
+
+First, check whether ingress is already configured:
+
+```bash
+vellum config get ingress.publicBaseUrl
+```
+
+Also determine the local gateway target. The gateway listens on `http://127.0.0.1:${GATEWAY_PORT:-7830}` by default.
+
+If `ingress.publicBaseUrl` is already set and the tunnel is running (check via `curl -s http://127.0.0.1:4040/api/tunnels`), tell the user the current status and ask if they want to reconfigure or if this is sufficient.
+
+## Step 2: Install ngrok
+
+Check if ngrok is installed:
+
+```bash
+ngrok version
+```
+
+If not installed, install it:
+
+**macOS (Homebrew):**
+```bash
+brew install ngrok/ngrok/ngrok
+```
+
+**Linux (snap):**
+```bash
+sudo snap install ngrok
+```
+
+**Linux (apt — alternative):**
+```bash
+curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+sudo apt update && sudo apt install ngrok
+```
+
+After installation, verify with `ngrok version`.
+
+## Step 3: Authenticate ngrok
+
+Check if ngrok already has an auth token configured:
+
+```bash
+ngrok config check
+```
+
+If not authenticated:
+
+1. Tell the user: "You need an ngrok account to create tunnels. If you don't have one, sign up at https://dashboard.ngrok.com/signup — it's free."
+2. Once they have an account, ask them to provide their auth token. Use `credential_store` with `action: "prompt"` to securely collect it:
+   - `action: "prompt"`
+   - `service: "ngrok"`
+   - `field: "authtoken"`
+   - `usage_description: "ngrok authentication token for creating public tunnels"`
+
+3. Configure ngrok with the token:
+```bash
+ngrok config add-authtoken <token>
+```
+
+Verify authentication succeeded by checking `ngrok config check` again.
+
+## Step 4: Start the Tunnel
+
+Before starting, check for an existing ngrok process to avoid duplicates:
+
+```bash
+curl -s http://127.0.0.1:4040/api/tunnels 2>/dev/null
+```
+
+If a tunnel is already running, check whether it points to the correct local target. If so, skip to Step 5. If it points elsewhere, stop it first:
+
+```bash
+pkill -f ngrok || true
+sleep 1
+```
+
+Start ngrok in the background, tunneling to the local gateway:
+
+```bash
+nohup ngrok http http://127.0.0.1:${GATEWAY_PORT:-7830} --log=stdout > /tmp/ngrok.log 2>&1 &
+echo $! > /tmp/ngrok.pid
+```
+
+Wait a few seconds for the tunnel to establish:
+
+```bash
+sleep 3
+```
+
+## Step 5: Discover the Public URL
+
+Query the ngrok local API for the tunnel's public URL:
+
+```bash
+curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+tunnels = data.get('tunnels', [])
+for t in tunnels:
+    url = t.get('public_url', '')
+    if url.startswith('https://'):
+        print(url)
+        sys.exit(0)
+for t in tunnels:
+    url = t.get('public_url', '')
+    if url:
+        print(url)
+        sys.exit(0)
+print('ERROR: no tunnel found')
+sys.exit(1)
+"
+```
+
+If no tunnel is found, check `/tmp/ngrok.log` for errors and report them to the user.
+
+## Step 6: Persist the Ingress Setting
+
+Save the discovered public URL as the assistant's ingress base URL:
+
+```bash
+vellum config set ingress.publicBaseUrl "<public-url>"
+```
+
+Verify it was saved:
+
+```bash
+vellum config get ingress.publicBaseUrl
+```
+
+## Step 7: Report Completion
+
+Summarize the setup:
+
+- **Public URL:** `<the-url>` (this is your `ingress.publicBaseUrl`)
+- **Local gateway:** `http://127.0.0.1:7830`
+- **ngrok dashboard:** http://127.0.0.1:4040
+
+Provide useful follow-up commands:
+
+- **Check tunnel status:** `curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "import sys,json; [print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]"`
+- **View ngrok logs:** `cat /tmp/ngrok.log`
+- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http http://127.0.0.1:7830 --log=stdout > /tmp/ngrok.log 2>&1 &`
+- **Stop tunnel:** `pkill -f ngrok`
+- **Rotate URL:** Stop and restart ngrok (free tier assigns a new URL each time; update `ingress.publicBaseUrl` afterward)
+
+**Important:** On ngrok's free tier, the public URL changes every time the tunnel restarts. After restarting, re-run this skill or manually update `ingress.publicBaseUrl` and any registered webhooks (e.g., Telegram).
+
+## Troubleshooting
+
+### ngrok not installed
+Run the install commands in Step 2. On macOS, make sure Homebrew is installed first (`brew --version`).
+
+### Auth token invalid or expired
+Sign in to https://dashboard.ngrok.com, copy a fresh token from the "Your Authtoken" page, and re-run Step 3.
+
+### ngrok API (port 4040) not responding
+The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not running, start it per Step 4. If running but 4040 is unresponsive, check `/tmp/ngrok.log` for errors.
+
+### Gateway not reachable on local target
+Ensure the Vellum gateway is running on `http://127.0.0.1:7830`. Check with `curl -s http://127.0.0.1:7830/health`. If not running, start the assistant daemon first.
+
+### "Too many connections" or tunnel limit errors
+ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels before starting a new one.

--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -2,13 +2,17 @@
 name: "Google OAuth Setup"
 description: "Create Google Cloud OAuth credentials for Gmail integration using browser automation"
 user-invocable: true
-includes: ["browser"]
+includes: ["browser", "public-ingress"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---
 
 You are helping your user create Google Cloud OAuth credentials so the Gmail and Google Calendar integrations can connect. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
 
 **Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+
+## Prerequisites
+
+Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -2,13 +2,17 @@
 name: "Slack OAuth Setup"
 description: "Create Slack App and OAuth credentials for Slack integration using browser automation"
 user-invocable: true
-includes: ["browser"]
+includes: ["browser", "public-ingress"]
 metadata: {"vellum": {"emoji": "🔑"}}
 ---
 
 You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
 
 **Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+
+## Prerequisites
+
+Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -2,6 +2,7 @@
 name: "Telegram Setup"
 description: "Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage"
 user-invocable: true
+includes: ["public-ingress"]
 metadata: {"vellum": {"emoji": "\ud83e\udd16"}}
 ---
 
@@ -10,7 +11,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 ## What You Need
 
 1. **Bot token** from Telegram's @BotFather (the user provides this)
-2. **Gateway webhook URL** — derived from the canonical ingress setting: `${ingress.publicBaseUrl}/webhooks/telegram`. The gateway is the only publicly reachable endpoint; Telegram sends webhooks to the gateway, which validates and forwards them to the assistant runtime internally. If `ingress.publicBaseUrl` is configured (Settings UI > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var), use it to auto-derive the webhook URL. If it is not configured, ask the user to set it before proceeding.
+2. **Gateway webhook URL** — derived from the canonical ingress setting: `${ingress.publicBaseUrl}/webhooks/telegram`. The gateway is the only publicly reachable endpoint; Telegram sends webhooks to the gateway, which validates and forwards them to the assistant runtime internally. If `ingress.publicBaseUrl` is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 
 If the user has already provided the bot token in the conversation, use it directly. Otherwise, ask for it.
 


### PR DESCRIPTION
## Summary
- Add new bundled `public-ingress` skill that provides complete ngrok setup and management workflow (install, auth, tunnel start, URL discovery, `ingress.publicBaseUrl` persistence)
- Update `telegram-setup`, `google-oauth-setup`, and `slack-oauth-setup` to declare `public-ingress` as a dependency via `includes` and reference it for prerequisite ingress setup
- Update `messaging` skill to describe `public-ingress` as the single reusable primitive for tunnel + ingress configuration across Gmail, Slack, and Telegram
- Add regression tests verifying the new bundled skill is discoverable and the three setup skills declare the dependency

## Original prompt
.private/plans/public-ingress-skill-one-pr-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
