### PR TITLE
fix: close standalone scope picker on Escape instead of invalid back-to-patterns state

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -491,11 +491,18 @@ public struct ToolConfirmationBubble: View {
         guard let model = popoverKeyboardModel else { return }
         switch model.handleEscape() {
         case .backToPatterns:
-            pendingPattern = nil
-            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                mode: .patterns,
-                itemCount: confirmation.allowlistOptions.count
-            )
+            if showScopePickerMenu {
+                // Standalone scope picker has no pattern list to return to — just close.
+                showScopePickerMenu = false
+                popoverKeyboardModel = nil
+                pendingPattern = nil
+            } else {
+                pendingPattern = nil
+                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
+                    mode: .patterns,
+                    itemCount: confirmation.allowlistOptions.count
+                )
+            }
         case .closePopover:
             if showAlwaysAllowMenu {
                 showAlwaysAllowMenu = false


### PR DESCRIPTION
## Summary
- Fix Escape key handling in standalone scope picker popover to close it directly rather than trying to navigate back to a non-existent pattern list
- When `showScopePickerMenu` is true, pressing Escape now correctly closes the popover and clears state, preventing the UI from entering a broken state where the keyboard model and visible popover are out of sync

Addresses feedback from #6025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
