### PR TITLE
fix: pass through key events to composer when text view has first responder

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -378,6 +378,13 @@ public struct ToolConfirmationBubble: View {
         removeKeyMonitor()
         keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Pass through when the first responder is a text view (e.g. the
+            // composer) so typing, Enter-to-send, Tab-to-accept-suggestion,
+            // and Escape-to-dismiss-slash-menu continue to work normally.
+            if let firstResponder = NSApp.keyWindow?.firstResponder,
+               firstResponder is NSTextView {
+                return event
+            }
             // Nested popover is open — handle up/down/enter/escape within it
             if showAlwaysAllowMenu || showScopePickerMenu {
                 return handlePopoverKey(event)


### PR DESCRIPTION
## Summary
- Add first-responder check to the NSEvent local monitor in ToolConfirmationBubble
- When the key window's first responder is an NSTextView (e.g. the composer), pass through events instead of consuming them
- Fixes Tab (ghost suggestion accept), Enter (send message), and Escape (slash menu dismiss) being intercepted by the confirmation bubble's key monitor

Addresses feedback from #5999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
