### PR TITLE
feat: keyboard focus handoff for stacked pending approvals

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,6 +363,7 @@ struct ChatView: View {
                         if msg.isSubagentNotification { return false }
                         return true
                     }
+                    let activePendingRequestId = PendingConfirmationFocusSelector.activeRequestId(from: displayMessages)
                     ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in
                         if shouldShowTimestamp(at: index, in: displayMessages) {
                             TimestampDivider(date: message.timestamp)
@@ -373,6 +374,7 @@ struct ChatView: View {
                                 // Show pending confirmations as inline buttons
                                 ToolConfirmationBubble(
                                     confirmation: confirmation,
+                                    isKeyboardActive: confirmation.requestId == activePendingRequestId,
                                     onAllow: { onConfirmationAllow(confirmation.requestId) },
                                     onDeny: { onConfirmationDeny(confirmation.requestId) },
                                     onAlwaysAllow: onAlwaysAllow

--- a/clients/shared/Features/Chat/PendingConfirmationFocusSelector.swift
+++ b/clients/shared/Features/Chat/PendingConfirmationFocusSelector.swift
@@ -1,0 +1,18 @@
+/// Deterministic selector for the single "active" pending confirmation in a
+/// list of chat messages. Only the first pending confirmation in display order
+/// should own keyboard focus; lower ones wait until promoted.
+public enum PendingConfirmationFocusSelector {
+    /// Returns the `requestId` of the first message whose confirmation is
+    /// `.pending`, or `nil` if no pending confirmation exists.
+    ///
+    /// - Parameter messages: The ordered messages as rendered in the chat
+    ///   (after any display filters have been applied).
+    public static func activeRequestId(from messages: [ChatMessage]) -> String? {
+        for message in messages {
+            if let confirmation = message.confirmation, confirmation.state == .pending {
+                return confirmation.requestId
+            }
+        }
+        return nil
+    }
+}

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -8,6 +8,10 @@ public struct ToolConfirmationBubble: View {
     public let onAllow: () -> Void
     public let onDeny: () -> Void
     public let onAlwaysAllow: (String, String, String, String) -> Void
+    /// When `true` this bubble owns the keyboard monitor and shows selection
+    /// highlights. When `false` the monitor is removed and keyboard-only state
+    /// is cleared so a lower stacked bubble doesn't steal input.
+    public let isKeyboardActive: Bool
 
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
@@ -21,8 +25,9 @@ public struct ToolConfirmationBubble: View {
     @State private var keyMonitor: Any?
     #endif
 
-    public init(confirmation: ToolConfirmationData, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
+    public init(confirmation: ToolConfirmationData, isKeyboardActive: Bool = true, onAllow: @escaping () -> Void, onDeny: @escaping () -> Void, onAlwaysAllow: @escaping (String, String, String, String) -> Void) {
         self.confirmation = confirmation
+        self.isKeyboardActive = isKeyboardActive
         self.onAllow = onAllow
         self.onDeny = onDeny
         self.onAlwaysAllow = onAlwaysAllow
@@ -357,17 +362,37 @@ public struct ToolConfirmationBubble: View {
             Spacer()
         }
         .onAppear {
-            #if os(macOS)
-            installKeyMonitor(actions: actions)
-            #else
-            keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
-            #endif
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: actions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+                #endif
+            }
         }
         .onDisappear {
             popoverKeyboardModel = nil
             #if os(macOS)
             removeKeyMonitor()
             #endif
+        }
+        .onChange(of: isKeyboardActive) {
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: actions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+                #endif
+            } else {
+                #if os(macOS)
+                removeKeyMonitor()
+                #endif
+                keyboardModel = nil
+                popoverKeyboardModel = nil
+                showAlwaysAllowMenu = false
+                showScopePickerMenu = false
+                pendingPattern = nil
+            }
         }
     }
 

--- a/clients/shared/Tests/PendingConfirmationFocusSelectorTests.swift
+++ b/clients/shared/Tests/PendingConfirmationFocusSelectorTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import VellumAssistantShared
+
+@Suite("PendingConfirmationFocusSelector")
+struct PendingConfirmationFocusSelectorTests {
+
+    // MARK: - Helpers
+
+    private func makeConfirmationMessage(requestId: String, state: ToolConfirmationState) -> ChatMessage {
+        ChatMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: requestId,
+                toolName: "host_bash",
+                input: [:],
+                riskLevel: "medium",
+                state: state
+            )
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test("Returns nil when no messages")
+    func emptyMessages() {
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: [])
+        #expect(result == nil)
+    }
+
+    @Test("Returns nil when no pending confirmations exist")
+    func noPendingConfirmations() {
+        let messages = [
+            ChatMessage(role: .user, text: "Hello"),
+            makeConfirmationMessage(requestId: "req-1", state: .approved),
+            makeConfirmationMessage(requestId: "req-2", state: .denied),
+            ChatMessage(role: .assistant, text: "Done"),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == nil)
+    }
+
+    @Test("Returns first pending confirmation requestId when one exists")
+    func singlePendingConfirmation() {
+        let messages = [
+            ChatMessage(role: .assistant, text: "Working..."),
+            makeConfirmationMessage(requestId: "req-42", state: .pending),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == "req-42")
+    }
+
+    @Test("Returns the first pending requestId when multiple pending confirmations exist")
+    func multiplePendingConfirmations() {
+        let messages = [
+            makeConfirmationMessage(requestId: "req-1", state: .pending),
+            makeConfirmationMessage(requestId: "req-2", state: .pending),
+            makeConfirmationMessage(requestId: "req-3", state: .pending),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == "req-1")
+    }
+
+    @Test("Ignores non-pending confirmations and returns first pending")
+    func ignoresNonPending() {
+        let messages = [
+            makeConfirmationMessage(requestId: "req-1", state: .approved),
+            makeConfirmationMessage(requestId: "req-2", state: .denied),
+            makeConfirmationMessage(requestId: "req-3", state: .timedOut),
+            makeConfirmationMessage(requestId: "req-4", state: .pending),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == "req-4")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PendingConfirmationFocusSelector` to deterministically pick the first pending approval as the keyboard-active one
- Add `isKeyboardActive` prop to `ToolConfirmationBubble` — when false, removes the key monitor and clears keyboard/popover state
- `ChatView` computes `activePendingRequestId` from display messages and passes it to each pending bubble
- Unit tests for the focus selector (empty, single, multiple, ignores non-pending)

## Original prompt
.private/plans/stacked-approvals-focus-handoff-one-pr-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
