### PR TITLE
feat: add toggle to enable/disable public ingress setting

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1136,6 +1136,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   ingress_config_response: {
     type: 'ingress_config_response',
+    enabled: true,
     publicBaseUrl: 'https://example.com',
     localGatewayTarget: 'http://127.0.0.1:7830',
     success: true,

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -228,6 +228,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     },
   },
   ingress: {
+    enabled: false,
     publicBaseUrl: '',
     mode: 'gateway_only' as const,
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -924,6 +924,9 @@ export const SkillsConfigSchema = z.object({
 });
 
 export const IngressConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'ingress.enabled must be a boolean' })
+    .default(false),
   publicBaseUrl: z
     .string({ error: 'ingress.publicBaseUrl must be a string' })
     .default(''),
@@ -1183,6 +1186,7 @@ export const AssistantConfigSchema = z.object({
     },
   }),
   ingress: IngressConfigSchema.default({
+    enabled: false,
     publicBaseUrl: '',
     mode: 'gateway_only',
   }),

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -420,7 +420,8 @@ export function handleIngressConfig(
       const raw = loadRawConfig();
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       const publicBaseUrl = (ingress.publicBaseUrl as string) ?? '';
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl, localGatewayTarget, success: true });
+      const enabled = (ingress.enabled as boolean) ?? false;
+      ctx.send(socket, { type: 'ingress_config_response', enabled, publicBaseUrl, localGatewayTarget, success: true });
     } else if (msg.action === 'set') {
       const value = (msg.publicBaseUrl ?? '').trim().replace(/\/+$/, '');
       const raw = loadRawConfig();
@@ -432,6 +433,9 @@ export function handleIngressConfig(
       // URL headers, so local tunnel updates generally apply without restarts.
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       ingress.publicBaseUrl = value || undefined;
+      if (msg.enabled !== undefined) {
+        ingress.enabled = msg.enabled;
+      }
 
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
@@ -460,13 +464,14 @@ export function handleIngressConfig(
         delete process.env.INGRESS_PUBLIC_BASE_URL;
       }
 
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: value, localGatewayTarget, success: true });
+      const enabled = (ingress.enabled as boolean) ?? false;
+      ctx.send(socket, { type: 'ingress_config_response', enabled, publicBaseUrl: value, localGatewayTarget, success: true });
     } else {
-      ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+      ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, { type: 'ingress_config_response', publicBaseUrl: '', localGatewayTarget, success: false, error: message });
+    ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: message });
   }
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -476,6 +476,7 @@ export interface IngressConfigRequest {
   type: 'ingress_config';
   action: 'get' | 'set';
   publicBaseUrl?: string;
+  enabled?: boolean;
 }
 
 export interface VercelApiConfigRequest {
@@ -1690,6 +1691,7 @@ export interface SlackWebhookConfigResponse {
 
 export interface IngressConfigResponse {
   type: 'ingress_config_response';
+  enabled: boolean;
   publicBaseUrl: string;
   /** Read-only gateway target computed from GATEWAY_PORT env var (default 7830) + loopback host. */
   localGatewayTarget: string;

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -28,7 +28,7 @@
  */
 
 export interface IngressConfig {
-  ingress?: { publicBaseUrl?: string };
+  ingress?: { enabled?: boolean; publicBaseUrl?: string };
 }
 
 /**
@@ -42,9 +42,19 @@ function normalizeUrl(url: string): string {
  * Resolve the canonical public base URL using the precedence chain
  * documented at the top of this module.
  *
- * Throws if no source provides a non-empty value.
+ * When `ingress.enabled` is explicitly `false`, the public ingress is
+ * considered disabled regardless of whether a URL is configured. This
+ * allows the user to toggle ingress off without clearing the URL value.
+ *
+ * Throws if no source provides a non-empty value or if ingress is disabled.
  */
 export function getPublicBaseUrl(config: IngressConfig): string {
+  if (config.ingress?.enabled === false) {
+    throw new Error(
+      'Public ingress is disabled. Enable it in Settings to use public-facing webhooks.',
+    );
+  }
+
   const ingressValue = config.ingress?.publicBaseUrl;
   if (ingressValue) {
     const normalized = normalizeUrl(ingressValue);

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -533,9 +533,19 @@ struct SettingsPanel: View {
 
             // PUBLIC INGRESS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Public Ingress")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
+                HStack {
+                    Text("Public Ingress")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { store.ingressEnabled },
+                        set: { store.setIngressEnabled($0) }
+                    ))
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
+                }
 
                 // Public Ingress URL field
                 HStack(spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -77,6 +77,7 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Ingress Config State
 
+    @Published var ingressEnabled: Bool = false
     @Published var ingressPublicBaseUrl: String = ""
     /// Read-only gateway target derived from daemon config (GATEWAY_PORT env var, default 7830).
     @Published var localGatewayTarget: String = "http://127.0.0.1:7830"
@@ -186,6 +187,7 @@ public final class SettingsStore: ObservableObject {
             guard let self else { return }
             self.localGatewayTarget = response.localGatewayTarget
             if response.success {
+                self.ingressEnabled = response.enabled
                 self.ingressPublicBaseUrl = response.publicBaseUrl
             }
         }
@@ -384,7 +386,12 @@ public final class SettingsStore: ObservableObject {
         // the text field to a stale URL. The daemon's success response
         // (handled by onIngressConfigResponse) will confirm or correct.
         ingressPublicBaseUrl = trimmed
-        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed))
+        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: ingressEnabled))
+    }
+
+    func setIngressEnabled(_ enabled: Bool) {
+        ingressEnabled = enabled
+        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: ingressPublicBaseUrl, enabled: enabled))
     }
 
     // MARK: - Model Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -326,6 +326,12 @@ public struct SettingsView: View {
             }
 
             Section("Public Ingress") {
+                Toggle("Enable Public Ingress", isOn: Binding(
+                    get: { store.ingressEnabled },
+                    set: { store.setIngressEnabled($0) }
+                ))
+                .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
+
                 TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
                     .focused($isIngressUrlFocused)
                     .textFieldStyle(.roundedBorder)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -786,10 +786,12 @@ public struct IPCIngressConfigRequest: Codable, Sendable {
     public let type: String
     public let action: String
     public let publicBaseUrl: String?
+    public let enabled: Bool?
 }
 
 public struct IPCIngressConfigResponse: Codable, Sendable {
     public let type: String
+    public let enabled: Bool
     public let publicBaseUrl: String
     /// Read-only gateway target computed from GATEWAY_PORT env var (default 7830) + loopback host.
     public let localGatewayTarget: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1625,15 +1625,18 @@ public struct IngressConfigRequestMessage: Encodable, Sendable {
     public let type = "ingress_config"
     public let action: String
     public let publicBaseUrl: String?
+    public let enabled: Bool?
 
-    public init(action: String, publicBaseUrl: String? = nil) {
+    public init(action: String, publicBaseUrl: String? = nil, enabled: Bool? = nil) {
         self.action = action
         self.publicBaseUrl = publicBaseUrl
+        self.enabled = enabled
     }
 }
 
 public struct IngressConfigResponseMessage: Sendable {
     public let type: String
+    public let enabled: Bool
     public let publicBaseUrl: String
     public let localGatewayTarget: String
     public let success: Bool
@@ -1644,6 +1647,7 @@ extension IngressConfigResponseMessage: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         type = try container.decode(String.self, forKey: .type)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         publicBaseUrl = try container.decode(String.self, forKey: .publicBaseUrl)
         localGatewayTarget = try container.decodeIfPresent(String.self, forKey: .localGatewayTarget) ?? "http://127.0.0.1:7830"
         success = try container.decode(Bool.self, forKey: .success)
@@ -1651,7 +1655,7 @@ extension IngressConfigResponseMessage: Decodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case type, publicBaseUrl, localGatewayTarget, success, error
+        case type, enabled, publicBaseUrl, localGatewayTarget, success, error
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ingress.enabled` boolean to config schema, IPC contract, and daemon handler
- Add a toggle switch in both SettingsPanel (side panel) and SettingsView (standalone window) that defaults to off and is disabled when no URL is configured
- `getPublicBaseUrl()` now throws when ingress is disabled, so all downstream consumers (Twilio webhooks, OAuth callbacks, Telegram, Twitter auth) respect the toggle state

## Original prompt
Add a toggle to enable/disable the public ingress setting in our settings page. You should be able to turn it off even if there is a value specified. It should default to off and should be disabled if there is no value provided.

Note that anything that makes use of this setting should respect the toggle's state downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
