### PR TITLE
Remove ingress.mode field, hardcode gateway_only behavior

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -1,13 +1,12 @@
 /**
- * Tests for gateway-only ingress mode enforcement in the runtime HTTP server.
+ * Tests for gateway-only ingress enforcement in the runtime HTTP server.
  *
  * Verifies:
- * - Direct Twilio webhook routes return 410 in gateway_only mode
- * - Internal forwarding routes (gateway→runtime) still work in gateway_only mode
- * - Relay WebSocket upgrade blocked for non-private-network origins (isPrivateNetworkOrigin) in gateway_only mode
- * - Relay WebSocket upgrade allowed from private network peers/origins in gateway_only mode
- * - All routes work normally in compat mode
- * - Startup warning when RUNTIME_HTTP_HOST is not loopback in gateway_only mode
+ * - Direct Twilio webhook routes return 410
+ * - Internal forwarding routes (gateway→runtime) still work
+ * - Relay WebSocket upgrade blocked for non-private-network origins (isPrivateNetworkOrigin)
+ * - Relay WebSocket upgrade allowed from private network peers/origins
+ * - Startup warning when RUNTIME_HTTP_HOST is not loopback
  */
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
@@ -31,9 +30,6 @@ mock.module('../util/platform.js', () => ({
   migrateToDataLayout: () => {},
   migrateToWorkspaceLayout: () => {},
 }));
-
-// Configurable ingress mode — tests toggle this between 'gateway_only' and 'compat'
-let mockIngressMode: 'gateway_only' | 'compat' = 'compat';
 
 const logMessages: { level: string; msg: string; args?: unknown }[] = [];
 
@@ -73,7 +69,6 @@ mock.module('../config/loader.js', () => ({
     },
     ingress: {
       publicBaseUrl: 'https://test.example.com',
-      mode: mockIngressMode,
     },
   }),
   getConfig: () => ({
@@ -85,7 +80,6 @@ mock.module('../config/loader.js', () => ({
     secretDetection: { enabled: false },
     ingress: {
       publicBaseUrl: 'https://test.example.com',
-      mode: mockIngressMode,
     },
   }),
   invalidateConfigCache: () => {},
@@ -171,9 +165,7 @@ describe('gateway-only ingress enforcement', () => {
 
   // ── Direct Twilio webhook routes blocked in gateway_only mode ──────
 
-  describe('gateway_only mode — direct webhook routes', () => {
-    beforeEach(() => { mockIngressMode = 'gateway_only'; });
-    afterEach(() => { mockIngressMode = 'compat'; });
+  describe('direct webhook routes are blocked', () => {
 
     test('POST /webhooks/twilio/voice returns 410', async () => {
       const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice`, {
@@ -232,11 +224,9 @@ describe('gateway-only ingress enforcement', () => {
     });
   });
 
-  // ── Internal forwarding routes still work in gateway_only mode ─────
+  // ── Internal forwarding routes still work ─────
 
-  describe('gateway_only mode — internal forwarding routes', () => {
-    beforeEach(() => { mockIngressMode = 'gateway_only'; });
-    afterEach(() => { mockIngressMode = 'compat'; });
+  describe('internal forwarding routes are not blocked', () => {
 
     test('POST /v1/internal/twilio/voice-webhook is NOT blocked', async () => {
       const res = await fetch(`http://127.0.0.1:${port}/v1/internal/twilio/voice-webhook`, {
@@ -288,11 +278,9 @@ describe('gateway-only ingress enforcement', () => {
     });
   });
 
-  // ── Relay WebSocket upgrade in gateway_only mode ───────────────────
+  // ── Relay WebSocket upgrade ───────────────────
 
-  describe('gateway_only mode — relay WebSocket upgrade', () => {
-    beforeEach(() => { mockIngressMode = 'gateway_only'; });
-    afterEach(() => { mockIngressMode = 'compat'; });
+  describe('relay WebSocket upgrade', () => {
 
     test('blocks non-private-network origin', async () => {
       // The peer address (127.0.0.1) passes the private network check,
@@ -339,66 +327,6 @@ describe('gateway-only ingress enforcement', () => {
         },
       });
       // Should NOT be 403
-      expect(res.status).not.toBe(403);
-    });
-  });
-
-  // ── Compat mode — everything works as before ───────────────────────
-
-  describe('compat mode — no enforcement', () => {
-    beforeEach(() => { mockIngressMode = 'compat'; });
-
-    test('POST /webhooks/twilio/voice is NOT blocked', async () => {
-      // In compat mode, disable webhook validation to focus on the ingress check
-      const savedDisable = process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
-      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
-      try {
-        const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice?callSessionId=test-compat`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: makeFormBody({ CallSid: 'CA_compat', AccountSid: 'AC_test' }),
-        });
-        // Should NOT be 410 (gateway-only)
-        expect(res.status).not.toBe(410);
-      } finally {
-        if (savedDisable !== undefined) {
-          process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = savedDisable;
-        } else {
-          delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
-        }
-      }
-    });
-
-    test('POST /webhooks/twilio/status is NOT blocked', async () => {
-      const savedDisable = process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
-      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
-      try {
-        const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/status`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: makeFormBody({ CallSid: 'CA_compat', CallStatus: 'completed' }),
-        });
-        expect(res.status).not.toBe(410);
-      } finally {
-        if (savedDisable !== undefined) {
-          process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = savedDisable;
-        } else {
-          delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
-        }
-      }
-    });
-
-    test('relay WebSocket upgrade is NOT blocked for external origin', async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/relay?callSessionId=sess-compat`, {
-        headers: {
-          'Upgrade': 'websocket',
-          'Connection': 'Upgrade',
-          'Origin': 'https://external.example.com',
-          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
-          'Sec-WebSocket-Version': '13',
-        },
-      });
-      // In compat mode, the gateway-only guard should not activate
       expect(res.status).not.toBe(403);
     });
   });
@@ -483,8 +411,7 @@ describe('gateway-only ingress enforcement', () => {
   // ── Startup warning for non-loopback host ──────────────────────────
 
   describe('startup guard — non-loopback host warning', () => {
-    test('logs warning when hostname is not loopback in gateway_only mode', async () => {
-      mockIngressMode = 'gateway_only';
+    test('logs warning when hostname is not loopback', async () => {
       logMessages.length = 0;
 
       const warnServer = new RuntimeHttpServer({
@@ -505,11 +432,9 @@ describe('gateway-only ingress enforcement', () => {
       expect(warnMsg).toBeDefined();
 
       await warnServer.stop();
-      mockIngressMode = 'compat';
     });
 
-    test('does NOT log warning when hostname is loopback in gateway_only mode', async () => {
-      mockIngressMode = 'gateway_only';
+    test('does NOT log warning when hostname is loopback', async () => {
       logMessages.length = 0;
 
       // The main test server already uses 127.0.0.1, so restart with
@@ -532,7 +457,6 @@ describe('gateway-only ingress enforcement', () => {
       expect(warnMsg).toBeUndefined();
 
       await loopbackServer.stop();
-      mockIngressMode = 'compat';
     });
   });
 });

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -20,20 +20,16 @@ export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const webhookBaseUrl = getPublicBaseUrl(config);
 
-  // In gateway_only mode, ignore TWILIO_WSS_BASE_URL and always use the
-  // centralized relay URL derived from the public ingress base URL.
+  // Always use the centralized relay URL derived from the public ingress base URL.
+  // TWILIO_WSS_BASE_URL is ignored.
   let wssBaseUrl: string;
-  if (config.ingress.mode === 'gateway_only') {
-    if (process.env.TWILIO_WSS_BASE_URL) {
-      log.warn('TWILIO_WSS_BASE_URL env var is ignored in gateway-only mode. Relay URL is derived from ingress.publicBaseUrl.');
-    }
-    try {
-      wssBaseUrl = getTwilioRelayUrl(config);
-    } catch {
-      wssBaseUrl = '';
-    }
-  } else {
-    wssBaseUrl = process.env.TWILIO_WSS_BASE_URL || '';
+  if (process.env.TWILIO_WSS_BASE_URL) {
+    log.warn('TWILIO_WSS_BASE_URL env var is ignored. Relay URL is derived from ingress.publicBaseUrl.');
+  }
+  try {
+    wssBaseUrl = getTwilioRelayUrl(config);
+  } catch {
+    wssBaseUrl = '';
   }
 
   if (!accountSid || !authToken) {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -230,6 +230,5 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   ingress: {
     enabled: false,
     publicBaseUrl: '',
-    mode: 'gateway_only' as const,
   },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -9,7 +9,6 @@ const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
-const VALID_INGRESS_MODES = ['gateway_only', 'compat'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -930,11 +929,6 @@ export const IngressConfigSchema = z.object({
   publicBaseUrl: z
     .string({ error: 'ingress.publicBaseUrl must be a string' })
     .default(''),
-  mode: z
-    .enum(VALID_INGRESS_MODES, {
-      error: `ingress.mode must be one of: ${VALID_INGRESS_MODES.join(', ')}`,
-    })
-    .default('gateway_only'),
 });
 
 export const AssistantConfigSchema = z.object({
@@ -1188,7 +1182,6 @@ export const AssistantConfigSchema = z.object({
   ingress: IngressConfigSchema.default({
     enabled: false,
     publicBaseUrl: '',
-    mode: 'gateway_only',
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -398,16 +398,9 @@ export class RuntimeHttpServer {
     }
 
     // Startup guard: log gateway-only mode warnings
-    try {
-      const config = loadConfig();
-      if (config.ingress.mode === 'gateway_only') {
-        log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');
-        if (!isLoopbackHost(this.hostname)) {
-          log.warn('gateway-only mode is enabled but RUNTIME_HTTP_HOST is not bound to loopback. This may expose the runtime to direct public access.');
-        }
-      }
-    } catch {
-      // Config loading may fail during startup — don't block server start
+    log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');
+    if (!isLoopbackHost(this.hostname)) {
+      log.warn('RUNTIME_HTTP_HOST is not bound to loopback. This may expose the runtime to direct public access.');
     }
 
     log.info({ port: this.actualPort, hostname: this.hostname, auth: !!this.bearerToken }, 'Runtime HTTP server listening');
@@ -448,14 +441,13 @@ export class RuntimeHttpServer {
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
     if (path.startsWith('/v1/calls/relay') && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
-      // In gateway_only mode, only allow relay connections from private network peers.
+      // Only allow relay connections from private network peers.
       // Primary check: actual peer address (cannot be spoofed) — accepts loopback
       // and RFC 1918/4193 private addresses to support container deployments.
       // Secondary check: Origin header (defense in depth).
-      const config = loadConfig();
-      if (config.ingress.mode === 'gateway_only' && (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req))) {
+      if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
         return Response.json(
-          { error: 'Direct relay access disabled in gateway-only mode', code: 'GATEWAY_ONLY' },
+          { error: 'Direct relay access disabled — only private network peers allowed', code: 'GATEWAY_ONLY' },
           { status: 403 },
         );
       }
@@ -489,11 +481,10 @@ export class RuntimeHttpServer {
     if (resolvedTwilioSubpath && req.method === 'POST') {
       const twilioSubpath = resolvedTwilioSubpath;
 
-      // In gateway_only mode, block direct Twilio webhook routes
-      const ingressConfig = loadConfig();
-      if (ingressConfig.ingress.mode === 'gateway_only' && GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
+      // Block direct Twilio webhook routes — must go through the gateway
+      if (GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
         return Response.json(
-          { error: 'Direct webhook access disabled in gateway-only mode. Use the gateway.', code: 'GATEWAY_ONLY' },
+          { error: 'Direct webhook access disabled. Use the gateway.', code: 'GATEWAY_ONLY' },
           { status: 410 },
         );
       }

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -1,9 +1,9 @@
 /**
  * General-purpose OAuth2 Authorization Code flow with PKCE.
  *
- * Supports two callback transports:
- *   - loopback: spins up a local HTTP server on 127.0.0.1 (default when no public URL configured)
- *   - gateway:  uses the gateway's OAuth callback route + in-memory registry (when ingress.publicBaseUrl is set)
+ * Uses the gateway callback transport: OAuth callbacks route through the
+ * gateway's OAuth callback route + in-memory registry (requires
+ * ingress.publicBaseUrl to be configured).
  *
  * Moved from integrations/oauth2.ts. Types that were in integrations/types.ts
  * are now inlined here since the integration framework is removed.
@@ -139,122 +139,6 @@ async function exchangeCodeForTokens(
 }
 
 // ---------------------------------------------------------------------------
-// Transport auto-detection
-// ---------------------------------------------------------------------------
-
-/**
- * Determine which callback transport to use when not explicitly specified.
- * Uses gateway if a public base URL is configured (ingress.publicBaseUrl or
- * INGRESS_PUBLIC_BASE_URL), otherwise loopback.
- */
-function detectTransport(): 'loopback' | 'gateway' {
-  try {
-    const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
-    const { getPublicBaseUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
-    const appConfig = loadConfig();
-    getPublicBaseUrl(appConfig); // throws if no public URL configured
-    return 'gateway';
-  } catch {
-    log.debug('No public base URL configured for transport auto-detection, defaulting to loopback');
-  }
-  return 'loopback';
-}
-
-// ---------------------------------------------------------------------------
-// Loopback transport
-// ---------------------------------------------------------------------------
-
-async function runLoopbackFlow(
-  config: OAuth2Config,
-  callbacks: OAuth2FlowCallbacks,
-  codeVerifier: string,
-  codeChallenge: string,
-  state: string,
-): Promise<OAuth2FlowResult> {
-  let resolveCode: (value: { code: string; returnedState: string }) => void;
-  let rejectCode: (reason: Error) => void;
-
-  const codePromise = new Promise<{ code: string; returnedState: string }>((resolve, reject) => {
-    resolveCode = resolve;
-    rejectCode = reject;
-  });
-
-  const FLOW_TIMEOUT_MS = 120_000;
-
-  const timeout = setTimeout(() => {
-    rejectCode(new Error('OAuth2 flow timed out waiting for user authorization'));
-  }, FLOW_TIMEOUT_MS);
-
-  const server = Bun.serve({
-    hostname: '127.0.0.1',
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      if (url.pathname !== '/callback') {
-        return new Response('Not found', { status: 404 });
-      }
-
-      const error = url.searchParams.get('error');
-      if (error) {
-        const desc = url.searchParams.get('error_description') ?? error;
-        rejectCode(new Error(`OAuth2 authorization denied: ${desc}`));
-        return new Response(
-          '<html><body><h2>Authorization denied</h2><p>You can close this tab.</p></body></html>',
-          { headers: { 'Content-Type': 'text/html' } },
-        );
-      }
-
-      const code = url.searchParams.get('code');
-      const returnedState = url.searchParams.get('state');
-      if (!code || !returnedState) {
-        rejectCode(new Error('OAuth2 callback missing code or state'));
-        return new Response('Missing code or state', { status: 400 });
-      }
-
-      if (returnedState !== state) {
-        rejectCode(new Error('OAuth2 state mismatch — possible CSRF attack'));
-        return new Response('State mismatch', { status: 400 });
-      }
-
-      resolveCode({ code, returnedState });
-      return new Response(
-        '<html><body><h2>Authorization successful!</h2><p>You can close this tab and return to Vellum.</p></body></html>',
-        { headers: { 'Content-Type': 'text/html' } },
-      );
-    },
-  });
-
-  const redirectUri = `http://127.0.0.1:${server.port}/callback`;
-
-  try {
-    const usePKCE = !config.clientSecret;
-    const authParams = new URLSearchParams({
-      ...config.extraParams,
-      client_id: config.clientId,
-      redirect_uri: redirectUri,
-      response_type: 'code',
-      scope: config.scopes.join(' '),
-      state,
-      ...(usePKCE ? { code_challenge: codeChallenge, code_challenge_method: 'S256' } : {}),
-    });
-
-    const authUrl = `${config.authUrl}?${authParams}`;
-    callbacks.openUrl(authUrl);
-
-    const { code, returnedState } = await codePromise;
-
-    if (returnedState !== state) {
-      throw new Error('OAuth2 state mismatch — possible CSRF attack');
-    }
-
-    return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
-  } finally {
-    clearTimeout(timeout);
-    server.stop(true);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Gateway transport
 // ---------------------------------------------------------------------------
 
@@ -302,12 +186,9 @@ async function runGatewayFlow(
 /**
  * Run a full OAuth2 authorization code flow with PKCE support.
  *
- * Supports two callback transports:
- *   - loopback (default): local HTTP server on 127.0.0.1
- *   - gateway: callback via the gateway's OAuth route + in-memory registry
- *
- * Transport is auto-detected based on ingress.publicBaseUrl config unless
- * explicitly specified via options.callbackTransport.
+ * Uses the gateway callback transport, which routes OAuth callbacks through
+ * the gateway's OAuth route + in-memory registry. Requires a public ingress
+ * URL to be configured.
  */
 export async function startOAuth2Flow(
   config: OAuth2Config,
@@ -318,49 +199,26 @@ export async function startOAuth2Flow(
   const codeChallenge = generateCodeChallenge(codeVerifier);
   const state = generateState();
 
-  // In gateway_only mode, enforce gateway transport and require a public ingress URL
-  let ingressMode: string | undefined;
+  // Always enforce gateway transport and require a public ingress URL
+  let hasPublicUrl = false;
   try {
     const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
-    ingressMode = loadConfig().ingress.mode;
+    const { getPublicBaseUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
+    getPublicBaseUrl(loadConfig());
+    hasPublicUrl = true;
   } catch {
-    // Fail closed: if config can't be loaded (e.g., malformed config.json), default to the
-    // most restrictive mode to prevent loopback fallback from creating a fail-open path.
-    log.warn('Failed to load config for OAuth ingress mode detection; defaulting to gateway_only (fail closed)');
-    ingressMode = 'gateway_only';
+    // No public URL configured
   }
 
-  if (ingressMode === 'gateway_only') {
-    // Verify a public ingress URL is configured; fail fast with actionable error if not
-    let hasPublicUrl = false;
-    try {
-      const { loadConfig } = require('../config/loader.js') as typeof import('../config/loader.js');
-      const { getPublicBaseUrl } = require('../inbound/public-ingress-urls.js') as typeof import('../inbound/public-ingress-urls.js');
-      getPublicBaseUrl(loadConfig());
-      hasPublicUrl = true;
-    } catch {
-      // No public URL configured
-    }
-
-    if (!hasPublicUrl) {
-      throw new Error(
-        'OAuth requires a public ingress URL in gateway-only mode. Set ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL so OAuth callbacks can route through the gateway.',
-      );
-    }
-
-    // In gateway_only mode, always use gateway transport — never fall back to loopback
-    log.debug({ transport: 'gateway' }, 'OAuth2 flow starting (gateway_only mode)');
-    return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  if (!hasPublicUrl) {
+    throw new Error(
+      'OAuth requires a public ingress URL. Set ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL so OAuth callbacks can route through the gateway.',
+    );
   }
 
-  const transport = options?.callbackTransport ?? detectTransport();
-  log.debug({ transport }, 'OAuth2 flow starting');
-
-  if (transport === 'gateway') {
-    return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
-  }
-
-  return runLoopbackFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  // Always use gateway transport — never fall back to loopback
+  log.debug({ transport: 'gateway' }, 'OAuth2 flow starting');
+  return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `VALID_INGRESS_MODES` enum, `mode` field from `IngressConfigSchema`, and the `mode` default
- Hardcode gateway_only behavior in `http-server.ts` (direct webhook blocking, relay WebSocket private-network-only), `oauth2.ts` (always use gateway transport, remove loopback flow), and `twilio-config.ts` (always derive WSS URL from config)
- Remove compat mode test cases and `mockIngressMode` toggle from `gateway-only-enforcement.test.ts`

## Original prompt
Remove the `ingress.mode` field entirely. Hardcode `gateway_only` behavior everywhere — remove all `compat` mode branches, the mode config field, the schema enum, the default, and the test cases that exercise `compat` mode. The `gateway_only` security posture should be the only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
