### PR TITLE
Fix ingress toggle bounce-back; enable ingress in public-ingress skill

### DIFF
--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -133,16 +133,18 @@ If no tunnel is found, check `/tmp/ngrok.log` for errors and report them to the 
 
 ## Step 6: Persist the Ingress Setting
 
-Save the discovered public URL as the assistant's ingress base URL:
+Save the discovered public URL and enable ingress:
 
 ```bash
 vellum config set ingress.publicBaseUrl "<public-url>"
+vellum config set ingress.enabled true
 ```
 
 Verify it was saved:
 
 ```bash
 vellum config get ingress.publicBaseUrl
+vellum config get ingress.enabled
 ```
 
 ## Step 7: Report Completion

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -95,6 +95,11 @@ public final class SettingsStore: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let configPath: String?
 
+    /// Guards against stale IPC `get` responses overwriting an optimistic
+    /// toggle. Set when `setIngressEnabled` fires; cleared once a matching
+    /// response arrives.
+    private var pendingIngressEnabled: Bool?
+
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
     private var lastDaemonModel: String?
@@ -187,8 +192,19 @@ public final class SettingsStore: ObservableObject {
             guard let self else { return }
             self.localGatewayTarget = response.localGatewayTarget
             if response.success {
+                if let pending = self.pendingIngressEnabled, response.enabled != pending {
+                    // A set operation is in-flight and this response disagrees
+                    // with the optimistic value — it's a stale get response.
+                    // Skip updating enabled to prevent the toggle from bouncing.
+                    self.ingressPublicBaseUrl = response.publicBaseUrl
+                    return
+                }
+                self.pendingIngressEnabled = nil
                 self.ingressEnabled = response.enabled
                 self.ingressPublicBaseUrl = response.publicBaseUrl
+            } else {
+                // On failure, clear pending so future responses apply normally
+                self.pendingIngressEnabled = nil
             }
         }
 
@@ -215,8 +231,9 @@ public final class SettingsStore: ObservableObject {
         // Refresh Twitter integration status on init
         refreshTwitterStatus()
 
-        // Refresh ingress config on init
-        refreshIngressConfig()
+        // Ingress config is refreshed by onAppear in SettingsPanel /
+        // SettingsView, not here, to avoid duplicate get requests whose
+        // stale responses could overwrite an optimistic toggle.
     }
 
     // MARK: - API Key Actions
@@ -391,6 +408,7 @@ public final class SettingsStore: ObservableObject {
 
     func setIngressEnabled(_ enabled: Bool) {
         ingressEnabled = enabled
+        pendingIngressEnabled = enabled
         try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: ingressPublicBaseUrl, enabled: enabled))
     }
 


### PR DESCRIPTION
## Summary
- Fix the ingress enabled toggle immediately reverting to OFF by guarding against stale IPC `get` responses overwriting optimistic `set` state
- Remove duplicate `refreshIngressConfig()` call from `SettingsStore.init()` (already called in `onAppear`)
- Update the bundled public-ingress skill to set `ingress.enabled true` alongside the public URL

## Original prompt
Fix the ingress toggle bounce-back bug and make the public-ingress skill enable the ingress setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
