### PR TITLE
fix: iOS chat background image not filling screen

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -344,7 +344,7 @@ struct ChatContentView: View {
         if colorScheme == .dark, let uiImage = chatBackgroundImage {
             Image(uiImage: uiImage)
                 .resizable()
-                .scaledToFit()
+                .scaledToFill()
                 .allowsHitTesting(false)
         }
     }

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -345,6 +345,7 @@ struct ChatContentView: View {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
+                .clipped()
                 .allowsHitTesting(false)
         }
     }


### PR DESCRIPTION
## Summary
- Fix iOS dark mode chat background image not filling the full screen
- Changed `.scaledToFit()` to `.scaledToFill()` so the background image scales up to cover the entire area instead of leaving empty space

## Original prompt
fix the background image, it is not filling the background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
