### PR TITLE
Move ingress warning above URL field; remove webhook paths note

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -547,6 +547,15 @@ struct SettingsPanel: View {
                     .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
                 }
 
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Setting a public base URL may expose this computer to the public internet. Use with caution.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
                 // Public Ingress URL field
                 HStack(spacing: VSpacing.xs) {
                     Text("Public Ingress URL")
@@ -566,19 +575,6 @@ struct SettingsPanel: View {
                         RoundedRectangle(cornerRadius: VRadius.md)
                             .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
                     )
-
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 12))
-                    Text("Setting a public base URL may expose this computer to the public internet. Use with caution.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-
-                Text("Webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
 
                 VButton(label: "Save", style: .primary) {
                     store.saveIngressPublicBaseUrl(ingressUrlText)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -332,10 +332,6 @@ public struct SettingsView: View {
                 ))
                 .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
 
-                TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
-                    .focused($isIngressUrlFocused)
-                    .textFieldStyle(.roundedBorder)
-
                 HStack(alignment: .top, spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundStyle(.orange)
@@ -345,9 +341,9 @@ public struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Text("Webhook paths (e.g. /webhooks/twilio/voice) are appended automatically.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
+                    .focused($isIngressUrlFocused)
+                    .textFieldStyle(.roundedBorder)
 
                 HStack {
                     Spacer()


### PR DESCRIPTION
## Summary
- Move the warning note ("Setting a public base URL may expose...") above the "Public Ingress URL" input label in both SettingsPanel and SettingsView
- Remove the "Webhook paths are appended automatically" note

## Original prompt
Remove the note about webhook paths and move the warning note above the "Public Ingress URL" input label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)