### PR TITLE
Add tooltips to gateway buttons; auto-reset health check

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -616,6 +616,7 @@ struct SettingsPanel: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Copy gateway address")
+                    .help("Copy address")
 
                     // Check Gateway button
                     Button {
@@ -640,6 +641,7 @@ struct SettingsPanel: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Check gateway health")
+                    .help("Check gateway health")
                 }
 
                 Text("Point your tunnel service at this local address.")
@@ -1081,6 +1083,11 @@ struct SettingsPanel: View {
             } catch {
                 gatewayReachable = false
             }
+
+            // Auto-reset after 4 seconds so the result is transient and
+            // the button returns to its default "check" icon.
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            gatewayReachable = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -375,6 +375,7 @@ public struct SettingsView: View {
                     }
                     .buttonStyle(.borderless)
                     .accessibilityLabel("Copy gateway address")
+                    .help("Copy address")
                 }
 
                 Text("Point your tunnel service at this local address.")


### PR DESCRIPTION
## Summary
- Add `.help()` tooltips to the copy and health-check buttons in the Local Gateway Target section (both SettingsPanel and SettingsView)
- Auto-reset the gateway health check result after 4 seconds so the button returns to its default antenna icon, making it clear the check is retriggerable

## Original prompt
Add tooltips to the gateway target icon buttons and improve the health check UX by auto-resetting the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
