### PR TITLE
fix: auto-open app after update/file-write

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -407,10 +407,11 @@ export function handleSurfaceAction(ctx: SurfaceSessionContext, surfaceId: strin
 /**
  * After an app_update, refresh any active surface that displays the updated app.
  */
-export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string, opts?: { fileChange?: boolean; status?: string }): void {
+export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string, opts?: { fileChange?: boolean; status?: string }): boolean {
   const app = getApp(appId);
-  if (!app) return;
+  if (!app) return false;
 
+  let refreshed = false;
   for (const [surfaceId, stored] of ctx.surfaceState.entries()) {
     if (stored.surfaceType !== 'dynamic_page') continue;
     const data = stored.data as DynamicPageSurfaceData;
@@ -436,8 +437,10 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string,
       data: updatedData,
     });
 
+    refreshed = true;
     log.info({ conversationId: ctx.conversationId, surfaceId, appId }, 'Auto-refreshed surface after app_update');
   }
+  return refreshed;
 }
 
 export function buildCompletionSummary(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>): string {

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -27,6 +27,7 @@ import {
 } from './session-surfaces.js';
 import type { SurfaceSessionContext } from './session-surfaces.js';
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
+import { openAppViaSurface } from '../tools/apps/open-proxy.js';
 import { registerSessionSender } from '../tools/browser/browser-screencast.js';
 import type { ProxyApprovalCallback, ProxyApprovalRequest } from '../tools/network/script-proxy/index.js';
 import { projectSkillTools, type SkillProjectionCache } from './session-skill-tools.js';
@@ -265,13 +266,18 @@ export function createToolExecutor(
       },
     });
 
-    // Auto-refresh workspace surfaces when a persisted app is updated
+    // Auto-refresh workspace surfaces when a persisted app is updated.
+    // If no surface is currently showing the app, auto-open it.
     if (name === 'app_update' && !result.isError) {
       const appId = input.app_id as string | undefined;
       if (appId) {
-        refreshSurfacesForApp(ctx, appId);
+        const refreshed = refreshSurfacesForApp(ctx, appId);
         broadcastToAllClients?.({ type: 'app_files_changed', appId });
         void updatePublishedAppDeployment(appId);
+        if (!refreshed) {
+          const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
+          void openAppViaSurface(appId, resolver);
+        }
       }
     }
 
@@ -286,14 +292,19 @@ export function createToolExecutor(
       broadcastToAllClients?.({ type: 'tasks_changed' });
     }
 
-    // Auto-refresh workspace surfaces when app files are edited
+    // Auto-refresh workspace surfaces when app files are edited.
+    // If no surface is currently showing the app, auto-open it.
     if ((name === 'app_file_edit' || name === 'app_file_write') && !result.isError) {
       const appId = input.app_id as string | undefined;
       const status = input.status as string | undefined;
       if (appId) {
-        refreshSurfacesForApp(ctx, appId, { fileChange: true, status });
+        const refreshed = refreshSurfacesForApp(ctx, appId, { fileChange: true, status });
         broadcastToAllClients?.({ type: 'app_files_changed', appId });
         void updatePublishedAppDeployment(appId);
+        if (!refreshed) {
+          const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
+          void openAppViaSurface(appId, resolver);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- When `app_update`, `app_file_write`, or `app_file_edit` completes, check if any workspace surface is currently showing the app
- If no surface is open, auto-open the app via `openAppViaSurface` so the user sees the update immediately
- `refreshSurfacesForApp` now returns `boolean` to indicate whether any surface was refreshed

Previously only `app_create` auto-opened; updates and file writes silently did nothing if the app wasn't visible.

## Test plan
- [ ] Create an app, close it, then ask the agent to update it — app should auto-open
- [ ] With app already open, ask the agent to update it — app should refresh in place (existing behavior)
- [ ] Verify `app_file_write` and `app_file_edit` also auto-open when app is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
