### PR TITLE
fix: skip auto-open app in non-interactive sessions

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -274,7 +274,7 @@ export function createToolExecutor(
         const refreshed = refreshSurfacesForApp(ctx, appId);
         broadcastToAllClients?.({ type: 'app_files_changed', appId });
         void updatePublishedAppDeployment(appId);
-        if (!refreshed) {
+        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
           const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
           void openAppViaSurface(appId, resolver);
         }
@@ -301,7 +301,7 @@ export function createToolExecutor(
         const refreshed = refreshSurfacesForApp(ctx, appId, { fileChange: true, status });
         broadcastToAllClients?.({ type: 'app_files_changed', appId });
         void updatePublishedAppDeployment(appId);
-        if (!refreshed) {
+        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
           const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
           void openAppViaSurface(appId, resolver);
         }


### PR DESCRIPTION
## Summary
- Guard both `openAppViaSurface` calls with `!ctx.hasNoClient && !ctx.headlessLock` check
- Prevents orphaned surface state in headless/HTTP-only sessions where no UI client handles the surface
- Addresses review feedback from #6067

## Original prompt
Guard auto-open app calls with interactivity check — addresses review feedback from #6067.

In `assistant/src/daemon/session-tool-setup.ts`, there are two `openAppViaSurface` calls (around lines 283-286 and 310-313) that fire unconditionally. They should be gated on the session being interactive to avoid creating orphaned surface state in headless/HTTP-only sessions.

The file already defines interactivity at line 218: `isInteractive: !ctx.hasNoClient && !ctx.headlessLock`

For both blocks, wrap the `openAppViaSurface` call with an interactivity check:

Block 1 (around line 283):
```typescript
        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
```

Block 2 (around line 310):
```typescript
        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
```

This prevents auto-open from creating orphaned surface state in non-interactive sessions while preserving the behavior for interactive sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
