### PR TITLE
refactor: move tool routing from system prompt to skill/tool descriptions

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -159,13 +159,10 @@ describe('Task/Schedule/Reminder routing section in system prompt', () => {
     expect(prompt).toContain('"Remind me at 5pm to buy groceries" → reminder_create');
   });
 
-  test('routing section appears after tool routing by content type', () => {
+  test('routing section is present in the system prompt', () => {
     const prompt = buildSystemPrompt();
-    const contentTypeIdx = prompt.indexOf('## Tool Routing by Content Type');
     const taskRoutingIdx = prompt.indexOf('## Tool Routing: Tasks vs Schedules vs Reminders');
-    // Both must be present
-    expect(contentTypeIdx).toBeGreaterThanOrEqual(0);
-    expect(taskRoutingIdx).toBeGreaterThan(contentTypeIdx);
+    expect(taskRoutingIdx).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "App Builder"
-description: "Create polished, professional local apps with HTML/CSS/JS"
+description: "Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS. Use when the user says build, create, or make an app/dashboard/calculator/game."
 ---
 
 You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -11,8 +11,16 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 - **document_create** — Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** — Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
 
+## Workflow
+
+1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
+2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, *italic*, code blocks, tables, lists, blockquotes as appropriate.
+3. **CRITICAL — Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. The user experiences real-time content appearing as you write.
+4. **Respond to edits**: When the user requests changes via the docked chat, use `document_update` with `replace` for full rewrites or `append` for additions.
+
 ## Usage Notes
 
-- Use `document_create` when the user asks to write a blog post, article, or any long-form content.
-- After creating a document, use `document_update` with the returned `surface_id` to stream or edit content.
 - The `mode` parameter on `document_update` defaults to `append`.
+- Documents are automatically saved and accessible via the Generated panel.
+- Users can manually edit documents at any time.
+- Write in clear, engaging prose. Use active voice, vary sentence structure, and break content into logical sections with descriptive headings.

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "Document"
-description: "Document creation and editing for UI surfaces"
+description: "Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides). Use when the user says write, draft, compose, or create a blog/article/essay."
 metadata: {"vellum": {"emoji": "📄"}}
 ---
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -112,7 +112,6 @@ export function buildSystemPrompt(): string {
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
   parts.push(buildActionableUiSection());
-  parts.push(buildDocumentCreationSection());
   parts.push(buildStarterTaskPlaybookSection());
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
@@ -458,75 +457,6 @@ function buildActionableUiSection(): string {
     '- The surface stays alive for multiple action rounds (select → act → select more → act again)',
     '- Use `widgets.groupedSelect()` to wire up grouped multi-select with action bar auto-show/hide',
     '- Use `widgets.removeItems()` to animate processed items out and auto-clean empty groups',
-  ].join('\n');
-}
-
-function buildDocumentCreationSection(): string {
-  return [
-    '## Document Creation Workflow',
-    '',
-    'When creating documents with `document_create` (see Tool Routing for when to use this):',
-    '',
-    '**IMPORTANT: Call tools immediately, not after conversational preamble.**',
-    'Example: User says "write a blog post about X" → You immediately call `document_create`, then explain what you\'re doing.',
-    '',
-    '### Workflow Steps',
-    '1. **Create the document**: Call `document_create` with a title (inferred from the request)',
-    '   - The editor opens in full-screen workspace mode with chat docked to the side',
-    '   - The user sees a rich text editor powered by Toast UI Editor',
-    '',
-    '2. **Write content**: Generate the content in Markdown format',
-    '   - Write naturally and continuously',
-    '   - Use proper Markdown structure: `#` for titles, `##` for sections, `###` for subsections',
-    '   - Use **bold** and *italic* for emphasis',
-    '   - Include code blocks with ` ```language ` syntax',
-    '   - Add tables, lists, blockquotes as appropriate',
-    '',
-    '3. **CRITICAL - Stream content in chunks**: You MUST call `document_update` multiple times, NOT just once',
-    '   - Break your content into logical chunks (paragraphs, sections, or every 200-300 words)',
-    '   - Call `document_update` with `mode: "append"` for EACH chunk separately',
-    '   - DO NOT generate all content and send it in one call - this defeats the purpose of streaming',
-    '   - Think: "First paragraph" → call document_update → "Second paragraph" → call document_update → etc.',
-    '   - The user experiences real-time content appearing as you write, not a dump at the end',
-    '',
-    '4. **Respond to edits**: When the user requests changes via the docked chat',
-    '   - Listen for edit requests like "make the intro shorter", "add a section about X"',
-    '   - Generate the updated content',
-    '   - Use `document_update` with appropriate mode (replace for full rewrites, append for additions)',
-    '',
-    '### Content quality standards',
-    '- Write in clear, engaging prose appropriate for the content type',
-    '- Use active voice and vary sentence structure',
-    '- Break content into logical sections with descriptive headings',
-    '- Include transitions between sections',
-    '- For technical content: use code blocks with syntax highlighting',
-    '- For data-heavy content: use Markdown tables',
-    '',
-    '### Example flow',
-    '```',
-    'User: "Write a blog post about the future of AI"',
-    '',
-    'Assistant: "I\'ll create a document for your blog post about the future of AI."',
-    '  → Calls document_create with title: "The Future of AI"',
-    '',
-    'Assistant: (generates content in SEPARATE chunks - one document_update call per chunk)',
-    '  → document_update with mode: "append", content: "# The Future of AI\\n\\nArtificial intelligence..."',
-    '  → document_update with mode: "append", content: "## Current State\\n\\nToday\'s AI landscape..."',
-    '  → document_update with mode: "append", content: "The past decade has witnessed..."',
-    '  → document_update with mode: "append", content: "## Emerging Trends\\n\\nLooking ahead..."',
-    '',
-    'User (via docked chat): "Add a section about ethical considerations"',
-    '',
-    'Assistant: "I\'ll add a section on AI ethics."',
-    '  → document_update with mode: "append", content: "## Ethical Considerations\\n\\n..."',
-    '```',
-    '',
-    '### Important notes',
-    '- Documents are automatically saved and accessible via the Generated panel',
-    '- Users can manually edit documents at any time - your role is to help generate and refine content',
-    '- The editor supports drag-and-drop images, which are converted to base64 inline',
-    '- Word count is tracked automatically and displayed to the user',
-    '- Acknowledge the document creation in chat before opening the editor',
   ].join('\n');
 }
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -108,7 +108,6 @@ export function buildSystemPrompt(): string {
     );
   }
   parts.push(buildConfigSection());
-  parts.push(buildToolRoutingSection());
   parts.push(buildTaskScheduleReminderRoutingSection());
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
@@ -126,72 +125,6 @@ export function buildSystemPrompt(): string {
   parts.push(buildPostToolResponseSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
-}
-
-function buildToolRoutingSection(): string {
-  return [
-    '## Tool Routing by Content Type',
-    '',
-    'Choose the right tool based on what the user is asking for:',
-    '',
-    '### Writing Text Content → `document_create` + multiple `document_update` calls',
-    '',
-    'Use when the user wants to **write or compose** long-form text:',
-    '- Blog posts, articles, essays',
-    '- Reports, documentation, guides',
-    '- Any long-form writing (500+ words)',
-    '',
-    '**CRITICAL ACTION REQUIRED:**',
-    '1. User says "write a blog post" → You MUST call `document_create` tool IMMEDIATELY',
-    '2. Do NOT just say "I\'ll create a document" - actually call the tool!',
-    '3. After creating the document, call `document_update` MULTIPLE times to stream content in chunks',
-    '- Content that benefits from editing and markdown formatting',
-    '',
-    '**Key indicators:** User says "write", "draft", "compose", "create a blog/article/essay"',
-    '**Workflow:** Call `document_create` with title, then stream content using `document_update`',
-    '**Output:** Opens the Documents tab with built-in rich text editor',
-    '',
-    '### Building Interactive Apps → `app_create`',
-    '',
-    'Use when the user wants to **build or create** an interactive application:',
-    '- Dashboards, calculators, tools, utilities',
-    '- Games, trackers, timers, counters',
-    '- Data visualizations with user interaction',
-    '- Forms, CRUD apps, admin panels',
-    '- Presentational sites (portfolios, landing pages, resumes)',
-    '',
-    '**Key indicators:** User says "build", "create", "make an app/dashboard/calculator"',
-    '**Workflow:** Call `app_create` with HTML/CSS/JS and schema',
-    '**Output:** Opens a dynamic_page surface with full interactivity',
-    '',
-    '### Showing Structured Data → `ui_show`',
-    '',
-    'Use when the user wants to **display or visualize** existing data:',
-    '- Weather forecasts, flight results, stock prices',
-    '- Quick tables, cards, lists from API/tool data',
-    '- Temporary displays (no persistence needed)',
-    '',
-    '**Key indicators:** User says "show", "display", "what\'s the weather/stock price"',
-    '**Workflow:** Gather data via tools, then call `ui_show` with formatted HTML',
-    '**Output:** Shows a temporary dynamic page in chat context',
-    '',
-    '### Decision Framework',
-    '',
-    '**Ask yourself:**',
-    '1. Is this primarily **text composition**? → `document_create`',
-    '2. Is this an **interactive app** with state/logic? → `app_create`',
-    '3. Is this **displaying data** from tools/APIs? → `ui_show`',
-    '',
-    '**Examples:**',
-    '- "Write a blog post about AI" → `document_create` (text composition)',
-    '- "Build a todo list app" → `app_create` (interactive, stateful)',
-    '- "Show me the weather in NYC" → `ui_show` (data display)',
-    '- "Create a markdown editor" → `app_create` (interactive tool)',
-    '- "Draft an essay on philosophy" → `document_create` (text composition)',
-    '- "Make a countdown timer" → `app_create` (interactive, dynamic)',
-    '',
-    '**All three tools are equally important — use the right one for the task.**',
-  ].join('\n');
 }
 
 function buildTaskScheduleReminderRoutingSection(): string {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -26,7 +26,7 @@ function proxyExecute(): Promise<ToolExecutionResult> {
 export const uiShowTool: Tool = {
   name: 'ui_show',
   description:
-    'Show a UI surface to the user. Use display: "inline" (default) to embed in chat, or "panel" for a floating window.\n\n' +
+    'Show structured data or UI to the user. Use for displaying weather, flights, stock prices, quick tables, cards, lists, forms, or any temporary data visualization. Use display: "inline" (default) to embed in chat, or "panel" for a floating window. For long-form writing use the document skill instead; for interactive apps use the app-builder skill instead.\n\n' +
     'Supported surface types:\n' +
     '- card: Informational card with title, subtitle, body text, and optional metadata key-value pairs. ' +
     'Cards support an optional template field for specialized native rendering. ' +


### PR DESCRIPTION
## Summary
- Remove `buildToolRoutingSection()` from the system prompt (~800 tokens saved on every message)
- Move routing guidance into skill descriptions (`document` and `app-builder` SKILL.md) and `ui_show` tool description
- The model discovers when to use each tool from the skills catalog XML and tool descriptions instead of a static system prompt section

## Test plan
- [ ] Send "Write me a blog post about AI" — model should load document skill and use `document_create`
- [ ] Send "Build me a todo list app" — model should load app-builder skill and use `app_create`
- [ ] Send "Show me a comparison table" — model should use `ui_show` directly
- [ ] Verify system prompt token count is ~800 tokens lower

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
