### PR TITLE
feat(ios): add Identity tab with full ID card

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -5,13 +5,13 @@
  * `RUNTIME_HTTP_PORT` is set (default: disabled).
  */
 
-import { existsSync, readFileSync, statfsSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, statfsSync } from 'node:fs';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
-import { getWorkspacePromptPath } from '../util/platform.js';
+import { getWorkspacePromptPath, getRootDir } from '../util/platform.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl } from '../inbound/public-ingress-urls.js';
@@ -961,6 +961,47 @@ export class RuntimeHttpServer {
       // ignore
     }
 
+    // Read createdAt from IDENTITY.md file birthtime
+    let createdAt: string | undefined;
+    try {
+      const stats = statSync(identityPath);
+      createdAt = stats.birthtime.toISOString();
+    } catch {
+      // ignore
+    }
+
+    // Read lockfile for assistantId, cloud, and originSystem
+    let assistantId: string | undefined;
+    let cloud: string | undefined;
+    let originSystem: string | undefined;
+    try {
+      const homedir = process.env.HOME ?? process.env.USERPROFILE ?? '';
+      const lockfilePaths = [
+        join(homedir, '.vellum.lock.json'),
+        join(homedir, '.vellum.lockfile.json'),
+      ];
+      for (const lockPath of lockfilePaths) {
+        if (!existsSync(lockPath)) continue;
+        const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
+        const assistants = lockData.assistants as Array<Record<string, unknown>> | undefined;
+        if (assistants && assistants.length > 0) {
+          // Use the most recently hatched assistant
+          const sorted = [...assistants].sort((a, b) => {
+            const dateA = new Date(a.hatchedAt as string || 0).getTime();
+            const dateB = new Date(b.hatchedAt as string || 0).getTime();
+            return dateB - dateA;
+          });
+          const latest = sorted[0];
+          assistantId = latest.assistantId as string | undefined;
+          cloud = latest.cloud as string | undefined;
+          originSystem = cloud === 'local' ? 'local' : cloud;
+        }
+        break;
+      }
+    } catch {
+      // ignore — lockfile may not exist
+    }
+
     return Response.json({
       name: fields.name ?? '',
       role: fields.role ?? '',
@@ -968,6 +1009,9 @@ export class RuntimeHttpServer {
       emoji: fields.emoji ?? '',
       home: fields.home ?? '',
       version,
+      assistantId,
+      createdAt,
+      originSystem,
     });
   }
 

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -16,6 +16,13 @@ struct ContentView: View {
                     Label("Chats", systemImage: "message")
                 }
 
+            IdentityView()
+                .environmentObject(clientProvider)
+                .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tabItem {
+                    Label("Identity", systemImage: "person.text.rectangle")
+                }
+
             SettingsView()
                 .environmentObject(clientProvider)
                 .tabItem {

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -1,0 +1,266 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - ViewModel
+
+@MainActor @Observable
+final class IdentityViewModel {
+    var identity: RemoteIdentityInfo?
+    var isLoading = false
+
+    func fetchIdentity(client: any DaemonClientProtocol) async {
+        guard let daemonClient = client as? DaemonClient else { return }
+        isLoading = true
+        identity = await daemonClient.fetchRemoteIdentity()
+        isLoading = false
+    }
+}
+
+// MARK: - View
+
+struct IdentityView: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    @State private var viewModel = IdentityViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if !clientProvider.isConnected {
+                    disconnectedState
+                } else if viewModel.isLoading && viewModel.identity == nil {
+                    loadingState
+                } else if let identity = viewModel.identity {
+                    idCardContent(identity)
+                } else {
+                    noIdentityState
+                }
+            }
+            .navigationTitle("Identity")
+        }
+        .task {
+            if clientProvider.isConnected {
+                await viewModel.fetchIdentity(client: clientProvider.client)
+            }
+        }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected {
+                Task {
+                    await viewModel.fetchIdentity(client: clientProvider.client)
+                }
+            }
+        }
+    }
+
+    // MARK: - ID Card Content
+
+    private func idCardContent(_ identity: RemoteIdentityInfo) -> some View {
+        ScrollView {
+            VStack(spacing: VSpacing.lg) {
+                avatarSection(identity)
+                idCard(identity)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.top, VSpacing.md)
+        }
+        .refreshable {
+            await viewModel.fetchIdentity(client: clientProvider.client)
+        }
+    }
+
+    private func avatarSection(_ identity: RemoteIdentityInfo) -> some View {
+        VStack(spacing: VSpacing.sm) {
+            Text(identity.emoji)
+                .font(.system(size: 64))
+                .accessibilityHidden(true)
+
+            if !identity.name.isEmpty {
+                Text(identity.name)
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+            }
+
+            if !identity.role.isEmpty {
+                Text(identity.role)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Avatar: \(identity.name), \(identity.role)")
+    }
+
+    private func idCard(_ identity: RemoteIdentityInfo) -> some View {
+        VStack(spacing: 0) {
+            cardHeader
+
+            VStack(spacing: 0) {
+                if let assistantId = identity.assistantId, !assistantId.isEmpty {
+                    idCardRow(label: "Assistant ID", value: assistantId)
+                }
+
+                if !identity.name.isEmpty {
+                    idCardRow(label: "Name", value: identity.name)
+                }
+
+                if !identity.role.isEmpty {
+                    idCardRow(label: "Role", value: identity.role)
+                }
+
+                if !identity.personality.isEmpty {
+                    idCardRow(label: "Personality", value: identity.personality)
+                }
+
+                if let version = identity.version, !version.isEmpty {
+                    idCardRow(label: "Version", value: version)
+                }
+
+                if let createdAt = identity.createdAt, !createdAt.isEmpty {
+                    idCardRow(label: "Created", value: formatDate(createdAt))
+                }
+
+                if let originSystem = identity.originSystem, !originSystem.isEmpty {
+                    idCardRow(label: "Origin", value: originSystem.capitalized)
+                }
+
+                if let home = identity.home, !home.isEmpty {
+                    idCardRow(label: "Home", value: home, isLast: true)
+                }
+            }
+        }
+        .background(VColor.surface)
+        .cornerRadius(VRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Identity card")
+    }
+
+    private var cardHeader: some View {
+        HStack {
+            Image(systemName: "person.text.rectangle")
+                .foregroundColor(VColor.accent)
+                .accessibilityHidden(true)
+            Text("ID Card")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(VColor.backgroundSubtle)
+    }
+
+    private func idCardRow(label: String, value: String, isLast: Bool = false) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 90, alignment: .leading)
+
+                Text(value)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+
+            if !isLast {
+                Divider()
+                    .padding(.leading, VSpacing.lg)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+
+    // MARK: - Empty States
+
+    private var disconnectedState: some View {
+        VStack(spacing: VSpacing.lg) {
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 48))
+                .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
+
+            Text("Connect to Your Mac")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Identity information is available when connected to your assistant on Mac.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading identity...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var noIdentityState: some View {
+        VStack(spacing: VSpacing.lg) {
+            Image(systemName: "person.crop.circle.badge.questionmark")
+                .font(.system(size: 48))
+                .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
+
+            Text("No Identity Found")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Your assistant doesn't have an IDENTITY.md file yet.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func formatDate(_ isoString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: isoString) {
+            return formatDisplayDate(date)
+        }
+        // Try without fractional seconds
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: isoString) {
+            return formatDisplayDate(date)
+        }
+        return isoString
+    }
+
+    private func formatDisplayDate(_ date: Date) -> String {
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .none
+        return display.string(from: date)
+    }
+}
+
+#Preview {
+    IdentityView()
+        .environmentObject(ClientProvider(client: DaemonClient(config: .default)))
+}
+#endif

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -928,10 +928,33 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Remote Identity
 
-    /// Fetch identity info from the remote daemon. Returns nil for local (socket) transports.
+    /// Fetch identity info from the daemon's `GET /v1/identity` endpoint.
     #if os(macOS)
     public func fetchRemoteIdentity() async -> RemoteIdentityInfo? {
         return await httpTransport?.fetchRemoteIdentity()
+    }
+    #elseif os(iOS)
+    /// On iOS, constructs the HTTP URL from the daemon config hostname and the
+    /// runtime HTTP port (received via `daemon_status` IPC message).
+    public func fetchRemoteIdentity() async -> RemoteIdentityInfo? {
+        guard let httpPort else { return nil }
+        let scheme = config.tlsEnabled ? "https" : "http"
+        let urlString = "\(scheme)://\(config.hostname):\(httpPort)/v1/identity"
+        guard let url = URL(string: urlString) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        if let token = config.authToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return try? JSONDecoder().decode(RemoteIdentityInfo.self, from: data)
+        } catch {
+            return nil
+        }
     }
     #endif
 

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -7,6 +7,10 @@ public struct RemoteIdentityInfo: Decodable {
     public let personality: String
     public let emoji: String
     public let version: String?
+    public let assistantId: String?
+    public let home: String?
+    public let createdAt: String?
+    public let originSystem: String?
 }
 
 public struct DaemonConfig {


### PR DESCRIPTION
## Summary
- Expand daemon `GET /v1/identity` to return `assistantId`, `createdAt`, `originSystem` from lockfile
- Enable `fetchRemoteIdentity()` on iOS by constructing HTTP URL from daemon config hostname + httpPort (received via `daemon_status`)
- Add Identity tab to iOS TabView with full ID card (name, role, personality, version, created, origin, home)
- Connected-mode gating: shows "Connect to Your Mac" empty state when disconnected

<details>
<summary>Plan: IOS_HOME_BASE_AND_IDENTITY.md</summary>

PR 1 of 4 — Expand identity endpoint + iOS Identity tab with ID card

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
