### PR TITLE
fix: add missing subagent_detail_request/response to IPC snapshot tests

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -501,6 +501,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     subagentId: 'sub-001',
     content: 'Hello subagent',
   },
+  subagent_detail_request: {
+    type: 'subagent_detail_request',
+    subagentId: 'sub-001',
+    conversationId: 'conv-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1441,6 +1446,19 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       text: 'Searching for docs...',
       sessionId: 'sub-sess-001',
     },
+  },
+  subagent_detail_response: {
+    type: 'subagent_detail_response',
+    subagentId: 'sub-001',
+    objective: 'Search for documentation',
+    events: [
+      {
+        type: 'tool_use',
+        content: 'Reading file...',
+        toolName: 'read_file',
+        isError: false,
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `subagent_detail_request` to client messages snapshot (was missing after the type was added to the IPC contract)
- Add `subagent_detail_response` to server messages snapshot (same reason)
- Fixes `tsc --noEmit` errors in `ipc-snapshot.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
