### PR TITLE
fix: resolve lint errors in browser navigation tools and scripts

### DIFF
--- a/assistant/scripts/capture-x-graphql.ts
+++ b/assistant/scripts/capture-x-graphql.ts
@@ -63,7 +63,7 @@ class CDPClient {
         const msg = JSON.parse(String(event.data));
         if (msg.id != null) {
           const cb = this.callbacks.get(msg.id);
-          if (cb) { this.callbacks.delete(msg.id); msg.error ? cb.reject(new Error(msg.error.message)) : cb.resolve(msg.result); }
+          if (cb) { this.callbacks.delete(msg.id); if (msg.error) { cb.reject(new Error(msg.error.message)); } else { cb.resolve(msg.result); } }
         } else if (msg.method) {
           for (const h of this.eventHandlers.get(msg.method) ?? []) h(msg.params ?? {});
         }
@@ -216,7 +216,7 @@ function notifyQuerySeen(queryName: string) {
   }
 }
 
-function waitForQuery(queryName: string, timeoutMs = 15000): Promise<boolean> {
+function _waitForQuery(queryName: string, timeoutMs = 15000): Promise<boolean> {
   if (seenQueries.has(queryName)) return Promise.resolve(true);
   return new Promise(resolve => {
     const timer = setTimeout(() => {
@@ -251,7 +251,7 @@ function waitForAnyQuery(queryNames: string[], timeoutMs = 15000): Promise<boole
 
 // We'll keep a reference to one client that's on an x.com tab for navigation
 let navigationClient: CDPClient | null = null;
-let navigationWsUrl: string | null = null;
+let _navigationWsUrl: string | null = null;
 
 for (const page of pages) {
   const client = new CDPClient();
@@ -261,7 +261,7 @@ for (const page of pages) {
   // Track which client is on an x.com tab for navigation
   if (page.url.includes('x.com') || page.url.includes('twitter.com')) {
     navigationClient = client;
-    navigationWsUrl = page.webSocketDebuggerUrl;
+    _navigationWsUrl =page.webSocketDebuggerUrl;
   }
 
   client.on('Network.requestWillBeSent', (params) => {
@@ -347,7 +347,7 @@ for (const page of pages) {
 if (!navigationClient && pages.length > 0) {
   navigationClient = new CDPClient();
   await navigationClient.connect(pages[0].webSocketDebuggerUrl);
-  navigationWsUrl = pages[0].webSocketDebuggerUrl;
+  _navigationWsUrl =pages[0].webSocketDebuggerUrl;
 }
 
 // ─── CDP navigation helpers ──────────────────────────────────────────────────

--- a/assistant/src/tools/browser/auto-navigate.ts
+++ b/assistant/src/tools/browser/auto-navigate.ts
@@ -38,7 +38,7 @@ class MiniCDP {
           const cb = this.callbacks.get(msg.id);
           if (cb) {
             this.callbacks.delete(msg.id);
-            msg.error ? cb.reject(new Error(msg.error.message)) : cb.resolve(msg.result);
+            if (msg.error) { cb.reject(new Error(msg.error.message)); } else { cb.resolve(msg.result); }
           }
         }
       };
@@ -130,7 +130,7 @@ export async function autoNavigate(domain: string, abortSignal?: { aborted: bool
   await sleep(SCROLL_WAIT_MS);
 
   // Discover internal links from the current page
-  let discoveredLinks = await discoverInternalLinks(cdp, domain);
+  const discoveredLinks = await discoverInternalLinks(cdp, domain);
   log.info({ count: discoveredLinks.length }, 'Discovered internal links from root');
 
   // Visit discovered pages

--- a/assistant/src/tools/browser/x-auto-navigate.ts
+++ b/assistant/src/tools/browser/x-auto-navigate.ts
@@ -35,7 +35,7 @@ class MiniCDP {
           const cb = this.callbacks.get(msg.id);
           if (cb) {
             this.callbacks.delete(msg.id);
-            msg.error ? cb.reject(new Error(msg.error.message)) : cb.resolve(msg.result);
+            if (msg.error) { cb.reject(new Error(msg.error.message)); } else { cb.resolve(msg.result); }
           }
         }
       };


### PR DESCRIPTION
## Summary
- Replace ternary expressions used as statements with if/else in auto-navigate.ts, x-auto-navigate.ts, capture-x-graphql.ts
- Use `const` for `discoveredLinks` (prefer-const)
- Prefix unused `waitForQuery` and `navigationWsUrl` with underscore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
