### PR TITLE
fix: remove dead code from capture-x-graphql.ts

### DIFF
--- a/assistant/scripts/capture-x-graphql.ts
+++ b/assistant/scripts/capture-x-graphql.ts
@@ -216,20 +216,6 @@ function notifyQuerySeen(queryName: string) {
   }
 }
 
-function _waitForQuery(queryName: string, timeoutMs = 15000): Promise<boolean> {
-  if (seenQueries.has(queryName)) return Promise.resolve(true);
-  return new Promise(resolve => {
-    const timer = setTimeout(() => {
-      queryWaiters.delete(queryName);
-      resolve(false);
-    }, timeoutMs);
-    queryWaiters.set(queryName, () => {
-      clearTimeout(timer);
-      resolve(true);
-    });
-  });
-}
-
 function waitForAnyQuery(queryNames: string[], timeoutMs = 15000): Promise<boolean> {
   if (queryNames.some(q => seenQueries.has(q))) return Promise.resolve(true);
   return new Promise(resolve => {
@@ -251,7 +237,6 @@ function waitForAnyQuery(queryNames: string[], timeoutMs = 15000): Promise<boole
 
 // We'll keep a reference to one client that's on an x.com tab for navigation
 let navigationClient: CDPClient | null = null;
-let _navigationWsUrl: string | null = null;
 
 for (const page of pages) {
   const client = new CDPClient();
@@ -261,7 +246,6 @@ for (const page of pages) {
   // Track which client is on an x.com tab for navigation
   if (page.url.includes('x.com') || page.url.includes('twitter.com')) {
     navigationClient = client;
-    _navigationWsUrl =page.webSocketDebuggerUrl;
   }
 
   client.on('Network.requestWillBeSent', (params) => {
@@ -347,7 +331,6 @@ for (const page of pages) {
 if (!navigationClient && pages.length > 0) {
   navigationClient = new CDPClient();
   await navigationClient.connect(pages[0].webSocketDebuggerUrl);
-  _navigationWsUrl =pages[0].webSocketDebuggerUrl;
 }
 
 // ─── CDP navigation helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Delete unused `_waitForQuery` function (never called)
- Delete unused `_navigationWsUrl` variable and its assignments (never read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
