### PR TITLE
feat(ios): add skills list and workspace file viewer to Identity

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,4 +1,2 @@
 
 https://github.com/vellum-ai/vellum-assistant/pull/5992
-
-https://github.com/vellum-ai/vellum-assistant/pull/6044

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -506,6 +506,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     subagentId: 'sub-001',
     conversationId: 'conv-001',
   },
+  workspace_files_list: {
+    type: 'workspace_files_list',
+  },
+  workspace_file_read: {
+    type: 'workspace_file_read',
+    path: 'IDENTITY.md',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1459,6 +1466,17 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         isError: false,
       },
     ],
+  },
+  workspace_files_list_response: {
+    type: 'workspace_files_list_response',
+    files: [
+      { path: 'IDENTITY.md', name: 'IDENTITY.md', exists: true },
+    ],
+  },
+  workspace_file_read_response: {
+    type: 'workspace_file_read_response',
+    path: 'IDENTITY.md',
+    content: '# My Identity',
   },
 };
 

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -20,6 +20,7 @@ import { subagentHandlers } from './subagents.js';
 import { browserHandlers } from './browser.js';
 import { signingHandlers } from './signing.js';
 import { twitterAuthHandlers } from './twitter-auth.js';
+import { workspaceFileHandlers } from './workspace-files.js';
 
 // Re-export types and utilities for backwards compatibility
 export type {
@@ -102,6 +103,7 @@ const handlers = {
   ...browserHandlers,
   ...signingHandlers,
   ...twitterAuthHandlers,
+  ...workspaceFileHandlers,
   ...inlineHandlers,
 } satisfies DispatchMap;
 

--- a/assistant/src/daemon/handlers/workspace-files.ts
+++ b/assistant/src/daemon/handlers/workspace-files.ts
@@ -1,0 +1,73 @@
+import * as net from 'node:net';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getWorkspaceDir } from '../../util/platform.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
+import type { WorkspaceFileReadRequest } from '../ipc-protocol.js';
+
+/** Well-known workspace prompt files shown in the Identity panel. */
+const WORKSPACE_FILES = ['IDENTITY.md', 'SOUL.md', 'USER.md', 'skills/'];
+
+function handleWorkspaceFilesList(socket: net.Socket, ctx: HandlerContext): void {
+  const base = getWorkspaceDir();
+  const files = WORKSPACE_FILES.map((name) => ({
+    path: name,
+    name,
+    exists: existsSync(join(base, name)),
+  }));
+  ctx.send(socket, { type: 'workspace_files_list_response', files });
+}
+
+function handleWorkspaceFileRead(
+  msg: WorkspaceFileReadRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const base = getWorkspaceDir();
+  const requested = msg.path;
+
+  // Prevent path traversal — reject paths that escape the workspace root.
+  const resolved = join(base, requested);
+  if (!resolved.startsWith(base)) {
+    log.warn({ path: requested }, 'Workspace file read blocked: path traversal attempt');
+    ctx.send(socket, {
+      type: 'workspace_file_read_response',
+      path: requested,
+      content: null,
+      error: 'Invalid path',
+    });
+    return;
+  }
+
+  try {
+    if (!existsSync(resolved)) {
+      ctx.send(socket, {
+        type: 'workspace_file_read_response',
+        path: requested,
+        content: null,
+        error: 'File not found',
+      });
+      return;
+    }
+    const content = readFileSync(resolved, 'utf-8');
+    ctx.send(socket, {
+      type: 'workspace_file_read_response',
+      path: requested,
+      content,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, path: requested }, 'Failed to read workspace file');
+    ctx.send(socket, {
+      type: 'workspace_file_read_response',
+      path: requested,
+      content: null,
+      error: message,
+    });
+  }
+}
+
+export const workspaceFileHandlers = defineHandlers({
+  workspace_files_list: (_msg, socket, ctx) => handleWorkspaceFilesList(socket, ctx),
+  workspace_file_read: handleWorkspaceFileRead,
+});

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -103,7 +103,9 @@
     "WorkItemPreflightRequest",
     "WorkItemRunTaskRequest",
     "WorkItemUpdateRequest",
-    "WorkItemsListRequest"
+    "WorkItemsListRequest",
+    "WorkspaceFileReadRequest",
+    "WorkspaceFilesListRequest"
   ],
   "serverMessageTypes": [
     "AcceptStarterBundleResponse",
@@ -222,7 +224,9 @@
     "WorkItemRunTaskResponse",
     "WorkItemStatusChanged",
     "WorkItemUpdateResponse",
-    "WorkItemsListResponse"
+    "WorkItemsListResponse",
+    "WorkspaceFileReadResponse",
+    "WorkspaceFilesListResponse"
   ],
   "clientWireTypes": [
     "accept_starter_bundle",
@@ -328,7 +332,9 @@
     "work_item_preflight",
     "work_item_run_task",
     "work_item_update",
-    "work_items_list"
+    "work_items_list",
+    "workspace_file_read",
+    "workspace_files_list"
   ],
   "serverWireTypes": [
     "accept_starter_bundle_response",
@@ -446,6 +452,8 @@
     "work_item_run_task_response",
     "work_item_status_changed",
     "work_item_update_response",
-    "work_items_list_response"
+    "work_items_list_response",
+    "workspace_file_read_response",
+    "workspace_files_list_response"
   ]
 }

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -876,6 +876,18 @@ export interface WorkItemCancelRequest {
   id: string;
 }
 
+// === Workspace File IPC ─────────────────────────────────────────────────────
+
+export interface WorkspaceFilesListRequest {
+  type: 'workspace_files_list';
+}
+
+export interface WorkspaceFileReadRequest {
+  type: 'workspace_file_read';
+  /** Relative path within the workspace directory (e.g. "IDENTITY.md"). */
+  path: string;
+}
+
 export type ClientMessage =
   | AuthMessage
   | UserMessage
@@ -980,7 +992,9 @@ export type ClientMessage =
   | SubagentAbortRequest
   | SubagentStatusRequest
   | SubagentMessageRequest
-  | SubagentDetailRequest;
+  | SubagentDetailRequest
+  | WorkspaceFilesListRequest
+  | WorkspaceFileReadRequest;
 
 export interface IntegrationListRequest {
   type: 'integration_list';
@@ -2105,6 +2119,27 @@ export interface TaskRunThreadCreated {
   title: string;
 }
 
+// === Workspace File Responses ────────────────────────────────────────────────
+
+export interface WorkspaceFilesListResponse {
+  type: 'workspace_files_list_response';
+  files: Array<{
+    /** Relative path within the workspace (e.g. "IDENTITY.md", "skills/my-skill"). */
+    path: string;
+    /** Display name (e.g. "IDENTITY.md"). */
+    name: string;
+    /** Whether the file/directory exists. */
+    exists: boolean;
+  }>;
+}
+
+export interface WorkspaceFileReadResponse {
+  type: 'workspace_file_read_response';
+  path: string;
+  content: string | null;
+  error?: string;
+}
+
 export type ServerMessage =
   | AuthResult
   | UserMessageEcho
@@ -2222,7 +2257,9 @@ export type ServerMessage =
   | SubagentSpawned
   | SubagentStatusChanged
   | SubagentEvent
-  | SubagentDetailResponse;
+  | SubagentDetailResponse
+  | WorkspaceFilesListResponse
+  | WorkspaceFileReadResponse;
 
 // === Subagent IPC ─────────────────────────────────────────────────────
 

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -7,13 +7,50 @@ import VellumAssistantShared
 @MainActor @Observable
 final class IdentityViewModel {
     var identity: RemoteIdentityInfo?
+    var skills: [SkillInfo] = []
+    var workspaceFiles: [WorkspaceFileInfo] = []
     var isLoading = false
 
-    func fetchIdentity(client: any DaemonClientProtocol) async {
+    func fetchAll(client: any DaemonClientProtocol) async {
         guard let daemonClient = client as? DaemonClient else { return }
         isLoading = true
-        identity = await daemonClient.fetchRemoteIdentity()
+        async let identityResult = daemonClient.fetchRemoteIdentity()
+        identity = await identityResult
         isLoading = false
+
+        // Fetch skills and workspace files via IPC (fire-and-forget subscribe)
+        await fetchSkills(daemonClient: daemonClient)
+        await fetchWorkspaceFiles(daemonClient: daemonClient)
+    }
+
+    private func fetchSkills(daemonClient: DaemonClient) async {
+        let stream = daemonClient.subscribe()
+        do {
+            try daemonClient.send(SkillsListRequestMessage())
+        } catch {
+            return
+        }
+        for await message in stream {
+            if case .skillsListResponse(let response) = message {
+                skills = response.skills.filter { $0.state == "enabled" }
+                return
+            }
+        }
+    }
+
+    private func fetchWorkspaceFiles(daemonClient: DaemonClient) async {
+        let stream = daemonClient.subscribe()
+        do {
+            try daemonClient.sendWorkspaceFilesList()
+        } catch {
+            return
+        }
+        for await message in stream {
+            if case .workspaceFilesListResponse(let response) = message {
+                workspaceFiles = response.files.filter { $0.exists }
+                return
+            }
+        }
     }
 }
 
@@ -22,6 +59,7 @@ final class IdentityViewModel {
 struct IdentityView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @State private var viewModel = IdentityViewModel()
+    @State private var viewingFile: WorkspaceFileInfo?
 
     var body: some View {
         NavigationStack {
@@ -40,15 +78,21 @@ struct IdentityView: View {
         }
         .task {
             if clientProvider.isConnected {
-                await viewModel.fetchIdentity(client: clientProvider.client)
+                await viewModel.fetchAll(client: clientProvider.client)
             }
         }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected {
                 Task {
-                    await viewModel.fetchIdentity(client: clientProvider.client)
+                    await viewModel.fetchAll(client: clientProvider.client)
                 }
             }
+        }
+        .sheet(item: $viewingFile) { file in
+            WorkspaceFileSheet(
+                file: file,
+                client: clientProvider.client as? DaemonClient
+            )
         }
     }
 
@@ -59,12 +103,20 @@ struct IdentityView: View {
             VStack(spacing: VSpacing.lg) {
                 avatarSection(identity)
                 idCard(identity)
+
+                if !viewModel.skills.isEmpty {
+                    skillsSection
+                }
+
+                if !viewModel.workspaceFiles.isEmpty {
+                    workspaceFilesSection
+                }
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.top, VSpacing.md)
         }
         .refreshable {
-            await viewModel.fetchIdentity(client: clientProvider.client)
+            await viewModel.fetchAll(client: clientProvider.client)
         }
     }
 
@@ -92,41 +144,17 @@ struct IdentityView: View {
         .accessibilityLabel("Avatar: \(identity.name), \(identity.role)")
     }
 
+    // MARK: - ID Card
+
     private func idCard(_ identity: RemoteIdentityInfo) -> some View {
-        VStack(spacing: 0) {
-            cardHeader
+        let rows = buildCardRows(identity)
+
+        return VStack(spacing: 0) {
+            sectionHeader(icon: "person.text.rectangle", title: "ID Card")
 
             VStack(spacing: 0) {
-                if let assistantId = identity.assistantId, !assistantId.isEmpty {
-                    idCardRow(label: "Assistant ID", value: assistantId)
-                }
-
-                if !identity.name.isEmpty {
-                    idCardRow(label: "Name", value: identity.name)
-                }
-
-                if !identity.role.isEmpty {
-                    idCardRow(label: "Role", value: identity.role)
-                }
-
-                if !identity.personality.isEmpty {
-                    idCardRow(label: "Personality", value: identity.personality)
-                }
-
-                if let version = identity.version, !version.isEmpty {
-                    idCardRow(label: "Version", value: version)
-                }
-
-                if let createdAt = identity.createdAt, !createdAt.isEmpty {
-                    idCardRow(label: "Created", value: formatDate(createdAt))
-                }
-
-                if let originSystem = identity.originSystem, !originSystem.isEmpty {
-                    idCardRow(label: "Origin", value: originSystem.capitalized)
-                }
-
-                if let home = identity.home, !home.isEmpty {
-                    idCardRow(label: "Home", value: home, isLast: true)
+                ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                    idCardRow(label: row.label, value: row.value, isLast: index == rows.count - 1)
                 }
             }
         }
@@ -140,12 +168,170 @@ struct IdentityView: View {
         .accessibilityLabel("Identity card")
     }
 
-    private var cardHeader: some View {
+    private struct CardRow {
+        let label: String
+        let value: String
+    }
+
+    private func buildCardRows(_ identity: RemoteIdentityInfo) -> [CardRow] {
+        var rows: [CardRow] = []
+        if let assistantId = identity.assistantId, !assistantId.isEmpty {
+            rows.append(CardRow(label: "Assistant ID", value: assistantId))
+        }
+        if !identity.name.isEmpty {
+            rows.append(CardRow(label: "Name", value: identity.name))
+        }
+        if !identity.role.isEmpty {
+            rows.append(CardRow(label: "Role", value: identity.role))
+        }
+        if !identity.personality.isEmpty {
+            rows.append(CardRow(label: "Personality", value: identity.personality))
+        }
+        if let version = identity.version, !version.isEmpty {
+            rows.append(CardRow(label: "Version", value: version))
+        }
+        if let createdAt = identity.createdAt, !createdAt.isEmpty {
+            rows.append(CardRow(label: "Created", value: formatDate(createdAt)))
+        }
+        if let originSystem = identity.originSystem, !originSystem.isEmpty {
+            rows.append(CardRow(label: "Origin", value: originSystem.capitalized))
+        }
+        if let home = identity.home, !home.isEmpty {
+            rows.append(CardRow(label: "Home", value: home))
+        }
+        return rows
+    }
+
+    // MARK: - Skills Section
+
+    private var skillsSection: some View {
+        VStack(spacing: 0) {
+            sectionHeader(icon: "star.fill", title: "Skills")
+
+            VStack(spacing: 0) {
+                ForEach(Array(viewModel.skills.enumerated()), id: \.element.id) { index, skill in
+                    skillRow(skill, isLast: index == viewModel.skills.count - 1)
+                }
+            }
+        }
+        .background(VColor.surface)
+        .cornerRadius(VRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Skills list")
+    }
+
+    private func skillRow(_ skill: SkillInfo, isLast: Bool) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: VSpacing.sm) {
+                Text(skill.emoji ?? "")
+                    .font(.system(size: 20))
+                    .frame(width: 28)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(skill.name)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if !skill.description.isEmpty {
+                        Text(skill.description)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if skill.degraded {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                        .font(.caption)
+                        .accessibilityLabel("Degraded")
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+
+            if !isLast {
+                Divider()
+                    .padding(.leading, VSpacing.lg + 28 + VSpacing.sm)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Skill: \(skill.name), enabled\(skill.degraded ? ", degraded" : "")")
+    }
+
+    // MARK: - Workspace Files Section
+
+    private var workspaceFilesSection: some View {
+        VStack(spacing: 0) {
+            sectionHeader(icon: "doc.text.fill", title: "Workspace Files")
+
+            VStack(spacing: 0) {
+                ForEach(Array(viewModel.workspaceFiles.enumerated()), id: \.element.id) { index, file in
+                    workspaceFileRow(file, isLast: index == viewModel.workspaceFiles.count - 1)
+                }
+            }
+        }
+        .background(VColor.surface)
+        .cornerRadius(VRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Workspace files")
+    }
+
+    private func workspaceFileRow(_ file: WorkspaceFileInfo, isLast: Bool) -> some View {
+        VStack(spacing: 0) {
+            Button {
+                viewingFile = file
+            } label: {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: file.name.hasSuffix("/") ? "folder.fill" : "doc.text")
+                        .foregroundColor(VColor.accent)
+                        .frame(width: 24)
+                        .accessibilityHidden(true)
+
+                    Text(file.name)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(VColor.textMuted)
+                        .font(.caption)
+                        .accessibilityHidden(true)
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+            }
+
+            if !isLast {
+                Divider()
+                    .padding(.leading, VSpacing.lg + 24 + VSpacing.sm)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(file.name)
+        .accessibilityHint("Opens file viewer")
+    }
+
+    // MARK: - Shared Section Header
+
+    private func sectionHeader(icon: String, title: String) -> some View {
         HStack {
-            Image(systemName: "person.text.rectangle")
+            Image(systemName: icon)
                 .foregroundColor(VColor.accent)
                 .accessibilityHidden(true)
-            Text("ID Card")
+            Text(title)
                 .font(VFont.headline)
                 .foregroundColor(VColor.textPrimary)
             Spacer()

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -1,0 +1,112 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+struct WorkspaceFileSheet: View {
+    let file: WorkspaceFileInfo
+    let client: DaemonClient?
+    @Environment(\.dismiss) private var dismiss
+    @State private var content: String?
+    @State private var isLoading = true
+    @State private var error: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    VStack(spacing: VSpacing.md) {
+                        ProgressView()
+                        Text("Loading file...")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error {
+                    VStack(spacing: VSpacing.md) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 36))
+                            .foregroundColor(VColor.textMuted)
+                            .accessibilityHidden(true)
+                        Text(error)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(VSpacing.xl)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let content {
+                    ScrollView {
+                        markdownContent(content)
+                            .padding(VSpacing.lg)
+                    }
+                } else {
+                    Text("No content")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .navigationTitle(file.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .task {
+            await loadContent()
+        }
+    }
+
+    @ViewBuilder
+    private func markdownContent(_ raw: String) -> some View {
+        if let attributed = try? AttributedString(markdown: raw, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+            Text(attributed)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            // Fallback to plain text
+            Text(raw)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func loadContent() async {
+        guard let client else {
+            error = "Not connected to daemon."
+            isLoading = false
+            return
+        }
+
+        let stream = client.subscribe()
+        do {
+            try client.sendWorkspaceFileRead(path: file.path)
+        } catch {
+            self.error = "Failed to request file."
+            isLoading = false
+            return
+        }
+
+        for await message in stream {
+            if case .workspaceFileReadResponse(let response) = message, response.path == file.path {
+                if let fileContent = response.content {
+                    content = fileContent
+                } else {
+                    self.error = response.error ?? "Unable to read file."
+                }
+                isLoading = false
+                return
+            }
+        }
+
+        error = "Connection lost."
+        isLoading = false
+    }
+}
+#endif

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -958,6 +958,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
     #endif
 
+    // MARK: - Workspace Files
+
+    /// Request the list of workspace files from the daemon.
+    public func sendWorkspaceFilesList() throws {
+        try send(WorkspaceFilesListRequestMessage())
+    }
+
+    /// Request the content of a workspace file from the daemon.
+    public func sendWorkspaceFileRead(path: String) throws {
+        try send(WorkspaceFileReadRequestMessage(path: path))
+    }
+
     // MARK: - Document Persistence
 
     public func sendDocumentSave(surfaceId: String, conversationId: String, title: String, content: String, wordCount: Int) throws {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2238,3 +2238,34 @@ public struct IPCWorkItemUpdateResponseItem: Codable, Sendable {
     public let createdAt: Int
     public let updatedAt: Int
 }
+
+public struct IPCWorkspaceFileReadRequest: Codable, Sendable {
+    public let type: String
+    /// Relative path within the workspace directory (e.g. "IDENTITY.md").
+    public let path: String
+}
+
+public struct IPCWorkspaceFileReadResponse: Codable, Sendable {
+    public let type: String
+    public let path: String
+    public let content: String?
+    public let error: String?
+}
+
+public struct IPCWorkspaceFilesListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCWorkspaceFilesListResponse: Codable, Sendable {
+    public let type: String
+    public let files: [IPCWorkspaceFilesListResponseFile]
+}
+
+public struct IPCWorkspaceFilesListResponseFile: Codable, Sendable {
+    /// Relative path within the workspace (e.g. "IDENTITY.md", "skills/my-skill").
+    public let path: String
+    /// Display name (e.g. "IDENTITY.md").
+    public let name: String
+    /// Whether the file/directory exists.
+    public let exists: Bool
+}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -981,6 +981,39 @@ public typealias SkillsListResponseMessage = IPCSkillsListResponse
 /// Backed by generated `IPCSkillDetailResponse`.
 public typealias SkillDetailResponseMessage = IPCSkillDetailResponse
 
+// MARK: - Workspace Files
+
+/// Request to list workspace files.
+public typealias WorkspaceFilesListRequestMessage = IPCWorkspaceFilesListRequest
+
+extension IPCWorkspaceFilesListRequest {
+    public init() {
+        self.init(type: "workspace_files_list")
+    }
+}
+
+/// Request to read a workspace file's content.
+public typealias WorkspaceFileReadRequestMessage = IPCWorkspaceFileReadRequest
+
+extension IPCWorkspaceFileReadRequest {
+    public init(path: String) {
+        self.init(type: "workspace_file_read", path: path)
+    }
+}
+
+/// Response containing the list of workspace files.
+public typealias WorkspaceFilesListResponseMessage = IPCWorkspaceFilesListResponse
+
+/// Individual workspace file entry.
+public typealias WorkspaceFileInfo = IPCWorkspaceFilesListResponseFile
+
+extension IPCWorkspaceFilesListResponseFile: Identifiable {
+    public var id: String { path }
+}
+
+/// Response containing a workspace file's content.
+public typealias WorkspaceFileReadResponseMessage = IPCWorkspaceFileReadResponse
+
 /// Push event: skill state changed.
 /// Backed by generated `IPCSkillStateChanged`.
 public typealias SkillStateChangedMessage = IPCSkillStateChanged
@@ -1952,6 +1985,8 @@ public enum ServerMessage: Decodable, Sendable {
     case subagentStatusChanged(IPCSubagentStatusChanged)
     indirect case subagentEvent(SubagentEventMessage)
     case subagentDetailResponse(IPCSubagentDetailResponse)
+    case workspaceFilesListResponse(WorkspaceFilesListResponseMessage)
+    case workspaceFileReadResponse(WorkspaceFileReadResponseMessage)
     case pong
     case unknown(String)
 
@@ -2273,6 +2308,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "subagent_detail_response":
             let message = try IPCSubagentDetailResponse(from: decoder)
             self = .subagentDetailResponse(message)
+        case "workspace_files_list_response":
+            let message = try WorkspaceFilesListResponseMessage(from: decoder)
+            self = .workspaceFilesListResponse(message)
+        case "workspace_file_read_response":
+            let message = try WorkspaceFileReadResponseMessage(from: decoder)
+            self = .workspaceFileReadResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Adds skills list and workspace file viewer sections to the iOS Identity tab
- Introduces new `workspace_files_list` and `workspace_file_read` IPC messages for iOS to access Mac workspace files remotely
- Fixes trailing divider bug from PR #6071 where the last visible ID card row showed a stray divider when `home` field was empty

## Implementation

**Backend (daemon):**
- New IPC types in `ipc-contract.ts`: `WorkspaceFilesListRequest/Response` and `WorkspaceFileReadRequest/Response`
- New handler `workspace-files.ts` that lists well-known workspace files (IDENTITY.md, SOUL.md, USER.md, skills/) and reads file content with path traversal protection

**Shared (Swift):**
- Generated types for workspace file IPC messages
- Hand-maintained typealiases, `Identifiable` conformance, and convenience inits in `IPCMessages.swift`
- `sendWorkspaceFilesList()` and `sendWorkspaceFileRead(path:)` methods on `DaemonClient`

**iOS:**
- Skills section: shows enabled skills with emoji icon, name, description, and degraded badge
- Workspace files section: shows existing workspace files with tap-to-view functionality
- `WorkspaceFileSheet`: renders markdown content using native `Text(AttributedString(markdown:))`
- ID card refactored to use `buildCardRows()` array for dynamic `isLast` detection (fixes trailing divider bug)
- Full accessibility labels on all new interactive elements

## Key Technical Choices
- Uses IPC subscribe pattern (not HTTP) for skills and workspace files, matching how macOS `SkillsManager` fetches data
- Path traversal protection in workspace file handler prevents reading files outside `~/.vellum/workspace/`
- Native `AttributedString(markdown:)` for rendering — no third-party dependency, available iOS 15+

<details>
<summary>Plan: IOS_HOME_BASE_AND_IDENTITY.md</summary>

PR 2 of 4 in the iOS Home Base & Identity rollout plan.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
