### PR TITLE
fix: harden workspace file path traversal check

### DIFF
--- a/assistant/src/daemon/handlers/workspace-files.ts
+++ b/assistant/src/daemon/handlers/workspace-files.ts
@@ -1,6 +1,6 @@
 import * as net from 'node:net';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { getWorkspaceDir } from '../../util/platform.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 import type { WorkspaceFileReadRequest } from '../ipc-protocol.js';
@@ -27,8 +27,10 @@ function handleWorkspaceFileRead(
   const requested = msg.path;
 
   // Prevent path traversal — reject paths that escape the workspace root.
-  const resolved = join(base, requested);
-  if (!resolved.startsWith(base)) {
+  // Use resolve() to canonicalize and check with trailing separator to prevent
+  // sibling directory prefix matches (e.g. "../workspace-evil/secret").
+  const resolved = resolve(base, requested);
+  if (!resolved.startsWith(base + sep) && resolved !== base) {
     log.warn({ path: requested }, 'Workspace file read blocked: path traversal attempt');
     ctx.send(socket, {
       type: 'workspace_file_read_response',


### PR DESCRIPTION
## Summary
- Fixes path traversal vulnerability in workspace file read handler identified by Codex and Devin in PR #6078
- Uses `resolve()` for canonical path resolution instead of `join()`
- Checks with trailing path separator to prevent sibling directory prefix matches

## The Issue
The original `startsWith(base)` check could be bypassed: a path like `../workspace-evil/secret` resolved to a sibling path (e.g. `~/.vellum/workspace-evil/secret`) that still started with the `~/.vellum/workspace` prefix.

## The Fix
- `join()` → `resolve()` for canonical path resolution
- `startsWith(base)` → `startsWith(base + sep) || resolved === base` to ensure the resolved path is truly inside the workspace directory

<details>
<summary>Plan: IOS_HOME_BASE_AND_IDENTITY.md</summary>

PR 4 of 4 in the iOS Home Base & Identity rollout plan.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
