### PR TITLE
refactor: skip starter task playbooks after onboarding

### DIFF
--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -134,14 +134,23 @@ describe('starter task playbook integration with buildSystemPrompt', () => {
     }
   });
 
-  test('buildSystemPrompt includes the starter task playbook section', () => {
+  test('buildSystemPrompt includes the starter task playbook section when BOOTSTRAP.md exists', () => {
     writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    writeFileSync(join(TEST_DIR, 'BOOTSTRAP.md'), '# First run');
     const result = buildSystemPrompt();
     expect(result).toContain('## Starter Task Playbooks');
   });
 
+  test('buildSystemPrompt omits starter task playbooks after onboarding is complete', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    // No BOOTSTRAP.md → onboarding complete
+    const result = buildSystemPrompt();
+    expect(result).not.toContain('## Starter Task Playbooks');
+  });
+
   test('starter task playbook appears before channel awareness', () => {
     writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    writeFileSync(join(TEST_DIR, 'BOOTSTRAP.md'), '# First run');
     const result = buildSystemPrompt();
     const starterIdx = result.indexOf('## Starter Task Playbooks');
     const channelIdx = result.indexOf('## Channel Awareness & Trust Gating');
@@ -150,8 +159,9 @@ describe('starter task playbook integration with buildSystemPrompt', () => {
     expect(starterIdx).toBeLessThan(channelIdx);
   });
 
-  test('all three kickoff intents present in full system prompt', () => {
+  test('all three kickoff intents present in full system prompt during onboarding', () => {
     writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    writeFileSync(join(TEST_DIR, 'BOOTSTRAP.md'), '# First run');
     const result = buildSystemPrompt();
     expect(result).toContain('[STARTER_TASK:make_it_yours]');
     expect(result).toContain('[STARTER_TASK:research_topic]');

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -215,6 +215,8 @@ describe('buildSystemPrompt', () => {
     });
 
     test('onboarding playbook uses app_file_edit for accent color, not app_update', () => {
+      // Starter task playbooks only included during onboarding (BOOTSTRAP.md exists)
+      writeFileSync(join(TEST_DIR, 'BOOTSTRAP.md'), '# First run');
       const result = buildSystemPrompt();
       expect(result).toContain('using `app_file_edit` to update the theme styles');
       expect(result).not.toContain('using `app_update` to regenerate the Home Base HTML');

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -110,7 +110,9 @@ export function buildSystemPrompt(): string {
   parts.push(buildConfigSection());
   parts.push(buildTaskScheduleReminderRoutingSection());
   parts.push(buildAttachmentSection());
-  parts.push(buildStarterTaskPlaybookSection());
+  if (!isOnboardingComplete()) {
+    parts.push(buildStarterTaskPlaybookSection());
+  }
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildChannelAwarenessSection());


### PR DESCRIPTION
## Summary
- Conditionally include `buildStarterTaskPlaybookSection()` only when `BOOTSTRAP.md` exists (onboarding in progress)
- Saves ~625 tokens per turn for all post-onboarding sessions
- Updated tests to create `BOOTSTRAP.md` when testing playbook content, and added a new test verifying playbooks are omitted after onboarding

## Test plan
- [x] `bun test src/__tests__/onboarding-starter-tasks.test.ts` — 17 pass (including new omission test)
- [x] `bun test src/__tests__/system-prompt.test.ts` — 41 pass
- [x] `bun test src/__tests__/intent-routing.test.ts` — 28 pass
- [ ] Manual: verify token count reduction after onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
