### PR TITLE
refactor: move LOOKS.md options from system prompt into template file

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -539,12 +539,7 @@ function buildConfigSection(): string {
     '**LOOKS.md** — update when:',
     '- They ask you to change your appearance, colors, or outfit',
     '- You want to refresh your look',
-    '- Available body/cheek colors: violet, emerald, rose, amber, indigo, slate, cyan, blue, green, red, orange, pink',
-    '- Available hats: none, top_hat, crown, cap, beanie, wizard_hat, cowboy_hat',
-    '- Available shirts: none, tshirt, suit, hoodie, tank_top, sweater',
-    '- Available accessories: none, sunglasses, monocle, bowtie, necklace, scarf, cape',
-    '- Available held items: none, sword, staff, shield, balloon',
-    '- Available outfit colors: red, blue, yellow, purple, orange, pink, cyan, brown, black, white, gold, silver',
+    '- Available options are listed in LOOKS.md itself',
     '',
     'When updating, read the file first, then make a targeted edit. Include all useful information, but don\'t bloat the files over time',
   ].join('\n');

--- a/assistant/src/config/templates/LOOKS.md
+++ b/assistant/src/config/templates/LOOKS.md
@@ -2,15 +2,14 @@ _ Lines starting with _ are comments — they won't appear in the system prompt
 
 # LOOKS.md
 
-## Purpose of this file
+## Available Options
 
-_ This file defines your avatar's appearance. Edit it to change how you look.
-_ Available body/cheek colors: violet, emerald, rose, amber, indigo, slate, cyan, blue, green, red, orange, pink
-_ Available hats: none, top_hat, crown, cap, beanie, wizard_hat, cowboy_hat
-_ Available shirts: none, tshirt, suit, hoodie, tank_top, sweater
-_ Available accessories: none, sunglasses, monocle, bowtie, necklace, scarf, cape
-_ Available held items: none, sword, staff, shield, balloon
-_ Available outfit colors: red, blue, yellow, purple, orange, pink, cyan, brown, black, white, gold, silver
+- **Body/cheek colors:** violet, emerald, rose, amber, indigo, slate, cyan, blue, green, red, orange, pink
+- **Hats:** none, top_hat, crown, cap, beanie, wizard_hat, cowboy_hat
+- **Shirts:** none, tshirt, suit, hoodie, tank_top, sweater
+- **Accessories:** none, sunglasses, monocle, bowtie, necklace, scarf, cape
+- **Held items:** none, sword, staff, shield, balloon
+- **Outfit colors:** red, blue, yellow, purple, orange, pink, cyan, brown, black, white, gold, silver
 
 ## Appearance
 


### PR DESCRIPTION
## Summary
- Removed 6 lines of appearance options (hats, shirts, accessories, colors) from `buildConfigSection` in system prompt
- Made these options visible in the LOOKS.md template itself (converted from `_` comment lines to regular markdown)
- System prompt now says "Available options are listed in LOOKS.md itself" — model reads them on-demand when editing appearance

Saves ~150 tokens per turn from the always-included system prompt.

## Test plan
- [x] All 57 system prompt + onboarding tests pass
- [ ] Verify model can still change appearance options correctly (reads LOOKS.md for valid values)
- [ ] Verify new workspace installs get the updated LOOKS.md template with visible options

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
