### PR TITLE
fix: return found=false in identity_get_response when IDENTITY.md is missing

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -530,6 +530,13 @@ exports[`IPC message snapshots ClientMessage types slack_webhook_config serializ
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types ingress_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "ingress_config",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types vercel_api_config serializes to expected JSON 1`] = `
 {
   "action": "get",
@@ -793,6 +800,33 @@ exports[`IPC message snapshots ClientMessage types subagent_message serializes t
   "content": "Hello subagent",
   "subagentId": "sub-001",
   "type": "subagent_message",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types subagent_detail_request serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-001",
+  "subagentId": "sub-001",
+  "type": "subagent_detail_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types workspace_files_list serializes to expected JSON 1`] = `
+{
+  "type": "workspace_files_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types workspace_file_read serializes to expected JSON 1`] = `
+{
+  "path": "IDENTITY.md",
+  "type": "workspace_file_read",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types identity_get serializes to expected JSON 1`] = `
+{
+  "type": "identity_get",
 }
 `;
 
@@ -1448,6 +1482,14 @@ exports[`IPC message snapshots ServerMessage types watcher_escalation serializes
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types agent_heartbeat_alert serializes to expected JSON 1`] = `
+{
+  "body": "No activity detected in the last 60 minutes.",
+  "title": "Agent heartbeat stalled",
+  "type": "agent_heartbeat_alert",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types watch_started serializes to expected JSON 1`] = `
 {
   "durationSeconds": 300,
@@ -1767,6 +1809,16 @@ exports[`IPC message snapshots ServerMessage types slack_webhook_config_response
   "success": true,
   "type": "slack_webhook_config_response",
   "webhookUrl": "https://hooks.slack.com/services/T00/B00/xxx",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ingress_config_response serializes to expected JSON 1`] = `
+{
+  "enabled": true,
+  "localGatewayTarget": "http://127.0.0.1:7830",
+  "publicBaseUrl": "https://example.com",
+  "success": true,
+  "type": "ingress_config_response",
 }
 `;
 
@@ -2175,6 +2227,15 @@ exports[`IPC message snapshots ServerMessage types open_tasks_window serializes 
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types task_run_thread_created serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-task-run-001",
+  "title": "Process report",
+  "type": "task_run_thread_created",
+  "workItemId": "wi-001",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types subagent_spawned serializes to expected JSON 1`] = `
 {
   "label": "Research Agent",
@@ -2202,67 +2263,6 @@ exports[`IPC message snapshots ServerMessage types subagent_event serializes to 
   },
   "subagentId": "sub-001",
   "type": "subagent_event",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types ingress_config serializes to expected JSON 1`] = `
-{
-  "action": "get",
-  "type": "ingress_config",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types subagent_detail_request serializes to expected JSON 1`] = `
-{
-  "conversationId": "conv-001",
-  "subagentId": "sub-001",
-  "type": "subagent_detail_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types workspace_files_list serializes to expected JSON 1`] = `
-{
-  "type": "workspace_files_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types workspace_file_read serializes to expected JSON 1`] = `
-{
-  "path": "IDENTITY.md",
-  "type": "workspace_file_read",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types identity_get serializes to expected JSON 1`] = `
-{
-  "type": "identity_get",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types agent_heartbeat_alert serializes to expected JSON 1`] = `
-{
-  "body": "No activity detected in the last 60 minutes.",
-  "title": "Agent heartbeat stalled",
-  "type": "agent_heartbeat_alert",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types ingress_config_response serializes to expected JSON 1`] = `
-{
-  "enabled": true,
-  "localGatewayTarget": "http://127.0.0.1:7830",
-  "publicBaseUrl": "https://example.com",
-  "success": true,
-  "type": "ingress_config_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types task_run_thread_created serializes to expected JSON 1`] = `
-{
-  "conversationId": "conv-task-run-001",
-  "title": "Process report",
-  "type": "task_run_thread_created",
-  "workItemId": "wi-001",
 }
 `;
 
@@ -2306,6 +2306,7 @@ exports[`IPC message snapshots ServerMessage types workspace_file_read_response 
 exports[`IPC message snapshots ServerMessage types identity_get_response serializes to expected JSON 1`] = `
 {
   "emoji": "✨",
+  "found": true,
   "home": "~/workspace",
   "name": "Vex",
   "personality": "Friendly",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1483,6 +1483,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   identity_get_response: {
     type: 'identity_get_response',
+    found: true,
     name: 'Vex',
     role: 'AI assistant',
     personality: 'Friendly',

--- a/assistant/src/daemon/handlers/identity.ts
+++ b/assistant/src/daemon/handlers/identity.ts
@@ -11,6 +11,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
   if (!existsSync(identityPath)) {
     ctx.send(socket, {
       type: 'identity_get_response',
+      found: false,
       name: '',
       role: '',
       personality: '',
@@ -96,6 +97,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
 
     ctx.send(socket, {
       type: 'identity_get_response',
+      found: true,
       name: fields.name ?? '',
       role: fields.role ?? '',
       personality: fields.personality ?? '',
@@ -110,6 +112,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
     log.error({ err }, 'Failed to read identity');
     ctx.send(socket, {
       type: 'identity_get_response',
+      found: false,
       name: '',
       role: '',
       personality: '',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2147,6 +2147,8 @@ export interface WorkspaceFileReadResponse {
 
 export interface IdentityGetResponse {
   type: 'identity_get_response';
+  /** Whether an IDENTITY.md file was found. When false, all fields are empty defaults. */
+  found: boolean;
   name: string;
   role: string;
   personality: string;

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -964,7 +964,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return first
         }
 
-        guard let response else { return nil }
+        guard let response, response.found else { return nil }
         return RemoteIdentityInfo(
             name: response.name,
             role: response.role,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -783,6 +783,8 @@ public struct IPCIdentityGetRequest: Codable, Sendable {
 
 public struct IPCIdentityGetResponse: Codable, Sendable {
     public let type: String
+    /// Whether an IDENTITY.md file was found. When false, all fields are empty defaults.
+    public let found: Bool
     public let name: String
     public let role: String
     public let personality: String


### PR DESCRIPTION
## Summary
- Adds a `found: boolean` field to the `identity_get_response` IPC message
- When `IDENTITY.md` doesn't exist, the handler now returns `found: false` so iOS can show the "No Identity Found" empty state instead of a blank card
- The iOS client checks `response.found` and returns `nil` from `fetchRemoteIdentity()` when false, preserving the previous HTTP 404 behavior

## Addresses Feedback From
- PR #6083 (Codex P2: return a not-found signal when identity file is missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
