### PR TITLE
fix: bundle tree-sitter WASM files for compiled daemon binary

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -92,6 +92,8 @@ jobs:
             -output ../clients/macos/daemon-bin/vellum-daemon
           rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
+          cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
+          cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -72,6 +72,8 @@ jobs:
             -output ../clients/macos/daemon-bin/vellum-daemon
           rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
+          cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
+          cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -67,6 +67,8 @@ jobs:
             -output ../clients/macos/daemon-bin/vellum-daemon
           rm ../clients/macos/daemon-bin/vellum-daemon-arm64 ../clients/macos/daemon-bin/vellum-daemon-x64
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
+          cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
+          cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -555,15 +555,23 @@ export function registerDoctorCommand(program: Command): void {
 
       // 11. WASM files
       const wasmFiles = [
-        'node_modules/web-tree-sitter/web-tree-sitter.wasm',
-        'node_modules/tree-sitter-bash/tree-sitter-bash.wasm',
+        { pkg: 'web-tree-sitter', file: 'web-tree-sitter.wasm' },
+        { pkg: 'tree-sitter-bash', file: 'tree-sitter-bash.wasm' },
       ];
       let wasmOk = true;
       const missingWasm: string[] = [];
       for (const wasm of wasmFiles) {
-        const fullPath = `${import.meta.dirname}/../../${wasm}`;
+        const dir = import.meta.dirname ?? __dirname;
+        let fullPath = `${dir}/../../node_modules/${wasm.pkg}/${wasm.file}`;
+        // In compiled binaries, fall back to Resources/ or next to the binary
+        if (!existsSync(fullPath) && dir.startsWith('/$bunfs/')) {
+          const { dirname: pathDirname, join: pathJoin } = await import('node:path');
+          const execDir = pathDirname(process.execPath);
+          const resourcesPath = pathJoin(execDir, '..', 'Resources', wasm.file);
+          fullPath = existsSync(resourcesPath) ? resourcesPath : pathJoin(execDir, wasm.file);
+        }
         if (!existsSync(fullPath)) {
-          missingWasm.push(wasm);
+          missingWasm.push(wasm.file);
           wasmOk = false;
         } else {
           try {

--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -1,5 +1,5 @@
-import { join } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { getLogger } from '../../util/logger.js';
 import { IntegrityError } from '../../util/errors.js';
@@ -75,11 +75,31 @@ function verifyWasmChecksum(filePath: string, label: string): void {
 let parserInstance: Parser | null = null;
 let initPromise: Promise<void> | null = null;
 
+/**
+ * Locate a WASM file from a dependency package.
+ *
+ * In development / `bunx` the file lives under `node_modules/` relative
+ * to the source tree.  In compiled Bun binaries `import.meta.dirname`
+ * points into the virtual `/$bunfs/` filesystem where binary assets
+ * don't exist — fall back to:
+ *   1. `../Resources/<file>` (macOS .app bundle layout)
+ *   2. Next to the compiled binary (process.execPath)
+ * This matches the pattern used by docker.ts for Dockerfile.sandbox.
+ */
 function findWasmPath(pkg: string, file: string): string {
-  return join(
-    import.meta.dirname ?? __dirname,
-    '..', '..', '..', 'node_modules', pkg, file,
-  );
+  const dir = import.meta.dirname ?? __dirname;
+  const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
+
+  if (!existsSync(sourcePath) && dir.startsWith('/$bunfs/')) {
+    const execDir = dirname(process.execPath);
+    // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
+    const resourcesPath = join(execDir, '..', 'Resources', file);
+    if (existsSync(resourcesPath)) return resourcesPath;
+    // Fallback: next to the binary itself (non-app-bundle deployments)
+    return join(execDir, file);
+  }
+
+  return sourcePath;
 }
 
 async function ensureParser(): Promise<Parser> {
@@ -93,7 +113,9 @@ async function ensureParser(): Promise<Parser> {
       verifyWasmChecksum(treeSitterWasm, 'web-tree-sitter.wasm');
       verifyWasmChecksum(bashWasmPath, 'tree-sitter-bash.wasm');
 
-      await Parser.init();
+      await Parser.init({
+        locateFile: () => treeSitterWasm,
+      });
 
       const Bash = await Language.load(bashWasmPath);
       const parser = new Parser();

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -180,6 +180,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
       --external electron --external "chromium-bidi/*" \
       --outfile "$SCRIPT_DIR/daemon-bin/vellum-daemon"
     chmod +x "$SCRIPT_DIR/daemon-bin/vellum-daemon"
+    # Copy WASM assets next to daemon binary (not bundled by bun --compile)
+    cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
+    cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
     echo "Daemon binary built: $SCRIPT_DIR/daemon-bin/vellum-daemon"
 fi
 
@@ -233,6 +236,10 @@ if [ "$NEEDS_REBUILD" = true ]; then
         echo "Bundling daemon binary..."
         cp "$DAEMON_BIN" "$MACOS_DIR/vellum-daemon"
         chmod +x "$MACOS_DIR/vellum-daemon"
+        # Bundle WASM assets into Resources (not embedded by bun --compile)
+        for wasm in "$SCRIPT_DIR/daemon-bin/"*.wasm; do
+            [ -f "$wasm" ] && cp "$wasm" "$RESOURCES_DIR/"
+        done
     else
         echo "No daemon binary at $DAEMON_BIN — skipping (dev mode)"
     fi


### PR DESCRIPTION
## Summary
- `bun build --compile` doesn't embed `.wasm` binary assets, causing ENOENT when the shell parser tries to load `web-tree-sitter.wasm` and `tree-sitter-bash.wasm` at runtime
- Updates `findWasmPath()` in `parser.ts` to detect `/$bunfs/` paths and fall back to `Contents/Resources/` (macOS app bundle) or next to the binary
- Passes `locateFile` to `Parser.init()` so `web-tree-sitter`'s internal WASM resolution uses the resolved path instead of `import.meta.url`
- Copies `.wasm` files alongside the daemon binary in `build.sh` and all CI workflows
- Bundles them into `Contents/Resources/` (not `Contents/MacOS/`) to avoid codesigning issues
- Updates the `doctor` command's WASM check to use the same fallback logic

## Test plan
- [x] `build.sh` compiles and codesigns without errors
- [ ] WASM files present in `Vellum.app/Contents/Resources/`
- [ ] Shell parser initializes without ENOENT in the compiled app
- [ ] `vellum doctor` reports WASM files as present in compiled binary
- [ ] Local dev mode (unbundled) continues to find WASM in `node_modules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
