### PR TITLE
feat: prioritize osascript for macOS app automation

### DIFF
--- a/assistant/src/config/bundled-skills/followups/icon.svg
+++ b/assistant/src/config/bundled-skills/followups/icon.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect width="16" height="16" fill="#f5f5f5"/>
+  
+  <!-- Envelope body -->
+  <rect x="2" y="4" width="12" height="8" fill="#4a90e2" stroke="#2c5aa0" stroke-width="1"/>
+  
+  <!-- Envelope flap -->
+  <polygon points="2,4 8,8 14,4" fill="#357abd"/>
+  
+  <!-- Paper/message inside -->
+  <rect x="3" y="6" width="10" height="5" fill="#ffffff"/>
+  
+  <!-- Lines on paper -->
+  <line x1="4" y1="7" x2="12" y2="7" stroke="#d0d0d0" stroke-width="1"/>
+  <line x1="4" y1="8.5" x2="12" y2="8.5" stroke="#d0d0d0" stroke-width="1"/>
+  <line x1="4" y1="10" x2="10" y2="10" stroke="#d0d0d0" stroke-width="1"/>
+  
+  <!-- Clock overlay (top right) -->
+  <circle cx="11" cy="3" r="2.5" fill="#ff6b6b" stroke="#c92a2a" stroke-width="0.5"/>
+  
+  <!-- Clock hands -->
+  <line x1="11" y1="1.5" x2="11" y2="2.2" stroke="#ffffff" stroke-width="0.8" stroke-linecap="round"/>
+  <line x1="12.2" y1="3" x2="11.7" y2="3" stroke="#ffffff" stroke-width="0.8" stroke-linecap="round"/>
+</svg>

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, copyFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getWorkspaceDir, getWorkspacePromptPath } from '../util/platform.js';
+import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { getConfig } from './loader.js';
@@ -408,6 +408,22 @@ function buildAccessPreferenceSection(): string {
     '- Can I get the data via web_fetch?',
     '',
     'If yes to any of these, use that path instead of the browser.',
+    ...(isMacOS() ? [
+      '',
+      '### macOS App Automation',
+      '',
+      'When automating macOS apps or system interactions (open an app, play music, send a notification,',
+      'control system settings, move windows, etc.), prefer **osascript** via host_bash over browser',
+      'automation or computer-use:',
+      '',
+      '```bash',
+      'osascript -e \'tell application "Spotify" to play\'',
+      'osascript -e \'display notification "Done!" with title "Vellum"\'',
+      '```',
+      '',
+      'osascript (AppleScript/JXA) has direct, reliable access to macOS app APIs and system events.',
+      'Use it whenever the task involves a native macOS app or system-level interaction.',
+    ] : []),
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Add a macOS App Automation subsection to the External Service Access Preference section of the system prompt
- Instructs the assistant to prefer `osascript` via `host_bash` over browser automation or computer-use for native macOS app interactions
- Section is conditionally included only when running on macOS (`isMacOS()` check)

## Original prompt
we should have something that is prioritizing osascript on macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
