### PR TITLE
Add version tool to assistant daemon

### DIFF
--- a/assistant/src/tools/system/version.ts
+++ b/assistant/src/tools/system/version.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { RiskLevel } from '../../permissions/types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+
+function readPackageVersion(): string {
+  try {
+    const pkgPath = join(import.meta.dir, '../../../package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+class VersionTool implements Tool {
+  name = 'version';
+  description = 'Return the current version of the Vellum assistant daemon.';
+  category = 'system';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    };
+  }
+
+  async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const version = readPackageVersion();
+    return { content: `Vellum assistant version: ${version}`, isError: false };
+  }
+}
+
+registerTool(new VersionTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -35,6 +35,7 @@ export async function loadEagerModules(): Promise<void> {
   await import('./calls/call-start.js');
   await import('./calls/call-status.js');
   await import('./calls/call-end.js');
+  await import('./system/version.js');
 }
 
 // Tool names registered by the eager modules above.  Listed explicitly so
@@ -57,6 +58,7 @@ export const eagerModuleToolNames: string[] = [
   'call_start',
   'call_status',
   'call_end',
+  'version',
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a `version` tool that the assistant can invoke to report its own daemon version
- Reads version from `package.json` at runtime
- Registered as an eager module in the tool manifest

## Test plan
- [ ] Start the daemon and ask the assistant "what version are you running?"
- [ ] Verify it invokes the `version` tool and returns the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
