### PR TITLE
fix: prevent Hatch New Assistant from skipping onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -10,6 +10,10 @@ struct OnboardingFlowView: View {
     var onOpenSettings: () -> Void
 
     @State private var isAdvancingFromWakeUp = false
+    /// Records whether the user was already authenticated when the flow appeared.
+    /// Prevents the onChange handler from immediately completing the flow when
+    /// replaying onboarding (e.g. "Hatch New Assistant") for an already-logged-in user.
+    @State private var wasAuthenticatedOnAppear = false
 
     private var maxOnboardingStep: Int {
         state.userHostedEnabled ? 2 : 1
@@ -114,8 +118,15 @@ struct OnboardingFlowView: View {
                 onComplete()
             }
         }
+        .onAppear {
+            wasAuthenticatedOnAppear = authManager.isAuthenticated
+        }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            if isAuthenticated {
+            // Only complete when a login happens DURING this onboarding session
+            // (isAuthenticated transitions false → true). If the user was already
+            // authenticated before entering the flow (e.g. "Hatch New Assistant"
+            // from settings), don't auto-complete.
+            if isAuthenticated && !wasAuthenticatedOnAppear {
                 onComplete()
             }
         }


### PR DESCRIPTION
## Summary
- Fixed a bug where clicking "Hatch New Assistant" in Advanced Settings would skip the onboarding flow entirely and land on the chat page for users already authenticated via Vellum Account
- The `onChange(of: authManager.isAuthenticated)` handler in `OnboardingFlowView` was immediately calling `onComplete()` because the user was already authenticated when the flow appeared
- Added `wasAuthenticatedOnAppear` state to track whether auth was pre-existing, so the handler only fires for logins that happen *during* the onboarding session

## Test plan
- [ ] Log in via Vellum Account, then go to Settings > Advanced > click "Hatch..."
- [ ] Verify the WakeUp step (API Key vs Vellum Account choice) appears instead of going straight to chat
- [ ] Verify first-time onboarding still works: unauthenticated user clicks "Vellum Account", logs in, flow completes automatically
- [ ] Verify first-time onboarding via "Own API Key" path still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
