### PR TITLE
fix: collapse multi-line JSDoc to single line for Swift codegen

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2147,8 +2147,7 @@ export interface WorkspaceFileReadResponse {
 
 export interface IdentityGetResponse {
   type: 'identity_get_response';
-  /** Whether an IDENTITY.md file was found. When false, all fields are empty defaults.
-   *  Optional for backwards compatibility with older daemons that don't send this field. */
+  /** Whether an IDENTITY.md file was found. When false, all fields are empty defaults. Optional for backwards compat with older daemons. */
   found?: boolean;
   name: string;
   role: string;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -783,8 +783,7 @@ public struct IPCIdentityGetRequest: Codable, Sendable {
 
 public struct IPCIdentityGetResponse: Codable, Sendable {
     public let type: String
-    /// Whether an IDENTITY.md file was found. When false, all fields are empty defaults.
-Optional for backwards compatibility with older daemons that don't send this field.
+    /// Whether an IDENTITY.md file was found. When false, all fields are empty defaults. Optional for backwards compat with older daemons.
     public let found: Bool?
     public let name: String
     public let role: String


### PR DESCRIPTION
## Summary
- Fixes a build-breaking issue where a multi-line JSDoc comment in `ipc-contract.ts` generated invalid Swift — the codegen only converts the first line to `///`, leaving the second line as plain text
- Collapses the `found` field's JSDoc to a single line so it generates a proper `///` Swift comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
