### PR TITLE
chore: untrack .private/UNREVIEWED_PRS.md

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,3 +1,0 @@
-
-https://github.com/vellum-ai/vellum-assistant/pull/5992
-https://github.com/vellum-ai/vellum-assistant/pull/6088


### PR DESCRIPTION
## Summary
- Removes `.private/UNREVIEWED_PRS.md` from git tracking — it was committed before `.private/` was added to `.gitignore`
- The file remains on disk locally; `.gitignore` will now apply going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
