### PR TITLE
fix: rename velly package references to vellum

### DIFF
--- a/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
+++ b/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "Self Upgrade"
-description: "Upgrade velly to the latest version, restart the daemon, and restart the gateway"
+description: "Upgrade vellum to the latest version, restart the daemon, and restart the gateway"
 user-invocable: true
 metadata: {"vellum": {"emoji": "⬆️"}}
 ---
@@ -15,16 +15,16 @@ vellum --version
 
 Save this value to report later.
 
-## Step 2: Install the latest velly
+## Step 2: Install the latest vellum
 
 ```bash
-bun update -g velly
+bun update -g vellum
 ```
 
-If `velly` was not installed globally via bun, try:
+If `vellum` was not installed globally via bun, try:
 
 ```bash
-npm update -g velly
+npm update -g vellum
 ```
 
 After updating, verify the new version:
@@ -68,7 +68,7 @@ vellum daemon status
 ## After Upgrade
 
 Report back to the user with:
-- The previous and new velly version
+- The previous and new vellum version
 - Daemon status (running, PID)
 - Gateway status (restarted or not found)
 - Any errors encountered during the process

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -156,7 +156,7 @@ export const claudeCodeTool: Tool = {
         return { behavior: 'allow' as const };
       }
 
-      // For tools that need approval, bridge to Velly's confirmation flow
+      // For tools that need approval, bridge to Vellum's confirmation flow
       if (!context.requestConfirmation) {
         log.warn({ toolName }, 'Claude Code tool requires approval but no requestConfirmation callback available');
         return { behavior: 'deny' as const, message: 'Tool approval not available in this context' };


### PR DESCRIPTION
## Summary
- Updates the self-upgrade skill to use `vellum` instead of `velly` as the npm package name in install/update commands
- Fixes a code comment in claude-code.ts

## Test plan
- [ ] Self-upgrade skill description says "vellum" not "velly"
- [ ] `bun update -g vellum` and `npm update -g vellum` are the correct commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
