### PR TITLE
fix: show hosting mode selector when hatching new assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1028,6 +1028,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         OnboardingState.clearPersistedState()
 
         let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
+        // Always show the hosting mode selector (Local/GCP/AWS/Custom) when
+        // hatching a new assistant, regardless of the userHostedEnabled flag.
+        onboarding.state.forceShowHostingMode = true
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
@@ -1041,6 +1044,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Clear any stale panel state so the user lands on chat, not settings
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+
+            // Reconnect the daemon to the newly hatched assistant
+            self?.hasSetupDaemon = false
+            self?.setupDaemonClient()
 
             self?.showMainWindow()
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -10,6 +10,10 @@ struct OnboardingFlowView: View {
     var onOpenSettings: () -> Void
 
     @State private var isAdvancingFromWakeUp = false
+    /// Tracks whether the user was already authenticated when the flow appeared,
+    /// so the auth onChange handler only fires for logins that happen during
+    /// this session (not for pre-existing auth from "Hatch New Assistant").
+    @State private var wasAuthenticatedOnAppear = false
 
     private var maxOnboardingStep: Int {
         state.userHostedEnabled ? 2 : 1
@@ -114,8 +118,11 @@ struct OnboardingFlowView: View {
                 onComplete()
             }
         }
+        .onAppear {
+            wasAuthenticatedOnAppear = authManager.isAuthenticated
+        }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            if isAuthenticated {
+            if isAuthenticated && !wasAuthenticatedOnAppear {
                 onComplete()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -74,8 +74,14 @@ final class OnboardingState {
         !speechGranted || !accessibilityGranted || !screenGranted
     }
 
+    /// When true, the hosting mode selector (Local/GCP/AWS/Custom) is always
+    /// shown regardless of the `userHostedEnabled` feature flag. Set by
+    /// `replayOnboarding` so that "Hatch New Assistant" always offers the
+    /// full infrastructure choice.
+    var forceShowHostingMode: Bool = false
+
     var userHostedEnabled: Bool {
-        FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
+        forceShowHostingMode || FeatureFlagManager.shared.isEnabled(.userHostedEnabled)
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.


### PR DESCRIPTION
## Summary
- The hosting mode selector (Local/GCP/AWS/Custom) in the onboarding flow was gated behind the `userHostedEnabled` feature flag, so "Hatch New Assistant" only showed the API key screen with no infrastructure choice
- Added `forceShowHostingMode` to `OnboardingState`, set by `replayOnboarding()`, so the full hosting mode selector always appears when hatching a new assistant
- Fixed the completion handler to reconnect the daemon to the newly hatched assistant (`hasSetupDaemon = false` + `setupDaemonClient()`)

## Test plan
- [ ] Enable `hatch_new_assistant_enabled` flag, go to Settings > Advanced > click "Hatch..."
- [ ] Verify the API key step shows the hosting mode selector (Local/GCP/AWS/Custom)
- [ ] Select a non-local hosting mode, verify it advances to the cloud credentials step
- [ ] Complete the full flow, verify the daemon reconnects to the new assistant
- [ ] Verify first-time onboarding still works normally (hosting mode only shows if `user_hosted_enabled` flag is on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
