### PR TITLE
fix: sync provider.isConnected when client already connected

### DIFF
--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -7,7 +7,10 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         let provider = appDelegate.clientProvider
-        guard !provider.client.isConnected else { return }
+        if provider.client.isConnected {
+            provider.isConnected = true
+            return
+        }
         Task {
             do {
                 await MainActor.run { provider.isConnected = false }


### PR DESCRIPTION
## Summary
- Fixes Home and Identity tabs permanently showing "Connect to Your Mac" even when the client is connected
- Root cause: `SceneDelegate.sceneWillEnterForeground` had a guard that returned early when `client.isConnected` was already `true`, but never synced `provider.isConnected = true` — so the `@Published` property observed by views stayed `false` forever
- Affects standalone mode (`DirectClaudeClient.isConnected` is always `true`) and connected mode when `DaemonClient` auto-reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
