### PR TITLE
fix: voice mode bugs — permission bypass, shutdown race, tap leak, prefix pollution, barge-in conflict

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -149,6 +149,8 @@ final class OpenAIVoiceService: ObservableObject {
             log.info("Recording started")
         } catch {
             log.error("Failed to start audio engine: \(error.localizedDescription)")
+            audioEngine.inputNode.removeTap(onBus: 0)
+            recordingFormat = nil
         }
     }
 
@@ -369,6 +371,7 @@ final class OpenAIVoiceService: ObservableObject {
             log.info("Barge-in monitor started")
         } catch {
             log.error("Failed to start barge-in monitor: \(error.localizedDescription)")
+            audioEngine.inputNode.removeTap(onBus: 0)
             bargeInMonitorActive = false
         }
     }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -114,6 +114,11 @@ final class VoiceModeManager: ObservableObject {
     func deactivate() {
         guard state != .off else { return }
 
+        // Set state to .off BEFORE shutdown so that any synchronous
+        // ttsOnComplete callbacks (from stopSpeaking) won't re-enter
+        // startListening() during teardown.
+        state = .off
+
         // Fully shut down audio engine to release the microphone
         voiceService.shutdown()
 
@@ -274,6 +279,12 @@ final class VoiceModeManager: ObservableObject {
             self.startListening()
         }
 
+        // Start monitoring mic for barge-in BEFORE finishTextStream,
+        // because finishTextStream may complete synchronously (no ElevenLabs key)
+        // and its completion calls startListening() which installs a recording tap.
+        // Starting barge-in after that would install a conflicting second tap.
+        voiceService.startBargeInMonitor()
+
         voiceService.finishTextStream { [weak self] in
             guard let self, self.state == .speaking else { return }
             self.ttsTimeoutTask?.cancel()
@@ -284,9 +295,6 @@ final class VoiceModeManager: ObservableObject {
             // Auto-start listening for the next turn
             self.startListening()
         }
-
-        // Start monitoring mic for barge-in (interrupt by speaking)
-        voiceService.startBargeInMonitor()
     }
 
     // MARK: - Voice-Driven Permission Handling
@@ -423,8 +431,13 @@ final class VoiceModeManager: ObservableObject {
                            "sure", "okay", "ok", "do it", "proceed"]
         let negative = ["no", "nope", "don't", "deny", "stop", "cancel", "reject"]
 
-        let isApproved = affirmative.contains(where: { lower.contains($0) })
-        let isDenied = negative.contains(where: { lower.contains($0) })
+        let hasAffirmative = affirmative.contains(where: { lower.contains($0) })
+        let hasNegative = negative.contains(where: { lower.contains($0) })
+
+        // If both affirmative and negative substrings match (e.g. "no, don't do it"
+        // contains "do it" + "no"/"don't"), treat as denial for safety.
+        let isApproved = hasAffirmative && !hasNegative
+        let isDenied = hasNegative
 
         guard let chatViewModel else {
             pendingPermissionIds = []

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -253,9 +253,9 @@ public final class ChatViewModel: ObservableObject {
 
         // Fire auto-title callback on the first user message (skip slash commands
         // like /model so the thread title isn't set to a command string)
-        if !text.isEmpty, !text.hasPrefix("/"), let callback = onFirstUserMessage {
+        if !rawText.isEmpty, !rawText.hasPrefix("/"), let callback = onFirstUserMessage {
             onFirstUserMessage = nil
-            callback(text)
+            callback(rawText)
         }
 
         // Block rapid-fire only when bootstrapping with a queued message.
@@ -272,7 +272,7 @@ public final class ChatViewModel: ObservableObject {
                     IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
                 }
                 isThinking = true
-                messages.append(ChatMessage(role: .user, text: text, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments))
+                messages.append(ChatMessage(role: .user, text: rawText, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments))
                 pendingSkillInvocation = nil
                 inputText = ""
                 suggestion = nil
@@ -286,7 +286,7 @@ public final class ChatViewModel: ObservableObject {
                 secretBlockedAttachments = nil
                 secretBlockedActiveSurfaceId = nil
                 secretBlockedCurrentPage = nil
-                currentTurnUserText = text
+                currentTurnUserText = rawText
                 return
             }
             pendingSkillInvocation = nil
@@ -304,7 +304,7 @@ public final class ChatViewModel: ObservableObject {
         var queuedMessageId: UUID?
         if !isWorkspaceRefinement {
             let status: ChatMessageStatus = willBeQueued ? .queued(position: 0) : .sent
-            let userMessage = ChatMessage(role: .user, text: text, status: status, skillInvocation: pendingSkillInvocation, attachments: attachments)
+            let userMessage = ChatMessage(role: .user, text: rawText, status: status, skillInvocation: pendingSkillInvocation, attachments: attachments)
             messages.append(userMessage)
             if willBeQueued {
                 pendingMessageIds.append(userMessage.id)
@@ -341,7 +341,7 @@ public final class ChatViewModel: ObservableObject {
         // response correctly (e.g. modelList for "/models") without scanning the
         // whole transcript. For queued messages this is set in messageDequeued.
         if !willBeQueued {
-            currentTurnUserText = text
+            currentTurnUserText = rawText
         }
 
         if sessionId == nil {


### PR DESCRIPTION
## Summary
- Fix permission bypass where denial phrases containing affirmative substrings (e.g. "No, don't do it" contains "do it") were incorrectly approved — now treats ambiguous as denial
- Fix shutdown race condition where `stopSpeaking()` during `deactivate()` re-entered `startListening()` via synchronous `ttsOnComplete` callback
- Fix audio tap leak when `audioEngine.start()` fails — clean up installed tap to prevent crash on next recording
- Fix voice prefix (`[Voice conversation — keep spoken responses brief...]`) polluting chat messages and thread titles — now only used for IPC to daemon
- Fix barge-in monitor conflict by reordering to start before `finishTextStream()` which may complete synchronously

## Original prompt
fix: voice mode bugs — permission bypass, shutdown race, tap leak, prefix pollution, barge-in conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
