### PR TITLE
fix: revert optimistic ingress URL on failure, fix iOS build warnings

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -100,7 +100,7 @@ class IOSThreadStore: ObservableObject {
             .filter { $0 }
             .first()
             .sink { [weak self] _ in
-                guard let self else { return }
+                guard self != nil else { return }
                 try? daemon.sendSessionList()
             }
             .store(in: &cancellables)

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -189,7 +189,7 @@ struct InputBarView: View {
 
     private func requestPermissionsAndRecord() {
         // Request microphone access
-        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+        AVAudioApplication.requestRecordPermission { granted in
             guard granted else {
                 log.warning("Microphone access denied")
                 return

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -103,6 +103,7 @@ public final class SettingsStore: ObservableObject {
     /// toggle. Set when `setIngressEnabled` fires; cleared once a matching
     /// response arrives.
     private var pendingIngressEnabled: Bool?
+    private var pendingIngressUrl: String?
 
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
@@ -210,10 +211,15 @@ public final class SettingsStore: ObservableObject {
                     return
                 }
                 self.pendingIngressEnabled = nil
+                self.pendingIngressUrl = nil
                 self.ingressEnabled = response.enabled
                 self.ingressPublicBaseUrl = response.publicBaseUrl
             } else {
-                // On failure, clear pending so future responses apply normally
+                // On failure, revert optimistic updates so the UI reflects reality
+                if let previousUrl = self.pendingIngressUrl {
+                    self.ingressPublicBaseUrl = previousUrl
+                }
+                self.pendingIngressUrl = nil
                 self.pendingIngressEnabled = nil
             }
         }
@@ -448,8 +454,16 @@ public final class SettingsStore: ObservableObject {
         // in SettingsPanel/SettingsView reads the new value instead of reverting
         // the text field to a stale URL. The daemon's success response
         // (handled by onIngressConfigResponse) will confirm or correct.
+        let previous = ingressPublicBaseUrl
         ingressPublicBaseUrl = trimmed
-        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: ingressEnabled))
+        pendingIngressUrl = previous
+        do {
+            try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: ingressEnabled))
+        } catch {
+            // IPC send failed — roll back the optimistic update
+            ingressPublicBaseUrl = previous
+            pendingIngressUrl = nil
+        }
     }
 
     func setIngressEnabled(_ enabled: Bool) {

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -46,11 +46,10 @@ public enum VFont {
         guard let uiFont = UIFont(name: name, size: size) else {
             return Font.custom(name, size: size)
         }
-        // iOS uses different key names: featureIdentifier = type, typeIdentifier = selector
         let descriptor = uiFont.fontDescriptor.addingAttributes([
             .featureSettings: [[
-                UIFontDescriptor.FeatureKey.featureIdentifier: kStylisticAlternativesType,
-                UIFontDescriptor.FeatureKey.typeIdentifier: kStylisticAltFiveOnSelector,
+                UIFontDescriptor.FeatureKey.type: kStylisticAlternativesType,
+                UIFontDescriptor.FeatureKey.selector: kStylisticAltFiveOnSelector,
             ]]
         ])
         return Font(UIFont(descriptor: descriptor, size: size))


### PR DESCRIPTION
## Summary
- Adds rollback for optimistic `ingressPublicBaseUrl` when IPC send fails or daemon responds with `success: false` — addresses PR #5992 review feedback about the UI showing an unpersisted URL
- Fixes 4 Xcode build warnings:
  - Unused `self` in IOSThreadStore sink closure (replaced with boolean test)
  - Deprecated `requestRecordPermission` (replaced with `AVAudioApplication.requestRecordPermission`)
  - Deprecated `featureIdentifier`/`typeIdentifier` (replaced with `type`/`selector`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
