### PR TITLE
feat: use global vellum install instead of bunx in install script

### DIFF
--- a/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
+++ b/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
@@ -18,13 +18,7 @@ Save this value to report later.
 ## Step 2: Install the latest vellum
 
 ```bash
-bun update -g vellum
-```
-
-If `vellum` was not installed globally via bun, try:
-
-```bash
-npm update -g vellum
+bun install -g vellum@latest
 ```
 
 After updating, verify the new version:

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -79,6 +79,23 @@ ensure_bun() {
     success "bun installed ($(bun --version))"
 }
 
+install_vellum() {
+    if command -v vellum >/dev/null 2>&1; then
+        info "Updating vellum to latest..."
+        bun install -g vellum@latest
+    else
+        info "Installing vellum globally..."
+        bun install -g vellum@latest
+    fi
+
+    if ! command -v vellum >/dev/null 2>&1; then
+        error "vellum installation failed. Please install manually: bun install -g vellum"
+        exit 1
+    fi
+
+    success "vellum installed ($(vellum --version 2>/dev/null || echo 'unknown'))"
+}
+
 main() {
     printf "\n"
     printf '  %bVellum Installer%b\n' "$BOLD" "$RESET"
@@ -86,13 +103,14 @@ main() {
 
     ensure_git
     ensure_bun
+    install_vellum
 
     info "Running vellum hatch..."
     printf "\n"
     if [ -n "${VELLUM_SSH_USER:-}" ] && [ "$(id -u)" = "0" ]; then
-        su - "$VELLUM_SSH_USER" -c "set -a; [ -f \"\$HOME/.vellum/.env\" ] && . \"\$HOME/.vellum/.env\"; set +a; export PATH=\"$HOME/.bun/bin:\$PATH\"; bunx vellum hatch"
+        su - "$VELLUM_SSH_USER" -c "set -a; [ -f \"\$HOME/.vellum/.env\" ] && . \"\$HOME/.vellum/.env\"; set +a; export PATH=\"$HOME/.bun/bin:\$PATH\"; vellum hatch"
     else
-        bunx vellum hatch
+        vellum hatch
     fi
 }
 


### PR DESCRIPTION
## Summary
- Replaces `bunx vellum hatch` with `bun install -g vellum@latest` followed by `vellum hatch` in the GCP install script
- Adds `install_vellum()` step to the installer that globally installs the vellum package, making the `vellum` CLI persistently available on PATH
- Updates self-upgrade skill to use `bun install -g vellum@latest` (consistent with the install path)

## Test plan
- [ ] Fresh GCP hatch: install script installs vellum globally, `vellum hatch` succeeds
- [ ] `which vellum` returns a valid path after install
- [ ] Self-upgrade skill runs `bun install -g vellum@latest` successfully
- [ ] Subsequent `vellum daemon restart` works without re-downloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
