### PR TITLE
M8: Control center green-tinted restyle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1123,31 +1123,36 @@ private struct ControlCenterRow: View {
     let onToggle: () -> Void
     @State private var isHovered = false
 
+    private let iconColor = adaptiveColor(light: Forest._700, dark: Forest._500)
+    private let textColor = adaptiveColor(light: Forest._800, dark: Forest._400)
+    private let chevronColor = adaptiveColor(light: Forest._700, dark: Forest._500)
+    private let bgColor = adaptiveColor(light: Forest._100, dark: Forest._900)
+
     var body: some View {
         Button(action: onToggle) {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "gearshape")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(VColor.textSecondary)
+                    .foregroundColor(iconColor)
                     .frame(width: 18)
                 Text("Control Center")
                     .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
+                    .foregroundColor(textColor)
                 Spacer()
                 Image(systemName: "chevron.up")
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
+                    .foregroundColor(chevronColor)
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.md)
-            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : .clear)
-            .contentShape(Rectangle())
+            .background(bgColor.opacity(isHovered ? 0.9 : 0.6))
+            .clipShape(Capsule())
+            .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.bottom, VSpacing.sm)
         .onHover { isHovered = $0 }
-        .overlay(alignment: .top) {
-            VColor.surfaceBorder.frame(height: 1)
-        }
     }
 }
 


### PR DESCRIPTION
Restyle the control center row with a green-tinted capsule background, forest green icon/text, and chevron-up indicator. Matches Figma design. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
