### PR TITLE
M3: Consolidate Sage into Forest green scale

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -1189,7 +1189,7 @@ struct ChatBubble: View {
             let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
             let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
             let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
-            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Sage._500, dark: Sage._300)
+            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Forest._500, dark: Forest._300)
         }
 
         // Store in cache (with size limit to prevent unbounded growth)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -785,7 +785,7 @@ private final class ComposerNativeTextView: NSTextView {
         if let match = text.range(of: #"^/\w+"#, options: .regularExpression) {
             let nsRange = NSRange(match, in: text)
             layoutManager.addTemporaryAttributes(
-                [.foregroundColor: NSColor(Sage._500)],
+                [.foregroundColor: NSColor(Forest._500)],
                 forCharacterRange: nsRange
             )
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -198,10 +198,10 @@ struct AppDirectoryView: View {
                                 Text("Shared")
                                     .font(VFont.small)
                             }
-                            .foregroundColor(Sage._400)
+                            .foregroundColor(Forest._400)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 1)
-                            .background(Sage._900.opacity(0.5))
+                            .background(Forest._900.opacity(0.5))
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -25,8 +25,8 @@ private enum SkillCategory: String, CaseIterable {
     var color: Color {
         switch self {
         case .core: return Amber._400
-        case .devTools: return Sage._400
-        case .communication: return Sage._400
+        case .devTools: return Forest._400
+        case .communication: return Forest._400
         case .daily: return Emerald._400
         case .utilities: return Stone._400
         case .skills: return Rose._400
@@ -343,7 +343,7 @@ struct ConstellationView: View {
         ZStack {
             // Background glow
             RadialGradient(
-                colors: [Sage._600.opacity(0.06), Color.clear],
+                colors: [Forest._600.opacity(0.06), Color.clear],
                 center: .center,
                 startRadius: 0,
                 endRadius: min(size.width, size.height) * 0.5

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -348,7 +348,7 @@ struct GeneratedPanel: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(item.isShared ? Sage._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
+                .stroke(item.isShared ? Forest._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
         )
         .contentShape(Rectangle())
         .onTapGesture {
@@ -374,10 +374,10 @@ struct GeneratedPanel: View {
             Text("Shared")
                 .font(VFont.small)
         }
-        .foregroundColor(Sage._400)
+        .foregroundColor(Forest._400)
         .padding(.horizontal, 5)
         .padding(.vertical, 1)
-        .background(Sage._900.opacity(0.5))
+        .background(Forest._900.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -117,7 +117,7 @@ struct TraceTimelineView: View {
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
                         .font(VFont.small)
-                        .foregroundColor(Sage._400)
+                        .foregroundColor(Forest._400)
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
@@ -150,7 +150,7 @@ struct TraceTimelineView: View {
         case .active: return Emerald._400
         case .completed: return Emerald._400
         case .cancelled: return Amber._500
-        case .handedOff: return Sage._400
+        case .handedOff: return Forest._400
         case .error: return Rose._500
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -122,9 +122,9 @@ struct APIKeyStepView: View {
                 }
                 Spacer()
                 Circle()
-                    .fill(isSelected ? Sage._600 : Color.clear)
+                    .fill(isSelected ? Forest._600 : Color.clear)
                     .overlay(
-                        Circle().stroke(isSelected ? Sage._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                        Circle().stroke(isSelected ? Forest._600 : VColor.surfaceBorder, lineWidth: 1.5)
                     )
                     .overlay(
                         isSelected
@@ -138,10 +138,10 @@ struct APIKeyStepView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Sage._600.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? Forest._600.opacity(0.1) : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Sage._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                            .stroke(isSelected ? Forest._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
                     )
             )
         }
@@ -206,11 +206,11 @@ struct APIKeyStepView: View {
                         .fill(primaryButtonDisabled
                             ? adaptiveColor(
                                 light: Stone._900.opacity(0.3),
-                                dark: Sage._600.opacity(0.3)
+                                dark: Forest._600.opacity(0.3)
                             )
                             : adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             )
                         )
                 )

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -254,7 +254,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.aws.amazon.com/iam/home#/roles")!) {
                 Text("Open AWS IAM Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Sage._400))
+                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
             }
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
@@ -300,7 +300,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.cloud.google.com/iam-admin/serviceaccounts")!) {
                 Text("Open Google Cloud Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Sage._400))
+                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
             }
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
@@ -354,7 +354,7 @@ struct CloudCredentialsStepView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "doc.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Sage._600))
+                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Forest._600))
                 Text(fileName)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
@@ -375,7 +375,7 @@ struct CloudCredentialsStepView: View {
             .padding(.vertical, VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Sage._600.opacity(0.3)), lineWidth: 1)
+                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3)), lineWidth: 1)
             )
         }
     }
@@ -436,11 +436,11 @@ struct CloudCredentialsStepView: View {
                         .fill(continueDisabled
                             ? adaptiveColor(
                                 light: Stone._900.opacity(0.3),
-                                dark: Sage._600.opacity(0.3)
+                                dark: Forest._600.opacity(0.3)
                             )
                             : adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             )
                         )
                 )

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
@@ -36,7 +36,7 @@ struct CapabilitiesModalView: View {
 
                     sectionView(
                         icon: "car.fill",
-                        iconColor: Sage._500,
+                        iconColor: Forest._500,
                         title: "How control works",
                         items: [
                             "You\u{2019}re always in the driver\u{2019}s seat",

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -98,7 +98,7 @@ struct FnKeyStepView: View {
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
                                     light: Stone._900,
-                                    dark: Sage._600
+                                    dark: Forest._600
                                 ))
                         )
                 }
@@ -118,7 +118,7 @@ struct FnKeyStepView: View {
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
                                     light: Stone._900,
-                                    dark: Sage._600
+                                    dark: Forest._600
                                 ))
                         )
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -57,7 +57,7 @@ struct ModelSelectionStepView: View {
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .fill(adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             ))
                     )
             }
@@ -109,9 +109,9 @@ struct ModelSelectionStepView: View {
                 }
                 Spacer()
                 Circle()
-                    .fill(isSelected ? Sage._600 : Color.clear)
+                    .fill(isSelected ? Forest._600 : Color.clear)
                     .overlay(
-                        Circle().stroke(isSelected ? Sage._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                        Circle().stroke(isSelected ? Forest._600 : VColor.surfaceBorder, lineWidth: 1.5)
                     )
                     .overlay(
                         isSelected
@@ -125,10 +125,10 @@ struct ModelSelectionStepView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Sage._600.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? Forest._600.opacity(0.1) : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Sage._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                            .stroke(isSelected ? Forest._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
                     )
             )
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
@@ -25,7 +25,7 @@ struct OnboardingFooter: View {
             HStack(spacing: VSpacing.sm) {
                 ForEach(0..<totalDots, id: \.self) { index in
                     Circle()
-                        .fill(index <= activeDotIndex ? Sage._600 : VColor.textMuted.opacity(0.3))
+                        .fill(index <= activeDotIndex ? Forest._600 : VColor.textMuted.opacity(0.3))
                         .frame(width: 8, height: 8)
                         .animation(.spring(duration: 0.4, bounce: 0.2), value: activeDotIndex)
                 }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -117,7 +117,7 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered ? Sage._600 : Sage._800
+            return isHovered ? Forest._600 : Forest._800
         case .danger:
             return isHovered ? Color(hex: 0xA53817) : Color(hex: 0x8A2F13)
         case .ghost:
@@ -128,9 +128,9 @@ private struct VButtonStyle: ButtonStyle {
     private func backgroundColor(isPressed: Bool) -> Color {
         switch style {
         case .primary:
-            if isPressed { return Sage._400 }
-            if isHovered { return Sage._500 }
-            return Sage._600
+            if isPressed { return Forest._400 }
+            if isHovered { return Forest._500 }
+            return Forest._600
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }

--- a/clients/shared/DesignSystem/Core/Buttons/VCircleButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VCircleButton.swift
@@ -66,7 +66,7 @@ private struct VCircleButtonStyle: ButtonStyle {
         HStack(spacing: 12) {
             VCircleButton(icon: "phone.fill", label: "Phone") {}
             VCircleButton(icon: "phone.fill", label: "Phone", fillColor: Emerald._600.opacity(0.5)) {}
-            VCircleButton(icon: "plus", label: "Add", fillColor: Sage._500, size: 28, iconSize: 12) {}
+            VCircleButton(icon: "plus", label: "Add", fillColor: Forest._500, size: 28, iconSize: 12) {}
         }
         .padding()
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -90,18 +90,18 @@ public struct VSlider: View {
     private var thumbView: some View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.xs)
-                .fill(Sage._700)
+                .fill(Forest._700)
                 .frame(width: thumbWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.xs)
-                        .stroke(Sage._800, lineWidth: 1)
+                        .stroke(Forest._800, lineWidth: 1)
                 )
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(Sage._300)
+                        .fill(Forest._300)
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -128,8 +128,8 @@ struct ButtonsGallerySection: View {
                         VCircleButton(icon: "plus", label: "Add") {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("Sage fill").font(VFont.caption).foregroundColor(VColor.textMuted)
-                        VCircleButton(icon: "phone.fill", label: "Call", fillColor: Sage._500) {}
+                        Text("Forest fill").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "phone.fill", label: "Call", fillColor: Forest._500) {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Large (48pt)").font(VFont.caption).foregroundColor(VColor.textMuted)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -78,19 +78,6 @@ public enum Violet {
     public static let _100 = Color(hex: 0xF4F0FD)
 }
 
-public enum Sage {
-    public static let _950 = Color(hex: 0x1A2316)
-    public static let _900 = Color(hex: 0x2A3825)
-    public static let _800 = Color(hex: 0x3D4F36)
-    public static let _700 = Color(hex: 0x516748)
-    public static let _600 = Color(hex: 0x657D5B)
-    public static let _500 = Color(hex: 0x7A8B6F)
-    public static let _400 = Color(hex: 0x98A88F)
-    public static let _300 = Color(hex: 0xB5C3AE)
-    public static let _200 = Color(hex: 0xD4DFD0)
-    public static let _100 = Color(hex: 0xEDF2EB)
-}
-
 public enum Indigo {
     public static let _950 = Color(hex: 0x180F66)
     public static let _900 = Color(hex: 0x261A96)
@@ -197,7 +184,7 @@ public enum VColor {
 
     // Send button — always green
     public static let sendButton = Color(hex: 0x216C37)
-    public static let accentSubtle = adaptiveColor(light: Sage._100, dark: Forest._900)
+    public static let accentSubtle = adaptiveColor(light: Forest._100, dark: Forest._900)
 
     // Onboarding accent (amber) — always dark theme
     public static let onboardingAccent = Amber._500

--- a/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
@@ -30,8 +30,8 @@ public enum Meadow {
     public static let artPixelSize: CGFloat = 5.0
 
     // Interview palette
-    public static let avatarGradientStart = Sage._600
-    public static let avatarGradientEnd = Sage._400
-    public static let userBubbleGradientStart = Sage._600
-    public static let userBubbleGradientEnd = Sage._400
+    public static let avatarGradientStart = Forest._600
+    public static let avatarGradientEnd = Forest._400
+    public static let userBubbleGradientStart = Forest._600
+    public static let userBubbleGradientEnd = Forest._400
 }

--- a/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
@@ -24,7 +24,7 @@ public enum VShadow {
     public static let glow = Definition(color: Amber._500.opacity(0.3), radius: 12, x: 0, y: 0)
 
     /// Violet glow for accent elements (focused inputs, active buttons)
-    public static let accentGlow = Definition(color: Sage._500.opacity(0.3), radius: 8, x: 0, y: 0)
+    public static let accentGlow = Definition(color: Forest._500.opacity(0.3), radius: 8, x: 0, y: 0)
 }
 
 public extension View {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -426,7 +426,7 @@ public struct InlineWeatherWidget: View {
                 Capsule()
                     .fill(
                         LinearGradient(
-                            colors: [Sage._400, Emerald._400],
+                            colors: [Forest._400, Emerald._400],
                             startPoint: .leading,
                             endPoint: .trailing
                         )
@@ -455,11 +455,11 @@ public struct InlineWeatherWidget: View {
         switch sfSymbol {
         case "sun.max.fill": return Amber._400
         case "cloud.sun.fill": return Amber._300
-        case "moon.fill": return Sage._200
-        case "cloud.moon.fill": return Sage._300
+        case "moon.fill": return Forest._200
+        case "cloud.moon.fill": return Forest._300
         case "cloud.fill": return Stone._400
-        case "cloud.rain.fill": return Sage._400
-        case "snowflake": return Sage._300
+        case "cloud.rain.fill": return Forest._400
+        case "snowflake": return Forest._300
         case "cloud.bolt.fill": return Amber._500
         case "cloud.fog.fill": return Stone._500
         default: return VColor.textSecondary

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -340,7 +340,7 @@ public struct ToolConfirmationBubble: View {
                 .foregroundColor(isPrimary || isDanger ? .white : VColor.textSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs + 1)
-                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Sage._600 : Color.clear)
+                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Forest._600 : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)


### PR DESCRIPTION
Replace all Sage color scale references with Forest equivalents, leaving a single green accent scale. Removes the Sage enum entirely. ~21 files updated. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
