### PR TITLE
M2: Replace Rose with Danger color scale

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -309,7 +309,7 @@ private struct UsedToolsRow: View {
         let isDiff = result.contains("@@") && result.contains("---") && result.contains("+++")
         guard isDiff else { return VColor.textSecondary }
         if line.hasPrefix("+") { return Emerald._400 }
-        if line.hasPrefix("-") { return Rose._400 }
+        if line.hasPrefix("-") { return Danger._400 }
         if line.hasPrefix("@@") { return VColor.textMuted }
         return VColor.textSecondary
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -745,7 +745,7 @@ struct DynamicWorkspaceWrapper: View {
                             .foregroundColor(VColor.error)
                             .padding(.horizontal, VSpacing.md)
                             .padding(.vertical, VSpacing.xs)
-                            .background(Rose._900.opacity(0.8))
+                            .background(Danger._900.opacity(0.8))
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .padding(.trailing, VSpacing.xl)
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -683,7 +683,7 @@ struct AgentPanelContent: View {
         if isError, let msg = errorMessage {
             Text(msg)
                 .font(VFont.caption)
-                .foregroundColor(Rose._500)
+                .foregroundColor(Danger._500)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -29,7 +29,7 @@ private enum SkillCategory: String, CaseIterable {
         case .communication: return Forest._400
         case .daily: return Emerald._400
         case .utilities: return Stone._400
-        case .skills: return Rose._400
+        case .skills: return Danger._400
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -76,7 +76,7 @@ struct DebugPanel: View {
                         icon: "exclamationmark.triangle.fill",
                         label: "Failures",
                         value: "\(failures)",
-                        color: Rose._500
+                        color: Danger._500
                     )
                 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -29,12 +29,12 @@ struct SubagentDetailPanel: View {
                                 Text("Abort")
                                     .font(VFont.captionMedium)
                             }
-                            .foregroundColor(Rose._400)
+                            .foregroundColor(Danger._400)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.vertical, VSpacing.xxs)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.pill)
-                                    .fill(Rose._500.opacity(0.12))
+                                    .fill(Danger._500.opacity(0.12))
                             )
                         }
                         .buttonStyle(.plain)
@@ -65,19 +65,19 @@ struct SubagentDetailPanel: View {
                     HStack(alignment: .top, spacing: VSpacing.xs) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 11))
-                            .foregroundColor(Rose._500)
+                            .foregroundColor(Danger._500)
                         Text(error)
                             .font(VFont.caption)
-                            .foregroundColor(Rose._400)
+                            .foregroundColor(Danger._400)
                     }
                     .padding(VSpacing.sm)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(Rose._500.opacity(0.08))
+                            .fill(Danger._500.opacity(0.08))
                             .overlay(
                                 RoundedRectangle(cornerRadius: VRadius.md)
-                                    .strokeBorder(Rose._500.opacity(0.2), lineWidth: 1)
+                                    .strokeBorder(Danger._500.opacity(0.2), lineWidth: 1)
                             )
                     )
                 }
@@ -128,7 +128,7 @@ struct SubagentDetailPanel: View {
     private func statusColor(_ status: SubagentStatus) -> Color {
         switch status {
         case .completed: return Emerald._500
-        case .failed, .aborted: return Rose._500
+        case .failed, .aborted: return Danger._500
         case .running: return Violet._500
         default: return Slate._400
         }
@@ -186,9 +186,9 @@ struct SubagentDetailPanel: View {
         case .toolUse:
             label(icon: "wrench.fill", text: "TOOL CALL", color: Violet._400)
         case .toolResult(let isError):
-            label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Rose._400 : Emerald._400)
+            label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Danger._400 : Emerald._400)
         case .error:
-            label(icon: "exclamationmark.triangle.fill", text: "ERROR", color: Rose._500)
+            label(icon: "exclamationmark.triangle.fill", text: "ERROR", color: Danger._500)
         }
     }
 
@@ -258,16 +258,16 @@ struct SubagentDetailPanel: View {
         case .error:
             Text(event.content)
                 .font(VFont.caption)
-                .foregroundColor(Rose._400)
+                .foregroundColor(Danger._400)
                 .textSelection(.enabled)
                 .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(Rose._500.opacity(0.08))
+                        .fill(Danger._500.opacity(0.08))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.md)
-                                .strokeBorder(Rose._500.opacity(0.15), lineWidth: 1)
+                                .strokeBorder(Danger._500.opacity(0.15), lineWidth: 1)
                         )
                 )
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -74,7 +74,7 @@ struct TraceRowView: View {
     private var statusColor: Color {
         switch event.status {
         case "error":
-            return Rose._500
+            return Danger._500
         case "warning":
             return Amber._500
         case "success":

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -121,7 +121,7 @@ struct TraceTimelineView: View {
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
-                        .foregroundColor(Rose._500)
+                        .foregroundColor(Danger._500)
                 }
 
                 Rectangle()
@@ -151,7 +151,7 @@ struct TraceTimelineView: View {
         case .completed: return Emerald._400
         case .cancelled: return Amber._500
         case .handedOff: return Forest._400
-        case .error: return Rose._500
+        case .error: return Danger._500
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
@@ -24,7 +24,7 @@ struct CapabilitiesModalView: View {
 
                     sectionView(
                         icon: "shield.lefthalf.filled",
-                        iconColor: Rose._500,
+                        iconColor: Danger._500,
                         title: "What I won\u{2019}t do",
                         items: [
                             "Act without asking when something\u{2019}s irreversible",

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
@@ -25,8 +25,8 @@ enum PixelArtData {
     static let dP: UInt32 = 0x1E293B // pupil
 
     // Dino accents
-    static let cK: UInt32 = 0xF99AAE // cheek pink (Rose._400)
-    static let tR: UInt32 = 0xF06A86 // tongue (Rose._500)
+    static let cK: UInt32 = 0xF99AAE // cheek pink (Danger._400)
+    static let tR: UInt32 = 0xF06A86 // tongue (Danger._500)
     static let wA: UInt32 = 0xFDD94E // wing light (Amber._400)
     static let wB: UInt32 = 0xFAC426 // wing mid (Amber._500)
     static let wC: UInt32 = 0xE8A020 // wing dark (Amber._600)

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -69,17 +69,17 @@
   --v-indigo-200: #D8D8FF;
   --v-indigo-100: #EEEEFF;
 
-  /* ── Palette: Rose ──────────────────────────────────────────── */
-  --v-rose-950: #620F21;
-  --v-rose-900: #85142F;
-  --v-rose-800: #A8183E;
-  --v-rose-700: #D02050;
-  --v-rose-600: #E84060;
-  --v-rose-500: #F06A86;
-  --v-rose-400: #F99AAE;
-  --v-rose-300: #FCBFC9;
-  --v-rose-200: #FFE1E6;
-  --v-rose-100: #FFF1F3;
+  /* ── Palette: Danger ─────────────────────────────────────────── */
+  --v-danger-950: #620F21;
+  --v-danger-900: #85142F;
+  --v-danger-800: #A8183E;
+  --v-danger-700: #D02050;
+  --v-danger-600: #E84060;
+  --v-danger-500: #F06A86;
+  --v-danger-400: #F99AAE;
+  --v-danger-300: #FCBFC9;
+  --v-danger-200: #FFE1E6;
+  --v-danger-100: #FFF1F3;
 
   /* ── Palette: Amber ─────────────────────────────────────────── */
   --v-amber-950: #5E3207;
@@ -103,7 +103,7 @@
   --v-accent:         var(--v-violet-600);
   --v-accent-hover:   var(--v-violet-700);
   --v-success:        var(--v-emerald-600);
-  --v-danger:         var(--v-rose-600);
+  --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
 
   /* ── Spacing (4pt grid) ─────────────────────────────────────── */

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -136,8 +136,8 @@ struct ButtonsGallerySection: View {
                         VCircleButton(icon: "mic.fill", label: "Record", size: 48, iconSize: 20) {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("Small (24pt, Rose)").font(VFont.caption).foregroundColor(VColor.textMuted)
-                        VCircleButton(icon: "xmark", label: "Close", fillColor: Rose._600, size: 24, iconSize: 10) {}
+                        Text("Small (24pt, Danger)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "xmark", label: "Close", fillColor: Danger._600, size: 24, iconSize: 10) {}
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -69,9 +69,9 @@ struct TokensGallerySection: View {
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
                         Emerald._500, Emerald._400, Emerald._300, Emerald._200, Emerald._100
                     ])
-                    colorScaleRow(name: "Rose", colors: [
-                        Rose._950, Rose._900, Rose._800, Rose._700, Rose._600,
-                        Rose._500, Rose._400, Rose._300, Rose._200, Rose._100
+                    colorScaleRow(name: "Danger", colors: [
+                        Danger._950, Danger._900, Danger._800, Danger._700, Danger._600,
+                        Danger._500, Danger._400, Danger._300, Danger._200, Danger._100
                     ])
                     colorScaleRow(name: "Amber", colors: [
                         Amber._950, Amber._900, Amber._800, Amber._700, Amber._600,

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -91,7 +91,7 @@ public enum Indigo {
     public static let _100 = Color(hex: 0xEEEEFF)
 }
 
-public enum Rose {
+public enum Danger {
     public static let _950 = Color(hex: 0x620F21)
     public static let _900 = Color(hex: 0x85142F)
     public static let _800 = Color(hex: 0xA8183E)
@@ -193,7 +193,7 @@ public enum VColor {
 
     // Status
     public static let success = adaptiveColor(light: Emerald._700, dark: Emerald._600)
-    public static let error = adaptiveColor(light: Rose._700, dark: Rose._600)
+    public static let error = adaptiveColor(light: Danger._700, dark: Danger._600)
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -159,7 +159,7 @@ public struct InlineTaskProgressWidget: View {
                 .foregroundColor(Amber._500)
         case "failed":
             Image(systemName: "xmark.circle.fill")
-                .foregroundColor(Rose._500)
+                .foregroundColor(Danger._500)
         default:
             Image(systemName: "circle")
                 .foregroundColor(Slate._500)
@@ -175,7 +175,7 @@ public struct InlineTaskProgressWidget: View {
         case "waiting":
             return ("Waiting", "clock.fill", Amber._500)
         case "failed":
-            return ("Failed", "xmark.circle.fill", Rose._500)
+            return ("Failed", "xmark.circle.fill", Danger._500)
         default:
             return ("Pending", "circle", Slate._500)
         }

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -11,7 +11,7 @@ public struct SubagentStatusChip: View {
     private var statusColor: Color {
         switch subagent.status {
         case .completed: return Emerald._500
-        case .failed, .aborted: return Rose._500
+        case .failed, .aborted: return Danger._500
         default: return Violet._500
         }
     }
@@ -59,7 +59,7 @@ public struct SubagentStatusChip: View {
                 if let error = subagent.error, !error.isEmpty {
                     Text(error)
                         .font(VFont.caption)
-                        .foregroundColor(Rose._400)
+                        .foregroundColor(Danger._400)
                         .lineLimit(2)
                 }
             }


### PR DESCRIPTION
Rename the Rose color scale to Danger throughout the design system. Same color values, but the name now semantically represents its purpose (error/danger states). Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
