### PR TITLE
M1: Remove Slate, Violet, Indigo color scales

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -105,7 +105,7 @@ private struct DotGridBackground: View {
                         width: dotRadius * 2,
                         height: dotRadius * 2
                     )
-                    context.fill(Circle().path(in: rect), with: .color(Slate._500.opacity(0.4)))
+                    context.fill(Circle().path(in: rect), with: .color(Moss._500.opacity(0.4)))
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -120,7 +120,7 @@ struct GeneratedPanel: View {
                     }
                 }
                 .padding(VSpacing.md)
-                .background(Slate._800)
+                .background(Moss._800)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
@@ -344,7 +344,7 @@ struct GeneratedPanel: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(isHovered ? Slate._800 : Slate._900)
+        .background(isHovered ? Moss._800 : Moss._900)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -129,8 +129,8 @@ struct SubagentDetailPanel: View {
         switch status {
         case .completed: return Emerald._500
         case .failed, .aborted: return Rose._500
-        case .running: return Violet._500
-        default: return Slate._400
+        case .running: return Forest._500
+        default: return Moss._400
         }
     }
 
@@ -182,9 +182,9 @@ struct SubagentDetailPanel: View {
     private func eventLabel(for kind: SubagentEventItem.Kind) -> some View {
         switch kind {
         case .text:
-            label(icon: "text.bubble.fill", text: "RESPONSE", color: Indigo._400)
+            label(icon: "text.bubble.fill", text: "RESPONSE", color: Forest._400)
         case .toolUse:
-            label(icon: "wrench.fill", text: "TOOL CALL", color: Violet._400)
+            label(icon: "wrench.fill", text: "TOOL CALL", color: Forest._400)
         case .toolResult(let isError):
             label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Rose._400 : Emerald._400)
         case .error:
@@ -222,7 +222,7 @@ struct SubagentDetailPanel: View {
             HStack(spacing: VSpacing.xs) {
                 Text(name)
                     .font(VFont.captionMedium)
-                    .foregroundColor(Violet._300)
+                    .foregroundColor(Forest._300)
                 if !event.content.isEmpty {
                     Text(event.content)
                         .font(VFont.monoSmall)
@@ -235,10 +235,10 @@ struct SubagentDetailPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(Violet._500.opacity(0.06))
+                    .fill(Forest._500.opacity(0.06))
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(Violet._500.opacity(0.12), lineWidth: 1)
+                            .strokeBorder(Forest._500.opacity(0.12), lineWidth: 1)
                     )
             )
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -80,7 +80,7 @@ struct TraceRowView: View {
         case "success":
             return Emerald._400
         default:
-            return Slate._400
+            return Moss._400
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -80,7 +80,7 @@ struct TraceTimelineView: View {
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .foregroundColor(Amber._500)
-                        .background(Slate._800)
+                        .background(Moss._800)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.sm)
@@ -204,7 +204,7 @@ struct TraceTimelineView: View {
                 .padding(.leading, 26)
                 .padding(.vertical, VSpacing.xs)
                 .padding(.trailing, VSpacing.sm)
-                .background(Slate._800.opacity(0.5))
+                .background(Moss._800.opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -26,8 +26,8 @@ struct OnboardingFlowView: View {
                     .background(
                         RadialGradient(
                             colors: [
-                                adaptiveColor(light: Slate._100, dark: Slate._900),
-                                adaptiveColor(light: Slate._200, dark: Slate._950)
+                                adaptiveColor(light: Stone._100, dark: Moss._900),
+                                adaptiveColor(light: Stone._200, dark: Moss._950)
                             ],
                             center: .center,
                             startRadius: 0,
@@ -93,8 +93,8 @@ struct OnboardingFlowView: View {
                 .background(
                     RadialGradient(
                         colors: [
-                            adaptiveColor(light: Stone._100, dark: Slate._900),
-                            adaptiveColor(light: Stone._200, dark: Slate._950)
+                            adaptiveColor(light: Stone._100, dark: Moss._900),
+                            adaptiveColor(light: Stone._200, dark: Moss._950)
                         ],
                         center: .center,
                         startRadius: 0,

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,7 +144,7 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Slate._800.opacity(0.4)))
+                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._800.opacity(0.4)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -20,18 +20,55 @@
 /* ─── Layer 1: Tokens ────────────────────────────────────────── */
 
 :root {
-  /* ── Palette: Slate ─────────────────────────────────────────── */
-  --v-slate-950: #070D19;
-  --v-slate-900: #0F172A;
-  --v-slate-800: #1E293B;
-  --v-slate-700: #334155;
-  --v-slate-600: #475569;
-  --v-slate-500: #64748B;
-  --v-slate-400: #94A3B8;
-  --v-slate-300: #CBD5E1;
-  --v-slate-200: #E2E8F0;
-  --v-slate-100: #F1F5F9;
-  --v-slate-50:  #F8FAFC;
+  /* ── Palette: Stone (warm neutral, light mode) ─────────────── */
+  --v-stone-950: #1C1917;
+  --v-stone-900: #292524;
+  --v-stone-800: #44403C;
+  --v-stone-700: #57534E;
+  --v-stone-600: #78716C;
+  --v-stone-500: #97918B;
+  --v-stone-400: #A8A29E;
+  --v-stone-300: #D6D3D1;
+  --v-stone-200: #E7E5E4;
+  --v-stone-100: #F5F5F4;
+  --v-stone-50:  #FAFAF9;
+
+  /* ── Palette: Moss (warm neutral, dark mode) ─────────────── */
+  --v-moss-950: #262624;
+  --v-moss-900: #2A2A28;
+  --v-moss-800: #2F2F2D;
+  --v-moss-700: #3A3A37;
+  --v-moss-600: #4A4A46;
+  --v-moss-500: #6B6B65;
+  --v-moss-400: #A1A096;
+  --v-moss-300: #BDB9A9;
+  --v-moss-200: #D4D1C1;
+  --v-moss-100: #E8E6DA;
+  --v-moss-50:  #F5F3EB;
+
+  /* ── Palette: Forest (green accent, dark mode) ───────────── */
+  --v-forest-950: #0A2A14;
+  --v-forest-900: #123D1F;
+  --v-forest-800: #18522A;
+  --v-forest-700: #1C5F30;
+  --v-forest-600: #216C37;
+  --v-forest-500: #3A8A4F;
+  --v-forest-400: #5AAB6A;
+  --v-forest-300: #85C991;
+  --v-forest-200: #B5E1BC;
+  --v-forest-100: #E2F4E5;
+
+  /* ── Palette: Sage ───────────────────────────────────────── */
+  --v-sage-950: #1A2316;
+  --v-sage-900: #2A3825;
+  --v-sage-800: #3D4F36;
+  --v-sage-700: #516748;
+  --v-sage-600: #657D5B;
+  --v-sage-500: #7A8B6F;
+  --v-sage-400: #98A88F;
+  --v-sage-300: #B5C3AE;
+  --v-sage-200: #D4DFD0;
+  --v-sage-100: #EDF2EB;
 
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
@@ -44,30 +81,6 @@
   --v-emerald-300: #A6F2D1;
   --v-emerald-200: #D2F9E8;
   --v-emerald-100: #ECFDF5;
-
-  /* ── Palette: Violet ────────────────────────────────────────── */
-  --v-violet-950: #321669;
-  --v-violet-900: #4A2390;
-  --v-violet-800: #5C2FB2;
-  --v-violet-700: #7240CC;
-  --v-violet-600: #8A5BE0;
-  --v-violet-500: #9878EA;
-  --v-violet-400: #B8A6F1;
-  --v-violet-300: #D4C8F7;
-  --v-violet-200: #E8E1FB;
-  --v-violet-100: #F4F0FD;
-
-  /* ── Palette: Indigo ────────────────────────────────────────── */
-  --v-indigo-950: #180F66;
-  --v-indigo-900: #261A96;
-  --v-indigo-800: #3525C4;
-  --v-indigo-700: #4636E8;
-  --v-indigo-600: #5B4EFF;
-  --v-indigo-500: #7B6BFF;
-  --v-indigo-400: #9488FF;
-  --v-indigo-300: #B8B4FF;
-  --v-indigo-200: #D8D8FF;
-  --v-indigo-100: #EEEEFF;
 
   /* ── Palette: Rose ──────────────────────────────────────────── */
   --v-rose-950: #620F21;
@@ -100,8 +113,8 @@
   --v-text:           #1D1D1F;
   --v-text-secondary: #86868B;
   --v-text-muted:     #AEAEB2;
-  --v-accent:         var(--v-violet-600);
-  --v-accent-hover:   var(--v-violet-700);
+  --v-accent:         var(--v-forest-600);
+  --v-accent-hover:   var(--v-forest-700);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-rose-600);
   --v-warning:        var(--v-amber-600);
@@ -152,12 +165,12 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --v-bg:             var(--v-slate-950);
-    --v-surface:        var(--v-slate-800);
-    --v-surface-border: var(--v-slate-700);
-    --v-text:           var(--v-slate-50);
-    --v-text-secondary: var(--v-slate-400);
-    --v-text-muted:     var(--v-slate-500);
+    --v-bg:             var(--v-moss-950);
+    --v-surface:        var(--v-moss-800);
+    --v-surface-border: var(--v-moss-700);
+    --v-text:           var(--v-moss-50);
+    --v-text-secondary: var(--v-moss-400);
+    --v-text-muted:     var(--v-moss-500);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
@@ -190,7 +203,7 @@ body > *:not(#vellum-bottom-fade):not(#vellum-branding):not(#v-toast-container) 
 @media (prefers-color-scheme: dark) {
   body {
     background:
-      radial-gradient(ellipse at 50% 0%, var(--v-slate-900) 0%, transparent 50%),
+      radial-gradient(ellipse at 50% 0%, var(--v-moss-900) 0%, transparent 50%),
       var(--v-bg);
   }
 }
@@ -1004,7 +1017,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   height: 36px;
   border-radius: 50%;
   background: var(--v-accent);
-  color: var(--v-slate-50);
+  color: var(--v-moss-50);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1539,7 +1552,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 /* Hero — top-of-page banner with gradient background */
 .v-hero {
   position: relative;
-  background: linear-gradient(135deg, var(--v-violet-950) 0%, var(--v-indigo-950) 100%);
+  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-sage-950) 100%);
   border-radius: var(--v-radius-xl);
   padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
   text-align: center;
@@ -1557,7 +1570,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   transform: translateX(-50%);
   width: 120%;
   height: 80%;
-  background: radial-gradient(ellipse, color-mix(in srgb, var(--v-violet-700) 30%, transparent) 0%, transparent 70%);
+  background: radial-gradient(ellipse, color-mix(in srgb, var(--v-forest-700) 30%, transparent) 0%, transparent 70%);
   pointer-events: none;
 }
 .v-hero-badge {
@@ -1572,13 +1585,13 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--v-slate-300);
+  color: var(--v-moss-300);
   position: relative;
 }
 .v-hero h1 {
   font-size: 2.5rem;
   font-weight: 800;
-  background: linear-gradient(180deg, #fff 30%, var(--v-slate-200) 100%);
+  background: linear-gradient(180deg, #fff 30%, var(--v-moss-200) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -1588,7 +1601,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 }
 .v-hero-subtitle {
   font-size: var(--v-font-size-base);
-  color: var(--v-slate-400);
+  color: var(--v-moss-400);
   max-width: 500px;
   margin: 0 auto;
   line-height: 1.5;
@@ -1636,7 +1649,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   top: var(--v-spacing-lg);
   bottom: var(--v-spacing-lg);
   width: 3px;
-  background: linear-gradient(180deg, var(--v-violet-600) 0%, var(--v-indigo-600) 100%);
+  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-sage-600) 100%);
   border-radius: var(--v-radius-pill);
 }
 .v-pullquote-text {
@@ -1750,9 +1763,9 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   line-height: 1.4;
 }
 
-/* Gradient Text — violet→indigo text fill */
+/* Gradient Text — forest→sage text fill */
 .v-gradient-text {
-  background: linear-gradient(135deg, var(--v-violet-500) 0%, var(--v-indigo-500) 100%);
+  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-sage-500) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -1975,7 +1988,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   opacity: 1 !important;
 }
 #vellum-branding a {
-  color: var(--v-accent, #6366f1);
+  color: var(--v-accent, #216C37);
   text-decoration: none;
   font-weight: 600;
   cursor: pointer;

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -57,13 +57,21 @@ struct TokensGallerySection: View {
                         .font(VFont.headline)
                         .foregroundColor(VColor.textPrimary)
 
-                    colorScaleRow(name: "Slate", colors: [
-                        Slate._900, Slate._800, Slate._700, Slate._600, Slate._500,
-                        Slate._400, Slate._300, Slate._200, Slate._100, Slate._50
+                    colorScaleRow(name: "Stone", colors: [
+                        Stone._950, Stone._900, Stone._800, Stone._700, Stone._600,
+                        Stone._500, Stone._400, Stone._300, Stone._200, Stone._100
                     ])
-                    colorScaleRow(name: "Violet", colors: [
-                        Violet._950, Violet._900, Violet._800, Violet._700, Violet._600,
-                        Violet._500, Violet._400, Violet._300, Violet._200, Violet._100
+                    colorScaleRow(name: "Moss", colors: [
+                        Moss._950, Moss._900, Moss._800, Moss._700, Moss._600,
+                        Moss._500, Moss._400, Moss._300, Moss._200, Moss._100
+                    ])
+                    colorScaleRow(name: "Forest", colors: [
+                        Forest._950, Forest._900, Forest._800, Forest._700, Forest._600,
+                        Forest._500, Forest._400, Forest._300, Forest._200, Forest._100
+                    ])
+                    colorScaleRow(name: "Sage", colors: [
+                        Sage._950, Sage._900, Sage._800, Sage._700, Sage._600,
+                        Sage._500, Sage._400, Sage._300, Sage._200, Sage._100
                     ])
                     colorScaleRow(name: "Emerald", colors: [
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
@@ -76,10 +84,6 @@ struct TokensGallerySection: View {
                     colorScaleRow(name: "Amber", colors: [
                         Amber._950, Amber._900, Amber._800, Amber._700, Amber._600,
                         Amber._500, Amber._400, Amber._300, Amber._200, Amber._100
-                    ])
-                    colorScaleRow(name: "Indigo", colors: [
-                        Indigo._950, Indigo._900, Indigo._800, Indigo._700, Indigo._600,
-                        Indigo._500, Indigo._400, Indigo._300, Indigo._200, Indigo._100
                     ])
                 }
             }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -38,20 +38,6 @@ public func adaptiveColor(light: Color, dark: Color) -> Color {
 
 // MARK: - Color Scales
 
-public enum Slate {
-    public static let _950 = Color(hex: 0x070D19)
-    public static let _900 = Color(hex: 0x0F172A)
-    public static let _800 = Color(hex: 0x1E293B)
-    public static let _700 = Color(hex: 0x334155)
-    public static let _600 = Color(hex: 0x475569)
-    public static let _500 = Color(hex: 0x64748B)
-    public static let _400 = Color(hex: 0x94A3B8)
-    public static let _300 = Color(hex: 0xCBD5E1)
-    public static let _200 = Color(hex: 0xE2E8F0)
-    public static let _100 = Color(hex: 0xF1F5F9)
-    public static let _50  = Color(hex: 0xF8FAFC)
-}
-
 public enum Emerald {
     public static let _950 = Color(hex: 0x073D2E)
     public static let _900 = Color(hex: 0x0A5843)
@@ -65,19 +51,6 @@ public enum Emerald {
     public static let _100 = Color(hex: 0xECFDF5)
 }
 
-public enum Violet {
-    public static let _950 = Color(hex: 0x321669)
-    public static let _900 = Color(hex: 0x4A2390)
-    public static let _800 = Color(hex: 0x5C2FB2)
-    public static let _700 = Color(hex: 0x7240CC)
-    public static let _600 = Color(hex: 0x8A5BE0)
-    public static let _500 = Color(hex: 0x9878EA)
-    public static let _400 = Color(hex: 0xB8A6F1)
-    public static let _300 = Color(hex: 0xD4C8F7)
-    public static let _200 = Color(hex: 0xE8E1FB)
-    public static let _100 = Color(hex: 0xF4F0FD)
-}
-
 public enum Sage {
     public static let _950 = Color(hex: 0x1A2316)
     public static let _900 = Color(hex: 0x2A3825)
@@ -89,19 +62,6 @@ public enum Sage {
     public static let _300 = Color(hex: 0xB5C3AE)
     public static let _200 = Color(hex: 0xD4DFD0)
     public static let _100 = Color(hex: 0xEDF2EB)
-}
-
-public enum Indigo {
-    public static let _950 = Color(hex: 0x180F66)
-    public static let _900 = Color(hex: 0x261A96)
-    public static let _800 = Color(hex: 0x3525C4)
-    public static let _700 = Color(hex: 0x4636E8)
-    public static let _600 = Color(hex: 0x5B4EFF)
-    public static let _500 = Color(hex: 0x7B6BFF)
-    public static let _400 = Color(hex: 0x9488FF)
-    public static let _300 = Color(hex: 0xB8B4FF)
-    public static let _200 = Color(hex: 0xD8D8FF)
-    public static let _100 = Color(hex: 0xEEEEFF)
 }
 
 public enum Rose {

--- a/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
@@ -5,11 +5,11 @@ public enum Meadow {
     // Panel
     public static let panelBackground = adaptiveColor(
         light: Color.white.opacity(0.85),
-        dark: Slate._900.opacity(0.75)
+        dark: Moss._900.opacity(0.75)
     )
     public static let panelBorder = adaptiveColor(
         light: Stone._200.opacity(0.6),
-        dark: Slate._700.opacity(0.4)
+        dark: Moss._700.opacity(0.4)
     )
 
     // Egg glow

--- a/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
@@ -23,7 +23,7 @@ public enum VShadow {
     /// Amber glow effect for brand elements (orb, highlights)
     public static let glow = Definition(color: Amber._500.opacity(0.3), radius: 12, x: 0, y: 0)
 
-    /// Violet glow for accent elements (focused inputs, active buttons)
+    /// Sage glow for accent elements (focused inputs, active buttons)
     public static let accentGlow = Definition(color: Sage._500.opacity(0.3), radius: 8, x: 0, y: 0)
 }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -114,7 +114,7 @@ public struct InlineTaskProgressWidget: View {
             ForEach(Array(data.steps.enumerated()), id: \.element.id) { index, step in
                 stepRow(step)
                 if index < data.steps.count - 1 {
-                    Divider().background(Slate._700.opacity(0.3))
+                    Divider().background(Moss._700.opacity(0.3))
                 }
             }
         }
@@ -162,7 +162,7 @@ public struct InlineTaskProgressWidget: View {
                 .foregroundColor(Rose._500)
         default:
             Image(systemName: "circle")
-                .foregroundColor(Slate._500)
+                .foregroundColor(Moss._500)
         }
     }
 
@@ -177,7 +177,7 @@ public struct InlineTaskProgressWidget: View {
         case "failed":
             return ("Failed", "xmark.circle.fill", Rose._500)
         default:
-            return ("Pending", "circle", Slate._500)
+            return ("Pending", "circle", Moss._500)
         }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -195,17 +195,17 @@ public struct InlineWeatherWidget: View {
         VStack(alignment: .leading, spacing: 0) {
             heroSection
             if !data.hourly.isEmpty {
-                Divider().background(Slate._700.opacity(0.3))
+                Divider().background(Moss._700.opacity(0.3))
                 hourlySection
             }
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
             dailyForecastHeader
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
 
             ForEach(Array(data.forecast.enumerated()), id: \.element.id) { index, item in
                 forecastRow(item, isFirst: index == 0)
                 if index < data.forecast.count - 1 {
-                    Divider().background(Slate._700.opacity(0.3))
+                    Divider().background(Moss._700.opacity(0.3))
                 }
             }
         }
@@ -312,7 +312,7 @@ public struct InlineWeatherWidget: View {
             }
             .padding(.vertical, VSpacing.sm)
 
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
 
             // Scrollable hourly row
             ScrollView(.horizontal, showsIndicators: false) {
@@ -419,7 +419,7 @@ public struct InlineWeatherWidget: View {
             ZStack(alignment: .leading) {
                 // Background track
                 Capsule()
-                    .fill(Slate._700.opacity(0.3))
+                    .fill(Moss._700.opacity(0.3))
                     .frame(height: 4)
 
                 // Filled portion with gradient

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,7 +31,7 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Slate._800)
+        .background(Moss._800)
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -12,7 +12,7 @@ public struct SubagentStatusChip: View {
         switch subagent.status {
         case .completed: return Emerald._500
         case .failed, .aborted: return Rose._500
-        default: return Violet._500
+        default: return Forest._500
         }
     }
 


### PR DESCRIPTION
Remove unused cool-toned color scales (Slate, Violet, Indigo) and replace all references with warm equivalents: Slate → Stone/Moss, Violet → Forest, Indigo → Forest/Emerald. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
