### PR TITLE
M4: Update user bubble & component colors per Figma

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -115,6 +115,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
+  --v-user-bubble:    var(--v-forest-100);
+  --v-user-bubble-text: var(--v-stone-900);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
@@ -171,6 +173,9 @@
     --v-text:           var(--v-moss-50);
     --v-text-secondary: var(--v-moss-400);
     --v-text-muted:     var(--v-moss-500);
+
+    --v-user-bubble:    var(--v-forest-900);
+    --v-user-bubble-text: var(--v-moss-100);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -44,7 +44,7 @@ public struct VToggle: View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
             RoundedRectangle(cornerRadius: VRadius.sm + 2)
-                .fill(isOn ? Emerald._500 : VColor.toggleOff)
+                .fill(isOn ? Forest._600 : VColor.toggleOff)
                 .frame(width: trackWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm + 2)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -170,9 +170,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Stone._200, dark: Color(hex: 0x191919))
-    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._200)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._200.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Forest._100, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._100)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._100.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)


### PR DESCRIPTION
Update user bubble colors to dark green (Forest._100 light / Forest._900 dark), align semantic tokens and CSS variables with Figma designs. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
