### PR TITLE
M9: Chat UI & message bubble styling per Figma

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -1188,7 +1188,7 @@ struct ChatBubble: View {
             let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
             let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
             let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
-            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Forest._500, dark: Forest._300)
+            parsed[attrStart..<attrEnd].foregroundColor = VColor.slashCommand
         }
 
         // Store in cache (with size limit to prevent unbounded growth)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -785,7 +785,7 @@ private final class ComposerNativeTextView: NSTextView {
         if let match = text.range(of: #"^/\w+"#, options: .regularExpression) {
             let nsRange = NSRange(match, in: text)
             layoutManager.addTemporaryAttributes(
-                [.foregroundColor: NSColor(Forest._500)],
+                [.foregroundColor: NSColor(VColor.slashCommand)],
                 forCharacterRange: nsRange
             )
         }

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -58,18 +58,6 @@
   --v-forest-200: #B5E1BC;
   --v-forest-100: #E2F4E5;
 
-  /* ── Palette: Sage ───────────────────────────────────────── */
-  --v-sage-950: #1A2316;
-  --v-sage-900: #2A3825;
-  --v-sage-800: #3D4F36;
-  --v-sage-700: #516748;
-  --v-sage-600: #657D5B;
-  --v-sage-500: #7A8B6F;
-  --v-sage-400: #98A88F;
-  --v-sage-300: #B5C3AE;
-  --v-sage-200: #D4DFD0;
-  --v-sage-100: #EDF2EB;
-
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
   --v-emerald-900: #0A5843;
@@ -1552,7 +1540,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 /* Hero — top-of-page banner with gradient background */
 .v-hero {
   position: relative;
-  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-sage-950) 100%);
+  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-forest-900) 100%);
   border-radius: var(--v-radius-xl);
   padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
   text-align: center;
@@ -1649,7 +1637,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   top: var(--v-spacing-lg);
   bottom: var(--v-spacing-lg);
   width: 3px;
-  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-sage-600) 100%);
+  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-forest-400) 100%);
   border-radius: var(--v-radius-pill);
 }
 .v-pullquote-text {
@@ -1765,7 +1753,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 
 /* Gradient Text — forest→sage text fill */
 .v-gradient-text {
-  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-sage-500) 100%);
+  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-forest-300) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -69,10 +69,6 @@ struct TokensGallerySection: View {
                         Forest._950, Forest._900, Forest._800, Forest._700, Forest._600,
                         Forest._500, Forest._400, Forest._300, Forest._200, Forest._100
                     ])
-                    colorScaleRow(name: "Sage", colors: [
-                        Sage._950, Sage._900, Sage._800, Sage._700, Sage._600,
-                        Sage._500, Sage._400, Sage._300, Sage._200, Sage._100
-                    ])
                     colorScaleRow(name: "Emerald", colors: [
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
                         Emerald._500, Emerald._400, Emerald._300, Emerald._200, Emerald._100

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -51,19 +51,6 @@ public enum Emerald {
     public static let _100 = Color(hex: 0xECFDF5)
 }
 
-public enum Sage {
-    public static let _950 = Color(hex: 0x1A2316)
-    public static let _900 = Color(hex: 0x2A3825)
-    public static let _800 = Color(hex: 0x3D4F36)
-    public static let _700 = Color(hex: 0x516748)
-    public static let _600 = Color(hex: 0x657D5B)
-    public static let _500 = Color(hex: 0x7A8B6F)
-    public static let _400 = Color(hex: 0x98A88F)
-    public static let _300 = Color(hex: 0xB5C3AE)
-    public static let _200 = Color(hex: 0xD4DFD0)
-    public static let _100 = Color(hex: 0xEDF2EB)
-}
-
 public enum Danger {
     public static let _950 = Color(hex: 0x620F21)
     public static let _900 = Color(hex: 0x85142F)
@@ -181,4 +168,7 @@ public enum VColor {
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
     public static let toggleOff = adaptiveColor(light: Stone._300, dark: Moss._700)
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)
+
+    // Slash command highlight — green tint for /command tokens in composer and chat
+    public static let slashCommand = adaptiveColor(light: Forest._500, dark: Forest._300)
 }


### PR DESCRIPTION
Review and update chat bubbles, composer, and chat view to align with Figma designs. Ensure all colors use correct semantic tokens in both light and dark mode. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
