### PR TITLE
M5: Gallery cleanup & visual polish

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -1756,7 +1756,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   line-height: 1.4;
 }
 
-/* Gradient Text — forest→sage text fill */
+/* Gradient Text — forest gradient text fill */
 .v-gradient-text {
   background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-forest-300) 100%);
   -webkit-background-clip: text;


### PR DESCRIPTION
Final cleanup pass after design token overhaul: verify no remaining references to removed scales (Slate, Violet, Indigo, Rose, Sage), update gallery sections, ensure build passes. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
