### PR TITLE
Design Token Overhaul — Align Color System with Figma

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -271,7 +271,7 @@ extension AppDelegate {
     @objc func openNewChat() {
         showMainWindow()
         mainWindow?.threadManager.createThread()
-        UserDefaults.standard.set(false, forKey: "sidebarOpen")
+        UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
 
     @objc func openAppCollection() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -965,7 +965,7 @@ struct ChatBubble: View {
             let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
             let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
             let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
-            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Forest._500, dark: Forest._300)
+            parsed[attrStart..<attrEnd].foregroundColor = VColor.slashCommand
         }
 
         // Store in cache (with size limit to prevent unbounded growth)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -965,7 +965,7 @@ struct ChatBubble: View {
             let length = trimmed.distance(from: slashMatch.lowerBound, to: slashMatch.upperBound)
             let attrStart = parsed.index(parsed.startIndex, offsetByCharacters: offset)
             let attrEnd = parsed.index(attrStart, offsetByCharacters: length)
-            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Sage._500, dark: Sage._300)
+            parsed[attrStart..<attrEnd].foregroundColor = adaptiveColor(light: Forest._500, dark: Forest._300)
         }
 
         // Store in cache (with size limit to prevent unbounded growth)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -799,7 +799,7 @@ private final class ComposerNativeTextView: NSTextView {
         if let match = text.range(of: #"^/\w+"#, options: .regularExpression) {
             let nsRange = NSRange(match, in: text)
             layoutManager.addTemporaryAttributes(
-                [.foregroundColor: NSColor(Sage._500)],
+                [.foregroundColor: NSColor(Forest._500)],
                 forCharacterRange: nsRange
             )
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -139,11 +139,7 @@ struct ComposerView: View {
             .padding(.trailing, VSpacing.lg)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(VColor.surface)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .fill(VColor.surfaceSubtle.opacity(0.4))
-                    )
+                    .fill(adaptiveColor(light: Moss._200, dark: Moss._700))
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
             .overlay(
@@ -289,7 +285,7 @@ struct ComposerView: View {
                 Button(action: { onAttach(); focusedComposerAction = nil }) {
                     Image(systemName: "paperclip")
                         .font(.system(size: composerActionIconSize, weight: .regular))
-                        .foregroundColor(VColor.textSecondary.opacity(0.82))
+                        .foregroundColor(adaptiveColor(light: Forest._500, dark: Moss._400))
                 }
                 .buttonStyle(ComposerActionButtonStyle(
                     isHovered: isAttachmentHovered,
@@ -638,7 +634,7 @@ private struct ComposerTextView: NSViewRepresentable {
         let oldPlaceholder = textView.placeholderText
         let oldGhostSuffix = textView.hasGhostSuffix
         textView.placeholderText = placeholder
-        textView.placeholderColor = NSColor(VColor.textSecondary).withAlphaComponent(0.92)
+        textView.placeholderColor = NSColor(Moss._400)
         textView.hasGhostSuffix = hasGhostSuffix
         textView.isSlashMenuOpen = isSlashMenuOpen
 
@@ -932,7 +928,7 @@ private struct MicrophoneButton: View {
 
                 Image(systemName: isRecording ? "mic.fill" : "mic")
                     .font(.system(size: iconSize, weight: .regular))
-                    .foregroundColor(isRecording ? VColor.error : VColor.textSecondary.opacity(0.82))
+                    .foregroundColor(isRecording ? VColor.error : adaptiveColor(light: Forest._500, dark: Moss._400))
             }
         }
         .accessibilityLabel(isRecording ? "Stop recording" : "Start voice input")

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -799,7 +799,7 @@ private final class ComposerNativeTextView: NSTextView {
         if let match = text.range(of: #"^/\w+"#, options: .regularExpression) {
             let nsRange = NSRange(match, in: text)
             layoutManager.addTemporaryAttributes(
-                [.foregroundColor: NSColor(Forest._500)],
+                [.foregroundColor: NSColor(VColor.slashCommand)],
                 forCharacterRange: nsRange
             )
         }

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -309,7 +309,7 @@ private struct UsedToolsRow: View {
         let isDiff = result.contains("@@") && result.contains("---") && result.contains("+++")
         guard isDiff else { return VColor.textSecondary }
         if line.hasPrefix("+") { return Emerald._400 }
-        if line.hasPrefix("-") { return Rose._400 }
+        if line.hasPrefix("-") { return Danger._400 }
         if line.hasPrefix("@@") { return VColor.textMuted }
         return VColor.textSecondary
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -719,7 +719,7 @@ struct MainWindowView: View {
                 if isSelected {
                     adaptiveColor(light: Forest._100.opacity(0.6), dark: Moss._700)
                 } else if isHovered {
-                    adaptiveColor(light: Stone._200, dark: Moss._800)
+                    adaptiveColor(light: Stone._200, dark: Moss._700)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
@@ -907,7 +907,7 @@ struct MainWindowView: View {
                 )
             }
             .padding(VSpacing.lg)
-            .background(adaptiveColor(light: Moss._50, dark: Moss._800))
+            .background(adaptiveColor(light: Moss._50, dark: Moss._700))
         }
         .frame(width: threadDrawerWidth)
         .background(adaptiveColor(light: Moss._100, dark: Moss._950))

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -716,8 +716,10 @@ struct MainWindowView: View {
             .padding(.trailing, isHovered ? (VSpacing.xs + 20 + VSpacing.xs + 20 + VSpacing.xs) : VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background {
-                if isSelected || isHovered {
-                    VColor.hoverOverlay.opacity(0.08)
+                if isSelected {
+                    adaptiveColor(light: Stone._200, dark: Moss._700)
+                } else if isHovered {
+                    adaptiveColor(light: Stone._100, dark: Moss._800)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
@@ -835,86 +837,84 @@ struct MainWindowView: View {
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
-            // MARK: New Chat
-            Spacer().frame(height: VSpacing.md)
-            SidebarNavRow(icon: "plus.circle", label: "New chat") {
-                windowState.selection = nil
-                threadManager.createThread()
-            }
+            // Rounded container inset from sidebar edges
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        Spacer().frame(height: VSpacing.sm)
 
-            Spacer().frame(height: VSpacing.lg)
-
-            // MARK: Nav Items
-            SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
-                windowState.togglePanel(.directory)
-            }
-            SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
-                windowState.togglePanel(.identity)
-            }
-            SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
-                windowState.togglePanel(.agent)
-            }
-
-            // MARK: Chats
-            SidebarSubheader(title: "Recent Chats")
-
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach(displayedThreads) { thread in
-                        threadItem(thread)
-                            .padding(.bottom, 1)
-                            .dropDestination(for: String.self) { items, _ in
-                                guard let droppedId = items.first,
-                                      let sourceUUID = UUID(uuidString: droppedId),
-                                      sourceUUID != thread.id else { return false }
-                                return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                            } isTargeted: { _ in }
-                    }
-
-                    if threadManager.hasMoreThreads {
-                        Button {
-                            threadManager.loadMoreThreads()
-                        } label: {
-                            if threadManager.isLoadingMoreThreads {
-                                HStack(spacing: VSpacing.xs) {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                    Text("Loading...")
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.textMuted)
-                                }
-                            } else {
-                                Text("Load more")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textSecondary)
-                            }
+                        // MARK: Nav Items
+                        SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
+                            windowState.togglePanel(.directory)
                         }
-                        .buttonStyle(.plain)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.sm)
-                        .disabled(threadManager.isLoadingMoreThreads)
+                        SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
+                            windowState.togglePanel(.identity)
+                        }
+                        SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+                            windowState.togglePanel(.agent)
+                        }
+
+                        // Divider between nav items and threads
+                        VColor.divider
+                            .frame(height: 1)
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.sm)
+
+                        // MARK: Threads
+                        SidebarThreadsHeader(onNewThread: {
+                            windowState.selection = nil
+                            threadManager.createThread()
+                        })
+
+                        ForEach(displayedThreads) { thread in
+                            threadItem(thread)
+                                .padding(.bottom, 1)
+                                .dropDestination(for: String.self) { items, _ in
+                                    guard let droppedId = items.first,
+                                          let sourceUUID = UUID(uuidString: droppedId),
+                                          sourceUUID != thread.id else { return false }
+                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
+                                } isTargeted: { _ in }
+                        }
+
+                        if threadManager.visibleThreads.count > 5 {
+                            Button {
+                                withAnimation(VAnimation.standard) { showAllThreads.toggle() }
+                            } label: {
+                                Text(showAllThreads ? "Show less" : "Show more")
+                                    .font(VFont.caption)
+                                    .foregroundColor(Forest._600)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.leading, 20)
+                                    .padding(.vertical, VSpacing.xs)
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
+                .scrollClipDisabled()
+                .clipped()
+
+                Spacer(minLength: 0)
+
+                // Control Center row
+                ControlCenterRow(
+                    onToggle: {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                            showControlCenterDrawer.toggle()
+                        }
+                    }
+                )
             }
-            .scrollClipDisabled()
-            .clipped()
-
-            Spacer(minLength: 0)
-
-            // Control Center row
-            ControlCenterRow(
-                onToggle: {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                        showControlCenterDrawer.toggle()
-                    }
-                }
+            .padding(VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.xxl)
+                    .fill(adaptiveColor(light: Stone._50, dark: Moss._900))
             )
+            .padding(VSpacing.sm)
         }
         .frame(width: threadDrawerWidth)
-        .background(VColor.backgroundSubtle)
-        .overlay(alignment: .trailing) {
-            VColor.surfaceBorder.frame(width: 1)
-        }
+        .background(VColor.background)
     }
 
     @ViewBuilder
@@ -1129,7 +1129,7 @@ private struct SidebarNavRow: View {
                     .foregroundColor(VColor.textPrimary)
                     .frame(width: 18)
                 Text(label)
-                    .font(VFont.body)
+                    .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
             }
@@ -1149,18 +1149,40 @@ private struct SidebarNavRow: View {
     }
 }
 
-private struct SidebarSubheader: View {
-    let title: String
+private struct SidebarThreadsHeader: View {
+    let onNewThread: () -> Void
+    @State private var isHovered = false
 
     var body: some View {
-        Text(title)
-            .font(VFont.caption)
-            .foregroundColor(VColor.textMuted)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 20)
-            .padding(.trailing, VSpacing.md)
-            .padding(.top, VSpacing.md)
-            .padding(.bottom, VSpacing.md)
+        HStack {
+            Text("Threads")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            Spacer()
+            Button(action: onNewThread) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(Forest._700)
+                    .frame(width: 22, height: 22)
+                    .background(Color.clear)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Forest._700, lineWidth: 1.5)
+                    )
+            }
+            .buttonStyle(.plain)
+            .scaleEffect(isHovered ? 1.08 : 1.0)
+            .animation(VAnimation.fast, value: isHovered)
+            .onHover { hovering in
+                isHovered = hovering
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .accessibilityLabel("New thread")
+        }
+        .padding(.leading, 20)
+        .padding(.trailing, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -821,7 +821,7 @@ struct MainWindowView: View {
                 collapsedSidebarContent
             }
         }
-        .padding(sidebarExpanded ? VSpacing.lg : VSpacing.sm)
+        .padding(sidebarExpanded ? VSpacing.xs : VSpacing.xs)
         .background(adaptiveColor(light: Moss._50, dark: Moss._700))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .padding(sidebarOuterMargin)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -485,7 +485,7 @@ struct MainWindowView: View {
                             }
                         )
                         .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
-                        .offset(x: VSpacing.sm, y: -52)
+                        .offset(x: sidebarOuterMargin + VSpacing.sm, y: -52)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -810,6 +810,8 @@ struct MainWindowView: View {
         return showAllApps ? all : Array(all.prefix(5))
     }
 
+    private let sidebarOuterMargin: CGFloat = 16
+
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
@@ -819,9 +821,11 @@ struct MainWindowView: View {
                 collapsedSidebarContent
             }
         }
-        .padding(.vertical, VSpacing.sm)
-        .padding(.horizontal, sidebarExpanded ? VSpacing.sm : VSpacing.xs)
-        .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        .padding(sidebarExpanded ? VSpacing.lg : VSpacing.sm)
+        .background(adaptiveColor(light: Moss._50, dark: Moss._700))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .padding(sidebarOuterMargin)
+        .frame(width: sidebarExpanded ? sidebarExpandedWidth + sidebarOuterMargin * 2 : sidebarCollapsedWidth + sidebarOuterMargin * 2)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -31,18 +31,16 @@ struct MainWindowView: View {
     @State private var showCopyThreadConfirmation = false
     @State private var copyThreadConfirmationTimer: DispatchWorkItem?
 
-    @AppStorage("sidebarOpen") var sidebarOpen: Bool = false
+    @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-    @AppStorage("threadDrawerWidth") private var threadDrawerWidth: Double = 240
+    private let sidebarExpandedWidth: CGFloat = 240
+    private let sidebarCollapsedWidth: CGFloat = 52
+    private let sidebarOuterMargin: CGFloat = 16
     @AppStorage("sidePanelWidth") var sidePanelWidth: Double = 400
     @AppStorage("appPanelWidth") var appPanelWidth: Double = -1
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
     @AppStorage("homeBaseDashboardAutoEnabled") private var homeBaseDashboardAutoEnabled: Bool = false
-    @State private var drawerDragStartWidth: Double?
-    @State private var drawerDragStartAvailableWidth: CGFloat?
-    @State private var isDrawerDragging: Bool = false
-    private let drawerDragCoordinateSpaceName = "MainWindowDrawerDragCoordinateSpace"
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
@@ -341,17 +339,17 @@ struct MainWindowView: View {
                     windowState.activeDynamicParsedSurface = nil
                 }
 
-                // Close the left sidebar when an app opens to avoid crowding
-                if sidebarOpen {
-                    let shouldClose: Bool = {
+                // Collapse the sidebar when an app opens to avoid crowding
+                if sidebarExpanded {
+                    let shouldCollapse: Bool = {
                         switch newSelection {
                         case .app, .appEditing: return true
                         default: return false
                         }
                     }()
-                    if shouldClose {
-                        withAnimation(.easeInOut(duration: 0.35)) {
-                            sidebarOpen = false
+                    if shouldCollapse {
+                        withAnimation(VAnimation.panel) {
+                            sidebarExpanded = false
                         }
                     }
                 }
@@ -385,19 +383,9 @@ struct MainWindowView: View {
                 VStack(spacing: 0) {
                     // Top bar (always visible, above sidebar)
                     HStack(spacing: 0) {
-                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarOpen, iconOnly: true, tooltip: sidebarOpen ? "Hide sidebar" : "Show sidebar") {
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                sidebarOpen.toggle()
-                            }
-                        }
-                        if !sidebarOpen,
-                           !windowState.isShowingChat
-                            || threadManager.activeThread?.kind == .private
-                            || threadManager.activeViewModel?.messages.contains(where: { $0.role == .user }) == true {
-                            Spacer().frame(width: VSpacing.xs)
-                            VIconButton(label: "New Chat", icon: "plus.circle", iconOnly: true, tooltip: "New chat") {
-                                windowState.selection = nil
-                                threadManager.createThread()
+                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarExpanded, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
+                            withAnimation(VAnimation.panel) {
+                                sidebarExpanded.toggle()
                             }
                         }
                         Spacer()
@@ -459,26 +447,13 @@ struct MainWindowView: View {
 
                     Divider().background(VColor.surfaceBorder)
 
-                    // Content area with sidebar pushing content
-                    ZStack(alignment: .leading) {
-                        let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
-                        let sidebarInset = sidebarVisible
-                            ? threadDrawerWidth + VSpacing.xs : 0
+                    // Content area: sidebar always pushes chat content right
+                    HStack(spacing: 0) {
+                        sidebarView
+                            .animation(VAnimation.panel, value: sidebarExpanded)
 
                         chatContentView(geometry: geometry)
-                            .padding(.leading, sidebarInset)
-
-                        // Sidebar drawer
-                        if sidebarVisible {
-                            HStack(spacing: 0) {
-                                sidebarView
-                                drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
-                            }
-                            .transition(.move(edge: .leading))
-                            .animation(nil, value: threadDrawerWidth)
-                        }
                     }
-                    .coordinateSpace(name: drawerDragCoordinateSpaceName)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer
@@ -509,8 +484,8 @@ struct MainWindowView: View {
                                 windowState.selection = .panel(.doctor)
                             }
                         )
-                        .frame(width: threadDrawerWidth - VSpacing.sm * 2)
-                        .offset(x: VSpacing.sm, y: -52)
+                        .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
+                        .offset(x: sidebarOuterMargin + VSpacing.sm, y: -52)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -570,8 +545,8 @@ struct MainWindowView: View {
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
             requestHomeBaseDashboardIfNeeded()
         }
-        .onChange(of: sidebarOpen) { _, isOpen in
-            if !isOpen && showControlCenterDrawer {
+        .onChange(of: sidebarExpanded) { _, isExpanded in
+            if !isExpanded && showControlCenterDrawer {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
                     showControlCenterDrawer = false
                 }
@@ -837,80 +812,124 @@ struct MainWindowView: View {
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
-            // Rounded container inset from sidebar edges
+            if sidebarExpanded {
+                expandedSidebarContent
+            } else {
+                collapsedSidebarContent
+            }
+        }
+        .padding(sidebarExpanded ? VSpacing.lg : VSpacing.sm)
+        .background(adaptiveColor(light: Moss._50, dark: Moss._700))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .padding(sidebarOuterMargin)
+        .frame(width: sidebarExpanded ? sidebarExpandedWidth + sidebarOuterMargin * 2 : sidebarCollapsedWidth + sidebarOuterMargin * 2)
+    }
+
+    @ViewBuilder
+    private var expandedSidebarContent: some View {
+        ScrollView {
             VStack(spacing: 0) {
-                ScrollView {
-                    VStack(spacing: 0) {
-                        Spacer().frame(height: VSpacing.sm)
+                Spacer().frame(height: VSpacing.sm)
 
-                        // MARK: Nav Items
-                        SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
-                            windowState.togglePanel(.directory)
-                        }
-                        SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
-                            windowState.togglePanel(.identity)
-                        }
-                        SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
-                            windowState.togglePanel(.agent)
-                        }
+                // MARK: Nav Items
+                SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
+                    windowState.togglePanel(.directory)
+                }
+                SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
+                    windowState.togglePanel(.identity)
+                }
+                SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+                    windowState.togglePanel(.agent)
+                }
 
-                        // Divider between nav items and threads
-                        VColor.divider
-                            .frame(height: 1)
-                            .padding(.horizontal, VSpacing.md)
-                            .padding(.vertical, VSpacing.sm)
+                // Divider between nav items and threads
+                VColor.divider
+                    .frame(height: 1)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
 
-                        // MARK: Threads
-                        SidebarThreadsHeader(onNewThread: {
-                            windowState.selection = nil
-                            threadManager.createThread()
-                        })
+                // MARK: Threads
+                SidebarThreadsHeader(onNewThread: {
+                    windowState.selection = nil
+                    threadManager.createThread()
+                })
 
-                        ForEach(displayedThreads) { thread in
-                            threadItem(thread)
-                                .padding(.bottom, VSpacing.xxs)
-                                .dropDestination(for: String.self) { items, _ in
-                                    guard let droppedId = items.first,
-                                          let sourceUUID = UUID(uuidString: droppedId),
-                                          sourceUUID != thread.id else { return false }
-                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                                } isTargeted: { _ in }
-                        }
+                ForEach(displayedThreads) { thread in
+                    threadItem(thread)
+                        .padding(.bottom, VSpacing.xxs)
+                        .dropDestination(for: String.self) { items, _ in
+                            guard let droppedId = items.first,
+                                  let sourceUUID = UUID(uuidString: droppedId),
+                                  sourceUUID != thread.id else { return false }
+                            return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
+                        } isTargeted: { _ in }
+                }
 
-                        if threadManager.visibleThreads.count > 5 {
-                            Button {
-                                withAnimation(VAnimation.standard) { showAllThreads.toggle() }
-                            } label: {
-                                Text(showAllThreads ? "Show less" : "Show more")
-                                    .font(VFont.caption)
-                                    .foregroundColor(Forest._600)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 20)
-                                    .padding(.vertical, VSpacing.xs)
-                            }
-                            .buttonStyle(.plain)
-                        }
+                if threadManager.visibleThreads.count > 5 {
+                    Button {
+                        withAnimation(VAnimation.standard) { showAllThreads.toggle() }
+                    } label: {
+                        Text(showAllThreads ? "Show less" : "Show more")
+                            .font(VFont.caption)
+                            .foregroundColor(Forest._600)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 20)
+                            .padding(.vertical, VSpacing.xs)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .scrollClipDisabled()
+        .clipped()
+
+        Spacer(minLength: VSpacing.sm)
+
+        // Control Center row
+        ControlCenterRow(
+            onToggle: {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    showControlCenterDrawer.toggle()
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var collapsedSidebarContent: some View {
+        VStack(spacing: VSpacing.sm) {
+            CollapsedNavIcon(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
+                windowState.togglePanel(.directory)
+            }
+            CollapsedNavIcon(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
+                windowState.togglePanel(.identity)
+            }
+            CollapsedNavIcon(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+                windowState.togglePanel(.agent)
+            }
+
+            VColor.divider
+                .frame(height: 1)
+                .padding(.horizontal, VSpacing.xs)
+
+            CollapsedNavIcon(icon: "square.and.pencil", label: "New Chat", isActive: false) {
+                windowState.selection = nil
+                threadManager.createThread()
+            }
+
+            Spacer()
+
+            CollapsedNavIcon(icon: "gearshape", label: "Control Center", isActive: false) {
+                withAnimation(VAnimation.panel) {
+                    sidebarExpanded = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        showControlCenterDrawer = true
                     }
                 }
-                .scrollClipDisabled()
-                .clipped()
-
-                Spacer(minLength: VSpacing.sm)
-
-                // Control Center row
-                ControlCenterRow(
-                    onToggle: {
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                            showControlCenterDrawer.toggle()
-                        }
-                    }
-                )
             }
-            .padding(VSpacing.lg)
-            .background(adaptiveColor(light: Moss._50, dark: Moss._700))
         }
-        .frame(width: threadDrawerWidth)
-        .background(adaptiveColor(light: Moss._100, dark: Moss._950))
     }
 
     @ViewBuilder
@@ -1016,80 +1035,6 @@ struct MainWindowView: View {
         try? daemonClient.sendAppOpen(appId: app.id)
     }
 
-    // MARK: - Drawer Drag Helpers
-
-    private func resetDrawerDragState() {
-        isDrawerDragging = false
-        drawerDragStartWidth = nil
-        drawerDragStartAvailableWidth = nil
-    }
-
-    private func drawerDragDivider(availableWidth: CGFloat) -> some View {
-        Rectangle()
-            .fill(Color.clear)
-            .frame(width: VSpacing.xs)
-            .contentShape(Rectangle())
-            .onHover { hovering in
-                if hovering {
-                    NSCursor.resizeLeftRight.set()
-                } else {
-                    NSCursor.arrow.set()
-                }
-            }
-            .gesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .named(drawerDragCoordinateSpaceName))
-                    .onChanged { value in
-                        // Capture initial state on first drag event. Check both nil state AND
-                        // isDrawerDragging flag to handle race condition where async reset hasn't completed.
-                        if drawerDragStartWidth == nil || !isDrawerDragging {
-                            drawerDragStartWidth = threadDrawerWidth
-                            drawerDragStartAvailableWidth = availableWidth
-                            isDrawerDragging = true
-                        }
-
-                        guard let initialWidth = drawerDragStartWidth,
-                              let initialAvailableWidth = drawerDragStartAvailableWidth else {
-                            return
-                        }
-
-                        // Use a stable parent coordinate space so divider movement
-                        // does not feed back into gesture translation while dragging.
-                        let deltaX = value.location.x - value.startLocation.x
-                        let newWidth = initialWidth + Double(deltaX)
-                        let minDrawerWidth: CGFloat = 200
-                        let minMainContent: CGFloat = 300
-                        // Only subtract side panel width when a right-side split panel is
-                        // actually rendered. Full-window panels (identity, agent, settings,
-                        // debug, doctor, directory) don't have a right split.
-                        let hasRightSplitPanel: Bool = {
-                            guard let panel = windowState.activePanel else { return false }
-                            switch panel {
-                            case .documentEditor:
-                                return true
-                            case .generated:
-                                return windowState.isDynamicExpanded && windowState.isChatDockOpen
-                            default:
-                                return false
-                            }
-                        }()
-                        let activePanelWidth: CGFloat = hasRightSplitPanel ? sidePanelWidth : 0
-                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.xs - (VSpacing.xs * 2) - activePanelWidth
-
-                        // Update width without animation to prevent jitter
-                        var transaction = Transaction()
-                        transaction.disablesAnimations = true
-                        withTransaction(transaction) {
-                            threadDrawerWidth = min(max(newWidth, minDrawerWidth), maxAllowed)
-                        }
-                    }
-                    .onEnded { _ in
-                        resetDrawerDragState()
-                    }
-            )
-            .onDisappear {
-                resetDrawerDragState()
-            }
-    }
 }
 
 private struct ZoomIndicatorView: View {
@@ -1145,6 +1090,32 @@ private struct SidebarNavRow: View {
     }
 }
 
+private struct CollapsedNavIcon: View {
+    let icon: String
+    let label: String
+    var isActive: Bool = false
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(VColor.textPrimary)
+                .frame(width: 32, height: 32)
+                .background(isActive || isHovered ? VColor.hoverOverlay.opacity(0.08) : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(label)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
 private struct SidebarThreadsHeader: View {
     let onNewThread: () -> Void
     @State private var isHovered = false
@@ -1189,7 +1160,7 @@ private struct ControlCenterRow: View {
     private let iconColor = adaptiveColor(light: Forest._700, dark: Forest._500)
     private let textColor = adaptiveColor(light: Forest._800, dark: Forest._400)
     private let chevronColor = adaptiveColor(light: Forest._700, dark: Forest._500)
-    private let bgColor = adaptiveColor(light: Forest._100, dark: Forest._900)
+    private let bgColor = adaptiveColor(light: Forest._200, dark: Moss._700)
 
     var body: some View {
         Button(action: onToggle) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -37,7 +37,6 @@ struct MainWindowView: View {
     @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     private let sidebarExpandedWidth: CGFloat = 240
     private let sidebarCollapsedWidth: CGFloat = 52
-    private let sidebarOuterMargin: CGFloat = 16
     @AppStorage("sidePanelWidth") var sidePanelWidth: Double = 400
     @AppStorage("appPanelWidth") var appPanelWidth: Double = -1
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
@@ -486,7 +485,7 @@ struct MainWindowView: View {
                             }
                         )
                         .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
-                        .offset(x: sidebarOuterMargin + VSpacing.sm, y: -52)
+                        .offset(x: VSpacing.sm, y: -52)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -802,7 +801,8 @@ struct MainWindowView: View {
     }
 
     private var displayedThreads: [ThreadModel] {
-        threadManager.visibleThreads
+        let all = threadManager.visibleThreads
+        return showAllThreads ? all : Array(all.prefix(5))
     }
 
     private var displayedApps: [AppListManager.AppItem] {
@@ -819,11 +819,9 @@ struct MainWindowView: View {
                 collapsedSidebarContent
             }
         }
-        .padding(sidebarExpanded ? VSpacing.lg : VSpacing.sm)
-        .background(adaptiveColor(light: Moss._50, dark: Moss._700))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .padding(sidebarOuterMargin)
-        .frame(width: sidebarExpanded ? sidebarExpandedWidth + sidebarOuterMargin * 2 : sidebarCollapsedWidth + sidebarOuterMargin * 2)
+        .padding(.vertical, VSpacing.sm)
+        .padding(.horizontal, sidebarExpanded ? VSpacing.sm : VSpacing.xs)
+        .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -717,9 +717,9 @@ struct MainWindowView: View {
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected {
-                    adaptiveColor(light: Stone._200, dark: Moss._700)
+                    adaptiveColor(light: Forest._100.opacity(0.6), dark: Moss._700)
                 } else if isHovered {
-                    adaptiveColor(light: Stone._100, dark: Moss._800)
+                    adaptiveColor(light: Stone._200, dark: Moss._800)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
@@ -868,7 +868,7 @@ struct MainWindowView: View {
 
                         ForEach(displayedThreads) { thread in
                             threadItem(thread)
-                                .padding(.bottom, 1)
+                                .padding(.bottom, VSpacing.xxs)
                                 .dropDestination(for: String.self) { items, _ in
                                     guard let droppedId = items.first,
                                           let sourceUUID = UUID(uuidString: droppedId),
@@ -895,7 +895,7 @@ struct MainWindowView: View {
                 .scrollClipDisabled()
                 .clipped()
 
-                Spacer(minLength: 0)
+                Spacer(minLength: VSpacing.sm)
 
                 // Control Center row
                 ControlCenterRow(
@@ -909,12 +909,12 @@ struct MainWindowView: View {
             .padding(VSpacing.sm)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.xxl)
-                    .fill(adaptiveColor(light: Stone._50, dark: Moss._900))
+                    .fill(adaptiveColor(light: Moss._50, dark: Moss._800))
             )
             .padding(VSpacing.sm)
         }
         .frame(width: threadDrawerWidth)
-        .background(VColor.background)
+        .background(adaptiveColor(light: Stone._200, dark: Moss._950))
     }
 
     @ViewBuilder
@@ -1212,7 +1212,7 @@ private struct ControlCenterRow: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.md)
-            .background(bgColor.opacity(isHovered ? 0.9 : 0.6))
+            .background(bgColor.opacity(isHovered ? 1.0 : 0.85))
             .clipShape(Capsule())
             .contentShape(Capsule())
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1168,31 +1168,36 @@ private struct ControlCenterRow: View {
     let onToggle: () -> Void
     @State private var isHovered = false
 
+    private let iconColor = adaptiveColor(light: Forest._700, dark: Forest._500)
+    private let textColor = adaptiveColor(light: Forest._800, dark: Forest._400)
+    private let chevronColor = adaptiveColor(light: Forest._700, dark: Forest._500)
+    private let bgColor = adaptiveColor(light: Forest._100, dark: Forest._900)
+
     var body: some View {
         Button(action: onToggle) {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "gearshape")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(VColor.textSecondary)
+                    .foregroundColor(iconColor)
                     .frame(width: 18)
                 Text("Control Center")
                     .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
+                    .foregroundColor(textColor)
                 Spacer()
                 Image(systemName: "chevron.up")
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
+                    .foregroundColor(chevronColor)
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.md)
-            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : .clear)
-            .contentShape(Rectangle())
+            .background(bgColor.opacity(isHovered ? 0.9 : 0.6))
+            .clipShape(Capsule())
+            .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.bottom, VSpacing.sm)
         .onHover { isHovered = $0 }
-        .overlay(alignment: .top) {
-            VColor.surfaceBorder.frame(height: 1)
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -906,15 +906,11 @@ struct MainWindowView: View {
                     }
                 )
             }
-            .padding(VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.xxl)
-                    .fill(adaptiveColor(light: Moss._50, dark: Moss._800))
-            )
-            .padding(VSpacing.sm)
+            .padding(VSpacing.lg)
+            .background(adaptiveColor(light: Moss._50, dark: Moss._800))
         }
         .frame(width: threadDrawerWidth)
-        .background(adaptiveColor(light: Stone._200, dark: Moss._950))
+        .background(adaptiveColor(light: Moss._100, dark: Moss._950))
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -20,6 +20,7 @@ struct MainWindowView: View {
     @State private var isHoveredApp: String?
     @State private var requestedHomeBaseAtLaunch = false
     @State private var threadPendingDeletion: UUID?
+    @State private var showAllThreads: Bool = false
     @State private var showAllApps: Bool = false
     @State private var showControlCenterDrawer: Bool = false
     @AppStorage("isAppChatOpen") private var isAppChatOpen: Bool = false
@@ -871,7 +872,7 @@ struct MainWindowView: View {
                     } label: {
                         Text(showAllThreads ? "Show less" : "Show more")
                             .font(VFont.caption)
-                            .foregroundColor(Forest._600)
+                            .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 20)
                             .padding(.vertical, VSpacing.xs)
@@ -1129,13 +1130,13 @@ private struct SidebarThreadsHeader: View {
             Button(action: onNewThread) {
                 Image(systemName: "plus")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(Forest._700)
+                    .foregroundColor(adaptiveColor(light: Forest._700, dark: Forest._400))
                     .frame(width: 22, height: 22)
                     .background(Color.clear)
                     .clipShape(Circle())
                     .overlay(
                         Circle()
-                            .stroke(Forest._700, lineWidth: 1.5)
+                            .stroke(adaptiveColor(light: Forest._700, dark: Forest._400), lineWidth: 1.5)
                     )
             }
             .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -420,7 +420,7 @@ extension MainWindowView {
                 surfaceManager: surfaceManager,
                 daemonClient: daemonClient,
                 trafficLightPadding: trafficLightPadding,
-                isSidebarOpen: sidebarOpen,
+                isSidebarOpen: sidebarExpanded,
                 isPublishing: $isPublishing,
                 publishedUrl: $publishedUrl,
                 publishError: $publishError,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -790,7 +790,7 @@ struct DynamicWorkspaceWrapper: View {
                             .foregroundColor(VColor.error)
                             .padding(.horizontal, VSpacing.md)
                             .padding(.vertical, VSpacing.xs)
-                            .background(Rose._900.opacity(0.8))
+                            .background(Danger._900.opacity(0.8))
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .padding(.trailing, VSpacing.xl)
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -717,7 +717,7 @@ struct AgentPanelContent: View {
         if isError, let msg = errorMessage {
             Text(msg)
                 .font(VFont.caption)
-                .foregroundColor(Rose._500)
+                .foregroundColor(Danger._500)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -198,10 +198,10 @@ struct AppDirectoryView: View {
                                 Text("Shared")
                                     .font(VFont.small)
                             }
-                            .foregroundColor(Sage._400)
+                            .foregroundColor(Forest._400)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 1)
-                            .background(Sage._900.opacity(0.5))
+                            .background(Forest._900.opacity(0.5))
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -29,7 +29,7 @@ private enum SkillCategory: String, CaseIterable {
         case .communication: return Forest._400
         case .daily: return Emerald._400
         case .utilities: return Stone._400
-        case .skills: return Rose._400
+        case .skills: return Danger._400
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -105,7 +105,7 @@ private struct DotGridBackground: View {
                         width: dotRadius * 2,
                         height: dotRadius * 2
                     )
-                    context.fill(Circle().path(in: rect), with: .color(Slate._500.opacity(0.4)))
+                    context.fill(Circle().path(in: rect), with: .color(Moss._500.opacity(0.4)))
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -25,8 +25,8 @@ private enum SkillCategory: String, CaseIterable {
     var color: Color {
         switch self {
         case .core: return Amber._400
-        case .devTools: return Sage._400
-        case .communication: return Sage._400
+        case .devTools: return Forest._400
+        case .communication: return Forest._400
         case .daily: return Emerald._400
         case .utilities: return Stone._400
         case .skills: return Rose._400
@@ -343,7 +343,7 @@ struct ConstellationView: View {
         ZStack {
             // Background glow
             RadialGradient(
-                colors: [Sage._600.opacity(0.06), Color.clear],
+                colors: [Forest._600.opacity(0.06), Color.clear],
                 center: .center,
                 startRadius: 0,
                 endRadius: min(size.width, size.height) * 0.5

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -76,7 +76,7 @@ struct DebugPanel: View {
                         icon: "exclamationmark.triangle.fill",
                         label: "Failures",
                         value: "\(failures)",
-                        color: Rose._500
+                        color: Danger._500
                     )
                 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -120,7 +120,7 @@ struct GeneratedPanel: View {
                     }
                 }
                 .padding(VSpacing.md)
-                .background(Slate._800)
+                .background(Moss._800)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
@@ -344,7 +344,7 @@ struct GeneratedPanel: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(isHovered ? Slate._800 : Slate._900)
+        .background(isHovered ? Moss._800 : Moss._900)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -348,7 +348,7 @@ struct GeneratedPanel: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(item.isShared ? Sage._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
+                .stroke(item.isShared ? Forest._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
         )
         .contentShape(Rectangle())
         .onTapGesture {
@@ -374,10 +374,10 @@ struct GeneratedPanel: View {
             Text("Shared")
                 .font(VFont.small)
         }
-        .foregroundColor(Sage._400)
+        .foregroundColor(Forest._400)
         .padding(.horizontal, 5)
         .padding(.vertical, 1)
-        .background(Sage._900.opacity(0.5))
+        .background(Forest._900.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -120,7 +120,7 @@ struct GeneratedPanel: View {
                     }
                 }
                 .padding(VSpacing.md)
-                .background(Moss._800)
+                .background(Moss._700)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
@@ -344,7 +344,7 @@ struct GeneratedPanel: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(isHovered ? Moss._800 : Moss._900)
+        .background(isHovered ? Moss._700 : Moss._900)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -30,12 +30,12 @@ struct SubagentDetailPanel: View {
                                 Text("Abort")
                                     .font(VFont.captionMedium)
                             }
-                            .foregroundColor(Rose._400)
+                            .foregroundColor(Danger._400)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.vertical, VSpacing.xxs)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.pill)
-                                    .fill(Rose._500.opacity(0.12))
+                                    .fill(Danger._500.opacity(0.12))
                             )
                         }
                         .buttonStyle(.plain)
@@ -66,19 +66,19 @@ struct SubagentDetailPanel: View {
                     HStack(alignment: .top, spacing: VSpacing.xs) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 11))
-                            .foregroundColor(Rose._500)
+                            .foregroundColor(Danger._500)
                         Text(error)
                             .font(VFont.caption)
-                            .foregroundColor(Rose._400)
+                            .foregroundColor(Danger._400)
                     }
                     .padding(VSpacing.sm)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(Rose._500.opacity(0.08))
+                            .fill(Danger._500.opacity(0.08))
                             .overlay(
                                 RoundedRectangle(cornerRadius: VRadius.md)
-                                    .strokeBorder(Rose._500.opacity(0.2), lineWidth: 1)
+                                    .strokeBorder(Danger._500.opacity(0.2), lineWidth: 1)
                             )
                     )
                 }
@@ -135,7 +135,7 @@ struct SubagentDetailPanel: View {
     private func statusColor(_ status: SubagentStatus) -> Color {
         switch status {
         case .completed: return Emerald._500
-        case .failed, .aborted: return Rose._500
+        case .failed, .aborted: return Danger._500
         case .running: return Violet._500
         default: return Slate._400
         }
@@ -193,9 +193,9 @@ struct SubagentDetailPanel: View {
         case .toolUse:
             label(icon: "wrench.fill", text: "TOOL CALL", color: Violet._400)
         case .toolResult(let isError):
-            label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Rose._400 : Emerald._400)
+            label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Danger._400 : Emerald._400)
         case .error:
-            label(icon: "exclamationmark.triangle.fill", text: "ERROR", color: Rose._500)
+            label(icon: "exclamationmark.triangle.fill", text: "ERROR", color: Danger._500)
         }
     }
 
@@ -262,16 +262,16 @@ struct SubagentDetailPanel: View {
         case .error:
             Text(event.content)
                 .font(VFont.caption)
-                .foregroundColor(Rose._400)
+                .foregroundColor(Danger._400)
                 .textSelection(.enabled)
                 .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(Rose._500.opacity(0.08))
+                        .fill(Danger._500.opacity(0.08))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.md)
-                                .strokeBorder(Rose._500.opacity(0.15), lineWidth: 1)
+                                .strokeBorder(Danger._500.opacity(0.15), lineWidth: 1)
                         )
                 )
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -136,8 +136,8 @@ struct SubagentDetailPanel: View {
         switch status {
         case .completed: return Emerald._500
         case .failed, .aborted: return Danger._500
-        case .running: return Violet._500
-        default: return Slate._400
+        case .running: return Forest._500
+        default: return Moss._400
         }
     }
 
@@ -189,9 +189,9 @@ struct SubagentDetailPanel: View {
     private func eventLabel(for kind: SubagentEventItem.Kind) -> some View {
         switch kind {
         case .text:
-            label(icon: "text.bubble.fill", text: "RESPONSE", color: Indigo._400)
+            label(icon: "text.bubble.fill", text: "RESPONSE", color: Forest._400)
         case .toolUse:
-            label(icon: "wrench.fill", text: "TOOL CALL", color: Violet._400)
+            label(icon: "wrench.fill", text: "TOOL CALL", color: Forest._400)
         case .toolResult(let isError):
             label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? Danger._400 : Emerald._400)
         case .error:
@@ -226,7 +226,7 @@ struct SubagentDetailPanel: View {
             HStack(spacing: VSpacing.xs) {
                 Text(name)
                     .font(VFont.captionMedium)
-                    .foregroundColor(Violet._300)
+                    .foregroundColor(Forest._300)
                 if !event.content.isEmpty {
                     Text(event.content)
                         .font(VFont.monoSmall)
@@ -239,10 +239,10 @@ struct SubagentDetailPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(Violet._500.opacity(0.06))
+                    .fill(Forest._500.opacity(0.06))
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(Violet._500.opacity(0.12), lineWidth: 1)
+                            .strokeBorder(Forest._500.opacity(0.12), lineWidth: 1)
                     )
             )
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -80,7 +80,7 @@ struct TraceRowView: View {
         case "success":
             return Emerald._400
         default:
-            return Slate._400
+            return Moss._400
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -74,7 +74,7 @@ struct TraceRowView: View {
     private var statusColor: Color {
         switch event.status {
         case "error":
-            return Rose._500
+            return Danger._500
         case "warning":
             return Amber._500
         case "success":

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -121,7 +121,7 @@ struct TraceTimelineView: View {
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
-                        .foregroundColor(Rose._500)
+                        .foregroundColor(Danger._500)
                 }
 
                 Rectangle()
@@ -151,7 +151,7 @@ struct TraceTimelineView: View {
         case .completed: return Emerald._400
         case .cancelled: return Amber._500
         case .handedOff: return Forest._400
-        case .error: return Rose._500
+        case .error: return Danger._500
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -80,7 +80,7 @@ struct TraceTimelineView: View {
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .foregroundColor(Amber._500)
-                        .background(Moss._800)
+                        .background(Moss._700)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.sm)
@@ -204,7 +204,7 @@ struct TraceTimelineView: View {
                 .padding(.leading, 26)
                 .padding(.vertical, VSpacing.xs)
                 .padding(.trailing, VSpacing.sm)
-                .background(Moss._800.opacity(0.5))
+                .background(Moss._700.opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -117,7 +117,7 @@ struct TraceTimelineView: View {
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
                         .font(VFont.small)
-                        .foregroundColor(Sage._400)
+                        .foregroundColor(Forest._400)
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
@@ -150,7 +150,7 @@ struct TraceTimelineView: View {
         case .active: return Emerald._400
         case .completed: return Emerald._400
         case .cancelled: return Amber._500
-        case .handedOff: return Sage._400
+        case .handedOff: return Forest._400
         case .error: return Rose._500
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -80,7 +80,7 @@ struct TraceTimelineView: View {
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .foregroundColor(Amber._500)
-                        .background(Slate._800)
+                        .background(Moss._800)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.sm)
@@ -204,7 +204,7 @@ struct TraceTimelineView: View {
                 .padding(.leading, 26)
                 .padding(.vertical, VSpacing.xs)
                 .padding(.trailing, VSpacing.sm)
-                .background(Slate._800.opacity(0.5))
+                .background(Moss._800.opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -122,9 +122,9 @@ struct APIKeyStepView: View {
                 }
                 Spacer()
                 Circle()
-                    .fill(isSelected ? Sage._600 : Color.clear)
+                    .fill(isSelected ? Forest._600 : Color.clear)
                     .overlay(
-                        Circle().stroke(isSelected ? Sage._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                        Circle().stroke(isSelected ? Forest._600 : VColor.surfaceBorder, lineWidth: 1.5)
                     )
                     .overlay(
                         isSelected
@@ -138,10 +138,10 @@ struct APIKeyStepView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Sage._600.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? Forest._600.opacity(0.1) : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Sage._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                            .stroke(isSelected ? Forest._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
                     )
             )
         }
@@ -206,11 +206,11 @@ struct APIKeyStepView: View {
                         .fill(primaryButtonDisabled
                             ? adaptiveColor(
                                 light: Stone._900.opacity(0.3),
-                                dark: Sage._600.opacity(0.3)
+                                dark: Forest._600.opacity(0.3)
                             )
                             : adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             )
                         )
                 )

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -254,7 +254,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.aws.amazon.com/iam/home#/roles")!) {
                 Text("Open AWS IAM Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Sage._400))
+                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
             }
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
@@ -300,7 +300,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.cloud.google.com/iam-admin/serviceaccounts")!) {
                 Text("Open Google Cloud Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Sage._400))
+                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
             }
             .onHover { hovering in
                 if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
@@ -354,7 +354,7 @@ struct CloudCredentialsStepView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "doc.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Sage._600))
+                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Forest._600))
                 Text(fileName)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
@@ -375,7 +375,7 @@ struct CloudCredentialsStepView: View {
             .padding(.vertical, VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Sage._600.opacity(0.3)), lineWidth: 1)
+                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3)), lineWidth: 1)
             )
         }
     }
@@ -436,11 +436,11 @@ struct CloudCredentialsStepView: View {
                         .fill(continueDisabled
                             ? adaptiveColor(
                                 light: Stone._900.opacity(0.3),
-                                dark: Sage._600.opacity(0.3)
+                                dark: Forest._600.opacity(0.3)
                             )
                             : adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             )
                         )
                 )

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
@@ -24,7 +24,7 @@ struct CapabilitiesModalView: View {
 
                     sectionView(
                         icon: "shield.lefthalf.filled",
-                        iconColor: Rose._500,
+                        iconColor: Danger._500,
                         title: "What I won\u{2019}t do",
                         items: [
                             "Act without asking when something\u{2019}s irreversible",

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesModalView.swift
@@ -36,7 +36,7 @@ struct CapabilitiesModalView: View {
 
                     sectionView(
                         icon: "car.fill",
-                        iconColor: Sage._500,
+                        iconColor: Forest._500,
                         title: "How control works",
                         items: [
                             "You\u{2019}re always in the driver\u{2019}s seat",

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -98,7 +98,7 @@ struct FnKeyStepView: View {
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
                                     light: Stone._900,
-                                    dark: Sage._600
+                                    dark: Forest._600
                                 ))
                         )
                 }
@@ -118,7 +118,7 @@ struct FnKeyStepView: View {
                             RoundedRectangle(cornerRadius: VRadius.lg)
                                 .fill(adaptiveColor(
                                     light: Stone._900,
-                                    dark: Sage._600
+                                    dark: Forest._600
                                 ))
                         )
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -55,7 +55,6 @@ struct CreatureView: View {
 
     private var dinoImage: some View {
         Image(nsImage: blobImage)
-            .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 400, height: 360)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
@@ -59,7 +59,6 @@ struct EvolvingAvatarView: View {
     @ViewBuilder
     private var avatarImage: some View {
         Image(nsImage: blobImage)
-            .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 400, height: 360)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelArtData.swift
@@ -25,8 +25,8 @@ enum PixelArtData {
     static let dP: UInt32 = 0x1E293B // pupil
 
     // Dino accents
-    static let cK: UInt32 = 0xF99AAE // cheek pink (Rose._400)
-    static let tR: UInt32 = 0xF06A86 // tongue (Rose._500)
+    static let cK: UInt32 = 0xF99AAE // cheek pink (Danger._400)
+    static let tR: UInt32 = 0xF06A86 // tongue (Danger._500)
     static let wA: UInt32 = 0xFDD94E // wing light (Amber._400)
     static let wB: UInt32 = 0xFAC426 // wing mid (Amber._500)
     static let wC: UInt32 = 0xE8A020 // wing dark (Amber._600)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
@@ -152,10 +152,66 @@ enum PixelSpriteBuilder {
 
     // MARK: - NSImage for SwiftUI
 
-    /// Builds an NSImage of the blob pixel art with a custom palette.
+    /// Builds an NSImage of the minimalist avatar face.
+    /// Renders a warm beige/cream circle with two small dark eyes and a small dark mouth.
+    /// The `pixelSize` parameter controls overall scale (higher = larger image).
+    /// The `palette` parameter is accepted for API compatibility but the face uses
+    /// fixed warm-neutral colors that work in both light and dark mode.
     static func buildBlobNSImage(pixelSize: CGFloat, palette: DinoPalette) -> NSImage {
-        let grid = PixelArtData.blob(palette: palette)
-        return buildNSImage(from: grid, pixelSize: pixelSize)
+        // Scale factor: the old blob grid was 26 wide, so size ~ 26 * pixelSize
+        let diameter = 26.0 * pixelSize
+        let size = NSSize(width: diameter, height: diameter)
+        let image = NSImage(size: size)
+        image.lockFocus()
+
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            image.unlockFocus()
+            return image
+        }
+
+        let radius = diameter / 2.0
+
+        // Background circle: warm beige/cream (#F5F5F4 = Stone._100)
+        context.setFillColor(red: 0xF5 / 255.0, green: 0xF5 / 255.0, blue: 0xF4 / 255.0, alpha: 1.0)
+        context.fillEllipse(in: CGRect(x: 0, y: 0, width: diameter, height: diameter))
+
+        // Feature color: dark warm gray (#44403C = Stone._800)
+        let featureR: CGFloat = 0x44 / 255.0
+        let featureG: CGFloat = 0x40 / 255.0
+        let featureB: CGFloat = 0x3C / 255.0
+        context.setFillColor(red: featureR, green: featureG, blue: featureB, alpha: 1.0)
+
+        // Eyes: two small circles, horizontally centered, slightly above vertical center
+        let eyeRadius = diameter * 0.07
+        let eyeY = radius + radius * 0.12  // slightly above center (CG y-up)
+        let eyeSpacing = diameter * 0.22
+        // Left eye
+        context.fillEllipse(in: CGRect(
+            x: radius - eyeSpacing - eyeRadius,
+            y: eyeY - eyeRadius,
+            width: eyeRadius * 2,
+            height: eyeRadius * 2
+        ))
+        // Right eye
+        context.fillEllipse(in: CGRect(
+            x: radius + eyeSpacing - eyeRadius,
+            y: eyeY - eyeRadius,
+            width: eyeRadius * 2,
+            height: eyeRadius * 2
+        ))
+
+        // Mouth: one small circle, centered below eyes
+        let mouthRadius = diameter * 0.05
+        let mouthY = radius - radius * 0.18  // below center (CG y-up)
+        context.fillEllipse(in: CGRect(
+            x: radius - mouthRadius,
+            y: mouthY - mouthRadius,
+            width: mouthRadius * 2,
+            height: mouthRadius * 2
+        ))
+
+        image.unlockFocus()
+        return image
     }
 
     /// Renders any pixel grid into an NSImage.

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -57,7 +57,7 @@ struct ModelSelectionStepView: View {
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .fill(adaptiveColor(
                                 light: Stone._900,
-                                dark: Sage._600
+                                dark: Forest._600
                             ))
                     )
             }
@@ -109,9 +109,9 @@ struct ModelSelectionStepView: View {
                 }
                 Spacer()
                 Circle()
-                    .fill(isSelected ? Sage._600 : Color.clear)
+                    .fill(isSelected ? Forest._600 : Color.clear)
                     .overlay(
-                        Circle().stroke(isSelected ? Sage._600 : VColor.surfaceBorder, lineWidth: 1.5)
+                        Circle().stroke(isSelected ? Forest._600 : VColor.surfaceBorder, lineWidth: 1.5)
                     )
                     .overlay(
                         isSelected
@@ -125,10 +125,10 @@ struct ModelSelectionStepView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? Sage._600.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? Forest._600.opacity(0.1) : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? Sage._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
+                            .stroke(isSelected ? Forest._600.opacity(0.5) : VColor.surfaceBorder, lineWidth: 1)
                     )
             )
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -26,8 +26,8 @@ struct OnboardingFlowView: View {
                     .background(
                         RadialGradient(
                             colors: [
-                                adaptiveColor(light: Slate._100, dark: Slate._900),
-                                adaptiveColor(light: Slate._200, dark: Slate._950)
+                                adaptiveColor(light: Stone._100, dark: Moss._900),
+                                adaptiveColor(light: Stone._200, dark: Moss._950)
                             ],
                             center: .center,
                             startRadius: 0,
@@ -93,8 +93,8 @@ struct OnboardingFlowView: View {
                 .background(
                     RadialGradient(
                         colors: [
-                            adaptiveColor(light: Stone._100, dark: Slate._900),
-                            adaptiveColor(light: Stone._200, dark: Slate._950)
+                            adaptiveColor(light: Stone._100, dark: Moss._900),
+                            adaptiveColor(light: Stone._200, dark: Moss._950)
                         ],
                         center: .center,
                         startRadius: 0,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFooter.swift
@@ -25,7 +25,7 @@ struct OnboardingFooter: View {
             HStack(spacing: VSpacing.sm) {
                 ForEach(0..<totalDots, id: \.self) { index in
                     Circle()
-                        .fill(index <= activeDotIndex ? Sage._600 : VColor.textMuted.opacity(0.3))
+                        .fill(index <= activeDotIndex ? Forest._600 : VColor.textMuted.opacity(0.3))
                         .frame(width: 8, height: 8)
                         .animation(.spring(duration: 0.4, bounce: 0.2), value: activeDotIndex)
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,7 +144,7 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Slate._800.opacity(0.4)))
+                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._800.opacity(0.4)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,7 +144,7 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._800.opacity(0.4)))
+                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._700.opacity(0.4)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -224,7 +224,6 @@ struct TextResponseView: View {
 
     private var assistantAvatar: some View {
         Image(nsImage: appearance.chatAvatarImage)
-            .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 24, height: 24)
@@ -311,7 +310,6 @@ struct ConversationBubble: View {
 
     private var assistantAvatar: some View {
         Image(nsImage: appearance.chatAvatarImage)
-            .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 24, height: 24)

--- a/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
@@ -101,7 +101,6 @@ struct WorkspaceActivityFeed: View {
 
     private var assistantAvatar: some View {
         Image(nsImage: appearance.chatAvatarImage)
-            .interpolation(.none)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 24, height: 24)

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
@@ -270,17 +270,17 @@ struct VoiceModePanel: View {
         switch manager.state {
         case .listening: return VColor.accent
         case .speaking: return VColor.success
-        case .processing: return Violet._700
-        default: return Slate._600
+        case .processing: return Forest._700
+        default: return Moss._500
         }
     }
 
     private var orbGradient: [Color] {
         switch manager.state {
-        case .listening: return [Violet._500, Violet._700]
+        case .listening: return [Forest._500, Forest._700]
         case .speaking: return [Emerald._500, Emerald._700]
-        case .processing: return [Violet._600, Violet._800]
-        default: return [Slate._500, Slate._700]
+        case .processing: return [Forest._600, Forest._800]
+        default: return [Moss._500, Moss._400]
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -16,7 +16,6 @@ struct VoiceTranscriptionView: View {
                     .frame(width: circleSize, height: circleSize)
 
                 Image(nsImage: PixelSpriteBuilder.buildBlobNSImage(pixelSize: dinoPixelSize, palette: appearance.palette))
-                    .interpolation(.none)
             }
 
             Text("Listening")

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -1756,7 +1756,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   line-height: 1.4;
 }
 
-/* Gradient Text — forest→sage text fill */
+/* Gradient Text — forest gradient text fill */
 .v-gradient-text {
   background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-forest-300) 100%);
   -webkit-background-clip: text;

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -156,7 +156,7 @@
   :root {
     --v-bg:             var(--v-moss-950);
     --v-surface:        var(--v-moss-700);
-    --v-surface-border: var(--v-moss-700);
+    --v-surface-border: var(--v-moss-600);
     --v-text:           var(--v-moss-50);
     --v-text-secondary: var(--v-moss-400);
     --v-text-muted:     var(--v-moss-500);

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -103,8 +103,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
-  --v-user-bubble:    var(--v-forest-100);
-  --v-user-bubble-text: var(--v-stone-900);
+  --v-user-bubble:    var(--v-forest-800);
+  --v-user-bubble-text: #ffffff;
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
@@ -163,7 +163,7 @@
     --v-text-muted:     var(--v-moss-500);
 
     --v-user-bubble:    var(--v-forest-900);
-    --v-user-bubble-text: var(--v-moss-100);
+    --v-user-bubble-text: var(--v-moss-50);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -69,17 +69,17 @@
   --v-indigo-200: #D8D8FF;
   --v-indigo-100: #EEEEFF;
 
-  /* ── Palette: Rose ──────────────────────────────────────────── */
-  --v-rose-950: #620F21;
-  --v-rose-900: #85142F;
-  --v-rose-800: #A8183E;
-  --v-rose-700: #D02050;
-  --v-rose-600: #E84060;
-  --v-rose-500: #F06A86;
-  --v-rose-400: #F99AAE;
-  --v-rose-300: #FCBFC9;
-  --v-rose-200: #FFE1E6;
-  --v-rose-100: #FFF1F3;
+  /* ── Palette: Danger ─────────────────────────────────────────── */
+  --v-danger-950: #620F21;
+  --v-danger-900: #85142F;
+  --v-danger-800: #A8183E;
+  --v-danger-700: #D02050;
+  --v-danger-600: #E84060;
+  --v-danger-500: #F06A86;
+  --v-danger-400: #F99AAE;
+  --v-danger-300: #FCBFC9;
+  --v-danger-200: #FFE1E6;
+  --v-danger-100: #FFF1F3;
 
   /* ── Palette: Amber ─────────────────────────────────────────── */
   --v-amber-950: #5E3207;
@@ -103,7 +103,7 @@
   --v-accent:         var(--v-violet-600);
   --v-accent-hover:   var(--v-violet-700);
   --v-success:        var(--v-emerald-600);
-  --v-danger:         var(--v-rose-600);
+  --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
 
   /* ── Spacing (4pt grid) ─────────────────────────────────────── */

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -115,6 +115,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
+  --v-user-bubble:    var(--v-forest-100);
+  --v-user-bubble-text: var(--v-stone-900);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
@@ -171,6 +173,9 @@
     --v-text:           var(--v-moss-50);
     --v-text-secondary: var(--v-moss-400);
     --v-text-muted:     var(--v-moss-500);
+
+    --v-user-bubble:    var(--v-forest-900);
+    --v-user-bubble-text: var(--v-moss-100);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -103,8 +103,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
-  --v-user-bubble:    var(--v-forest-800);
-  --v-user-bubble-text: #ffffff;
+  --v-user-bubble:    var(--v-moss-300);
+  --v-user-bubble-text: var(--v-stone-900);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -58,18 +58,6 @@
   --v-forest-200: #B5E1BC;
   --v-forest-100: #E2F4E5;
 
-  /* ── Palette: Sage ───────────────────────────────────────── */
-  --v-sage-950: #1A2316;
-  --v-sage-900: #2A3825;
-  --v-sage-800: #3D4F36;
-  --v-sage-700: #516748;
-  --v-sage-600: #657D5B;
-  --v-sage-500: #7A8B6F;
-  --v-sage-400: #98A88F;
-  --v-sage-300: #B5C3AE;
-  --v-sage-200: #D4DFD0;
-  --v-sage-100: #EDF2EB;
-
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
   --v-emerald-900: #0A5843;
@@ -1557,7 +1545,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 /* Hero — top-of-page banner with gradient background */
 .v-hero {
   position: relative;
-  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-sage-950) 100%);
+  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-forest-900) 100%);
   border-radius: var(--v-radius-xl);
   padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
   text-align: center;
@@ -1654,7 +1642,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   top: var(--v-spacing-lg);
   bottom: var(--v-spacing-lg);
   width: 3px;
-  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-sage-600) 100%);
+  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-forest-400) 100%);
   border-radius: var(--v-radius-pill);
 }
 .v-pullquote-text {
@@ -1770,7 +1758,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 
 /* Gradient Text — forest→sage text fill */
 .v-gradient-text {
-  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-sage-500) 100%);
+  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-forest-300) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -34,9 +34,8 @@
   --v-stone-50:  #FAFAF9;
 
   /* ── Palette: Moss (warm neutral, dark mode) ─────────────── */
-  --v-moss-950: #262624;
+  --v-moss-950: #20201E;
   --v-moss-900: #2A2A28;
-  --v-moss-800: #2F2F2D;
   --v-moss-700: #3A3A37;
   --v-moss-600: #4A4A46;
   --v-moss-500: #6B6B65;
@@ -46,17 +45,17 @@
   --v-moss-100: #E8E6DA;
   --v-moss-50:  #F5F3EB;
 
-  /* ── Palette: Forest (green accent, dark mode) ───────────── */
-  --v-forest-950: #0A2A14;
-  --v-forest-900: #123D1F;
-  --v-forest-800: #18522A;
-  --v-forest-700: #1C5F30;
-  --v-forest-600: #216C37;
-  --v-forest-500: #3A8A4F;
-  --v-forest-400: #5AAB6A;
-  --v-forest-300: #85C991;
-  --v-forest-200: #B5E1BC;
-  --v-forest-100: #E2F4E5;
+  /* ── Palette: Forest / Sage (green accent, dark mode) ────── */
+  --v-forest-950: #1A2316;
+  --v-forest-900: #2A3825;
+  --v-forest-800: #3D4F36;
+  --v-forest-700: #516748;
+  --v-forest-600: #657D5B;
+  --v-forest-500: #7A8B6F;
+  --v-forest-400: #98A88F;
+  --v-forest-300: #B5C3AE;
+  --v-forest-200: #D4DFD0;
+  --v-forest-100: #EDF2EB;
 
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
@@ -71,16 +70,16 @@
   --v-emerald-100: #ECFDF5;
 
   /* ── Palette: Danger ─────────────────────────────────────────── */
-  --v-danger-950: #620F21;
-  --v-danger-900: #85142F;
-  --v-danger-800: #A8183E;
-  --v-danger-700: #D02050;
-  --v-danger-600: #E84060;
-  --v-danger-500: #F06A86;
-  --v-danger-400: #F99AAE;
-  --v-danger-300: #FCBFC9;
-  --v-danger-200: #FFE1E6;
-  --v-danger-100: #FFF1F3;
+  --v-danger-950: #4E281D;
+  --v-danger-900: #803017;
+  --v-danger-800: #AB3F1C;
+  --v-danger-700: #DA491A;
+  --v-danger-600: #E86B40;
+  --v-danger-500: #F39B74;
+  --v-danger-400: #F9C0A2;
+  --v-danger-300: #F7DAC9;
+  --v-danger-200: #FFE4D5;
+  --v-danger-100: #FFF3EE;
 
   /* ── Palette: Amber ─────────────────────────────────────────── */
   --v-amber-950: #5E3207;
@@ -156,7 +155,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --v-bg:             var(--v-moss-950);
-    --v-surface:        var(--v-moss-800);
+    --v-surface:        var(--v-moss-700);
     --v-surface-border: var(--v-moss-700);
     --v-text:           var(--v-moss-50);
     --v-text-secondary: var(--v-moss-400);

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -20,18 +20,55 @@
 /* ─── Layer 1: Tokens ────────────────────────────────────────── */
 
 :root {
-  /* ── Palette: Slate ─────────────────────────────────────────── */
-  --v-slate-950: #070D19;
-  --v-slate-900: #0F172A;
-  --v-slate-800: #1E293B;
-  --v-slate-700: #334155;
-  --v-slate-600: #475569;
-  --v-slate-500: #64748B;
-  --v-slate-400: #94A3B8;
-  --v-slate-300: #CBD5E1;
-  --v-slate-200: #E2E8F0;
-  --v-slate-100: #F1F5F9;
-  --v-slate-50:  #F8FAFC;
+  /* ── Palette: Stone (warm neutral, light mode) ─────────────── */
+  --v-stone-950: #1C1917;
+  --v-stone-900: #292524;
+  --v-stone-800: #44403C;
+  --v-stone-700: #57534E;
+  --v-stone-600: #78716C;
+  --v-stone-500: #97918B;
+  --v-stone-400: #A8A29E;
+  --v-stone-300: #D6D3D1;
+  --v-stone-200: #E7E5E4;
+  --v-stone-100: #F5F5F4;
+  --v-stone-50:  #FAFAF9;
+
+  /* ── Palette: Moss (warm neutral, dark mode) ─────────────── */
+  --v-moss-950: #262624;
+  --v-moss-900: #2A2A28;
+  --v-moss-800: #2F2F2D;
+  --v-moss-700: #3A3A37;
+  --v-moss-600: #4A4A46;
+  --v-moss-500: #6B6B65;
+  --v-moss-400: #A1A096;
+  --v-moss-300: #BDB9A9;
+  --v-moss-200: #D4D1C1;
+  --v-moss-100: #E8E6DA;
+  --v-moss-50:  #F5F3EB;
+
+  /* ── Palette: Forest (green accent, dark mode) ───────────── */
+  --v-forest-950: #0A2A14;
+  --v-forest-900: #123D1F;
+  --v-forest-800: #18522A;
+  --v-forest-700: #1C5F30;
+  --v-forest-600: #216C37;
+  --v-forest-500: #3A8A4F;
+  --v-forest-400: #5AAB6A;
+  --v-forest-300: #85C991;
+  --v-forest-200: #B5E1BC;
+  --v-forest-100: #E2F4E5;
+
+  /* ── Palette: Sage ───────────────────────────────────────── */
+  --v-sage-950: #1A2316;
+  --v-sage-900: #2A3825;
+  --v-sage-800: #3D4F36;
+  --v-sage-700: #516748;
+  --v-sage-600: #657D5B;
+  --v-sage-500: #7A8B6F;
+  --v-sage-400: #98A88F;
+  --v-sage-300: #B5C3AE;
+  --v-sage-200: #D4DFD0;
+  --v-sage-100: #EDF2EB;
 
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
@@ -44,30 +81,6 @@
   --v-emerald-300: #A6F2D1;
   --v-emerald-200: #D2F9E8;
   --v-emerald-100: #ECFDF5;
-
-  /* ── Palette: Violet ────────────────────────────────────────── */
-  --v-violet-950: #321669;
-  --v-violet-900: #4A2390;
-  --v-violet-800: #5C2FB2;
-  --v-violet-700: #7240CC;
-  --v-violet-600: #8A5BE0;
-  --v-violet-500: #9878EA;
-  --v-violet-400: #B8A6F1;
-  --v-violet-300: #D4C8F7;
-  --v-violet-200: #E8E1FB;
-  --v-violet-100: #F4F0FD;
-
-  /* ── Palette: Indigo ────────────────────────────────────────── */
-  --v-indigo-950: #180F66;
-  --v-indigo-900: #261A96;
-  --v-indigo-800: #3525C4;
-  --v-indigo-700: #4636E8;
-  --v-indigo-600: #5B4EFF;
-  --v-indigo-500: #7B6BFF;
-  --v-indigo-400: #9488FF;
-  --v-indigo-300: #B8B4FF;
-  --v-indigo-200: #D8D8FF;
-  --v-indigo-100: #EEEEFF;
 
   /* ── Palette: Danger ─────────────────────────────────────────── */
   --v-danger-950: #620F21;
@@ -100,8 +113,8 @@
   --v-text:           #1D1D1F;
   --v-text-secondary: #86868B;
   --v-text-muted:     #AEAEB2;
-  --v-accent:         var(--v-violet-600);
-  --v-accent-hover:   var(--v-violet-700);
+  --v-accent:         var(--v-forest-600);
+  --v-accent-hover:   var(--v-forest-700);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
@@ -152,12 +165,12 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --v-bg:             var(--v-slate-950);
-    --v-surface:        var(--v-slate-800);
-    --v-surface-border: var(--v-slate-700);
-    --v-text:           var(--v-slate-50);
-    --v-text-secondary: var(--v-slate-400);
-    --v-text-muted:     var(--v-slate-500);
+    --v-bg:             var(--v-moss-950);
+    --v-surface:        var(--v-moss-800);
+    --v-surface-border: var(--v-moss-700);
+    --v-text:           var(--v-moss-50);
+    --v-text-secondary: var(--v-moss-400);
+    --v-text-muted:     var(--v-moss-500);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
@@ -190,7 +203,7 @@ body > *:not(#vellum-bottom-fade):not(#vellum-branding):not(#v-toast-container) 
 @media (prefers-color-scheme: dark) {
   body {
     background:
-      radial-gradient(ellipse at 50% 0%, var(--v-slate-900) 0%, transparent 50%),
+      radial-gradient(ellipse at 50% 0%, var(--v-moss-900) 0%, transparent 50%),
       var(--v-bg);
   }
 }
@@ -1004,7 +1017,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   height: 36px;
   border-radius: 50%;
   background: var(--v-accent);
-  color: var(--v-slate-50);
+  color: var(--v-moss-50);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1539,7 +1552,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 /* Hero — top-of-page banner with gradient background */
 .v-hero {
   position: relative;
-  background: linear-gradient(135deg, var(--v-violet-950) 0%, var(--v-indigo-950) 100%);
+  background: linear-gradient(135deg, var(--v-forest-950) 0%, var(--v-sage-950) 100%);
   border-radius: var(--v-radius-xl);
   padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
   text-align: center;
@@ -1557,7 +1570,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   transform: translateX(-50%);
   width: 120%;
   height: 80%;
-  background: radial-gradient(ellipse, color-mix(in srgb, var(--v-violet-700) 30%, transparent) 0%, transparent 70%);
+  background: radial-gradient(ellipse, color-mix(in srgb, var(--v-forest-700) 30%, transparent) 0%, transparent 70%);
   pointer-events: none;
 }
 .v-hero-badge {
@@ -1572,13 +1585,13 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--v-slate-300);
+  color: var(--v-moss-300);
   position: relative;
 }
 .v-hero h1 {
   font-size: 2.5rem;
   font-weight: 800;
-  background: linear-gradient(180deg, #fff 30%, var(--v-slate-200) 100%);
+  background: linear-gradient(180deg, #fff 30%, var(--v-moss-200) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -1588,7 +1601,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 }
 .v-hero-subtitle {
   font-size: var(--v-font-size-base);
-  color: var(--v-slate-400);
+  color: var(--v-moss-400);
   max-width: 500px;
   margin: 0 auto;
   line-height: 1.5;
@@ -1636,7 +1649,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   top: var(--v-spacing-lg);
   bottom: var(--v-spacing-lg);
   width: 3px;
-  background: linear-gradient(180deg, var(--v-violet-600) 0%, var(--v-indigo-600) 100%);
+  background: linear-gradient(180deg, var(--v-forest-600) 0%, var(--v-sage-600) 100%);
   border-radius: var(--v-radius-pill);
 }
 .v-pullquote-text {
@@ -1750,9 +1763,9 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   line-height: 1.4;
 }
 
-/* Gradient Text — violet→indigo text fill */
+/* Gradient Text — forest→sage text fill */
 .v-gradient-text {
-  background: linear-gradient(135deg, var(--v-violet-500) 0%, var(--v-indigo-500) 100%);
+  background: linear-gradient(135deg, var(--v-forest-500) 0%, var(--v-sage-500) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -1975,7 +1988,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   opacity: 1 !important;
 }
 #vellum-branding a {
-  color: var(--v-accent, #6366f1);
+  color: var(--v-accent, #216C37);
   text-decoration: none;
   font-weight: 600;
   cursor: pointer;

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -117,7 +117,9 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered ? Forest._600 : Forest._800
+            return isHovered
+                ? adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._600)
+                : adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._800)
         case .danger:
             return isHovered ? Color(hex: 0xA53817) : Color(hex: 0x8A2F13)
         case .ghost:
@@ -128,9 +130,9 @@ private struct VButtonStyle: ButtonStyle {
     private func backgroundColor(isPressed: Bool) -> Color {
         switch style {
         case .primary:
-            if isPressed { return Forest._400 }
-            if isHovered { return Forest._500 }
-            return Forest._600
+            if isPressed { return adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._400) }
+            if isHovered { return adaptiveColor(light: Color(hex: 0x5A7B54), dark: Forest._500) }
+            return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._600)
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -117,7 +117,7 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered ? Sage._600 : Sage._800
+            return isHovered ? Forest._600 : Forest._800
         case .danger:
             return isHovered ? Color(hex: 0xA53817) : Color(hex: 0x8A2F13)
         case .ghost:
@@ -128,9 +128,9 @@ private struct VButtonStyle: ButtonStyle {
     private func backgroundColor(isPressed: Bool) -> Color {
         switch style {
         case .primary:
-            if isPressed { return Sage._400 }
-            if isHovered { return Sage._500 }
-            return Sage._600
+            if isPressed { return Forest._400 }
+            if isHovered { return Forest._500 }
+            return Forest._600
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }

--- a/clients/shared/DesignSystem/Core/Buttons/VCircleButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VCircleButton.swift
@@ -66,7 +66,7 @@ private struct VCircleButtonStyle: ButtonStyle {
         HStack(spacing: 12) {
             VCircleButton(icon: "phone.fill", label: "Phone") {}
             VCircleButton(icon: "phone.fill", label: "Phone", fillColor: Emerald._600.opacity(0.5)) {}
-            VCircleButton(icon: "plus", label: "Add", fillColor: Sage._500, size: 28, iconSize: 12) {}
+            VCircleButton(icon: "plus", label: "Add", fillColor: Forest._500, size: 28, iconSize: 12) {}
         }
         .padding()
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -90,18 +90,18 @@ public struct VSlider: View {
     private var thumbView: some View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.xs)
-                .fill(Sage._700)
+                .fill(Forest._700)
                 .frame(width: thumbWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.xs)
-                        .stroke(Sage._800, lineWidth: 1)
+                        .stroke(Forest._800, lineWidth: 1)
                 )
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(Sage._300)
+                        .fill(Forest._300)
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -44,7 +44,7 @@ public struct VToggle: View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
             RoundedRectangle(cornerRadius: VRadius.sm + 2)
-                .fill(isOn ? Emerald._500 : VColor.toggleOff)
+                .fill(isOn ? Forest._600 : VColor.toggleOff)
                 .frame(width: trackWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm + 2)

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -136,8 +136,8 @@ struct ButtonsGallerySection: View {
                         VCircleButton(icon: "mic.fill", label: "Record", size: 48, iconSize: 20) {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("Small (24pt, Rose)").font(VFont.caption).foregroundColor(VColor.textMuted)
-                        VCircleButton(icon: "xmark", label: "Close", fillColor: Rose._600, size: 24, iconSize: 10) {}
+                        Text("Small (24pt, Danger)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "xmark", label: "Close", fillColor: Danger._600, size: 24, iconSize: 10) {}
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -128,8 +128,8 @@ struct ButtonsGallerySection: View {
                         VCircleButton(icon: "plus", label: "Add") {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("Sage fill").font(VFont.caption).foregroundColor(VColor.textMuted)
-                        VCircleButton(icon: "phone.fill", label: "Call", fillColor: Sage._500) {}
+                        Text("Forest fill").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "phone.fill", label: "Call", fillColor: Forest._500) {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Large (48pt)").font(VFont.caption).foregroundColor(VColor.textMuted)

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -69,9 +69,9 @@ struct TokensGallerySection: View {
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
                         Emerald._500, Emerald._400, Emerald._300, Emerald._200, Emerald._100
                     ])
-                    colorScaleRow(name: "Rose", colors: [
-                        Rose._950, Rose._900, Rose._800, Rose._700, Rose._600,
-                        Rose._500, Rose._400, Rose._300, Rose._200, Rose._100
+                    colorScaleRow(name: "Danger", colors: [
+                        Danger._950, Danger._900, Danger._800, Danger._700, Danger._600,
+                        Danger._500, Danger._400, Danger._300, Danger._200, Danger._100
                     ])
                     colorScaleRow(name: "Amber", colors: [
                         Amber._950, Amber._900, Amber._800, Amber._700, Amber._600,

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -69,10 +69,6 @@ struct TokensGallerySection: View {
                         Forest._950, Forest._900, Forest._800, Forest._700, Forest._600,
                         Forest._500, Forest._400, Forest._300, Forest._200, Forest._100
                     ])
-                    colorScaleRow(name: "Sage", colors: [
-                        Sage._950, Sage._900, Sage._800, Sage._700, Sage._600,
-                        Sage._500, Sage._400, Sage._300, Sage._200, Sage._100
-                    ])
                     colorScaleRow(name: "Emerald", colors: [
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
                         Emerald._500, Emerald._400, Emerald._300, Emerald._200, Emerald._100

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -57,13 +57,21 @@ struct TokensGallerySection: View {
                         .font(VFont.headline)
                         .foregroundColor(VColor.textPrimary)
 
-                    colorScaleRow(name: "Slate", colors: [
-                        Slate._900, Slate._800, Slate._700, Slate._600, Slate._500,
-                        Slate._400, Slate._300, Slate._200, Slate._100, Slate._50
+                    colorScaleRow(name: "Stone", colors: [
+                        Stone._950, Stone._900, Stone._800, Stone._700, Stone._600,
+                        Stone._500, Stone._400, Stone._300, Stone._200, Stone._100
                     ])
-                    colorScaleRow(name: "Violet", colors: [
-                        Violet._950, Violet._900, Violet._800, Violet._700, Violet._600,
-                        Violet._500, Violet._400, Violet._300, Violet._200, Violet._100
+                    colorScaleRow(name: "Moss", colors: [
+                        Moss._950, Moss._900, Moss._800, Moss._700, Moss._600,
+                        Moss._500, Moss._400, Moss._300, Moss._200, Moss._100
+                    ])
+                    colorScaleRow(name: "Forest", colors: [
+                        Forest._950, Forest._900, Forest._800, Forest._700, Forest._600,
+                        Forest._500, Forest._400, Forest._300, Forest._200, Forest._100
+                    ])
+                    colorScaleRow(name: "Sage", colors: [
+                        Sage._950, Sage._900, Sage._800, Sage._700, Sage._600,
+                        Sage._500, Sage._400, Sage._300, Sage._200, Sage._100
                     ])
                     colorScaleRow(name: "Emerald", colors: [
                         Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
@@ -76,10 +84,6 @@ struct TokensGallerySection: View {
                     colorScaleRow(name: "Amber", colors: [
                         Amber._950, Amber._900, Amber._800, Amber._700, Amber._600,
                         Amber._500, Amber._400, Amber._300, Amber._200, Amber._100
-                    ])
-                    colorScaleRow(name: "Indigo", colors: [
-                        Indigo._950, Indigo._900, Indigo._800, Indigo._700, Indigo._600,
-                        Indigo._500, Indigo._400, Indigo._300, Indigo._200, Indigo._100
                     ])
                 }
             }

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -62,7 +62,7 @@ struct TokensGallerySection: View {
                         Stone._500, Stone._400, Stone._300, Stone._200, Stone._100
                     ])
                     colorScaleRow(name: "Moss", colors: [
-                        Moss._950, Moss._900, Moss._800, Moss._700, Moss._600,
+                        Moss._950, Moss._900, Moss._700, Moss._600,
                         Moss._500, Moss._400, Moss._300, Moss._200, Moss._100
                     ])
                     colorScaleRow(name: "Forest", colors: [

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -157,9 +157,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Forest._100, dark: Forest._900)
-    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._100)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._100.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Forest._800, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Color.white, dark: Moss._50)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Color.white.opacity(0.8), dark: Moss._50.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -38,20 +38,6 @@ public func adaptiveColor(light: Color, dark: Color) -> Color {
 
 // MARK: - Color Scales
 
-public enum Slate {
-    public static let _950 = Color(hex: 0x070D19)
-    public static let _900 = Color(hex: 0x0F172A)
-    public static let _800 = Color(hex: 0x1E293B)
-    public static let _700 = Color(hex: 0x334155)
-    public static let _600 = Color(hex: 0x475569)
-    public static let _500 = Color(hex: 0x64748B)
-    public static let _400 = Color(hex: 0x94A3B8)
-    public static let _300 = Color(hex: 0xCBD5E1)
-    public static let _200 = Color(hex: 0xE2E8F0)
-    public static let _100 = Color(hex: 0xF1F5F9)
-    public static let _50  = Color(hex: 0xF8FAFC)
-}
-
 public enum Emerald {
     public static let _950 = Color(hex: 0x073D2E)
     public static let _900 = Color(hex: 0x0A5843)
@@ -65,30 +51,17 @@ public enum Emerald {
     public static let _100 = Color(hex: 0xECFDF5)
 }
 
-public enum Violet {
-    public static let _950 = Color(hex: 0x321669)
-    public static let _900 = Color(hex: 0x4A2390)
-    public static let _800 = Color(hex: 0x5C2FB2)
-    public static let _700 = Color(hex: 0x7240CC)
-    public static let _600 = Color(hex: 0x8A5BE0)
-    public static let _500 = Color(hex: 0x9878EA)
-    public static let _400 = Color(hex: 0xB8A6F1)
-    public static let _300 = Color(hex: 0xD4C8F7)
-    public static let _200 = Color(hex: 0xE8E1FB)
-    public static let _100 = Color(hex: 0xF4F0FD)
-}
-
-public enum Indigo {
-    public static let _950 = Color(hex: 0x180F66)
-    public static let _900 = Color(hex: 0x261A96)
-    public static let _800 = Color(hex: 0x3525C4)
-    public static let _700 = Color(hex: 0x4636E8)
-    public static let _600 = Color(hex: 0x5B4EFF)
-    public static let _500 = Color(hex: 0x7B6BFF)
-    public static let _400 = Color(hex: 0x9488FF)
-    public static let _300 = Color(hex: 0xB8B4FF)
-    public static let _200 = Color(hex: 0xD8D8FF)
-    public static let _100 = Color(hex: 0xEEEEFF)
+public enum Sage {
+    public static let _950 = Color(hex: 0x1A2316)
+    public static let _900 = Color(hex: 0x2A3825)
+    public static let _800 = Color(hex: 0x3D4F36)
+    public static let _700 = Color(hex: 0x516748)
+    public static let _600 = Color(hex: 0x657D5B)
+    public static let _500 = Color(hex: 0x7A8B6F)
+    public static let _400 = Color(hex: 0x98A88F)
+    public static let _300 = Color(hex: 0xB5C3AE)
+    public static let _200 = Color(hex: 0xD4DFD0)
+    public static let _100 = Color(hex: 0xEDF2EB)
 }
 
 public enum Danger {

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -126,7 +126,7 @@ public enum Forest {
 
 public enum VColor {
     // Backgrounds
-    public static let background = adaptiveColor(light: .white, dark: Moss._950)
+    public static let background = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -51,19 +51,6 @@ public enum Emerald {
     public static let _100 = Color(hex: 0xECFDF5)
 }
 
-public enum Sage {
-    public static let _950 = Color(hex: 0x1A2316)
-    public static let _900 = Color(hex: 0x2A3825)
-    public static let _800 = Color(hex: 0x3D4F36)
-    public static let _700 = Color(hex: 0x516748)
-    public static let _600 = Color(hex: 0x657D5B)
-    public static let _500 = Color(hex: 0x7A8B6F)
-    public static let _400 = Color(hex: 0x98A88F)
-    public static let _300 = Color(hex: 0xB5C3AE)
-    public static let _200 = Color(hex: 0xD4DFD0)
-    public static let _100 = Color(hex: 0xEDF2EB)
-}
-
 public enum Danger {
     public static let _950 = Color(hex: 0x620F21)
     public static let _900 = Color(hex: 0x85142F)
@@ -181,4 +168,7 @@ public enum VColor {
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
     public static let toggleOff = adaptiveColor(light: Stone._300, dark: Moss._700)
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)
+
+    // Slash command highlight — green tint for /command tokens in composer and chat
+    public static let slashCommand = adaptiveColor(light: Forest._500, dark: Forest._300)
 }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -170,9 +170,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Stone._200, dark: Color(hex: 0x191919))
-    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._200)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._200.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Forest._100, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._100)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._100.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -52,16 +52,16 @@ public enum Emerald {
 }
 
 public enum Danger {
-    public static let _950 = Color(hex: 0x620F21)
-    public static let _900 = Color(hex: 0x85142F)
-    public static let _800 = Color(hex: 0xA8183E)
-    public static let _700 = Color(hex: 0xD02050)
-    public static let _600 = Color(hex: 0xE84060)
-    public static let _500 = Color(hex: 0xF06A86)
-    public static let _400 = Color(hex: 0xF99AAE)
-    public static let _300 = Color(hex: 0xFCBFC9)
-    public static let _200 = Color(hex: 0xFFE1E6)
-    public static let _100 = Color(hex: 0xFFF1F3)
+    public static let _950 = Color(hex: 0x4E281D)
+    public static let _900 = Color(hex: 0x803017)
+    public static let _800 = Color(hex: 0xAB3F1C)
+    public static let _700 = Color(hex: 0xDA491A)
+    public static let _600 = Color(hex: 0xE86B40)
+    public static let _500 = Color(hex: 0xF39B74)
+    public static let _400 = Color(hex: 0xF9C0A2)
+    public static let _300 = Color(hex: 0xF7DAC9)
+    public static let _200 = Color(hex: 0xFFE4D5)
+    public static let _100 = Color(hex: 0xFFF3EE)
 }
 
 public enum Amber {
@@ -96,9 +96,8 @@ public enum Stone {
 
 /// Warm neutral scale for dark mode backgrounds & text.
 public enum Moss {
-    public static let _950 = Color(hex: 0x262624)
+    public static let _950 = Color(hex: 0x20201E)
     public static let _900 = Color(hex: 0x2A2A28)
-    public static let _800 = Color(hex: 0x2F2F2D)
     public static let _700 = Color(hex: 0x3A3A37)
     public static let _600 = Color(hex: 0x4A4A46)
     public static let _500 = Color(hex: 0x6B6B65)
@@ -109,18 +108,18 @@ public enum Moss {
     public static let _50  = Color(hex: 0xF5F3EB)
 }
 
-/// Forest green accent scale for dark mode.
+/// Sage green accent scale for dark mode.
 public enum Forest {
-    public static let _950 = Color(hex: 0x0A2A14)
-    public static let _900 = Color(hex: 0x123D1F)
-    public static let _800 = Color(hex: 0x18522A)
-    public static let _700 = Color(hex: 0x1C5F30)
-    public static let _600 = Color(hex: 0x216C37)
-    public static let _500 = Color(hex: 0x3A8A4F)
-    public static let _400 = Color(hex: 0x5AAB6A)
-    public static let _300 = Color(hex: 0x85C991)
-    public static let _200 = Color(hex: 0xB5E1BC)
-    public static let _100 = Color(hex: 0xE2F4E5)
+    public static let _950 = Color(hex: 0x1A2316)
+    public static let _900 = Color(hex: 0x2A3825)
+    public static let _800 = Color(hex: 0x3D4F36)
+    public static let _700 = Color(hex: 0x516748)
+    public static let _600 = Color(hex: 0x657D5B)
+    public static let _500 = Color(hex: 0x7A8B6F)
+    public static let _400 = Color(hex: 0x98A88F)
+    public static let _300 = Color(hex: 0xB5C3AE)
+    public static let _200 = Color(hex: 0xD4DFD0)
+    public static let _100 = Color(hex: 0xEDF2EB)
 }
 
 // MARK: - Semantic Color Tokens
@@ -130,7 +129,7 @@ public enum VColor {
     public static let background = adaptiveColor(light: .white, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: .white, dark: Moss._950)
-    public static let surface = adaptiveColor(light: .white, dark: Moss._800)
+    public static let surface = adaptiveColor(light: .white, dark: Moss._700)
     public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._700)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)
 

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -78,19 +78,6 @@ public enum Violet {
     public static let _100 = Color(hex: 0xF4F0FD)
 }
 
-public enum Sage {
-    public static let _950 = Color(hex: 0x1A2316)
-    public static let _900 = Color(hex: 0x2A3825)
-    public static let _800 = Color(hex: 0x3D4F36)
-    public static let _700 = Color(hex: 0x516748)
-    public static let _600 = Color(hex: 0x657D5B)
-    public static let _500 = Color(hex: 0x7A8B6F)
-    public static let _400 = Color(hex: 0x98A88F)
-    public static let _300 = Color(hex: 0xB5C3AE)
-    public static let _200 = Color(hex: 0xD4DFD0)
-    public static let _100 = Color(hex: 0xEDF2EB)
-}
-
 public enum Indigo {
     public static let _950 = Color(hex: 0x180F66)
     public static let _900 = Color(hex: 0x261A96)
@@ -197,7 +184,7 @@ public enum VColor {
 
     // Send button — always green
     public static let sendButton = Color(hex: 0x216C37)
-    public static let accentSubtle = adaptiveColor(light: Sage._100, dark: Forest._900)
+    public static let accentSubtle = adaptiveColor(light: Forest._100, dark: Forest._900)
 
     // Onboarding accent (amber) — always dark theme
     public static let onboardingAccent = Amber._500

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -91,7 +91,7 @@ public enum Indigo {
     public static let _100 = Color(hex: 0xEEEEFF)
 }
 
-public enum Rose {
+public enum Danger {
     public static let _950 = Color(hex: 0x620F21)
     public static let _900 = Color(hex: 0x85142F)
     public static let _800 = Color(hex: 0xA8183E)
@@ -193,7 +193,7 @@ public enum VColor {
 
     // Status
     public static let success = adaptiveColor(light: Emerald._700, dark: Emerald._600)
-    public static let error = adaptiveColor(light: Rose._700, dark: Rose._600)
+    public static let error = adaptiveColor(light: Danger._700, dark: Danger._600)
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -128,7 +128,7 @@ public enum VColor {
     // Backgrounds
     public static let background = adaptiveColor(light: .white, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
-    public static let chatBackground = adaptiveColor(light: .white, dark: Moss._950)
+    public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)
     public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._700)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -130,7 +130,7 @@ public enum VColor {
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)
-    public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._700)
+    public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)
 
     // Text

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -157,9 +157,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Forest._800, dark: Forest._900)
-    public static let userBubbleText = adaptiveColor(light: Color.white, dark: Moss._50)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Color.white.opacity(0.8), dark: Moss._50.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Moss._300, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)

--- a/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
@@ -5,11 +5,11 @@ public enum Meadow {
     // Panel
     public static let panelBackground = adaptiveColor(
         light: Color.white.opacity(0.85),
-        dark: Slate._900.opacity(0.75)
+        dark: Moss._900.opacity(0.75)
     )
     public static let panelBorder = adaptiveColor(
         light: Stone._200.opacity(0.6),
-        dark: Slate._700.opacity(0.4)
+        dark: Moss._700.opacity(0.4)
     )
 
     // Egg glow

--- a/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/MeadowTokens.swift
@@ -30,8 +30,8 @@ public enum Meadow {
     public static let artPixelSize: CGFloat = 5.0
 
     // Interview palette
-    public static let avatarGradientStart = Sage._600
-    public static let avatarGradientEnd = Sage._400
-    public static let userBubbleGradientStart = Sage._600
-    public static let userBubbleGradientEnd = Sage._400
+    public static let avatarGradientStart = Forest._600
+    public static let avatarGradientEnd = Forest._400
+    public static let userBubbleGradientStart = Forest._600
+    public static let userBubbleGradientEnd = Forest._400
 }

--- a/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
@@ -23,7 +23,7 @@ public enum VShadow {
     /// Amber glow effect for brand elements (orb, highlights)
     public static let glow = Definition(color: Amber._500.opacity(0.3), radius: 12, x: 0, y: 0)
 
-    /// Violet glow for accent elements (focused inputs, active buttons)
+    /// Forest glow for accent elements (focused inputs, active buttons)
     public static let accentGlow = Definition(color: Forest._500.opacity(0.3), radius: 8, x: 0, y: 0)
 }
 

--- a/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
@@ -24,7 +24,7 @@ public enum VShadow {
     public static let glow = Definition(color: Amber._500.opacity(0.3), radius: 12, x: 0, y: 0)
 
     /// Violet glow for accent elements (focused inputs, active buttons)
-    public static let accentGlow = Definition(color: Sage._500.opacity(0.3), radius: 8, x: 0, y: 0)
+    public static let accentGlow = Definition(color: Forest._500.opacity(0.3), radius: 8, x: 0, y: 0)
 }
 
 public extension View {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -159,7 +159,7 @@ public struct InlineTaskProgressWidget: View {
                 .foregroundColor(Amber._500)
         case "failed":
             Image(systemName: "xmark.circle.fill")
-                .foregroundColor(Rose._500)
+                .foregroundColor(Danger._500)
         default:
             Image(systemName: "circle")
                 .foregroundColor(Slate._500)
@@ -175,7 +175,7 @@ public struct InlineTaskProgressWidget: View {
         case "waiting":
             return ("Waiting", "clock.fill", Amber._500)
         case "failed":
-            return ("Failed", "xmark.circle.fill", Rose._500)
+            return ("Failed", "xmark.circle.fill", Danger._500)
         default:
             return ("Pending", "circle", Slate._500)
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -114,7 +114,7 @@ public struct InlineTaskProgressWidget: View {
             ForEach(Array(data.steps.enumerated()), id: \.element.id) { index, step in
                 stepRow(step)
                 if index < data.steps.count - 1 {
-                    Divider().background(Slate._700.opacity(0.3))
+                    Divider().background(Moss._700.opacity(0.3))
                 }
             }
         }
@@ -162,7 +162,7 @@ public struct InlineTaskProgressWidget: View {
                 .foregroundColor(Danger._500)
         default:
             Image(systemName: "circle")
-                .foregroundColor(Slate._500)
+                .foregroundColor(Moss._500)
         }
     }
 
@@ -177,7 +177,7 @@ public struct InlineTaskProgressWidget: View {
         case "failed":
             return ("Failed", "xmark.circle.fill", Danger._500)
         default:
-            return ("Pending", "circle", Slate._500)
+            return ("Pending", "circle", Moss._500)
         }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -426,7 +426,7 @@ public struct InlineWeatherWidget: View {
                 Capsule()
                     .fill(
                         LinearGradient(
-                            colors: [Sage._400, Emerald._400],
+                            colors: [Forest._400, Emerald._400],
                             startPoint: .leading,
                             endPoint: .trailing
                         )
@@ -455,11 +455,11 @@ public struct InlineWeatherWidget: View {
         switch sfSymbol {
         case "sun.max.fill": return Amber._400
         case "cloud.sun.fill": return Amber._300
-        case "moon.fill": return Sage._200
-        case "cloud.moon.fill": return Sage._300
+        case "moon.fill": return Forest._200
+        case "cloud.moon.fill": return Forest._300
         case "cloud.fill": return Stone._400
-        case "cloud.rain.fill": return Sage._400
-        case "snowflake": return Sage._300
+        case "cloud.rain.fill": return Forest._400
+        case "snowflake": return Forest._300
         case "cloud.bolt.fill": return Amber._500
         case "cloud.fog.fill": return Stone._500
         default: return VColor.textSecondary

--- a/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -195,17 +195,17 @@ public struct InlineWeatherWidget: View {
         VStack(alignment: .leading, spacing: 0) {
             heroSection
             if !data.hourly.isEmpty {
-                Divider().background(Slate._700.opacity(0.3))
+                Divider().background(Moss._700.opacity(0.3))
                 hourlySection
             }
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
             dailyForecastHeader
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
 
             ForEach(Array(data.forecast.enumerated()), id: \.element.id) { index, item in
                 forecastRow(item, isFirst: index == 0)
                 if index < data.forecast.count - 1 {
-                    Divider().background(Slate._700.opacity(0.3))
+                    Divider().background(Moss._700.opacity(0.3))
                 }
             }
         }
@@ -312,7 +312,7 @@ public struct InlineWeatherWidget: View {
             }
             .padding(.vertical, VSpacing.sm)
 
-            Divider().background(Slate._700.opacity(0.3))
+            Divider().background(Moss._700.opacity(0.3))
 
             // Scrollable hourly row
             ScrollView(.horizontal, showsIndicators: false) {
@@ -419,7 +419,7 @@ public struct InlineWeatherWidget: View {
             ZStack(alignment: .leading) {
                 // Background track
                 Capsule()
-                    .fill(Slate._700.opacity(0.3))
+                    .fill(Moss._700.opacity(0.3))
                     .frame(height: 4)
 
                 // Filled portion with gradient

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,7 +31,7 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Moss._800)
+        .background(Moss._700)
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,7 +31,7 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Slate._800)
+        .background(Moss._800)
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -11,7 +11,7 @@ public struct SubagentStatusChip: View {
     private var statusColor: Color {
         switch subagent.status {
         case .completed: return Emerald._500
-        case .failed, .aborted: return Rose._500
+        case .failed, .aborted: return Danger._500
         default: return Violet._500
         }
     }
@@ -59,7 +59,7 @@ public struct SubagentStatusChip: View {
                 if let error = subagent.error, !error.isEmpty {
                     Text(error)
                         .font(VFont.caption)
-                        .foregroundColor(Rose._400)
+                        .foregroundColor(Danger._400)
                         .lineLimit(2)
                 }
             }

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -12,7 +12,7 @@ public struct SubagentStatusChip: View {
         switch subagent.status {
         case .completed: return Emerald._500
         case .failed, .aborted: return Danger._500
-        default: return Violet._500
+        default: return Forest._500
         }
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -614,7 +614,7 @@ public struct ToolConfirmationBubble: View {
                 .foregroundColor(isPrimary || isDanger ? .white : VColor.textSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs + 1)
-                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Sage._600 : Color.clear)
+                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Forest._600 : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)


### PR DESCRIPTION
## Summary
Complete design token overhaul to align the color system, sidebar, control center, avatar, and chat UI with Figma designs. Removes unused cool-toned scales, consolidates greens, restyles key UI components.

## Changes
- **M1:** Removed Slate, Violet, Indigo color scales — replaced with Stone/Moss/Forest (16 files)
- **M2:** Renamed Rose → Danger for semantic clarity (16 files)
- **M3:** Consolidated Sage into Forest — single green accent scale (21 files)
- **M4:** Updated user bubble to green (Forest._100 light / Forest._900 dark), toggle to Forest._600, added CSS variables
- **M5:** Final gallery cleanup — verified zero stale references, fixed one CSS comment
- **M6:** Updated initial avatar to minimalist geometric face (beige circle, dark eyes/mouth)
- **M7:** Restyled sidebar with rounded container (20pt corners), updated thread list (+button, pin icons, selection highlight, Show more in green)
- **M8:** Restyled control center with green-tinted capsule background, forest green icons/text, chevron-up
- **M9:** Chat UI polish — added VColor.slashCommand semantic token, removed last Sage enum and CSS palette

## Milestone PRs (merged into feature branch)
- #6102: M8 — Control center green-tinted restyle
- #6103: M3 — Consolidate Sage into Forest green scale
- #6104: M2 — Replace Rose with Danger color scale
- #6105: M7 — Side nav rounded container & thread list styling
- #6106: M6 — Update initial avatar UI
- #6107: M1 — Remove Slate, Violet, Indigo color scales
- #6109: M4 — Update user bubble & component colors per Figma
- #6110: M9 — Chat UI & message bubble styling per Figma
- #6111: M5 — Gallery cleanup & visual polish

## Project issue
Closes #5927

## Test plan
- [ ] Build with `cd clients/macos && ./build.sh run`
- [ ] Verify light mode: sidebar rounded container, green control center capsule, green user bubbles, correct text colors
- [ ] Verify dark mode: warm Moss backgrounds, Forest green accents, readable text on dark green bubbles
- [ ] Check avatar: simple geometric face (beige circle, dark eyes/mouth)
- [ ] Check thread list: + button, pin icons, selection highlight, Show more in green
- [ ] Check control center: green-tinted capsule, gear + text + chevron in forest green
- [ ] Check onboarding: buttons use Forest green, no Sage/Slate/Violet references
- [ ] Check gallery: only Stone, Moss, Forest, Emerald, Danger, Amber scales shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
