### PR TITLE
Add ps command to CLI

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -1,0 +1,92 @@
+import { loadAllAssistants } from "../lib/assistant-config";
+import { checkHealth } from "../lib/health-check";
+import { withStatusEmoji } from "../lib/status-emoji";
+
+interface TableRow {
+  name: string;
+  status: string;
+  info: string;
+}
+
+interface ColWidths {
+  name: number;
+  status: number;
+  info: number;
+}
+
+function pad(s: string, w: number): string {
+  return s + " ".repeat(Math.max(0, w - s.length));
+}
+
+function computeColWidths(rows: TableRow[]): ColWidths {
+  const headers: TableRow = { name: "NAME", status: "STATUS", info: "INFO" };
+  const all = [headers, ...rows];
+  return {
+    name: Math.max(...all.map((r) => r.name.length)),
+    status: Math.max(...all.map((r) => r.status.length), "checking...".length),
+    info: Math.max(...all.map((r) => r.info.length)),
+  };
+}
+
+function formatRow(r: TableRow, colWidths: ColWidths): string {
+  return `  ${pad(r.name, colWidths.name)}  ${pad(r.status, colWidths.status)}  ${r.info}`;
+}
+
+export async function ps(): Promise<void> {
+  const assistants = loadAllAssistants();
+
+  if (assistants.length === 0) {
+    console.log("No assistants found.");
+    return;
+  }
+
+  const rows: TableRow[] = assistants.map((a) => {
+    const infoParts = [a.runtimeUrl];
+    if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
+    if (a.species) infoParts.push(`species: ${a.species}`);
+
+    return {
+      name: a.assistantId,
+      status: withStatusEmoji("checking..."),
+      info: infoParts.join(" | "),
+    };
+  });
+
+  const colWidths = computeColWidths(rows);
+
+  const headers: TableRow = { name: "NAME", status: "STATUS", info: "INFO" };
+  console.log(formatRow(headers, colWidths));
+  const sep = `  ${"-".repeat(colWidths.name)}  ${"-".repeat(colWidths.status)}  ${"-".repeat(colWidths.info)}`;
+  console.log(sep);
+  for (const row of rows) {
+    console.log(formatRow(row, colWidths));
+  }
+
+  const totalDataRows = rows.length;
+
+  await Promise.all(
+    assistants.map(async (a, rowIndex) => {
+      const health = await checkHealth(a.runtimeUrl);
+
+      const infoParts = [a.runtimeUrl];
+      if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
+      if (a.species) infoParts.push(`species: ${a.species}`);
+      if (health.detail) infoParts.push(health.detail);
+
+      const updatedRow: TableRow = {
+        name: a.assistantId,
+        status: withStatusEmoji(health.status),
+        info: infoParts.join(" | "),
+      };
+
+      const linesUp = totalDataRows - rowIndex;
+      process.stdout.write(
+        `\x1b[${linesUp}A` +
+          `\r\x1b[K` +
+          formatRow(updatedRow, colWidths) +
+          `\n` +
+          (linesUp > 1 ? `\x1b[${linesUp - 1}B` : ""),
+      );
+    }),
+  );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env bun
 
 import { hatch } from "./commands/hatch";
+import { ps } from "./commands/ps";
 import { retire } from "./commands/retire";
 import { sleep } from "./commands/sleep";
 
 const commands = {
   hatch,
+  ps,
   retire,
   sleep,
 } as const;
@@ -21,6 +23,7 @@ async function main() {
     console.log("");
     console.log("Commands:");
     console.log("  hatch    Create a new assistant instance");
+    console.log("  ps       List assistants and their health status");
     console.log("  retire   Delete an assistant instance");
     console.log("  sleep    Stop the daemon process");
     process.exit(0);

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -89,6 +89,10 @@ export function removeAssistantEntry(assistantId: string): void {
   writeAssistants(entries.filter((e) => e.assistantId !== assistantId));
 }
 
+export function loadAllAssistants(): AssistantEntry[] {
+  return readAssistants();
+}
+
 export function saveAssistantEntry(entry: AssistantEntry): void {
   const entries = readAssistants();
   entries.unshift(entry);


### PR DESCRIPTION
## Summary
- Adds `vellum-cli ps` command that lists all registered assistants from `~/.vellum.lock.json`
- Shows NAME, STATUS, INFO table with live health check updates (ANSI in-place rewrite)
- Exports `loadAllAssistants()` from `assistant-config.ts`

## Test plan
- [ ] Run `vellum-cli ps` with assistants in the lockfile — verify table renders and health checks update in-place
- [ ] Run `vellum-cli ps` with no assistants — verify "No assistants found." message
- [ ] Run `vellum-cli --help` — verify `ps` appears in command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
