### PR TITLE
feat: add `wake` CLI command

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "bin": {

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -898,14 +898,7 @@ async function discoverPublicUrl(): Promise<string | undefined> {
   return undefined;
 }
 
-async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false): Promise<void> {
-  const instanceName =
-    name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
-
-  console.log(`🥚 Hatching local assistant: ${instanceName}`);
-  console.log(`   Species: ${species}`);
-  console.log("");
-
+export async function startLocalDaemon(): Promise<void> {
   if (process.env.VELLUM_DESKTOP_APP) {
     // When running inside the desktop app, the CLI owns the daemon lifecycle.
     // Find the vellum-daemon binary adjacent to the CLI binary.
@@ -1052,6 +1045,54 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
       child.on("error", reject);
     });
   }
+}
+
+export async function startGateway(): Promise<string> {
+  const publicUrl = await discoverPublicUrl();
+  if (publicUrl) {
+    console.log(`   Public URL: ${publicUrl}`);
+  }
+
+  console.log("🌐 Starting gateway...");
+  const gatewayDir = resolveGatewayDir();
+  const gatewayEnv: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    GATEWAY_RUNTIME_PROXY_ENABLED: "true",
+    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
+  };
+  const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
+  const ingressPublicBaseUrl =
+    workspaceIngressPublicBaseUrl
+    ?? normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL);
+  if (ingressPublicBaseUrl) {
+    gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressPublicBaseUrl;
+    console.log(`   Ingress URL: ${ingressPublicBaseUrl}`);
+    if (!workspaceIngressPublicBaseUrl) {
+      console.log("   (using INGRESS_PUBLIC_BASE_URL env fallback)");
+    }
+  }
+  if (publicUrl) gatewayEnv.GATEWAY_PUBLIC_URL = publicUrl;
+
+  const gateway = spawn("bun", ["run", "src/index.ts"], {
+    cwd: gatewayDir,
+    detached: true,
+    stdio: "ignore",
+    env: gatewayEnv,
+  });
+  gateway.unref();
+  console.log("✅ Gateway started\n");
+  return publicUrl || `http://localhost:${GATEWAY_PORT}`;
+}
+
+async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false): Promise<void> {
+  const instanceName =
+    name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
+
+  console.log(`🥚 Hatching local assistant: ${instanceName}`);
+  console.log(`   Species: ${species}`);
+  console.log("");
+
+  await startLocalDaemon();
 
   // The desktop app communicates with the daemon directly via Unix socket,
   // so the HTTP gateway is only needed for non-desktop (CLI) usage.
@@ -1061,40 +1102,7 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
     // No gateway needed — the macOS app uses DaemonClient over the Unix socket.
     runtimeUrl = "local";
   } else {
-    const publicUrl = await discoverPublicUrl();
-    if (publicUrl) {
-      console.log(`   Public URL: ${publicUrl}`);
-    }
-
-    console.log("🌐 Starting gateway...");
-    const gatewayDir = resolveGatewayDir();
-    const gatewayEnv: Record<string, string> = {
-      ...process.env as Record<string, string>,
-      GATEWAY_RUNTIME_PROXY_ENABLED: "true",
-      GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
-    };
-    const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
-    const ingressPublicBaseUrl =
-      workspaceIngressPublicBaseUrl
-      ?? normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL);
-    if (ingressPublicBaseUrl) {
-      gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressPublicBaseUrl;
-      console.log(`   Ingress URL: ${ingressPublicBaseUrl}`);
-      if (!workspaceIngressPublicBaseUrl) {
-        console.log("   (using INGRESS_PUBLIC_BASE_URL env fallback)");
-      }
-    }
-    if (publicUrl) gatewayEnv.GATEWAY_PUBLIC_URL = publicUrl;
-
-    const gateway = spawn("bun", ["run", "src/index.ts"], {
-      cwd: gatewayDir,
-      detached: true,
-      stdio: "ignore",
-      env: gatewayEnv,
-    });
-    gateway.unref();
-    console.log("✅ Gateway started\n");
-    runtimeUrl = publicUrl || `http://localhost:${GATEWAY_PORT}`;
+    runtimeUrl = await startGateway();
   }
 
   const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { startLocalDaemon, startGateway } from "./hatch";
+
+export async function wake(): Promise<void> {
+  const vellumDir = join(homedir(), ".vellum");
+  const pidFile = join(vellumDir, "vellum.pid");
+
+  // Check if daemon is already running
+  let daemonRunning = false;
+  if (existsSync(pidFile)) {
+    const pidStr = readFileSync(pidFile, "utf-8").trim();
+    const pid = parseInt(pidStr, 10);
+    if (!isNaN(pid)) {
+      try {
+        process.kill(pid, 0);
+        daemonRunning = true;
+        console.log(`Daemon already running (pid ${pid}).`);
+      } catch {
+        // Process not alive, will start below
+      }
+    }
+  }
+
+  if (!daemonRunning) {
+    await startLocalDaemon();
+  }
+
+  // Start gateway (non-desktop only)
+  if (!process.env.VELLUM_DESKTOP_APP) {
+    await startGateway();
+  }
+
+  console.log("✅ Wake complete.");
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,11 +3,13 @@
 import { hatch } from "./commands/hatch";
 import { retire } from "./commands/retire";
 import { sleep } from "./commands/sleep";
+import { wake } from "./commands/wake";
 
 const commands = {
   hatch,
   retire,
   sleep,
+  wake,
 } as const;
 
 type CommandName = keyof typeof commands;
@@ -23,6 +25,7 @@ async function main() {
     console.log("  hatch    Create a new assistant instance");
     console.log("  retire   Delete an assistant instance");
     console.log("  sleep    Stop the daemon process");
+    console.log("  wake     Start the daemon and gateway");
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary
- Adds a `wake` CLI command that starts the daemon and gateway without the full onboarding/provisioning steps of `hatch` — the inverse of `sleep`
- Extracts `startLocalDaemon()` and `startGateway()` from `hatchLocal()` as reusable exported functions so both `hatch` and `wake` share the same logic
- Registers `wake` in the CLI command list with help text

## Test plan
- [ ] `bun run src/index.ts --help` shows `wake` in the command list
- [ ] With a stopped daemon: `bun run src/index.ts wake` starts daemon and gateway
- [ ] With a running daemon: `bun run src/index.ts wake` prints "already running", starts gateway
- [ ] `sleep` then `wake` round-trip works
- [ ] `hatch` still works unchanged (refactoring is behavior-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
