### PR TITLE
fix: address review feedback from PRs #6118 and #6120

### DIFF
--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -6,8 +6,10 @@ public extension Notification.Name {
 
 /// Cross-platform session token storage using Keychain via APIKeyManager.
 /// Replaces the macOS-only `/usr/bin/security` CLI approach.
+/// Uses provider "session-token" to match the old keychain account name
+/// so existing macOS users' stored sessions are preserved after upgrade.
 public enum SessionTokenManager {
-    private static let provider = "platform-session-token"
+    private static let provider = "session-token"
 
     public static func getToken() -> String? {
         APIKeyManager.shared.getAPIKey(provider: provider)

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -118,7 +118,13 @@ public struct DaemonConfig {
         // Check for a stored runtime URL — if present, use HTTP transport
         if let runtimeUrl = UserDefaults.standard.string(forKey: "runtime_url"), !runtimeUrl.isEmpty {
             let bearerToken = APIKeyManager.shared.getAPIKey(provider: "runtime-bearer-token")
-            let conversationKey = UserDefaults.standard.string(forKey: "conversation_key") ?? UUID().uuidString
+            let conversationKey: String
+            if let stored = UserDefaults.standard.string(forKey: "conversation_key"), !stored.isEmpty {
+                conversationKey = stored
+            } else {
+                conversationKey = UUID().uuidString
+                UserDefaults.standard.set(conversationKey, forKey: "conversation_key")
+            }
             return DaemonConfig(transport: .http(baseURL: runtimeUrl, bearerToken: bearerToken, conversationKey: conversationKey))
         }
 

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -203,7 +203,12 @@ extension DaemonClient {
 
     #if os(macOS)
     func authenticate() async throws {
-        guard let token = readSessionToken() else {
+        // Try session-token file first, then fall back to transport's configured authToken
+        let transportToken: String? = {
+            if case .tcp(_, _, _, let t) = config.transport { return t }
+            return nil
+        }()
+        guard let token = readSessionToken() ?? transportToken else {
             throw AuthError.missingToken
         }
 


### PR DESCRIPTION
## Summary
- Fix SessionTokenManager keychain account name to preserve existing macOS sessions (both Codex and Devin flagged this on #6120)
- Persist generated conversationKey to UserDefaults for HTTP transport conversation continuity (Devin flagged on #6118)
- Honor configured authToken as fallback in macOS TCP transport authentication (Codex flagged on #6118)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
