### PR TITLE
feat: add platform login to iOS with two-path onboarding

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -21,6 +21,7 @@ final class ClientProvider: ObservableObject {
 @MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
     let clientProvider: ClientProvider
+    let authManager = AuthManager()
 
     override init() {
         self.clientProvider = ClientProvider(client: DaemonClient(config: .fromUserDefaults()))

--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -20,10 +20,10 @@ struct VellumAssistantApp: App {
         WindowGroup {
             Group {
                 if onboardingCompleted {
-                    ContentView()
+                    ContentView(authManager: appDelegate.authManager)
                         .environmentObject(appDelegate.clientProvider)
                 } else {
-                    OnboardingView(isCompleted: $onboardingCompleted)
+                    OnboardingView(isCompleted: $onboardingCompleted, authManager: appDelegate.authManager)
                 }
             }
             .preferredColorScheme(preferredScheme)

--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -37,6 +37,7 @@
             <key>CFBundleURLSchemes</key>
             <array>
                 <string>vellum</string>
+                <string>vellum-assistant</string>
             </array>
         </dict>
     </array>

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 
 struct ContentView: View {
     @EnvironmentObject var clientProvider: ClientProvider
+    @Bindable var authManager: AuthManager
 
     var body: some View {
         TabView {
@@ -30,17 +31,20 @@ struct ContentView: View {
                     Label("Identity", systemImage: "person.text.rectangle")
                 }
 
-            SettingsView()
+            SettingsView(authManager: authManager)
                 .environmentObject(clientProvider)
                 .tabItem {
                     Label("Settings", systemImage: "gear")
                 }
         }
+        .task {
+            await authManager.checkSession()
+        }
     }
 }
 
 #Preview {
-    ContentView()
+    ContentView(authManager: AuthManager())
         .environmentObject(ClientProvider(client: DaemonClient(config: .default)))
 }
 #endif

--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -1,0 +1,52 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+struct LoginView: View {
+    @Bindable var authManager: AuthManager
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            Spacer()
+
+            Text("✨")
+                .font(VFont.onboardingEmoji)
+
+            Text("Log in with Vellum")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+                .multilineTextAlignment(.center)
+
+            Text("Sign in to connect to your cloud assistant")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+
+            if let error = authManager.errorMessage {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+            }
+
+            Button {
+                Task { await authManager.startWorkOSLogin() }
+            } label: {
+                if authManager.isSubmitting {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text("Sign In")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(authManager.isSubmitting)
+
+            Spacer()
+        }
+        .padding(VSpacing.xl)
+    }
+}
+#endif

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -4,26 +4,41 @@ import VellumAssistantShared
 
 struct OnboardingView: View {
     @Binding var isCompleted: Bool
+    @Bindable var authManager: AuthManager
     @State private var currentStep = 0
 
-    // Steps: Welcome(0) → Daemon(1) → Permissions(2) → Ready(3)
+    // Steps: Welcome(0) → ChoosePath(1) → Login(2)/DaemonSetup(3) → Permissions(4) → Ready(5)
 
     var body: some View {
         TabView(selection: $currentStep) {
             WelcomeStep(onContinue: { currentStep = 1 })
                 .tag(0)
 
-            DaemonSetupStep(onContinue: { currentStep = 2 })
-                .tag(1)
+            ChoosePathStep(
+                onLoginWithVellum: { currentStep = 2 },
+                onConnectToMac: { currentStep = 3 }
+            )
+            .tag(1)
 
-            PermissionsStep(onContinue: { currentStep = 3 })
+            LoginView(authManager: authManager)
                 .tag(2)
 
-            ReadyStep(isCompleted: $isCompleted)
+            DaemonSetupStep(onContinue: { currentStep = 4 })
                 .tag(3)
+
+            PermissionsStep(onContinue: { currentStep = 5 })
+                .tag(4)
+
+            ReadyStep(isCompleted: $isCompleted)
+                .tag(5)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         .animation(.easeInOut, value: currentStep)
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                currentStep = 4
+            }
+        }
     }
 }
 
@@ -59,6 +74,76 @@ struct WelcomeStep: View {
     }
 }
 
+// MARK: - ChoosePathStep
+
+struct ChoosePathStep: View {
+    var onLoginWithVellum: () -> Void
+    var onConnectToMac: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            Spacer()
+
+            Text("How would you like to connect?")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: VSpacing.lg) {
+                Button(action: onLoginWithVellum) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Log in with Vellum")
+                                .font(VFont.bodyBold)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("Connect to your cloud assistant")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        Spacer()
+                        Image(systemName: "cloud")
+                            .foregroundColor(VColor.accent)
+                    }
+                    .padding(VSpacing.lg)
+                    .background(VColor.surface)
+                    .cornerRadius(VRadius.md)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                }
+
+                Button(action: onConnectToMac) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Connect to Mac")
+                                .font(VFont.bodyBold)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("Use your Mac's local daemon")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        Spacer()
+                        Image(systemName: "desktopcomputer")
+                            .foregroundColor(VColor.accent)
+                    }
+                    .padding(VSpacing.lg)
+                    .background(VColor.surface)
+                    .cornerRadius(VRadius.md)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                }
+            }
+            .padding(.horizontal, VSpacing.xl)
+
+            Spacer()
+        }
+        .padding(VSpacing.xl)
+    }
+}
+
 // MARK: - DaemonSetupStep
 
 struct DaemonSetupStep: View {
@@ -72,9 +157,6 @@ struct DaemonSetupStep: View {
     var body: some View {
         VStack(spacing: VSpacing.xl) {
             Spacer()
-
-            Text("🔌")
-                .font(VFont.onboardingEmoji)
 
             Text("Connect to Mac")
                 .font(VFont.title)
@@ -101,7 +183,7 @@ struct DaemonSetupStep: View {
                     .autocapitalization(.none)
                     .autocorrectionDisabled()
 
-                Text("Find the token at ~/.vellum/session-token on your Mac, or in Mac app → Settings → Daemon.")
+                Text("Find the token at ~/.vellum/session-token on your Mac, or in Mac app Settings.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .multilineTextAlignment(.center)
@@ -118,7 +200,6 @@ struct DaemonSetupStep: View {
                 UserDefaults.standard.set(portInt, forKey: UserDefaultsKeys.daemonPort)
                 if sessionToken.isEmpty {
                     _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
-                    // Also clear legacy UserDefaults key so migration can't resurrect it
                     UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.legacyDaemonToken)
                 } else {
                     _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
@@ -159,9 +240,6 @@ struct PermissionsStep: View {
         VStack(spacing: VSpacing.xl) {
             Spacer()
 
-            Text("🎤")
-                .font(VFont.onboardingEmoji)
-
             Text("Permissions")
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
@@ -198,9 +276,6 @@ struct ReadyStep: View {
         VStack(spacing: VSpacing.xl) {
             Spacer()
 
-            Text("🎉")
-                .font(VFont.onboardingEmoji)
-
             Text("You're All Set!")
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
@@ -222,6 +297,6 @@ struct ReadyStep: View {
 }
 
 #Preview {
-    OnboardingView(isCompleted: .constant(false))
+    OnboardingView(isCompleted: .constant(false), authManager: AuthManager())
 }
 #endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -4,11 +4,13 @@ import VellumAssistantShared
 
 struct SettingsView: View {
     @EnvironmentObject var clientProvider: ClientProvider
+    @Bindable var authManager: AuthManager
     @AppStorage(UserDefaultsKeys.appearanceMode) private var appearanceMode: String = "system"
 
     var body: some View {
         NavigationStack {
             Form {
+                AccountSection(authManager: authManager)
                 DaemonConnectionSection()
                 IntegrationsSection()
                 TrustRulesSection()
@@ -38,6 +40,49 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Account Section
+
+struct AccountSection: View {
+    @Bindable var authManager: AuthManager
+
+    var body: some View {
+        Section("Account") {
+            if let user = authManager.currentUser {
+                if let email = user.email {
+                    LabeledContent("Email", value: email)
+                }
+                if let display = user.display {
+                    LabeledContent("Name", value: display)
+                }
+                Button("Log Out", role: .destructive) {
+                    Task { await authManager.logout() }
+                }
+            } else {
+                Button {
+                    Task { await authManager.startWorkOSLogin() }
+                } label: {
+                    if authManager.isSubmitting {
+                        HStack {
+                            Text("Signing in...")
+                            Spacer()
+                            ProgressView()
+                        }
+                    } else {
+                        Text("Log in with Vellum")
+                    }
+                }
+                .disabled(authManager.isSubmitting)
+            }
+
+            if let error = authManager.errorMessage {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+    }
+}
+
 extension Bundle {
     var appVersion: String {
         infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
@@ -45,7 +90,7 @@ extension Bundle {
 }
 
 #Preview {
-    SettingsView()
+    SettingsView(authManager: AuthManager())
         .environmentObject(ClientProvider(client: DaemonClient(config: .fromUserDefaults())))
 }
 #endif


### PR DESCRIPTION
## Summary
- Add WorkOS OIDC login to iOS using the shared `AuthManager` from PR #6120
- Two-path onboarding: "Log in with Vellum" (cloud assistant) or "Connect to Mac" (local TCP daemon)
- Account section in Settings showing user email, name, and logout button
- Session state is restored across app launches via `AuthManager.checkSession()`

## Implementation
- `AuthManager` is created in `AppDelegate` and passed through `VellumAssistantApp` to both `OnboardingView` and `ContentView`
- `LoginView` — simple view with "Sign In" button that calls `authManager.startWorkOSLogin()`
- `ChoosePathStep` — two-card onboarding step offering cloud login or local Mac connection
- On successful login, `onChange(of: authManager.isAuthenticated)` advances onboarding to the permissions step
- `AccountSection` in `SettingsView` shows user info when authenticated, login button when not
- `vellum-assistant` URL scheme registered in Info.plist for ASWebAuthenticationSession callback

## Key Technical Choices
- **`@Bindable` for AuthManager** — AuthManager uses `@Observable`, so views bind with `@Bindable` (not `@ObservedObject`)
- **No auto-discovery yet** — the platform API doesn't expose runtime URLs to clients (the backend proxies runtime requests). Auto-discovery will be added when the platform supports it. For now, users configure the runtime URL manually or via the "Connect to Mac" path.
- **Session check on ContentView load** — `.task { await authManager.checkSession() }` restores auth state on every app launch

## Deferred Work
- Auto-discovery of assistant runtime URL after login (requires platform API changes)
- iMessage App Extension (PR 5)

<details>
<summary>Plan: IOS_CONNECTION_AUTH.md</summary>

$(cat .private/plans/IOS_CONNECTION_AUTH.md)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
