### PR TITLE
fix: handle auth loading state in onboarding and settings

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -34,6 +34,9 @@ struct OnboardingView: View {
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         .animation(.easeInOut, value: currentStep)
+        .task {
+            await authManager.checkSession()
+        }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
                 currentStep = 4

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -47,7 +47,13 @@ struct AccountSection: View {
 
     var body: some View {
         Section("Account") {
-            if let user = authManager.currentUser {
+            if authManager.isLoading {
+                HStack {
+                    Text("Checking session...")
+                    Spacer()
+                    ProgressView()
+                }
+            } else if let user = authManager.currentUser {
                 if let email = user.email {
                     LabeledContent("Email", value: email)
                 }

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -34,6 +34,11 @@ public final class AuthManager {
         return false
     }
 
+    public var isLoading: Bool {
+        if case .loading = state { return true }
+        return false
+    }
+
     public var currentUser: AllauthUser? {
         if case .authenticated(let user) = state { return user }
         return nil


### PR DESCRIPTION
## Summary
- Add `checkSession()` call in `OnboardingView` so relaunches during onboarding restore persisted auth and advance past the login step
- Add `isLoading` computed property to `AuthManager`
- Show "Checking session..." in `AccountSection` during loading state instead of prematurely showing the login button

Addresses review feedback on PR #6123 from Codex (onboarding not resumable across app relaunches) and Devin (login button race condition during `checkSession()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
