### PR TITLE
fix: add LoginView.swift to iOS Xcode project

### DIFF
--- a/clients/ios/vellum-assistant-ios.xcodeproj/project.pbxproj
+++ b/clients/ios/vellum-assistant-ios.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7B4CE559E79D5A61D91725B6 /* ChatViewModelIOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF70C2471B1A4D9574FC218B /* ChatViewModelIOSTests.swift */; };
 		7F96B79FD8BD30F7E0833168 /* InlineVideoEmbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C6F32737D9EE793FE0CC3F /* InlineVideoEmbedView.swift */; };
 		831E2260278404A3AA07ECCB /* MessageMediaEmbedsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6DA4FDE9AA57C723CC06AA /* MessageMediaEmbedsView.swift */; };
+		836EA14C137EA48A214A519E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA3496A6F3D741B4690BB86 /* LoginView.swift */; };
 		864657EF8C4B63FA518F6174 /* TrustRulesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F415E8AE00310C58BD65D /* TrustRulesSection.swift */; };
 		88E91BC08EF99C6D68C08BF9 /* background.png in Resources */ = {isa = PBXBuildFile; fileRef = DB16B16FAD390171DB879B88 /* background.png */; };
 		94892E15EB458399785C9B2B /* WorkspaceFileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505C277A9ED9027CA064DB10 /* WorkspaceFileSheet.swift */; };
@@ -73,6 +74,7 @@
 		DDED15E4C12EADF58BD0CA16 /* ChatTranscriptFormatterIOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptFormatterIOSTests.swift; sourceTree = "<group>"; };
 		E566C15A0B4BC68B2692544F /* HomeBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBaseView.swift; sourceTree = "<group>"; };
 		EEAAA98AE5EB03645C49AA68 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		EFA3496A6F3D741B4690BB86 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		F63F4587FF04E8540849A2A8 /* VellumIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumIntents.swift; sourceTree = "<group>"; };
 		F67E8033119EC7F1089E8688 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F835A2D424DED22906123993 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				6469D4E238ADC7A9CCCD3F0E /* IdentityView.swift */,
 				46C6F32737D9EE793FE0CC3F /* InlineVideoEmbedView.swift */,
 				2A1EFD5A3C08E7AD764FB62F /* InputBarView.swift */,
+				EFA3496A6F3D741B4690BB86 /* LoginView.swift */,
 				DA6DA4FDE9AA57C723CC06AA /* MessageMediaEmbedsView.swift */,
 				EEAAA98AE5EB03645C49AA68 /* OnboardingView.swift */,
 				BA17A2DA662CD75C73E4726C /* SettingsView.swift */,
@@ -306,6 +309,7 @@
 				7F96B79FD8BD30F7E0833168 /* InlineVideoEmbedView.swift in Sources */,
 				AADDAC2861DD3CB70D50C6AB /* InputBarView.swift in Sources */,
 				F6E66C2F942C26A210459312 /* IntegrationsSection.swift in Sources */,
+				836EA14C137EA48A214A519E /* LoginView.swift in Sources */,
 				831E2260278404A3AA07ECCB /* MessageMediaEmbedsView.swift in Sources */,
 				B61091E975453A5D9A073D5B /* OnboardingView.swift in Sources */,
 				E82000F70C38CD07957C2F0F /* PermissionRowView.swift in Sources */,


### PR DESCRIPTION
## Summary
- Regenerated `project.pbxproj` via xcodegen to include `LoginView.swift` which was added in PR #6123 but missing from the Xcode project file
- CI uses the committed pbxproj (not xcodegen), so the file wasn't being compiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
