### PR TITLE
feat: default iOS onboarding to Mac daemon connection

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -7,41 +7,26 @@ struct OnboardingView: View {
     @Bindable var authManager: AuthManager
     @State private var currentStep = 0
 
-    // Steps: Welcome(0) → ChoosePath(1) → Login(2)/DaemonSetup(3) → Permissions(4) → Ready(5)
+    // Steps: Welcome(0) → DaemonSetup(1) → Permissions(2) → Ready(3)
+    // Note: Cloud login path (ChoosePath/LoginView) is disabled until
+    // platform.vellum.ai is deployed. Re-enable when the platform is live.
 
     var body: some View {
         TabView(selection: $currentStep) {
             WelcomeStep(onContinue: { currentStep = 1 })
                 .tag(0)
 
-            ChoosePathStep(
-                onLoginWithVellum: { currentStep = 2 },
-                onConnectToMac: { currentStep = 3 }
-            )
-            .tag(1)
+            DaemonSetupStep(onContinue: { currentStep = 2 })
+                .tag(1)
 
-            LoginView(authManager: authManager)
+            PermissionsStep(onContinue: { currentStep = 3 })
                 .tag(2)
 
-            DaemonSetupStep(onContinue: { currentStep = 4 })
-                .tag(3)
-
-            PermissionsStep(onContinue: { currentStep = 5 })
-                .tag(4)
-
             ReadyStep(isCompleted: $isCompleted)
-                .tag(5)
+                .tag(3)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         .animation(.easeInOut, value: currentStep)
-        .task {
-            await authManager.checkSession()
-        }
-        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            if isAuthenticated {
-                currentStep = 4
-            }
-        }
     }
 }
 

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -10,7 +10,12 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                AccountSection(authManager: authManager)
+                // Account section hidden until platform.vellum.ai is deployed.
+                // Only show if the user is already authenticated (e.g. from a
+                // previous session) so they can see their info and log out.
+                if authManager.isAuthenticated {
+                    AccountSection(authManager: authManager)
+                }
                 DaemonConnectionSection()
                 IntegrationsSection()
                 TrustRulesSection()


### PR DESCRIPTION
## Summary
- Simplify iOS onboarding to Welcome → Daemon Setup → Permissions → Ready (removes cloud login path)
- Hide Account section in Settings unless already authenticated
- Cloud login (`platform.vellum.ai`) isn't deployed yet — auth code stays in place for re-enabling when the platform goes live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
