### PR TITLE
fix: improve wasm path resolution for compiled Bun binaries

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -90,7 +90,14 @@ function findWasmPath(pkg: string, file: string): string {
   const dir = import.meta.dirname ?? __dirname;
   const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
 
-  if (!existsSync(sourcePath) && dir.startsWith('/$bunfs/')) {
+  if (existsSync(sourcePath)) return sourcePath;
+
+  // Fallback: resolve from process.cwd() (the assistant/ directory).
+  // import.meta.dirname can resolve unexpectedly in compiled/daemon contexts.
+  const cwdPath = join(process.cwd(), 'node_modules', pkg, file);
+  if (existsSync(cwdPath)) return cwdPath;
+
+  if (dir.startsWith('/$bunfs/')) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(execDir, '..', 'Resources', file);


### PR DESCRIPTION
## Summary
- Add `existsSync` guard on default source path before returning it
- Add `process.cwd()` fallback for compiled/daemon contexts where `import.meta.dirname` resolves into `/\$bunfs/`
- Retain existing `Contents/Resources/` lookup for macOS .app bundle layout

Without this fix, the compiled daemon binary fails to locate `web-tree-sitter.wasm` and `tree-sitter-bash.wasm`, breaking all shell command parsing.

🚀 Generated with Vellum
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
