### PR TITLE
fix: remove Show more toggle from sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -20,7 +20,6 @@ struct MainWindowView: View {
     @State private var isHoveredApp: String?
     @State private var requestedHomeBaseAtLaunch = false
     @State private var threadPendingDeletion: UUID?
-    @State private var showAllThreads: Bool = false
     @State private var showAllApps: Bool = false
     @State private var showControlCenterDrawer: Bool = false
     @AppStorage("isAppChatOpen") private var isAppChatOpen: Bool = false
@@ -824,8 +823,7 @@ struct MainWindowView: View {
     }
 
     private var displayedThreads: [ThreadModel] {
-        let visible = threadManager.visibleThreads
-        return showAllThreads ? visible : Array(visible.prefix(5))
+        threadManager.visibleThreads
     }
 
     private var displayedApps: [AppListManager.AppItem] {
@@ -873,20 +871,6 @@ struct MainWindowView: View {
                                       sourceUUID != thread.id else { return false }
                                 return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
                             } isTargeted: { _ in }
-                    }
-
-                    if threadManager.visibleThreads.count > 5 {
-                        Button {
-                            withAnimation(VAnimation.standard) { showAllThreads.toggle() }
-                        } label: {
-                            Text(showAllThreads ? "Show less" : "Show more")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 20)
-                                .padding(.vertical, VSpacing.xs)
-                        }
-                        .buttonStyle(.plain)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Remove the "Show more" / "Show less" button from the sidebar thread list
- Always display all threads — there's nothing below the list, so the toggle was unnecessary clutter
- Remove associated `showAllThreads` state and `.prefix(5)` truncation

## Test plan
- [ ] Launch app with >5 threads and verify all threads are visible without needing to click "Show more"
- [ ] Verify sidebar scrolls correctly with many threads
- [ ] Verify Control Center row still pinned at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
