### PR TITLE
fix: restore all sessions on restart instead of only 5

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -94,7 +94,7 @@ final class ThreadSessionRestorer {
             return
         }
 
-        let recentSessions = Array(response.sessions.filter { $0.threadType != "private" }.prefix(5))
+        let recentSessions = response.sessions.filter { $0.threadType != "private" }
 
         let defaultThreadIsEmpty = delegate.threads.count == 1
             && delegate.chatViewModel(for: delegate.threads[0].id)?.messages.isEmpty ?? true


### PR DESCRIPTION
## Summary
- Remove `.prefix(5)` cap in `ThreadSessionRestorer` that was discarding threads on app restart
- The daemon already limits session list responses to 50 — the client-side truncation to 5 was causing threads to disappear

## Test plan
- [ ] Create >5 threads, restart the app, verify all threads are restored in the sidebar
- [ ] Verify archived threads remain archived after restart
- [ ] Verify active thread is correctly restored after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
