### PR TITLE
fix: pin sidebar nav items, only scroll chat list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -834,34 +834,34 @@ struct MainWindowView: View {
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
+            // MARK: New Chat
+            Spacer().frame(height: VSpacing.md)
+            SidebarNavRow(icon: "plus.circle", label: "New chat") {
+                windowState.selection = nil
+                threadManager.createThread()
+                withAnimation(.easeInOut(duration: 0.35)) {
+                    sidebarOpen = false
+                }
+            }
+
+            Spacer().frame(height: VSpacing.lg)
+
+            // MARK: Nav Items
+            SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
+                windowState.togglePanel(.directory)
+            }
+            SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
+                windowState.togglePanel(.identity)
+            }
+            SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+                windowState.togglePanel(.agent)
+            }
+
+            // MARK: Chats
+            SidebarSubheader(title: "Recent Chats")
+
             ScrollView {
                 VStack(spacing: 0) {
-                    // MARK: New Chat
-                    Spacer().frame(height: VSpacing.md)
-                    SidebarNavRow(icon: "plus.circle", label: "New chat") {
-                        windowState.selection = nil
-                        threadManager.createThread()
-                        withAnimation(.easeInOut(duration: 0.35)) {
-                            sidebarOpen = false
-                        }
-                    }
-
-                    Spacer().frame(height: VSpacing.lg)
-
-                    // MARK: Nav Items
-                    SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
-                        windowState.togglePanel(.directory)
-                    }
-                    SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
-                        windowState.togglePanel(.identity)
-                    }
-                    SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
-                        windowState.togglePanel(.agent)
-                    }
-
-                    // MARK: Chats
-                    SidebarSubheader(title: "Recent Chats")
-
                     ForEach(displayedThreads) { thread in
                         threadItem(thread)
                             .padding(.bottom, 1)


### PR DESCRIPTION
## Summary
- Move New Chat, Home Base, Identity, Skills, and "Recent Chats" header outside the ScrollView
- Only the thread list scrolls — nav items stay pinned at the top, Control Center stays pinned at the bottom

## Test plan
- [ ] Verify nav items (New Chat, Home Base, Identity, Skills) stay visible when scrolling many threads
- [ ] Verify thread list scrolls independently
- [ ] Verify Control Center row stays pinned at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
