### PR TITLE
fix: only reorder threads when a message is sent

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -282,7 +282,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func selectThread(id: UUID) {
         guard threads.contains(where: { $0.id == id }) else { return }
         activeThreadId = id
-        updateLastInteracted(threadId: id)
     }
 
     /// Returns true if the thread has at least one user message.
@@ -480,6 +479,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 if let error {
                     log.error("Failed to post voice response notification: \(error.localizedDescription)")
                 }
+            }
+        }
+        viewModel.onUserMessageSent = { [weak self, weak viewModel] in
+            guard let self, let viewModel else { return }
+            if let threadId = self.chatViewModels.first(where: { $0.value === viewModel })?.key {
+                self.updateLastInteracted(threadId: threadId)
             }
         }
         return viewModel

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -178,6 +178,10 @@ public final class ChatViewModel: ObservableObject {
     /// Used by ThreadManager to auto-title the thread.
     public var onFirstUserMessage: ((String) -> Void)?
 
+    /// Called every time a user message is sent. Used by ThreadManager to
+    /// bump the thread's lastInteractedAt so it rises to the top of the list.
+    public var onUserMessageSent: (() -> Void)?
+
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
 
@@ -257,6 +261,9 @@ public final class ChatViewModel: ObservableObject {
             onFirstUserMessage = nil
             callback(rawText)
         }
+
+        // Notify ThreadManager so the thread rises to the top of the list
+        onUserMessageSent?()
 
         // Block rapid-fire only when bootstrapping with a queued message.
         // When a message-less bootstrap is in flight (e.g. private thread


### PR DESCRIPTION
## Summary
- Stop bumping threads to the top of the sidebar when merely clicked/selected
- Add `onUserMessageSent` callback to ChatViewModel, fired on every `sendMessage()`
- ThreadManager hooks into it via `makeViewModel()` to call `updateLastInteracted` only when a message is actually sent

## Test plan
- [ ] Click on a thread lower in the list — verify it stays in place
- [ ] Send a message in that thread — verify it moves to the top
- [ ] Create a new thread and send a message — verify it appears at the top
- [ ] Restored threads after restart maintain correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
