### PR TITLE
fix: activate GCP service account in isolated config for hatch

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import { existsSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
 import { tmpdir, userInfo } from "os";
 import { join } from "path";
@@ -475,6 +475,22 @@ async function hatchGcp(
 ): Promise<void> {
   const startTime = Date.now();
   const account = process.env.GCP_ACCOUNT_EMAIL;
+  const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  // Activate the service account in an isolated gcloud config directory so
+  // we don't mutate the user's global ~/.config/gcloud credentials.
+  let gcpConfigDir: string | null = null;
+  if (account && keyFile) {
+    gcpConfigDir = mkdtempSync(join(tmpdir(), "vellum-gcloud-"));
+    process.env.CLOUDSDK_CONFIG = gcpConfigDir;
+    await exec("gcloud", [
+      "auth",
+      "activate-service-account",
+      account,
+      `--key-file=${keyFile}`,
+    ]);
+  }
+
   try {
     const project = process.env.GCP_PROJECT ?? (await getActiveProject());
     let instanceName: string;
@@ -655,6 +671,11 @@ async function hatchGcp(
   } catch (error) {
     console.error("❌ Error:", error instanceof Error ? error.message : error);
     process.exit(1);
+  } finally {
+    if (gcpConfigDir) {
+      delete process.env.CLOUDSDK_CONFIG;
+      try { rmSync(gcpConfigDir, { recursive: true, force: true }); } catch {}
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- When hatching via the desktop app, `gcloud` commands fail because the service account credentials are only set via `GOOGLE_APPLICATION_CREDENTIALS` (which gcloud CLI ignores) and `--account=<email>` (which requires the account to be activated in gcloud's credential store)
- Fix by calling `gcloud auth activate-service-account` before any gcloud commands, using an isolated `CLOUDSDK_CONFIG` temp directory so the user's global `~/.config/gcloud` is never modified
- The temp config dir is cleaned up in a `finally` block after hatch completes

## Test plan
- [ ] Test GCP hatch from the desktop app with a service account key configured
- [ ] Verify the user's `gcloud config configurations list` is unchanged after hatch
- [ ] Verify hatch still works when `GCP_ACCOUNT_EMAIL` is not set (no-op path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
