### PR TITLE
fix: don't attach default compute SA to hatched GCP instances

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -566,6 +566,8 @@ async function hatchGcp(
         `--metadata-from-file=startup-script=${startupScriptPath}`,
         `--labels=species=${species},vellum-assistant=true`,
         "--tags=vellum-assistant",
+        "--no-service-account",
+        "--no-scopes",
       ];
       if (account) createArgs.push(`--account=${account}`);
       await exec("gcloud", createArgs);


### PR DESCRIPTION
## Summary
- GCP hatch from the desktop app fails because the `desktop-app-demo` service account lacks `iam.serviceAccountUser` permission on the project's default Compute Engine service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`)
- The hatched instance doesn't need GCP API access — it only runs the assistant daemon and calls the Anthropic API
- Pass `--no-service-account` and `--no-scopes` to `gcloud compute instances create` to skip attaching any service account to the instance

## Test plan
- [ ] Test GCP hatch from the desktop app with a service account that lacks `iam.serviceAccountUser` on the default compute SA
- [ ] Verify the instance starts up and runs the assistant daemon correctly without a service account

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
