### PR TITLE
M10: Fix user bubble — dark green background with white text

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -103,8 +103,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
-  --v-user-bubble:    var(--v-forest-100);
-  --v-user-bubble-text: var(--v-stone-900);
+  --v-user-bubble:    var(--v-forest-800);
+  --v-user-bubble-text: #ffffff;
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);
@@ -163,7 +163,7 @@
     --v-text-muted:     var(--v-moss-500);
 
     --v-user-bubble:    var(--v-forest-900);
-    --v-user-bubble-text: var(--v-moss-100);
+    --v-user-bubble-text: var(--v-moss-50);
 
     --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -157,9 +157,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Forest._100, dark: Forest._900)
-    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._100)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._100.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Forest._800, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Color.white, dark: Moss._50)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Color.white.opacity(0.8), dark: Moss._50.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)


### PR DESCRIPTION
Fix user bubble colors: dark green/olive background (Forest._800 light / Forest._900 dark) with white text. Previous implementation incorrectly used light green. Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
