### PR TITLE
fix: use correct platform URL and skip local daemon for remote hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -146,6 +146,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         hasSetupApp = true
 
+        // On first launch (post-onboarding), the lockfile now has the
+        // hatched assistant. Reset hasSetupDaemon so setupDaemonClient()
+        // re-reads the lockfile, configures the correct transport (HTTP
+        // for remote), and wires all callbacks to the right DaemonClient.
+        if isFirstLaunch {
+            hasSetupDaemon = false
+        }
+
         setupDaemonClient()
         setupMenuBar()
         setupFileMenu()

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -317,6 +317,10 @@ final class AssistantCli {
         env["HOME"] = FileManager.default.homeDirectoryForCurrentUser.path
         env["VELLUM_DESKTOP_APP"] = "1"
 
+        if env["VELLUM_ASSISTANT_PLATFORM_URL"] == nil {
+            env["VELLUM_ASSISTANT_PLATFORM_URL"] = "https://dev-assistant.vellum.ai"
+        }
+
         if !config.anthropicApiKey.isEmpty {
             env["ANTHROPIC_API_KEY"] = config.anthropicApiKey
         }
@@ -510,6 +514,7 @@ final class AssistantCli {
             ]
             // Forward optional config vars the CLI or daemon may need
             for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
+                        "VELLUM_ASSISTANT_PLATFORM_URL",
                         "SENTRY_DSN", "TMPDIR", "USER", "LANG"] {
                 if let val = fullEnv[key] {
                     env[key] = val


### PR DESCRIPTION
## Summary
- Forward `VELLUM_ASSISTANT_PLATFORM_URL` env var from the desktop app to the CLI so the GCP startup script downloads from the correct platform (e.g. `dev-assistant.vellum.ai` instead of the hardcoded `assistant.vellum.ai` default)
- After onboarding completes a remote hatch, reload the lockfile and reconfigure daemon transport to HTTP before `ensureDaemonConnected()` runs — previously `setupDaemonClient()` ran before the hatch existed and defaulted to socket transport, causing a local daemon to be started for remote assistants

## Test plan
- [ ] Set `VELLUM_ASSISTANT_PLATFORM_URL=https://dev-assistant.vellum.ai` and do a GCP hatch from the desktop app — verify the instance downloads from `dev-assistant.vellum.ai/install.sh`
- [ ] Verify no local daemon process is started after a remote GCP hatch completes
- [ ] Verify local hatch still works (daemon started normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
