### PR TITLE
fix: stop swallowing auth errors during GCP retire

### DIFF
--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -277,8 +277,12 @@ export async function instanceExists(
     if (account) args.push(`--account=${account}`);
     await execOutput("gcloud", args);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("was not found") || msg.includes("could not fetch resource")) {
+      return false;
+    }
+    throw error;
   }
 }
 
@@ -732,7 +736,17 @@ export async function retireInstance(
     );
   }
 
-  const exists = await instanceExists(name, project, zone);
+  let exists: boolean;
+  try {
+    exists = await instanceExists(name, project, zone);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot verify GCP instance '${name}': gcloud authentication failed.\n` +
+        `Ensure you are authenticated with 'gcloud auth login' or provide valid credentials.\n\n` +
+        `Details: ${detail}`,
+    );
+  }
   if (!exists) {
     console.warn(
       `\u26a0\ufe0f  Instance ${name} not found in GCP (project=${project}, zone=${zone}).`,

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -152,7 +152,11 @@ final class AssistantCli {
                 "VELLUM_DESKTOP_APP": "1",
             ]
             for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
-                        "SENTRY_DSN", "TMPDIR", "USER", "LANG"] {
+                        "SENTRY_DSN", "TMPDIR", "USER", "LANG",
+                        "CLOUDSDK_CONFIG", "GOOGLE_APPLICATION_CREDENTIALS",
+                        "GCP_ACCOUNT_EMAIL",
+                        "AWS_PROFILE", "AWS_DEFAULT_REGION",
+                        "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"] {
                 if let val = fullEnv[key] { env[key] = val }
             }
             proc.environment = env


### PR DESCRIPTION
## Summary

- **`instanceExists()` no longer swallows auth errors** — only returns `false` for genuine "not found" errors (`"was not found"` / `"could not fetch resource"`); re-throws everything else (auth failures, network errors, etc.)
- **`retireInstance()` catches and wraps auth errors** from `instanceExists()` into a descriptive error message, so the CLI exits non-zero instead of silently succeeding
- **`AssistantCli.swift` forwards cloud credential env vars** (`CLOUDSDK_CONFIG`, `GOOGLE_APPLICATION_CREDENTIALS`, `GCP_ACCOUNT_EMAIL`, `AWS_PROFILE`, `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) in the `retire()` method so `gcloud`/`aws` can authenticate when called from the desktop app

## Test plan

- [ ] With invalid gcloud auth, `vellum-cli retire <gcp-name>` should exit non-zero with auth error
- [ ] With valid auth but nonexistent instance, should warn "not found" and exit 0
- [ ] With valid auth and existing instance, should delete and exit 0
- [ ] Desktop app retire on GCP assistant with missing credentials shows error dialog (not silent exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
