### PR TITLE
feat: move macOS app automation into a bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/macos-automation/SKILL.md
+++ b/assistant/src/config/bundled-skills/macos-automation/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: "macOS Automation"
+description: "Automate native macOS apps and system interactions via osascript (AppleScript)"
+user-invocable: false
+disable-model-invocation: false
+metadata: {"vellum": {"emoji": "🍎", "os": ["darwin"]}}
+---
+
+Use this skill to interact with native macOS apps and system-level features via `osascript` (AppleScript) through `host_bash`. Always prefer osascript over browser automation or computer-use for anything involving a native macOS app.
+
+## Supported Apps
+
+**Communication:** Messages, Mail, Microsoft Outlook, FaceTime
+**Contacts & Calendar:** Contacts, Calendar, Reminders
+**Notes & Writing:** Notes, TextEdit, Pages, BBEdit, CotEditor
+**Files:** Finder, Path Finder
+**Browsers:** Safari, Google Chrome
+**Music & Media:** Music (iTunes), Spotify, VLC, Podcasts, TV
+**Productivity:** OmniFocus, Things 3, OmniOutliner, OmniPlan, OmniGraffle
+**Office:** Microsoft Word, Microsoft Excel, Numbers, Keynote
+**Developer tools:** Xcode, Terminal, iTerm2, Script Editor
+**System:** System Events (UI scripting for any app), System Settings
+**Automation:** Keyboard Maestro, Alfred, Automator
+**Creative:** Adobe Photoshop, Final Cut Pro
+
+For any unlisted app, check scriptability first:
+```bash
+osascript -e 'tell application "AppName" to get name'
+```
+
+## Examples
+
+```bash
+# Send an iMessage
+osascript -e 'tell application "Messages" to send "Hello!" to buddy "user@example.com"'
+
+# Look up a contact
+osascript -e 'tell application "Contacts" to get {name, phones} of every person whose name contains "Marina"'
+
+# Read upcoming calendar events
+osascript -e 'tell application "Calendar" to get summary of every event of calendar "Home" whose start date > (current date)'
+
+# Create a reminder
+osascript -e 'tell application "Reminders" to make new reminder with properties {name:"Buy milk", due date:((current date) + 1 * hours)}'
+
+# Send an email
+osascript -e 'tell application "Mail" to send (make new outgoing message with properties {subject:"Hi", content:"Hello", visible:true})'
+
+# Create a note
+osascript -e 'tell application "Notes" to make new note at folder "Notes" with properties {body:"My note"}'
+
+# Open a URL in Safari
+osascript -e 'tell application "Safari" to open location "https://example.com"'
+
+# Play/pause Music
+osascript -e 'tell application "Music" to playpause'
+
+# Display a system notification
+osascript -e 'display notification "Done!" with title "Vellum"'
+```
+
+## Tips
+
+- For multi-line scripts, write them to a `.applescript` file and run with `osascript path/to/script.applescript`
+- Use `System Events` for UI scripting apps that don't have their own AppleScript dictionary
+- AppleScript permissions are gated by macOS TCC — if a command fails with a permission error, use `request_system_permission` to prompt the user

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -410,63 +410,8 @@ function buildAccessPreferenceSection(): string {
     'If yes to any of these, use that path instead of the browser.',
     ...(isMacOS() ? [
       '',
-      '### macOS App Automation',
-      '',
-      'When interacting with native macOS apps or performing system-level actions, prefer **osascript**',
-      'via host_bash over browser automation or computer-use.',
-      '',
-      'The following apps support AppleScript and should be automated via osascript:',
-      '',
-      '**Communication:** Messages, Mail, Microsoft Outlook, FaceTime',
-      '**Contacts & Calendar:** Contacts, Calendar, Reminders',
-      '**Notes & Writing:** Notes, TextEdit, Pages, BBEdit, CotEditor',
-      '**Files & Finder:** Finder, Path Finder',
-      '**Browsers:** Safari, Google Chrome',
-      '**Music & Media:** Music (iTunes), Spotify, VLC, Podcasts, TV',
-      '**Productivity:** OmniFocus, Things 3, OmniOutliner, OmniPlan, OmniGraffle',
-      '**Office:** Microsoft Word, Microsoft Excel, Numbers, Keynote',
-      '**Developer tools:** Xcode, Terminal, iTerm2, Script Editor',
-      '**System:** Finder, System Events (UI scripting for any app), System Settings',
-      '**Automation:** Keyboard Maestro, Alfred, Automator',
-      '**Creative:** Adobe Photoshop, Final Cut Pro',
-      '',
-      'For any other app, try osascript first — check scriptability with:',
-      '```bash',
-      'osascript -e \'tell application "AppName" to get name\'',
-      '```',
-      '',
-      'Common examples:',
-      '```bash',
-      '# Send an iMessage',
-      'osascript -e \'tell application "Messages" to send "Hello!" to buddy "user@example.com"\'',
-      '',
-      '# Look up a contact',
-      'osascript -e \'tell application "Contacts" to get {name, phones} of every person whose name contains "Marina"\'',
-      '',
-      '# Read upcoming calendar events',
-      'osascript -e \'tell application "Calendar" to get summary of every event of calendar "Home" whose start date > (current date)\'',
-      '',
-      '# Create a reminder',
-      'osascript -e \'tell application "Reminders" to make new reminder with properties {name:"Buy milk", due date:((current date) + 1 * hours)}\'',
-      '',
-      '# Send an email',
-      'osascript -e \'tell application "Mail" to send (make new outgoing message with properties {subject:"Hi", content:"Hello", visible:true})\'',
-      '',
-      '# Create a note',
-      'osascript -e \'tell application "Notes" to make new note at folder "Notes" with properties {body:"My note"}\'',
-      '',
-      '# Open a URL in Safari',
-      'osascript -e \'tell application "Safari" to open location "https://example.com"\'',
-      '',
-      '# Play/pause Music',
-      'osascript -e \'tell application "Music" to playpause\'',
-      '',
-      '# Display a system notification',
-      'osascript -e \'display notification "Done!" with title "Vellum"\'',
-      '```',
-      '',
-      'osascript (AppleScript/JXA) has direct, reliable access to macOS app APIs and system events.',
-      'Use it whenever the task involves a native macOS app or system-level interaction.',
+      'On macOS, also consider the `macos-automation` skill for interacting with native apps',
+      '(Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript.',
     ] : []),
   ].join('\n');
 }
@@ -702,8 +647,13 @@ function escapeXml(str: string): string {
 }
 
 function formatSkillsCatalog(skills: SkillSummary[]): string {
-  // Filter out skills with disableModelInvocation
-  const visible = skills.filter(s => !s.disableModelInvocation);
+  // Filter out skills with disableModelInvocation or unsupported OS
+  const visible = skills.filter(s => {
+    if (s.disableModelInvocation) return false;
+    const os = s.metadata?.os;
+    if (os && os.length > 0 && !os.includes(process.platform)) return false;
+    return true;
+  });
   if (visible.length === 0) return '';
 
   const lines = ['<available_skills>'];


### PR DESCRIPTION
## Summary
- Create `macos-automation` bundled skill with full AppleScript app list and examples (Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.)
- Remove the large inline osascript section from the system prompt, replacing it with a short hint pointing to the skill
- Add OS filtering to `formatSkillsCatalog` so skills with an `os` constraint (e.g. `darwin`) are hidden on unsupported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
