### PR TITLE
Move Assistant ID & Home to Settings > Advanced

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -136,10 +136,6 @@ struct IdentityPanel: View {
     @ViewBuilder
     private func idCardSection(identity: IdentityInfo?, remoteIdentity: RemoteIdentityInfo?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            if let assistantId = lockfileAssistant?.assistantId {
-                idRow(label: "Assistant ID", value: assistantId, mono: true)
-            }
-
             // Agent ID (only available from local identity)
             if let identity {
                 idRow(label: "Agent ID", value: identity.agentID, mono: true)
@@ -172,39 +168,6 @@ struct IdentityPanel: View {
             }
 
             idRow(label: "Origin system", value: metadata?.originSystem ?? "local")
-
-            let home = lockfileAssistant?.home ?? identity?.home ?? .local(workspacePath: NSHomeDirectory() + "/.vellum/workspace")
-            homeRow(home: home)
-        }
-    }
-
-    @ViewBuilder
-    private func homeRow(home: AssistantHome) -> some View {
-        HStack(alignment: .top) {
-            Text("Home")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 100, alignment: .leading)
-
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(home.displayLabel)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textPrimary)
-
-                ForEach(Array(home.displayDetails.enumerated()), id: \.offset) { _, detail in
-                    HStack(spacing: VSpacing.xs) {
-                        Text(detail.label + ":")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                        Text(detail.value)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textSecondary)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-
-            Spacer()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -16,6 +16,8 @@ struct SettingsAdvancedTab: View {
     @State private var isRetiring: Bool = false
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
+    @State private var identity: IdentityInfo?
+    @State private var remoteIdentity: RemoteIdentityInfo?
     #if DEBUG
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
@@ -24,6 +26,7 @@ struct SettingsAdvancedTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
+            assistantInfoSection
             computerUsageSection
             privateThreadSection
             archivedThreadsSection
@@ -41,6 +44,13 @@ struct SettingsAdvancedTab: View {
             sessionToken = (try? String(contentsOfFile: tokenPath, encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            identity = IdentityInfo.load()
+
+            if identity == nil, let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }), assistant.isRemote {
+                Task {
+                    remoteIdentity = await daemonClient?.fetchRemoteIdentity()
+                }
+            }
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -84,6 +94,71 @@ struct SettingsAdvancedTab: View {
             daemonClient?.onEnvVarsResponse = nil
         }
         #endif
+    }
+
+    // MARK: - Assistant Info
+
+    private var assistantInfoSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Assistant Info")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
+                infoRow(label: "Assistant ID", value: assistant.assistantId, mono: true)
+
+                let home = assistant.home
+                homeRow(home: home)
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    private func infoRow(label: String, value: String, mono: Bool = false) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 100, alignment: .leading)
+
+            Text(value)
+                .font(mono ? VFont.mono : VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func homeRow(home: AssistantHome) -> some View {
+        HStack(alignment: .top) {
+            Text("Home")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 100, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(home.displayLabel)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                ForEach(Array(home.displayDetails.enumerated()), id: \.offset) { _, detail in
+                    HStack(spacing: VSpacing.xs) {
+                        Text(detail.label + ":")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                        Text(detail.value)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textSecondary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+
+            Spacer()
+        }
     }
 
     // MARK: - Computer Usage


### PR DESCRIPTION
## Summary
- Removes the Assistant ID row and Home row from the Identity panel to reduce clutter
- Adds a new "Assistant Info" section at the top of Settings > Advanced tab displaying the same information
- Home details remain expandable with GCP/local details

## Test plan
- [ ] Open Identity panel — verify Assistant ID and Home rows are no longer shown
- [ ] Open Settings > Advanced — verify new "Assistant Info" section appears at top with Assistant ID and Home
- [ ] Verify Home details are expandable (GCP shows project/zone/instance, local shows workspace path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
