### PR TITLE
Fix Retire/Switch/Hatch buttons in Settings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -47,6 +47,11 @@ enum InteractionType {
 
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate {
+    /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
+    /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps
+    /// the delegate.  Use `AppDelegate.shared` instead.
+    public static var shared: AppDelegate?
+
     var statusItem: NSStatusItem!
     private var hotKeyMonitor: Any?
     private var escapeMonitor: Any?
@@ -100,6 +105,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @AppStorage("themePreference") private var themePreference: String = "system"
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
+        Self.shared = self
+
         if let envPath = FeatureFlagManager.findRepoEnvFile() {
             FeatureFlagManager.shared.loadFromFile(at: envPath)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -57,7 +57,7 @@ struct SettingsAdvancedTab: View {
             Button("Retire", role: .destructive) {
                 isRetiring = true
                 Task {
-                    let completed = await (NSApp.delegate as? AppDelegate)?.performRetireAsync() ?? false
+                    let completed = await AppDelegate.shared?.performRetireAsync() ?? false
                     if !completed {
                         isRetiring = false
                     }
@@ -343,7 +343,7 @@ struct SettingsAdvancedTab: View {
     }
 
     private func switchToAssistant(_ assistant: LockfileAssistant) {
-        (NSApp.delegate as? AppDelegate)?.performSwitchAssistant(to: assistant)
+        AppDelegate.shared?.performSwitchAssistant(to: assistant)
         onClose()
     }
 
@@ -401,7 +401,7 @@ struct SettingsAdvancedTab: View {
                     }
                     Spacer()
                     VButton(label: "Hatch...", style: .primary) {
-                        (NSApp.delegate as? AppDelegate)?.replayOnboarding()
+                        AppDelegate.shared?.replayOnboarding()
                         onClose()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -24,9 +24,7 @@ struct SettingsAppearanceTab: View {
                         get: { themePreference },
                         set: { newValue in
                             themePreference = newValue
-                            if let delegate = NSApp.delegate as? AppDelegate {
-                                delegate.applyThemePreference()
-                            }
+                            AppDelegate.shared?.applyThemePreference()
                         }
                     )) {
                         Text("System").tag("system")


### PR DESCRIPTION
## Summary
- `NSApp.delegate as? AppDelegate` returns `nil` under SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps the delegate in its own proxy object (`SwiftUI.AppDelegate`)
- This silently broke **Retire** (the CLI never ran — `performRetireAsync` was never called), **Switch Assistant**, **Hatch New**, and **theme switching** from Settings
- Add `AppDelegate.shared` static reference set in `applicationDidFinishLaunching` and replace all `NSApp.delegate as? AppDelegate` casts with it

## Root cause
When using `@NSApplicationDelegateAdaptor(AppDelegate.self)`, SwiftUI creates its own delegate wrapper. `NSApp.delegate` returns `SwiftUI.AppDelegate`, not our custom `AppDelegate`. The `as? AppDelegate` cast fails, the optional chain returns `nil`, and all Settings actions that depend on AppDelegate silently no-op.

## Test plan
- [ ] Click Retire in Settings > Advanced — should actually delete the GCP instance and tear down
- [ ] Switch Assistant — should switch to the selected assistant
- [ ] Hatch New — should open onboarding flow
- [ ] Theme switching in Settings > Appearance — should apply immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
