### PR TITLE
fix: add close button to onboarding window and fix title text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -5,6 +5,7 @@ import SwiftUI
 @MainActor
 final class OnboardingWindow {
     private var window: NSWindow?
+    private var closeObserver: NSObjectProtocol?
     let state = OnboardingState()
     let daemonClient: DaemonClientProtocol
     let authManager: AuthManager
@@ -44,7 +45,7 @@ final class OnboardingWindow {
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
-            styleMask: [.titled, .miniaturizable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -72,6 +73,24 @@ final class OnboardingWindow {
         // Make the app a regular app so the window gets focus
         NSApp.setActivationPolicy(.regular)
 
+        // Trigger onComplete when the window is closed via the title bar
+        // close button so AppDelegate can clean up and transition the app.
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.onComplete?(self.state)
+                if let observer = self.closeObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                self.closeObserver = nil
+            }
+        }
+
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
@@ -79,6 +98,10 @@ final class OnboardingWindow {
     }
 
     func close() {
+        if let observer = closeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            closeObserver = nil
+        }
         window?.close()
         window = nil
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -30,7 +30,7 @@ struct WakeUpStepView: View {
 
     var body: some View {
         // Title
-        Text("Create your Velly")
+        Text("Create your Vellum")
             .font(.system(size: 32, weight: .regular, design: .serif))
             .foregroundColor(VColor.textPrimary)
             .opacity(showTitle ? 1 : 0)


### PR DESCRIPTION
## Summary
- Add `.closable` to the onboarding window's `styleMask` so the red close (x) button appears in the title bar — it was missing, unlike all other windows in the app
- Rename "Create your Velly" to "Create your Vellum" in the onboarding welcome step

## Test plan
- [ ] Launch onboarding — verify the red close button appears
- [ ] Verify the title reads "Create your Vellum"
- [ ] Click the close button — verify it dismisses the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
