### PR TITLE
Add bundled phone-calls skill

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: "Phone Calls"
+description: "Set up Twilio for outgoing phone calls and place AI-powered voice calls on behalf of the user"
+user-invocable: true
+metadata: {"vellum": {"emoji": "📞", "requires": {"config": ["calls.enabled"]}}}
+includes: ["public-ingress"]
+---
+
+You are helping the user set up and make outgoing phone calls via Twilio. This skill covers the full lifecycle: Twilio account setup, credential storage, public ingress configuration, enabling the calls feature, placing calls, and monitoring live transcripts.
+
+## Overview
+
+The calling system uses Twilio's ConversationRelay to place outbound phone calls. When a call is placed:
+
+1. The assistant initiates an outbound call via the Twilio REST API
+2. Twilio connects to the gateway's voice webhook, which returns TwiML
+3. Twilio opens a ConversationRelay WebSocket for real-time voice streaming
+4. An LLM-driven orchestrator manages the conversation — receiving caller speech (transcribed by Deepgram), generating responses via Claude, and streaming text back for TTS playback
+5. The transcript is relayed live to the user's conversation thread
+
+The user's assistant gets its own personal phone number through Twilio.
+
+## Step 1: Check Current Configuration
+
+First, check whether Twilio is already configured:
+
+```bash
+vellum config get calls.enabled
+```
+
+Also check for existing credentials:
+
+```bash
+credential_store action=get service=credential:twilio:account_sid
+credential_store action=get service=credential:twilio:auth_token
+credential_store action=get service=credential:twilio:phone_number
+```
+
+If all three credentials exist and `calls.enabled` is `true`, skip to the **Making Calls** section. If credentials are partially configured, skip to whichever step is still needed.
+
+## Step 2: Create a Twilio Account
+
+If the user doesn't have a Twilio account yet, guide them through setup:
+
+1. Tell the user: **"You'll need a Twilio account to make phone calls. Sign up at https://www.twilio.com/try-twilio — it's free to start and includes trial credit."**
+2. Once they have an account, they need three pieces of information:
+   - **Account SID** — found on the Twilio Console dashboard at https://console.twilio.com
+   - **Auth Token** — found on the same dashboard (click "Show" to reveal it)
+   - **Phone Number** — a Twilio phone number capable of making voice calls
+
+### Getting a Twilio Phone Number
+
+If the user doesn't have a Twilio phone number yet:
+
+1. Direct them to https://console.twilio.com/us1/develop/phone-numbers/manage/incoming
+2. Click **"Buy a Number"**
+3. Select a number with **Voice** capability enabled
+4. For trial accounts, Twilio provides one free number automatically — check "Active Numbers" first
+
+Tell the user: **"This will be your assistant's personal phone number — the number that shows up on caller ID when calls are placed."**
+
+## Step 3: Store Twilio Credentials
+
+Once the user provides their credentials, store them securely using the `credential_store` tool. Ask the user to paste each value, then store them one at a time:
+
+**Account SID:**
+```
+credential_store action=set service=credential:twilio:account_sid value=<their_account_sid>
+```
+
+**Auth Token:**
+```
+credential_store action=set service=credential:twilio:auth_token value=<their_auth_token>
+```
+
+**Phone Number** (must be in E.164 format, e.g. `+14155551234`):
+```
+credential_store action=set service=credential:twilio:phone_number value=<their_phone_number>
+```
+
+After storing, verify each credential was saved:
+```
+credential_store action=get service=credential:twilio:account_sid
+credential_store action=get service=credential:twilio:auth_token
+credential_store action=get service=credential:twilio:phone_number
+```
+
+**Important:** Credentials are stored in the OS keychain (macOS Keychain / Linux secret-service) or encrypted at rest. They are never logged or exposed in plaintext.
+
+## Step 4: Set Up Public Ingress
+
+Twilio needs a publicly reachable URL to send voice webhooks and establish the ConversationRelay WebSocket. The **public-ingress** skill handles this via ngrok.
+
+Check if ingress is already configured:
+
+```bash
+vellum config get ingress.publicBaseUrl
+vellum config get ingress.enabled
+```
+
+If not configured, load and run the public-ingress skill:
+
+```
+skill_load skill=public-ingress
+```
+
+Follow the public-ingress skill's instructions to set up the ngrok tunnel. Once complete, the gateway will be reachable at the configured `ingress.publicBaseUrl`.
+
+**Twilio needs these webhook endpoints (handled automatically by the gateway):**
+- Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
+- Status callback: `{publicBaseUrl}/webhooks/twilio/status`
+- ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
+
+No manual Twilio webhook configuration is needed — the assistant registers webhook URLs dynamically when placing each call.
+
+## Step 5: Enable Calls
+
+Enable the calls feature:
+
+```bash
+vellum config set calls.enabled true
+```
+
+Verify:
+```bash
+vellum config get calls.enabled
+```
+
+## Step 6: Verify Setup (Test Call)
+
+Before making real calls, offer a quick verification:
+
+1. Confirm credentials are stored: all three `credential:twilio:*` keys must be present
+2. Confirm ingress is running: `ingress.publicBaseUrl` must be set and the tunnel active
+3. Confirm calls are enabled: `calls.enabled` must be `true`
+
+Suggest a test call to the user's own phone: **"Want to do a quick test call to your phone to make sure everything works?"**
+
+If they agree, ask for their personal phone number and place a test call with a simple task like "Introduce yourself and confirm the call system is working."
+
+## Making Calls
+
+Use the `call_start` tool to place outbound calls. Every call requires:
+- **phone_number**: The number to call in E.164 format (e.g. `+14155551234`)
+- **task**: What the call should accomplish — this becomes the AI voice agent's objective
+- **context** (optional): Additional background information for the conversation
+
+### Example calls:
+
+**Making a reservation:**
+```
+call_start phone_number="+14155551234" task="Make a dinner reservation for 2 people tonight at 7pm" context="The user's name is John Smith. Prefer a table by the window if available."
+```
+
+**Calling a business:**
+```
+call_start phone_number="+18005551234" task="Check if they have a specific product in stock" context="Looking for a 65-inch Samsung OLED TV, model QN65S95D. Ask about availability and price."
+```
+
+**Following up on an appointment:**
+```
+call_start phone_number="+12125551234" task="Confirm the dentist appointment scheduled for next Tuesday at 2pm" context="The appointment is under the name Jane Doe, DOB 03/15/1990."
+```
+
+### Phone number format
+
+Phone numbers MUST be in E.164 format: `+` followed by country code and number with no spaces, dashes, or parentheses.
+- US/Canada: `+1XXXXXXXXXX` (e.g. `+14155551234`)
+- UK: `+44XXXXXXXXXX` (e.g. `+442071234567`)
+- International: `+{country_code}{number}`
+
+If the user provides a number in a different format, convert it to E.164 before calling. If the country is ambiguous, ask.
+
+### Trial account limitations
+
+On Twilio trial accounts, outbound calls can ONLY be made to **verified numbers**. If a call fails with a "not verified" error:
+1. Tell the user they need to verify the number at https://console.twilio.com/us1/develop/phone-numbers/manage/verified
+2. Or upgrade to a paid Twilio account to call any number
+
+## Live Call Monitoring
+
+### Showing the live transcript
+
+By default, always show the live transcript of the call as it happens. When a call is in progress:
+
+1. After placing the call with `call_start`, immediately begin polling with `call_status` to track the call state
+2. The system fires transcript notifications as the conversation unfolds — both caller speech and assistant responses appear in real time in the conversation thread
+3. Present each transcript entry clearly as it arrives:
+
+```
+📞 Call in progress...
+
+🗣️ Assistant: "Hi, I'm calling on behalf of John to make a dinner reservation for tonight."
+👤 Caller: "Sure, what time would you like?"
+🗣️ Assistant: "We'd like a table for two at 7pm, please."
+👤 Caller: "Let me check... yes, we have availability at 7pm."
+🗣️ Assistant: "Wonderful! The reservation would be under John Smith."
+```
+
+4. Continue monitoring until the call completes or fails
+
+### Handling questions during a call
+
+The AI voice agent may encounter situations where it needs input from the user. When this happens:
+
+1. The call status changes to `waiting_on_user`
+2. A **pending question** appears in `call_status` output
+3. Present the question prominently to the user:
+
+```
+❓ The person on the call asked something the assistant needs your help with:
+   "They're asking if you'd prefer the smoking or non-smoking section?"
+```
+
+4. The user can reply directly in the chat — their response is automatically routed to the live call via the call bridge
+5. The AI voice agent receives the answer and continues the conversation naturally
+
+**Important:** Respond to pending questions quickly. There is a consultation timeout (default: 2 minutes). If no answer is provided in time, the AI voice agent will move on.
+
+### Call status values
+
+- **initiated** — Call is being placed
+- **ringing** — Phone is ringing on the other end
+- **in_progress** — Call is connected, conversation is active
+- **waiting_on_user** — AI agent needs input from the user (check pending question)
+- **completed** — Call ended successfully
+- **failed** — Call failed (check lastError for details)
+- **cancelled** — Call was manually cancelled
+
+### Ending a call early
+
+Use `call_end` with the call session ID to terminate an active call:
+```
+call_end call_session_id="<session_id>" reason="User requested to end the call"
+```
+
+## Call Quality Tips
+
+When crafting tasks for the AI voice agent, follow these guidelines for the best call experience:
+
+### Writing good task descriptions
+
+- **Be specific about the objective**: "Make a dinner reservation for 2 at 7pm tonight" is better than "Call the restaurant"
+- **Include relevant context**: Names, account numbers, appointment details — anything the agent might need
+- **Specify what information to collect**: "Ask about their return policy and store hours" tells the agent what to gather
+- **Set clear completion criteria**: The agent knows to end the call when the task is fulfilled
+
+### Providing context
+
+The `context` field is powerful — use it to give the agent background that helps it sound natural:
+
+- User's name and identifying details (for making appointments, verifying accounts)
+- Preferences and constraints (dietary restrictions, budget limits, scheduling conflicts)
+- Previous interaction history ("I called last week and spoke with Sarah about...")
+- Special instructions ("If they put you on hold for more than 5 minutes, hang up and we'll try again later")
+
+### Things the AI voice agent handles well
+
+- Making reservations and appointments
+- Checking business hours, availability, or pricing
+- Confirming or rescheduling existing appointments
+- Gathering information (store policies, product availability)
+- Simple customer service interactions
+- Leaving voicemails (it will speak the message if voicemail picks up)
+
+### Things to be aware of
+
+- Calls have a maximum duration (configurable via `calls.maxDurationSeconds`, default: 1 hour)
+- The agent gives a 2-minute warning before the time limit
+- Emergency numbers (911, 112, 999, etc.) are blocked and cannot be called
+- The AI disclosure setting (`calls.disclosure.enabled`) controls whether the agent announces it's an AI at the start of the call
+
+## Configuration Reference
+
+All call-related settings can be managed via `vellum config`:
+
+| Setting | Description | Default |
+|---|---|---|
+| `calls.enabled` | Master switch for the calling feature | `false` |
+| `calls.provider` | Voice provider (currently only `twilio`) | `twilio` |
+| `calls.maxDurationSeconds` | Maximum call length in seconds | `3600` (1 hour) |
+| `calls.userConsultTimeoutSeconds` | How long to wait for user answers | `120` (2 min) |
+| `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
+| `calls.disclosure.text` | The disclosure message spoken at call start | `"I should let you know that I'm an AI assistant calling on behalf of my user."` |
+
+### Adjusting settings
+
+```bash
+# Increase max call duration to 2 hours
+vellum config set calls.maxDurationSeconds 7200
+
+# Disable AI disclosure (check local regulations first)
+vellum config set calls.disclosure.enabled false
+
+# Custom disclosure message
+vellum config set calls.disclosure.text "Just so you know, this is an AI assistant calling for my user."
+
+# Give more time for user consultation
+vellum config set calls.userConsultTimeoutSeconds 300
+```
+
+## Troubleshooting
+
+### "Twilio credentials not configured"
+Run Step 3 to store your Account SID, Auth Token, and Phone Number via `credential_store`.
+
+### "Calls feature is disabled"
+Run `vellum config set calls.enabled true`.
+
+### "No public base URL configured"
+Run the **public-ingress** skill to set up ngrok and configure `ingress.publicBaseUrl`.
+
+### Call fails immediately after initiating
+- Check that the phone number is in E.164 format
+- Verify Twilio credentials are correct (wrong auth token causes API errors)
+- On trial accounts, ensure the destination number is verified
+- Check that the ngrok tunnel is still running (`curl -s http://127.0.0.1:4040/api/tunnels`)
+
+### Call connects but no audio / one-way audio
+- The ConversationRelay WebSocket may not be connecting. Check that `ingress.publicBaseUrl` is correct and the tunnel is active
+- Verify the gateway is running on `http://127.0.0.1:${GATEWAY_PORT:-7830}`
+
+### "This phone number is not allowed to be called"
+Emergency numbers (911, 112, 999, 000, 110, 119) are permanently blocked for safety.
+
+### ngrok tunnel URL changed
+If you restarted ngrok, the public URL has changed. Update it:
+```bash
+vellum config set ingress.publicBaseUrl "<new-url>"
+```
+Or re-run the public-ingress skill to auto-detect and save the new URL.
+
+### Call drops after 30 seconds of silence
+The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the agent will ask "Are you still there?" This is expected behavior.


### PR DESCRIPTION
## Summary
- Add new bundled skill `phone-calls` that guides users through Twilio account setup, credential storage, public ingress configuration, and making outbound AI-powered phone calls
- Includes comprehensive instructions for live call transcript monitoring, handling mid-call questions, and call quality best practices
- Declares `public-ingress` as a dependency and documents all call-related configuration options

## Original prompt
Help me create a new bundled skill for outgoing phone calls. It should help the user set up a twilio account, collect the necessary twilio secrets, store them, use the public ingress skill as a dependency, and then include details on how to make phone calls fromt he assistant's own personal number. It should include instructions for the assistant to, by default, show the live transcript fo the call as it is happening. Generally, this skill should contain all instructions needed for how an assistant should set up phone calls and them perform them to an excellent degree of quality and user experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
