### PR TITLE
Replace silent try? with logged error handling

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -339,15 +339,27 @@ extension AppDelegate {
         let storedIcon = info["icon"]
         let appIcon = cachedApp?.icon ?? (storedIcon?.isEmpty == false ? storedIcon : nil)
         mainWindow?.appListManager.recordAppOpen(id: appId, name: appName, icon: appIcon)
-        try? daemonClient.sendAppOpen(appId: appId)
+        do {
+            try daemonClient.sendAppOpen(appId: appId)
+        } catch {
+            log.error("Failed to send app open for \(appId): \(error)")
+        }
     }
 
     @objc func toggleSkill(_ sender: NSMenuItem) {
         guard let name = sender.representedObject as? String else { return }
         if sender.state == .on {
-            try? daemonClient.disableSkill(name)
+            do {
+                try daemonClient.disableSkill(name)
+            } catch {
+                log.error("Failed to disable skill \(name): \(error)")
+            }
         } else {
-            try? daemonClient.enableSkill(name)
+            do {
+                try daemonClient.enableSkill(name)
+            } catch {
+                log.error("Failed to enable skill \(name): \(error)")
+            }
         }
         refreshSkillsCache()
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -33,7 +33,11 @@ extension AppDelegate {
         Task { @MainActor in
             guard await waitForAccessibilityPermission() else {
                 log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
-                try? daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                do {
+                    try daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                } catch {
+                    log.error("Failed to send CU session abort for escalation \(routed.sessionId): \(error)")
+                }
                 self.mainWindow?.windowState.showToast(
                     message: "Computer control requires Accessibility permission. Grant it in System Settings → Privacy & Security → Accessibility.",
                     style: .error
@@ -132,13 +136,17 @@ extension AppDelegate {
                     extractedText: $0.extractedText
                 )
             }
-            try? self.daemonClient.send(TaskSubmitMessage(
-                task: effectiveTask,
-                screenWidth: Int(screenBounds.width),
-                screenHeight: Int(screenBounds.height),
-                attachments: ipcAttachments,
-                source: submission.source
-            ))
+            do {
+                try self.daemonClient.send(TaskSubmitMessage(
+                    task: effectiveTask,
+                    screenWidth: Int(screenBounds.width),
+                    screenHeight: Int(screenBounds.height),
+                    attachments: ipcAttachments,
+                    source: submission.source
+                ))
+            } catch {
+                log.error("Failed to send task submit message: \(error)")
+            }
 
             // 3. Wait for task_routed response (or error)
             var routedMessage: TaskRoutedMessage?
@@ -169,7 +177,11 @@ extension AppDelegate {
             case "computer_use":
                 guard await self.waitForAccessibilityPermission() else {
                     log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
-                    try? self.daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                    do {
+                        try self.daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                    } catch {
+                        log.error("Failed to send CU session abort for \(routed.sessionId): \(error)")
+                    }
                     return
                 }
                 let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -196,12 +196,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Task {
             if !isRemoteTransport {
-                try? await assistantCli.hatch(daemonOnly: true)
+                do {
+                    try await assistantCli.hatch(daemonOnly: true)
+                } catch {
+                    log.error("Failed to hatch assistant in ensureDaemonConnected: \(error)")
+                }
                 assistantCli.startMonitoring()
             }
             // Only connect if setupDaemonClient's connect hasn't already started
             guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
-            try? await daemonClient.connect()
+            do {
+                try await daemonClient.connect()
+            } catch {
+                log.error("Failed to connect to daemon in ensureDaemonConnected: \(error)")
+            }
             if daemonClient.isConnected {
                 setupAmbientAgent()
                 refreshAppsCache()
@@ -609,7 +617,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             Task {
                 // Don't reset an in-progress connection attempt
                 guard !self.daemonClient.isConnected, !self.daemonClient.isConnecting else { return }
-                try? await self.daemonClient.connect()
+                do {
+                    try await self.daemonClient.connect()
+                } catch {
+                    log.error("Failed to reconnect to daemon after restart: \(error)")
+                }
                 if self.daemonClient.isConnected {
                     self.setupAmbientAgent()
                     self.refreshAppsCache()
@@ -631,10 +643,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             if !isRemoteTransport {
                 // Hatch the assistant via CLI (spawns daemon in release builds).
                 // daemonOnly: true prevents creating a new lockfile entry on every launch.
-                try? await assistantCli.hatch(daemonOnly: true)
+                do {
+                    try await assistantCli.hatch(daemonOnly: true)
+                } catch {
+                    log.error("Failed to hatch assistant during daemon setup: \(error)")
+                }
                 assistantCli.startMonitoring()
             }
-            try? await daemonClient.connect()
+            do {
+                try await daemonClient.connect()
+            } catch {
+                log.error("Failed to connect to daemon during setup: \(error)")
+            }
             // Once connected, start ambient agent if it was waiting for daemon
             if daemonClient.isConnected {
                 setupAmbientAgent()
@@ -712,25 +732,34 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         surfaceManager.onAction = { [weak self] sessionId, surfaceId, actionId, data in
             guard let self else { return }
             let codableData: [String: AnyCodable]? = data?.mapValues { AnyCodable($0) }
-            try? self.daemonClient.sendSurfaceAction(
-                sessionId: sessionId,
-                surfaceId: surfaceId,
-                actionId: actionId,
-                data: codableData
-            )
+            do {
+                try self.daemonClient.sendSurfaceAction(
+                    sessionId: sessionId,
+                    surfaceId: surfaceId,
+                    actionId: actionId,
+                    data: codableData
+                )
+            } catch {
+                log.error("Failed to send surface action \(actionId) for surface \(surfaceId): \(error)")
+            }
         }
 
         // Data request: JS -> Swift -> daemon
         surfaceManager.onDataRequest = { [weak self] surfaceId, callId, method, appId, recordId, data in
+            guard let self else { return }
             let codableData = data?.mapValues { AnyCodable($0) }
-            try? self?.daemonClient.send(AppDataRequestMessage(
-                surfaceId: surfaceId,
-                callId: callId,
-                method: method,
-                appId: appId,
-                recordId: recordId,
-                data: codableData
-            ))
+            do {
+                try self.daemonClient.send(AppDataRequestMessage(
+                    surfaceId: surfaceId,
+                    callId: callId,
+                    method: method,
+                    appId: appId,
+                    recordId: recordId,
+                    data: codableData
+                ))
+            } catch {
+                log.error("Failed to send app data request (method: \(method), appId: \(appId)): \(error)")
+            }
         }
 
         // Data response: daemon -> Swift -> JS
@@ -740,8 +769,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Link open: JS -> Swift -> daemon
         surfaceManager.onLinkOpen = { [weak self] url, metadata in
+            guard let self else { return }
             let codableMetadata = metadata?.mapValues { AnyCodable($0) }
-            try? self?.daemonClient.sendLinkOpenRequest(url: url, metadata: codableMetadata)
+            do {
+                try self.daemonClient.sendLinkOpenRequest(url: url, metadata: codableMetadata)
+            } catch {
+                log.error("Failed to send link open request for \(url): \(error)")
+            }
         }
 
         // Forward layout config from daemon to MainWindowState
@@ -1282,10 +1316,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 createChromeDebugLaunchAgent()
             }
 
-            try? daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: success))
+            do {
+                try daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: success))
+            } catch {
+                log.error("Failed to send browser CDP response (open): \(error)")
+            }
         } else {
             // User chose background browser
-            try? daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: false, declined: true))
+            do {
+                try daemonClient.send(BrowserCDPResponseMessage(sessionId: msg.sessionId, success: false, declined: true))
+            } catch {
+                log.error("Failed to send browser CDP response (background): \(error)")
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -342,10 +342,15 @@ final class AssistantCli {
                 try config.gcpServiceAccountKey.write(to: tmpKeyPath, atomically: true, encoding: .utf8)
                 env["GOOGLE_APPLICATION_CREDENTIALS"] = tmpKeyPath.path
 
-                if let data = config.gcpServiceAccountKey.data(using: .utf8),
-                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let email = json["client_email"] as? String {
-                    env["GCP_ACCOUNT_EMAIL"] = email
+                if let data = config.gcpServiceAccountKey.data(using: .utf8) {
+                    do {
+                        if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                           let email = json["client_email"] as? String {
+                            env["GCP_ACCOUNT_EMAIL"] = email
+                        }
+                    } catch {
+                        log.error("Failed to parse GCP service account key JSON: \(error)")
+                    }
                 }
             }
         } else if config.remote == "aws" {
@@ -419,8 +424,14 @@ final class AssistantCli {
 
     /// Returns `true` if the daemon process is alive based on the PID file.
     private func isDaemonAlive() -> Bool {
-        guard let pidData = try? Data(contentsOf: pidFileURL),
-              let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+        let pidData: Data
+        do {
+            pidData = try Data(contentsOf: pidFileURL)
+        } catch {
+            log.error("Failed to read PID file at \(self.pidFileURL.path): \(error)")
+            return false
+        }
+        guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
               let pid = pid_t(pidString) else {
             return false
         }
@@ -466,8 +477,14 @@ final class AssistantCli {
 
     /// Kill the daemon directly via PID file — fallback when CLI binary is unavailable.
     private func killViaPIDFile() {
-        guard let pidData = try? Data(contentsOf: pidFileURL),
-              let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+        let pidData: Data
+        do {
+            pidData = try Data(contentsOf: pidFileURL)
+        } catch {
+            log.error("Failed to read PID file at \(self.pidFileURL.path): \(error)")
+            return
+        }
+        guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
               let pid = pid_t(pidString),
               kill(pid, 0) == 0 else {
             return
@@ -485,7 +502,11 @@ final class AssistantCli {
             kill(pid, SIGKILL)
         }
 
-        try? FileManager.default.removeItem(at: pidFileURL)
+        do {
+            try FileManager.default.removeItem(at: pidFileURL)
+        } catch {
+            log.error("Failed to remove PID file at \(self.pidFileURL.path): \(error)")
+        }
     }
 
     /// Run a CLI command and return (stdout, stderr, exit code).

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -131,23 +131,35 @@ final class ComputerUseSession: ObservableObject {
             case .computerUse: "computer_use"
             case .textQA: "text_qa"
             }
-            try? daemonClient.send(CuSessionCreateMessage(
-                sessionId: id,
-                task: task,
-                screenWidth: Int(screenSize.width),
-                screenHeight: Int(screenSize.height),
-                attachments: ipcAttachments,
-                interactionType: interactionTypeString
-            ))
+            do {
+                try daemonClient.send(CuSessionCreateMessage(
+                    sessionId: id,
+                    task: task,
+                    screenWidth: Int(screenSize.width),
+                    screenHeight: Int(screenSize.height),
+                    attachments: ipcAttachments,
+                    interactionType: interactionTypeString
+                ))
+            } catch {
+                log.error("Failed to send session create message: \(error)")
+            }
         }
 
         // 3. Initial perceive + send first observation
         let obs = await buildObservation(executionResult: nil, executionError: nil)
         if let obs {
-            try? daemonClient.send(obs)
+            do {
+                try daemonClient.send(obs)
+            } catch {
+                log.error("Failed to send initial observation: \(error)")
+            }
         } else {
             state = .failed(reason: "No focused window and screen capture failed")
-            try? daemonClient.send(CuSessionAbortMessage(sessionId: id))
+            do {
+                try daemonClient.send(CuSessionAbortMessage(sessionId: id))
+            } catch {
+                log.error("Failed to send session abort message: \(error)")
+            }
             logger.finishSession(result: "failed: no window")
             return
         }
@@ -321,7 +333,11 @@ final class ComputerUseSession: ObservableObject {
             // Send observation with block error so daemon can adapt
             let obs = await buildObservation(executionResult: nil, executionError: "BLOCKED: \(reason)")
             if let obs {
-                try? daemonClient.send(obs)
+                do {
+                    try daemonClient.send(obs)
+                } catch {
+                    log.error("Failed to send blocked observation: \(error)")
+                }
             }
             state = .thinking(step: action.stepNumber + 1, maxSteps: maxSteps)
             return
@@ -362,7 +378,11 @@ final class ComputerUseSession: ObservableObject {
         // PERCEIVE + send next observation
         let obs = await buildObservation(executionResult: executionResult, executionError: executionError)
         if let obs {
-            try? daemonClient.send(obs)
+            do {
+                try daemonClient.send(obs)
+            } catch {
+                log.error("Failed to send observation after action execution: \(error)")
+            }
         }
 
         state = .thinking(step: action.stepNumber + 1, maxSteps: maxSteps)
@@ -739,7 +759,11 @@ final class ComputerUseSession: ObservableObject {
         verifier.resetBlockCount()
         let obs = await buildObservation(executionResult: nil, executionError: message)
         if let obs {
-            try? daemonClient.send(obs)
+            do {
+                try daemonClient.send(obs)
+            } catch {
+                log.error("Failed to send recoverable execution error observation: \(error)")
+            }
         }
         state = .thinking(step: stepNumber + 1, maxSteps: maxSteps)
     }
@@ -898,7 +922,11 @@ final class ComputerUseSession: ObservableObject {
         confirmationContinuation?.resume(returning: false)
         confirmationContinuation = nil
         // Tell the daemon to abort the server-side CU session so it stops burning tokens
-        try? daemonClient.send(CuSessionAbortMessage(sessionId: id))
+        do {
+            try daemonClient.send(CuSessionAbortMessage(sessionId: id))
+        } catch {
+            log.error("Failed to send session abort on cancel: \(error)")
+        }
     }
 
     func approveConfirmation() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfigStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfigStore.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LayoutConfigStore")
 
 public enum LayoutConfigStore {
     private static var configURL: URL {
@@ -7,20 +10,43 @@ public enum LayoutConfigStore {
     }
 
     public static func load() -> LayoutConfig {
-        guard let data = try? Data(contentsOf: configURL),
-              let config = try? JSONDecoder().decode(LayoutConfig.self, from: data) else {
+        let data: Data
+        do {
+            data = try Data(contentsOf: configURL)
+        } catch {
+            log.error("Failed to read layout config data from \(self.configURL.path): \(error)")
             return .default
         }
-        return config
+        do {
+            return try JSONDecoder().decode(LayoutConfig.self, from: data)
+        } catch {
+            log.error("Failed to decode layout config: \(error)")
+            return .default
+        }
     }
 
     public static func save(_ config: LayoutConfig) {
         let url = configURL
         let dir = url.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            log.error("Failed to create layout config directory at \(dir.path): \(error)")
+            return
+        }
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
-        guard let data = try? encoder.encode(config) else { return }
-        try? data.write(to: url, options: .atomic)
+        let data: Data
+        do {
+            data = try encoder.encode(config)
+        } catch {
+            log.error("Failed to encode layout config: \(error)")
+            return
+        }
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            log.error("Failed to write layout config to \(url.path): \(error)")
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -31,7 +31,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Without this, socketToSession stays stale after thread switches,
                 // causing ownership checks (e.g. subagent abort) to fail.
                 if let sessionId = chatViewModels[activeThreadId]?.sessionId {
-                    try? daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+                    do {
+                        try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+                    } catch {
+                        log.error("Failed to send session switch request: \(error)")
+                    }
                 }
             } else {
                 lastActiveThreadIdString = nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,6 +1,9 @@
 import Combine
 import Foundation
+import os
 import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SettingsStore")
 
 /// Single source of truth for settings state shared between `SettingsView`
 /// (standalone window) and `SettingsPanel` (main window side panel).
@@ -242,7 +245,11 @@ public final class SettingsStore: ObservableObject {
         refreshVercelKeyState()
 
         // Fetch current model from daemon
-        try? daemonClient?.sendModelGet()
+        do {
+            try daemonClient?.sendModelGet()
+        } catch {
+            log.error("Failed to send model get request: \(error)")
+        }
 
         // Refresh Twitter integration status on init
         refreshTwitterStatus()
@@ -341,7 +348,11 @@ public final class SettingsStore: ObservableObject {
     func setImageGenModel(_ model: String) {
         selectedImageGenModel = model
         UserDefaults.standard.set(model, forKey: "selectedImageGenModel")
-        try? daemonClient?.sendImageGenModelSet(model: model)
+        do {
+            try daemonClient?.sendImageGenModelSet(model: model)
+        } catch {
+            log.error("Failed to send image gen model set: \(error)")
+        }
     }
 
     func refreshAPIKeyState() {
@@ -387,40 +398,68 @@ public final class SettingsStore: ObservableObject {
     func saveVercelKey(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        try? daemonClient?.sendVercelApiConfig(action: "set", apiToken: trimmed)
+        do {
+            try daemonClient?.sendVercelApiConfig(action: "set", apiToken: trimmed)
+        } catch {
+            log.error("Failed to send Vercel API config set: \(error)")
+        }
     }
 
     func clearVercelKey() {
-        try? daemonClient?.sendVercelApiConfig(action: "delete")
+        do {
+            try daemonClient?.sendVercelApiConfig(action: "delete")
+        } catch {
+            log.error("Failed to send Vercel API config delete: \(error)")
+        }
     }
 
     func refreshVercelKeyState() {
-        try? daemonClient?.sendVercelApiConfig(action: "get")
+        do {
+            try daemonClient?.sendVercelApiConfig(action: "get")
+        } catch {
+            log.error("Failed to send Vercel API config get: \(error)")
+        }
     }
 
     // MARK: - Twitter Integration Actions
 
     func refreshTwitterStatus() {
-        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "get"))
+        do {
+            try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "get"))
+        } catch {
+            log.error("Failed to send Twitter integration config get: \(error)")
+        }
     }
 
     func setTwitterMode(_ mode: String) {
-        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "set_mode", mode: mode))
+        do {
+            try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "set_mode", mode: mode))
+        } catch {
+            log.error("Failed to send Twitter set_mode: \(error)")
+        }
     }
 
     func saveTwitterLocalClient(clientId: String, clientSecret: String?) {
         let trimmedId = clientId.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedSecret = clientSecret?.trimmingCharacters(in: .whitespacesAndNewlines)
-        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(
-            action: "set_local_client",
-            clientId: trimmedId,
-            clientSecret: trimmedSecret
-        ))
+        do {
+            try daemonClient?.send(TwitterIntegrationConfigRequestMessage(
+                action: "set_local_client",
+                clientId: trimmedId,
+                clientSecret: trimmedSecret
+            ))
+        } catch {
+            log.error("Failed to send Twitter set_local_client: \(error)")
+        }
     }
 
     func clearTwitterLocalClient() {
         twitterAuthInProgress = false
-        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "clear_local_client"))
+        do {
+            try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "clear_local_client"))
+        } catch {
+            log.error("Failed to send Twitter clear_local_client: \(error)")
+        }
     }
 
     func connectTwitter() {
@@ -439,13 +478,21 @@ public final class SettingsStore: ObservableObject {
 
     func disconnectTwitter() {
         twitterAuthInProgress = false
-        try? daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
+        do {
+            try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
+        } catch {
+            log.error("Failed to send Twitter disconnect: \(error)")
+        }
     }
 
     // MARK: - Ingress Config Actions
 
     func refreshIngressConfig() {
-        try? daemonClient?.send(IngressConfigRequestMessage(action: "get"))
+        do {
+            try daemonClient?.send(IngressConfigRequestMessage(action: "get"))
+        } catch {
+            log.error("Failed to send ingress config get: \(error)")
+        }
     }
 
     func saveIngressPublicBaseUrl(_ raw: String) {
@@ -469,7 +516,11 @@ public final class SettingsStore: ObservableObject {
     func setIngressEnabled(_ enabled: Bool) {
         ingressEnabled = enabled
         pendingIngressEnabled = enabled
-        try? daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: ingressPublicBaseUrl, enabled: enabled))
+        do {
+            try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: ingressPublicBaseUrl, enabled: enabled))
+        } catch {
+            log.error("Failed to send ingress config set (enabled): \(error)")
+        }
     }
 
     // MARK: - Model Actions
@@ -519,7 +570,11 @@ public final class SettingsStore: ObservableObject {
         existingMediaEmbeds["videoAllowlistDomains"] = normalized
         existingUI["mediaEmbeds"] = existingMediaEmbeds
 
-        try? WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
+        do {
+            try WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for video allowlist domains: \(error)")
+        }
     }
 
     /// Writes the current `mediaEmbedsEnabled` and `mediaEmbedsEnabledSince` to
@@ -545,7 +600,11 @@ public final class SettingsStore: ObservableObject {
         }
         existingUI["mediaEmbeds"] = existingMediaEmbeds
 
-        try? WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
+        do {
+            try WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for media embed state: \(error)")
+        }
     }
 
     // MARK: - Media Embed Loading

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -248,7 +248,11 @@ public final class ChatViewModel: ObservableObject {
 
         // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data
         if (text == "/model" || text == "/models") && !hasSkillInvocation {
-            try? daemonClient.send(ModelGetRequestMessage())
+            do {
+                try daemonClient.send(ModelGetRequestMessage())
+            } catch {
+                log.error("Failed to send ModelGetRequest: \(error)")
+            }
         }
 
         // Fire auto-title callback on the first user message (skip slash commands
@@ -564,7 +568,11 @@ public final class ChatViewModel: ObservableObject {
         if messageLoopTask == nil {
             startMessageLoop()
         }
-        try? daemonClient.send(ModelSetRequestMessage(model: modelId))
+        do {
+            try daemonClient.send(ModelSetRequestMessage(model: modelId))
+        } catch {
+            log.error("Failed to send ModelSetRequest: \(error)")
+        }
     }
 
     // MARK: - Actions
@@ -577,7 +585,11 @@ public final class ChatViewModel: ObservableObject {
             actionId: actionId,
             data: data
         )
-        try? daemonClient.send(msg)
+        do {
+            try daemonClient.send(msg)
+        } catch {
+            log.error("Failed to send UiSurfaceAction: \(error)")
+        }
     }
 
     /// Cancel the queued user message without clearing `bootstrapCorrelationId`.
@@ -1375,7 +1387,11 @@ public final class ChatViewModel: ObservableObject {
         }
         // Refresh model/provider state so the picker/table has correct data on restart
         if hasModelCommand {
-            try? daemonClient.send(ModelGetRequestMessage())
+            do {
+                try daemonClient.send(ModelGetRequestMessage())
+            } catch {
+                log.error("Failed to send ModelGetRequest: \(error)")
+            }
         }
 
         self.isLoadingHistory = true

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -46,8 +46,14 @@ func resolveSessionTokenPath(environment: [String: String]? = nil) -> String {
 /// Read the daemon session token from disk.
 func readSessionToken(environment: [String: String]? = nil) -> String? {
     let tokenPath = resolveSessionTokenPath(environment: environment)
-    guard let data = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
-          let token = String(data: data, encoding: .utf8)?
+    let data: Data
+    do {
+        data = try Data(contentsOf: URL(fileURLWithPath: tokenPath))
+    } catch {
+        log.error("Failed to read session token from \(tokenPath): \(error)")
+        return nil
+    }
+    guard let token = String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
           !token.isEmpty else {
         return nil
@@ -1006,7 +1012,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 #endif
             }
             let tokenPath = tokenBase + "/.vellum/http-token"
-            bearerToken = (try? String(contentsOfFile: tokenPath, encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines)
+            do {
+                bearerToken = try String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                log.error("Failed to read HTTP bearer token from \(tokenPath): \(error)")
+                bearerToken = nil
+            }
         } else {
             return nil
         }

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -150,16 +150,24 @@ extension DaemonClient {
         #elseif os(iOS)
         case .signBundlePayload(let msg):
             log.warning("Received sign_bundle_payload request on iOS — signing not supported")
-            try? send(SignBundlePayloadResponseMessage(
-                requestId: msg.requestId,
-                error: "Signing operations are not available on iOS"
-            ))
+            do {
+                try send(SignBundlePayloadResponseMessage(
+                    requestId: msg.requestId,
+                    error: "Signing operations are not available on iOS"
+                ))
+            } catch {
+                log.error("Failed to send SignBundlePayloadResponse: \(error)")
+            }
         case .getSigningIdentity(let msg):
             log.warning("Received get_signing_identity request on iOS — signing not supported")
-            try? send(GetSigningIdentityResponseMessage(
-                requestId: msg.requestId,
-                error: "Signing operations are not available on iOS"
-            ))
+            do {
+                try send(GetSigningIdentityResponseMessage(
+                    requestId: msg.requestId,
+                    error: "Signing operations are not available on iOS"
+                ))
+            } catch {
+                log.error("Failed to send GetSigningIdentityResponse: \(error)")
+            }
         #else
         case .signBundlePayload, .getSigningIdentity:
             log.error("Signing operations are not supported on this platform")
@@ -253,10 +261,14 @@ extension DaemonClient {
             ))
         } catch {
             log.error("Failed to sign bundle payload: \(error.localizedDescription)")
-            try? send(SignBundlePayloadResponseMessage(
-                requestId: msg.requestId,
-                error: error.localizedDescription
-            ))
+            do {
+                try send(SignBundlePayloadResponseMessage(
+                    requestId: msg.requestId,
+                    error: error.localizedDescription
+                ))
+            } catch {
+                log.error("Failed to send SignBundlePayloadResponse: \(error)")
+            }
         }
     }
 
@@ -273,10 +285,14 @@ extension DaemonClient {
             ))
         } catch {
             log.error("Failed to get signing identity: \(error.localizedDescription)")
-            try? send(GetSigningIdentityResponseMessage(
-                requestId: msg.requestId,
-                error: error.localizedDescription
-            ))
+            do {
+                try send(GetSigningIdentityResponseMessage(
+                    requestId: msg.requestId,
+                    error: error.localizedDescription
+                ))
+            } catch {
+                log.error("Failed to send GetSigningIdentityResponse: \(error)")
+            }
         }
     }
     #endif

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -245,10 +245,14 @@ final class HTTPTransport {
             guard let http = response as? HTTPURLResponse else { return }
 
             if http.statusCode == 201 || http.statusCode == 200 {
-                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let runId = json["id"] as? String {
-                    self.activeRunId = runId
-                    log.info("Run created: \(runId)")
+                do {
+                    if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let runId = json["id"] as? String {
+                        self.activeRunId = runId
+                        log.info("Run created: \(runId)")
+                    }
+                } catch {
+                    log.error("Failed to deserialize create run response: \(error)")
                 }
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
@@ -344,12 +348,14 @@ final class HTTPTransport {
                 return
             }
 
-            if let decoded = try? decoder.decode(ConversationsListResponse.self, from: data) {
+            do {
+                let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
                     IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions)))
-            } else {
+            } catch {
+                log.error("Failed to decode session list response: \(error)")
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [])))
             }
         } catch {
@@ -375,26 +381,29 @@ final class HTTPTransport {
 
             // The /v1/messages endpoint returns { messages: [...] } which doesn't
             // directly map to a HistoryResponseMessage. We need to construct one.
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let messages = json["messages"] as? [[String: Any]] {
-                // Convert REST messages to IPC history format
-                var historyMessages: [[String: Any]] = []
-                for msg in messages {
-                    historyMessages.append(msg)
-                }
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let messages = json["messages"] as? [[String: Any]] {
+                    // Convert REST messages to IPC history format
+                    var historyMessages: [[String: Any]] = []
+                    for msg in messages {
+                        historyMessages.append(msg)
+                    }
 
-                // Emit as raw JSON that the history response decoder can handle
-                var historyPayload: [String: Any] = [
-                    "type": "history_response",
-                    "sessionId": conversationKey,
-                    "messages": historyMessages
-                ]
-                _ = historyPayload.removeValue(forKey: "")
+                    // Emit as raw JSON that the history response decoder can handle
+                    var historyPayload: [String: Any] = [
+                        "type": "history_response",
+                        "sessionId": conversationKey,
+                        "messages": historyMessages
+                    ]
+                    _ = historyPayload.removeValue(forKey: "")
 
-                if let historyData = try? JSONSerialization.data(withJSONObject: historyPayload),
-                   let historyResponse = try? decoder.decode(ServerMessage.self, from: historyData) {
+                    let historyData = try JSONSerialization.data(withJSONObject: historyPayload)
+                    let historyResponse = try decoder.decode(ServerMessage.self, from: historyData)
                     onMessage?(historyResponse)
                 }
+            } catch {
+                log.error("Failed to deserialize history response: \(error)")
             }
         } catch {
             log.error("Fetch history error: \(error.localizedDescription)")
@@ -414,7 +423,12 @@ final class HTTPTransport {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
-            return try? JSONDecoder().decode(RemoteIdentityInfo.self, from: data)
+            do {
+                return try JSONDecoder().decode(RemoteIdentityInfo.self, from: data)
+            } catch {
+                log.error("Failed to decode remote identity response: \(error)")
+                return nil
+            }
         } catch {
             log.error("fetchRemoteIdentity failed: \(error.localizedDescription)")
             return nil

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -52,11 +52,15 @@ public final class IpcBlobStore: Sendable {
 
     /// Ensure the blob directory exists.
     public func ensureDirectory() {
-        try? FileManager.default.createDirectory(
-            atPath: blobDirPath,
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
+        do {
+            try FileManager.default.createDirectory(
+                atPath: blobDirPath,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        } catch {
+            log.error("Failed to create blob directory at \(self.blobDirPath): \(error)")
+        }
     }
 
     /// Write data atomically to a blob file and return a ref describing the blob.
@@ -85,7 +89,11 @@ public final class IpcBlobStore: Sendable {
             )
         } catch {
             log.error("Failed to write blob \(id): \(error.localizedDescription)")
-            try? FileManager.default.removeItem(atPath: tempPath)
+            do {
+                try FileManager.default.removeItem(atPath: tempPath)
+            } catch {
+                log.error("Failed to clean up temp blob file at \(tempPath): \(error)")
+            }
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Replaces ~50 silent `try?` calls across the macOS app with `do/catch` blocks that log errors via `os.Logger`
- Makes IPC failures, daemon connection issues, file I/O errors, and config problems visible in `log stream` instead of being silently swallowed
- Adds a logger to `LayoutConfigStore.swift` (the only file that needed one)
- Intentionally preserves `try?` for `Task.sleep` (cancellation expected), markdown parsing (cosmetic), and `AnyCodable` type probing (pattern)

## Files changed
- `AppDelegate.swift` — 10 daemon connect/hatch/send calls
- `AppDelegate+Sessions.swift` — 3 CU session abort/submit calls
- `AppDelegate+MenuBar.swift` — 3 skill toggle/app open calls
- `ChatViewModel.swift` — 4 model get/set/surface action calls
- `SettingsStore.swift` — 14 daemon send + config merge calls
- `Session.swift` — 7 observation send calls
- `DaemonMessageRouter.swift` — 4 IPC response send calls
- `ThreadManager.swift` — 1 session switch call
- `HTTPDaemonClient.swift` — 5 response deserialization calls
- `DaemonClient.swift` — 2 token file read calls
- `IpcBlobStore.swift` — 2 directory create/cleanup calls
- `AssistantCli.swift` — 4 PID/JSON file operations
- `LayoutConfigStore.swift` — 5 config load/save calls + added logger

## Test plan
- [ ] Build succeeds (`cd clients/macos && swift build`)
- [ ] Kill daemon while app is running — verify errors appear in `log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level debug`
- [ ] Normal app usage still works (no behavioral changes, only logging added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
