### PR TITLE
feat: stream hatch logs to macOS app log box

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -42,6 +42,12 @@ const DEFAULT_SPECIES: Species = "vellum";
 
 const SPINNER_FRAMES= ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+const IS_DESKTOP = !!process.env.VELLUM_DESKTOP_APP;
+
+function desktopLog(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
 function buildTimestampRedirect(): string {
   return `exec > >(while IFS= read -r line; do printf '[%s] %s\\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$line"; done > /var/log/startup-script.log) 2>&1`;
 }
@@ -215,6 +221,10 @@ export async function watchHatching(
   startTime: number,
   species: Species,
 ): Promise<WatchHatchingResult> {
+  if (IS_DESKTOP) {
+    return watchHatchingDesktop(pollFn, instanceName, startTime, species);
+  }
+
   let spinnerIdx = 0;
   let lastLogLine: string | null = null;
   let linesDrawn = 0;
@@ -316,6 +326,70 @@ export async function watchHatching(
       console.log(`   ⚠️  Detaching. Instance is still running.`);
       console.log(`   Monitor with: vel logs ${instanceName}`);
       console.log("");
+      process.exit(0);
+    });
+  });
+}
+
+function watchHatchingDesktop(
+  pollFn: () => Promise<PollResult>,
+  instanceName: string,
+  startTime: number,
+  species: Species,
+): Promise<WatchHatchingResult> {
+  return new Promise<WatchHatchingResult>((resolve) => {
+    let prevLogLine: string | null = null;
+    let lastErrorContent = "";
+    let pollInFlight = false;
+    let nextPollAt = Date.now() + 15000;
+
+    desktopLog("Waiting for instance to start...");
+
+    const interval = setInterval(async () => {
+      const elapsed = Date.now() - startTime;
+
+      if (elapsed >= HATCH_TIMEOUT_MS[species]) {
+        clearInterval(interval);
+        desktopLog(`Timed out after ${formatElapsed(elapsed)}. Instance is still running.`);
+        desktopLog(`Monitor with: vel logs ${instanceName}`);
+        resolve({ success: true, errorContent: lastErrorContent });
+        return;
+      }
+
+      if (Date.now() < nextPollAt || pollInFlight) return;
+
+      pollInFlight = true;
+      try {
+        const result = await pollFn();
+
+        if (result.lastLine && result.lastLine !== prevLogLine) {
+          prevLogLine = result.lastLine;
+          desktopLog(result.lastLine);
+        }
+
+        if (result.errorContent) {
+          lastErrorContent = result.errorContent;
+        }
+
+        if (result.done) {
+          clearInterval(interval);
+          if (result.failed) {
+            desktopLog("Startup script failed");
+          } else {
+            desktopLog("Your assistant has hatched!");
+          }
+          resolve({ success: !result.failed, errorContent: lastErrorContent });
+        }
+      } finally {
+        pollInFlight = false;
+        nextPollAt = Date.now() + 5000;
+      }
+    }, 5000);
+
+    process.on("SIGINT", () => {
+      clearInterval(interval);
+      desktopLog("Detaching. Instance is still running.");
+      desktopLog(`Monitor with: vel logs ${instanceName}`);
       process.exit(0);
     });
   });


### PR DESCRIPTION
## Summary
- When `VELLUM_DESKTOP_APP=1`, the CLI's `watchHatching()` now outputs clean newline-separated log lines instead of ANSI spinner escape codes
- Adds a `watchHatchingDesktop()` function that polls every 5s and only outputs when a new log line appears, completing, failing, or timing out
- TTY spinner behavior is completely unchanged when the env var is not set

## Test plan
- [ ] Set `VELLUM_DESKTOP_APP=1` and run `vel hatch --remote gcp` manually — verify clean log output with no ANSI codes
- [ ] Launch the macOS app and trigger GCP hatching — confirm logs appear in the Hatching screen log box
- [ ] Run `vel hatch --remote gcp` without the env var — verify the TTY spinner still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
