### PR TITLE
fix: improve daemon connection error UX with doctor navigation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -234,7 +234,7 @@ extension AppDelegate {
             daemonClient: daemonClient,
             maxSteps: 1
         )
-        session.state = .failed(reason: "Cannot connect to daemon. Please ensure the daemon is running.")
+        session.state = .failed(reason: "Failed to connect to the assistant.")
         currentSession = session
         let overlay = SessionOverlayWindow(session: session)
         overlay.show()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -8,6 +8,8 @@ struct ChatErrorBanner: View {
     let onSendAnyway: () -> Void
     let isRetryableError: Bool
     let onRetryError: () -> Void
+    let isConnectionError: Bool
+    let onOpenDoctor: () -> Void
     let onDismissError: () -> Void
 
     var body: some View {
@@ -32,6 +34,21 @@ struct ChatErrorBanner: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Send message anyway")
+            } else if isConnectionError {
+                Button(action: onOpenDoctor) {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "stethoscope")
+                            .font(VFont.caption)
+                        Text("Vellum Doctor")
+                            .font(VFont.captionMedium)
+                    }
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(Color.white.opacity(0.2)) // Intentional: translucent contrast on VColor.error banner
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open Vellum Doctor")
             } else if isRetryableError {
                 Button(action: onRetryError) {
                     Text("Retry")

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -19,6 +19,8 @@ struct ChatView: View {
     let onDismissError: () -> Void
     let isRetryableError: Bool
     let onRetryError: () -> Void
+    let isConnectionError: Bool
+    let onOpenDoctor: () -> Void
     let isSecretBlockError: Bool
     let onSendAnyway: () -> Void
     let onAcceptSuggestion: () -> Void
@@ -217,6 +219,8 @@ struct ChatView: View {
                     onSendAnyway: onSendAnyway,
                     isRetryableError: isRetryableError,
                     onRetryError: onRetryError,
+                    isConnectionError: isConnectionError,
+                    onOpenDoctor: onOpenDoctor,
                     onDismissError: onDismissError
                 )
             }
@@ -713,6 +717,8 @@ private struct ChatViewPreviewWrapper: View {
                 onDismissError: {},
                 isRetryableError: false,
                 onRetryError: {},
+                isConnectionError: false,
+                onOpenDoctor: {},
                 isSecretBlockError: false,
                 onSendAnyway: {},
                 onAcceptSuggestion: {},

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -508,6 +508,8 @@ struct ActiveChatViewWrapper: View {
             onDismissError: viewModel.dismissError,
             isRetryableError: viewModel.isRetryableError,
             onRetryError: { viewModel.retryLastMessage() },
+            isConnectionError: viewModel.isConnectionError,
+            onOpenDoctor: { windowState.selection = .panel(.doctor) },
             isSecretBlockError: viewModel.isSecretBlockError,
             onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -381,7 +381,7 @@ public final class ChatViewModel: ObservableObject {
                     self.bootstrapCorrelationId = nil
                     self.lastFailedMessageText = self.pendingUserMessage
                     self.lastFailedMessageAttachments = self.pendingUserAttachments
-                    self.lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
+                    self.lastFailedSendError = "Failed to connect to the assistant."
                     self.pendingUserMessage = nil
                     self.pendingUserAttachments = nil
                     self.errorText = self.lastFailedSendError
@@ -428,7 +428,7 @@ public final class ChatViewModel: ObservableObject {
             // retry). A queued retry failing must not clobber the active turn's
             // isSending/isThinking flags or show an error banner over it.
             if queuedMessageId == nil {
-                lastFailedSendError = "Cannot connect to daemon. Please ensure it's running."
+                lastFailedSendError = "Failed to connect to the assistant."
                 errorText = lastFailedSendError
             }
             // Remove the queued message ID to prevent stale FIFO entries
@@ -765,7 +765,7 @@ public final class ChatViewModel: ObservableObject {
     public func regenerateLastMessage() {
         guard let sessionId, !isSending else { return }
         guard daemonClient.isConnected else {
-            errorText = "Cannot connect to daemon. Please ensure it's running."
+            errorText = "Failed to connect to the assistant."
             return
         }
 
@@ -968,7 +968,12 @@ public final class ChatViewModel: ObservableObject {
     /// validation, confirmation response failures, regenerate errors) from
     /// offering to resend a stale cached message.
     public var isRetryableError: Bool {
-        lastFailedMessageText != nil && lastFailedSendError != nil
+        lastFailedMessageText != nil && lastFailedSendError != nil && !isConnectionError
+    }
+
+    /// Whether the current error is a daemon/assistant connection failure.
+    public var isConnectionError: Bool {
+        lastFailedSendError == "Failed to connect to the assistant."
     }
 
     /// Whether the current error is a secret-ingress block that can be bypassed.


### PR DESCRIPTION
## Summary
- Change "Cannot connect to daemon. Please ensure it's running." to "Failed to connect to the assistant." (user-facing, less technical)
- For connection errors, replace the "Retry" button with a "Vellum Doctor" button that opens the doctor panel for diagnostics
- Other retryable errors (session creation, message send failures) still show the "Retry" button

## Test plan
- [ ] Trigger a daemon connection error — verify the error says "Failed to connect to the assistant." with a "Vellum Doctor" button
- [ ] Click "Vellum Doctor" — verify it opens the doctor panel
- [ ] Trigger a non-connection send error — verify the "Retry" button still appears
- [ ] Dismiss the error with the X button — verify it clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
