### PR TITLE
M2: Runtime Integration — TwiML + Orchestrator + ElevenLabs Client

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -29,6 +29,8 @@ mock.module('../util/logger.js', () => ({
 
 // ── Config mock ─────────────────────────────────────────────────────
 
+let mockCallModel: string | undefined = undefined;
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     apiKeys: { anthropic: 'test-key' },
@@ -41,6 +43,7 @@ mock.module('../config/loader.js', () => ({
       silenceTimeoutSeconds: 30,
       disclosure: { enabled: false, text: '' },
       safety: { denyCategories: [] },
+      model: mockCallModel,
     },
   }),
 }));
@@ -192,6 +195,7 @@ function setupOrchestrator(task?: string) {
 describe('call-orchestrator', () => {
   beforeEach(() => {
     resetTables();
+    mockCallModel = undefined;
     // Reset the stream mock to default behaviour
     mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
   });
@@ -450,5 +454,33 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
     // Second destroy should not throw
     expect(() => orchestrator.destroy()).not.toThrow();
+  });
+
+  // ── Model override from config ──────────────────────────────────────
+
+  test('uses default model when calls.model is not set', async () => {
+    mockCallModel = undefined;
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Default model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  test('uses calls.model override from config when set', async () => {
+    mockCallModel = 'claude-haiku-4-5-20251001';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-haiku-4-5-20251001');
+      return createMockStream(['Override model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
   });
 });

--- a/assistant/src/__tests__/elevenlabs-client.test.ts
+++ b/assistant/src/__tests__/elevenlabs-client.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  ElevenLabsClient,
+  ElevenLabsError,
+  type ElevenLabsClientOptions,
+  type ElevenLabsRegisterCallRequest,
+} from '../calls/elevenlabs-client.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS: ElevenLabsClientOptions = {
+  apiBaseUrl: 'https://api.elevenlabs.io',
+  apiKey: 'test-api-key-secret',
+  timeoutMs: 5000,
+};
+
+const DEFAULT_REQUEST: ElevenLabsRegisterCallRequest = {
+  agent_id: 'agent-123',
+  from_number: '+15551111111',
+  to_number: '+15552222222',
+  direction: 'outbound',
+};
+
+let fetchMock: ReturnType<typeof mock>;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('ElevenLabsClient', () => {
+  describe('registerCall', () => {
+    test('successful register-call returns TwiML', async () => {
+      const twimlResponse = '<?xml version="1.0"?><Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twimlResponse, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twimlResponse);
+    });
+
+    test('passes xi-api-key header in request', async () => {
+      let capturedHeaders: Headers | null = null;
+
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      expect(capturedHeaders).not.toBeNull();
+      expect(capturedHeaders!.get('xi-api-key')).toBe('test-api-key-secret');
+      expect(capturedHeaders!.get('Content-Type')).toBe('application/json');
+    });
+
+    test('sends correct URL and request body', async () => {
+      let capturedUrl = '';
+      let capturedBody = '';
+
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      expect(capturedUrl).toBe('https://api.elevenlabs.io/v1/convai/twilio/register-call');
+      const parsed = JSON.parse(capturedBody);
+      expect(parsed.agent_id).toBe('agent-123');
+      expect(parsed.from_number).toBe('+15551111111');
+      expect(parsed.to_number).toBe('+15552222222');
+      expect(parsed.direction).toBe('outbound');
+    });
+
+    test('non-2xx response throws ELEVENLABS_HTTP_ERROR', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('Internal Server Error', { status: 500 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_HTTP_ERROR');
+        expect(elErr.statusCode).toBe(500);
+        expect(elErr.message).toContain('500');
+      }
+    });
+
+    test('empty response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+      }
+    });
+
+    test('whitespace-only response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('   \n  ', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+      }
+    });
+
+    test('timeout throws ELEVENLABS_TIMEOUT', async () => {
+      globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        // Wait longer than the timeout
+        return new Promise<Response>((resolve, reject) => {
+          const timer = setTimeout(() => resolve(new Response('<Response/>', { status: 200 })), 10000);
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient({ ...DEFAULT_OPTIONS, timeoutMs: 50 });
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_TIMEOUT');
+        expect(elErr.message).toContain('50ms');
+      }
+    });
+
+    test('network error throws ELEVENLABS_HTTP_ERROR', async () => {
+      globalThis.fetch = mock(async () => {
+        throw new TypeError('Failed to fetch');
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_HTTP_ERROR');
+        expect(elErr.message).toContain('Failed to fetch');
+      }
+    });
+
+    test('API key is not included in logged data', async () => {
+      // The ElevenLabsClient logs agent_id and direction, but should never log the API key.
+      // We verify this by checking the request structure, not the log output.
+      let capturedBody = '';
+
+      globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      // The request body should not contain the API key
+      expect(capturedBody).not.toContain('test-api-key-secret');
+    });
+  });
+});

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for TwiML generation with voice quality profiles.
+ *
+ * Tests that generateTwiML correctly uses profile values for
+ * ttsProvider, voice, language, and transcriptionProvider.
+ */
+import { describe, test, expect, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { generateTwiML } from '../calls/twilio-routes.js';
+
+describe('generateTwiML with voice quality profile', () => {
+  const callSessionId = 'test-session-123';
+  const relayUrl = 'wss://test.example.com/v1/calls/relay';
+  const welcomeGreeting = 'Hello, how can I help?';
+
+  test('TwiML includes ttsProvider="Google" when profile specifies Google', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+    expect(twiml).toContain('language="en-US"');
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+  });
+
+  test('TwiML includes ttsProvider="ElevenLabs" when profile specifies ElevenLabs', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+    });
+
+    expect(twiml).toContain('ttsProvider="ElevenLabs"');
+    expect(twiml).toContain('voice="voice123-turbo_v2_5-0.5_0.75_0"');
+  });
+
+  test('voice attribute reflects configured voice for twilio_standard mode', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+  });
+
+  test('voice attribute reflects configured voice for twilio_elevenlabs_tts mode', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'abc123-turbo_v2_5-0.5_0.75_0',
+    });
+
+    expect(twiml).toContain('voice="abc123-turbo_v2_5-0.5_0.75_0"');
+  });
+
+  test('language attribute reflects configured language', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'es-MX',
+      transcriptionProvider: 'Google',
+      ttsProvider: 'Google',
+      voice: 'Google.es-MX-Standard-A',
+    });
+
+    expect(twiml).toContain('language="es-MX"');
+  });
+
+  test('transcriptionProvider reflects configured value', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Google',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('transcriptionProvider="Google"');
+  });
+
+  test('TwiML properly escapes XML characters in profile values', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'voice<>&"test',
+    });
+
+    expect(twiml).toContain('voice="voice&lt;&gt;&amp;&quot;test"');
+    expect(twiml).not.toContain('voice="voice<>&"test"');
+  });
+
+  test('TwiML includes callSessionId in relay URL', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain(`callSessionId=${callSessionId}`);
+  });
+
+  test('TwiML includes interruptible and dtmfDetection attributes', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('interruptible="true"');
+    expect(twiml).toContain('dtmfDetection="true"');
+  });
+});

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -190,9 +190,11 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
+      const callModel = getConfig().calls.model ?? 'claude-sonnet-4-20250514';
+
       const stream = client.messages.stream(
         {
-          model: 'claude-sonnet-4-20250514',
+          model: callModel,
           max_tokens: 512,
           system: this.buildSystemPrompt(),
           messages: this.conversationHistory.map((m) => ({

--- a/assistant/src/calls/elevenlabs-client.ts
+++ b/assistant/src/calls/elevenlabs-client.ts
@@ -1,0 +1,89 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('elevenlabs-client');
+
+export interface ElevenLabsRegisterCallRequest {
+  agent_id: string;
+  from_number: string;
+  to_number: string;
+  direction: 'outbound' | 'inbound';
+  conversation_initiation_client_data?: Record<string, unknown>;
+}
+
+export interface ElevenLabsRegisterCallResult {
+  twiml: string;
+}
+
+export interface ElevenLabsClientOptions {
+  apiBaseUrl: string;
+  apiKey: string;
+  timeoutMs: number;
+}
+
+export type ElevenLabsErrorCode = 'ELEVENLABS_TIMEOUT' | 'ELEVENLABS_HTTP_ERROR' | 'ELEVENLABS_INVALID_RESPONSE';
+
+export class ElevenLabsError extends Error {
+  code: ElevenLabsErrorCode;
+  statusCode?: number;
+
+  constructor(code: ElevenLabsErrorCode, message: string, statusCode?: number) {
+    super(message);
+    this.name = 'ElevenLabsError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class ElevenLabsClient {
+  private options: ElevenLabsClientOptions;
+
+  constructor(options: ElevenLabsClientOptions) {
+    this.options = options;
+  }
+
+  async registerCall(request: ElevenLabsRegisterCallRequest): Promise<ElevenLabsRegisterCallResult> {
+    const url = `${this.options.apiBaseUrl}/v1/convai/twilio/register-call`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      log.info({ agent_id: request.agent_id, direction: request.direction }, 'Registering call with ElevenLabs');
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'xi-api-key': this.options.apiKey,
+        },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_HTTP_ERROR',
+          `ElevenLabs register-call returned ${response.status}`,
+          response.status,
+        );
+      }
+
+      const body = await response.text();
+      if (!body || body.trim().length === 0) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_INVALID_RESPONSE',
+          'ElevenLabs register-call returned empty response',
+        );
+      }
+
+      return { twiml: body };
+    } catch (err) {
+      if (err instanceof ElevenLabsError) throw err;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new ElevenLabsError('ELEVENLABS_TIMEOUT', `ElevenLabs register-call timed out after ${this.options.timeoutMs}ms`);
+      }
+      throw new ElevenLabsError('ELEVENLABS_HTTP_ERROR', `ElevenLabs register-call failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/assistant/src/calls/elevenlabs-config.ts
+++ b/assistant/src/calls/elevenlabs-config.ts
@@ -1,0 +1,29 @@
+import { getConfig } from '../config/loader.js';
+import { getSecureKey } from '../security/secure-keys.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('elevenlabs-config');
+
+export interface ElevenLabsConfig {
+  apiKey: string;
+  apiBaseUrl: string;
+  agentId: string;
+  registerCallTimeoutMs: number;
+}
+
+export function getElevenLabsConfig(): ElevenLabsConfig {
+  const config = getConfig();
+  const voice = config.calls.voice;
+
+  const apiKey = getSecureKey('credential:elevenlabs:api_key') ?? '';
+  if (!apiKey) {
+    log.warn('No ElevenLabs API key found in secure key store (credential:elevenlabs:api_key)');
+  }
+
+  return {
+    apiKey,
+    apiBaseUrl: voice.elevenlabs.apiBaseUrl,
+    agentId: voice.elevenlabs.agentId,
+    registerCallTimeoutMs: voice.elevenlabs.registerCallTimeoutMs,
+  };
+}

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -25,6 +25,9 @@ import { getTwilioConfig } from './twilio-config.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { fireCallCompletionNotifier } from './call-state.js';
+import { resolveVoiceQualityProfile } from './voice-quality.js';
+import { getElevenLabsConfig } from './elevenlabs-config.js';
+import { ElevenLabsClient } from './elevenlabs-client.js';
 
 const log = getLogger('twilio-routes');
 
@@ -39,17 +42,22 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function generateTwiML(callSessionId: string, relayUrl: string, welcomeGreeting: string): string {
+export function generateTwiML(
+  callSessionId: string,
+  relayUrl: string,
+  welcomeGreeting: string,
+  profile: { language: string; transcriptionProvider: string; ttsProvider: string; voice: string },
+): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <ConversationRelay
       url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}"
       welcomeGreeting="${escapeXml(welcomeGreeting)}"
-      voice="Google.en-US-Journey-O"
-      language="en-US"
-      transcriptionProvider="Deepgram"
-      ttsProvider="Google"
+      voice="${escapeXml(profile.voice)}"
+      language="${escapeXml(profile.language)}"
+      transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"
+      ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"
     />
@@ -131,6 +139,14 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
+  const profile = resolveVoiceQualityProfile(loadConfig());
+
+  log.info({ callSessionId, mode: profile.mode, ttsProvider: profile.ttsProvider, voice: profile.voice }, 'Voice quality profile resolved');
+
+  if (profile.validationErrors.length > 0) {
+    log.warn({ callSessionId, errors: profile.validationErrors }, 'Voice quality profile has validation warnings');
+  }
+
   const twilioConfig = getTwilioConfig();
   let relayUrl: string;
   try {
@@ -141,7 +157,40 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
-  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting);
+  if (profile.mode === 'elevenlabs_agent') {
+    try {
+      const elevenLabsConfig = getElevenLabsConfig();
+      const client = new ElevenLabsClient({
+        apiBaseUrl: elevenLabsConfig.apiBaseUrl,
+        apiKey: elevenLabsConfig.apiKey,
+        timeoutMs: elevenLabsConfig.registerCallTimeoutMs,
+      });
+
+      const result = await client.registerCall({
+        agent_id: elevenLabsConfig.agentId,
+        from_number: formBody.get('From') || session.fromNumber,
+        to_number: formBody.get('To') || session.toNumber,
+        direction: 'outbound',
+      });
+
+      log.info({ callSessionId }, 'ElevenLabs register-call succeeded');
+      return new Response(result.twiml, {
+        status: 200,
+        headers: { 'Content-Type': 'text/xml' },
+      });
+    } catch (err) {
+      log.error({ err, callSessionId }, 'ElevenLabs register-call failed');
+      if (profile.fallbackToStandardOnError) {
+        log.warn({ callSessionId }, 'Falling back to twilio_standard mode');
+        const standardProfile = resolveVoiceQualityProfile({ ...loadConfig(), calls: { ...loadConfig().calls, voice: { ...loadConfig().calls.voice, mode: 'twilio_standard' } } });
+        const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, standardProfile);
+        return new Response(twiml, { status: 200, headers: { 'Content-Type': 'text/xml' } });
+      }
+      return new Response('ElevenLabs service unavailable', { status: 502 });
+    }
+  }
+
+  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 
   log.info({ callSessionId }, 'Returning ConversationRelay TwiML');
 


### PR DESCRIPTION
Wire resolveVoiceQualityProfile into handleVoiceWebhook for mode-dependent TwiML generation. Add ElevenLabsClient for register-call API. Add elevenlabs-config for credential loading. Wire calls.model into CallOrchestrator. Part of #6158, closes #6160.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
