### PR TITLE
Fix: Include agentId in voice quality profile

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -944,6 +944,7 @@ describe('resolveVoiceQualityProfile', () => {
     expect(profile.mode).toBe('elevenlabs_agent');
     expect(profile.ttsProvider).toBe('ElevenLabs');
     expect(profile.voice).toBe('v1-turbo_v2_5-0.5_0.75_0');
+    expect(profile.agentId).toBe('agent-123');
     expect(profile.validationErrors).toEqual([]);
   });
 

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -6,6 +6,7 @@ export interface VoiceQualityProfile {
   transcriptionProvider: string;
   ttsProvider: string;
   voice: string;
+  agentId?: string;
   fallbackToStandardOnError: boolean;
   validationErrors: string[];
 }
@@ -81,6 +82,7 @@ export function resolveVoiceQualityProfile(config?: ReturnType<typeof loadConfig
       transcriptionProvider: voice.transcriptionProvider,
       ttsProvider: 'ElevenLabs',
       voice: buildElevenLabsVoiceSpec(voice.elevenlabs),
+      agentId: voice.elevenlabs.agentId,
       fallbackToStandardOnError: voice.fallbackToStandardOnError,
       validationErrors: errors,
     };


### PR DESCRIPTION
Address Codex review feedback on #6162: the VoiceQualityProfile now carries agentId for elevenlabs_agent mode, making the profile self-documenting and ensuring downstream consumers don't need to re-read config separately. Part of #6158.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
