### PR TITLE
Fix: Treat blank calls.model as unset

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -483,4 +483,30 @@ describe('call-orchestrator', () => {
     await orchestrator.handleCallerUtterance('Hello');
     orchestrator.destroy();
   });
+
+  test('treats empty string calls.model as unset and falls back to default', async () => {
+    mockCallModel = '';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Fallback model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  test('treats whitespace-only calls.model as unset and falls back to default', async () => {
+    mockCallModel = '   ';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Fallback model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
 });

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -190,7 +190,7 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      const callModel = getConfig().calls.model ?? 'claude-sonnet-4-20250514';
+      const callModel = getConfig().calls.model?.trim() || 'claude-sonnet-4-20250514';
 
       const stream = client.messages.stream(
         {


### PR DESCRIPTION
Address Codex feedback on #6165: empty/whitespace-only calls.model now falls back to default model instead of being sent to the API. Part of #6158.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
