### PR TITLE
Optional ElevenLabs Voice Quality for Calls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3525,6 +3525,7 @@ sequenceDiagram
 | `assistant/src/calls/call-state.ts` | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and orchestrator registry |
 | `assistant/src/calls/call-constants.ts` | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers |
 | `assistant/src/calls/voice-provider.ts` | Abstract VoiceProvider interface for provider-agnostic call initiation |
+| `assistant/src/calls/voice-quality.ts` | Voice quality profile resolution: `resolveVoiceQualityProfile()` reads `calls.voice` config and returns effective TTS provider, voice spec, and fallback settings for the active mode |
 | `assistant/src/calls/twilio-config.ts` | Twilio credential and configuration resolution from secure key store and environment |
 | `assistant/src/calls/types.ts` | TypeScript type definitions: CallSession, CallEvent, CallPendingQuestion, CallStatus, CallEventType |
 | `gateway/src/http/routes/twilio-voice-webhook.ts` | Gateway route: validates Twilio signature, forwards voice webhook to runtime |
@@ -3670,6 +3671,25 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.disclosure.enabled` | boolean | `true` | Whether the AI should disclose it is an AI at the start of the call. |
 | `calls.disclosure.text` | string | *(default disclosure prompt)* | The disclosure instruction included in the system prompt. |
 | `calls.safety.denyCategories` | string[] | `[]` | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting). |
+| `calls.model` | string | *(unset — uses default model)* | Optional override for the LLM model used in call orchestration. |
+| `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay), `elevenlabs_agent` (full ElevenLabs conversational agent). |
+| `calls.voice.language` | string | `'en-US'` | Language code for TTS and transcription. |
+| `calls.voice.transcriptionProvider` | enum | `'Deepgram'` | Speech-to-text provider (`Deepgram` or `Google`). |
+| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors). |
+| `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
+| `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
+
+### Voice Quality Profile Resolution
+
+Voice and TTS settings are configurable via the `calls.voice` config block — they are not hardcoded. The function `resolveVoiceQualityProfile()` in `voice-quality.ts` reads the current config and resolves it into an effective `VoiceQualityProfile` containing the TTS provider, voice spec string, language, transcription provider, and fallback policy.
+
+The resolution logic works as follows:
+
+- **`twilio_standard`** — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
+- **`twilio_elevenlabs_tts`** — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
+- **`elevenlabs_agent`** — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`.
+
+When `fallbackToStandardOnError` is `true` (default), any misconfiguration or runtime error in ElevenLabs modes causes a graceful fallback to standard Twilio TTS rather than a call failure. Validation errors are captured in `validationErrors` on the profile for logging.
 
 ---
 

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -29,6 +29,8 @@ mock.module('../util/logger.js', () => ({
 
 // ── Config mock ─────────────────────────────────────────────────────
 
+let mockCallModel: string | undefined = undefined;
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     apiKeys: { anthropic: 'test-key' },
@@ -41,6 +43,7 @@ mock.module('../config/loader.js', () => ({
       silenceTimeoutSeconds: 30,
       disclosure: { enabled: false, text: '' },
       safety: { denyCategories: [] },
+      model: mockCallModel,
     },
   }),
 }));
@@ -192,6 +195,7 @@ function setupOrchestrator(task?: string) {
 describe('call-orchestrator', () => {
   beforeEach(() => {
     resetTables();
+    mockCallModel = undefined;
     // Reset the stream mock to default behaviour
     mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
   });
@@ -450,5 +454,33 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
     // Second destroy should not throw
     expect(() => orchestrator.destroy()).not.toThrow();
+  });
+
+  // ── Model override from config ──────────────────────────────────────
+
+  test('uses default model when calls.model is not set', async () => {
+    mockCallModel = undefined;
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Default model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  test('uses calls.model override from config when set', async () => {
+    mockCallModel = 'claude-haiku-4-5-20251001';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-haiku-4-5-20251001');
+      return createMockStream(['Override model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
   });
 });

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -483,4 +483,30 @@ describe('call-orchestrator', () => {
     await orchestrator.handleCallerUtterance('Hello');
     orchestrator.destroy();
   });
+
+  test('treats empty string calls.model as unset and falls back to default', async () => {
+    mockCallModel = '';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Fallback model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  test('treats whitespace-only calls.model as unset and falls back to default', async () => {
+    mockCallModel = '   ';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { model: string };
+      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
+      return createMockStream(['Fallback model response.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
 });

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -55,6 +55,7 @@ import { _setBackend } from '../security/secure-keys.js';
 import { loadConfig, invalidateConfigCache } from '../config/loader.js';
 import { AssistantConfigSchema } from '../config/schema.js';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
+import { buildElevenLabsVoiceSpec, resolveVoiceQualityProfile } from '../calls/voice-quality.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -655,6 +656,23 @@ describe('AssistantConfigSchema', () => {
       safety: {
         denyCategories: [],
       },
+      voice: {
+        mode: 'twilio_standard',
+        language: 'en-US',
+        transcriptionProvider: 'Deepgram',
+        fallbackToStandardOnError: true,
+        elevenlabs: {
+          voiceId: '',
+          voiceModelId: 'turbo_v2_5',
+          stability: 0.5,
+          similarityBoost: 0.75,
+          style: 0.0,
+          useSpeakerBoost: true,
+          agentId: '',
+          apiBaseUrl: 'https://api.elevenlabs.io',
+          registerCallTimeoutMs: 5000,
+        },
+      },
     });
   });
 
@@ -744,6 +762,260 @@ describe('AssistantConfigSchema', () => {
       calls: { safety: { denyCategories: 'spam' } },
     });
     expect(result.success).toBe(false);
+  });
+
+  // ── Calls voice config ──────────────────────────────────────────────
+
+  test('config without calls.voice parses correctly and produces defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.calls.voice.mode).toBe('twilio_standard');
+    expect(result.calls.voice.language).toBe('en-US');
+    expect(result.calls.voice.transcriptionProvider).toBe('Deepgram');
+    expect(result.calls.voice.fallbackToStandardOnError).toBe(true);
+    expect(result.calls.voice.elevenlabs.voiceId).toBe('');
+    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('turbo_v2_5');
+    expect(result.calls.voice.elevenlabs.stability).toBe(0.5);
+    expect(result.calls.voice.elevenlabs.similarityBoost).toBe(0.75);
+    expect(result.calls.voice.elevenlabs.style).toBe(0.0);
+    expect(result.calls.voice.elevenlabs.useSpeakerBoost).toBe(true);
+    expect(result.calls.voice.elevenlabs.agentId).toBe('');
+    expect(result.calls.voice.elevenlabs.apiBaseUrl).toBe('https://api.elevenlabs.io');
+    expect(result.calls.voice.elevenlabs.registerCallTimeoutMs).toBe(5000);
+  });
+
+  test('accepts valid calls.voice overrides', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'twilio_elevenlabs_tts',
+          language: 'es-ES',
+          transcriptionProvider: 'Google',
+          fallbackToStandardOnError: false,
+          elevenlabs: {
+            voiceId: 'abc123',
+            stability: 0.8,
+          },
+        },
+      },
+    });
+    expect(result.calls.voice.mode).toBe('twilio_elevenlabs_tts');
+    expect(result.calls.voice.language).toBe('es-ES');
+    expect(result.calls.voice.transcriptionProvider).toBe('Google');
+    expect(result.calls.voice.fallbackToStandardOnError).toBe(false);
+    expect(result.calls.voice.elevenlabs.voiceId).toBe('abc123');
+    expect(result.calls.voice.elevenlabs.stability).toBe(0.8);
+    // Defaults preserved for unset fields
+    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('turbo_v2_5');
+    expect(result.calls.voice.elevenlabs.similarityBoost).toBe(0.75);
+  });
+
+  test('rejects invalid calls.voice.mode', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { mode: 'invalid_mode' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('calls.voice.mode'))).toBe(true);
+    }
+  });
+
+  test('rejects invalid calls.voice.transcriptionProvider', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { transcriptionProvider: 'AWS' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('calls.voice.transcriptionProvider'))).toBe(true);
+    }
+  });
+
+  test('rejects calls.voice.elevenlabs.stability out of range', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { elevenlabs: { stability: 1.5 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects calls.voice.elevenlabs.registerCallTimeoutMs below 1000', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { elevenlabs: { registerCallTimeoutMs: 500 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects calls.voice.elevenlabs.registerCallTimeoutMs above 15000', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { elevenlabs: { registerCallTimeoutMs: 20000 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts optional calls.model', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: { model: 'claude-haiku-4-5-20251001' },
+    });
+    expect(result.calls.model).toBe('claude-haiku-4-5-20251001');
+  });
+
+  test('calls.model is undefined by default', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.calls.model).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Voice quality profile resolver
+// ---------------------------------------------------------------------------
+
+describe('resolveVoiceQualityProfile', () => {
+  test('returns correct profile for twilio_standard', () => {
+    const config = AssistantConfigSchema.parse({});
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('twilio_standard');
+    expect(profile.ttsProvider).toBe('Google');
+    expect(profile.voice).toBe('Google.en-US-Journey-O');
+    expect(profile.transcriptionProvider).toBe('Deepgram');
+    expect(profile.fallbackToStandardOnError).toBe(true);
+    expect(profile.validationErrors).toEqual([]);
+  });
+
+  test('returns correct profile for twilio_elevenlabs_tts with valid voiceId', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'twilio_elevenlabs_tts',
+          elevenlabs: { voiceId: 'test-voice-id' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('twilio_elevenlabs_tts');
+    expect(profile.ttsProvider).toBe('ElevenLabs');
+    expect(profile.voice).toBe('test-voice-id-turbo_v2_5-0.5_0.75_0');
+    expect(profile.validationErrors).toEqual([]);
+  });
+
+  test('falls back for twilio_elevenlabs_tts with empty voiceId and fallback enabled', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'twilio_elevenlabs_tts',
+          fallbackToStandardOnError: true,
+          elevenlabs: { voiceId: '' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('twilio_standard');
+    expect(profile.ttsProvider).toBe('Google');
+    expect(profile.voice).toBe('Google.en-US-Journey-O');
+    expect(profile.validationErrors.length).toBe(1);
+    expect(profile.validationErrors[0]).toContain('falling back');
+  });
+
+  test('returns errors for twilio_elevenlabs_tts with empty voiceId and fallback disabled', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'twilio_elevenlabs_tts',
+          fallbackToStandardOnError: false,
+          elevenlabs: { voiceId: '' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('twilio_elevenlabs_tts');
+    expect(profile.validationErrors.length).toBe(1);
+    expect(profile.validationErrors[0]).toContain('voiceId is required');
+  });
+
+  test('returns correct profile for elevenlabs_agent with valid agentId', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'elevenlabs_agent',
+          elevenlabs: { agentId: 'agent-123', voiceId: 'v1' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('elevenlabs_agent');
+    expect(profile.ttsProvider).toBe('ElevenLabs');
+    expect(profile.voice).toBe('v1-turbo_v2_5-0.5_0.75_0');
+    expect(profile.validationErrors).toEqual([]);
+  });
+
+  test('falls back for elevenlabs_agent with empty agentId and fallback enabled', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'elevenlabs_agent',
+          fallbackToStandardOnError: true,
+          elevenlabs: { agentId: '' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('twilio_standard');
+    expect(profile.validationErrors.length).toBe(1);
+    expect(profile.validationErrors[0]).toContain('agentId is empty');
+  });
+
+  test('returns errors for elevenlabs_agent with empty agentId and fallback disabled', () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          mode: 'elevenlabs_agent',
+          fallbackToStandardOnError: false,
+          elevenlabs: { agentId: '' },
+        },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.mode).toBe('elevenlabs_agent');
+    expect(profile.validationErrors.length).toBe(1);
+    expect(profile.validationErrors[0]).toContain('agentId is required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildElevenLabsVoiceSpec
+// ---------------------------------------------------------------------------
+
+describe('buildElevenLabsVoiceSpec', () => {
+  test('produces correct voice string with all params', () => {
+    const spec = buildElevenLabsVoiceSpec({
+      voiceId: 'abc123',
+      voiceModelId: 'turbo_v2_5',
+      stability: 0.5,
+      similarityBoost: 0.75,
+      style: 0.0,
+    });
+    expect(spec).toBe('abc123-turbo_v2_5-0.5_0.75_0');
+  });
+
+  test('returns empty string when voiceId is empty', () => {
+    const spec = buildElevenLabsVoiceSpec({
+      voiceId: '',
+      voiceModelId: 'turbo_v2_5',
+      stability: 0.5,
+      similarityBoost: 0.75,
+      style: 0.0,
+    });
+    expect(spec).toBe('');
+  });
+
+  test('formats custom parameters correctly', () => {
+    const spec = buildElevenLabsVoiceSpec({
+      voiceId: 'myVoice',
+      voiceModelId: 'eleven_multilingual_v2',
+      stability: 0.8,
+      similarityBoost: 0.9,
+      style: 0.3,
+    });
+    expect(spec).toBe('myVoice-eleven_multilingual_v2-0.8_0.9_0.3');
   });
 });
 
@@ -994,6 +1266,11 @@ describe('loadConfig with schema validation', () => {
     expect(config.calls.userConsultTimeoutSeconds).toBe(120);
     expect(config.calls.disclosure.enabled).toBe(true);
     expect(config.calls.safety.denyCategories).toEqual([]);
+    expect(config.calls.voice.mode).toBe('twilio_standard');
+    expect(config.calls.voice.language).toBe('en-US');
+    expect(config.calls.voice.transcriptionProvider).toBe('Deepgram');
+    expect(config.calls.voice.elevenlabs.voiceId).toBe('');
+    expect(config.calls.model).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -944,6 +944,7 @@ describe('resolveVoiceQualityProfile', () => {
     expect(profile.mode).toBe('elevenlabs_agent');
     expect(profile.ttsProvider).toBe('ElevenLabs');
     expect(profile.voice).toBe('v1-turbo_v2_5-0.5_0.75_0');
+    expect(profile.agentId).toBe('agent-123');
     expect(profile.validationErrors).toEqual([]);
   });
 

--- a/assistant/src/__tests__/elevenlabs-client.test.ts
+++ b/assistant/src/__tests__/elevenlabs-client.test.ts
@@ -29,7 +29,6 @@ const DEFAULT_REQUEST: ElevenLabsRegisterCallRequest = {
   direction: 'outbound',
 };
 
-let fetchMock: ReturnType<typeof mock>;
 let originalFetch: typeof globalThis.fetch;
 
 beforeEach(() => {

--- a/assistant/src/__tests__/elevenlabs-client.test.ts
+++ b/assistant/src/__tests__/elevenlabs-client.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  ElevenLabsClient,
+  ElevenLabsError,
+  type ElevenLabsClientOptions,
+  type ElevenLabsRegisterCallRequest,
+} from '../calls/elevenlabs-client.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS: ElevenLabsClientOptions = {
+  apiBaseUrl: 'https://api.elevenlabs.io',
+  apiKey: 'test-api-key-secret',
+  timeoutMs: 5000,
+};
+
+const DEFAULT_REQUEST: ElevenLabsRegisterCallRequest = {
+  agent_id: 'agent-123',
+  from_number: '+15551111111',
+  to_number: '+15552222222',
+  direction: 'outbound',
+};
+
+let fetchMock: ReturnType<typeof mock>;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('ElevenLabsClient', () => {
+  describe('registerCall', () => {
+    test('successful register-call returns TwiML', async () => {
+      const twimlResponse = '<?xml version="1.0"?><Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twimlResponse, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twimlResponse);
+    });
+
+    test('passes xi-api-key header in request', async () => {
+      let capturedHeaders: Headers | null = null;
+
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      expect(capturedHeaders).not.toBeNull();
+      expect(capturedHeaders!.get('xi-api-key')).toBe('test-api-key-secret');
+      expect(capturedHeaders!.get('Content-Type')).toBe('application/json');
+    });
+
+    test('sends correct URL and request body', async () => {
+      let capturedUrl = '';
+      let capturedBody = '';
+
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      expect(capturedUrl).toBe('https://api.elevenlabs.io/v1/convai/twilio/register-call');
+      const parsed = JSON.parse(capturedBody);
+      expect(parsed.agent_id).toBe('agent-123');
+      expect(parsed.from_number).toBe('+15551111111');
+      expect(parsed.to_number).toBe('+15552222222');
+      expect(parsed.direction).toBe('outbound');
+    });
+
+    test('non-2xx response throws ELEVENLABS_HTTP_ERROR', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('Internal Server Error', { status: 500 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_HTTP_ERROR');
+        expect(elErr.statusCode).toBe(500);
+        expect(elErr.message).toContain('500');
+      }
+    });
+
+    test('empty response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+      }
+    });
+
+    test('whitespace-only response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('   \n  ', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+      }
+    });
+
+    test('timeout throws ELEVENLABS_TIMEOUT', async () => {
+      globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        // Wait longer than the timeout
+        return new Promise<Response>((resolve, reject) => {
+          const timer = setTimeout(() => resolve(new Response('<Response/>', { status: 200 })), 10000);
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient({ ...DEFAULT_OPTIONS, timeoutMs: 50 });
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_TIMEOUT');
+        expect(elErr.message).toContain('50ms');
+      }
+    });
+
+    test('network error throws ELEVENLABS_HTTP_ERROR', async () => {
+      globalThis.fetch = mock(async () => {
+        throw new TypeError('Failed to fetch');
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_HTTP_ERROR');
+        expect(elErr.message).toContain('Failed to fetch');
+      }
+    });
+
+    test('API key is not included in logged data', async () => {
+      // The ElevenLabsClient logs agent_id and direction, but should never log the API key.
+      // We verify this by checking the request structure, not the log output.
+      let capturedBody = '';
+
+      globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('<Response/>', { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      await client.registerCall(DEFAULT_REQUEST);
+
+      // The request body should not contain the API key
+      expect(capturedBody).not.toContain('test-api-key-secret');
+    });
+  });
+});

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for TwiML generation with voice quality profiles.
+ *
+ * Tests that generateTwiML correctly uses profile values for
+ * ttsProvider, voice, language, and transcriptionProvider.
+ */
+import { describe, test, expect, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { generateTwiML } from '../calls/twilio-routes.js';
+
+describe('generateTwiML with voice quality profile', () => {
+  const callSessionId = 'test-session-123';
+  const relayUrl = 'wss://test.example.com/v1/calls/relay';
+  const welcomeGreeting = 'Hello, how can I help?';
+
+  test('TwiML includes ttsProvider="Google" when profile specifies Google', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+    expect(twiml).toContain('language="en-US"');
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+  });
+
+  test('TwiML includes ttsProvider="ElevenLabs" when profile specifies ElevenLabs', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+    });
+
+    expect(twiml).toContain('ttsProvider="ElevenLabs"');
+    expect(twiml).toContain('voice="voice123-turbo_v2_5-0.5_0.75_0"');
+  });
+
+  test('voice attribute reflects configured voice for twilio_standard mode', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+  });
+
+  test('voice attribute reflects configured voice for twilio_elevenlabs_tts mode', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'abc123-turbo_v2_5-0.5_0.75_0',
+    });
+
+    expect(twiml).toContain('voice="abc123-turbo_v2_5-0.5_0.75_0"');
+  });
+
+  test('language attribute reflects configured language', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'es-MX',
+      transcriptionProvider: 'Google',
+      ttsProvider: 'Google',
+      voice: 'Google.es-MX-Standard-A',
+    });
+
+    expect(twiml).toContain('language="es-MX"');
+  });
+
+  test('transcriptionProvider reflects configured value', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Google',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('transcriptionProvider="Google"');
+  });
+
+  test('TwiML properly escapes XML characters in profile values', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'voice<>&"test',
+    });
+
+    expect(twiml).toContain('voice="voice&lt;&gt;&amp;&quot;test"');
+    expect(twiml).not.toContain('voice="voice<>&"test"');
+  });
+
+  test('TwiML includes callSessionId in relay URL', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain(`callSessionId=${callSessionId}`);
+  });
+
+  test('TwiML includes interruptible and dtmfDetection attributes', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).toContain('interruptible="true"');
+    expect(twiml).toContain('dtmfDetection="true"');
+  });
+});

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -190,9 +190,11 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
+      const callModel = getConfig().calls.model ?? 'claude-sonnet-4-20250514';
+
       const stream = client.messages.stream(
         {
-          model: 'claude-sonnet-4-20250514',
+          model: callModel,
           max_tokens: 512,
           system: this.buildSystemPrompt(),
           messages: this.conversationHistory.map((m) => ({

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -190,7 +190,7 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      const callModel = getConfig().calls.model ?? 'claude-sonnet-4-20250514';
+      const callModel = getConfig().calls.model?.trim() || 'claude-sonnet-4-20250514';
 
       const stream = client.messages.stream(
         {

--- a/assistant/src/calls/elevenlabs-client.ts
+++ b/assistant/src/calls/elevenlabs-client.ts
@@ -1,0 +1,89 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('elevenlabs-client');
+
+export interface ElevenLabsRegisterCallRequest {
+  agent_id: string;
+  from_number: string;
+  to_number: string;
+  direction: 'outbound' | 'inbound';
+  conversation_initiation_client_data?: Record<string, unknown>;
+}
+
+export interface ElevenLabsRegisterCallResult {
+  twiml: string;
+}
+
+export interface ElevenLabsClientOptions {
+  apiBaseUrl: string;
+  apiKey: string;
+  timeoutMs: number;
+}
+
+export type ElevenLabsErrorCode = 'ELEVENLABS_TIMEOUT' | 'ELEVENLABS_HTTP_ERROR' | 'ELEVENLABS_INVALID_RESPONSE';
+
+export class ElevenLabsError extends Error {
+  code: ElevenLabsErrorCode;
+  statusCode?: number;
+
+  constructor(code: ElevenLabsErrorCode, message: string, statusCode?: number) {
+    super(message);
+    this.name = 'ElevenLabsError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class ElevenLabsClient {
+  private options: ElevenLabsClientOptions;
+
+  constructor(options: ElevenLabsClientOptions) {
+    this.options = options;
+  }
+
+  async registerCall(request: ElevenLabsRegisterCallRequest): Promise<ElevenLabsRegisterCallResult> {
+    const url = `${this.options.apiBaseUrl}/v1/convai/twilio/register-call`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      log.info({ agent_id: request.agent_id, direction: request.direction }, 'Registering call with ElevenLabs');
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'xi-api-key': this.options.apiKey,
+        },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_HTTP_ERROR',
+          `ElevenLabs register-call returned ${response.status}`,
+          response.status,
+        );
+      }
+
+      const body = await response.text();
+      if (!body || body.trim().length === 0) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_INVALID_RESPONSE',
+          'ElevenLabs register-call returned empty response',
+        );
+      }
+
+      return { twiml: body };
+    } catch (err) {
+      if (err instanceof ElevenLabsError) throw err;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new ElevenLabsError('ELEVENLABS_TIMEOUT', `ElevenLabs register-call timed out after ${this.options.timeoutMs}ms`);
+      }
+      throw new ElevenLabsError('ELEVENLABS_HTTP_ERROR', `ElevenLabs register-call failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/assistant/src/calls/elevenlabs-config.ts
+++ b/assistant/src/calls/elevenlabs-config.ts
@@ -1,0 +1,29 @@
+import { getConfig } from '../config/loader.js';
+import { getSecureKey } from '../security/secure-keys.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('elevenlabs-config');
+
+export interface ElevenLabsConfig {
+  apiKey: string;
+  apiBaseUrl: string;
+  agentId: string;
+  registerCallTimeoutMs: number;
+}
+
+export function getElevenLabsConfig(): ElevenLabsConfig {
+  const config = getConfig();
+  const voice = config.calls.voice;
+
+  const apiKey = getSecureKey('credential:elevenlabs:api_key') ?? '';
+  if (!apiKey) {
+    log.warn('No ElevenLabs API key found in secure key store (credential:elevenlabs:api_key)');
+  }
+
+  return {
+    apiKey,
+    apiBaseUrl: voice.elevenlabs.apiBaseUrl,
+    agentId: voice.elevenlabs.agentId,
+    registerCallTimeoutMs: voice.elevenlabs.registerCallTimeoutMs,
+  };
+}

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -25,6 +25,9 @@ import { getTwilioConfig } from './twilio-config.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { fireCallCompletionNotifier } from './call-state.js';
+import { resolveVoiceQualityProfile } from './voice-quality.js';
+import { getElevenLabsConfig } from './elevenlabs-config.js';
+import { ElevenLabsClient } from './elevenlabs-client.js';
 
 const log = getLogger('twilio-routes');
 
@@ -39,17 +42,22 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function generateTwiML(callSessionId: string, relayUrl: string, welcomeGreeting: string): string {
+export function generateTwiML(
+  callSessionId: string,
+  relayUrl: string,
+  welcomeGreeting: string,
+  profile: { language: string; transcriptionProvider: string; ttsProvider: string; voice: string },
+): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <ConversationRelay
       url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}"
       welcomeGreeting="${escapeXml(welcomeGreeting)}"
-      voice="Google.en-US-Journey-O"
-      language="en-US"
-      transcriptionProvider="Deepgram"
-      ttsProvider="Google"
+      voice="${escapeXml(profile.voice)}"
+      language="${escapeXml(profile.language)}"
+      transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"
+      ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"
     />
@@ -131,6 +139,14 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
+  const profile = resolveVoiceQualityProfile(loadConfig());
+
+  log.info({ callSessionId, mode: profile.mode, ttsProvider: profile.ttsProvider, voice: profile.voice }, 'Voice quality profile resolved');
+
+  if (profile.validationErrors.length > 0) {
+    log.warn({ callSessionId, errors: profile.validationErrors }, 'Voice quality profile has validation warnings');
+  }
+
   const twilioConfig = getTwilioConfig();
   let relayUrl: string;
   try {
@@ -141,7 +157,40 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
-  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting);
+  if (profile.mode === 'elevenlabs_agent') {
+    try {
+      const elevenLabsConfig = getElevenLabsConfig();
+      const client = new ElevenLabsClient({
+        apiBaseUrl: elevenLabsConfig.apiBaseUrl,
+        apiKey: elevenLabsConfig.apiKey,
+        timeoutMs: elevenLabsConfig.registerCallTimeoutMs,
+      });
+
+      const result = await client.registerCall({
+        agent_id: elevenLabsConfig.agentId,
+        from_number: formBody.get('From') || session.fromNumber,
+        to_number: formBody.get('To') || session.toNumber,
+        direction: 'outbound',
+      });
+
+      log.info({ callSessionId }, 'ElevenLabs register-call succeeded');
+      return new Response(result.twiml, {
+        status: 200,
+        headers: { 'Content-Type': 'text/xml' },
+      });
+    } catch (err) {
+      log.error({ err, callSessionId }, 'ElevenLabs register-call failed');
+      if (profile.fallbackToStandardOnError) {
+        log.warn({ callSessionId }, 'Falling back to twilio_standard mode');
+        const standardProfile = resolveVoiceQualityProfile({ ...loadConfig(), calls: { ...loadConfig().calls, voice: { ...loadConfig().calls.voice, mode: 'twilio_standard' } } });
+        const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, standardProfile);
+        return new Response(twiml, { status: 200, headers: { 'Content-Type': 'text/xml' } });
+      }
+      return new Response('ElevenLabs service unavailable', { status: 502 });
+    }
+  }
+
+  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 
   log.info({ callSessionId }, 'Returning ConversationRelay TwiML');
 

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -6,6 +6,7 @@ export interface VoiceQualityProfile {
   transcriptionProvider: string;
   ttsProvider: string;
   voice: string;
+  agentId?: string;
   fallbackToStandardOnError: boolean;
   validationErrors: string[];
 }
@@ -81,6 +82,7 @@ export function resolveVoiceQualityProfile(config?: ReturnType<typeof loadConfig
       transcriptionProvider: voice.transcriptionProvider,
       ttsProvider: 'ElevenLabs',
       voice: buildElevenLabsVoiceSpec(voice.elevenlabs),
+      agentId: voice.elevenlabs.agentId,
       fallbackToStandardOnError: voice.fallbackToStandardOnError,
       validationErrors: errors,
     };

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,0 +1,90 @@
+import { loadConfig } from '../config/loader.js';
+
+export interface VoiceQualityProfile {
+  mode: 'twilio_standard' | 'twilio_elevenlabs_tts' | 'elevenlabs_agent';
+  language: string;
+  transcriptionProvider: string;
+  ttsProvider: string;
+  voice: string;
+  fallbackToStandardOnError: boolean;
+  validationErrors: string[];
+}
+
+/**
+ * Build a Twilio-compatible ElevenLabs voice string.
+ * Format: voiceId or voiceId-modelId-stability_similarity_style
+ */
+export function buildElevenLabsVoiceSpec(config: {
+  voiceId: string;
+  voiceModelId: string;
+  stability: number;
+  similarityBoost: number;
+  style: number;
+}): string {
+  if (!config.voiceId) return '';
+  return `${config.voiceId}-${config.voiceModelId}-${config.stability}_${config.similarityBoost}_${config.style}`;
+}
+
+/**
+ * Resolve the effective voice quality profile from config.
+ * Returns a profile with all resolved values ready for use by TwiML generation
+ * and call orchestration.
+ */
+export function resolveVoiceQualityProfile(config?: ReturnType<typeof loadConfig>): VoiceQualityProfile {
+  const cfg = config ?? loadConfig();
+  const voice = cfg.calls.voice;
+  const errors: string[] = [];
+
+  // Default/standard profile
+  const standardProfile: VoiceQualityProfile = {
+    mode: 'twilio_standard',
+    language: voice.language,
+    transcriptionProvider: voice.transcriptionProvider,
+    ttsProvider: 'Google',
+    voice: 'Google.en-US-Journey-O',
+    fallbackToStandardOnError: voice.fallbackToStandardOnError,
+    validationErrors: [],
+  };
+
+  if (voice.mode === 'twilio_standard') {
+    return standardProfile;
+  }
+
+  if (voice.mode === 'twilio_elevenlabs_tts') {
+    if (!voice.elevenlabs.voiceId && !voice.fallbackToStandardOnError) {
+      errors.push('calls.voice.elevenlabs.voiceId is required for twilio_elevenlabs_tts mode when fallback is disabled');
+    }
+    if (!voice.elevenlabs.voiceId && voice.fallbackToStandardOnError) {
+      return { ...standardProfile, validationErrors: ['calls.voice.elevenlabs.voiceId is empty; falling back to twilio_standard'] };
+    }
+    return {
+      mode: 'twilio_elevenlabs_tts',
+      language: voice.language,
+      transcriptionProvider: voice.transcriptionProvider,
+      ttsProvider: 'ElevenLabs',
+      voice: buildElevenLabsVoiceSpec(voice.elevenlabs),
+      fallbackToStandardOnError: voice.fallbackToStandardOnError,
+      validationErrors: errors,
+    };
+  }
+
+  if (voice.mode === 'elevenlabs_agent') {
+    if (!voice.elevenlabs.agentId && !voice.fallbackToStandardOnError) {
+      errors.push('calls.voice.elevenlabs.agentId is required for elevenlabs_agent mode when fallback is disabled');
+    }
+    if (!voice.elevenlabs.agentId && voice.fallbackToStandardOnError) {
+      return { ...standardProfile, validationErrors: ['calls.voice.elevenlabs.agentId is empty; falling back to twilio_standard'] };
+    }
+    return {
+      mode: 'elevenlabs_agent',
+      language: voice.language,
+      transcriptionProvider: voice.transcriptionProvider,
+      ttsProvider: 'ElevenLabs',
+      voice: buildElevenLabsVoiceSpec(voice.elevenlabs),
+      fallbackToStandardOnError: voice.fallbackToStandardOnError,
+      validationErrors: errors,
+    };
+  }
+
+  return standardProfile;
+}

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -10,13 +10,22 @@ You are helping the user set up and make outgoing phone calls via Twilio. This s
 
 ## Overview
 
-The calling system uses Twilio's ConversationRelay to place outbound phone calls. When a call is placed:
+The calling system uses Twilio's ConversationRelay to place outbound phone calls. Twilio works out of the box as the default voice provider. Optionally, you can enable ElevenLabs integration for higher-quality, more natural-sounding voices — but this is entirely optional.
+
+When a call is placed:
 
 1. The assistant initiates an outbound call via the Twilio REST API
 2. Twilio connects to the gateway's voice webhook, which returns TwiML
 3. Twilio opens a ConversationRelay WebSocket for real-time voice streaming
 4. An LLM-driven orchestrator manages the conversation — receiving caller speech (transcribed by Deepgram), generating responses via Claude, and streaming text back for TTS playback
 5. The transcript is relayed live to the user's conversation thread
+
+Three voice quality modes are available:
+- **`twilio_standard`** (default) — Standard Twilio TTS with Google voices. No extra setup required.
+- **`twilio_elevenlabs_tts`** — Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
+- **`elevenlabs_agent`** — Full ElevenLabs conversational agent mode for the highest quality (requires ElevenLabs agent setup).
+
+You can keep using Twilio only — no changes needed. Enabling ElevenLabs can improve naturalness and quality.
 
 The user's assistant gets its own personal phone number through Twilio.
 
@@ -137,6 +146,59 @@ Before making real calls, offer a quick verification:
 Suggest a test call to the user's own phone: **"Want to do a quick test call to your phone to make sure everything works?"**
 
 If they agree, ask for their personal phone number and place a test call with a simple task like "Introduce yourself and confirm the call system is working."
+
+## Optional: Higher Quality Voice with ElevenLabs
+
+ElevenLabs integration is entirely optional. The standard Twilio-only setup works unchanged — this section is only relevant if you want to improve voice quality.
+
+### Mode: `twilio_elevenlabs_tts`
+
+Uses ElevenLabs voices through Twilio's ConversationRelay. Speech is more natural-sounding than the default Google TTS voices. No ElevenLabs API key is needed for this mode — just a voice ID.
+
+**Setup:**
+
+1. Browse ElevenLabs voices at https://elevenlabs.io/voice-library and pick a voice ID
+2. Set the voice mode and voice ID:
+
+```bash
+vellum config set calls.voice.mode twilio_elevenlabs_tts
+vellum config set calls.voice.elevenlabs.voiceId "<your-voice-id>"
+```
+
+### Mode: `elevenlabs_agent`
+
+Full ElevenLabs conversational agent mode. This requires an ElevenLabs account with an agent configured on their platform.
+
+**Setup:**
+
+1. Store your ElevenLabs API key securely:
+
+```
+credential_store action=set service=credential:elevenlabs:api_key value=<your_api_key>
+```
+
+2. Set the voice mode and agent ID:
+
+```bash
+vellum config set calls.voice.mode elevenlabs_agent
+vellum config set calls.voice.elevenlabs.agentId "<your-agent-id>"
+```
+
+### Fallback behavior
+
+By default, `calls.voice.fallbackToStandardOnError` is `true`. This means if ElevenLabs is unavailable or misconfigured (e.g., missing voice ID, API errors), calls automatically fall back to standard Twilio TTS rather than failing. You can disable this if you want strict ElevenLabs-only behavior:
+
+```bash
+vellum config set calls.voice.fallbackToStandardOnError false
+```
+
+### Reverting to standard Twilio
+
+To go back to the default voice at any time:
+
+```bash
+vellum config set calls.voice.mode twilio_standard
+```
 
 ## Making Calls
 
@@ -282,6 +344,13 @@ All call-related settings can be managed via `vellum config`:
 | `calls.userConsultTimeoutSeconds` | How long to wait for user answers | `120` (2 min) |
 | `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
 | `calls.disclosure.text` | The disclosure message spoken at call start | `"I should let you know that I'm an AI assistant calling on behalf of my user."` |
+| `calls.model` | Override LLM model for call orchestration | *(uses default model)* |
+| `calls.voice.mode` | Voice quality mode (`twilio_standard`, `twilio_elevenlabs_tts`, `elevenlabs_agent`) | `twilio_standard` |
+| `calls.voice.language` | Language code for TTS and transcription | `en-US` |
+| `calls.voice.transcriptionProvider` | Speech-to-text provider (`Deepgram`, `Google`) | `Deepgram` |
+| `calls.voice.fallbackToStandardOnError` | Auto-fallback to standard Twilio TTS on ElevenLabs errors | `true` |
+| `calls.voice.elevenlabs.voiceId` | ElevenLabs voice ID (for `twilio_elevenlabs_tts` mode) | *(empty)* |
+| `calls.voice.elevenlabs.agentId` | ElevenLabs agent ID (for `elevenlabs_agent` mode) | *(empty)* |
 
 ### Adjusting settings
 
@@ -332,3 +401,14 @@ Or re-run the public-ingress skill to auto-detect and save the new URL.
 
 ### Call drops after 30 seconds of silence
 The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the agent will ask "Are you still there?" This is expected behavior.
+
+### Call quality didn't improve after enabling ElevenLabs
+- Verify `calls.voice.mode` is set to `twilio_elevenlabs_tts` or `elevenlabs_agent` (not still `twilio_standard`)
+- Check that `calls.voice.elevenlabs.voiceId` contains a valid ElevenLabs voice ID
+- If mode is `elevenlabs_agent`, ensure `calls.voice.elevenlabs.agentId` is also set
+
+### ElevenLabs mode falls back to standard
+When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error. Check:
+- For `elevenlabs_agent` mode: verify the API key is stored (`credential_store action=get service=credential:elevenlabs:api_key`) and that `calls.voice.elevenlabs.agentId` is configured
+- For `twilio_elevenlabs_tts` mode: verify `calls.voice.elevenlabs.voiceId` is set to a valid voice ID
+- Review daemon logs for error messages related to ElevenLabs

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -226,6 +226,24 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     safety: {
       denyCategories: [],
     },
+    voice: {
+      mode: 'twilio_standard' as const,
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram' as const,
+      fallbackToStandardOnError: true,
+      elevenlabs: {
+        voiceId: '',
+        voiceModelId: 'turbo_v2_5',
+        stability: 0.5,
+        similarityBoost: 0.75,
+        style: 0.0,
+        useSpeakerBoost: true,
+        agentId: '',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 5000,
+      },
+    },
+    model: undefined,
   },
   ingress: {
     enabled: false,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -9,6 +9,8 @@ const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
+const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
+const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -885,6 +887,75 @@ export const CallsSafetyConfigSchema = z.object({
     .default([]),
 });
 
+export const CallsElevenLabsConfigSchema = z.object({
+  voiceId: z
+    .string({ error: 'calls.voice.elevenlabs.voiceId must be a string' })
+    .default(''),
+  voiceModelId: z
+    .string({ error: 'calls.voice.elevenlabs.voiceModelId must be a string' })
+    .default('turbo_v2_5'),
+  stability: z
+    .number({ error: 'calls.voice.elevenlabs.stability must be a number' })
+    .min(0, 'calls.voice.elevenlabs.stability must be >= 0')
+    .max(1, 'calls.voice.elevenlabs.stability must be <= 1')
+    .default(0.5),
+  similarityBoost: z
+    .number({ error: 'calls.voice.elevenlabs.similarityBoost must be a number' })
+    .min(0, 'calls.voice.elevenlabs.similarityBoost must be >= 0')
+    .max(1, 'calls.voice.elevenlabs.similarityBoost must be <= 1')
+    .default(0.75),
+  style: z
+    .number({ error: 'calls.voice.elevenlabs.style must be a number' })
+    .min(0, 'calls.voice.elevenlabs.style must be >= 0')
+    .max(1, 'calls.voice.elevenlabs.style must be <= 1')
+    .default(0.0),
+  useSpeakerBoost: z
+    .boolean({ error: 'calls.voice.elevenlabs.useSpeakerBoost must be a boolean' })
+    .default(true),
+  agentId: z
+    .string({ error: 'calls.voice.elevenlabs.agentId must be a string' })
+    .default(''),
+  apiBaseUrl: z
+    .string({ error: 'calls.voice.elevenlabs.apiBaseUrl must be a string' })
+    .default('https://api.elevenlabs.io'),
+  registerCallTimeoutMs: z
+    .number({ error: 'calls.voice.elevenlabs.registerCallTimeoutMs must be a number' })
+    .int('calls.voice.elevenlabs.registerCallTimeoutMs must be an integer')
+    .min(1000, 'calls.voice.elevenlabs.registerCallTimeoutMs must be >= 1000')
+    .max(15000, 'calls.voice.elevenlabs.registerCallTimeoutMs must be <= 15000')
+    .default(5000),
+});
+
+export const CallsVoiceConfigSchema = z.object({
+  mode: z
+    .enum(VALID_CALL_VOICE_MODES, {
+      error: `calls.voice.mode must be one of: ${VALID_CALL_VOICE_MODES.join(', ')}`,
+    })
+    .default('twilio_standard'),
+  language: z
+    .string({ error: 'calls.voice.language must be a string' })
+    .default('en-US'),
+  transcriptionProvider: z
+    .enum(VALID_CALL_TRANSCRIPTION_PROVIDERS, {
+      error: `calls.voice.transcriptionProvider must be one of: ${VALID_CALL_TRANSCRIPTION_PROVIDERS.join(', ')}`,
+    })
+    .default('Deepgram'),
+  fallbackToStandardOnError: z
+    .boolean({ error: 'calls.voice.fallbackToStandardOnError must be a boolean' })
+    .default(true),
+  elevenlabs: CallsElevenLabsConfigSchema.default({
+    voiceId: '',
+    voiceModelId: 'turbo_v2_5',
+    stability: 0.5,
+    similarityBoost: 0.75,
+    style: 0.0,
+    useSpeakerBoost: true,
+    agentId: '',
+    apiBaseUrl: 'https://api.elevenlabs.io',
+    registerCallTimeoutMs: 5000,
+  }),
+});
+
 export const CallsConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'calls.enabled must be a boolean' })
@@ -913,6 +984,26 @@ export const CallsConfigSchema = z.object({
   safety: CallsSafetyConfigSchema.default({
     denyCategories: [],
   }),
+  voice: CallsVoiceConfigSchema.default({
+    mode: 'twilio_standard',
+    language: 'en-US',
+    transcriptionProvider: 'Deepgram',
+    fallbackToStandardOnError: true,
+    elevenlabs: {
+      voiceId: '',
+      voiceModelId: 'turbo_v2_5',
+      stability: 0.5,
+      similarityBoost: 0.75,
+      style: 0.0,
+      useSpeakerBoost: true,
+      agentId: '',
+      apiBaseUrl: 'https://api.elevenlabs.io',
+      registerCallTimeoutMs: 5000,
+    },
+  }),
+  model: z
+    .string({ error: 'calls.model must be a string' })
+    .optional(),
 });
 
 export const SkillsConfigSchema = z.object({
@@ -1178,6 +1269,23 @@ export const AssistantConfigSchema = z.object({
     safety: {
       denyCategories: [],
     },
+    voice: {
+      mode: 'twilio_standard',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      fallbackToStandardOnError: true,
+      elevenlabs: {
+        voiceId: '',
+        voiceModelId: 'turbo_v2_5',
+        stability: 0.5,
+        similarityBoost: 0.75,
+        style: 0.0,
+        useSpeakerBoost: true,
+        agentId: '',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 5000,
+      },
+    },
   }),
   ingress: IngressConfigSchema.default({
     enabled: false,
@@ -1243,4 +1351,6 @@ export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;
 export type CallsConfig = z.infer<typeof CallsConfigSchema>;
 export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;
 export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
+export type CallsVoiceConfig = z.infer<typeof CallsVoiceConfigSchema>;
+export type CallsElevenLabsConfig = z.infer<typeof CallsElevenLabsConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -34,5 +34,7 @@ export type {
   CallsConfig,
   CallsDisclosureConfig,
   CallsSafetyConfig,
+  CallsVoiceConfig,
+  CallsElevenLabsConfig,
   IngressConfig,
 } from './schema.js';


### PR DESCRIPTION
## Summary
Add an optional ElevenLabs voice path to improve outbound call quality while preserving the existing Twilio-only calling stack as the default. Three configurable voice modes: `twilio_standard` (default, no change), `twilio_elevenlabs_tts` (ElevenLabs voices via Twilio ConversationRelay), and `elevenlabs_agent` (full ElevenLabs conversational agent flow).

## Changes

**Config + Voice Quality Profile (#6162, #6166)**
- Extended `CallsConfigSchema` with `calls.voice.*` (mode, language, transcriptionProvider, fallbackToStandardOnError, elevenlabs settings) and `calls.model`
- Created `voice-quality.ts` with `resolveVoiceQualityProfile()` — resolves config into effective TTS/voice settings
- Profile carries `agentId` for `elevenlabs_agent` mode for self-documenting downstream use

**Runtime Integration (#6165, #6167)**
- Refactored `generateTwiML()` to use resolved voice profile instead of hardcoded values
- Added mode branching in `handleVoiceWebhook`: standard → current behavior, ElevenLabs TTS → ElevenLabs voice settings in ConversationRelay, agent → register-call API
- Created `ElevenLabsClient` for typed register-call API integration with timeout and error normalization
- Created `elevenlabs-config.ts` for credential loading from secure key store
- Wired `calls.model` into `CallOrchestrator` with empty-string guard (falls back to default)
- Implemented fallback behavior: if ElevenLabs fails and `fallbackToStandardOnError=true`, gracefully falls back to standard Twilio TTS

**Documentation (#6163)**
- Updated phone-calls `SKILL.md` with optional ElevenLabs section, config reference, and troubleshooting
- Updated `ARCHITECTURE.md` with voice quality profile resolution docs

## Milestone PRs (merged into feature branch)
- #6162: M1 — Config + Voice Quality Profile
- #6163: M3 — Skill + Architecture Documentation
- #6165: M2 — Runtime Integration (TwiML + Orchestrator + ElevenLabs Client)
- #6166: Fix — Include agentId in voice quality profile (Codex feedback)
- #6167: Fix — Treat blank calls.model as unset (Codex feedback)

## Project issue
Closes #6158

## Test plan
- [ ] Existing call flow works unchanged (default `twilio_standard` mode)
- [ ] Config without `calls.voice` parses correctly with backwards-compatible defaults
- [ ] `twilio_elevenlabs_tts` mode emits ElevenLabs TTS settings in TwiML
- [ ] `elevenlabs_agent` mode calls register-call API and returns provider TwiML
- [ ] Fallback to standard on ElevenLabs failure when enabled
- [ ] Empty/whitespace `calls.model` falls back to default model
- [ ] API key never appears in logs
- [ ] No new public ingress routes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
