### PR TITLE
fix: replace unavailable homeDirectoryForCurrentUser with NSHomeDirectory

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1005,11 +1005,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                !baseDir.isEmpty {
                 tokenBase = baseDir
             } else {
-                #if os(macOS)
                 tokenBase = NSHomeDirectory()
-                #else
-                tokenBase = FileManager.default.homeDirectoryForCurrentUser.path
-                #endif
             }
             let tokenPath = tokenBase + "/.vellum/http-token"
             do {


### PR DESCRIPTION
## Summary
- `FileManager.homeDirectoryForCurrentUser` is unavailable on iOS, causing a build failure in the shared `DaemonClient`
- Replaced with `NSHomeDirectory()` which works on both macOS and iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
