### PR TITLE
fix: exclude react-devtools-core from CLI bundle

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -207,7 +207,7 @@ if [ "$CLI_BIN_NEEDS_BUILD" = true ]; then
     echo "Building CLI binary from source..."
     mkdir -p "$SCRIPT_DIR/cli-bin"
     (cd "$CLI_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
-    bun build --compile "$CLI_SRC_DIR/src/index.ts" --outfile "$SCRIPT_DIR/cli-bin/vellum-cli"
+    bun build --compile "$CLI_SRC_DIR/src/index.ts" --external react-devtools-core --outfile "$SCRIPT_DIR/cli-bin/vellum-cli"
     chmod +x "$SCRIPT_DIR/cli-bin/vellum-cli"
     echo "CLI binary built: $SCRIPT_DIR/cli-bin/vellum-cli"
 fi


### PR DESCRIPTION
## Summary
- Add `--external react-devtools-core` to the CLI `bun build --compile` command in `build.sh`
- `ink` declares `react-devtools-core` as an optional peer dep, but bun's bundler tries to resolve it statically during compilation, causing a build failure
- Marking it external tells the bundler to skip it — the devtools code path is only used when `DEV=true` at runtime

## Original prompt
```
error: Could not resolve: "react-devtools-core". Maybe you need to "bun install"?
    at /Users/sidd/vocify/vellum-assistant/cli/node_modules/ink/build/devtools.js:6:22
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
