### PR TITLE
fix: include package.json and bun.lock in binary staleness checks

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -170,6 +170,9 @@ if [ -d "$ASSISTANT_SRC_DIR/src" ] && command -v bun &>/dev/null; then
         DAEMON_BIN_NEEDS_BUILD=true
     elif [ -n "$(find "$ASSISTANT_SRC_DIR/src" -name '*.ts' -newer "$SCRIPT_DIR/daemon-bin/vellum-daemon" -print -quit 2>/dev/null)" ]; then
         DAEMON_BIN_NEEDS_BUILD=true
+    elif [ "$ASSISTANT_SRC_DIR/package.json" -nt "$SCRIPT_DIR/daemon-bin/vellum-daemon" ] || \
+         [ "$ASSISTANT_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/daemon-bin/vellum-daemon" ]; then
+        DAEMON_BIN_NEEDS_BUILD=true
     fi
 fi
 if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
@@ -200,6 +203,9 @@ if [ -d "$CLI_SRC_DIR/src" ] && command -v bun &>/dev/null; then
     if [ ! -f "$SCRIPT_DIR/cli-bin/vellum-cli" ]; then
         CLI_BIN_NEEDS_BUILD=true
     elif [ -n "$(find "$CLI_SRC_DIR/src" -name '*.ts' -newer "$SCRIPT_DIR/cli-bin/vellum-cli" -print -quit 2>/dev/null)" ]; then
+        CLI_BIN_NEEDS_BUILD=true
+    elif [ "$CLI_SRC_DIR/package.json" -nt "$SCRIPT_DIR/cli-bin/vellum-cli" ] || \
+         [ "$CLI_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/cli-bin/vellum-cli" ]; then
         CLI_BIN_NEEDS_BUILD=true
     fi
 fi


### PR DESCRIPTION
## Summary
- The previous fix (adding `react-devtools-core` as a dependency) was correct but the binary wasn't being rebuilt because `build.sh` only checked `.ts` file timestamps for staleness
- Add `package.json` and `bun.lock` to the staleness checks for both daemon and CLI binaries
- This ensures dependency changes trigger a rebuild, not just source code changes

## Original prompt
fix this (screenshot showing "Cannot find package 'react-devtools-core' from '/$bunfs/root/vellum-cli'" — the binary was stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
