### PR TITLE
Add debug state snapshot for external debugging tools

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -67,6 +67,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public let services = AppServices()
     private let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
+    private let debugStateWriter = DebugStateWriter()
 
     // Forwarding accessors — ownership lives in `services`, these keep
     // existing internal references working without a mass-rename.
@@ -176,6 +177,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupNotifications()
         setupAutoUpdate()
         showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil, isFirstLaunch: isFirstLaunch)
+        debugStateWriter.start(appDelegate: self)
 
         if isFirstLaunch {
             ensureDaemonConnected()
@@ -1286,6 +1288,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         surfaceManager.dismissAll()
         toolConfirmationNotificationService.dismissAll()
         secretPromptManager.dismissAll()
+        debugStateWriter.stop()
         assistantCli.stop()
     }
 

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -1,0 +1,186 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DebugStateWriter")
+
+/// Periodically writes a JSON snapshot of the app's live state to a well-known
+/// file path so external tools (e.g. Claude Code) can read it for instant
+/// debugging context without needing the Xcode debugger or `log stream`.
+///
+/// File: `~/Library/Application Support/vellum-assistant/debug-state.json`
+@MainActor
+final class DebugStateWriter {
+    private var timer: Timer?
+    private weak var appDelegate: AppDelegate?
+
+    private let fileURL: URL
+    private let encoder: JSONEncoder
+
+    init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.fileURL = dir.appendingPathComponent("debug-state.json")
+
+        self.encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+    }
+
+    func start(appDelegate: AppDelegate) {
+        self.appDelegate = appDelegate
+        captureAndWrite()
+        timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.captureAndWrite()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func captureAndWrite() {
+        guard let appDelegate else { return }
+        let snapshot = captureSnapshot(from: appDelegate)
+        do {
+            let data = try encoder.encode(snapshot)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            log.error("Failed to write debug state snapshot: \(error)")
+        }
+    }
+
+    // MARK: - Snapshot Capture
+
+    private func captureSnapshot(from appDelegate: AppDelegate) -> DebugSnapshot {
+        let daemonClient = appDelegate.services.daemonClient
+        let threadManager = appDelegate.mainWindow?.threadManager
+
+        let transport: String
+        switch daemonClient.config.transport {
+        case .socket:
+            transport = "socket"
+        case .tcp:
+            transport = "tcp"
+        case .http:
+            transport = "http"
+        }
+
+        let daemonState = DebugSnapshot.DaemonState(
+            isConnected: daemonClient.isConnected,
+            isConnecting: daemonClient.isConnecting,
+            daemonVersion: daemonClient.daemonVersion,
+            transport: transport
+        )
+
+        let threadSnapshots: [DebugSnapshot.ThreadInfo] = (threadManager?.threads ?? []).map { thread in
+            let vm = threadManager?.chatViewModel(for: thread.id)
+            return DebugSnapshot.ThreadInfo(
+                id: thread.id.uuidString,
+                title: thread.title,
+                sessionId: thread.sessionId,
+                messageCount: vm?.messages.count ?? 0,
+                kind: thread.kind == .private ? "private" : "standard",
+                isArchived: thread.isArchived,
+                isPinned: thread.isPinned
+            )
+        }
+
+        let threadsState = DebugSnapshot.ThreadsState(
+            activeThreadId: threadManager?.activeThreadId?.uuidString,
+            count: threadManager?.threads.count ?? 0,
+            threads: threadSnapshots
+        )
+
+        var activeChatState: DebugSnapshot.ActiveChatState?
+        if let vm = threadManager?.activeViewModel {
+            activeChatState = DebugSnapshot.ActiveChatState(
+                sessionId: vm.sessionId,
+                isThinking: vm.isThinking,
+                isSending: vm.isSending,
+                isBootstrapping: vm.isBootstrapping,
+                errorText: vm.errorText,
+                sessionErrorCategory: vm.sessionError.map { "\($0.category)" },
+                selectedModel: vm.selectedModel,
+                messageCount: vm.messages.count,
+                pendingQueuedCount: vm.pendingQueuedCount,
+                pendingAttachmentCount: vm.pendingAttachments.count,
+                isRecording: vm.isRecording,
+                activeSubagentCount: vm.activeSubagents.count
+            )
+        }
+
+        let cuState = DebugSnapshot.ComputerUseState(
+            isActive: appDelegate.currentSession != nil,
+            isStarting: appDelegate.isStartingSession
+        )
+
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+
+        return DebugSnapshot(
+            timestamp: Date(),
+            appVersion: version ?? "unknown",
+            daemon: daemonState,
+            threads: threadsState,
+            activeChat: activeChatState,
+            computerUse: cuState
+        )
+    }
+}
+
+// MARK: - Snapshot Models
+
+struct DebugSnapshot: Codable {
+    let timestamp: Date
+    let appVersion: String
+    let daemon: DaemonState
+    let threads: ThreadsState
+    let activeChat: ActiveChatState?
+    let computerUse: ComputerUseState
+
+    struct DaemonState: Codable {
+        let isConnected: Bool
+        let isConnecting: Bool
+        let daemonVersion: String?
+        let transport: String
+    }
+
+    struct ThreadsState: Codable {
+        let activeThreadId: String?
+        let count: Int
+        let threads: [ThreadInfo]
+    }
+
+    struct ThreadInfo: Codable {
+        let id: String
+        let title: String
+        let sessionId: String?
+        let messageCount: Int
+        let kind: String
+        let isArchived: Bool
+        let isPinned: Bool
+    }
+
+    struct ActiveChatState: Codable {
+        let sessionId: String?
+        let isThinking: Bool
+        let isSending: Bool
+        let isBootstrapping: Bool
+        let errorText: String?
+        let sessionErrorCategory: String?
+        let selectedModel: String
+        let messageCount: Int
+        let pendingQueuedCount: Int
+        let pendingAttachmentCount: Int
+        let isRecording: Bool
+        let activeSubagentCount: Int
+    }
+
+    struct ComputerUseState: Codable {
+        let isActive: Bool
+        let isStarting: Bool
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DebugStateWriter` that writes a JSON snapshot of app state every 5 seconds to `~/Library/Application Support/vellum-assistant/debug-state.json`
- Captures daemon connection state, thread list with metadata, active chat state (thinking/sending/errors/model), and computer-use session state
- Uses atomic file writes (same pattern as `LayoutConfigStore` and `AppListManager`)
- Started in `proceedToApp()`, stopped in `applicationWillTerminate`
- Enables Claude Code sessions to instantly read app state without Xcode debugger or `log stream`

## Files changed
- `DebugStateWriter.swift` (new) — snapshot capture, timer, atomic JSON write
- `AppDelegate.swift` — wire up start/stop lifecycle

## Test plan
- [ ] Build succeeds (`cd clients/macos && swift build`)
- [ ] Launch app → verify `~/Library/Application Support/vellum-assistant/debug-state.json` exists
- [ ] Read the file — valid JSON with daemon, threads, activeChat sections
- [ ] Switch threads → re-read after 5s → activeThreadId updates
- [ ] Send a message → re-read → isThinking flips
- [ ] Kill daemon → re-read → isConnected becomes false

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
