### PR TITLE
Add process status indicators to Settings > Advanced

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -111,23 +111,9 @@ struct SettingsAdvancedTab: View {
                 homeRow(home: home)
             }
 
-            // Process status
-            statusRow(
-                label: "Daemon",
-                isHealthy: daemonClient?.isConnected == true,
-                detail: daemonClient?.isConnected == true
-                    ? "Connected" + (daemonClient?.daemonVersion.map { " (v\($0))" } ?? "")
-                    : "Disconnected"
-            )
-
-            if let memoryStatus = daemonClient?.latestMemoryStatus {
-                statusRow(
-                    label: "Memory",
-                    isHealthy: memoryStatus.enabled && !memoryStatus.degraded,
-                    detail: !memoryStatus.enabled ? "Disabled"
-                        : memoryStatus.degraded ? "Degraded\(memoryStatus.reason.map { " — \($0)" } ?? "")"
-                        : "Healthy"
-                )
+            // Process status (child view observes @Published changes)
+            if let daemonClient {
+                DaemonStatusRows(daemonClient: daemonClient)
             }
         }
         .padding(VSpacing.lg)
@@ -175,25 +161,6 @@ struct SettingsAdvancedTab: View {
                     }
                 }
             }
-
-            Spacer()
-        }
-    }
-
-    private func statusRow(label: String, isHealthy: Bool, detail: String) -> some View {
-        HStack(alignment: .center) {
-            Text(label)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 100, alignment: .leading)
-
-            Circle()
-                .fill(isHealthy ? VColor.success : VColor.error)
-                .frame(width: 8, height: 8)
-
-            Text(detail)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
 
             Spacer()
         }
@@ -492,4 +459,51 @@ struct SettingsAdvancedTab: View {
         }
     }
     #endif
+}
+
+// MARK: - Daemon Status Rows
+
+/// Extracted child view so SwiftUI observes `DaemonClient`'s `@Published`
+/// properties and re-renders when connection or memory status changes.
+private struct DaemonStatusRows: View {
+    @ObservedObject var daemonClient: DaemonClient
+
+    var body: some View {
+        statusRow(
+            label: "Daemon",
+            isHealthy: daemonClient.isConnected,
+            detail: daemonClient.isConnected
+                ? "Connected" + (daemonClient.daemonVersion.map { " (v\($0))" } ?? "")
+                : "Disconnected"
+        )
+
+        if let memoryStatus = daemonClient.latestMemoryStatus {
+            statusRow(
+                label: "Memory",
+                isHealthy: memoryStatus.enabled && !memoryStatus.degraded,
+                detail: !memoryStatus.enabled ? "Disabled"
+                    : memoryStatus.degraded ? "Degraded\(memoryStatus.reason.map { " — \($0)" } ?? "")"
+                    : "Healthy"
+            )
+        }
+    }
+
+    private func statusRow(label: String, isHealthy: Bool, detail: String) -> some View {
+        HStack(alignment: .center) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 100, alignment: .leading)
+
+            Circle()
+                .fill(isHealthy ? VColor.success : VColor.error)
+                .frame(width: 8, height: 8)
+
+            Text(detail)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            Spacer()
+        }
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -110,6 +110,25 @@ struct SettingsAdvancedTab: View {
                 let home = assistant.home
                 homeRow(home: home)
             }
+
+            // Process status
+            statusRow(
+                label: "Daemon",
+                isHealthy: daemonClient?.isConnected == true,
+                detail: daemonClient?.isConnected == true
+                    ? "Connected" + (daemonClient?.daemonVersion.map { " (v\($0))" } ?? "")
+                    : "Disconnected"
+            )
+
+            if let memoryStatus = daemonClient?.latestMemoryStatus {
+                statusRow(
+                    label: "Memory",
+                    isHealthy: memoryStatus.enabled && !memoryStatus.degraded,
+                    detail: !memoryStatus.enabled ? "Disabled"
+                        : memoryStatus.degraded ? "Degraded\(memoryStatus.reason.map { " — \($0)" } ?? "")"
+                        : "Healthy"
+                )
+            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
@@ -156,6 +175,25 @@ struct SettingsAdvancedTab: View {
                     }
                 }
             }
+
+            Spacer()
+        }
+    }
+
+    private func statusRow(label: String, isHealthy: Bool, detail: String) -> some View {
+        HStack(alignment: .center) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 100, alignment: .leading)
+
+            Circle()
+                .fill(isHealthy ? VColor.success : VColor.error)
+                .frame(width: 8, height: 8)
+
+            Text(detail)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
 
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Adds daemon and memory health status rows to the "Assistant Info" section in Settings > Advanced
- Shows colored status dots (green=healthy, red=error) similar to the CLI `vellum ps` command
- Daemon row: connected/disconnected with version string
- Memory row: healthy/degraded/disabled with reason when degraded
- Uses existing `DaemonClient` published state — no new IPC messages needed

## Test plan
- [ ] Build succeeds (`cd clients/macos && swift build`)
- [ ] Open Settings > Advanced — Assistant Info shows Daemon status with green dot when connected
- [ ] Kill daemon → Daemon status shows red dot with "Disconnected"
- [ ] Memory row shows "Healthy" with green dot when memory system is operational
- [ ] If memory is degraded, shows reason text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
