### PR TITLE
feat: add border lines around CLI chat input

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1021,7 +1021,7 @@ function ChatApp({
     : secretInput
       ? 5
       : spinnerText
-        ? 2
+        ? 4
         : 3;
   const availableRows = Math.max(3, terminalRows - headerHeight - bottomHeight);
 

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1022,7 +1022,7 @@ function ChatApp({
       ? 5
       : spinnerText
         ? 2
-        : 1;
+        : 3;
   const availableRows = Math.max(3, terminalRows - headerHeight - bottomHeight);
 
   const addMessage = useCallback((msg: RuntimeMessage) => {
@@ -1852,9 +1852,11 @@ function ChatApp({
       ) : null}
 
       {!selection && !secretInput ? (
-        <Box>
-          <Text color="green" bold>
-            you{">"}
+        <Box flexDirection="column">
+          <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
+          <Box paddingLeft={1}>
+            <Text color="green" bold>
+              you{">"}
             {" "}
           </Text>
           <TextInput
@@ -1863,6 +1865,8 @@ function ChatApp({
             onSubmit={handleSubmit}
             focus={inputFocused}
           />
+          </Box>
+          <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
         </Box>
       ) : null}
     </Box>


### PR DESCRIPTION
## Summary
- Adds dim horizontal rule lines (`─`) above and below the `you>` input prompt, spanning the full terminal width
- Adds left padding to the input area for better visual margin
- Updates `bottomHeight` calculation to account for the two extra border lines

Inspired by Claude Code's input styling.

## Test plan
- [ ] Run `vel client` and verify horizontal lines appear above and below the input
- [ ] Verify the `you>` prompt and text input still work correctly
- [ ] Resize terminal and confirm borders adapt to terminal width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
