### PR TITLE
Remove response timeout from CLI message polling

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -28,7 +28,6 @@ export const SLASH_COMMANDS = ["/clear", "/doctor", "/exit", "/help", "/q", "/qu
 const POLL_INTERVAL_MS = 3000;
 const SEND_TIMEOUT_MS = 5000;
 const RESPONSE_POLL_INTERVAL_MS = 1000;
-const RESPONSE_TIMEOUT_MS = 180000;
 
 interface ListMessagesResponse {
   messages: RuntimeMessage[];
@@ -1515,8 +1514,7 @@ function ChatApp({
 
         h.showSpinner("Working...");
 
-        const startTime = Date.now();
-        while (Date.now() - startTime < RESPONSE_TIMEOUT_MS) {
+        while (true) {
           await new Promise((resolve) => setTimeout(resolve, RESPONSE_POLL_INTERVAL_MS));
 
           if (runId) {
@@ -1609,26 +1607,6 @@ function ChatApp({
           }
         }
 
-        h.setBusy(false);
-        h.hideSpinner();
-        h.showError("Response timed out. The assistant may still be processing.");
-        try {
-          const doctorResult = await callDoctorDaemon(
-            assistantId,
-            project,
-            zone,
-            undefined,
-            undefined,
-            doctorSessionIdRef.current,
-          );
-          if (doctorResult.diagnostics) {
-            h.addStatus(
-              `--- SSH Diagnostics ---\n${doctorResult.diagnostics}\n--- End Diagnostics ---`,
-            );
-          }
-        } catch {
-          // Doctor daemon unreachable; skip diagnostics
-        }
       } catch (error) {
         h.setBusy(false);
         h.hideSpinner();


### PR DESCRIPTION
## Summary
- Removed the hard 3-minute `RESPONSE_TIMEOUT_MS` timeout from the CLI's run-polling loop in `DefaultMainScreen.tsx`
- The loop now polls until the run reaches a terminal state (`completed` or `failed`) with no time bound
- Eliminates the false "Response timed out. The assistant may still be processing." error for long-running operations
- Background message poller (3s interval) and all interactive states (tool approval, secret prompts) continue to work unchanged

## Test plan
- [ ] Send a message — response arrives normally
- [ ] Simulate a long-running operation (>3 min) — no timeout error, spinner persists until completion
- [ ] Tool approval prompts still appear and work during runs
- [ ] Secret entry prompts still appear and work during runs
- [ ] Ctrl+C still exits cleanly during a long wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
