### PR TITLE
fix: auto-allow memory_search without permission prompt

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -741,6 +741,7 @@ describe('Trust Store', () => {
         'host_file_edit',
         'host_file_read',
         'host_file_write',
+        'memory_search',
         'scaffold_managed_skill',
         'skill_load',
         'ui_dismiss',

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -225,6 +225,16 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  // memory_search is a read-only tool — always allow without prompting.
+  const memorySearchRule: DefaultRuleTemplate = {
+    id: 'default:allow-memory_search-global',
+    tool: 'memory_search',
+    pattern: 'memory_search:*',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 100,
+  };
+
   return [
     ...hostFileRules,
     hostShellRule,
@@ -239,5 +249,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...browserToolRules,
     ...uiSurfaceRules,
     viewImageRule,
+    memorySearchRule,
   ];
 }


### PR DESCRIPTION
## Summary
- Adds a default allow trust rule for `memory_search` in `permissions/defaults.ts`
- In strict permissions mode (the default), every tool needs an explicit trust rule — `memory_search` was missing one, causing unnecessary permission prompts for a read-only operation
- Updates the trust-store test's expected default tools list

## Test plan
- [x] `checker.test.ts` and `trust-store.test.ts` pass (476 tests)
- [ ] Verify `memory_search` no longer triggers a permission prompt in the macOS app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
