### PR TITLE
M2: Harden ElevenLabs config, enrich register-call payload, validate response as TwiML

### DIFF
--- a/assistant/src/__tests__/elevenlabs-client.test.ts
+++ b/assistant/src/__tests__/elevenlabs-client.test.ts
@@ -189,6 +189,68 @@ describe('ElevenLabsClient', () => {
       }
     });
 
+    test('valid TwiML with XML declaration passes validation', async () => {
+      const twiml = '<?xml version="1.0"?><Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twiml, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twiml);
+    });
+
+    test('valid TwiML with Response tag but no XML declaration passes validation', async () => {
+      const twiml = '<Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twiml, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twiml);
+    });
+
+    test('non-XML response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('{"error": "invalid"}', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+        expect(elErr.message).toContain('not valid TwiML/XML');
+      }
+    });
+
+    test('plain text response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('some random text', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+        expect(elErr.message).toContain('not valid TwiML/XML');
+      }
+    });
+
     test('API key is not included in logged data', async () => {
       // The ElevenLabsClient logs agent_id and direction, but should never log the API key.
       // We verify this by checking the request structure, not the log output.

--- a/assistant/src/calls/elevenlabs-client.ts
+++ b/assistant/src/calls/elevenlabs-client.ts
@@ -75,6 +75,14 @@ export class ElevenLabsClient {
         );
       }
 
+      const lower = body.toLowerCase();
+      if (!lower.includes('<?xml') && !lower.includes('<response')) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_INVALID_RESPONSE',
+          'Register-call response is not valid TwiML/XML',
+        );
+      }
+
       return { twiml: body };
     } catch (err) {
       if (err instanceof ElevenLabsError) throw err;

--- a/assistant/src/calls/elevenlabs-config.ts
+++ b/assistant/src/calls/elevenlabs-config.ts
@@ -1,8 +1,5 @@
 import { getConfig } from '../config/loader.js';
 import { getSecureKey } from '../security/secure-keys.js';
-import { getLogger } from '../util/logger.js';
-
-const log = getLogger('elevenlabs-config');
 
 export interface ElevenLabsConfig {
   apiKey: string;
@@ -17,13 +14,18 @@ export function getElevenLabsConfig(): ElevenLabsConfig {
 
   const apiKey = getSecureKey('credential:elevenlabs:api_key') ?? '';
   if (!apiKey) {
-    log.warn('No ElevenLabs API key found in secure key store (credential:elevenlabs:api_key)');
+    throw new Error('ElevenLabs API key is not configured. Set credential:elevenlabs:api_key in the secure key store.');
+  }
+
+  const agentId = voice.elevenlabs.agentId;
+  if (!agentId) {
+    throw new Error('ElevenLabs agent ID is not configured. Set calls.voice.elevenlabs.agentId in config.');
   }
 
   return {
     apiKey,
     apiBaseUrl: voice.elevenlabs.apiBaseUrl,
-    agentId: voice.elevenlabs.agentId,
+    agentId,
     registerCallTimeoutMs: voice.elevenlabs.registerCallTimeoutMs,
   };
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -171,6 +171,13 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
         from_number: formBody.get('From') || session.fromNumber,
         to_number: formBody.get('To') || session.toNumber,
         direction: 'outbound',
+        conversation_initiation_client_data: {
+          dynamic_variables: {
+            task: session.task,
+            call_session_id: session.id,
+            conversation_id: session.conversationId,
+          },
+        },
       });
 
       log.info({ callSessionId }, 'ElevenLabs register-call succeeded');


### PR DESCRIPTION
Part of #6184. Closes #6186.

## Changes
- Add precondition checks in loadElevenLabsConfig(): fail early with clear non-secret message when API key or agentId missing
- Pass conversation_initiation_client_data with dynamic_variables (task, call_session_id, conversation_id) in register-call request
- Add TwiML/XML response validation in registerCall(): reject non-XML responses with ELEVENLABS_INVALID_RESPONSE
- Add tests for TwiML validation (valid XML passes, non-XML rejected)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
