### PR TITLE
M4: Update SKILL.md and ARCHITECTURE.md for supported vs restricted behavior

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3518,7 +3518,7 @@ sequenceDiagram
 | `assistant/src/calls/call-state-machine.ts` | Deterministic state transition validator with allowed-transition table and terminal-state enforcement |
 | `assistant/src/calls/call-recovery.ts` | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions |
 | `assistant/src/calls/twilio-provider.ts` | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency |
-| `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML), status callback, connect action |
+| `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML with WS-A/WS-B guardrails), status callback, connect action |
 | `assistant/src/calls/relay-server.ts` | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call |
 | `assistant/src/calls/speaker-identification.ts` | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
 | `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_USER and END_CALL control markers |
@@ -3672,10 +3672,10 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.disclosure.text` | string | *(default disclosure prompt)* | The disclosure instruction included in the system prompt. |
 | `calls.safety.denyCategories` | string[] | `[]` | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting). |
 | `calls.model` | string | *(unset — uses default model)* | Optional override for the LLM model used in call orchestration. |
-| `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay), `elevenlabs_agent` (full ElevenLabs conversational agent). |
+| `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices — fully supported), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay — fully supported), `elevenlabs_agent` (full ElevenLabs conversational agent — experimental/restricted, blocked by runtime guard). |
 | `calls.voice.language` | string | `'en-US'` | Language code for TTS and transcription. |
 | `calls.voice.transcriptionProvider` | enum | `'Deepgram'` | Speech-to-text provider (`Deepgram` or `Google`). |
-| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors). |
+| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors) or is restricted (e.g., `elevenlabs_agent` guard). When `false`, errors return HTTP 500/501/502 instead of falling back. |
 | `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
 | `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
 
@@ -3685,11 +3685,39 @@ Voice and TTS settings are configurable via the `calls.voice` config block — t
 
 The resolution logic works as follows:
 
-- **`twilio_standard`** — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
-- **`twilio_elevenlabs_tts`** — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
-- **`elevenlabs_agent`** — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`.
+- **`twilio_standard`** (fully supported) — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
+- **`twilio_elevenlabs_tts`** (fully supported) — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
+- **`elevenlabs_agent`** (experimental/restricted) — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`. Even when the profile resolves successfully, a runtime guard in `handleVoiceWebhook` blocks this mode (see below).
 
 When `fallbackToStandardOnError` is `true` (default), any misconfiguration or runtime error in ElevenLabs modes causes a graceful fallback to standard Twilio TTS rather than a call failure. Validation errors are captured in `validationErrors` on the profile for logging.
+
+### Voice Mode Guardrails in `handleVoiceWebhook`
+
+The voice webhook (`twilio-routes.ts`) enforces two sequential guardrails before returning TwiML:
+
+**WS-A: Invalid profile guard** — If `isVoiceProfileValid(profile)` returns false (i.e., there are validation errors such as missing `voiceId` or `agentId`):
+- `fallbackToStandardOnError=true` (default): the profile has already been resolved to `twilio_standard` by the profile resolver; proceeds normally.
+- `fallbackToStandardOnError=false`: returns **HTTP 500** with the validation error details.
+
+**WS-B: `elevenlabs_agent` mode guard** — If the resolved profile mode is `elevenlabs_agent`, a guard fires *before* any ElevenLabs API calls because consultation bridging (`waiting_on_user`) is not yet supported in this mode:
+- `fallbackToStandardOnError=true` (default): logs a warning and falls back to standard ConversationRelay TwiML.
+- `fallbackToStandardOnError=false`: returns **HTTP 501** `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
+
+The guard order ensures invalid configs are caught first (WS-A), then mode-level restrictions are enforced (WS-B). For `twilio_standard` and `twilio_elevenlabs_tts` modes, both guards pass and the webhook proceeds to return ConversationRelay TwiML.
+
+```mermaid
+flowchart TD
+    A["handleVoiceWebhook"] --> B["resolveVoiceQualityProfile()"]
+    B --> C{"isVoiceProfileValid?<br/>(WS-A)"}
+    C -- "yes" --> D{"mode == elevenlabs_agent?<br/>(WS-B)"}
+    C -- "no, fallback=true" --> F["proceed with standard profile"]
+    C -- "no, fallback=false" --> G["HTTP 500: config error"]
+    D -- "no (twilio_standard /<br/>twilio_elevenlabs_tts)" --> H["return ConversationRelay TwiML"]
+    D -- "yes, fallback=true" --> I["warn + fallback to<br/>standard TwiML"]
+    D -- "yes, fallback=false" --> J["HTTP 501: consultation<br/>bridging not supported"]
+    F --> H
+    I --> H
+```
 
 ---
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -21,9 +21,9 @@ When a call is placed:
 5. The transcript is relayed live to the user's conversation thread
 
 Three voice quality modes are available:
-- **`twilio_standard`** (default) — Standard Twilio TTS with Google voices. No extra setup required.
-- **`twilio_elevenlabs_tts`** — Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
-- **`elevenlabs_agent`** — Full ElevenLabs conversational agent mode for the highest quality (requires ElevenLabs agent setup).
+- **`twilio_standard`** (default) — Fully supported. Standard Twilio TTS with Google voices. No extra setup required.
+- **`twilio_elevenlabs_tts`** — Fully supported. Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
+- **`elevenlabs_agent`** — **Experimental/restricted.** Full ElevenLabs conversational agent mode. Consultation bridging (`waiting_on_user`) is not yet supported in this mode; the runtime guard blocks it before any ElevenLabs API calls are made. See the "Runtime behavior" section below for fallback and strict-fail details.
 
 You can keep using Twilio only — no changes needed. Enabling ElevenLabs can improve naturalness and quality.
 
@@ -165,9 +165,11 @@ vellum config set calls.voice.mode twilio_elevenlabs_tts
 vellum config set calls.voice.elevenlabs.voiceId "<your-voice-id>"
 ```
 
-### Mode: `elevenlabs_agent`
+### Mode: `elevenlabs_agent` (experimental/restricted)
 
 Full ElevenLabs conversational agent mode. This requires an ElevenLabs account with an agent configured on their platform.
+
+**Restriction:** This mode is currently restricted because consultation bridging (`waiting_on_user`) is not yet supported. A runtime guard in `handleVoiceWebhook` blocks `elevenlabs_agent` before any ElevenLabs API calls are made.
 
 **Setup:**
 
@@ -184,9 +186,26 @@ vellum config set calls.voice.mode elevenlabs_agent
 vellum config set calls.voice.elevenlabs.agentId "<your-agent-id>"
 ```
 
-### Fallback behavior
+### Fallback behavior and `fallbackToStandardOnError`
 
-By default, `calls.voice.fallbackToStandardOnError` is `true`. This means if ElevenLabs is unavailable or misconfigured (e.g., missing voice ID, API errors), calls automatically fall back to standard Twilio TTS rather than failing. You can disable this if you want strict ElevenLabs-only behavior:
+By default, `calls.voice.fallbackToStandardOnError` is `true`. This setting controls what happens when an ElevenLabs mode encounters errors or is restricted.
+
+#### Invalid configuration (e.g., missing voiceId or agentId)
+
+- **`true` (default):** The profile resolver silently falls back to `twilio_standard` mode and logs a warning. The call proceeds with standard Twilio TTS.
+- **`false`:** The voice webhook returns **HTTP 500** with the specific configuration error details (e.g., `"Voice quality configuration error: calls.voice.elevenlabs.voiceId is required..."`).
+
+#### `elevenlabs_agent` mode guard (consultation bridging unsupported)
+
+- **`true` (default):** The `elevenlabs_agent` mode is silently downgraded to standard ConversationRelay TwiML with a warning log. The call proceeds normally with standard Twilio TTS.
+- **`false`:** The voice webhook returns **HTTP 501** with the message: `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
+
+#### ElevenLabs API errors (register-call failure)
+
+- **`true` (default):** Falls back to `twilio_standard` mode and proceeds with the call.
+- **`false`:** Returns **HTTP 502** `"ElevenLabs service unavailable"`.
+
+You can disable fallback if you want strict ElevenLabs-only behavior:
 
 ```bash
 vellum config set calls.voice.fallbackToStandardOnError false
@@ -408,7 +427,8 @@ The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the
 - If mode is `elevenlabs_agent`, ensure `calls.voice.elevenlabs.agentId` is also set
 
 ### ElevenLabs mode falls back to standard
-When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error. Check:
-- For `elevenlabs_agent` mode: verify the API key is stored (`credential_store action=get service=credential:elevenlabs:api_key`) and that `calls.voice.elevenlabs.agentId` is configured
+When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error or restriction. Check:
+- For `elevenlabs_agent` mode: this mode is currently restricted (consultation bridging not yet supported) and will always fall back to standard when fallback is enabled. If fallback is disabled, the voice webhook returns HTTP 501.
 - For `twilio_elevenlabs_tts` mode: verify `calls.voice.elevenlabs.voiceId` is set to a valid voice ID
-- Review daemon logs for error messages related to ElevenLabs
+- For invalid configs (missing voiceId/agentId): if fallback is disabled, the voice webhook returns HTTP 500 with the config error
+- Review daemon logs for warning messages about fallback or guard activation


### PR DESCRIPTION
Part of #6184. Closes #6188.

## Changes
- Mark elevenlabs_agent as experimental/restricted in SKILL.md
- Document fallback vs strict-fail behavior for all voice modes
- Update ARCHITECTURE.md to reflect voice mode guardrails and fallback flow
- Docs now accurately match runtime behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
