### PR TITLE
M3: Add handler-level ElevenLabs test coverage and stabilize port-flaky tests

### DIFF
--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Handler-level tests for ElevenLabs voice webhook branches in handleVoiceWebhook.
+ *
+ * Tests the WS-A (invalid profile + fallback semantics) and WS-B
+ * (elevenlabs_agent guard) paths by mocking resolveVoiceQualityProfile
+ * to return specific profiles and asserting on HTTP response status/body.
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'twilio-routes-11labs-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    calls: {
+      voice: {
+        mode: 'twilio_standard',
+        language: 'en-US',
+        transcriptionProvider: 'Deepgram',
+        fallbackToStandardOnError: true,
+        elevenlabs: {
+          voiceId: '',
+          voiceModelId: 'turbo_v2_5',
+          stability: 0.5,
+          similarityBoost: 0.75,
+          style: 0.0,
+          useSpeakerBoost: true,
+          agentId: '',
+          apiBaseUrl: 'https://api.elevenlabs.io',
+          registerCallTimeoutMs: 5000,
+        },
+      },
+    },
+    ingress: { enabled: false, publicBaseUrl: '' },
+  }),
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => undefined,
+}));
+
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    readonly name = 'twilio';
+    static getAuthToken(): string | null { return null; }
+    static verifyWebhookSignature(): boolean { return true; }
+    async initiateCall() { return { callSid: 'CA_mock_test' }; }
+    async endCall() { return; }
+  },
+}));
+
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test-auth-token',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+// Mock resolveVoiceQualityProfile and isVoiceProfileValid so we can control
+// the profile returned to handleVoiceWebhook per-test.
+import type { VoiceQualityProfile } from '../calls/voice-quality.js';
+
+let mockProfile: VoiceQualityProfile = {
+  mode: 'twilio_standard',
+  language: 'en-US',
+  transcriptionProvider: 'Deepgram',
+  ttsProvider: 'Google',
+  voice: 'Google.en-US-Journey-O',
+  fallbackToStandardOnError: true,
+  validationErrors: [],
+};
+
+mock.module('../calls/voice-quality.js', () => ({
+  resolveVoiceQualityProfile: () => mockProfile,
+  isVoiceProfileValid: (profile: VoiceQualityProfile) => profile.validationErrors.length === 0,
+}));
+
+// Mock the ingress URL to avoid config lookup issues
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getTwilioRelayUrl: () => 'wss://test.example.com/v1/calls/relay',
+  getPublicBaseUrl: () => 'https://test.example.com',
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import {
+  createCallSession,
+  updateCallSession,
+} from '../calls/call-store.js';
+import { handleVoiceWebhook } from '../calls/twilio-routes.js';
+
+initializeDb();
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+let ensuredConvIds = new Set<string>();
+
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM processed_callbacks');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+function createTestSession(convId: string, callSid: string) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15559998888',
+    task: 'test task',
+  });
+  updateCallSession(session.id, { providerCallSid: callSid });
+  return session;
+}
+
+function makeVoiceRequest(sessionId: string, params: Record<string, string>): Request {
+  return new Request(`http://127.0.0.1/v1/calls/twilio/voice-webhook?callSessionId=${sessionId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('handleVoiceWebhook ElevenLabs branches', () => {
+  beforeEach(() => {
+    resetTables();
+    // Reset to standard default profile between tests
+    mockProfile = {
+      mode: 'twilio_standard',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    };
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  // ── WS-A: Invalid config + fallback disabled => 500 ────────────────
+  test('twilio_elevenlabs_tts invalid config with fallback disabled returns 500', async () => {
+    mockProfile = {
+      mode: 'twilio_elevenlabs_tts',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: '',
+      fallbackToStandardOnError: false,
+      validationErrors: ['voiceId is required'],
+    };
+
+    const session = createTestSession('conv-11labs-1', 'CA_11labs_1');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_1' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toContain('Voice quality configuration error');
+    expect(body).toContain('voiceId is required');
+  });
+
+  // ── WS-A: Invalid config + fallback enabled => standard TwiML ──────
+  test('twilio_elevenlabs_tts invalid config with fallback enabled returns standard TwiML', async () => {
+    // When fallback is enabled and voiceId is missing, resolveVoiceQualityProfile
+    // falls back to standard mode but retains validation errors.
+    mockProfile = {
+      mode: 'twilio_standard',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: ['calls.voice.elevenlabs.voiceId is empty; falling back to twilio_standard'],
+    };
+
+    const session = createTestSession('conv-11labs-2', 'CA_11labs_2');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_2' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(200);
+    const twiml = await res.text();
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('<ConversationRelay');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+  });
+
+  // ── WS-B: elevenlabs_agent strict mode (fallback false) => 501 ─────
+  test('elevenlabs_agent with fallback disabled returns 501', async () => {
+    mockProfile = {
+      mode: 'elevenlabs_agent',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+      agentId: 'agent-abc',
+      fallbackToStandardOnError: false,
+      validationErrors: [],
+    };
+
+    const session = createTestSession('conv-11labs-3', 'CA_11labs_3');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_3' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(501);
+    const body = await res.text();
+    expect(body).toContain('consultation bridging');
+    expect(body).toContain('elevenlabs_agent mode is restricted');
+  });
+
+  // ── WS-B: elevenlabs_agent with fallback true => standard TwiML ────
+  test('elevenlabs_agent with fallback enabled returns standard TwiML', async () => {
+    mockProfile = {
+      mode: 'elevenlabs_agent',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+      agentId: 'agent-abc',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    };
+
+    const session = createTestSession('conv-11labs-4', 'CA_11labs_4');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_4' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(200);
+    const twiml = await res.text();
+    // When elevenlabs_agent is guarded with fallback enabled, the handler
+    // sets elevenLabsAgentGuarded=true and falls through to standard TwiML
+    // generation, which uses the profile's ttsProvider/voice. But since
+    // the profile has mode=elevenlabs_agent with guard set, it skips the
+    // ElevenLabs register-call path and generates standard TwiML using
+    // whatever profile values exist.
+    expect(twiml).toContain('<ConversationRelay');
+    // The TwiML should be generated (not an ElevenLabs register-call response)
+    expect(twiml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(twiml).toContain('<Response>');
+    expect(twiml).toContain('<Connect>');
+  });
+});

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -8,7 +8,7 @@
  * - Unknown status and malformed payload handling
  * - Handler-level idempotency concurrency (concurrent duplicates, failure-retry)
  */
-import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock, spyOn } from 'bun:test';
 import { createHmac } from 'node:crypto';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -211,6 +211,13 @@ describe('twilio webhook routes', () => {
     mockWssBaseUrl = 'wss://test.example.com';
     mockWebhookBaseUrl = 'https://test.example.com';
     delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+  });
+
+  // Deterministic teardown: always stop the server after each test so a
+  // failed assertion between startServer/stopServer doesn't leave the
+  // port bound, causing EADDRINUSE flakes in subsequent tests.
+  afterEach(async () => {
+    await stopServer();
   });
 
   afterAll(() => {


### PR DESCRIPTION
Part of #6184. Closes #6187.

## Changes
- Add handler-level tests for ElevenLabs voice webhook branches
- Test invalid config + fallback disabled → 500
- Test invalid config + fallback enabled → standard TwiML
- Test elevenlabs_agent strict mode → 501
- Test elevenlabs_agent fallback → standard TwiML
- Stabilize port allocation to prevent EADDRINUSE flakes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
