### PR TITLE
M1: Caller identity model + config surface

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -673,6 +673,10 @@ describe('AssistantConfigSchema', () => {
           registerCallTimeoutMs: 5000,
         },
       },
+      callerIdentity: {
+        defaultMode: 'assistant_number',
+        allowPerCallOverride: true,
+      },
     });
   });
 
@@ -862,6 +866,68 @@ describe('AssistantConfigSchema', () => {
   test('calls.model is undefined by default', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.calls.model).toBeUndefined();
+  });
+
+  // ── Caller identity config ────────────────────────────────────────
+
+  test('applies calls.callerIdentity defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.calls.callerIdentity).toEqual({
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    });
+  });
+
+  test('accepts valid calls.callerIdentity overrides', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: {
+        callerIdentity: {
+          defaultMode: 'user_number',
+          allowPerCallOverride: false,
+          userNumber: '+14155559999',
+        },
+      },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(false);
+    expect(result.calls.callerIdentity.userNumber).toBe('+14155559999');
+  });
+
+  test('accepts partial calls.callerIdentity with defaults for missing fields', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: {
+        callerIdentity: { defaultMode: 'user_number' },
+      },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
+    expect(result.calls.callerIdentity.userNumber).toBeUndefined();
+  });
+
+  test('rejects invalid calls.callerIdentity.defaultMode', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { callerIdentity: { defaultMode: 'custom_number' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('calls.callerIdentity.defaultMode'))).toBe(true);
+    }
+  });
+
+  test('rejects non-boolean calls.callerIdentity.allowPerCallOverride', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { callerIdentity: { allowPerCallOverride: 'yes' } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('default behavior unchanged when callerIdentity omitted', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: { enabled: true },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('assistant_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
   });
 });
 
@@ -1272,6 +1338,10 @@ describe('loadConfig with schema validation', () => {
     expect(config.calls.voice.transcriptionProvider).toBe('Deepgram');
     expect(config.calls.voice.elevenlabs.voiceId).toBe('');
     expect(config.calls.model).toBeUndefined();
+    expect(config.calls.callerIdentity).toEqual({
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    });
   });
 });
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -22,7 +22,9 @@ import { TwilioConversationRelayProvider } from './twilio-provider.js';
 import { getTwilioConfig } from './twilio-config.js';
 import { getTwilioVoiceWebhookUrl, getTwilioStatusCallbackUrl } from '../inbound/public-ingress-urls.js';
 import { loadConfig } from '../config/loader.js';
+import { getSecureKey } from '../security/secure-keys.js';
 import type { CallSession } from './types.js';
+import type { AssistantConfig } from '../config/types.js';
 
 const log = getLogger('call-domain');
 
@@ -47,6 +49,7 @@ export type StartCallInput = {
   task: string;
   context?: string;
   conversationId: string;
+  callerIdentityMode?: 'assistant_number' | 'user_number';
 };
 
 export type CancelCallInput = {
@@ -59,13 +62,68 @@ export type AnswerCallInput = {
   answer: string;
 };
 
+// ── Caller identity resolution ───────────────────────────────────────
+
+export type CallerIdentityResult =
+  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve which phone number to use as the caller ID for an outbound call.
+ *
+ * - If `requestedMode` is provided and per-call overrides are allowed, use it.
+ * - If `requestedMode` is provided but overrides are disabled, return an error.
+ * - Otherwise fall through to the configured default mode.
+ *
+ * For `assistant_number`: uses the Twilio phone number from `getTwilioConfig()`.
+ * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
+ * secure key `credential:twilio:user_phone_number`.
+ */
+export function resolveCallerIdentity(
+  config: AssistantConfig,
+  requestedMode?: 'assistant_number' | 'user_number',
+): CallerIdentityResult {
+  const identityConfig = config.calls.callerIdentity;
+  let mode: 'assistant_number' | 'user_number';
+
+  if (requestedMode != null) {
+    if (!identityConfig.allowPerCallOverride) {
+      return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };
+    }
+    mode = requestedMode;
+  } else {
+    mode = identityConfig.defaultMode;
+  }
+
+  if (mode === 'assistant_number') {
+    const twilioConfig = getTwilioConfig();
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber };
+  }
+
+  // user_number mode: resolve from config or secure key
+  const userNumber =
+    identityConfig.userNumber ||
+    process.env.TWILIO_USER_PHONE_NUMBER ||
+    getSecureKey('credential:twilio:user_phone_number') ||
+    '';
+
+  if (!userNumber) {
+    return {
+      ok: false,
+      error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
+    };
+  }
+
+  return { ok: true, mode, fromNumber: userNumber };
+}
+
 // ── Domain operations ────────────────────────────────────────────────
 
 /**
  * Initiate a new outbound call.
  */
 export async function startCall(input: StartCallInput): Promise<StartCallResult | CallError> {
-  const { phoneNumber, task, context: callContext, conversationId } = input;
+  const { phoneNumber, task, context: callContext, conversationId, callerIdentityMode } = input;
 
   if (!phoneNumber || typeof phoneNumber !== 'string') {
     return { ok: false, error: 'phone_number is required and must be a string', status: 400 };
@@ -90,23 +148,29 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
   let sessionId: string | null = null;
 
   try {
-    const twilioConfig = getTwilioConfig();
     const ingressConfig = loadConfig();
     const provider = new TwilioConversationRelayProvider();
+
+    // Resolve which phone number to use as caller ID
+    const identityResult = resolveCallerIdentity(ingressConfig, callerIdentityMode);
+    if (!identityResult.ok) {
+      return { ok: false, error: identityResult.error, status: 400 };
+    }
+    const fromNumber = identityResult.fromNumber;
 
     const session = createCallSession({
       conversationId,
       provider: 'twilio',
-      fromNumber: twilioConfig.phoneNumber,
+      fromNumber,
       toNumber: phoneNumber,
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
     });
     sessionId = session.id;
 
-    log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
+    log.info({ callSessionId: session.id, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
 
     const { callSid } = await provider.initiateCall({
-      from: twilioConfig.phoneNumber,
+      from: fromNumber,
       to: phoneNumber,
       webhookUrl: getTwilioVoiceWebhookUrl(ingressConfig, session.id),
       statusCallbackUrl: getTwilioStatusCallbackUrl(ingressConfig),

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -244,6 +244,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       },
     },
     model: undefined,
+    callerIdentity: {
+      defaultMode: 'assistant_number' as const,
+      allowPerCallOverride: true,
+    },
   },
   ingress: {
     enabled: false,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,6 +10,7 @@ const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
+const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
 
 export const TimeoutConfigSchema = z.object({
@@ -956,6 +957,20 @@ export const CallsVoiceConfigSchema = z.object({
   }),
 });
 
+export const CallerIdentityConfigSchema = z.object({
+  defaultMode: z
+    .enum(VALID_CALLER_IDENTITY_MODES, {
+      error: `calls.callerIdentity.defaultMode must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}`,
+    })
+    .default('assistant_number'),
+  allowPerCallOverride: z
+    .boolean({ error: 'calls.callerIdentity.allowPerCallOverride must be a boolean' })
+    .default(true),
+  userNumber: z
+    .string({ error: 'calls.callerIdentity.userNumber must be a string' })
+    .optional(),
+});
+
 export const CallsConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'calls.enabled must be a boolean' })
@@ -1004,6 +1019,10 @@ export const CallsConfigSchema = z.object({
   model: z
     .string({ error: 'calls.model must be a string' })
     .optional(),
+  callerIdentity: CallerIdentityConfigSchema.default({
+    defaultMode: 'assistant_number',
+    allowPerCallOverride: true,
+  }),
 });
 
 export const SkillsConfigSchema = z.object({
@@ -1286,6 +1305,10 @@ export const AssistantConfigSchema = z.object({
         registerCallTimeoutMs: 5000,
       },
     },
+    callerIdentity: {
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    },
   }),
   ingress: IngressConfigSchema.default({
     enabled: false,
@@ -1353,4 +1376,5 @@ export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;
 export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
 export type CallsVoiceConfig = z.infer<typeof CallsVoiceConfigSchema>;
 export type CallsElevenLabsConfig = z.infer<typeof CallsElevenLabsConfigSchema>;
+export type CallerIdentityConfig = z.infer<typeof CallerIdentityConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -36,5 +36,6 @@ export type {
   CallsSafetyConfig,
   CallsVoiceConfig,
   CallsElevenLabsConfig,
+  CallerIdentityConfig,
   IngressConfig,
 } from './schema.js';


### PR DESCRIPTION
Part of #6189: Calls Caller Identity

- Add calls.callerIdentity config block with defaultMode, allowPerCallOverride, and userNumber fields
- Extend StartCallInput with optional callerIdentityMode field
- Add resolveCallerIdentity helper in call-domain.ts for identity resolution
- Wire identity resolution into startCall flow
- Default behavior (assistant_number) unchanged when callerIdentityMode omitted

Closes #6190
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
