### PR TITLE
Fix: elevenlabs_agent guard fallback uses standard profile

### DIFF
--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -108,8 +108,10 @@ let mockProfile: VoiceQualityProfile = {
   validationErrors: [],
 };
 
+const mockResolveVoiceQualityProfile = mock(() => mockProfile);
+
 mock.module('../calls/voice-quality.js', () => ({
-  resolveVoiceQualityProfile: () => mockProfile,
+  resolveVoiceQualityProfile: mockResolveVoiceQualityProfile,
   isVoiceProfileValid: (profile: VoiceQualityProfile) => profile.validationErrors.length === 0,
 }));
 
@@ -182,6 +184,8 @@ function makeVoiceRequest(sessionId: string, params: Record<string, string>): Re
 describe('handleVoiceWebhook ElevenLabs branches', () => {
   beforeEach(() => {
     resetTables();
+    // Reset mock to default implementation
+    mockResolveVoiceQualityProfile.mockReset();
     // Reset to standard default profile between tests
     mockProfile = {
       mode: 'twilio_standard',
@@ -192,6 +196,7 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
       fallbackToStandardOnError: true,
       validationErrors: [],
     };
+    mockResolveVoiceQualityProfile.mockImplementation(() => mockProfile);
   });
 
   afterAll(() => {
@@ -274,8 +279,9 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
 
   // ── WS-B: elevenlabs_agent with fallback true => standard TwiML ────
   test('elevenlabs_agent with fallback enabled returns standard TwiML', async () => {
-    mockProfile = {
-      mode: 'elevenlabs_agent',
+    // First call returns the elevenlabs_agent profile (triggers the guard)
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'elevenlabs_agent' as const,
       language: 'en-US',
       transcriptionProvider: 'Deepgram',
       ttsProvider: 'ElevenLabs',
@@ -283,7 +289,17 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
       agentId: 'agent-abc',
       fallbackToStandardOnError: true,
       validationErrors: [],
-    };
+    }));
+    // Second call returns the standard profile (used for TwiML generation)
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'twilio_standard' as const,
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    }));
 
     const session = createTestSession('conv-11labs-4', 'CA_11labs_4');
     const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_4' });
@@ -293,15 +309,13 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
     expect(res.status).toBe(200);
     const twiml = await res.text();
     // When elevenlabs_agent is guarded with fallback enabled, the handler
-    // sets elevenLabsAgentGuarded=true and falls through to standard TwiML
-    // generation, which uses the profile's ttsProvider/voice. But since
-    // the profile has mode=elevenlabs_agent with guard set, it skips the
-    // ElevenLabs register-call path and generates standard TwiML using
-    // whatever profile values exist.
+    // replaces the profile with a standard twilio_standard profile and
+    // generates TwiML with Google TTS instead of ElevenLabs.
     expect(twiml).toContain('<ConversationRelay');
-    // The TwiML should be generated (not an ElevenLabs register-call response)
     expect(twiml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(twiml).toContain('<Response>');
     expect(twiml).toContain('<Connect>');
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
   });
 });

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -139,7 +139,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
-  const profile = resolveVoiceQualityProfile(loadConfig());
+  let profile = resolveVoiceQualityProfile(loadConfig());
 
   log.info({ callSessionId, mode: profile.mode, ttsProvider: profile.ttsProvider, voice: profile.voice }, 'Voice quality profile resolved');
 
@@ -169,6 +169,14 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     }
     log.warn({ callSessionId }, 'elevenlabs_agent mode is restricted/experimental — consultation bridging is not yet supported; falling back to standard ConversationRelay TwiML');
     elevenLabsAgentGuarded = true;
+    const standardConfig = loadConfig();
+    profile = resolveVoiceQualityProfile({
+      ...standardConfig,
+      calls: {
+        ...standardConfig.calls,
+        voice: { ...standardConfig.calls.voice, mode: 'twilio_standard' },
+      },
+    });
   }
 
   const twilioConfig = getTwilioConfig();


### PR DESCRIPTION
Addresses review feedback from PR #6195.

## Problem
When elevenlabs_agent mode is guarded and fallback is enabled, the code skipped the ElevenLabs API call but still used the ElevenLabs profile for TwiML generation. This meant TwiML contained ttsProvider=ElevenLabs instead of ttsProvider=Google.

## Fix
- Replace profile with standard twilio_standard profile when guard fires with fallback enabled
- Update test to verify standard profile is used in TwiML output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
