### PR TITLE
M2: Twilio eligibility checks for user-number mode

### DIFF
--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for TwilioConversationRelayProvider — signature validation and
- * fail-closed auth token behavior.
+ * Tests for TwilioConversationRelayProvider — signature validation,
+ * fail-closed auth token behavior, and caller ID eligibility checks.
  */
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { createHmac } from 'node:crypto';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -174,6 +174,115 @@ describe('TwilioConversationRelayProvider', () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+  });
+
+  describe('checkCallerIdEligibility', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test('returns eligible when number is found in IncomingPhoneNumbers', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({
+              incoming_phone_numbers: [{ sid: 'PN_test', phone_number: '+15550001111' }],
+            }),
+            { status: 200 },
+          );
+        }
+        // Should not reach OutgoingCallerIds since IncomingPhoneNumbers matched
+        return new Response(JSON.stringify({ outgoing_caller_ids: [] }), { status: 200 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    test('returns eligible when number is found in OutgoingCallerIds', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [] }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({
+              outgoing_caller_ids: [{ sid: 'PNverified', phone_number: '+15550001111' }],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    test('returns ineligible when number is not found in either endpoint', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [] }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({ outgoing_caller_ids: [] }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15559999999');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('not owned by or verified');
+      expect(result.reason).toContain('Twilio Console');
+    });
+
+    test('passes correct phone number as query parameter', async () => {
+      const provider = new TwilioConversationRelayProvider();
+      const capturedUrls: string[] = [];
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        capturedUrls.push(String(url));
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [{ sid: 'PN1' }] }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ outgoing_caller_ids: [] }), { status: 200 });
+      }) as typeof fetch;
+
+      await provider.checkCallerIdEligibility('+15550001111');
+
+      expect(capturedUrls[0]).toContain('PhoneNumber=%2B15550001111');
+      expect(capturedUrls[0]).toContain('/IncomingPhoneNumbers.json');
     });
   });
 });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -76,13 +76,15 @@ export type CallerIdentityResult =
  * - Otherwise fall through to the configured default mode.
  *
  * For `assistant_number`: uses the Twilio phone number from `getTwilioConfig()`.
+ *   No eligibility check is performed — this is a fast path.
  * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
- * secure key `credential:twilio:user_phone_number`.
+ *   secure key `credential:twilio:user_phone_number`, then validates that the
+ *   number is usable as an outbound caller ID via the Twilio API.
  */
-export function resolveCallerIdentity(
+export async function resolveCallerIdentity(
   config: AssistantConfig,
   requestedMode?: 'assistant_number' | 'user_number',
-): CallerIdentityResult {
+): Promise<CallerIdentityResult> {
   const identityConfig = config.calls.callerIdentity;
   let mode: 'assistant_number' | 'user_number';
 
@@ -112,6 +114,13 @@ export function resolveCallerIdentity(
       ok: false,
       error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
     };
+  }
+
+  // Verify the user number is eligible as a caller ID with Twilio
+  const provider = new TwilioConversationRelayProvider();
+  const eligibility = await provider.checkCallerIdEligibility(userNumber);
+  if (!eligibility.eligible) {
+    return { ok: false, error: eligibility.reason! };
   }
 
   return { ok: true, mode, fromNumber: userNumber };
@@ -152,7 +161,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     const provider = new TwilioConversationRelayProvider();
 
     // Resolve which phone number to use as caller ID
-    const identityResult = resolveCallerIdentity(ingressConfig, callerIdentityMode);
+    const identityResult = await resolveCallerIdentity(ingressConfig, callerIdentityMode);
     if (!identityResult.ok) {
       return { ok: false, error: identityResult.error, status: 400 };
     }

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -131,6 +131,80 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     return data.status;
   }
 
+  // ── Caller ID eligibility ───────────────────────────────────────────
+
+  /**
+   * Check whether a phone number can be used as an outbound caller ID
+   * by the current Twilio account. A number is eligible if it appears as
+   * either an Incoming Phone Number (owned) or an Outgoing Caller ID
+   * (verified) on the account.
+   */
+  async checkCallerIdEligibility(
+    phoneNumber: string,
+  ): Promise<{ eligible: boolean; reason?: string }> {
+    const { accountSid, authToken } = this.getCredentials();
+    const encodedNumber = encodeURIComponent(phoneNumber);
+
+    // Check incoming phone numbers (owned by this account)
+    const incomingRes = await fetch(
+      `${this.baseUrl(accountSid)}/IncomingPhoneNumbers.json?PhoneNumber=${encodedNumber}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: this.authHeader(accountSid, authToken),
+        },
+      },
+    );
+
+    if (incomingRes.ok) {
+      const incomingData = (await incomingRes.json()) as {
+        incoming_phone_numbers: unknown[];
+      };
+      if (incomingData.incoming_phone_numbers.length > 0) {
+        log.info({ phoneNumber }, 'Number found in IncomingPhoneNumbers — eligible as caller ID');
+        return { eligible: true };
+      }
+    } else {
+      log.warn(
+        { status: incomingRes.status, phoneNumber },
+        'Failed to query IncomingPhoneNumbers — falling through to OutgoingCallerIds',
+      );
+    }
+
+    // Check outgoing caller IDs (verified with this account)
+    const outgoingRes = await fetch(
+      `${this.baseUrl(accountSid)}/OutgoingCallerIds.json?PhoneNumber=${encodedNumber}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: this.authHeader(accountSid, authToken),
+        },
+      },
+    );
+
+    if (outgoingRes.ok) {
+      const outgoingData = (await outgoingRes.json()) as {
+        outgoing_caller_ids: unknown[];
+      };
+      if (outgoingData.outgoing_caller_ids.length > 0) {
+        log.info({ phoneNumber }, 'Number found in OutgoingCallerIds — eligible as caller ID');
+        return { eligible: true };
+      }
+    } else {
+      log.warn(
+        { status: outgoingRes.status, phoneNumber },
+        'Failed to query OutgoingCallerIds',
+      );
+    }
+
+    log.info({ phoneNumber }, 'Number not found in either IncomingPhoneNumbers or OutgoingCallerIds');
+    return {
+      eligible: false,
+      reason:
+        'Number is not owned by or verified with your Twilio account. To use this number as caller ID, either: (1) add it as an Incoming Phone Number, or (2) verify it as an Outgoing Caller ID in the Twilio Console.',
+    };
+  }
+
   // ── Webhook signature verification ──────────────────────────────────
 
   /**


### PR DESCRIPTION
Part of #6189: Calls Caller Identity

- Add checkCallerIdEligibility method to TwilioConversationRelayProvider
- Checks Twilio IncomingPhoneNumbers and OutgoingCallerIds endpoints
- Make resolveCallerIdentity async and enforce eligibility check for user_number mode
- Assistant-number mode remains fast path with no extra API calls
- Add tests for eligibility check scenarios

Closes #6191
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
