### PR TITLE
M3: Tool + HTTP API support for per-call identity selection

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -31,6 +31,19 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+const mockCallsConfig = {
+  enabled: true,
+  provider: 'twilio',
+  maxDurationSeconds: 3600,
+  userConsultTimeoutSeconds: 120,
+  disclosure: { enabled: false, text: '' },
+  safety: { denyCategories: [] },
+  callerIdentity: {
+    defaultMode: 'assistant_number' as const,
+    allowPerCallOverride: true,
+  },
+};
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     model: 'test',
@@ -39,13 +52,19 @@ mock.module('../config/loader.js', () => ({
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
-    calls: {
+    calls: mockCallsConfig,
+  }),
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    calls: mockCallsConfig,
+    ingress: {
       enabled: true,
-      provider: 'twilio',
-      maxDurationSeconds: 3600,
-      userConsultTimeoutSeconds: 120,
-      disclosure: { enabled: false, text: '' },
-      safety: { denyCategories: [] },
+      publicBaseUrl: 'https://test.example.com',
     },
   }),
 }));
@@ -237,6 +256,63 @@ describe('runtime call routes — HTTP layer', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Invalid JSON');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start with callerIdentityMode user_number is accepted', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-1');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-1',
+        callerIdentityMode: 'user_number',
+      }),
+    });
+
+    // user_number mode requires a configured user phone number;
+    // since we haven't set one, this should return a 400 explaining why
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('user_number');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start without callerIdentityMode defaults to assistant_number', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-2');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-2',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+
+    const body = await res.json() as {
+      callSessionId: string;
+      callSid: string;
+      status: string;
+      toNumber: string;
+      fromNumber: string;
+      callerIdentityMode: string;
+    };
+
+    expect(body.callSessionId).toBeDefined();
+    expect(body.callSid).toBe('CA_mock_sid_123');
+    expect(body.fromNumber).toBe('+15550001111');
+    expect(body.callerIdentityMode).toBe('assistant_number');
 
     await stopServer();
   });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -36,6 +36,7 @@ export interface StartCallResult {
   ok: true;
   session: CallSession;
   callSid: string;
+  callerIdentityMode: 'assistant_number' | 'user_number';
 }
 
 export interface CallError {
@@ -193,6 +194,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       ok: true,
       session: { ...session, providerCallSid: callSid },
       callSid,
+      callerIdentityMode: identityResult.mode,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -13,7 +13,7 @@ import { getConfig } from '../../config/loader.js';
 /**
  * POST /v1/calls/start
  *
- * Body: { phoneNumber: string; task: string; context?: string; conversationId: string }
+ * Body: { phoneNumber: string; task: string; context?: string; conversationId: string; callerIdentityMode?: 'assistant_number' | 'user_number' }
  */
 export async function handleStartCall(req: Request): Promise<Response> {
   if (!getConfig().calls.enabled) {
@@ -28,6 +28,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     task?: string;
     context?: string;
     conversationId?: string;
+    callerIdentityMode?: 'assistant_number' | 'user_number';
   };
   try {
     body = await req.json() as typeof body;
@@ -44,6 +45,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     task: body.task ?? '',
     context: body.context,
     conversationId: body.conversationId,
+    callerIdentityMode: body.callerIdentityMode,
   });
 
   if (!result.ok) {
@@ -56,6 +58,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     status: result.session.status,
     toNumber: result.session.toNumber,
     fromNumber: result.session.fromNumber,
+    callerIdentityMode: result.callerIdentityMode,
   }, { status: 201 });
 }
 

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -24,6 +24,11 @@ const definition: ToolDefinition = {
         type: 'string',
         description: 'Additional context for the conversation',
       },
+      caller_identity_mode: {
+        type: 'string',
+        enum: ['assistant_number', 'user_number'],
+        description: 'Which phone number to use as the caller ID. assistant_number uses the AI assistant\'s Twilio number; user_number uses the user\'s verified personal number.',
+      },
     },
     required: ['phone_number', 'task'],
   },
@@ -49,6 +54,7 @@ class CallStartTool implements Tool {
       task: input.task as string,
       context: input.context as string | undefined,
       conversationId: context.conversationId,
+      callerIdentityMode: input.caller_identity_mode as 'assistant_number' | 'user_number' | undefined,
     });
 
     if (!result.ok) {
@@ -61,6 +67,8 @@ class CallStartTool implements Tool {
         `  Call Session ID: ${result.session.id}`,
         `  Call SID: ${result.callSid}`,
         `  To: ${result.session.toNumber}`,
+        `  From: ${result.session.fromNumber}`,
+        `  Caller Identity Mode: ${result.callerIdentityMode}`,
         `  Status: initiated`,
         '',
         'The AI voice assistant is now placing the call. Use call_status to check progress.',


### PR DESCRIPTION
Part of #6189: Calls Caller Identity

- Add caller_identity_mode parameter to call_start tool
- Accept callerIdentityMode in POST /v1/calls/start HTTP endpoint
- Include resolved callerIdentityMode in startCall result and API responses
- Update tests for new parameter handling

Closes #6192
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
