### PR TITLE
Calls ElevenLabs Fidelity Gap Closure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3518,7 +3518,7 @@ sequenceDiagram
 | `assistant/src/calls/call-state-machine.ts` | Deterministic state transition validator with allowed-transition table and terminal-state enforcement |
 | `assistant/src/calls/call-recovery.ts` | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions |
 | `assistant/src/calls/twilio-provider.ts` | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency |
-| `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML), status callback, connect action |
+| `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML with WS-A/WS-B guardrails), status callback, connect action |
 | `assistant/src/calls/relay-server.ts` | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call |
 | `assistant/src/calls/speaker-identification.ts` | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
 | `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_USER and END_CALL control markers |
@@ -3672,10 +3672,10 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.disclosure.text` | string | *(default disclosure prompt)* | The disclosure instruction included in the system prompt. |
 | `calls.safety.denyCategories` | string[] | `[]` | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting). |
 | `calls.model` | string | *(unset — uses default model)* | Optional override for the LLM model used in call orchestration. |
-| `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay), `elevenlabs_agent` (full ElevenLabs conversational agent). |
+| `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices — fully supported), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay — fully supported), `elevenlabs_agent` (full ElevenLabs conversational agent — experimental/restricted, blocked by runtime guard). |
 | `calls.voice.language` | string | `'en-US'` | Language code for TTS and transcription. |
 | `calls.voice.transcriptionProvider` | enum | `'Deepgram'` | Speech-to-text provider (`Deepgram` or `Google`). |
-| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors). |
+| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors) or is restricted (e.g., `elevenlabs_agent` guard). When `false`, errors return HTTP 500/501/502 instead of falling back. |
 | `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
 | `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
 
@@ -3685,11 +3685,39 @@ Voice and TTS settings are configurable via the `calls.voice` config block — t
 
 The resolution logic works as follows:
 
-- **`twilio_standard`** — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
-- **`twilio_elevenlabs_tts`** — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
-- **`elevenlabs_agent`** — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`.
+- **`twilio_standard`** (fully supported) — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
+- **`twilio_elevenlabs_tts`** (fully supported) — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
+- **`elevenlabs_agent`** (experimental/restricted) — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`. Even when the profile resolves successfully, a runtime guard in `handleVoiceWebhook` blocks this mode (see below).
 
 When `fallbackToStandardOnError` is `true` (default), any misconfiguration or runtime error in ElevenLabs modes causes a graceful fallback to standard Twilio TTS rather than a call failure. Validation errors are captured in `validationErrors` on the profile for logging.
+
+### Voice Mode Guardrails in `handleVoiceWebhook`
+
+The voice webhook (`twilio-routes.ts`) enforces two sequential guardrails before returning TwiML:
+
+**WS-A: Invalid profile guard** — If `isVoiceProfileValid(profile)` returns false (i.e., there are validation errors such as missing `voiceId` or `agentId`):
+- `fallbackToStandardOnError=true` (default): the profile has already been resolved to `twilio_standard` by the profile resolver; proceeds normally.
+- `fallbackToStandardOnError=false`: returns **HTTP 500** with the validation error details.
+
+**WS-B: `elevenlabs_agent` mode guard** — If the resolved profile mode is `elevenlabs_agent`, a guard fires *before* any ElevenLabs API calls because consultation bridging (`waiting_on_user`) is not yet supported in this mode:
+- `fallbackToStandardOnError=true` (default): logs a warning and falls back to standard ConversationRelay TwiML.
+- `fallbackToStandardOnError=false`: returns **HTTP 501** `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
+
+The guard order ensures invalid configs are caught first (WS-A), then mode-level restrictions are enforced (WS-B). For `twilio_standard` and `twilio_elevenlabs_tts` modes, both guards pass and the webhook proceeds to return ConversationRelay TwiML.
+
+```mermaid
+flowchart TD
+    A["handleVoiceWebhook"] --> B["resolveVoiceQualityProfile()"]
+    B --> C{"isVoiceProfileValid?<br/>(WS-A)"}
+    C -- "yes" --> D{"mode == elevenlabs_agent?<br/>(WS-B)"}
+    C -- "no, fallback=true" --> F["proceed with standard profile"]
+    C -- "no, fallback=false" --> G["HTTP 500: config error"]
+    D -- "no (twilio_standard /<br/>twilio_elevenlabs_tts)" --> H["return ConversationRelay TwiML"]
+    D -- "yes, fallback=true" --> I["warn + fallback to<br/>standard TwiML"]
+    D -- "yes, fallback=false" --> J["HTTP 501: consultation<br/>bridging not supported"]
+    F --> H
+    I --> H
+```
 
 ---
 

--- a/assistant/src/__tests__/elevenlabs-client.test.ts
+++ b/assistant/src/__tests__/elevenlabs-client.test.ts
@@ -189,6 +189,68 @@ describe('ElevenLabsClient', () => {
       }
     });
 
+    test('valid TwiML with XML declaration passes validation', async () => {
+      const twiml = '<?xml version="1.0"?><Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twiml, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twiml);
+    });
+
+    test('valid TwiML with Response tag but no XML declaration passes validation', async () => {
+      const twiml = '<Response><Connect><Stream url="wss://el.io/stream"/></Connect></Response>';
+
+      globalThis.fetch = mock(async () =>
+        new Response(twiml, { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+      const result = await client.registerCall(DEFAULT_REQUEST);
+
+      expect(result.twiml).toBe(twiml);
+    });
+
+    test('non-XML response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('{"error": "invalid"}', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+        expect(elErr.message).toContain('not valid TwiML/XML');
+      }
+    });
+
+    test('plain text response throws ELEVENLABS_INVALID_RESPONSE', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('some random text', { status: 200 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = new ElevenLabsClient(DEFAULT_OPTIONS);
+
+      try {
+        await client.registerCall(DEFAULT_REQUEST);
+        expect(true).toBe(false); // Should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(ElevenLabsError);
+        const elErr = err as ElevenLabsError;
+        expect(elErr.code).toBe('ELEVENLABS_INVALID_RESPONSE');
+        expect(elErr.message).toContain('not valid TwiML/XML');
+      }
+    });
+
     test('API key is not included in logged data', async () => {
       // The ElevenLabsClient logs agent_id and direction, but should never log the API key.
       // We verify this by checking the request structure, not the log output.

--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Handler-level tests for ElevenLabs voice webhook branches in handleVoiceWebhook.
+ *
+ * Tests the WS-A (invalid profile + fallback semantics) and WS-B
+ * (elevenlabs_agent guard) paths by mocking resolveVoiceQualityProfile
+ * to return specific profiles and asserting on HTTP response status/body.
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'twilio-routes-11labs-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    calls: {
+      voice: {
+        mode: 'twilio_standard',
+        language: 'en-US',
+        transcriptionProvider: 'Deepgram',
+        fallbackToStandardOnError: true,
+        elevenlabs: {
+          voiceId: '',
+          voiceModelId: 'turbo_v2_5',
+          stability: 0.5,
+          similarityBoost: 0.75,
+          style: 0.0,
+          useSpeakerBoost: true,
+          agentId: '',
+          apiBaseUrl: 'https://api.elevenlabs.io',
+          registerCallTimeoutMs: 5000,
+        },
+      },
+    },
+    ingress: { enabled: false, publicBaseUrl: '' },
+  }),
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => undefined,
+}));
+
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    readonly name = 'twilio';
+    static getAuthToken(): string | null { return null; }
+    static verifyWebhookSignature(): boolean { return true; }
+    async initiateCall() { return { callSid: 'CA_mock_test' }; }
+    async endCall() { return; }
+  },
+}));
+
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test-auth-token',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+// Mock resolveVoiceQualityProfile and isVoiceProfileValid so we can control
+// the profile returned to handleVoiceWebhook per-test.
+import type { VoiceQualityProfile } from '../calls/voice-quality.js';
+
+let mockProfile: VoiceQualityProfile = {
+  mode: 'twilio_standard',
+  language: 'en-US',
+  transcriptionProvider: 'Deepgram',
+  ttsProvider: 'Google',
+  voice: 'Google.en-US-Journey-O',
+  fallbackToStandardOnError: true,
+  validationErrors: [],
+};
+
+mock.module('../calls/voice-quality.js', () => ({
+  resolveVoiceQualityProfile: () => mockProfile,
+  isVoiceProfileValid: (profile: VoiceQualityProfile) => profile.validationErrors.length === 0,
+}));
+
+// Mock the ingress URL to avoid config lookup issues
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getTwilioRelayUrl: () => 'wss://test.example.com/v1/calls/relay',
+  getPublicBaseUrl: () => 'https://test.example.com',
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import {
+  createCallSession,
+  updateCallSession,
+} from '../calls/call-store.js';
+import { handleVoiceWebhook } from '../calls/twilio-routes.js';
+
+initializeDb();
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+let ensuredConvIds = new Set<string>();
+
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Test conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  ensuredConvIds.add(id);
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM processed_callbacks');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM conversations');
+  ensuredConvIds = new Set();
+}
+
+function createTestSession(convId: string, callSid: string) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15559998888',
+    task: 'test task',
+  });
+  updateCallSession(session.id, { providerCallSid: callSid });
+  return session;
+}
+
+function makeVoiceRequest(sessionId: string, params: Record<string, string>): Request {
+  return new Request(`http://127.0.0.1/v1/calls/twilio/voice-webhook?callSessionId=${sessionId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('handleVoiceWebhook ElevenLabs branches', () => {
+  beforeEach(() => {
+    resetTables();
+    // Reset to standard default profile between tests
+    mockProfile = {
+      mode: 'twilio_standard',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    };
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  // ── WS-A: Invalid config + fallback disabled => 500 ────────────────
+  test('twilio_elevenlabs_tts invalid config with fallback disabled returns 500', async () => {
+    mockProfile = {
+      mode: 'twilio_elevenlabs_tts',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: '',
+      fallbackToStandardOnError: false,
+      validationErrors: ['voiceId is required'],
+    };
+
+    const session = createTestSession('conv-11labs-1', 'CA_11labs_1');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_1' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toContain('Voice quality configuration error');
+    expect(body).toContain('voiceId is required');
+  });
+
+  // ── WS-A: Invalid config + fallback enabled => standard TwiML ──────
+  test('twilio_elevenlabs_tts invalid config with fallback enabled returns standard TwiML', async () => {
+    // When fallback is enabled and voiceId is missing, resolveVoiceQualityProfile
+    // falls back to standard mode but retains validation errors.
+    mockProfile = {
+      mode: 'twilio_standard',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: ['calls.voice.elevenlabs.voiceId is empty; falling back to twilio_standard'],
+    };
+
+    const session = createTestSession('conv-11labs-2', 'CA_11labs_2');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_2' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(200);
+    const twiml = await res.text();
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('<ConversationRelay');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+  });
+
+  // ── WS-B: elevenlabs_agent strict mode (fallback false) => 501 ─────
+  test('elevenlabs_agent with fallback disabled returns 501', async () => {
+    mockProfile = {
+      mode: 'elevenlabs_agent',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+      agentId: 'agent-abc',
+      fallbackToStandardOnError: false,
+      validationErrors: [],
+    };
+
+    const session = createTestSession('conv-11labs-3', 'CA_11labs_3');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_3' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(501);
+    const body = await res.text();
+    expect(body).toContain('consultation bridging');
+    expect(body).toContain('elevenlabs_agent mode is restricted');
+  });
+
+  // ── WS-B: elevenlabs_agent with fallback true => standard TwiML ────
+  test('elevenlabs_agent with fallback enabled returns standard TwiML', async () => {
+    mockProfile = {
+      mode: 'elevenlabs_agent',
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+      agentId: 'agent-abc',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    };
+
+    const session = createTestSession('conv-11labs-4', 'CA_11labs_4');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_4' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(200);
+    const twiml = await res.text();
+    // When elevenlabs_agent is guarded with fallback enabled, the handler
+    // sets elevenLabsAgentGuarded=true and falls through to standard TwiML
+    // generation, which uses the profile's ttsProvider/voice. But since
+    // the profile has mode=elevenlabs_agent with guard set, it skips the
+    // ElevenLabs register-call path and generates standard TwiML using
+    // whatever profile values exist.
+    expect(twiml).toContain('<ConversationRelay');
+    // The TwiML should be generated (not an ElevenLabs register-call response)
+    expect(twiml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(twiml).toContain('<Response>');
+    expect(twiml).toContain('<Connect>');
+  });
+});

--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -108,8 +108,10 @@ let mockProfile: VoiceQualityProfile = {
   validationErrors: [],
 };
 
+const mockResolveVoiceQualityProfile = mock(() => mockProfile);
+
 mock.module('../calls/voice-quality.js', () => ({
-  resolveVoiceQualityProfile: () => mockProfile,
+  resolveVoiceQualityProfile: mockResolveVoiceQualityProfile,
   isVoiceProfileValid: (profile: VoiceQualityProfile) => profile.validationErrors.length === 0,
 }));
 
@@ -182,6 +184,8 @@ function makeVoiceRequest(sessionId: string, params: Record<string, string>): Re
 describe('handleVoiceWebhook ElevenLabs branches', () => {
   beforeEach(() => {
     resetTables();
+    // Reset mock to default implementation
+    mockResolveVoiceQualityProfile.mockReset();
     // Reset to standard default profile between tests
     mockProfile = {
       mode: 'twilio_standard',
@@ -192,6 +196,7 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
       fallbackToStandardOnError: true,
       validationErrors: [],
     };
+    mockResolveVoiceQualityProfile.mockImplementation(() => mockProfile);
   });
 
   afterAll(() => {
@@ -274,8 +279,9 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
 
   // ── WS-B: elevenlabs_agent with fallback true => standard TwiML ────
   test('elevenlabs_agent with fallback enabled returns standard TwiML', async () => {
-    mockProfile = {
-      mode: 'elevenlabs_agent',
+    // First call returns the elevenlabs_agent profile (triggers the guard)
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'elevenlabs_agent' as const,
       language: 'en-US',
       transcriptionProvider: 'Deepgram',
       ttsProvider: 'ElevenLabs',
@@ -283,7 +289,17 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
       agentId: 'agent-abc',
       fallbackToStandardOnError: true,
       validationErrors: [],
-    };
+    }));
+    // Second call returns the standard profile (used for TwiML generation)
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'twilio_standard' as const,
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    }));
 
     const session = createTestSession('conv-11labs-4', 'CA_11labs_4');
     const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_4' });
@@ -293,15 +309,13 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
     expect(res.status).toBe(200);
     const twiml = await res.text();
     // When elevenlabs_agent is guarded with fallback enabled, the handler
-    // sets elevenLabsAgentGuarded=true and falls through to standard TwiML
-    // generation, which uses the profile's ttsProvider/voice. But since
-    // the profile has mode=elevenlabs_agent with guard set, it skips the
-    // ElevenLabs register-call path and generates standard TwiML using
-    // whatever profile values exist.
+    // replaces the profile with a standard twilio_standard profile and
+    // generates TwiML with Google TTS instead of ElevenLabs.
     expect(twiml).toContain('<ConversationRelay');
-    // The TwiML should be generated (not an ElevenLabs register-call response)
     expect(twiml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(twiml).toContain('<Response>');
     expect(twiml).toContain('<Connect>');
+    expect(twiml).toContain('ttsProvider="Google"');
+    expect(twiml).toContain('voice="Google.en-US-Journey-O"');
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -8,7 +8,7 @@
  * - Unknown status and malformed payload handling
  * - Handler-level idempotency concurrency (concurrent duplicates, failure-retry)
  */
-import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock, spyOn } from 'bun:test';
 import { createHmac } from 'node:crypto';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -211,6 +211,13 @@ describe('twilio webhook routes', () => {
     mockWssBaseUrl = 'wss://test.example.com';
     mockWebhookBaseUrl = 'https://test.example.com';
     delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
+  });
+
+  // Deterministic teardown: always stop the server after each test so a
+  // failed assertion between startServer/stopServer doesn't leave the
+  // port bound, causing EADDRINUSE flakes in subsequent tests.
+  afterEach(async () => {
+    await stopServer();
   });
 
   afterAll(() => {

--- a/assistant/src/calls/elevenlabs-client.ts
+++ b/assistant/src/calls/elevenlabs-client.ts
@@ -75,6 +75,14 @@ export class ElevenLabsClient {
         );
       }
 
+      const lower = body.toLowerCase();
+      if (!lower.includes('<?xml') && !lower.includes('<response')) {
+        throw new ElevenLabsError(
+          'ELEVENLABS_INVALID_RESPONSE',
+          'Register-call response is not valid TwiML/XML',
+        );
+      }
+
       return { twiml: body };
     } catch (err) {
       if (err instanceof ElevenLabsError) throw err;

--- a/assistant/src/calls/elevenlabs-config.ts
+++ b/assistant/src/calls/elevenlabs-config.ts
@@ -1,8 +1,5 @@
 import { getConfig } from '../config/loader.js';
 import { getSecureKey } from '../security/secure-keys.js';
-import { getLogger } from '../util/logger.js';
-
-const log = getLogger('elevenlabs-config');
 
 export interface ElevenLabsConfig {
   apiKey: string;
@@ -17,13 +14,18 @@ export function getElevenLabsConfig(): ElevenLabsConfig {
 
   const apiKey = getSecureKey('credential:elevenlabs:api_key') ?? '';
   if (!apiKey) {
-    log.warn('No ElevenLabs API key found in secure key store (credential:elevenlabs:api_key)');
+    throw new Error('ElevenLabs API key is not configured. Set credential:elevenlabs:api_key in the secure key store.');
+  }
+
+  const agentId = voice.elevenlabs.agentId;
+  if (!agentId) {
+    throw new Error('ElevenLabs agent ID is not configured. Set calls.voice.elevenlabs.agentId in config.');
   }
 
   return {
     apiKey,
     apiBaseUrl: voice.elevenlabs.apiBaseUrl,
-    agentId: voice.elevenlabs.agentId,
+    agentId,
     registerCallTimeoutMs: voice.elevenlabs.registerCallTimeoutMs,
   };
 }

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -25,7 +25,7 @@ import { getTwilioConfig } from './twilio-config.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { fireCallCompletionNotifier } from './call-state.js';
-import { resolveVoiceQualityProfile } from './voice-quality.js';
+import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality.js';
 import { getElevenLabsConfig } from './elevenlabs-config.js';
 import { ElevenLabsClient } from './elevenlabs-client.js';
 
@@ -147,6 +147,30 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.warn({ callSessionId, errors: profile.validationErrors }, 'Voice quality profile has validation warnings');
   }
 
+  // WS-A: Enforce strict fallback semantics — reject invalid profiles when fallback is disabled
+  if (!isVoiceProfileValid(profile)) {
+    if (!profile.fallbackToStandardOnError) {
+      const errorMsg = `Voice quality configuration error: ${profile.validationErrors.join('; ')}`;
+      log.error({ callSessionId, errors: profile.validationErrors }, errorMsg);
+      return new Response(errorMsg, { status: 500 });
+    }
+    // Fallback is enabled — profile already resolved to standard; log explicitly
+    log.info({ callSessionId }, 'Profile invalid with fallback enabled; proceeding with standard mode');
+  }
+
+  // WS-B: Guard elevenlabs_agent until consultation bridge exists.
+  // This fires BEFORE any ElevenLabs API calls, blocking the entire mode.
+  let elevenLabsAgentGuarded = false;
+  if (profile.mode === 'elevenlabs_agent') {
+    if (!profile.fallbackToStandardOnError) {
+      const msg = 'elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported. Set calls.voice.fallbackToStandardOnError=true to fall back to standard mode.';
+      log.error({ callSessionId }, msg);
+      return new Response(msg, { status: 501 });
+    }
+    log.warn({ callSessionId }, 'elevenlabs_agent mode is restricted/experimental — consultation bridging is not yet supported; falling back to standard ConversationRelay TwiML');
+    elevenLabsAgentGuarded = true;
+  }
+
   const twilioConfig = getTwilioConfig();
   let relayUrl: string;
   try {
@@ -157,7 +181,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   }
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
 
-  if (profile.mode === 'elevenlabs_agent') {
+  if (profile.mode === 'elevenlabs_agent' && !elevenLabsAgentGuarded) {
     try {
       const elevenLabsConfig = getElevenLabsConfig();
       const client = new ElevenLabsClient({

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -195,6 +195,13 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
         from_number: formBody.get('From') || session.fromNumber,
         to_number: formBody.get('To') || session.toNumber,
         direction: 'outbound',
+        conversation_initiation_client_data: {
+          dynamic_variables: {
+            task: session.task,
+            call_session_id: session.id,
+            conversation_id: session.conversationId,
+          },
+        },
       });
 
       log.info({ callSessionId }, 'ElevenLabs register-call succeeded');

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -139,7 +139,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
-  const profile = resolveVoiceQualityProfile(loadConfig());
+  let profile = resolveVoiceQualityProfile(loadConfig());
 
   log.info({ callSessionId, mode: profile.mode, ttsProvider: profile.ttsProvider, voice: profile.voice }, 'Voice quality profile resolved');
 
@@ -169,6 +169,14 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     }
     log.warn({ callSessionId }, 'elevenlabs_agent mode is restricted/experimental — consultation bridging is not yet supported; falling back to standard ConversationRelay TwiML');
     elevenLabsAgentGuarded = true;
+    const standardConfig = loadConfig();
+    profile = resolveVoiceQualityProfile({
+      ...standardConfig,
+      calls: {
+        ...standardConfig.calls,
+        voice: { ...standardConfig.calls.voice, mode: 'twilio_standard' },
+      },
+    });
   }
 
   const twilioConfig = getTwilioConfig();

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -90,3 +90,8 @@ export function resolveVoiceQualityProfile(config?: ReturnType<typeof loadConfig
 
   return standardProfile;
 }
+
+/** Returns false when the profile has any validation errors. */
+export function isVoiceProfileValid(profile: VoiceQualityProfile): boolean {
+  return profile.validationErrors.length === 0;
+}

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -21,9 +21,9 @@ When a call is placed:
 5. The transcript is relayed live to the user's conversation thread
 
 Three voice quality modes are available:
-- **`twilio_standard`** (default) — Standard Twilio TTS with Google voices. No extra setup required.
-- **`twilio_elevenlabs_tts`** — Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
-- **`elevenlabs_agent`** — Full ElevenLabs conversational agent mode for the highest quality (requires ElevenLabs agent setup).
+- **`twilio_standard`** (default) — Fully supported. Standard Twilio TTS with Google voices. No extra setup required.
+- **`twilio_elevenlabs_tts`** — Fully supported. Uses ElevenLabs voices through Twilio ConversationRelay for more natural speech.
+- **`elevenlabs_agent`** — **Experimental/restricted.** Full ElevenLabs conversational agent mode. Consultation bridging (`waiting_on_user`) is not yet supported in this mode; the runtime guard blocks it before any ElevenLabs API calls are made. See the "Runtime behavior" section below for fallback and strict-fail details.
 
 You can keep using Twilio only — no changes needed. Enabling ElevenLabs can improve naturalness and quality.
 
@@ -165,9 +165,11 @@ vellum config set calls.voice.mode twilio_elevenlabs_tts
 vellum config set calls.voice.elevenlabs.voiceId "<your-voice-id>"
 ```
 
-### Mode: `elevenlabs_agent`
+### Mode: `elevenlabs_agent` (experimental/restricted)
 
 Full ElevenLabs conversational agent mode. This requires an ElevenLabs account with an agent configured on their platform.
+
+**Restriction:** This mode is currently restricted because consultation bridging (`waiting_on_user`) is not yet supported. A runtime guard in `handleVoiceWebhook` blocks `elevenlabs_agent` before any ElevenLabs API calls are made.
 
 **Setup:**
 
@@ -184,9 +186,26 @@ vellum config set calls.voice.mode elevenlabs_agent
 vellum config set calls.voice.elevenlabs.agentId "<your-agent-id>"
 ```
 
-### Fallback behavior
+### Fallback behavior and `fallbackToStandardOnError`
 
-By default, `calls.voice.fallbackToStandardOnError` is `true`. This means if ElevenLabs is unavailable or misconfigured (e.g., missing voice ID, API errors), calls automatically fall back to standard Twilio TTS rather than failing. You can disable this if you want strict ElevenLabs-only behavior:
+By default, `calls.voice.fallbackToStandardOnError` is `true`. This setting controls what happens when an ElevenLabs mode encounters errors or is restricted.
+
+#### Invalid configuration (e.g., missing voiceId or agentId)
+
+- **`true` (default):** The profile resolver silently falls back to `twilio_standard` mode and logs a warning. The call proceeds with standard Twilio TTS.
+- **`false`:** The voice webhook returns **HTTP 500** with the specific configuration error details (e.g., `"Voice quality configuration error: calls.voice.elevenlabs.voiceId is required..."`).
+
+#### `elevenlabs_agent` mode guard (consultation bridging unsupported)
+
+- **`true` (default):** The `elevenlabs_agent` mode is silently downgraded to standard ConversationRelay TwiML with a warning log. The call proceeds normally with standard Twilio TTS.
+- **`false`:** The voice webhook returns **HTTP 501** with the message: `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
+
+#### ElevenLabs API errors (register-call failure)
+
+- **`true` (default):** Falls back to `twilio_standard` mode and proceeds with the call.
+- **`false`:** Returns **HTTP 502** `"ElevenLabs service unavailable"`.
+
+You can disable fallback if you want strict ElevenLabs-only behavior:
 
 ```bash
 vellum config set calls.voice.fallbackToStandardOnError false
@@ -408,7 +427,8 @@ The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the
 - If mode is `elevenlabs_agent`, ensure `calls.voice.elevenlabs.agentId` is also set
 
 ### ElevenLabs mode falls back to standard
-When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error. Check:
-- For `elevenlabs_agent` mode: verify the API key is stored (`credential_store action=get service=credential:elevenlabs:api_key`) and that `calls.voice.elevenlabs.agentId` is configured
+When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error or restriction. Check:
+- For `elevenlabs_agent` mode: this mode is currently restricted (consultation bridging not yet supported) and will always fall back to standard when fallback is enabled. If fallback is disabled, the voice webhook returns HTTP 501.
 - For `twilio_elevenlabs_tts` mode: verify `calls.voice.elevenlabs.voiceId` is set to a valid voice ID
-- Review daemon logs for error messages related to ElevenLabs
+- For invalid configs (missing voiceId/agentId): if fallback is disabled, the voice webhook returns HTTP 500 with the config error
+- Review daemon logs for warning messages about fallback or guard activation


### PR DESCRIPTION
## Summary
Close implementation gaps in the ElevenLabs integration (commit a511be20) without regressing existing Twilio call behavior. Enforces strict fallback semantics, guards `elevenlabs_agent` mode until consultation bridging exists, hardens API config preconditions, validates TwiML responses, and adds comprehensive handler-level tests.

## Changes
- **Strict fallback semantics (WS-A):** `handleVoiceWebhook` now returns HTTP 500 with config error details when voice profile is invalid and `fallbackToStandardOnError=false`. Falls back to standard TwiML when enabled.
- **`elevenlabs_agent` guard (WS-B):** Runtime guard blocks `elevenlabs_agent` mode before any ElevenLabs API calls — returns HTTP 501 in strict mode, falls back to standard `twilio_standard` profile when fallback enabled.
- **Config hardening (WS-C):** `loadElevenLabsConfig()` fails early with clear non-secret error when API key or agentId is missing.
- **Dynamic variables:** Register-call payload now includes `conversation_initiation_client_data` with task, call_session_id, and conversation_id.
- **TwiML validation (WS-D):** `registerCall()` validates response contains XML/TwiML markers before returning to Twilio.
- **Handler-level tests (WS-E):** 4 new tests covering all ElevenLabs webhook branches (invalid config ± fallback, agent guard ± fallback).
- **Port stabilization:** `afterEach` hook ensures deterministic server teardown, preventing EADDRINUSE flakes.
- **Docs:** SKILL.md and ARCHITECTURE.md updated to reflect supported vs restricted modes, guardrail flow, and Mermaid diagram.

## Milestone PRs (merged into feature branch)
- #6195: M1 — Enforce strict fallback semantics and guard elevenlabs_agent mode
- #6196: M2 — Harden ElevenLabs config, enrich register-call payload, validate response as TwiML
- #6197: M4 — Update SKILL.md and ARCHITECTURE.md for supported vs restricted behavior
- #6198: M3 — Add handler-level ElevenLabs test coverage and stabilize port-flaky tests
- #6201: Fix — elevenlabs_agent guard fallback uses standard profile (addressed review feedback)

## Project issue
Closes #6184

## Test plan
- [ ] `cd assistant && bun test src/__tests__/elevenlabs-client.test.ts` — 13 tests pass
- [ ] `cd assistant && bun test src/__tests__/twilio-routes-elevenlabs.test.ts` — 4 tests pass
- [ ] `cd assistant && bun test src/__tests__/twilio-routes.test.ts` — 33 tests pass
- [ ] `cd assistant && bunx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
