### PR TITLE
M1: Fix attachment delivery path

### DIFF
--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -51,6 +51,112 @@ function mockTelegramApi() {
   }) as any;
 }
 
+describe("/deliver/telegram attachment delivery without assistantId", () => {
+  test("delivers attachments without assistantId using assistant-less download path", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      calls.push(urlStr);
+      // Runtime attachment download (assistant-less path)
+      if (urlStr.includes("/v1/attachments/att-1")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-1",
+            filename: "photo.png",
+            mimeType: "image/png",
+            sizeBytes: 100,
+            kind: "generated_image",
+            data: "iVBORw0KGgo=",
+          }),
+        );
+      }
+      // Telegram API calls
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chatId: "123",
+        attachments: [
+          { id: "att-1", filename: "photo.png", mimeType: "image/png", sizeBytes: 100, kind: "generated_image" },
+        ],
+      }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Should have downloaded via /v1/attachments/att-1 (no assistantId in URL)
+    const downloadCall = calls.find((u) => u.includes("/attachments/att-1"));
+    expect(downloadCall).toBeDefined();
+    expect(downloadCall).not.toContain("/assistants/");
+
+    // Should have sent the photo via Telegram
+    const telegramCall = calls.find((u) => u.includes("sendPhoto"));
+    expect(telegramCall).toBeDefined();
+  });
+
+  test("delivers attachments with assistantId using legacy download path", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      calls.push(urlStr);
+      // Runtime attachment download (legacy path)
+      if (urlStr.includes("/attachments/att-2")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-2",
+            filename: "doc.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 200,
+            kind: "filesystem",
+            data: "JVBER",
+          }),
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chatId: "456",
+        assistantId: "my-assistant",
+        attachments: [
+          { id: "att-2", filename: "doc.pdf", mimeType: "application/pdf", sizeBytes: 200, kind: "filesystem" },
+        ],
+      }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Should have downloaded via legacy /v1/assistants/my-assistant/attachments/att-2
+    const downloadCall = calls.find((u) => u.includes("/attachments/att-2"));
+    expect(downloadCall).toBeDefined();
+    expect(downloadCall).toContain("/assistants/my-assistant/");
+  });
+});
+
 describe("/deliver/telegram bearer auth enforcement", () => {
   test("rejects request without Authorization header with 401", async () => {
     const handler = createTelegramDeliverHandler(makeConfig());

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -148,6 +148,45 @@ describe("sendTelegramAttachments", () => {
     expect(calls[0]).toContain("sendMessage");
   });
 
+  test("downloads via assistant-less path when assistantId is undefined", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-no-assist")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-no-assist",
+            filename: "image.jpg",
+            mimeType: "image/jpeg",
+            sizeBytes: 80,
+            kind: "generated_image",
+            data: "/9j/4AAQ",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = {
+      id: "att-no-assist",
+      filename: "image.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 80,
+      kind: "generated_image",
+    };
+
+    await sendTelegramAttachments(config, "chat-1", undefined, [meta]);
+
+    expect(calls).toHaveLength(2);
+    // Should use /v1/attachments/ path (no assistantId in URL)
+    const downloadUrl = calls[0];
+    expect(downloadUrl).toContain("/v1/attachments/att-no-assist");
+    expect(downloadUrl).not.toContain("/assistants/");
+    expect(calls[1]).toContain("sendPhoto");
+  });
+
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -51,7 +51,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
         await sendTelegramReply(config, chatId, text);
       }
 
-      if (attachments && attachments.length > 0 && assistantId) {
+      if (attachments && attachments.length > 0) {
         await sendTelegramAttachments(config, chatId, assistantId, attachments);
       }
     } catch (err) {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -182,6 +182,30 @@ export async function downloadAttachment(
   return (await response.json()) as RuntimeAttachmentPayload;
 }
 
+/**
+ * Download an attachment without requiring an assistantId.
+ * Uses the assistant-less /v1/attachments/:attachmentId endpoint.
+ */
+export async function downloadAttachmentById(
+  config: GatewayConfig,
+  attachmentId: string,
+): Promise<RuntimeAttachmentPayload> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: runtimeHeaders(config),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Attachment download failed (${response.status}): ${body}`);
+  }
+
+  return (await response.json()) as RuntimeAttachmentPayload;
+}
+
 // ── Twilio webhook forwarding ────────────────────────────────────────
 
 export type TwilioForwardResponse = {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -689,7 +689,7 @@ export function buildSchema(): Record<string, unknown> {
           properties: {
             chatId: { type: "string", description: "Telegram chat ID to deliver the message to" },
             text: { type: "string", description: "Text content to send", minLength: 1 },
-            assistantId: { type: "string", description: "Assistant ID (required when sending attachments)" },
+            assistantId: { type: "string", description: "Assistant ID (optional — attachments are downloaded via the assistant-less endpoint when omitted)" },
             attachments: {
               type: "array",
               description: "Attachments to deliver (images sent via sendPhoto, others via sendDocument)",

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,6 +1,6 @@
 import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
-import { downloadAttachment, type RuntimeAttachmentMeta } from "../runtime/client.js";
+import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
 
 const log = getLogger("telegram-send");
@@ -48,7 +48,7 @@ export async function sendTelegramReply(
 export async function sendTelegramAttachments(
   config: GatewayConfig,
   chatId: string,
-  assistantId: string,
+  assistantId: string | undefined,
   attachments: RuntimeAttachmentMeta[],
 ): Promise<void> {
   const failures: string[] = [];
@@ -61,7 +61,11 @@ export async function sendTelegramAttachments(
     }
 
     try {
-      const payload = await downloadAttachment(config, assistantId, meta.id);
+      // Prefer the assistant-less download path; fall back to the legacy
+      // assistant-scoped path when assistantId is available.
+      const payload = assistantId
+        ? await downloadAttachment(config, assistantId, meta.id)
+        : await downloadAttachmentById(config, meta.id);
       const buffer = Buffer.from(payload.data, "base64");
       const blob = new Blob([buffer], { type: meta.mimeType });
 


### PR DESCRIPTION
Remove the hard dependency on assistantId for Telegram attachment delivery. Attachments are now downloaded via /v1/attachments/:attachmentId endpoint that doesn't require assistantId. This fixes the bug where outbound attachments were silently dropped in channel callback flows. Part of #6200.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
