### PR TITLE
Unify GATEWAY_PUBLIC_URL into INGRESS_PUBLIC_BASE_URL

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -295,15 +295,12 @@ export async function startGateway(): Promise<string> {
   const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
   const ingressPublicBaseUrl =
     workspaceIngressPublicBaseUrl
-    ?? normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL);
+    ?? normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL)
+    ?? publicUrl;
   if (ingressPublicBaseUrl) {
     gatewayEnv.INGRESS_PUBLIC_BASE_URL = ingressPublicBaseUrl;
     console.log(`   Ingress URL: ${ingressPublicBaseUrl}`);
-    if (!workspaceIngressPublicBaseUrl) {
-      console.log("   (using INGRESS_PUBLIC_BASE_URL env fallback)");
-    }
   }
-  if (publicUrl) gatewayEnv.GATEWAY_PUBLIC_URL = publicUrl;
 
   const gateway = spawn("bun", ["run", "src/index.ts"], {
     cwd: gatewayDir,

--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -29,7 +29,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
-    publicUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -29,7 +29,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
-    publicUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -35,7 +35,6 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
-  publicUrl: undefined,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -31,7 +31,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
-    publicUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -29,7 +29,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
-    publicUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -31,7 +31,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
-    publicUrl: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -29,7 +29,6 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
-  publicUrl: undefined,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -43,7 +43,6 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
-  publicUrl: undefined,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -33,7 +33,6 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: AUTH_TOKEN,
   ingressPublicBaseUrl: undefined,
-  publicUrl: undefined,
   ...overrides,
 });
 

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -40,8 +40,6 @@ export type GatewayConfig = {
   /** Canonical public ingress base URL, used for webhook signature reconstruction. */
   ingressPublicBaseUrl: string | undefined;
   unmappedPolicy: "reject" | "default";
-  /** The gateway's own public-facing URL (e.g. http://<external-ip>:7830). */
-  publicUrl?: string;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -210,12 +208,6 @@ export function loadConfig(): GatewayConfig {
   }
 
   const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || undefined;
-  const publicUrl = process.env.GATEWAY_PUBLIC_URL || undefined;
-
-  // In the default local deployment, the assistant's hatch process sets this
-  // env var from config.ingress.publicBaseUrl when spawning the gateway.
-  // This ensures the gateway reconstructs the same canonical URL that the
-  // assistant used to register Twilio webhooks, preventing signature mismatch.
   const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
 
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;
@@ -241,7 +233,7 @@ export function loadConfig(): GatewayConfig {
       runtimeProxyEnabled,
       runtimeProxyRequireAuth,
       hasTwilioAuthToken: !!twilioAuthToken,
-      publicUrl,
+      ingressPublicBaseUrl,
     },
     "Configuration loaded",
   );
@@ -269,7 +261,6 @@ export function loadConfig(): GatewayConfig {
     telegramMaxRetries,
     telegramTimeoutMs,
     telegramWebhookSecret,
-    publicUrl,
     twilioAuthToken,
     ingressPublicBaseUrl,
     unmappedPolicy,


### PR DESCRIPTION
## Summary
- Removed the unused `GATEWAY_PUBLIC_URL` env var and `publicUrl` config field from the gateway
- Made the cloud-discovered public URL (from GCP/AWS metadata API) fall through as a fallback for `INGRESS_PUBLIC_BASE_URL` in `startGateway()`
- Fixes GCP/AWS-hatched assistants not knowing their public ingress URL, which broke Twilio webhook signature validation, OAuth callbacks, and Telegram webhooks

## Context
`GATEWAY_PUBLIC_URL` (#5880) and `INGRESS_PUBLIC_BASE_URL` (#5891) were introduced on the same day by different authors serving the same purpose. `GATEWAY_PUBLIC_URL` was only ever logged — never functionally used. Meanwhile `INGRESS_PUBLIC_BASE_URL` drives webhook signature validation. The discovered external IP was being set as `GATEWAY_PUBLIC_URL` but never bridged to `INGRESS_PUBLIC_BASE_URL`, leaving remote-hatched assistants with no configured public URL.

## Files changed
- `cli/src/lib/local.ts` — discovered URL now falls through to `INGRESS_PUBLIC_BASE_URL`; removed `GATEWAY_PUBLIC_URL` injection
- `gateway/src/config.ts` — removed `GATEWAY_PUBLIC_URL` reading, `publicUrl` from type and config object
- 9 gateway test files — removed `publicUrl: undefined` from `makeConfig()` helpers

## Test plan
- [ ] `cd gateway && bun test` — all tests pass (pre-existing failures unchanged)
- [ ] `cd assistant && bun test src/__tests__/ingress-url-consistency.test.ts` — 5/5 pass
- [ ] `cd cli && npx tsc --noEmit` — clean
- [ ] Hatch locally — ingress URL logged correctly from workspace config or env fallback
- [ ] Hatch on GCP — discovered external IP now appears as ingress URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
