### PR TITLE
Fix remote thread history not loading in desktop app

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -46,19 +46,26 @@ export function handleListMessages(
   url: URL,
   interfacesDir: string | null,
 ): Response {
+  const conversationId = url.searchParams.get('conversationId');
   const conversationKey = url.searchParams.get('conversationKey');
-  if (!conversationKey) {
+
+  let resolvedConversationId: string | undefined;
+  if (conversationId) {
+    resolvedConversationId = conversationId;
+  } else if (conversationKey) {
+    const mapping = getConversationByKey(conversationKey);
+    resolvedConversationId = mapping?.conversationId;
+  } else {
     return Response.json(
-      { error: 'conversationKey query parameter is required' },
+      { error: 'conversationKey or conversationId query parameter is required' },
       { status: 400 },
     );
   }
 
-  const mapping = getConversationByKey(conversationKey);
-  if (!mapping) {
+  if (!resolvedConversationId) {
     return Response.json({ messages: [] });
   }
-  const rawMessages = conversationStore.getMessages(mapping.conversationId);
+  const rawMessages = conversationStore.getMessages(resolvedConversationId);
 
   // Parse content blocks and extract text + tool calls
   const parsed = rawMessages.map((msg) => {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "exports": {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -213,8 +213,8 @@ final class HTTPTransport {
             onMessage?(info)
         } else if message is SessionListRequestMessage {
             Task { await self.fetchSessionList() }
-        } else if message is HistoryRequestMessage {
-            Task { await self.fetchHistory() }
+        } else if let msg = message as? HistoryRequestMessage {
+            Task { await self.fetchHistory(sessionId: msg.sessionId) }
         } else if message is PingMessage {
             // No-op for HTTP transport — SSE keepalive is handled by the connection
         } else {
@@ -364,8 +364,9 @@ final class HTTPTransport {
         }
     }
 
-    private func fetchHistory() async {
-        let urlString = "\(baseURL)/v1/messages?conversationKey=\(conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey)"
+    private func fetchHistory(sessionId: String) async {
+        let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
+        let urlString = "\(baseURL)/v1/messages?conversationId=\(encoded)"
         guard let url = URL(string: urlString) else { return }
 
         var request = URLRequest(url: url)
@@ -384,19 +385,11 @@ final class HTTPTransport {
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let messages = json["messages"] as? [[String: Any]] {
-                    // Convert REST messages to IPC history format
-                    var historyMessages: [[String: Any]] = []
-                    for msg in messages {
-                        historyMessages.append(msg)
-                    }
-
-                    // Emit as raw JSON that the history response decoder can handle
-                    var historyPayload: [String: Any] = [
+                    let historyPayload: [String: Any] = [
                         "type": "history_response",
-                        "sessionId": conversationKey,
-                        "messages": historyMessages
+                        "sessionId": sessionId,
+                        "messages": messages
                     ]
-                    _ = historyPayload.removeValue(forKey: "")
 
                     let historyData = try JSONSerialization.data(withJSONObject: historyPayload)
                     let historyResponse = try decoder.decode(ServerMessage.self, from: historyData)


### PR DESCRIPTION
## Summary
- Fixed message history never loading when clicking threads while connected to a remote (GCP/AWS) assistant
- Root cause: two identifier mismatches in `HTTPDaemonClient.fetchHistory()` — the conversation UUID from the session list was discarded and replaced with the transport-level `conversationKey`, causing the response to be silently dropped by `ThreadSessionRestorer`

## Changes
- **`clients/shared/IPC/HTTPDaemonClient.swift`**: Cast `HistoryRequestMessage` to extract `sessionId`; query by `conversationId` instead of `conversationKey`; pass correct UUID in synthetic response
- **`assistant/src/runtime/routes/conversation-routes.ts`**: Support `conversationId` query param on `GET /v1/messages` as an alternative to `conversationKey`, allowing direct lookup by conversation UUID

## Test plan
- [ ] Connect desktop app to a remote GCP assistant
- [ ] Click on a thread in the sidebar — message history should load
- [ ] Click on different threads — each should show its own history
- [ ] Local (socket) transport still works as before (unaffected code path)
- [ ] CLI `pollMessages` still works via `conversationKey` param (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
