### PR TITLE
fix: show loading spinner instead of empty state when switching threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -50,6 +50,7 @@ struct ChatView: View {
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
     var daemonHttpPort: Int?
+    var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
 
@@ -75,7 +76,7 @@ struct ChatView: View {
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private var isEmptyState: Bool {
-        messages.isEmpty
+        messages.isEmpty && isHistoryLoaded
     }
 
     private let composerMinHeight: CGFloat = 34
@@ -84,7 +85,16 @@ struct ChatView: View {
         ZStack {
             VStack(spacing: 0) {
                 apiKeyBanner
-                if isEmptyState {
+                if messages.isEmpty && !isHistoryLoaded {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                            .controlSize(.small)
+                        Spacer()
+                    }
+                    Spacer()
+                } else if isEmptyState {
                     if isTemporaryChat {
                         ChatTemporaryChatEmptyStateView(
                             inputText: $inputText,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -572,6 +572,7 @@ struct ActiveChatViewWrapper: View {
                 windowState.selectedSubagentId = subagentId
             },
             daemonHttpPort: daemonClient.httpPort,
+            isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) }
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -113,6 +113,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         let thread = ThreadModel()
         let viewModel = makeViewModel()
+        viewModel.isHistoryLoaded = true  // No session yet — nothing to load
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] text in
             self?.updateThreadTitle(id: threadId, title: "Untitled")
@@ -130,6 +131,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func createPrivateThread() {
         let thread = ThreadModel(kind: .private)
         let viewModel = makeViewModel()
+        viewModel.isHistoryLoaded = true  // No session yet — nothing to load
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] text in
             self?.updateThreadTitle(id: threadId, title: "Untitled")


### PR DESCRIPTION
## Summary
- When switching between chat threads, the user briefly saw the "new chat" greeting UI before messages loaded in
- Root cause: `ChatView.isEmptyState` only checked `messages.isEmpty` without considering whether history had been loaded from the daemon
- Now `ChatView` receives `isHistoryLoaded` from the view model and shows a centered spinner while history is pending
- New threads (no session to load) set `isHistoryLoaded = true` immediately so they still show the empty state greeting

## Test plan
- [ ] Build: `cd clients/macos && ./build.sh`
- [ ] Switch between threads with message history — should see a brief spinner (or nothing) instead of the "new chat" greeting flash
- [ ] Create a new thread — should still show the empty state greeting as before
- [ ] Temporary/private threads should also work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
