### PR TITLE
Fix chat message scrolling when sidebar is open

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -435,21 +435,24 @@ struct MainWindowView: View {
                         let sidebarInset = sidebarVisible && sidebarPushesContent
                             ? threadDrawerWidth + VSpacing.xs : 0
 
-                        chatContentView(geometry: geometry)
-                            .padding(.leading, sidebarInset)
-
-                        // Sidebar drawer
-                        if sidebarVisible {
-                            // Click-outside-to-dismiss scrim (overlay mode only)
-                            if !sidebarPushesContent {
-                                Color.clear
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
+                        if sidebarVisible && !sidebarPushesContent {
+                            chatContentView(geometry: geometry)
+                                .padding(.leading, sidebarInset)
+                                .contentShape(Rectangle())
+                                .highPriorityGesture(
+                                    TapGesture().onEnded {
                                         withAnimation(.easeInOut(duration: 0.35)) {
                                             sidebarOpen = false
                                         }
                                     }
-                            }
+                                )
+                        } else {
+                            chatContentView(geometry: geometry)
+                                .padding(.leading, sidebarInset)
+                        }
+
+                        // Sidebar drawer
+                        if sidebarVisible {
                             HStack(spacing: 0) {
                                 sidebarView
                                 drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)


### PR DESCRIPTION
This updates the main window sidebar overlay behavior so chat content remains scrollable while the left sidebar is open.
It removes the full-screen transparent scrim in overlay mode and adds a high-priority tap gesture on chat content to preserve outside-click dismissal of the sidebar.
The workspace diff is limited to clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift.
Validation: cd clients && swift test --filter MainWindowAvatarRoutingTests passed.
