### PR TITLE
M5: Persistence, observability, docs, and architecture alignment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3679,6 +3679,19 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
 | `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
 
+### Caller Identity Resolution
+
+When a call is initiated, the system resolves the caller identity (which phone number to show as the caller ID). By default, the assistant's Twilio number is used (`assistant_number` mode). Users can opt into `user_number` mode, which uses their own verified phone number. The identity mode is validated against Twilio's eligible caller IDs before the call is placed. The resolved identity mode and source are persisted in the `call_sessions` table for auditability.
+
+The resolution is performed by `resolveCallerIdentity()` in `call-domain.ts`:
+
+1. **Per-call override** — If `callerIdentityMode` is provided in the call input and `calls.callerIdentity.allowPerCallOverride` is enabled, the requested mode is used (source: `per_call_override`).
+2. **Config default** — Otherwise, the configured `calls.callerIdentity.defaultMode` is used (source: `config_default`).
+3. **User number lookup** — For `user_number` mode, the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`), `TWILIO_USER_PHONE_NUMBER` environment variable (source: `env_var`), or the `credential:twilio:user_phone_number` secure key (source: `secure_key`).
+4. **Eligibility check** — User numbers are verified against the Twilio API to confirm they can be used as an outbound caller ID.
+
+Both the resolved mode and source are logged at info level on success, and rejections are logged at warn level.
+
 ### Voice Quality Profile Resolution
 
 Voice and TTS settings are configurable via the `calls.voice` config block — they are not hardcoded. The function `resolveVoiceQualityProfile()` in `voice-quality.ts` reads the current config and resolves it into an effective `VoiceQualityProfile` containing the TTS provider, voice spec string, language, transcription provider, and fallback policy.

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -65,8 +65,10 @@ export type AnswerCallInput = {
 
 // ── Caller identity resolution ───────────────────────────────────────
 
+export type CallerIdentitySource = 'per_call_override' | 'config_default' | 'twilio_config' | 'user_config' | 'secure_key' | 'env_var';
+
 export type CallerIdentityResult =
-  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string }
+  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string; source: CallerIdentitySource }
   | { ok: false; error: string };
 
 /**
@@ -88,29 +90,46 @@ export async function resolveCallerIdentity(
 ): Promise<CallerIdentityResult> {
   const identityConfig = config.calls.callerIdentity;
   let mode: 'assistant_number' | 'user_number';
+  let source: CallerIdentitySource;
 
   if (requestedMode != null) {
     if (!identityConfig.allowPerCallOverride) {
+      log.warn({ requestedMode }, 'Caller identity override rejected — per-call override is disabled in configuration');
       return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };
     }
     mode = requestedMode;
+    source = 'per_call_override';
   } else {
     mode = identityConfig.defaultMode;
+    source = 'config_default';
   }
 
   if (mode === 'assistant_number') {
     const twilioConfig = getTwilioConfig();
-    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber };
+    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
   }
 
-  // user_number mode: resolve from config or secure key
-  const userNumber =
-    identityConfig.userNumber ||
-    process.env.TWILIO_USER_PHONE_NUMBER ||
-    getSecureKey('credential:twilio:user_phone_number') ||
-    '';
+  // user_number mode: resolve from config or secure key, tracking where the number came from
+  let userNumber = '';
+  let numberSource: CallerIdentitySource = source;
+
+  if (identityConfig.userNumber) {
+    userNumber = identityConfig.userNumber;
+    numberSource = source === 'per_call_override' ? source : 'user_config';
+  } else if (process.env.TWILIO_USER_PHONE_NUMBER) {
+    userNumber = process.env.TWILIO_USER_PHONE_NUMBER;
+    numberSource = source === 'per_call_override' ? source : 'env_var';
+  } else {
+    const secureKeyValue = getSecureKey('credential:twilio:user_phone_number');
+    if (secureKeyValue) {
+      userNumber = secureKeyValue;
+      numberSource = source === 'per_call_override' ? source : 'secure_key';
+    }
+  }
 
   if (!userNumber) {
+    log.warn({ mode, source }, 'Caller identity resolution failed — no user phone number configured');
     return {
       ok: false,
       error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
@@ -121,10 +140,12 @@ export async function resolveCallerIdentity(
   const provider = new TwilioConversationRelayProvider();
   const eligibility = await provider.checkCallerIdEligibility(userNumber);
   if (!eligibility.eligible) {
+    log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };
   }
 
-  return { ok: true, mode, fromNumber: userNumber };
+  log.info({ mode, source: numberSource, fromNumber: userNumber }, 'Resolved caller identity');
+  return { ok: true, mode, fromNumber: userNumber, source: numberSource };
 }
 
 // ── Domain operations ────────────────────────────────────────────────
@@ -174,6 +195,8 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       fromNumber,
       toNumber: phoneNumber,
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
+      callerIdentityMode: identityResult.mode,
+      callerIdentitySource: identityResult.source,
     });
     sessionId = session.id;
 

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -20,6 +20,8 @@ function parseCallSession(row: typeof callSessions.$inferSelect): CallSession {
     toNumber: row.toNumber,
     task: row.task,
     status: row.status as CallSession['status'],
+    callerIdentityMode: row.callerIdentityMode,
+    callerIdentitySource: row.callerIdentitySource,
     startedAt: row.startedAt,
     endedAt: row.endedAt,
     lastError: row.lastError,
@@ -58,6 +60,8 @@ export function createCallSession(opts: {
   fromNumber: string;
   toNumber: string;
   task?: string;
+  callerIdentityMode?: string;
+  callerIdentitySource?: string;
 }): CallSession {
   const db = getDb();
   const now = Date.now();
@@ -70,6 +74,8 @@ export function createCallSession(opts: {
     toNumber: opts.toNumber,
     task: opts.task ?? null,
     status: 'initiated' as const,
+    callerIdentityMode: opts.callerIdentityMode ?? null,
+    callerIdentitySource: opts.callerIdentitySource ?? null,
     startedAt: null,
     endedAt: null,
     lastError: null,

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -11,6 +11,8 @@ export interface CallSession {
   toNumber: string;
   task: string | null;
   status: CallStatus;
+  callerIdentityMode: string | null;
+  callerIdentitySource: string | null;
   startedAt: number | null;
   endedAt: number | null;
   lastError: string | null;

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -790,6 +790,10 @@ export function initializeDb(): void {
   // Add claim ownership token to prevent cross-handler claim interference
   try { database.run(/*sql*/ `ALTER TABLE processed_callbacks ADD COLUMN claim_id TEXT`); } catch { /* already exists */ }
 
+  // Caller identity persistence for auditability
+  try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_mode TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_source TEXT`); } catch { /* already exists */ }
+
   // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid).
   // On upgraded databases that pre-date this constraint, duplicate rows may exist; deduplicate
   // them first to avoid a UNIQUE constraint failure that would prevent startup.

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -548,6 +548,8 @@ export const callSessions = sqliteTable('call_sessions', {
   toNumber: text('to_number').notNull(),
   task: text('task'),
   status: text('status').notNull().default('initiated'),
+  callerIdentityMode: text('caller_identity_mode'),
+  callerIdentitySource: text('caller_identity_source'),
   startedAt: integer('started_at'),
   endedAt: integer('ended_at'),
   lastError: text('last_error'),


### PR DESCRIPTION
Part of #6189: Calls Caller Identity

- Add caller_identity_mode and caller_identity_source columns to call_sessions table
- Update Drizzle schema, call-store, and call-domain to persist identity metadata
- Add source tracking to resolveCallerIdentity for auditability
- Update ARCHITECTURE.md with caller identity resolution documentation
- Add info/warn logging for identity resolution outcomes

Closes #6194
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
