### PR TITLE
fix: load iOS tab data on connection instead of requiring a message

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import Combine
 import UIKit
 import UserNotifications
 import VellumAssistantShared
@@ -9,12 +10,22 @@ import VellumAssistantShared
 @MainActor
 final class ClientProvider: ObservableObject {
     @Published var client: any DaemonClientProtocol
-    /// Flipped to `true` after a successful `connect()` call; sections observe
-    /// this to trigger data reloads once the daemon is reachable.
+    /// Mirrors the daemon client's `isConnected` state so views can observe a
+    /// single source of truth. Automatically synced via Combine when the
+    /// underlying client is a `DaemonClient`.
     @Published var isConnected: Bool = false
 
     init(client: any DaemonClientProtocol) {
         self.client = client
+        if let daemon = client as? DaemonClient {
+            // Bridge DaemonClient's @Published isConnected to our own.
+            // Both types are @MainActor so the publisher already emits on the
+            // main actor — no receive(on:) needed. assign(to:) writes directly
+            // through the @Published property wrapper, firing objectWillChange
+            // synchronously so SwiftUI picks up the change immediately.
+            daemon.$isConnected
+                .assign(to: &$isConnected)
+        }
     }
 }
 

--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -94,13 +94,15 @@ class IOSThreadStore: ObservableObject {
             self?.handleSubagentDetailResponse(response)
         }
 
-        // Fetch session list once connected
-        daemon.$isConnected
-            .removeDuplicates()
-            .filter { $0 }
-            .first()
-            .sink { [weak self] _ in
-                guard self != nil else { return }
+        // Fetch session list once connected. Try immediately if already connected,
+        // otherwise wait for the daemonDidReconnect notification.
+        if daemon.isConnected {
+            try? daemon.sendSessionList()
+        }
+
+        NotificationCenter.default.publisher(for: .daemonDidReconnect)
+            .sink { [weak self, weak daemon] _ in
+                guard let daemon, self != nil else { return }
                 try? daemon.sendSessionList()
             }
             .store(in: &cancellables)

--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -7,18 +7,11 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         let provider = appDelegate.clientProvider
-        if provider.client.isConnected {
-            provider.isConnected = true
-            return
-        }
-        Task {
-            do {
-                await MainActor.run { provider.isConnected = false }
-                try await provider.client.connect()
-                await MainActor.run { provider.isConnected = true }
-            } catch {
-                // Connection failed — will retry on next foreground transition
-            }
+        guard !provider.client.isConnected else { return }
+        // @MainActor ensures isConnected assignment runs on the main actor,
+        // which is required for @Published properties on @MainActor types.
+        Task { @MainActor in
+            try? await provider.client.connect()
         }
     }
 }

--- a/clients/ios/Views/HomeBaseView.swift
+++ b/clients/ios/Views/HomeBaseView.swift
@@ -75,9 +75,7 @@ struct HomeBaseView: View {
         }
         .task(id: clientProvider.isConnected) {
             guard clientProvider.isConnected else { return }
-            if viewModel.response == nil {
-                await viewModel.fetch(client: clientProvider.client)
-            }
+            await viewModel.fetch(client: clientProvider.client)
         }
     }
 

--- a/clients/ios/Views/HomeBaseView.swift
+++ b/clients/ios/Views/HomeBaseView.swift
@@ -73,16 +73,10 @@ struct HomeBaseView: View {
             }
             .navigationTitle("Home")
         }
-        .task {
-            if clientProvider.isConnected {
+        .task(id: clientProvider.isConnected) {
+            guard clientProvider.isConnected else { return }
+            if viewModel.response == nil {
                 await viewModel.fetch(client: clientProvider.client)
-            }
-        }
-        .onChange(of: clientProvider.isConnected) { _, connected in
-            if connected {
-                Task {
-                    await viewModel.fetch(client: clientProvider.client)
-                }
             }
         }
     }

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -108,16 +108,10 @@ struct IdentityView: View {
             }
             .navigationTitle("Identity")
         }
-        .task {
-            if clientProvider.isConnected {
+        .task(id: clientProvider.isConnected) {
+            guard clientProvider.isConnected else { return }
+            if viewModel.identity == nil {
                 await viewModel.fetchAll(client: clientProvider.client)
-            }
-        }
-        .onChange(of: clientProvider.isConnected) { _, connected in
-            if connected {
-                Task {
-                    await viewModel.fetchAll(client: clientProvider.client)
-                }
             }
         }
         .sheet(item: $viewingFile) { file in

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -110,9 +110,7 @@ struct IdentityView: View {
         }
         .task(id: clientProvider.isConnected) {
             guard clientProvider.isConnected else { return }
-            if viewModel.identity == nil {
-                await viewModel.fetchAll(client: clientProvider.client)
-            }
+            await viewModel.fetchAll(client: clientProvider.client)
         }
         .sheet(item: $viewingFile) { file in
             WorkspaceFileSheet(

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -99,6 +99,12 @@ struct DaemonConnectionSection: View {
                 } else {
                     _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
                 }
+                // Reconnect with the new settings. DaemonClient.connect() re-reads
+                // hostname/port/token from UserDefaults on iOS, so the saved values
+                // above are picked up automatically.
+                Task {
+                    try? await clientProvider.client.connect()
+                }
                 alertMessage = "Daemon connection settings updated"
                 showingAlert = true
             }


### PR DESCRIPTION
## Summary

iOS Home, Identity, and Chats tabs were not populating data until the user sent a chat message. This fixes the root cause and ensures all tabs load data as soon as the daemon connection is established.

## Implementation

**Root cause:** The initial `connect()` in SceneDelegate could fail silently (`try?` swallows errors), and changing connection settings in Settings only saved to UserDefaults without triggering a reconnect. Views used `.task` (no id) which fires once on appearance and never re-fires when connection state changes — so if `isConnected` was `false` when the view appeared, data loading never happened.

**Key changes:**

- **`.task(id: clientProvider.isConnected)`** in HomeBaseView and IdentityView — the Apple-recommended pattern for reacting to async state changes. The task re-fires whenever `isConnected` changes, triggering data loading when the connection succeeds.
- **Trigger `connect()` after saving settings** — ConnectionSettingsSection now calls `clientProvider.client.connect()` after writing hostname/port/token to UserDefaults. Since `DaemonClient.connect()` re-reads these values from UserDefaults on iOS, the new settings are picked up automatically.
- **Remove `.first()` from IOSThreadStore** — the notification subscription for `.daemonDidReconnect` was limited to firing once. Now every reconnection refreshes the session list.
- **Combine bridge for `isConnected`** — `ClientProvider` uses `daemon.$isConnected.assign(to: &$isConnected)` to mirror the daemon's connection state, providing a single source of truth for SwiftUI views.
- **Simplify SceneDelegate** — use `Task { @MainActor in }` for the connect call.

## Files Changed

| File | Change |
|------|--------|
| `clients/ios/Views/HomeBaseView.swift` | `.task` + `.onChange` → `.task(id: clientProvider.isConnected)` |
| `clients/ios/Views/IdentityView.swift` | Same pattern |
| `clients/ios/Views/Settings/ConnectionSettingsSection.swift` | Add `connect()` call after saving settings |
| `clients/ios/App/IOSThreadStore.swift` | Remove `.first()`, add immediate check + reconnect handling |
| `clients/ios/App/AppDelegate.swift` | Add Combine bridge for `isConnected` in ClientProvider |
| `clients/ios/App/SceneDelegate.swift` | Simplify to `@MainActor` Task |

## Testing

1. Open iOS app → go to Settings → enter daemon connection info → tap Update
2. Switch to Home tab → should show Home Base data immediately
3. Switch to Identity tab → should show identity card immediately
4. Switch to Chats tab → should show session list immediately
5. No need to send a message first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
