### PR TITLE
fix: clear focus ring on attachment button after click

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -284,7 +284,7 @@ struct ComposerView: View {
                 }
                 .accessibilityLabel("Stop generation")
             } else {
-                Button(action: onAttach) {
+                Button(action: { onAttach(); focusedComposerAction = nil }) {
                     Image(systemName: "paperclip")
                         .font(.system(size: composerActionIconSize, weight: .regular))
                         .foregroundColor(VColor.textSecondary.opacity(0.82))


### PR DESCRIPTION
## Summary
- Clear `focusedComposerAction` after `onAttach()` so the blue focus ring doesn't persist on the paperclip button after selecting an attachment

## Original prompt
please remove this blue circle after we select an attachment, not sure if this is focus or what

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
