### PR TITLE
Treat Twilio eligibility API failures as hard errors

### DIFF
--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -263,6 +263,47 @@ describe('TwilioConversationRelayProvider', () => {
       expect(result.reason).toContain('Twilio Console');
     });
 
+    test('throws when both API calls return non-ok responses', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      await expect(provider.checkCallerIdEligibility('+15550001111')).rejects.toThrow(
+        'Unable to verify caller ID eligibility',
+      );
+    });
+
+    test('returns ineligible (not throws) when only one API call fails but the other succeeds with no match', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({ outgoing_caller_ids: [] }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('not owned by or verified');
+    });
+
     test('passes correct phone number as query parameter', async () => {
       const provider = new TwilioConversationRelayProvider();
       const capturedUrls: string[] = [];

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -138,7 +138,14 @@ export async function resolveCallerIdentity(
 
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
-  const eligibility = await provider.checkCallerIdEligibility(userNumber);
+  let eligibility: { eligible: boolean; reason?: string };
+  try {
+    eligibility = await provider.checkCallerIdEligibility(userNumber);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ mode, source: numberSource, userNumber, err }, 'Caller ID eligibility check encountered an API error');
+    return { ok: false, error: msg };
+  }
   if (!eligibility.eligible) {
     log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -145,6 +145,9 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     const { accountSid, authToken } = this.getCredentials();
     const encodedNumber = encodeURIComponent(phoneNumber);
 
+    let incomingOk = false;
+    let outgoingOk = false;
+
     // Check incoming phone numbers (owned by this account)
     const incomingRes = await fetch(
       `${this.baseUrl(accountSid)}/IncomingPhoneNumbers.json?PhoneNumber=${encodedNumber}`,
@@ -157,6 +160,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     );
 
     if (incomingRes.ok) {
+      incomingOk = true;
       const incomingData = (await incomingRes.json()) as {
         incoming_phone_numbers: unknown[];
       };
@@ -183,6 +187,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     );
 
     if (outgoingRes.ok) {
+      outgoingOk = true;
       const outgoingData = (await outgoingRes.json()) as {
         outgoing_caller_ids: unknown[];
       };
@@ -194,6 +199,14 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       log.warn(
         { status: outgoingRes.status, phoneNumber },
         'Failed to query OutgoingCallerIds',
+      );
+    }
+
+    // If neither API call succeeded, the eligibility check is inconclusive —
+    // propagate as an error rather than returning a false negative.
+    if (!incomingOk && !outgoingOk) {
+      throw new Error(
+        `Unable to verify caller ID eligibility for ${phoneNumber}: both Twilio API calls failed (IncomingPhoneNumbers: ${incomingRes.status}, OutgoingCallerIds: ${outgoingRes.status}). This may indicate a network issue, auth error, or Twilio outage.`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Modified checkCallerIdEligibility to distinguish API failures from confirmed-absent results
- When both IncomingPhoneNumbers and OutgoingCallerIds API calls fail (non-ok responses), now throws an error instead of returning eligible: false
- Added test coverage for the dual API failure scenario

## Original prompt
Address feedback on PR #6207: Twilio API failures should not be silently treated as 'number ineligible'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
