### PR TITLE
Validate callerIdentityMode enum value at HTTP and domain layers

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -317,6 +317,31 @@ describe('runtime call routes — HTTP layer', () => {
     await stopServer();
   });
 
+  test('POST /v1/calls/start returns 400 for invalid callerIdentityMode', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-bogus');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-bogus',
+        callerIdentityMode: 'bogus',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid callerIdentityMode');
+    expect(body.error).toContain('bogus');
+    expect(body.error).toContain('assistant_number');
+    expect(body.error).toContain('user_number');
+
+    await stopServer();
+  });
+
   // ── GET /v1/calls/:id ───────────────────────────────────────────────
 
   test('GET /v1/calls/:id returns call status', async () => {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -24,6 +24,7 @@ import { getTwilioVoiceWebhookUrl, getTwilioStatusCallbackUrl } from '../inbound
 import { loadConfig } from '../config/loader.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import type { CallSession } from './types.js';
+import { VALID_CALLER_IDENTITY_MODES } from '../config/schema.js';
 import type { AssistantConfig } from '../config/types.js';
 
 const log = getLogger('call-domain');
@@ -93,6 +94,9 @@ export async function resolveCallerIdentity(
   let source: CallerIdentitySource;
 
   if (requestedMode != null) {
+    if (!(VALID_CALLER_IDENTITY_MODES as readonly string[]).includes(requestedMode)) {
+      return { ok: false, error: `Invalid callerIdentityMode: "${requestedMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}` };
+    }
     if (!identityConfig.allowPerCallOverride) {
       log.warn({ requestedMode }, 'Caller identity override rejected — per-call override is disabled in configuration');
       return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,7 +10,7 @@ const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
-const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
+export const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
 
 export const TimeoutConfigSchema = z.object({

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -9,6 +9,7 @@
 
 import { startCall, getCallStatus, cancelCall, answerCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
+import { VALID_CALLER_IDENTITY_MODES } from '../../config/schema.js';
 
 /**
  * POST /v1/calls/start
@@ -38,6 +39,14 @@ export async function handleStartCall(req: Request): Promise<Response> {
 
   if (!body.conversationId) {
     return Response.json({ error: 'conversationId is required' }, { status: 400 });
+  }
+
+  if (body.callerIdentityMode != null &&
+      !(VALID_CALLER_IDENTITY_MODES as readonly string[]).includes(body.callerIdentityMode as string)) {
+    return Response.json(
+      { error: `Invalid callerIdentityMode: "${body.callerIdentityMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}` },
+      { status: 400 },
+    );
   }
 
   const result = await startCall({


### PR DESCRIPTION
## Summary
- Added runtime validation of callerIdentityMode in resolveCallerIdentity to reject invalid enum values
- Added early validation in HTTP handler for cleaner 400 errors
- Added test coverage for invalid callerIdentityMode values

## Original prompt
Address feedback on PR #6208: Invalid callerIdentityMode values should not silently fall through to user_number behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
