### PR TITLE
PR8: Document assistant-events SSE endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3776,17 +3776,17 @@ Every event published through the hub is wrapped in an `AssistantEvent` (defined
 ### SSE Frame Format
 
 ```
-event: assistant_event\r\n
-id: <uuid>\r\n
-data: <JSON-serialised AssistantEvent>\r\n
-\r\n
+event: assistant_event\n
+id: <uuid>\n
+data: <JSON-serialised AssistantEvent>\n
+\n
 ```
 
 Keep-alive heartbeats (every 30 s by default):
 
 ```
-: heartbeat\r\n
-\r\n
+: heartbeat\n
+\n
 ```
 
 ### Subscription Lifecycle

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3806,7 +3806,7 @@ Keep-alive heartbeats (every 30 s by default):
 | `assistant/src/runtime/assistant-event.ts` | `AssistantEvent` type, `buildAssistantEvent()` factory, SSE framing helpers |
 | `assistant/src/runtime/assistant-event-hub.ts` | `AssistantEventHub` class and process-level singleton |
 | `assistant/src/runtime/routes/events-routes.ts` | `handleSubscribeAssistantEvents()` — SSE route handler |
-| `assistant/src/daemon/session-notifiers.ts` | IPC send paths that publish to the hub |
+| `assistant/src/daemon/server.ts` | IPC send/broadcast paths that publish to the hub (`send` → `publishAssistantEvent`) |
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3731,7 +3731,7 @@ The assistant-events system provides a single, shared publish path that fans out
 graph TB
     subgraph "Event Sources"
         direction TB
-        IPC_DAEMON["Daemon IPC send paths<br/>(session_notifiers.ts)"]
+        IPC_DAEMON["Daemon IPC send paths<br/>(daemon/server.ts)"]
         HTTP_RUN["HTTP Run path<br/>(run-orchestrator.ts)"]
     end
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3721,6 +3721,95 @@ flowchart TD
 
 ---
 
+## Assistant Events — SSE Transport Layer
+
+The assistant-events system provides a single, shared publish path that fans out to both the Unix socket IPC layer (native clients) and an HTTP SSE endpoint (web/remote clients). There is no separate message schema for SSE — the `ServerMessage` payload is wrapped in an `AssistantEvent` envelope and serialised as JSON.
+
+### Data Flow
+
+```mermaid
+graph TB
+    subgraph "Event Sources"
+        direction TB
+        IPC_DAEMON["Daemon IPC send paths<br/>(session_notifiers.ts)"]
+        HTTP_RUN["HTTP Run path<br/>(run-orchestrator.ts)"]
+    end
+
+    subgraph "Event Bus"
+        HUB["AssistantEventHub<br/>(assistant-event-hub.ts)<br/>──────────────────────<br/>maxSubscribers: 100<br/>FIFO eviction on overflow<br/>Synchronous fan-out"]
+    end
+
+    subgraph "Transports"
+        SSE_ROUTE["SSE Route<br/>GET /v1/events?conversationKey=...<br/>(events-routes.ts)<br/>──────────────────────<br/>ReadableStream + CountQueuingStrategy(16)<br/>Heartbeat every 30 s<br/>Slow-consumer shed"]
+        SOCK["Unix Socket<br/>(daemon/session-surfaces.ts)"]
+    end
+
+    subgraph "Clients"
+        MACOS["macOS App<br/>(DaemonClient / ServerMessage)"]
+        IOS["iOS App<br/>(DaemonClient / ServerMessage)"]
+        WEB["Web / Remote clients<br/>(EventSource / fetch)"]
+    end
+
+    IPC_DAEMON -->|"buildAssistantEvent()"| HUB
+    HTTP_RUN -->|"buildAssistantEvent()"| HUB
+    IPC_DAEMON --> SOCK
+
+    HUB -->|"subscriber callback"| SSE_ROUTE
+
+    SOCK --> MACOS
+    SOCK --> IOS
+    SSE_ROUTE --> WEB
+```
+
+### AssistantEvent Envelope
+
+Every event published through the hub is wrapped in an `AssistantEvent` (defined in `runtime/assistant-event.ts`):
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` (UUID) | Globally unique event identifier |
+| `assistantId` | `string` | Logical assistant identifier (`"self"` for HTTP runs) |
+| `sessionId` | `string?` | Resolved conversation ID when available |
+| `emittedAt` | `string` (ISO-8601) | Server-side timestamp |
+| `message` | `ServerMessage` | Unchanged IPC outbound message — no schema fork |
+
+### SSE Frame Format
+
+```
+event: assistant_event\r\n
+id: <uuid>\r\n
+data: <JSON-serialised AssistantEvent>\r\n
+\r\n
+```
+
+Keep-alive heartbeats (every 30 s by default):
+
+```
+: heartbeat\r\n
+\r\n
+```
+
+### Subscription Lifecycle
+
+| Event | Action |
+|---|---|
+| `GET /v1/events` received | Hub subscribes eagerly before `ReadableStream` is created |
+| Client disconnects / aborts | `req.signal` abort listener disposes subscription and closes stream |
+| Client cancels reader | `ReadableStream.cancel()` disposes subscription and closes stream |
+| New connection pushes over cap (100) | Oldest subscriber evicted (FIFO); its `onEvict` callback closes its stream |
+| Client buffer full (16 queued frames) | `desiredSize <= 0` guard sheds the subscriber immediately |
+
+### Key Source Files
+
+| File | Role |
+|---|---|
+| `assistant/src/runtime/assistant-event.ts` | `AssistantEvent` type, `buildAssistantEvent()` factory, SSE framing helpers |
+| `assistant/src/runtime/assistant-event-hub.ts` | `AssistantEventHub` class and process-level singleton |
+| `assistant/src/runtime/routes/events-routes.ts` | `handleSubscribeAssistantEvents()` — SSE route handler |
+| `assistant/src/daemon/session-notifiers.ts` | IPC send paths that publish to the hub |
+
+---
+
 ## Storage Summary
 
 | What | Where | Format | ORM/Driver | Retention |

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams
 GET /v1/events?conversationKey=<key>
 ```
 
-**Auth**: Bearer token (same rules as other runtime HTTP endpoints). Set via `RUNTIME_HTTP_AUTH_TOKEN` on the server and pass as `Authorization: Bearer <token>` on the client.
+**Auth**: Bearer token (same rules as other runtime HTTP endpoints). The token is read from the `RUNTIME_PROXY_BEARER_TOKEN` environment variable; if unset, the daemon generates a random token and writes it to `~/.vellum/http-token`. Pass it as `Authorization: Bearer <token>` on the client.
 
 **Query params**:
 
@@ -449,16 +449,35 @@ The `message` field is the unchanged IPC `ServerMessage` payload — the same ty
 
 ### Example (JavaScript)
 
+The standard browser `EventSource` API does not support custom request headers, so authenticated connections require `fetch()` with manual SSE stream parsing:
+
 ```js
-const events = new EventSource(
+const TOKEN = '<token>'; // read from ~/.vellum/http-token or RUNTIME_PROXY_BEARER_TOKEN
+const res = await fetch(
   'http://localhost:3001/v1/events?conversationKey=my-conversation',
-  { headers: { Authorization: 'Bearer <token>' } },
+  { headers: { Authorization: `Bearer ${TOKEN}` } },
 );
 
-events.addEventListener('assistant_event', (e) => {
-  const event = JSON.parse(e.data);
-  console.log(event.message.type, event.message);
-});
+const reader = res.body.getReader();
+const decoder = new TextDecoder();
+let buf = '';
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  buf += decoder.decode(value, { stream: true });
+
+  // SSE frames are separated by a blank line (\n\n).
+  const frames = buf.split('\n\n');
+  buf = frames.pop() ?? ''; // keep the incomplete trailing chunk
+
+  for (const frame of frames) {
+    const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
+    if (!dataLine) continue;
+    const event = JSON.parse(dataLine.slice(6));
+    console.log(event.message.type, event.message);
+  }
+}
 ```
 
 ## Inline Media Embeds

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ The `message` field is the unchanged IPC `ServerMessage` payload — the same ty
 |---|---|
 | `assistant_text_delta` | Incremental text token from the model |
 | `assistant_thinking_delta` | Incremental thinking/reasoning token |
-| `tool_use` | Tool invocation starting |
+| `tool_use_start` | Tool invocation starting |
 | `tool_input_delta` | Streaming tool input chunk |
 | `tool_output_chunk` | Streaming tool output chunk |
 | `tool_result` | Tool execution result |

--- a/README.md
+++ b/README.md
@@ -374,6 +374,93 @@ The assistant creates attachments from two sources:
 
 Limits: up to 5 attachments per turn, 20 MB each.
 
+## Assistant Events SSE Stream
+
+The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams real-time assistant events for a specific conversation. This provides a transport-agnostic alternative to the Unix socket IPC for HTTP clients (web apps, remote integrations, etc.).
+
+### Endpoint
+
+```
+GET /v1/events?conversationKey=<key>
+```
+
+**Auth**: Bearer token (same rules as other runtime HTTP endpoints). Set via `RUNTIME_HTTP_AUTH_TOKEN` on the server and pass as `Authorization: Bearer <token>` on the client.
+
+**Query params**:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `conversationKey` | Yes | Stable, client-chosen key that maps to a conversation. Same key used for `POST /v1/assistants/:id/runs`. |
+
+**Response**: `200 OK` with `Content-Type: text/event-stream`. Each frame is a standard SSE event:
+
+```
+event: assistant_event
+id: <uuid>
+data: {"id":"...","assistantId":"self","sessionId":"conv_xxx","emittedAt":"2026-02-21T12:00:00.000Z","message":{...}}
+
+```
+
+Keep-alive heartbeat comments are emitted every 30 seconds to prevent proxy timeouts:
+
+```
+: heartbeat
+
+```
+
+### Event Payload
+
+Each `data` field is a JSON-serialized `AssistantEvent`:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "assistantId": "self",
+  "sessionId": "conv_abc123",
+  "emittedAt": "2026-02-21T12:00:00.000Z",
+  "message": {
+    "type": "assistant_text_delta",
+    "sessionId": "conv_abc123",
+    "text": "Working on it..."
+  }
+}
+```
+
+The `message` field is the unchanged IPC `ServerMessage` payload — the same types sent over the Unix socket to native clients. All delta semantics are preserved:
+
+| Message type | Description |
+|---|---|
+| `assistant_text_delta` | Incremental text token from the model |
+| `assistant_thinking_delta` | Incremental thinking/reasoning token |
+| `tool_use` | Tool invocation starting |
+| `tool_input_delta` | Streaming tool input chunk |
+| `tool_output_chunk` | Streaming tool output chunk |
+| `tool_result` | Tool execution result |
+| `message_complete` | Turn complete; full message + attachments included |
+| `confirmation_request` | User approval needed before an action executes |
+| `generation_handoff` | Model handed off to a sub-agent |
+| `generation_cancelled` | Run was cancelled |
+
+### Connection Management
+
+- **Capacity**: Up to 100 concurrent SSE connections are maintained. When the cap is reached the **oldest** connection is evicted (stream closed) to make room for the new one.
+- **Slow consumers**: If a client's receive buffer fills (16 events queued, unread), the connection is closed.
+- **Disconnect cleanup**: Closing the browser tab, cancelling the reader, or aborting the request all dispose the subscription deterministically.
+
+### Example (JavaScript)
+
+```js
+const events = new EventSource(
+  'http://localhost:3001/v1/events?conversationKey=my-conversation',
+  { headers: { Authorization: 'Bearer <token>' } },
+);
+
+events.addEventListener('assistant_event', (e) => {
+  const event = JSON.parse(e.data);
+  console.log(event.message.type, event.message);
+});
+```
+
 ## Inline Media Embeds
 
 The desktop app automatically renders inline previews for images and video URLs that appear in chat messages. Instead of showing a bare link, recognized URLs are replaced with an embedded preview directly in the conversation.

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams
 GET /v1/events?conversationKey=<key>
 ```
 
-**Auth**: Bearer token (same rules as other runtime HTTP endpoints). The token is read from the `RUNTIME_PROXY_BEARER_TOKEN` environment variable; if unset, the daemon generates a random token and writes it to `~/.vellum/http-token`. Pass it as `Authorization: Bearer <token>` on the client.
+**Auth**: Bearer token (same rules as other runtime HTTP endpoints). The token is read from the `RUNTIME_PROXY_BEARER_TOKEN` environment variable; if unset, the daemon generates a random token and writes it to `~/.vellum/http-token` (or `${BASE_DATA_DIR}/.vellum/http-token` when the `BASE_DATA_DIR` env var is configured). Pass it as `Authorization: Bearer <token>` on the client.
 
 **Query params**:
 


### PR DESCRIPTION
## Summary

- Add **Assistant Events SSE Stream** section to `README.md` covering the `GET /v1/events?conversationKey=` endpoint, event payload format, supported message types, connection management, and a JS usage example.
- Add **Assistant Events — SSE Transport Layer** section to `ARCHITECTURE.md` with a Mermaid data-flow diagram showing the single publish path feeding both IPC (Unix socket) and SSE (HTTP) transports, plus subscription lifecycle and key source files tables.

Part of plan: ASSISTANT-EVENTS-SSE-INCREMENTAL.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
