### PR TITLE
Validate user phone number E.164 format in resolveCallerIdentity

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -140,6 +140,14 @@ export async function resolveCallerIdentity(
     };
   }
 
+  if (!E164_REGEX.test(userNumber)) {
+    log.warn({ mode, source: numberSource, userNumber }, 'User phone number is not in E.164 format');
+    return {
+      ok: false,
+      error: `User phone number "${userNumber}" is not in E.164 format (must start with + followed by digits, e.g. +14155551234). Check calls.callerIdentity.userNumber in config or credential:twilio:user_phone_number.`,
+    };
+  }
+
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
   let eligibility: { eligible: boolean; reason?: string };


### PR DESCRIPTION
## Summary
- Added E.164 format validation for user phone number in resolveCallerIdentity before calling Twilio eligibility API
- Invalid numbers now get a clear error message instead of a generic 500 from Twilio

## Original prompt
Address feedback on PR #6199: Validate user_number caller ID format before initiating call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
