### PR TITLE
Align SKILL.md caller identity decision rule with configurable defaultMode

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -264,7 +264,7 @@ call_start phone_number="+12125551234" task="Confirm the dentist appointment sch
 
 ### Caller identity in calls
 
-By default, calls use the assistant's Twilio number — no extra parameters needed. Only use `caller_identity_mode` when the user explicitly asks to call from their own number.
+By default, calls use the configured default caller identity mode (see `calls.callerIdentity.defaultMode` — defaults to `assistant_number`). Only specify `caller_identity_mode` when you need to override the configured default for a specific call.
 
 **Default call (assistant number):**
 ```
@@ -276,7 +276,7 @@ call_start phone_number="+14155551234" task="Check store hours for today"
 call_start phone_number="+14155551234" task="Check store hours for today" caller_identity_mode="user_number"
 ```
 
-**Decision rule:** Default to the assistant number unless the user explicitly asks to call from their own number.
+**Decision rule:** Use the configured default mode (`calls.callerIdentity.defaultMode`) unless the user explicitly requests a different mode for this call. When the configured default is `assistant_number`, the assistant's Twilio number is used. When configured as `user_number`, the user's verified number is used.
 
 ### Phone number format
 


### PR DESCRIPTION
## Summary
- Updated SKILL.md decision rule to reference configurable defaultMode instead of hard-coding assistant_number behavior
- Ensures assistant behavior matches runtime configuration when defaultMode is set to user_number

## Original prompt
Address feedback on PR #6213: SKILL.md decision rule should respect configured defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
