### PR TITLE
Fix caller_identity_source to reflect actual number provenance

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -120,15 +120,15 @@ export async function resolveCallerIdentity(
 
   if (identityConfig.userNumber) {
     userNumber = identityConfig.userNumber;
-    numberSource = source === 'per_call_override' ? source : 'user_config';
+    numberSource = 'user_config';
   } else if (process.env.TWILIO_USER_PHONE_NUMBER) {
     userNumber = process.env.TWILIO_USER_PHONE_NUMBER;
-    numberSource = source === 'per_call_override' ? source : 'env_var';
+    numberSource = 'env_var';
   } else {
     const secureKeyValue = getSecureKey('credential:twilio:user_phone_number');
     if (secureKeyValue) {
       userNumber = secureKeyValue;
-      numberSource = source === 'per_call_override' ? source : 'secure_key';
+      numberSource = 'secure_key';
     }
   }
 


### PR DESCRIPTION
## Summary
- Changed user_number resolution in resolveCallerIdentity to always track where the phone number was actually resolved from (user_config, env_var, secure_key)
- Previously, per-call overrides would mask the actual number source as per_call_override, making audit data misleading
- The mode vs source distinction is now clean: mode tracks how the identity was selected, source tracks where the number came from

## Original prompt
Address feedback on PR #6220: Preserve actual number source when override selects user_number

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
