### PR TITLE
fix: iOS chat navigation and auto-connect on launch

### DIFF
--- a/clients/ios/App/SceneDelegate.swift
+++ b/clients/ios/App/SceneDelegate.swift
@@ -3,13 +3,27 @@ import UIKit
 
 /// Handles iOS scene lifecycle events, reconnecting the daemon client
 /// whenever the app returns to the foreground from a backgrounded state.
+///
+/// The initial connection attempt on launch is handled by ContentView
+/// (which shows a "Connecting..." screen). SceneDelegate only handles
+/// subsequent background→foreground reconnections.
 class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    private var hasLaunched = false
+
     func sceneWillEnterForeground(_ scene: UIScene) {
+        // ContentView owns the initial connection attempt so it can
+        // show a connecting screen instead of flashing disconnected tabs.
+        guard hasLaunched else {
+            hasLaunched = true
+            return
+        }
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         let provider = appDelegate.clientProvider
         guard !provider.client.isConnected else { return }
         // @MainActor ensures isConnected assignment runs on the main actor,
         // which is required for @Published properties on @MainActor types.
+        // The Combine bridge in ClientProvider auto-syncs isConnected from
+        // DaemonClient, so no manual state management is needed here.
         Task { @MainActor in
             try? await provider.client.connect()
         }

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -5,21 +5,131 @@ import VellumAssistantShared
 struct ContentView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @Bindable var authManager: AuthManager
+    @State private var connectPhase: ConnectPhase = .initial
+    @State private var selectedTab: Tab = .home
+
+    private enum Tab { case home, chats, identity, settings }
+
+    private enum ConnectPhase {
+        case initial    // Haven't attempted connection yet
+        case connecting // Connection in progress
+        case failed     // Connection attempt failed
+        case ready      // Connected, or no saved settings (show tabs)
+    }
+
+    /// Whether the user has previously saved daemon connection settings.
+    private var hasSavedSettings: Bool {
+        if let url = UserDefaults.standard.string(forKey: "runtime_url"), !url.isEmpty {
+            return true
+        }
+        return UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname) != nil
+    }
 
     var body: some View {
-        TabView {
+        Group {
+            if clientProvider.isConnected || connectPhase == .ready {
+                tabContent
+            } else if connectPhase == .failed {
+                connectionFailedView
+            } else {
+                connectingView
+            }
+        }
+        .task {
+            await authManager.checkSession()
+            await attemptInitialConnection()
+        }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { connectPhase = .ready }
+        }
+    }
+
+    // MARK: - Initial Connection
+
+    private func attemptInitialConnection() async {
+        guard hasSavedSettings, !clientProvider.isConnected else {
+            connectPhase = .ready
+            return
+        }
+        connectPhase = .connecting
+        do {
+            try await clientProvider.client.connect()
+            clientProvider.isConnected = true
+            connectPhase = .ready
+        } catch {
+            connectPhase = .failed
+        }
+    }
+
+    // MARK: - Connecting Screen
+
+    private var connectingView: some View {
+        VStack(spacing: VSpacing.lg) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Connecting to your assistant...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Connection Failed Screen
+
+    private var connectionFailedView: some View {
+        VStack(spacing: VSpacing.lg) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.system(size: 48))
+                .foregroundColor(VColor.textMuted)
+
+            Text("Unable to Connect")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Could not reach your assistant. Check that your Mac is running and try again.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+
+            VStack(spacing: VSpacing.md) {
+                Button {
+                    Task { await attemptInitialConnection() }
+                } label: {
+                    Text("Retry")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(VColor.accent)
+
+                Button {
+                    selectedTab = .settings
+                    connectPhase = .ready
+                } label: {
+                    Text("Go to Settings")
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Tab Content
+
+    private var tabContent: some View {
+        TabView(selection: $selectedTab) {
             HomeBaseView()
                 .environmentObject(clientProvider)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tag(Tab.home)
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
 
             ThreadListView(daemonClient: clientProvider.client)
-                // Force @StateObject teardown + recreation when the client changes.
-                // Without this, IOSThreadStore keeps its original (now-disconnected)
-                // client reference after a mode switch in Settings.
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tag(Tab.chats)
                 .tabItem {
                     Label("Chats", systemImage: "message")
                 }
@@ -27,18 +137,17 @@ struct ContentView: View {
             IdentityView()
                 .environmentObject(clientProvider)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tag(Tab.identity)
                 .tabItem {
                     Label("Identity", systemImage: "person.text.rectangle")
                 }
 
             SettingsView(authManager: authManager)
                 .environmentObject(clientProvider)
+                .tag(Tab.settings)
                 .tabItem {
                     Label("Settings", systemImage: "gear")
                 }
-        }
-        .task {
-            await authManager.checkSession()
         }
     }
 }

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -22,7 +22,10 @@ struct ContentView: View {
         if let url = UserDefaults.standard.string(forKey: "runtime_url"), !url.isEmpty {
             return true
         }
-        return UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname) != nil
+        if let hostname = UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname), !hostname.isEmpty {
+            return true
+        }
+        return false
     }
 
     var body: some View {
@@ -31,8 +34,12 @@ struct ContentView: View {
                 tabContent
             } else if connectPhase == .failed {
                 connectionFailedView
-            } else {
+            } else if hasSavedSettings {
                 connectingView
+            } else {
+                // No saved settings — show tabs immediately so the user
+                // can navigate to Settings and configure their connection.
+                tabContent
             }
         }
         .task {

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -6,8 +6,10 @@ import VellumAssistantShared
 // MARK: - ThreadListView
 
 struct ThreadListView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @StateObject private var store: IOSThreadStore
     @State private var navigationPath: [UUID] = []
+    @State private var selectedThreadId: UUID?
     @State private var searchText: String = ""
     @State private var renamingThreadId: UUID?
     @State private var renameText: String = ""
@@ -36,32 +38,60 @@ struct ThreadListView: View {
     }
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            threadList
-                .navigationDestination(for: UUID.self) { threadId in
-                    if let thread = store.threads.first(where: { $0.id == threadId }) {
-                        ThreadChatView(
-                            viewModel: store.viewModel(for: threadId),
-                            threadTitle: thread.title
-                        )
-                        .onAppear {
-                            store.loadHistoryIfNeeded(for: threadId)
-                            store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
-                        }
-                        .onOpenURL { _ in
-                            DispatchQueue.main.async {
-                                store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
-                            }
-                        }
+        if horizontalSizeClass == .regular {
+            NavigationSplitView {
+                threadList
+            } detail: {
+                detailView
+            }
+        } else {
+            NavigationStack(path: $navigationPath) {
+                threadList
+                    .navigationDestination(for: UUID.self) { threadId in
+                        threadDetailContent(for: threadId)
                     }
+            }
+        }
+    }
+
+    // MARK: - Detail Views
+
+    @ViewBuilder
+    private func threadDetailContent(for threadId: UUID) -> some View {
+        if let thread = store.threads.first(where: { $0.id == threadId }) {
+            ThreadChatView(
+                viewModel: store.viewModel(for: threadId),
+                threadTitle: thread.title
+            )
+            .onAppear {
+                store.loadHistoryIfNeeded(for: threadId)
+                store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
+            }
+            .onOpenURL { _ in
+                DispatchQueue.main.async {
+                    store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
                 }
+            }
+        } else {
+            Text("Select a chat")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        if let selectedId = selectedThreadId {
+            threadDetailContent(for: selectedId)
+        } else {
+            Text("Select a chat")
+                .foregroundStyle(.secondary)
         }
     }
 
     // MARK: - Thread List
 
     private var threadList: some View {
-        List {
+        List(selection: horizontalSizeClass == .regular ? $selectedThreadId : nil) {
             ForEach(filteredActiveThreads) { thread in
                 NavigationLink(value: thread.id) {
                     threadRow(thread)
@@ -121,7 +151,11 @@ struct ThreadListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     let thread = store.newThread()
-                    navigationPath = [thread.id]
+                    if horizontalSizeClass == .regular {
+                        selectedThreadId = thread.id
+                    } else {
+                        navigationPath = [thread.id]
+                    }
                 } label: {
                     Image(systemName: "square.and.pencil")
                 }

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -99,11 +99,17 @@ struct ThreadListView: View {
                 .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
                         store.deleteThread(thread)
+                        if horizontalSizeClass == .regular && selectedThreadId == thread.id {
+                            selectedThreadId = activeThreads.first?.id
+                        }
                     } label: {
                         Label("Delete", systemImage: "trash")
                     }
                     Button {
                         store.archiveThread(thread)
+                        if horizontalSizeClass == .regular && selectedThreadId == thread.id {
+                            selectedThreadId = activeThreads.first?.id
+                        }
                     } label: {
                         Label("Archive", systemImage: "archivebox")
                     }
@@ -130,6 +136,9 @@ struct ThreadListView: View {
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {
                                     store.deleteThread(thread)
+                                    if horizontalSizeClass == .regular && selectedThreadId == thread.id {
+                                        selectedThreadId = activeThreads.first?.id
+                                    }
                                 } label: {
                                     Label("Delete", systemImage: "trash")
                                 }

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -7,7 +7,7 @@ import VellumAssistantShared
 
 struct ThreadListView: View {
     @StateObject private var store: IOSThreadStore
-    @State private var selectedThreadId: UUID?
+    @State private var navigationPath: [UUID] = []
     @State private var searchText: String = ""
     @State private var renamingThreadId: UUID?
     @State private var renameText: String = ""
@@ -36,17 +36,32 @@ struct ThreadListView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
+        NavigationStack(path: $navigationPath) {
             threadList
-        } detail: {
-            detailView
+                .navigationDestination(for: UUID.self) { threadId in
+                    if let thread = store.threads.first(where: { $0.id == threadId }) {
+                        ThreadChatView(
+                            viewModel: store.viewModel(for: threadId),
+                            threadTitle: thread.title
+                        )
+                        .onAppear {
+                            store.loadHistoryIfNeeded(for: threadId)
+                            store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
+                        }
+                        .onOpenURL { _ in
+                            DispatchQueue.main.async {
+                                store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
+                            }
+                        }
+                    }
+                }
         }
     }
 
-    // MARK: - Sidebar
+    // MARK: - Thread List
 
     private var threadList: some View {
-        List(selection: $selectedThreadId) {
+        List {
             ForEach(filteredActiveThreads) { thread in
                 NavigationLink(value: thread.id) {
                     threadRow(thread)
@@ -54,17 +69,11 @@ struct ThreadListView: View {
                 .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
                         store.deleteThread(thread)
-                        if selectedThreadId == thread.id {
-                            selectedThreadId = activeThreads.first?.id
-                        }
                     } label: {
                         Label("Delete", systemImage: "trash")
                     }
                     Button {
                         store.archiveThread(thread)
-                        if selectedThreadId == thread.id {
-                            selectedThreadId = activeThreads.first?.id
-                        }
                     } label: {
                         Label("Archive", systemImage: "archivebox")
                     }
@@ -90,11 +99,7 @@ struct ThreadListView: View {
                             }
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {
-                                    let wasSelected = selectedThreadId == thread.id
                                     store.deleteThread(thread)
-                                    if wasSelected {
-                                        selectedThreadId = activeThreads.first?.id
-                                    }
                                 } label: {
                                     Label("Delete", systemImage: "trash")
                                 }
@@ -115,16 +120,11 @@ struct ThreadListView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
-                    store.newThread()
-                    selectedThreadId = store.threads.last?.id
+                    let thread = store.newThread()
+                    navigationPath = [thread.id]
                 } label: {
                     Image(systemName: "square.and.pencil")
                 }
-            }
-        }
-        .onAppear {
-            if selectedThreadId == nil {
-                selectedThreadId = activeThreads.first?.id
             }
         }
         .alert("Rename Chat", isPresented: Binding(
@@ -170,31 +170,6 @@ struct ThreadListView: View {
 
     private func relativeDate(_ date: Date) -> String {
         DateFormatting.relativeTimestamp(date)
-    }
-
-    // MARK: - Detail
-
-    @ViewBuilder
-    private var detailView: some View {
-        if let selectedId = selectedThreadId,
-           let thread = store.threads.first(where: { $0.id == selectedId }) {
-            ThreadChatView(
-                viewModel: store.viewModel(for: selectedId),
-                threadTitle: thread.title
-            )
-                .onAppear {
-                    store.loadHistoryIfNeeded(for: selectedId)
-                    store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
-                }
-                .onOpenURL { _ in
-                    DispatchQueue.main.async {
-                        store.viewModel(for: selectedId).consumeDeepLinkIfNeeded()
-                    }
-                }
-        } else {
-            Text("Select a chat")
-                .foregroundStyle(.secondary)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Two iOS UX fixes:
1. **Chat navigation broken on iPhone** — tapping a chat in the list didn't open it
2. **No auto-connect on launch** — app showed disconnected states even with saved connection settings, requiring manual Settings > Update

## Fix 1: Chat Navigation

`NavigationSplitView` has a known SwiftUI limitation on iPhone (compact horizontal size class) where tapping a list item after navigating back from the detail view fails to push again.

Replaced with `NavigationStack` + `.navigationDestination(for:)`, which is the standard iPhone navigation pattern and matches every other tab in the iOS app.

**Changes:**
- `NavigationSplitView { sidebar } detail: { ... }` → `NavigationStack(path:) { list.navigationDestination(for:) }`
- `List(selection:)` → plain `List` (NavigationStack handles navigation via NavigationLink)
- "New Chat" button pushes to new thread via `navigationPath = [thread.id]`

## Fix 2: Auto-Connect Gate Screen

When saved connection settings exist, the app now shows a "Connecting to your assistant..." screen on launch instead of flashing disconnected tab states. If connection fails, a retry screen offers "Retry" and "Go to Settings" buttons.

**Changes:**
- ContentView owns the initial connection attempt with visual feedback
- SceneDelegate skips the first foreground event (ContentView handles it), only handles subsequent background→foreground reconnections
- If no saved settings, tabs show immediately (user configures via Settings)

**Flow:**
1. App launches with saved settings → "Connecting..." spinner
2. Connection succeeds → tabs appear with data
3. Connection fails → "Unable to Connect" with Retry / Go to Settings

## Files Changed

| File | Change |
|------|--------|
| `clients/ios/Views/ThreadListView.swift` | NavigationSplitView → NavigationStack |
| `clients/ios/Views/ContentView.swift` | Add connection gate with connecting/failed states |
| `clients/ios/App/SceneDelegate.swift` | Skip initial foreground, handle subsequent reconnections only |

## Testing

**Chat navigation:**
1. Open Chats tab → see list of threads
2. Tap any thread → pushes to chat detail
3. Tap back → returns to list
4. Tap another thread → pushes correctly (was broken before)

**Auto-connect:**
1. Configure daemon settings → quit app → reopen
2. See "Connecting..." spinner instead of disconnected state
3. If Mac daemon is running → connects and shows tabs with data
4. If Mac daemon is off → "Unable to Connect" with Retry and Go to Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)