### PR TITLE
Let Twilio eligibility API errors propagate as 500s

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -150,14 +150,7 @@ export async function resolveCallerIdentity(
 
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
-  let eligibility: { eligible: boolean; reason?: string };
-  try {
-    eligibility = await provider.checkCallerIdEligibility(userNumber);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ mode, source: numberSource, userNumber, err }, 'Caller ID eligibility check encountered an API error');
-    return { ok: false, error: msg };
-  }
+  const eligibility = await provider.checkCallerIdEligibility(userNumber);
   if (!eligibility.eligible) {
     log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };


### PR DESCRIPTION
## Summary
- Removed try/catch around checkCallerIdEligibility in resolveCallerIdentity
- Twilio API failures now propagate to startCall's catch block which correctly returns HTTP 500
- Previously these errors were caught and returned as { ok: false } which mapped to HTTP 400

## Original prompt
Address feedback on PR #6225: Twilio API failures should return 5xx, not 4xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
