### PR TITLE
Fix misleading comment in send.ts (feedback from #6210)

### DIFF
--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -61,8 +61,8 @@ export async function sendTelegramAttachments(
     }
 
     try {
-      // Prefer the assistant-less download path; fall back to the legacy
-      // assistant-scoped path when assistantId is available.
+      // Use the legacy assistant-scoped download path when assistantId is
+      // available; fall back to the assistant-less endpoint otherwise.
       const payload = assistantId
         ? await downloadAttachment(config, assistantId, meta.id)
         : await downloadAttachmentById(config, meta.id);


### PR DESCRIPTION
Fix comment in gateway/src/telegram/send.ts that described the opposite of the code's actual behavior for attachment download path selection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
