### PR TITLE
M2: OAuth operation client for core commands

### DIFF
--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// --- Mocks (must be declared before importing the module under test) ---
+
+let secureKeyStore: Record<string, string> = {};
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: () => true,
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+// withValidToken: call the callback directly with a fake token.
+mock.module('../security/token-manager.js', () => ({
+  withValidToken: async (_service: string, cb: (token: string) => Promise<unknown>) =>
+    cb('fake-oauth-token'),
+  TokenExpiredError: class TokenExpiredError extends Error {
+    constructor(public readonly service: string, message?: string) {
+      super(message ?? `Token expired for "${service}".`);
+      this.name = 'TokenExpiredError';
+    }
+  },
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import {
+  oauthPostTweet,
+  oauthIsAvailable,
+  oauthSupportsOperation,
+  UnsupportedOAuthOperationError,
+} from '../twitter/oauth-client.js';
+
+// --- Global fetch mock ---
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof mock> | null = null;
+
+beforeEach(() => {
+  secureKeyStore = {};
+  fetchMock = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockFetch(response: { ok: boolean; status: number; json?: unknown; text?: string }) {
+  const fn = mock(() =>
+    Promise.resolve({
+      ok: response.ok,
+      status: response.status,
+      json: () => Promise.resolve(response.json),
+      text: () => Promise.resolve(response.text ?? ''),
+    }),
+  );
+  globalThis.fetch = fn as unknown as typeof fetch;
+  fetchMock = fn;
+  return fn;
+}
+
+describe('Twitter OAuth client', () => {
+  describe('oauthPostTweet', () => {
+    test('successfully posts and returns tweet ID', async () => {
+      const fn = mockFetch({
+        ok: true,
+        status: 200,
+        json: { data: { id: '12345', text: 'Hello world' } },
+      });
+
+      const result = await oauthPostTweet('Hello world');
+
+      expect(result.tweetId).toBe('12345');
+      expect(result.text).toBe('Hello world');
+
+      // Verify the request was made correctly
+      expect(fn).toHaveBeenCalledTimes(1);
+      const [url, opts] = fn.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.x.com/2/tweets');
+      expect(opts.method).toBe('POST');
+      expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer fake-oauth-token');
+      expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(opts.body as string);
+      expect(body.text).toBe('Hello world');
+      expect(body.reply).toBeUndefined();
+    });
+
+    test('with reply returns correct result', async () => {
+      const fn = mockFetch({
+        ok: true,
+        status: 200,
+        json: { data: { id: '67890', text: 'My reply' } },
+      });
+
+      const result = await oauthPostTweet('My reply', { inReplyToTweetId: '11111' });
+
+      expect(result.tweetId).toBe('67890');
+      expect(result.text).toBe('My reply');
+
+      const [, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(opts.body as string);
+      expect(body.text).toBe('My reply');
+      expect(body.reply).toEqual({ in_reply_to_tweet_id: '11111' });
+    });
+
+    test('throws on API error', async () => {
+      mockFetch({
+        ok: false,
+        status: 429,
+        text: 'Rate limit exceeded',
+      });
+
+      await expect(oauthPostTweet('will fail')).rejects.toThrow(
+        /Twitter API error \(429\)/,
+      );
+    });
+
+    test('attaches status to thrown error for token manager retry', async () => {
+      mockFetch({
+        ok: false,
+        status: 401,
+        text: 'Unauthorized',
+      });
+
+      try {
+        await oauthPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect((err as Error & { status: number }).status).toBe(401);
+      }
+    });
+  });
+
+  describe('oauthIsAvailable', () => {
+    test('returns true when access token exists', () => {
+      secureKeyStore['credential:integration:twitter:access_token'] = 'some-token';
+      expect(oauthIsAvailable()).toBe(true);
+    });
+
+    test('returns false when no access token', () => {
+      expect(oauthIsAvailable()).toBe(false);
+    });
+  });
+
+  describe('oauthSupportsOperation', () => {
+    test('returns true for post', () => {
+      expect(oauthSupportsOperation('post')).toBe(true);
+    });
+
+    test('returns true for reply', () => {
+      expect(oauthSupportsOperation('reply')).toBe(true);
+    });
+
+    test('returns false for unsupported operations', () => {
+      const unsupported = [
+        'timeline',
+        'search',
+        'bookmarks',
+        'home',
+        'notifications',
+        'likes',
+        'followers',
+        'following',
+        'media',
+        'tweet',
+      ];
+      for (const op of unsupported) {
+        expect(oauthSupportsOperation(op)).toBe(false);
+      }
+    });
+  });
+
+  describe('UnsupportedOAuthOperationError', () => {
+    test('has correct properties', () => {
+      const err = new UnsupportedOAuthOperationError('search');
+      expect(err.name).toBe('UnsupportedOAuthOperationError');
+      expect(err.operation).toBe('search');
+      expect(err.suggestFallback).toBe(true);
+      expect(err.fallbackPath).toBe('browser');
+      expect(err.message).toContain('search');
+      expect(err.message).toContain('not available via the OAuth API');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/assistant/src/twitter/oauth-client.ts
+++ b/assistant/src/twitter/oauth-client.ts
@@ -1,0 +1,102 @@
+/**
+ * OAuth-backed Twitter API client.
+ *
+ * Uses stored OAuth2 Bearer tokens (via the token manager) to execute
+ * Twitter API v2 operations directly, without requiring a browser session.
+ * Currently supports post and reply; all other operations fall back to the
+ * browser-based CDP client.
+ */
+
+import { withValidToken } from '../security/token-manager.js';
+import { getSecureKey } from '../security/secure-keys.js';
+
+const TWITTER_API_BASE = 'https://api.x.com/2';
+const SERVICE = 'integration:twitter';
+
+/** Operations that the OAuth client can handle natively. */
+const SUPPORTED_OPERATIONS = new Set(['post', 'reply']);
+
+export interface OAuthPostResult {
+  tweetId: string;
+  text: string;
+  url?: string;
+}
+
+export interface OAuthOperationError {
+  message: string;
+  suggestFallback: boolean;
+  fallbackPath: 'browser';
+  operation: string;
+}
+
+export class UnsupportedOAuthOperationError extends Error {
+  public readonly suggestFallback = true;
+  public readonly fallbackPath = 'browser' as const;
+  public readonly operation: string;
+  constructor(operation: string) {
+    super(`The "${operation}" operation is not available via the OAuth API. Use the browser path instead.`);
+    this.name = 'UnsupportedOAuthOperationError';
+    this.operation = operation;
+  }
+}
+
+/**
+ * Post a tweet (or reply) using OAuth2 Bearer token authentication.
+ *
+ * The token manager handles refresh transparently — if the stored token
+ * is expired it will be refreshed before (or after a 401) calling the API.
+ */
+export async function oauthPostTweet(
+  text: string,
+  opts?: { inReplyToTweetId?: string },
+): Promise<OAuthPostResult> {
+  return withValidToken(SERVICE, async (token) => {
+    const body: Record<string, unknown> = { text };
+    if (opts?.inReplyToTweetId) {
+      body.reply = { in_reply_to_tweet_id: opts.inReplyToTweetId };
+    }
+
+    const res = await fetch(`${TWITTER_API_BASE}/tweets`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text().catch(() => '');
+      const err = new Error(
+        `Twitter API error (${res.status}): ${errorBody.slice(0, 500)}`,
+      );
+      // Attach status so the token manager's 401-retry logic can detect it.
+      (err as Error & { status: number }).status = res.status;
+      throw err;
+    }
+
+    const json = (await res.json()) as { data: { id: string; text: string } };
+    return {
+      tweetId: json.data.id,
+      text: json.data.text,
+    };
+  });
+}
+
+/**
+ * Check whether OAuth credentials are available for the Twitter integration.
+ * Returns true if an access token has been stored (the token manager will
+ * handle refresh if it's expired).
+ */
+export function oauthIsAvailable(): boolean {
+  return getSecureKey('credential:integration:twitter:access_token') !== undefined;
+}
+
+/**
+ * Check whether a given operation is supported via the OAuth API path.
+ * Only `post` and `reply` are currently supported; everything else
+ * (timeline, search, bookmarks, etc.) requires the browser path.
+ */
+export function oauthSupportsOperation(operation: string): boolean {
+  return SUPPORTED_OPERATIONS.has(operation);
+}


### PR DESCRIPTION
Part of #6232. Creates assistant/src/twitter/oauth-client.ts implementing OAuth-backed post and reply operations using withValidToken pattern. Adds UnsupportedOAuthOperationError for unsupported operations with browser fallback suggestion. Includes comprehensive tests. Closes #6234.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
