### PR TITLE
Fix Telegram provider auth and error handling (feedback from #6222)

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -37,11 +37,16 @@ export function resolveProvider(platformInput?: string): MessagingProvider {
 
 /**
  * Execute a callback with a valid OAuth token for the given provider.
+ * Providers that manage their own auth (e.g. Telegram with a bot token)
+ * expose isConnected() and don't need an OAuth access_token lookup.
  */
 export async function withProviderToken<T>(
   provider: MessagingProvider,
   fn: (token: string) => Promise<T>,
 ): Promise<T> {
+  if (provider.isConnected?.()) {
+    return fn('');
+  }
   return withValidToken(provider.credentialService, fn);
 }
 

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -74,26 +74,35 @@ export const telegramBotMessagingProvider: MessagingProvider = {
       };
     }
 
-    const resp = await telegram.getMe(botToken);
-    if (!resp.ok || !resp.result) {
+    try {
+      const resp = await telegram.getMe(botToken);
+      if (!resp.ok || !resp.result) {
+        return {
+          connected: false,
+          user: 'unknown',
+          platform: 'telegram',
+          metadata: { error: resp.description ?? 'getMe failed' },
+        };
+      }
+
+      return {
+        connected: true,
+        user: resp.result.username ?? resp.result.first_name,
+        platform: 'telegram',
+        metadata: {
+          botId: resp.result.id,
+          botUsername: resp.result.username,
+          botName: resp.result.first_name,
+        },
+      };
+    } catch (e) {
       return {
         connected: false,
         user: 'unknown',
         platform: 'telegram',
-        metadata: { error: resp.description ?? 'getMe failed' },
+        metadata: { error: e instanceof Error ? e.message : 'getMe failed' },
       };
     }
-
-    return {
-      connected: true,
-      user: resp.result.username ?? resp.result.first_name,
-      platform: 'telegram',
-      metadata: {
-        botId: resp.result.id,
-        botUsername: resp.result.username,
-        botName: resp.result.first_name,
-      },
-    };
   },
 
   async sendMessage(_token: string, conversationId: string, text: string, _options?: SendOptions): Promise<SendResult> {


### PR DESCRIPTION
Update withProviderToken to skip OAuth token lookup for providers that manage their own auth (like Telegram). Fix unreachable error handling in testConnection by wrapping getMe in try/catch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
