### PR TITLE
M1: Strategy state, config, and status foundation

### DIFF
--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -715,4 +715,138 @@ describe('Twitter integration config handler', () => {
     expect(responseStr).not.toContain('secret-client-secret-xyz789');
     expect(responseStr).not.toContain('secret-access-token-def456');
   });
+
+  // --- Strategy tests ---
+
+  test('get_strategy returns auto by default', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get_strategy',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(true);
+    expect(res.strategy).toBe('auto');
+  });
+
+  test('set_strategy persists and can be read back', () => {
+    // Set strategy to oauth
+    const setMsg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+      strategy: 'oauth',
+    };
+    const { ctx: ctx1, sent: sent1 } = createTestContext();
+    handleMessage(setMsg, {} as net.Socket, ctx1);
+
+    expect(sent1).toHaveLength(1);
+    const setRes = sent1[0] as { type: string; success: boolean; strategy: string };
+    expect(setRes.success).toBe(true);
+    expect(setRes.strategy).toBe('oauth');
+
+    // Read it back with get_strategy
+    const getMsg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get_strategy',
+    };
+    const { ctx: ctx2, sent: sent2 } = createTestContext();
+    handleMessage(getMsg, {} as net.Socket, ctx2);
+
+    expect(sent2).toHaveLength(1);
+    const getRes = sent2[0] as { type: string; success: boolean; strategy: string };
+    expect(getRes.success).toBe(true);
+    expect(getRes.strategy).toBe('oauth');
+
+    // Verify persistence via saveRawConfig
+    expect(saveRawConfigCalls.length).toBeGreaterThan(0);
+    const lastSaved = saveRawConfigCalls[saveRawConfigCalls.length - 1]!;
+    expect(lastSaved.twitterOperationStrategy).toBe('oauth');
+  });
+
+  test('set_strategy with invalid value returns error', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+      strategy: 'invalid_value',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Invalid strategy value');
+    expect(res.error).toContain('invalid_value');
+  });
+
+  test('set_strategy without value returns error', () => {
+    const msg = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+    } as unknown as TwitterIntegrationConfigRequest;
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Invalid strategy value');
+  });
+
+  test('get action includes strategy field', () => {
+    // Set a specific strategy first
+    rawConfigStore = { twitterOperationStrategy: 'browser' };
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string; mode: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(true);
+    expect(res.strategy).toBe('browser');
+  });
+
+  test('get action returns auto strategy by default', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    expect(res.strategy).toBe('auto');
+  });
+
+  test('set_strategy cycles through all valid values', () => {
+    for (const value of ['oauth', 'browser', 'auto'] as const) {
+      const msg: TwitterIntegrationConfigRequest = {
+        type: 'twitter_integration_config',
+        action: 'set_strategy',
+        strategy: value,
+      };
+      const { ctx, sent } = createTestContext();
+      handleMessage(msg, {} as net.Socket, ctx);
+      expect(sent).toHaveLength(1);
+      const res = sent[0] as { type: string; success: boolean; strategy: string };
+      expect(res.success).toBe(true);
+      expect(res.strategy).toBe(value);
+    }
+  });
 });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -172,25 +172,93 @@ export function registerTwitterCommand(program: Command): void {
     });
 
   // =========================================================================
-  // status — check session status
+  // status — check session status + OAuth and strategy info
   // =========================================================================
   tw.command('status')
-    .description('Check if a Twitter session is active')
-    .action((_opts: unknown, cmd: Command) => {
+    .description('Check Twitter session, OAuth, and strategy status')
+    .action(async (_opts: unknown, cmd: Command) => {
       const session = loadSession();
-      if (session) {
-        output(
-          {
-            ok: true,
-            loggedIn: true,
+      const browserInfo: Record<string, unknown> = session
+        ? {
+            browserSessionActive: true,
             cookieCount: session.cookies.length,
             importedAt: session.importedAt,
             recordingId: session.recordingId,
-          },
-          getJson(cmd),
-        );
-      } else {
-        output({ ok: true, loggedIn: false }, getJson(cmd));
+          }
+        : { browserSessionActive: false };
+
+      // Query daemon for OAuth / strategy config
+      let oauthInfo: Record<string, unknown> = {};
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'get',
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        oauthInfo = {
+          oauthConnected: r.connected ?? false,
+          oauthAccount: r.accountInfo ?? undefined,
+          preferredStrategy: r.strategy ?? 'auto',
+        };
+      } catch {
+        // Daemon may not be running; report what we can from the local session
+        oauthInfo = {
+          oauthConnected: undefined,
+          oauthAccount: undefined,
+          preferredStrategy: undefined,
+        };
+      }
+
+      output(
+        {
+          ok: true,
+          loggedIn: !!session,
+          ...browserInfo,
+          ...oauthInfo,
+        },
+        getJson(cmd),
+      );
+    });
+
+  // =========================================================================
+  // strategy — get or set the Twitter operation strategy
+  // =========================================================================
+  const strategyCli = tw.command('strategy')
+    .description('Get or set the Twitter operation strategy (oauth, browser, auto)')
+    .action(async (_opts: unknown, cmd: Command) => {
+      const json = getJson(cmd);
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'get_strategy',
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        output({ ok: true, strategy: r.strategy ?? 'auto' }, json);
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  strategyCli.command('set')
+    .description('Set the Twitter operation strategy')
+    .argument('<value>', 'Strategy value: oauth, browser, or auto')
+    .action(async (value: string, _opts: unknown, cmd: Command) => {
+      const json = getJson(cmd);
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'set_strategy',
+          strategy: value,
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        if (r.success) {
+          output({ ok: true, strategy: r.strategy }, json);
+        } else {
+          output({ ok: false, error: r.error ?? 'Failed to set strategy' }, json);
+          process.exitCode = 1;
+        }
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
       }
     });
 
@@ -380,6 +448,84 @@ export function registerTwitterCommand(program: Command): void {
         return { user, tweets };
       });
     });
+}
+
+// ---------------------------------------------------------------------------
+// Daemon IPC helper — send a message and wait for the first response
+// ---------------------------------------------------------------------------
+
+function sendDaemonMessage(
+  message: import('../daemon/ipc-protocol.js').ClientMessage,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const socketPath = getSocketPath();
+    const sessionToken = readSessionToken();
+    const socket = net.createConnection(socketPath);
+    const parser = createMessageParser();
+
+    const timeoutHandle = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('Daemon request timed out after 10s'));
+    }, 10_000);
+    timeoutHandle.unref();
+
+    let authenticated = !sessionToken;
+    let messageSent = false;
+
+    const sendPayload = () => {
+      if (messageSent) return;
+      messageSent = true;
+      socket.write(serialize(message));
+    };
+
+    socket.on('error', (err) => {
+      clearTimeout(timeoutHandle);
+      reject(new Error(`Cannot connect to daemon: ${err.message}. Is the daemon running?`));
+    });
+
+    socket.on('data', (chunk) => {
+      const messages = parser.feed(chunk.toString('utf-8'));
+      for (const msg of messages) {
+        const m = msg as unknown as Record<string, unknown>;
+
+        if (!authenticated && m.type === 'auth_result') {
+          if ((m as { success: boolean }).success) {
+            authenticated = true;
+            sendPayload();
+          } else {
+            clearTimeout(timeoutHandle);
+            socket.destroy();
+            reject(new Error('Daemon authentication failed'));
+          }
+          continue;
+        }
+
+        // Skip auth_result echoes and daemon_status broadcasts
+        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong') {
+          continue;
+        }
+
+        // First substantive response — return it
+        clearTimeout(timeoutHandle);
+        socket.destroy();
+        resolve(m);
+        return;
+      }
+    });
+
+    socket.on('connect', () => {
+      if (sessionToken) {
+        socket.write(
+          serialize({
+            type: 'auth',
+            token: sessionToken,
+          } as unknown as import('../daemon/ipc-protocol.js').ClientMessage),
+        );
+      } else {
+        sendPayload();
+      }
+    });
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -546,6 +546,7 @@ export function handleTwitterIntegrationConfig(
     if (msg.action === 'get') {
       const raw = loadRawConfig();
       const mode = (raw.twitterIntegrationMode as 'local_byo' | 'managed' | undefined) ?? 'local_byo';
+      const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
       const localClientConfigured = !!getSecureKey('credential:integration:twitter:oauth_client_id');
       const connected = !!getSecureKey('credential:integration:twitter:access_token');
       const meta = getCredentialMetadata('integration:twitter', 'access_token');
@@ -557,6 +558,43 @@ export function handleTwitterIntegrationConfig(
         localClientConfigured,
         connected,
         accountInfo: meta?.accountInfo ?? undefined,
+        strategy,
+      });
+    } else if (msg.action === 'get_strategy') {
+      const raw = loadRawConfig();
+      const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
+      ctx.send(socket, {
+        type: 'twitter_integration_config_response',
+        success: true,
+        managedAvailable: false,
+        localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
+        connected: !!getSecureKey('credential:integration:twitter:access_token'),
+        strategy,
+      });
+    } else if (msg.action === 'set_strategy') {
+      const valid = ['oauth', 'browser', 'auto'];
+      const value = msg.strategy;
+      if (!value || !valid.includes(value)) {
+        ctx.send(socket, {
+          type: 'twitter_integration_config_response',
+          success: false,
+          managedAvailable: false,
+          localClientConfigured: false,
+          connected: false,
+          error: `Invalid strategy value: ${String(value)}. Must be one of: ${valid.join(', ')}`,
+        });
+        return;
+      }
+      const raw = loadRawConfig();
+      raw.twitterOperationStrategy = value;
+      saveRawConfig(raw);
+      ctx.send(socket, {
+        type: 'twitter_integration_config_response',
+        success: true,
+        managedAvailable: false,
+        localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
+        connected: !!getSecureKey('credential:integration:twitter:access_token'),
+        strategy: value as 'oauth' | 'browser' | 'auto',
       });
     } else if (msg.action === 'set_mode') {
       const raw = loadRawConfig();

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -494,10 +494,11 @@ export interface VercelApiConfigResponse {
 
 export interface TwitterIntegrationConfigRequest {
   type: 'twitter_integration_config';
-  action: 'get' | 'set_mode' | 'set_local_client' | 'clear_local_client' | 'disconnect';
+  action: 'get' | 'set_mode' | 'set_local_client' | 'clear_local_client' | 'disconnect' | 'get_strategy' | 'set_strategy';
   mode?: 'local_byo' | 'managed';
   clientId?: string;
   clientSecret?: string;
+  strategy?: string;
 }
 
 export interface TwitterIntegrationConfigResponse {
@@ -508,6 +509,7 @@ export interface TwitterIntegrationConfigResponse {
   localClientConfigured: boolean;
   connected: boolean;
   accountInfo?: string;
+  strategy?: 'oauth' | 'browser' | 'auto';
   error?: string;
 }
 


### PR DESCRIPTION
Part of #6232. Adds persisted twitterOperationStrategy config field (oauth/browser/auto), extends IPC contract, adds vellum x strategy CLI subcommand, and enriches vellum x status with OAuth readiness info. Closes #6233.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
