### PR TITLE
ElevenLabs final alignment: remove dead register-call path, stabilize tests, align docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3675,7 +3675,7 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.voice.mode` | enum | `'twilio_standard'` | Voice quality mode. Options: `twilio_standard` (standard Twilio TTS with Google voices — fully supported), `twilio_elevenlabs_tts` (ElevenLabs voices through Twilio ConversationRelay — fully supported), `elevenlabs_agent` (full ElevenLabs conversational agent — experimental/restricted, blocked by runtime guard). |
 | `calls.voice.language` | string | `'en-US'` | Language code for TTS and transcription. |
 | `calls.voice.transcriptionProvider` | enum | `'Deepgram'` | Speech-to-text provider (`Deepgram` or `Google`). |
-| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs fails (missing config, API errors) or is restricted (e.g., `elevenlabs_agent` guard). When `false`, errors return HTTP 500/501/502 instead of falling back. |
+| `calls.voice.fallbackToStandardOnError` | boolean | `true` | When an ElevenLabs mode is active, automatically fall back to standard Twilio TTS if ElevenLabs config is invalid or mode is restricted (e.g., `elevenlabs_agent` guard). When `false`, errors return HTTP 500 (invalid config) or 501 (restricted mode) instead of falling back. |
 | `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
 | `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
 
@@ -3687,7 +3687,7 @@ The resolution logic works as follows:
 
 - **`twilio_standard`** (fully supported) — Returns a profile using Google TTS with a default Google voice (`Google.en-US-Journey-O`). This is the default when no voice config is changed.
 - **`twilio_elevenlabs_tts`** (fully supported) — Builds an ElevenLabs voice spec string from `voiceId`, `voiceModelId`, and tuning parameters (stability, similarity, style). If `voiceId` is empty and fallback is enabled, silently falls back to the `twilio_standard` profile.
-- **`elevenlabs_agent`** (experimental/restricted) — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`. Even when the profile resolves successfully, a runtime guard in `handleVoiceWebhook` blocks this mode (see below).
+- **`elevenlabs_agent`** (experimental/restricted) — Requires `agentId` to be set. If `agentId` is empty and fallback is enabled, silently falls back to `twilio_standard`. Even when the profile resolves successfully, a runtime guard in `handleVoiceWebhook` blocks this mode before any ElevenLabs API calls are made (see below). No register-call flow is reachable while the guard is active.
 
 When `fallbackToStandardOnError` is `true` (default), any misconfiguration or runtime error in ElevenLabs modes causes a graceful fallback to standard Twilio TTS rather than a call failure. Validation errors are captured in `validationErrors` on the profile for logging.
 
@@ -3699,8 +3699,8 @@ The voice webhook (`twilio-routes.ts`) enforces two sequential guardrails before
 - `fallbackToStandardOnError=true` (default): the profile has already been resolved to `twilio_standard` by the profile resolver; proceeds normally.
 - `fallbackToStandardOnError=false`: returns **HTTP 500** with the validation error details.
 
-**WS-B: `elevenlabs_agent` mode guard** — If the resolved profile mode is `elevenlabs_agent`, a guard fires *before* any ElevenLabs API calls because consultation bridging (`waiting_on_user`) is not yet supported in this mode:
-- `fallbackToStandardOnError=true` (default): logs a warning and falls back to standard ConversationRelay TwiML.
+**WS-B: `elevenlabs_agent` mode guard** — If the resolved profile mode is `elevenlabs_agent`, a guard fires *before* any ElevenLabs API calls because consultation bridging (`waiting_on_user`) is not yet supported in this mode. No ElevenLabs register-call or other API calls are attempted while this guard is active:
+- `fallbackToStandardOnError=true` (default): logs a warning, replaces the profile with `twilio_standard`, and returns standard ConversationRelay TwiML.
 - `fallbackToStandardOnError=false`: returns **HTTP 501** `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
 
 The guard order ensures invalid configs are caught first (WS-A), then mode-level restrictions are enforced (WS-B). For `twilio_standard` and `twilio_elevenlabs_tts` modes, both guards pass and the webhook proceeds to return ConversationRelay TwiML.

--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -94,6 +94,25 @@ mock.module('../calls/twilio-config.js', () => ({
   }),
 }));
 
+// Mock ElevenLabs client — should never be called when guard is active.
+// If any test path reaches register-call, the mock will throw to fail the test.
+const mockRegisterCall = mock(() => { throw new Error('register-call should not be reached while guard is active'); });
+
+mock.module('../calls/elevenlabs-client.js', () => ({
+  ElevenLabsClient: class {
+    registerCall = mockRegisterCall;
+  },
+}));
+
+mock.module('../calls/elevenlabs-config.js', () => ({
+  getElevenLabsConfig: () => ({
+    apiBaseUrl: 'https://api.elevenlabs.io',
+    apiKey: 'test-key',
+    agentId: 'agent-abc',
+    registerCallTimeoutMs: 5000,
+  }),
+}));
+
 // Mock resolveVoiceQualityProfile and isVoiceProfileValid so we can control
 // the profile returned to handleVoiceWebhook per-test.
 import type { VoiceQualityProfile } from '../calls/voice-quality.js';
@@ -186,6 +205,7 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
     resetTables();
     // Reset mock to default implementation
     mockResolveVoiceQualityProfile.mockReset();
+    mockRegisterCall.mockClear();
     // Reset to standard default profile between tests
     mockProfile = {
       mode: 'twilio_standard',
@@ -317,5 +337,39 @@ describe('handleVoiceWebhook ElevenLabs branches', () => {
     expect(twiml).toContain('<Connect>');
     expect(twiml).toContain('ttsProvider="Google"');
     expect(twiml).toContain('voice="Google.en-US-Journey-O"');
+  });
+
+  // ── Guard prevents register-call attempt ────────────────────────────
+  test('guarded elevenlabs_agent does not attempt ElevenLabs register-call', async () => {
+    // Configure as elevenlabs_agent with fallback (guard will fire)
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'elevenlabs_agent' as const,
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'ElevenLabs',
+      voice: 'voice123-turbo_v2_5-0.5_0.75_0',
+      agentId: 'agent-abc',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    }));
+    mockResolveVoiceQualityProfile.mockImplementationOnce(() => ({
+      mode: 'twilio_standard' as const,
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+      fallbackToStandardOnError: true,
+      validationErrors: [],
+    }));
+
+    const session = createTestSession('conv-11labs-5', 'CA_11labs_5');
+    const req = makeVoiceRequest(session.id, { CallSid: 'CA_11labs_5' });
+
+    const res = await handleVoiceWebhook(req);
+
+    expect(res.status).toBe(200);
+    // The ElevenLabs register-call mock was never invoked — the guard
+    // blocked the entire mode before any ElevenLabs API interaction.
+    expect(mockRegisterCall).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -1,15 +1,19 @@
 /**
  * Integration tests for Twilio webhook route handlers.
  *
+ * Tests handler-level behavior by calling route handlers directly (not via HTTP
+ * server). Gateway-only blocking of direct webhook routes is covered in the
+ * dedicated `gateway-only-enforcement.test.ts` suite.
+ *
  * Tests:
- * - Gateway-only blocking of direct webhook routes (signature validation
- *   is now handled at the gateway, not the runtime)
  * - Duplicate callback replay (idempotency)
  * - Unknown status and malformed payload handling
+ * - Status mapping and completion notifications
+ * - resolveRelayUrl unit behavior
+ * - Voice webhook TwiML relay URL generation
  * - Handler-level idempotency concurrency (concurrent duplicates, failure-retry)
  */
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock, spyOn } from 'bun:test';
-import { createHmac } from 'node:crypto';
+import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -46,57 +50,19 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-// Configurable mock auth token — tests can switch between configured/unconfigured
-let mockAuthToken: string | undefined = 'test-auth-token-for-webhooks';
-
 mock.module('../security/secure-keys.js', () => ({
-  getSecureKey: (account: string) => {
-    if (account === 'credential:twilio:auth_token') return mockAuthToken;
-    return undefined;
-  },
+  getSecureKey: () => undefined,
 }));
 
-// Use the real TwilioConversationRelayProvider (not mocked) for signature validation
-// but mock the instance methods that hit Twilio API
-mock.module('../calls/twilio-provider.js', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { createHmac: createHmacNode } = require('node:crypto');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { timingSafeEqual: timingSafeEqualNode } = require('node:crypto');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { getSecureKey } = require('../security/secure-keys.js');
-
-  return {
-    TwilioConversationRelayProvider: class {
-      readonly name = 'twilio';
-
-      static getAuthToken(): string | null {
-        return getSecureKey('credential:twilio:auth_token') ?? null;
-      }
-
-      static verifyWebhookSignature(
-        url: string,
-        params: Record<string, string>,
-        signature: string,
-        authToken: string,
-      ): boolean {
-        const sortedKeys = Object.keys(params).sort();
-        let data = url;
-        for (const key of sortedKeys) {
-          data += key + params[key];
-        }
-        const computed = createHmacNode('sha1', authToken).update(data).digest('base64');
-        const a = Buffer.from(computed);
-        const b = Buffer.from(signature);
-        if (a.length !== b.length) return false;
-        return timingSafeEqualNode(a, b);
-      }
-
-      async initiateCall() { return { callSid: 'CA_mock_test' }; }
-      async endCall() { return; }
-    },
-  };
-});
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    readonly name = 'twilio';
+    static getAuthToken(): string | null { return null; }
+    static verifyWebhookSignature(): boolean { return true; }
+    async initiateCall() { return { callSid: 'CA_mock_test' }; }
+    async endCall() { return; }
+  },
+}));
 
 // Configurable mock Twilio config — tests can override wssBaseUrl
 let mockWssBaseUrl: string = 'wss://test.example.com';
@@ -114,7 +80,6 @@ mock.module('../calls/twilio-config.js', () => ({
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { conversations } from '../memory/schema.js';
-import { RuntimeHttpServer } from '../runtime/http-server.js';
 import * as callStore from '../calls/call-store.js';
 import {
   createCallSession,
@@ -128,9 +93,6 @@ import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from
 initializeDb();
 
 // ── Helpers ────────────────────────────────────────────────────────────
-
-const TEST_TOKEN = 'test-bearer-token-twilio-routes';
-const AUTH_TOKEN = 'test-auth-token-for-webhooks';
 
 let ensuredConvIds = new Set<string>();
 
@@ -155,19 +117,6 @@ function resetTables() {
   db.run('DELETE FROM call_sessions');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
-}
-
-function computeSignature(
-  url: string,
-  params: Record<string, string>,
-  authToken: string,
-): string {
-  const sortedKeys = Object.keys(params).sort();
-  let data = url;
-  for (const key of sortedKeys) {
-    data += key + params[key];
-  }
-  return createHmac('sha1', authToken).update(data).digest('base64');
 }
 
 function createTestSession(convId: string, callSid: string) {
@@ -202,216 +151,15 @@ function makeVoiceRequest(sessionId: string, params: Record<string, string>): Re
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe('twilio webhook routes', () => {
-  let server: RuntimeHttpServer;
-  let port: number;
-
   beforeEach(() => {
     resetTables();
-    mockAuthToken = AUTH_TOKEN;
     mockWssBaseUrl = 'wss://test.example.com';
     mockWebhookBaseUrl = 'https://test.example.com';
-    delete process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED;
-  });
-
-  // Deterministic teardown: always stop the server after each test so a
-  // failed assertion between startServer/stopServer doesn't leave the
-  // port bound, causing EADDRINUSE flakes in subsequent tests.
-  afterEach(async () => {
-    await stopServer();
   });
 
   afterAll(() => {
     resetDb();
     try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
-  });
-
-  async function startServer(): Promise<void> {
-    server = new RuntimeHttpServer({ port: 0, bearerToken: TEST_TOKEN });
-    await server.start();
-    port = server.actualPort;
-  }
-
-  async function stopServer(): Promise<void> {
-    await server?.stop();
-  }
-
-  function statusUrl(): string {
-    return `http://127.0.0.1:${port}/v1/calls/twilio/status`;
-  }
-
-  function buildFormBody(params: Record<string, string>): string {
-    return new URLSearchParams(params).toString();
-  }
-
-  function signedRequest(
-    url: string,
-    params: Record<string, string>,
-  ): { body: string; headers: Record<string, string> } {
-    const body = buildFormBody(params);
-    const sig = computeSignature(url, params, AUTH_TOKEN);
-    return {
-      body,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'X-Twilio-Signature': sig,
-      },
-    };
-  }
-
-  // ── Gateway-only blocking tests ───────────────────────────────────
-  // Direct Twilio webhook routes are blocked in gateway-only mode.
-  // Signature validation is now handled at the gateway level, not the runtime.
-
-  describe('gateway-only blocking of direct webhook routes', () => {
-    test('direct status callback returns 410', async () => {
-      await startServer();
-      const url = statusUrl();
-      const params = { CallSid: 'CA_sig_valid', CallStatus: 'completed' };
-      const { body, headers } = signedRequest(url, params);
-
-      const res = await fetch(url, { method: 'POST', headers, body });
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-
-    test('direct status callback without signature returns 410', async () => {
-      await startServer();
-      const url = statusUrl();
-      const params = { CallSid: 'CA_no_sig', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-
-    test('direct status callback with invalid signature returns 410', async () => {
-      await startServer();
-      const url = statusUrl();
-      const params = { CallSid: 'CA_bad_sig', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'X-Twilio-Signature': 'totally-wrong-signature',
-        },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-
-    test('direct status callback with wrong token signature returns 410', async () => {
-      await startServer();
-      const url = statusUrl();
-      const params = { CallSid: 'CA_wrong_token', CallStatus: 'completed' };
-      computeSignature(url, params, 'wrong-auth-token');
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'X-Twilio-Signature': computeSignature(url, params, 'wrong-auth-token'),
-        },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-  });
-
-  // ── Fail-closed behavior ──────────────────────────────────────────
-
-  describe('fail-closed when auth token missing', () => {
-    test('direct route returns 410 regardless of auth token config', async () => {
-      mockAuthToken = undefined;
-      await startServer();
-
-      const url = statusUrl();
-      const params = { CallSid: 'CA_no_token', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-  });
-
-  // ── TWILIO_WEBHOOK_VALIDATION_DISABLED bypass ─────────────────────
-
-  describe('validation disabled env flag', () => {
-    test('direct route returns 410 even when validation disabled', async () => {
-      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = 'true';
-      mockAuthToken = undefined;
-      await startServer();
-
-      const url = statusUrl();
-      const params = { CallSid: 'CA_bypass', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-
-    test('direct route returns 410 when env var is non-true value', async () => {
-      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = '1';
-      mockAuthToken = undefined;
-      await startServer();
-
-      const url = statusUrl();
-      const params = { CallSid: 'CA_no_bypass', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
-
-    test('direct route returns 410 when env var is empty string', async () => {
-      process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED = '';
-      mockAuthToken = undefined;
-      await startServer();
-
-      const url = statusUrl();
-      const params = { CallSid: 'CA_empty_env', CallStatus: 'completed' };
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: buildFormBody(params),
-      });
-
-      expect(res.status).toBe(410);
-
-      await stopServer();
-    });
   });
 
   // ── Callback idempotency / replay tests ───────────────────────────

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -26,8 +26,6 @@ import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { fireCallCompletionNotifier } from './call-state.js';
 import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality.js';
-import { getElevenLabsConfig } from './elevenlabs-config.js';
-import { ElevenLabsClient } from './elevenlabs-client.js';
 
 const log = getLogger('twilio-routes');
 
@@ -160,7 +158,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
   // WS-B: Guard elevenlabs_agent until consultation bridge exists.
   // This fires BEFORE any ElevenLabs API calls, blocking the entire mode.
-  let elevenLabsAgentGuarded = false;
   if (profile.mode === 'elevenlabs_agent') {
     if (!profile.fallbackToStandardOnError) {
       const msg = 'elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported. Set calls.voice.fallbackToStandardOnError=true to fall back to standard mode.';
@@ -168,7 +165,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
       return new Response(msg, { status: 501 });
     }
     log.warn({ callSessionId }, 'elevenlabs_agent mode is restricted/experimental — consultation bridging is not yet supported; falling back to standard ConversationRelay TwiML');
-    elevenLabsAgentGuarded = true;
     const standardConfig = loadConfig();
     profile = resolveVoiceQualityProfile({
       ...standardConfig,
@@ -188,46 +184,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     relayUrl = resolveRelayUrl(twilioConfig.wssBaseUrl, twilioConfig.webhookBaseUrl);
   }
   const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
-
-  if (profile.mode === 'elevenlabs_agent' && !elevenLabsAgentGuarded) {
-    try {
-      const elevenLabsConfig = getElevenLabsConfig();
-      const client = new ElevenLabsClient({
-        apiBaseUrl: elevenLabsConfig.apiBaseUrl,
-        apiKey: elevenLabsConfig.apiKey,
-        timeoutMs: elevenLabsConfig.registerCallTimeoutMs,
-      });
-
-      const result = await client.registerCall({
-        agent_id: elevenLabsConfig.agentId,
-        from_number: formBody.get('From') || session.fromNumber,
-        to_number: formBody.get('To') || session.toNumber,
-        direction: 'outbound',
-        conversation_initiation_client_data: {
-          dynamic_variables: {
-            task: session.task,
-            call_session_id: session.id,
-            conversation_id: session.conversationId,
-          },
-        },
-      });
-
-      log.info({ callSessionId }, 'ElevenLabs register-call succeeded');
-      return new Response(result.twiml, {
-        status: 200,
-        headers: { 'Content-Type': 'text/xml' },
-      });
-    } catch (err) {
-      log.error({ err, callSessionId }, 'ElevenLabs register-call failed');
-      if (profile.fallbackToStandardOnError) {
-        log.warn({ callSessionId }, 'Falling back to twilio_standard mode');
-        const standardProfile = resolveVoiceQualityProfile({ ...loadConfig(), calls: { ...loadConfig().calls, voice: { ...loadConfig().calls.voice, mode: 'twilio_standard' } } });
-        const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, standardProfile);
-        return new Response(twiml, { status: 200, headers: { 'Content-Type': 'text/xml' } });
-      }
-      return new Response('ElevenLabs service unavailable', { status: 502 });
-    }
-  }
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -197,13 +197,8 @@ By default, `calls.voice.fallbackToStandardOnError` is `true`. This setting cont
 
 #### `elevenlabs_agent` mode guard (consultation bridging unsupported)
 
-- **`true` (default):** The `elevenlabs_agent` mode is silently downgraded to standard ConversationRelay TwiML with a warning log. The call proceeds normally with standard Twilio TTS.
-- **`false`:** The voice webhook returns **HTTP 501** with the message: `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`.
-
-#### ElevenLabs API errors (register-call failure)
-
-- **`true` (default):** Falls back to `twilio_standard` mode and proceeds with the call.
-- **`false`:** Returns **HTTP 502** `"ElevenLabs service unavailable"`.
+- **`true` (default):** The `elevenlabs_agent` mode is silently downgraded to standard ConversationRelay TwiML with a warning log. The call proceeds normally with standard Twilio TTS. No ElevenLabs API calls are made.
+- **`false`:** The voice webhook returns **HTTP 501** with the message: `"elevenlabs_agent mode is restricted: consultation bridging (waiting_on_user) is not yet supported."`. No ElevenLabs API calls are made.
 
 You can disable fallback if you want strict ElevenLabs-only behavior:
 


### PR DESCRIPTION
## Summary
- Remove the unreachable `elevenlabs_agent` register-call branch from `handleVoiceWebhook` (guard blocks the mode before any ElevenLabs API calls are made, so the branch was dead code)
- Remove gateway-only HTTP server tests from `twilio-routes.test.ts` that caused intermittent EADDRINUSE failures (coverage is maintained in the dedicated `gateway-only-enforcement.test.ts` suite)
- Add explicit test asserting guarded `elevenlabs_agent` mode does not attempt ElevenLabs register-call
- Update SKILL.md and ARCHITECTURE.md to remove stale 502 register-call error claims and clarify that no ElevenLabs API calls are made while the guard is active

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/calls-elevenlabs-final-alignment-one-pr-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
