### PR TITLE
M3: Strategy router for command execution

### DIFF
--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -1,0 +1,251 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mocks (must be declared before importing the module under test) ---
+
+let mockStrategy: string | undefined = undefined;
+let mockOauthAvailable = false;
+let mockOauthPostResult: { tweetId: string; text: string; url?: string } | null = null;
+let mockOauthPostError: Error | null = null;
+let mockBrowserPostResult: { tweetId: string; text: string; url: string } | null = null;
+let mockBrowserPostError: Error | null = null;
+
+// Mock the config loader to return a controllable strategy
+mock.module('../config/loader.js', () => ({
+  loadRawConfig: () => {
+    if (mockStrategy !== undefined) {
+      return { twitterOperationStrategy: mockStrategy };
+    }
+    return {};
+  },
+  loadConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+}));
+
+// Mock the OAuth client
+mock.module('../twitter/oauth-client.js', () => ({
+  oauthIsAvailable: () => mockOauthAvailable,
+  oauthSupportsOperation: (op: string) => op === 'post' || op === 'reply',
+  oauthPostTweet: async (_text: string, _opts?: { inReplyToTweetId?: string }) => {
+    if (mockOauthPostError) throw mockOauthPostError;
+    if (mockOauthPostResult) return mockOauthPostResult;
+    throw new Error('OAuth mock not configured');
+  },
+  UnsupportedOAuthOperationError: class UnsupportedOAuthOperationError extends Error {
+    public readonly suggestFallback = true;
+    public readonly fallbackPath = 'browser' as const;
+    public readonly operation: string;
+    constructor(operation: string) {
+      super(`The "${operation}" operation is not available via the OAuth API.`);
+      this.name = 'UnsupportedOAuthOperationError';
+      this.operation = operation;
+    }
+  },
+}));
+
+// Create a SessionExpiredError class that matches the real one
+class MockSessionExpiredError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+// Mock the browser client
+mock.module('../twitter/client.js', () => ({
+  postTweet: async (_text: string, _opts?: { inReplyToTweetId?: string }) => {
+    if (mockBrowserPostError) throw mockBrowserPostError;
+    if (mockBrowserPostResult) return mockBrowserPostResult;
+    throw new Error('Browser mock not configured');
+  },
+  SessionExpiredError: MockSessionExpiredError,
+}));
+
+// Mock the logger to silence output
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { routedPostTweet } from '../twitter/router.js';
+
+beforeEach(() => {
+  mockStrategy = undefined;
+  mockOauthAvailable = false;
+  mockOauthPostResult = null;
+  mockOauthPostError = null;
+  mockBrowserPostResult = null;
+  mockBrowserPostError = null;
+});
+
+describe('Twitter strategy router', () => {
+  describe('auto strategy', () => {
+    test('uses OAuth when available and supported', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '111', text: 'hello', url: 'https://x.com/u/status/111' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('111');
+      expect(result.text).toBe('hello');
+      expect(result.url).toBe('https://x.com/u/status/111');
+    });
+
+    test('falls back to browser when OAuth is unavailable', async () => {
+      mockOauthAvailable = false;
+      mockBrowserPostResult = { tweetId: '222', text: 'hello', url: 'https://x.com/u/status/222' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('222');
+    });
+
+    test('falls back to browser when OAuth fails', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostError = new Error('OAuth token expired');
+      mockBrowserPostResult = { tweetId: '333', text: 'hello', url: 'https://x.com/u/status/333' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('333');
+    });
+
+    test('constructs URL from tweetId when OAuth result has no url', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '444', text: 'no url' };
+
+      const { result, pathUsed } = await routedPostTweet('no url');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.url).toBe('https://x.com/i/status/444');
+    });
+
+    test('throws combined error when both OAuth and browser fail with SessionExpiredError', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostError = new Error('OAuth failed');
+      mockBrowserPostError = new MockSessionExpiredError('Browser session expired');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain('Browser session expired and OAuth was already tried');
+        expect(e.pathUsed).toBe('auto');
+      }
+    });
+  });
+
+  describe('explicit oauth strategy', () => {
+    test('fails with helpful error when OAuth is not configured', async () => {
+      mockStrategy = 'oauth';
+      mockOauthAvailable = false;
+
+      try {
+        await routedPostTweet('hello');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string; suggestAlternative: string };
+        expect(e.message).toContain('OAuth is not configured');
+        expect(e.message).toContain('vellum x strategy set browser');
+        expect(e.pathUsed).toBe('oauth');
+        expect(e.suggestAlternative).toBe('browser');
+      }
+    });
+
+    test('uses OAuth when available', async () => {
+      mockStrategy = 'oauth';
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '555', text: 'oauth post' };
+
+      const { result, pathUsed } = await routedPostTweet('oauth post');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('555');
+    });
+  });
+
+  describe('explicit browser strategy', () => {
+    test('uses browser directly, ignoring OAuth availability', async () => {
+      mockStrategy = 'browser';
+      mockOauthAvailable = true; // available but should be ignored
+      mockBrowserPostResult = { tweetId: '666', text: 'browser post', url: 'https://x.com/u/status/666' };
+
+      const { result, pathUsed } = await routedPostTweet('browser post');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('666');
+    });
+
+    test('provides OAuth hint on SessionExpiredError', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostError = new MockSessionExpiredError('Session expired');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string; suggestAlternative: string };
+        expect(e.message).toContain('Browser session expired');
+        expect(e.message).toContain('vellum x refresh');
+        expect(e.message).toContain('vellum x strategy set oauth');
+        expect(e.pathUsed).toBe('browser');
+        expect(e.suggestAlternative).toBe('oauth');
+      }
+    });
+
+    test('re-throws non-session errors without wrapping', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostError = new Error('Network failure');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect((err as Error).message).toBe('Network failure');
+      }
+    });
+  });
+
+  describe('reply routing', () => {
+    test('auto strategy routes reply through OAuth when available', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '777', text: 'reply text', url: 'https://x.com/u/status/777' };
+
+      const { result, pathUsed } = await routedPostTweet('reply text', { inReplyToTweetId: '100' });
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('777');
+    });
+
+    test('browser strategy routes reply through browser', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostResult = { tweetId: '888', text: 'reply text', url: 'https://x.com/u/status/888' };
+
+      const { result, pathUsed } = await routedPostTweet('reply text', { inReplyToTweetId: '200' });
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('888');
+    });
+  });
+});

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -13,7 +13,6 @@ import {
   clearSession,
 } from '../twitter/session.js';
 import {
-  postTweet,
   getUserByScreenName,
   getUserTweets,
   getTweetDetail,
@@ -27,6 +26,7 @@ import {
   getUserMedia,
   SessionExpiredError,
 } from '../twitter/client.js';
+import { routedPostTweet } from '../twitter/router.js';
 import { getSocketPath, readSessionToken } from '../util/platform.js';
 import {
   serialize,
@@ -270,11 +270,12 @@ export function registerTwitterCommand(program: Command): void {
     .argument('<text>', 'Tweet text')
     .action(async (text: string, _opts: unknown, cmd: Command) => {
       await run(cmd, async () => {
-        const result = await postTweet(text);
+        const { result, pathUsed } = await routedPostTweet(text);
         return {
           tweetId: result.tweetId,
           text: result.text,
           url: result.url,
+          pathUsed,
         };
       });
     });
@@ -294,12 +295,13 @@ export function registerTwitterCommand(program: Command): void {
           throw new Error(`Could not extract tweet ID from: ${tweetUrl}`);
         }
         const inReplyToTweetId = idMatch[1];
-        const result = await postTweet(text, { inReplyToTweetId });
+        const { result, pathUsed } = await routedPostTweet(text, { inReplyToTweetId });
         return {
           tweetId: result.tweetId,
           text: result.text,
           url: result.url,
           inReplyToTweetId,
+          pathUsed,
         };
       });
     });

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -1,0 +1,91 @@
+/**
+ * Strategy router for Twitter operations.
+ * Selects OAuth or browser path based on persisted preference and capability.
+ */
+
+import { loadRawConfig } from '../config/loader.js';
+import { oauthPostTweet, oauthIsAvailable, oauthSupportsOperation } from './oauth-client.js';
+import { postTweet as browserPostTweet, SessionExpiredError } from './client.js';
+import type { PostTweetResult } from './client.js';
+
+export type TwitterStrategy = 'oauth' | 'browser' | 'auto';
+
+export interface RoutedResult<T> {
+  result: T;
+  pathUsed: TwitterStrategy;
+}
+
+export interface RoutedError {
+  message: string;
+  pathUsed: TwitterStrategy;
+  suggestAlternative?: TwitterStrategy;
+  alternativeSetupHint?: string;
+}
+
+function getPreferredStrategy(): TwitterStrategy {
+  try {
+    const raw = loadRawConfig();
+    const strategy = raw.twitterOperationStrategy as string | undefined;
+    if (strategy === 'oauth' || strategy === 'browser') return strategy;
+  } catch { /* fall through */ }
+  return 'auto';
+}
+
+export async function routedPostTweet(
+  text: string,
+  opts?: { inReplyToTweetId?: string },
+): Promise<RoutedResult<PostTweetResult>> {
+  const strategy = getPreferredStrategy();
+  const operation = opts?.inReplyToTweetId ? 'reply' : 'post';
+
+  if (strategy === 'oauth') {
+    // User explicitly wants OAuth
+    if (!oauthIsAvailable()) {
+      throw Object.assign(new Error('OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy: `vellum x strategy set browser`.'), {
+        pathUsed: 'oauth' as const,
+        suggestAlternative: 'browser' as const,
+      });
+    }
+    const result = await oauthPostTweet(text, opts);
+    return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
+  }
+
+  if (strategy === 'browser') {
+    // User explicitly wants browser
+    try {
+      const result = await browserPostTweet(text, opts);
+      return { result, pathUsed: 'browser' };
+    } catch (err) {
+      if (err instanceof SessionExpiredError) {
+        throw Object.assign(new Error(`Browser session expired. Refresh with \`vellum x refresh\`, or switch to OAuth: \`vellum x strategy set oauth\`.`), {
+          pathUsed: 'browser' as const,
+          suggestAlternative: 'oauth' as const,
+        });
+      }
+      throw err;
+    }
+  }
+
+  // auto strategy: try OAuth first if available and supported, fallback to browser
+  if (oauthIsAvailable() && oauthSupportsOperation(operation)) {
+    try {
+      const result = await oauthPostTweet(text, opts);
+      return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
+    } catch {
+      // OAuth failed, fall through to browser
+    }
+  }
+
+  // Fallback to browser
+  try {
+    const result = await browserPostTweet(text, opts);
+    return { result, pathUsed: 'browser' };
+  } catch (err) {
+    if (err instanceof SessionExpiredError && oauthIsAvailable()) {
+      throw Object.assign(new Error(`Browser session expired and OAuth was already tried. Refresh browser session with \`vellum x refresh\` or check OAuth credentials.`), {
+        pathUsed: 'auto' as const,
+      });
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Part of #6232. Creates assistant/src/twitter/router.ts with strategy-aware routing for post/reply operations. Wires router into CLI post and reply commands. Adds tests for auto/oauth/browser strategy selection and fallback behavior. Closes #6235.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
