### PR TITLE
Calls Caller Identity: Assistant Default + User Number Option

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3679,6 +3679,19 @@ Call behavior is controlled via the `calls` config block in the assistant config
 | `calls.voice.elevenlabs.voiceId` | string | `''` | ElevenLabs voice ID, used by `twilio_elevenlabs_tts` mode. |
 | `calls.voice.elevenlabs.agentId` | string | `''` | ElevenLabs agent ID, used by `elevenlabs_agent` mode. |
 
+### Caller Identity Resolution
+
+When a call is initiated, the system resolves the caller identity (which phone number to show as the caller ID). By default, the assistant's Twilio number is used (`assistant_number` mode). Users can opt into `user_number` mode, which uses their own verified phone number. The identity mode is validated against Twilio's eligible caller IDs before the call is placed. The resolved identity mode and source are persisted in the `call_sessions` table for auditability.
+
+The resolution is performed by `resolveCallerIdentity()` in `call-domain.ts`:
+
+1. **Per-call override** — If `callerIdentityMode` is provided in the call input and `calls.callerIdentity.allowPerCallOverride` is enabled, the requested mode is used (source: `per_call_override`).
+2. **Config default** — Otherwise, the configured `calls.callerIdentity.defaultMode` is used (source: `config_default`).
+3. **User number lookup** — For `user_number` mode, the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`), `TWILIO_USER_PHONE_NUMBER` environment variable (source: `env_var`), or the `credential:twilio:user_phone_number` secure key (source: `secure_key`).
+4. **Eligibility check** — User numbers are verified against the Twilio API to confirm they can be used as an outbound caller ID.
+
+Both the resolved mode and source are logged at info level on success, and rejections are logged at warn level.
+
 ### Voice Quality Profile Resolution
 
 Voice and TTS settings are configurable via the `calls.voice` config block — they are not hardcoded. The function `resolveVoiceQualityProfile()` in `voice-quality.ts` reads the current config and resolves it into an effective `VoiceQualityProfile` containing the TTS provider, voice spec string, language, transcription provider, and fallback policy.

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -31,6 +31,19 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+const mockCallsConfig = {
+  enabled: true,
+  provider: 'twilio',
+  maxDurationSeconds: 3600,
+  userConsultTimeoutSeconds: 120,
+  disclosure: { enabled: false, text: '' },
+  safety: { denyCategories: [] },
+  callerIdentity: {
+    defaultMode: 'assistant_number' as const,
+    allowPerCallOverride: true,
+  },
+};
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     model: 'test',
@@ -39,13 +52,19 @@ mock.module('../config/loader.js', () => ({
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
-    calls: {
+    calls: mockCallsConfig,
+  }),
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    calls: mockCallsConfig,
+    ingress: {
       enabled: true,
-      provider: 'twilio',
-      maxDurationSeconds: 3600,
-      userConsultTimeoutSeconds: 120,
-      disclosure: { enabled: false, text: '' },
-      safety: { denyCategories: [] },
+      publicBaseUrl: 'https://test.example.com',
     },
   }),
 }));
@@ -237,6 +256,63 @@ describe('runtime call routes — HTTP layer', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Invalid JSON');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start with callerIdentityMode user_number is accepted', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-1');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-1',
+        callerIdentityMode: 'user_number',
+      }),
+    });
+
+    // user_number mode requires a configured user phone number;
+    // since we haven't set one, this should return a 400 explaining why
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('user_number');
+
+    await stopServer();
+  });
+
+  test('POST /v1/calls/start without callerIdentityMode defaults to assistant_number', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-2');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-2',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+
+    const body = await res.json() as {
+      callSessionId: string;
+      callSid: string;
+      status: string;
+      toNumber: string;
+      fromNumber: string;
+      callerIdentityMode: string;
+    };
+
+    expect(body.callSessionId).toBeDefined();
+    expect(body.callSid).toBe('CA_mock_sid_123');
+    expect(body.fromNumber).toBe('+15550001111');
+    expect(body.callerIdentityMode).toBe('assistant_number');
 
     await stopServer();
   });

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -317,6 +317,31 @@ describe('runtime call routes — HTTP layer', () => {
     await stopServer();
   });
 
+  test('POST /v1/calls/start returns 400 for invalid callerIdentityMode', async () => {
+    await startServer();
+    ensureConversation('conv-start-identity-bogus');
+
+    const res = await fetch(callsUrl('/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({
+        phoneNumber: '+15559998888',
+        task: 'Book a table for two',
+        conversationId: 'conv-start-identity-bogus',
+        callerIdentityMode: 'bogus',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid callerIdentityMode');
+    expect(body.error).toContain('bogus');
+    expect(body.error).toContain('assistant_number');
+    expect(body.error).toContain('user_number');
+
+    await stopServer();
+  });
+
   // ── GET /v1/calls/:id ───────────────────────────────────────────────
 
   test('GET /v1/calls/:id returns call status', async () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -673,6 +673,10 @@ describe('AssistantConfigSchema', () => {
           registerCallTimeoutMs: 5000,
         },
       },
+      callerIdentity: {
+        defaultMode: 'assistant_number',
+        allowPerCallOverride: true,
+      },
     });
   });
 
@@ -862,6 +866,68 @@ describe('AssistantConfigSchema', () => {
   test('calls.model is undefined by default', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.calls.model).toBeUndefined();
+  });
+
+  // ── Caller identity config ────────────────────────────────────────
+
+  test('applies calls.callerIdentity defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.calls.callerIdentity).toEqual({
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    });
+  });
+
+  test('accepts valid calls.callerIdentity overrides', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: {
+        callerIdentity: {
+          defaultMode: 'user_number',
+          allowPerCallOverride: false,
+          userNumber: '+14155559999',
+        },
+      },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(false);
+    expect(result.calls.callerIdentity.userNumber).toBe('+14155559999');
+  });
+
+  test('accepts partial calls.callerIdentity with defaults for missing fields', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: {
+        callerIdentity: { defaultMode: 'user_number' },
+      },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
+    expect(result.calls.callerIdentity.userNumber).toBeUndefined();
+  });
+
+  test('rejects invalid calls.callerIdentity.defaultMode', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { callerIdentity: { defaultMode: 'custom_number' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('calls.callerIdentity.defaultMode'))).toBe(true);
+    }
+  });
+
+  test('rejects non-boolean calls.callerIdentity.allowPerCallOverride', () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { callerIdentity: { allowPerCallOverride: 'yes' } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('default behavior unchanged when callerIdentity omitted', () => {
+    const result = AssistantConfigSchema.parse({
+      calls: { enabled: true },
+    });
+    expect(result.calls.callerIdentity.defaultMode).toBe('assistant_number');
+    expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
   });
 });
 
@@ -1272,6 +1338,10 @@ describe('loadConfig with schema validation', () => {
     expect(config.calls.voice.transcriptionProvider).toBe('Deepgram');
     expect(config.calls.voice.elevenlabs.voiceId).toBe('');
     expect(config.calls.model).toBeUndefined();
+    expect(config.calls.callerIdentity).toEqual({
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    });
   });
 });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -185,6 +185,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'email/providers/index.ts',      // email provider API key lookup
       'tools/network/script-proxy/session-manager.ts', // proxy credential injection at runtime
       'messaging/registry.ts',          // checks stored credentials for connected providers
+      'calls/call-domain.ts',            // caller identity resolution (user phone number lookup)
       'calls/twilio-config.ts',         // call infrastructure credential lookup
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
       'runtime/http-server.ts',         // HTTP server credential lookup

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -186,8 +186,10 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'tools/network/script-proxy/session-manager.ts', // proxy credential injection at runtime
       'messaging/registry.ts',          // checks stored credentials for connected providers
       'calls/call-domain.ts',            // caller identity resolution (user phone number lookup)
+      'calls/elevenlabs-config.ts',     // ElevenLabs voice quality API key lookup
       'calls/twilio-config.ts',         // call infrastructure credential lookup
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
+      'cli/config-commands.ts',         // CLI credential management commands
       'runtime/http-server.ts',         // HTTP server credential lookup
       'daemon/handlers/twitter-auth.ts', // Twitter OAuth token storage
       'messaging/providers/telegram-bot/adapter.ts', // Telegram bot token lookup for connectivity check

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for TwilioConversationRelayProvider — signature validation and
- * fail-closed auth token behavior.
+ * Tests for TwilioConversationRelayProvider — signature validation,
+ * fail-closed auth token behavior, and caller ID eligibility checks.
  */
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { createHmac } from 'node:crypto';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -174,6 +174,115 @@ describe('TwilioConversationRelayProvider', () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+  });
+
+  describe('checkCallerIdEligibility', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test('returns eligible when number is found in IncomingPhoneNumbers', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({
+              incoming_phone_numbers: [{ sid: 'PN_test', phone_number: '+15550001111' }],
+            }),
+            { status: 200 },
+          );
+        }
+        // Should not reach OutgoingCallerIds since IncomingPhoneNumbers matched
+        return new Response(JSON.stringify({ outgoing_caller_ids: [] }), { status: 200 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    test('returns eligible when number is found in OutgoingCallerIds', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [] }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({
+              outgoing_caller_ids: [{ sid: 'PNverified', phone_number: '+15550001111' }],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    test('returns ineligible when number is not found in either endpoint', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [] }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({ outgoing_caller_ids: [] }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15559999999');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('not owned by or verified');
+      expect(result.reason).toContain('Twilio Console');
+    });
+
+    test('passes correct phone number as query parameter', async () => {
+      const provider = new TwilioConversationRelayProvider();
+      const capturedUrls: string[] = [];
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        capturedUrls.push(String(url));
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response(
+            JSON.stringify({ incoming_phone_numbers: [{ sid: 'PN1' }] }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ outgoing_caller_ids: [] }), { status: 200 });
+      }) as typeof fetch;
+
+      await provider.checkCallerIdEligibility('+15550001111');
+
+      expect(capturedUrls[0]).toContain('PhoneNumber=%2B15550001111');
+      expect(capturedUrls[0]).toContain('/IncomingPhoneNumbers.json');
     });
   });
 });

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -263,6 +263,47 @@ describe('TwilioConversationRelayProvider', () => {
       expect(result.reason).toContain('Twilio Console');
     });
 
+    test('throws when both API calls return non-ok responses', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      await expect(provider.checkCallerIdEligibility('+15550001111')).rejects.toThrow(
+        'Unable to verify caller ID eligibility',
+      );
+    });
+
+    test('returns ineligible (not throws) when only one API call fails but the other succeeds with no match', async () => {
+      const provider = new TwilioConversationRelayProvider();
+
+      globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
+        const urlStr = String(url);
+        if (urlStr.includes('/IncomingPhoneNumbers.json')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        if (urlStr.includes('/OutgoingCallerIds.json')) {
+          return new Response(
+            JSON.stringify({ outgoing_caller_ids: [] }),
+            { status: 200 },
+          );
+        }
+        return new Response('Not found', { status: 404 });
+      }) as typeof fetch;
+
+      const result = await provider.checkCallerIdEligibility('+15550001111');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('not owned by or verified');
+    });
+
     test('passes correct phone number as query parameter', async () => {
       const provider = new TwilioConversationRelayProvider();
       const capturedUrls: string[] = [];

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -282,7 +282,7 @@ describe('TwilioConversationRelayProvider', () => {
       );
     });
 
-    test('returns ineligible (not throws) when only one API call fails but the other succeeds with no match', async () => {
+    test('throws when only one API call fails but the other succeeds with no match', async () => {
       const provider = new TwilioConversationRelayProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
@@ -299,9 +299,9 @@ describe('TwilioConversationRelayProvider', () => {
         return new Response('Not found', { status: 404 });
       }) as typeof fetch;
 
-      const result = await provider.checkCallerIdEligibility('+15550001111');
-      expect(result.eligible).toBe(false);
-      expect(result.reason).toContain('not owned by or verified');
+      await expect(provider.checkCallerIdEligibility('+15550001111')).rejects.toThrow(
+        'Unable to verify caller ID eligibility',
+      );
     });
 
     test('passes correct phone number as query parameter', async () => {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -22,7 +22,9 @@ import { TwilioConversationRelayProvider } from './twilio-provider.js';
 import { getTwilioConfig } from './twilio-config.js';
 import { getTwilioVoiceWebhookUrl, getTwilioStatusCallbackUrl } from '../inbound/public-ingress-urls.js';
 import { loadConfig } from '../config/loader.js';
+import { getSecureKey } from '../security/secure-keys.js';
 import type { CallSession } from './types.js';
+import type { AssistantConfig } from '../config/types.js';
 
 const log = getLogger('call-domain');
 
@@ -47,6 +49,7 @@ export type StartCallInput = {
   task: string;
   context?: string;
   conversationId: string;
+  callerIdentityMode?: 'assistant_number' | 'user_number';
 };
 
 export type CancelCallInput = {
@@ -59,13 +62,68 @@ export type AnswerCallInput = {
   answer: string;
 };
 
+// ── Caller identity resolution ───────────────────────────────────────
+
+export type CallerIdentityResult =
+  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve which phone number to use as the caller ID for an outbound call.
+ *
+ * - If `requestedMode` is provided and per-call overrides are allowed, use it.
+ * - If `requestedMode` is provided but overrides are disabled, return an error.
+ * - Otherwise fall through to the configured default mode.
+ *
+ * For `assistant_number`: uses the Twilio phone number from `getTwilioConfig()`.
+ * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
+ * secure key `credential:twilio:user_phone_number`.
+ */
+export function resolveCallerIdentity(
+  config: AssistantConfig,
+  requestedMode?: 'assistant_number' | 'user_number',
+): CallerIdentityResult {
+  const identityConfig = config.calls.callerIdentity;
+  let mode: 'assistant_number' | 'user_number';
+
+  if (requestedMode != null) {
+    if (!identityConfig.allowPerCallOverride) {
+      return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };
+    }
+    mode = requestedMode;
+  } else {
+    mode = identityConfig.defaultMode;
+  }
+
+  if (mode === 'assistant_number') {
+    const twilioConfig = getTwilioConfig();
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber };
+  }
+
+  // user_number mode: resolve from config or secure key
+  const userNumber =
+    identityConfig.userNumber ||
+    process.env.TWILIO_USER_PHONE_NUMBER ||
+    getSecureKey('credential:twilio:user_phone_number') ||
+    '';
+
+  if (!userNumber) {
+    return {
+      ok: false,
+      error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
+    };
+  }
+
+  return { ok: true, mode, fromNumber: userNumber };
+}
+
 // ── Domain operations ────────────────────────────────────────────────
 
 /**
  * Initiate a new outbound call.
  */
 export async function startCall(input: StartCallInput): Promise<StartCallResult | CallError> {
-  const { phoneNumber, task, context: callContext, conversationId } = input;
+  const { phoneNumber, task, context: callContext, conversationId, callerIdentityMode } = input;
 
   if (!phoneNumber || typeof phoneNumber !== 'string') {
     return { ok: false, error: 'phone_number is required and must be a string', status: 400 };
@@ -90,23 +148,29 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
   let sessionId: string | null = null;
 
   try {
-    const twilioConfig = getTwilioConfig();
     const ingressConfig = loadConfig();
     const provider = new TwilioConversationRelayProvider();
+
+    // Resolve which phone number to use as caller ID
+    const identityResult = resolveCallerIdentity(ingressConfig, callerIdentityMode);
+    if (!identityResult.ok) {
+      return { ok: false, error: identityResult.error, status: 400 };
+    }
+    const fromNumber = identityResult.fromNumber;
 
     const session = createCallSession({
       conversationId,
       provider: 'twilio',
-      fromNumber: twilioConfig.phoneNumber,
+      fromNumber,
       toNumber: phoneNumber,
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
     });
     sessionId = session.id;
 
-    log.info({ callSessionId: session.id, to: phoneNumber, task }, 'Initiating outbound call');
+    log.info({ callSessionId: session.id, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
 
     const { callSid } = await provider.initiateCall({
-      from: twilioConfig.phoneNumber,
+      from: fromNumber,
       to: phoneNumber,
       webhookUrl: getTwilioVoiceWebhookUrl(ingressConfig, session.id),
       statusCallbackUrl: getTwilioStatusCallbackUrl(ingressConfig),

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -110,8 +110,8 @@ export async function resolveCallerIdentity(
 
   if (mode === 'assistant_number') {
     const twilioConfig = getTwilioConfig();
-    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
-    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
+    log.info({ mode, source: 'twilio_config', fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source: 'twilio_config' };
   }
 
   // user_number mode: resolve from config or secure key, tracking where the number came from

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -65,8 +65,10 @@ export type AnswerCallInput = {
 
 // ── Caller identity resolution ───────────────────────────────────────
 
+export type CallerIdentitySource = 'per_call_override' | 'config_default' | 'twilio_config' | 'user_config' | 'secure_key' | 'env_var';
+
 export type CallerIdentityResult =
-  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string }
+  | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string; source: CallerIdentitySource }
   | { ok: false; error: string };
 
 /**
@@ -88,29 +90,46 @@ export async function resolveCallerIdentity(
 ): Promise<CallerIdentityResult> {
   const identityConfig = config.calls.callerIdentity;
   let mode: 'assistant_number' | 'user_number';
+  let source: CallerIdentitySource;
 
   if (requestedMode != null) {
     if (!identityConfig.allowPerCallOverride) {
+      log.warn({ requestedMode }, 'Caller identity override rejected — per-call override is disabled in configuration');
       return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };
     }
     mode = requestedMode;
+    source = 'per_call_override';
   } else {
     mode = identityConfig.defaultMode;
+    source = 'config_default';
   }
 
   if (mode === 'assistant_number') {
     const twilioConfig = getTwilioConfig();
-    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber };
+    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
   }
 
-  // user_number mode: resolve from config or secure key
-  const userNumber =
-    identityConfig.userNumber ||
-    process.env.TWILIO_USER_PHONE_NUMBER ||
-    getSecureKey('credential:twilio:user_phone_number') ||
-    '';
+  // user_number mode: resolve from config or secure key, tracking where the number came from
+  let userNumber = '';
+  let numberSource: CallerIdentitySource = source;
+
+  if (identityConfig.userNumber) {
+    userNumber = identityConfig.userNumber;
+    numberSource = source === 'per_call_override' ? source : 'user_config';
+  } else if (process.env.TWILIO_USER_PHONE_NUMBER) {
+    userNumber = process.env.TWILIO_USER_PHONE_NUMBER;
+    numberSource = source === 'per_call_override' ? source : 'env_var';
+  } else {
+    const secureKeyValue = getSecureKey('credential:twilio:user_phone_number');
+    if (secureKeyValue) {
+      userNumber = secureKeyValue;
+      numberSource = source === 'per_call_override' ? source : 'secure_key';
+    }
+  }
 
   if (!userNumber) {
+    log.warn({ mode, source }, 'Caller identity resolution failed — no user phone number configured');
     return {
       ok: false,
       error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
@@ -121,10 +140,12 @@ export async function resolveCallerIdentity(
   const provider = new TwilioConversationRelayProvider();
   const eligibility = await provider.checkCallerIdEligibility(userNumber);
   if (!eligibility.eligible) {
+    log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };
   }
 
-  return { ok: true, mode, fromNumber: userNumber };
+  log.info({ mode, source: numberSource, fromNumber: userNumber }, 'Resolved caller identity');
+  return { ok: true, mode, fromNumber: userNumber, source: numberSource };
 }
 
 // ── Domain operations ────────────────────────────────────────────────
@@ -174,6 +195,8 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       fromNumber,
       toNumber: phoneNumber,
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
+      callerIdentityMode: identityResult.mode,
+      callerIdentitySource: identityResult.source,
     });
     sessionId = session.id;
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -36,6 +36,7 @@ export interface StartCallResult {
   ok: true;
   session: CallSession;
   callSid: string;
+  callerIdentityMode: 'assistant_number' | 'user_number';
 }
 
 export interface CallError {
@@ -193,6 +194,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       ok: true,
       session: { ...session, providerCallSid: callSid },
       callSid,
+      callerIdentityMode: identityResult.mode,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -150,14 +150,7 @@ export async function resolveCallerIdentity(
 
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
-  let eligibility: { eligible: boolean; reason?: string };
-  try {
-    eligibility = await provider.checkCallerIdEligibility(userNumber);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ mode, source: numberSource, userNumber, err }, 'Caller ID eligibility check encountered an API error');
-    return { ok: false, error: msg };
-  }
+  const eligibility = await provider.checkCallerIdEligibility(userNumber);
   if (!eligibility.eligible) {
     log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -138,7 +138,14 @@ export async function resolveCallerIdentity(
 
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
-  const eligibility = await provider.checkCallerIdEligibility(userNumber);
+  let eligibility: { eligible: boolean; reason?: string };
+  try {
+    eligibility = await provider.checkCallerIdEligibility(userNumber);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ mode, source: numberSource, userNumber, err }, 'Caller ID eligibility check encountered an API error');
+    return { ok: false, error: msg };
+  }
   if (!eligibility.eligible) {
     log.warn({ mode, source: numberSource, userNumber, reason: eligibility.reason }, 'Caller ID eligibility check failed');
     return { ok: false, error: eligibility.reason! };

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -140,6 +140,14 @@ export async function resolveCallerIdentity(
     };
   }
 
+  if (!E164_REGEX.test(userNumber)) {
+    log.warn({ mode, source: numberSource, userNumber }, 'User phone number is not in E.164 format');
+    return {
+      ok: false,
+      error: `User phone number "${userNumber}" is not in E.164 format (must start with + followed by digits, e.g. +14155551234). Check calls.callerIdentity.userNumber in config or credential:twilio:user_phone_number.`,
+    };
+  }
+
   // Verify the user number is eligible as a caller ID with Twilio
   const provider = new TwilioConversationRelayProvider();
   let eligibility: { eligible: boolean; reason?: string };

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -120,15 +120,15 @@ export async function resolveCallerIdentity(
 
   if (identityConfig.userNumber) {
     userNumber = identityConfig.userNumber;
-    numberSource = source === 'per_call_override' ? source : 'user_config';
+    numberSource = 'user_config';
   } else if (process.env.TWILIO_USER_PHONE_NUMBER) {
     userNumber = process.env.TWILIO_USER_PHONE_NUMBER;
-    numberSource = source === 'per_call_override' ? source : 'env_var';
+    numberSource = 'env_var';
   } else {
     const secureKeyValue = getSecureKey('credential:twilio:user_phone_number');
     if (secureKeyValue) {
       userNumber = secureKeyValue;
-      numberSource = source === 'per_call_override' ? source : 'secure_key';
+      numberSource = 'secure_key';
     }
   }
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -76,13 +76,15 @@ export type CallerIdentityResult =
  * - Otherwise fall through to the configured default mode.
  *
  * For `assistant_number`: uses the Twilio phone number from `getTwilioConfig()`.
+ *   No eligibility check is performed — this is a fast path.
  * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
- * secure key `credential:twilio:user_phone_number`.
+ *   secure key `credential:twilio:user_phone_number`, then validates that the
+ *   number is usable as an outbound caller ID via the Twilio API.
  */
-export function resolveCallerIdentity(
+export async function resolveCallerIdentity(
   config: AssistantConfig,
   requestedMode?: 'assistant_number' | 'user_number',
-): CallerIdentityResult {
+): Promise<CallerIdentityResult> {
   const identityConfig = config.calls.callerIdentity;
   let mode: 'assistant_number' | 'user_number';
 
@@ -112,6 +114,13 @@ export function resolveCallerIdentity(
       ok: false,
       error: 'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.',
     };
+  }
+
+  // Verify the user number is eligible as a caller ID with Twilio
+  const provider = new TwilioConversationRelayProvider();
+  const eligibility = await provider.checkCallerIdEligibility(userNumber);
+  if (!eligibility.eligible) {
+    return { ok: false, error: eligibility.reason! };
   }
 
   return { ok: true, mode, fromNumber: userNumber };
@@ -152,7 +161,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     const provider = new TwilioConversationRelayProvider();
 
     // Resolve which phone number to use as caller ID
-    const identityResult = resolveCallerIdentity(ingressConfig, callerIdentityMode);
+    const identityResult = await resolveCallerIdentity(ingressConfig, callerIdentityMode);
     if (!identityResult.ok) {
       return { ok: false, error: identityResult.error, status: 400 };
     }

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -24,6 +24,7 @@ import { getTwilioVoiceWebhookUrl, getTwilioStatusCallbackUrl } from '../inbound
 import { loadConfig } from '../config/loader.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import type { CallSession } from './types.js';
+import { VALID_CALLER_IDENTITY_MODES } from '../config/schema.js';
 import type { AssistantConfig } from '../config/types.js';
 
 const log = getLogger('call-domain');
@@ -93,6 +94,9 @@ export async function resolveCallerIdentity(
   let source: CallerIdentitySource;
 
   if (requestedMode != null) {
+    if (!(VALID_CALLER_IDENTITY_MODES as readonly string[]).includes(requestedMode)) {
+      return { ok: false, error: `Invalid callerIdentityMode: "${requestedMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}` };
+    }
     if (!identityConfig.allowPerCallOverride) {
       log.warn({ requestedMode }, 'Caller identity override rejected — per-call override is disabled in configuration');
       return { ok: false, error: 'Per-call caller identity override is disabled in configuration' };

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -20,6 +20,8 @@ function parseCallSession(row: typeof callSessions.$inferSelect): CallSession {
     toNumber: row.toNumber,
     task: row.task,
     status: row.status as CallSession['status'],
+    callerIdentityMode: row.callerIdentityMode,
+    callerIdentitySource: row.callerIdentitySource,
     startedAt: row.startedAt,
     endedAt: row.endedAt,
     lastError: row.lastError,
@@ -58,6 +60,8 @@ export function createCallSession(opts: {
   fromNumber: string;
   toNumber: string;
   task?: string;
+  callerIdentityMode?: string;
+  callerIdentitySource?: string;
 }): CallSession {
   const db = getDb();
   const now = Date.now();
@@ -70,6 +74,8 @@ export function createCallSession(opts: {
     toNumber: opts.toNumber,
     task: opts.task ?? null,
     status: 'initiated' as const,
+    callerIdentityMode: opts.callerIdentityMode ?? null,
+    callerIdentitySource: opts.callerIdentitySource ?? null,
     startedAt: null,
     endedAt: null,
     lastError: null,

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -202,11 +202,15 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       );
     }
 
-    // If neither API call succeeded, the eligibility check is inconclusive —
+    // If any API call failed, the eligibility check is inconclusive —
     // propagate as an error rather than returning a false negative.
-    if (!incomingOk && !outgoingOk) {
+    if (!incomingOk || !outgoingOk) {
+      const failedEndpoints = [
+        ...(!incomingOk ? [`IncomingPhoneNumbers: ${incomingRes.status}`] : []),
+        ...(!outgoingOk ? [`OutgoingCallerIds: ${outgoingRes.status}`] : []),
+      ].join(', ');
       throw new Error(
-        `Unable to verify caller ID eligibility for ${phoneNumber}: both Twilio API calls failed (IncomingPhoneNumbers: ${incomingRes.status}, OutgoingCallerIds: ${outgoingRes.status}). This may indicate a network issue, auth error, or Twilio outage.`,
+        `Unable to verify caller ID eligibility for ${phoneNumber}: Twilio API error (${failedEndpoints}). The number may be eligible but could not be confirmed. Please check your Twilio credentials and try again.`,
       );
     }
 

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -145,6 +145,9 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     const { accountSid, authToken } = this.getCredentials();
     const encodedNumber = encodeURIComponent(phoneNumber);
 
+    let incomingOk = false;
+    let outgoingOk = false;
+
     // Check incoming phone numbers (owned by this account)
     const incomingRes = await fetch(
       `${this.baseUrl(accountSid)}/IncomingPhoneNumbers.json?PhoneNumber=${encodedNumber}`,
@@ -157,6 +160,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     );
 
     if (incomingRes.ok) {
+      incomingOk = true;
       const incomingData = (await incomingRes.json()) as {
         incoming_phone_numbers: unknown[];
       };
@@ -183,6 +187,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     );
 
     if (outgoingRes.ok) {
+      outgoingOk = true;
       const outgoingData = (await outgoingRes.json()) as {
         outgoing_caller_ids: unknown[];
       };
@@ -194,6 +199,14 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       log.warn(
         { status: outgoingRes.status, phoneNumber },
         'Failed to query OutgoingCallerIds',
+      );
+    }
+
+    // If neither API call succeeded, the eligibility check is inconclusive —
+    // propagate as an error rather than returning a false negative.
+    if (!incomingOk && !outgoingOk) {
+      throw new Error(
+        `Unable to verify caller ID eligibility for ${phoneNumber}: both Twilio API calls failed (IncomingPhoneNumbers: ${incomingRes.status}, OutgoingCallerIds: ${outgoingRes.status}). This may indicate a network issue, auth error, or Twilio outage.`,
       );
     }
 

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -131,6 +131,80 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     return data.status;
   }
 
+  // ── Caller ID eligibility ───────────────────────────────────────────
+
+  /**
+   * Check whether a phone number can be used as an outbound caller ID
+   * by the current Twilio account. A number is eligible if it appears as
+   * either an Incoming Phone Number (owned) or an Outgoing Caller ID
+   * (verified) on the account.
+   */
+  async checkCallerIdEligibility(
+    phoneNumber: string,
+  ): Promise<{ eligible: boolean; reason?: string }> {
+    const { accountSid, authToken } = this.getCredentials();
+    const encodedNumber = encodeURIComponent(phoneNumber);
+
+    // Check incoming phone numbers (owned by this account)
+    const incomingRes = await fetch(
+      `${this.baseUrl(accountSid)}/IncomingPhoneNumbers.json?PhoneNumber=${encodedNumber}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: this.authHeader(accountSid, authToken),
+        },
+      },
+    );
+
+    if (incomingRes.ok) {
+      const incomingData = (await incomingRes.json()) as {
+        incoming_phone_numbers: unknown[];
+      };
+      if (incomingData.incoming_phone_numbers.length > 0) {
+        log.info({ phoneNumber }, 'Number found in IncomingPhoneNumbers — eligible as caller ID');
+        return { eligible: true };
+      }
+    } else {
+      log.warn(
+        { status: incomingRes.status, phoneNumber },
+        'Failed to query IncomingPhoneNumbers — falling through to OutgoingCallerIds',
+      );
+    }
+
+    // Check outgoing caller IDs (verified with this account)
+    const outgoingRes = await fetch(
+      `${this.baseUrl(accountSid)}/OutgoingCallerIds.json?PhoneNumber=${encodedNumber}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: this.authHeader(accountSid, authToken),
+        },
+      },
+    );
+
+    if (outgoingRes.ok) {
+      const outgoingData = (await outgoingRes.json()) as {
+        outgoing_caller_ids: unknown[];
+      };
+      if (outgoingData.outgoing_caller_ids.length > 0) {
+        log.info({ phoneNumber }, 'Number found in OutgoingCallerIds — eligible as caller ID');
+        return { eligible: true };
+      }
+    } else {
+      log.warn(
+        { status: outgoingRes.status, phoneNumber },
+        'Failed to query OutgoingCallerIds',
+      );
+    }
+
+    log.info({ phoneNumber }, 'Number not found in either IncomingPhoneNumbers or OutgoingCallerIds');
+    return {
+      eligible: false,
+      reason:
+        'Number is not owned by or verified with your Twilio account. To use this number as caller ID, either: (1) add it as an Incoming Phone Number, or (2) verify it as an Outgoing Caller ID in the Twilio Console.',
+    };
+  }
+
   // ── Webhook signature verification ──────────────────────────────────
 
   /**

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -11,6 +11,8 @@ export interface CallSession {
   toNumber: string;
   task: string | null;
   status: CallStatus;
+  callerIdentityMode: string | null;
+  callerIdentitySource: string | null;
   startedAt: number | null;
   endedAt: number | null;
   lastError: string | null;

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -27,7 +27,7 @@ Three voice quality modes are available:
 
 You can keep using Twilio only — no changes needed. Enabling ElevenLabs can improve naturalness and quality.
 
-The user's assistant gets its own personal phone number through Twilio.
+The user's assistant gets its own personal phone number through Twilio. By default, all outbound calls are placed from this assistant number. Optionally, users can call from their own phone number if it's authorized with the Twilio account — this is called "caller identity mode" and can be configured as a default or selected per-call.
 
 ## Step 1: Check Current Configuration
 
@@ -147,6 +147,44 @@ Suggest a test call to the user's own phone: **"Want to do a quick test call to 
 
 If they agree, ask for their personal phone number and place a test call with a simple task like "Introduce yourself and confirm the call system is working."
 
+## Caller Identity
+
+By default, calls are placed from the assistant's Twilio phone number (the one stored as `credential:twilio:phone_number`). This is the number that appears on the recipient's caller ID.
+
+### User-number mode
+
+If the user wants calls to appear as coming from their own phone number instead, they can enable **user-number mode**. The user's phone number must be either owned by or verified with the same Twilio account.
+
+**To configure a user phone number:**
+
+```
+credential_store action=set service=credential:twilio:user_phone_number value=+14155559999
+```
+
+**To set user-number mode as the default:**
+
+```bash
+vellum config set calls.callerIdentity.defaultMode user_number
+```
+
+**To use it for a single call** (without changing the default), pass `caller_identity_mode: 'user_number'` when calling `call_start` — see the Making Calls section for examples.
+
+### Configuration reference
+
+| Setting | Description | Default |
+|---|---|---|
+| `calls.callerIdentity.defaultMode` | Which number to use as caller ID: `assistant_number` or `user_number` | `assistant_number` |
+| `calls.callerIdentity.allowPerCallOverride` | Whether per-call mode selection is allowed | `true` |
+| `calls.callerIdentity.userNumber` | Optional E.164 phone number for user-number mode (alternative to storing via `credential_store`) | *(empty)* |
+
+### Reverting to assistant number
+
+To switch back to the default:
+
+```bash
+vellum config set calls.callerIdentity.defaultMode assistant_number
+```
+
 ## Optional: Higher Quality Voice with ElevenLabs
 
 ElevenLabs integration is entirely optional. The standard Twilio-only setup works unchanged — this section is only relevant if you want to improve voice quality.
@@ -223,6 +261,22 @@ call_start phone_number="+18005551234" task="Check if they have a specific produ
 ```
 call_start phone_number="+12125551234" task="Confirm the dentist appointment scheduled for next Tuesday at 2pm" context="The appointment is under the name Jane Doe, DOB 03/15/1990."
 ```
+
+### Caller identity in calls
+
+By default, calls use the assistant's Twilio number — no extra parameters needed. Only use `caller_identity_mode` when the user explicitly asks to call from their own number.
+
+**Default call (assistant number):**
+```
+call_start phone_number="+14155551234" task="Check store hours for today"
+```
+
+**Call from the user's own number:**
+```
+call_start phone_number="+14155551234" task="Check store hours for today" caller_identity_mode="user_number"
+```
+
+**Decision rule:** Default to the assistant number unless the user explicitly asks to call from their own number.
 
 ### Phone number format
 
@@ -345,6 +399,9 @@ All call-related settings can be managed via `vellum config`:
 | `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
 | `calls.disclosure.text` | The disclosure message spoken at call start | `"I should let you know that I'm an AI assistant calling on behalf of my user."` |
 | `calls.model` | Override LLM model for call orchestration | *(uses default model)* |
+| `calls.callerIdentity.defaultMode` | Default caller ID mode: `assistant_number` or `user_number` | `assistant_number` |
+| `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection | `true` |
+| `calls.callerIdentity.userNumber` | E.164 phone number for user-number mode | *(empty)* |
 | `calls.voice.mode` | Voice quality mode (`twilio_standard`, `twilio_elevenlabs_tts`, `elevenlabs_agent`) | `twilio_standard` |
 | `calls.voice.language` | Language code for TTS and transcription | `en-US` |
 | `calls.voice.transcriptionProvider` | Speech-to-text provider (`Deepgram`, `Google`) | `Deepgram` |
@@ -388,6 +445,15 @@ Run the **public-ingress** skill to set up ngrok and configure `ingress.publicBa
 ### Call connects but no audio / one-way audio
 - The ConversationRelay WebSocket may not be connecting. Check that `ingress.publicBaseUrl` is correct and the tunnel is active
 - Verify the gateway is running on `http://127.0.0.1:${GATEWAY_PORT:-7830}`
+
+### "Number not eligible for caller identity"
+The user's phone number is not owned by or verified with the Twilio account. The number must be either purchased through Twilio or added as a verified caller ID at https://console.twilio.com/us1/develop/phone-numbers/manage/verified.
+
+### "Per-call caller identity override is disabled"
+The setting `calls.callerIdentity.allowPerCallOverride` is set to `false`, so per-call `caller_identity_mode` selection is not allowed. Either change the default mode with `vellum config set calls.callerIdentity.defaultMode user_number`, or re-enable overrides with `vellum config set calls.callerIdentity.allowPerCallOverride true`.
+
+### Caller identity call fails on trial account
+Twilio trial accounts can only place calls to verified numbers, regardless of caller identity mode. The user's phone number must also be verified with Twilio. Upgrade to a paid account or verify both the source and destination numbers.
 
 ### "This phone number is not allowed to be called"
 Emergency numbers (911, 112, 999, 000, 110, 119) are permanently blocked for safety.

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -264,7 +264,7 @@ call_start phone_number="+12125551234" task="Confirm the dentist appointment sch
 
 ### Caller identity in calls
 
-By default, calls use the assistant's Twilio number — no extra parameters needed. Only use `caller_identity_mode` when the user explicitly asks to call from their own number.
+By default, calls use the configured default caller identity mode (see `calls.callerIdentity.defaultMode` — defaults to `assistant_number`). Only specify `caller_identity_mode` when you need to override the configured default for a specific call.
 
 **Default call (assistant number):**
 ```
@@ -276,7 +276,7 @@ call_start phone_number="+14155551234" task="Check store hours for today"
 call_start phone_number="+14155551234" task="Check store hours for today" caller_identity_mode="user_number"
 ```
 
-**Decision rule:** Default to the assistant number unless the user explicitly asks to call from their own number.
+**Decision rule:** Use the configured default mode (`calls.callerIdentity.defaultMode`) unless the user explicitly requests a different mode for this call. When the configured default is `assistant_number`, the assistant's Twilio number is used. When configured as `user_number`, the user's verified number is used.
 
 ### Phone number format
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -244,6 +244,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       },
     },
     model: undefined,
+    callerIdentity: {
+      defaultMode: 'assistant_number' as const,
+      allowPerCallOverride: true,
+    },
   },
   ingress: {
     enabled: false,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,6 +10,7 @@ const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
+const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
 
 export const TimeoutConfigSchema = z.object({
@@ -956,6 +957,20 @@ export const CallsVoiceConfigSchema = z.object({
   }),
 });
 
+export const CallerIdentityConfigSchema = z.object({
+  defaultMode: z
+    .enum(VALID_CALLER_IDENTITY_MODES, {
+      error: `calls.callerIdentity.defaultMode must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}`,
+    })
+    .default('assistant_number'),
+  allowPerCallOverride: z
+    .boolean({ error: 'calls.callerIdentity.allowPerCallOverride must be a boolean' })
+    .default(true),
+  userNumber: z
+    .string({ error: 'calls.callerIdentity.userNumber must be a string' })
+    .optional(),
+});
+
 export const CallsConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'calls.enabled must be a boolean' })
@@ -1004,6 +1019,10 @@ export const CallsConfigSchema = z.object({
   model: z
     .string({ error: 'calls.model must be a string' })
     .optional(),
+  callerIdentity: CallerIdentityConfigSchema.default({
+    defaultMode: 'assistant_number',
+    allowPerCallOverride: true,
+  }),
 });
 
 export const SkillsConfigSchema = z.object({
@@ -1286,6 +1305,10 @@ export const AssistantConfigSchema = z.object({
         registerCallTimeoutMs: 5000,
       },
     },
+    callerIdentity: {
+      defaultMode: 'assistant_number',
+      allowPerCallOverride: true,
+    },
   }),
   ingress: IngressConfigSchema.default({
     enabled: false,
@@ -1353,4 +1376,5 @@ export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;
 export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
 export type CallsVoiceConfig = z.infer<typeof CallsVoiceConfigSchema>;
 export type CallsElevenLabsConfig = z.infer<typeof CallsElevenLabsConfigSchema>;
+export type CallerIdentityConfig = z.infer<typeof CallerIdentityConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,7 +10,7 @@ const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
-const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
+export const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
 
 export const TimeoutConfigSchema = z.object({

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -36,5 +36,6 @@ export type {
   CallsSafetyConfig,
   CallsVoiceConfig,
   CallsElevenLabsConfig,
+  CallerIdentityConfig,
   IngressConfig,
 } from './schema.js';

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -790,6 +790,10 @@ export function initializeDb(): void {
   // Add claim ownership token to prevent cross-handler claim interference
   try { database.run(/*sql*/ `ALTER TABLE processed_callbacks ADD COLUMN claim_id TEXT`); } catch { /* already exists */ }
 
+  // Caller identity persistence for auditability
+  try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_mode TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_source TEXT`); } catch { /* already exists */ }
+
   // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid).
   // On upgraded databases that pre-date this constraint, duplicate rows may exist; deduplicate
   // them first to avoid a UNIQUE constraint failure that would prevent startup.

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -548,6 +548,8 @@ export const callSessions = sqliteTable('call_sessions', {
   toNumber: text('to_number').notNull(),
   task: text('task'),
   status: text('status').notNull().default('initiated'),
+  callerIdentityMode: text('caller_identity_mode'),
+  callerIdentitySource: text('caller_identity_source'),
   startedAt: integer('started_at'),
   endedAt: integer('ended_at'),
   lastError: text('last_error'),

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -13,7 +13,7 @@ import { getConfig } from '../../config/loader.js';
 /**
  * POST /v1/calls/start
  *
- * Body: { phoneNumber: string; task: string; context?: string; conversationId: string }
+ * Body: { phoneNumber: string; task: string; context?: string; conversationId: string; callerIdentityMode?: 'assistant_number' | 'user_number' }
  */
 export async function handleStartCall(req: Request): Promise<Response> {
   if (!getConfig().calls.enabled) {
@@ -28,6 +28,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     task?: string;
     context?: string;
     conversationId?: string;
+    callerIdentityMode?: 'assistant_number' | 'user_number';
   };
   try {
     body = await req.json() as typeof body;
@@ -44,6 +45,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     task: body.task ?? '',
     context: body.context,
     conversationId: body.conversationId,
+    callerIdentityMode: body.callerIdentityMode,
   });
 
   if (!result.ok) {
@@ -56,6 +58,7 @@ export async function handleStartCall(req: Request): Promise<Response> {
     status: result.session.status,
     toNumber: result.session.toNumber,
     fromNumber: result.session.fromNumber,
+    callerIdentityMode: result.callerIdentityMode,
   }, { status: 201 });
 }
 

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -9,6 +9,7 @@
 
 import { startCall, getCallStatus, cancelCall, answerCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
+import { VALID_CALLER_IDENTITY_MODES } from '../../config/schema.js';
 
 /**
  * POST /v1/calls/start
@@ -38,6 +39,14 @@ export async function handleStartCall(req: Request): Promise<Response> {
 
   if (!body.conversationId) {
     return Response.json({ error: 'conversationId is required' }, { status: 400 });
+  }
+
+  if (body.callerIdentityMode != null &&
+      !(VALID_CALLER_IDENTITY_MODES as readonly string[]).includes(body.callerIdentityMode as string)) {
+    return Response.json(
+      { error: `Invalid callerIdentityMode: "${body.callerIdentityMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}` },
+      { status: 400 },
+    );
   }
 
   const result = await startCall({

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -24,6 +24,11 @@ const definition: ToolDefinition = {
         type: 'string',
         description: 'Additional context for the conversation',
       },
+      caller_identity_mode: {
+        type: 'string',
+        enum: ['assistant_number', 'user_number'],
+        description: 'Which phone number to use as the caller ID. assistant_number uses the AI assistant\'s Twilio number; user_number uses the user\'s verified personal number.',
+      },
     },
     required: ['phone_number', 'task'],
   },
@@ -49,6 +54,7 @@ class CallStartTool implements Tool {
       task: input.task as string,
       context: input.context as string | undefined,
       conversationId: context.conversationId,
+      callerIdentityMode: input.caller_identity_mode as 'assistant_number' | 'user_number' | undefined,
     });
 
     if (!result.ok) {
@@ -61,6 +67,8 @@ class CallStartTool implements Tool {
         `  Call Session ID: ${result.session.id}`,
         `  Call SID: ${result.callSid}`,
         `  To: ${result.session.toNumber}`,
+        `  From: ${result.session.fromNumber}`,
+        `  Caller Identity Mode: ${result.callerIdentityMode}`,
         `  Status: initiated`,
         '',
         'The AI voice assistant is now placing the call. Use call_status to check progress.',


### PR DESCRIPTION
## Summary
Adds a provider-agnostic caller identity system that allows outbound calls to be placed from either the assistant's Twilio number (default) or the user's own verified phone number. The feature is fully configurable via `calls.callerIdentity` config, supports per-call overrides via tool/API, and includes eligibility verification, E.164 validation, audit persistence, and comprehensive skill documentation.

## Changes
- **M1 — Caller identity model + config surface** (#6199): Added `CallerIdentityConfigSchema` with `defaultMode`, `allowPerCallOverride`, `userNumber` fields. Extended `StartCallInput` and added `resolveCallerIdentity()` in call-domain.
- **M2 — Twilio eligibility checks** (#6207): Added `checkCallerIdEligibility()` to verify user numbers are owned by or verified with the Twilio account before placing calls. Checks both IncomingPhoneNumbers and OutgoingCallerIds endpoints.
- **M3 — Tool + HTTP API support** (#6208): Added `caller_identity_mode` parameter to the `call_start` tool and `POST /v1/calls/start` HTTP endpoint. Response includes resolved mode.
- **M4 — Skill documentation** (#6213): Updated SKILL.md with caller identity section, configuration reference, examples, and troubleshooting guidance.
- **M5 — Persistence and observability** (#6220): Added `caller_identity_mode` and `caller_identity_source` columns to `call_sessions`, updated Drizzle schema, call-store, and ARCHITECTURE.md.

## Feedback fixes (post-review)
- #6225: Twilio API failures now throw instead of silently returning `eligible: false`
- #6226: Added runtime validation of `callerIdentityMode` enum at HTTP and domain layers
- #6229: Added E.164 format validation for user phone numbers before Twilio API call
- #6230: Aligned SKILL.md decision rule with configurable `defaultMode`
- #6231: Fixed `caller_identity_source` to reflect actual number provenance instead of masking with `per_call_override`
- #6240: Removed try/catch so Twilio API errors propagate as HTTP 500 instead of 400

## Milestone PRs (merged into feature branch)
- #6199: Add caller identity model and config surface
- #6207: Add Twilio caller ID eligibility checks for user-number mode
- #6208: Add tool and HTTP API support for per-call caller identity selection
- #6213: Update SKILL.md with caller identity documentation and examples
- #6220: Add caller identity persistence, observability, and architecture docs
- #6225: Treat Twilio eligibility API failures as hard errors
- #6226: Validate callerIdentityMode enum at HTTP and domain layers
- #6229: Validate user phone number E.164 format
- #6230: Align SKILL.md decision rule with configurable defaultMode
- #6231: Fix caller_identity_source to reflect actual number provenance
- #6240: Let Twilio eligibility API errors propagate as 500s

## Project issue
Closes #6189

## Test plan
- [ ] Verify default behavior: `call_start` without mode uses assistant number
- [ ] Verify explicit user-number success path with eligible number
- [ ] Verify user-number with ineligible number returns clear error
- [ ] Verify invalid callerIdentityMode values return 400
- [ ] Verify per-call override rejected when `allowPerCallOverride=false`
- [ ] Verify Twilio API failures return 500 not 400
- [ ] Verify non-E.164 user numbers return clear validation error
- [ ] Verify existing clients that omit caller identity remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
