### PR TITLE
M4: Twitter skill rewrite with dual-path UX

### DIFF
--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -7,13 +7,107 @@ metadata: {"vellum": {"emoji": "𝕏"}}
 
 You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `vellum x` CLI commands.
 
+## Connection Options
+
+There are two supported ways to connect to X. Both are fully functional; choose whichever fits the user's situation.
+
+### OAuth (recommended with X developer credentials)
+
+OAuth uses the official X API v2. It is the most reliable connection method and does not depend on browser sessions.
+
+- Supports: **post** and **reply**
+- Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) are not yet available via OAuth; they use the browser path automatically when the strategy is set to `auto`.
+- Setup: The user connects OAuth credentials through the Settings UI or the `twitter_auth_start` IPC flow.
+- Set the strategy: `vellum x strategy set oauth`
+
+### Browser session (no developer credentials needed)
+
+The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X.
+
+- Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
+- Setup: Run `vellum x refresh` to open Chrome and capture session cookies automatically.
+- Set the strategy: `vellum x strategy set browser`
+
+### Auto mode (default)
+
+When the strategy is `auto` (the default), the router tries OAuth first for supported operations if credentials are available, then falls back to the browser path. This gives the best of both worlds without requiring manual switching.
+
+- Set auto mode: `vellum x strategy set auto`
+
+## First-Use Decision Flow
+
+When the user triggers a Twitter operation and no strategy has been configured yet, follow these steps:
+
+1. **Check current status:**
+   ```bash
+   vellum x status --json
+   ```
+   Look at `oauthConnected`, `browserSessionActive`, and `preferredStrategy` in the response.
+
+2. **Present both options with trade-offs:**
+   - **OAuth**: Most reliable and official. Requires X developer app credentials (API key and secret). Supports posting and replying. Set up through Settings UI.
+   - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh`.
+
+3. **Ask the user which they prefer.** Do not choose for them.
+
+4. **Execute setup for the chosen path:**
+   - If OAuth: Guide the user to the Settings UI to connect their X developer credentials, or initiate the `twitter_auth_start` IPC flow.
+   - If browser: Run `vellum x refresh` to capture session cookies from Chrome.
+
+5. **Set the preferred strategy:**
+   ```bash
+   vellum x strategy set <oauth|browser|auto>
+   ```
+
+## Failure Recovery Flow
+
+When a Twitter operation fails, follow these steps:
+
+1. **Detect the failure type from the error output:**
+   - `session_expired` or `SessionExpiredError` — the browser session cookies have expired.
+   - `OAuth is not configured` — the user chose OAuth but credentials are not set up.
+   - `Twitter API error (401)` — OAuth token may be expired or revoked.
+   - `UnsupportedOAuthOperationError` — the requested operation is not available via OAuth (e.g., timeline, search).
+   - `Cannot connect to daemon` — the Vellum daemon is not running.
+
+2. **Explain the likely cause clearly** to the user.
+
+3. **Suggest trying the other path as an alternative:**
+   - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `vellum x refresh`.
+   - If OAuth failed or is not configured: suggest using the browser path with `vellum x strategy set browser` and `vellum x refresh`.
+   - If the operation is unsupported via OAuth: explain that this specific operation requires the browser path, and run it via browser. No strategy change is needed if the user is on `auto`.
+
+4. **Offer concrete steps to switch:**
+   ```bash
+   # Switch to the other strategy
+   vellum x strategy set <oauth|browser|auto>
+
+   # If switching to browser, refresh the session
+   vellum x refresh
+   ```
+
+## Strategy Management Commands
+
+```bash
+# Check current strategy
+vellum x strategy
+
+# Set strategy to OAuth, browser, or auto
+vellum x strategy set <oauth|browser|auto>
+
+# Check full status (session, OAuth, and strategy info)
+vellum x status --json
+```
+
 ## Posting
 
 ```bash
 vellum x post "The post text here"
 ```
 
-Returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share the URL with the user so they can verify the post.
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. The `pathUsed` field indicates whether the post was sent via `oauth` or `browser`. Share the URL with the user so they can verify the post.
+
+The `post` command routes through the strategy router: it uses OAuth if configured and available, otherwise falls back to the browser path.
 
 ## Replying
 
@@ -23,7 +117,11 @@ vellum x reply <tweetUrl> "The reply text here"
 
 The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID.
 
+Like `post`, the `reply` command routes through the strategy router and returns a `pathUsed` field.
+
 ## Reading
+
+Read-only operations currently only work via the browser path. When the strategy is set to `auto` or `browser`, these work as expected. When the strategy is set to `oauth`, these operations will fail because OAuth does not yet support them — suggest switching to `auto` or `browser` if this happens.
 
 ### User timeline
 ```bash
@@ -76,20 +174,6 @@ vellum x media <screenName> [--count N]
 ```
 Returns tweets that contain media from the user's profile.
 
-## Session Management
-
-Check if a session exists:
-```bash
-vellum x status --json
-```
-
-If there is no session or the session has expired, refresh it:
-```bash
-vellum x refresh
-```
-
-This opens Chrome, navigates through x.com automatically, and captures auth cookies. Do NOT tell the user to run this manually — run it yourself.
-
 ## Workflows
 
 ### Check Mentions
@@ -131,4 +215,6 @@ When the user wants to see how their posts are performing:
 - All commands return JSON with an `ok` field
 - When drafting replies, match the tone of the conversation — casual threads get casual replies
 - Always show the user what you're about to post and get approval before sending
-- If a session is expired, refresh it silently with `vellum x refresh` before retrying
+- If a browser session is expired, refresh it with `vellum x refresh` before retrying, or suggest switching to OAuth for post/reply operations
+- If an operation fails, check `vellum x status --json` to diagnose the issue before retrying
+- The `post` and `reply` commands include a `pathUsed` field in their response so you can tell the user which connection method was used


### PR DESCRIPTION
Rewrites the Twitter SKILL.md to support dual-path (OAuth + Browser) connection options. Adds first-use decision flow, failure-recovery guidance, and strategy management commands. Positions OAuth as recommended but keeps browser path fully supported.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
