### PR TITLE
Fix sendDaemonMessage to filter session_info messages

### DIFF
--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -502,8 +502,8 @@ function sendDaemonMessage(
           continue;
         }
 
-        // Skip auth_result echoes and daemon_status broadcasts
-        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong') {
+        // Skip auth_result echoes, daemon_status broadcasts, and session_info
+        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong' || m.type === 'session_info') {
           continue;
         }
 


### PR DESCRIPTION
Addresses Codex feedback on PR #6246. The sendDaemonMessage helper now skips session_info messages from the daemon, preventing vellum x status/strategy from consuming the wrong response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
