### PR TITLE
Fix router to preserve SessionExpiredError for CLI contract

### DIFF
--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -150,7 +150,8 @@ describe('Twitter strategy router', () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & { pathUsed: string };
-        expect(e.message).toContain('Browser session expired and OAuth was already tried');
+        expect(e).toBeInstanceOf(MockSessionExpiredError);
+        expect(e.message).toBe('Browser session expired');
         expect(e.pathUsed).toBe('auto');
       }
     });
@@ -197,7 +198,7 @@ describe('Twitter strategy router', () => {
       expect(result.tweetId).toBe('666');
     });
 
-    test('provides OAuth hint on SessionExpiredError', async () => {
+    test('preserves SessionExpiredError type with router metadata', async () => {
       mockStrategy = 'browser';
       mockBrowserPostError = new MockSessionExpiredError('Session expired');
 
@@ -206,9 +207,8 @@ describe('Twitter strategy router', () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & { pathUsed: string; suggestAlternative: string };
-        expect(e.message).toContain('Browser session expired');
-        expect(e.message).toContain('vellum x refresh');
-        expect(e.message).toContain('vellum x strategy set oauth');
+        expect(e).toBeInstanceOf(MockSessionExpiredError);
+        expect(e.message).toBe('Session expired');
         expect(e.pathUsed).toBe('browser');
         expect(e.suggestAlternative).toBe('oauth');
       }

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -57,7 +57,7 @@ export async function routedPostTweet(
       return { result, pathUsed: 'browser' };
     } catch (err) {
       if (err instanceof SessionExpiredError) {
-        throw Object.assign(new Error(`Browser session expired. Refresh with \`vellum x refresh\`, or switch to OAuth: \`vellum x strategy set oauth\`.`), {
+        throw Object.assign(err, {
           pathUsed: 'browser' as const,
           suggestAlternative: 'oauth' as const,
         });
@@ -82,7 +82,7 @@ export async function routedPostTweet(
     return { result, pathUsed: 'browser' };
   } catch (err) {
     if (err instanceof SessionExpiredError && oauthIsAvailable()) {
-      throw Object.assign(new Error(`Browser session expired and OAuth was already tried. Refresh browser session with \`vellum x refresh\` or check OAuth credentials.`), {
+      throw Object.assign(err, {
         pathUsed: 'auto' as const,
       });
     }


### PR DESCRIPTION
Addresses Codex feedback on PR #6249. The strategy router now preserves the original SessionExpiredError instead of wrapping it in a plain Error, maintaining the CLI's instanceof check and structured session_expired response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
