### PR TITLE
Twitter OAuth + Browser Dual-Path Assistant

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2464,7 +2464,7 @@ sequenceDiagram
 
 ### Twitter Integration Architecture
 
-Twitter uses a standalone OAuth2 flow separate from the unified messaging layer. The OAuth2 flow handles identity verification only (confirming the user's Twitter account). Posting is done exclusively via Chrome DevTools Protocol (CDP).
+Twitter uses a standalone OAuth2 flow separate from the unified messaging layer. It supports a dual-path operation architecture: an **OAuth path** that calls X API v2 directly for posting and replying, and a **Browser path** that uses Chrome DevTools Protocol (CDP) for all operations including read-only ones. A strategy router (`router.ts`) selects the appropriate path based on user preference and capability.
 
 #### Twitter OAuth2 Flow
 
@@ -2502,6 +2502,35 @@ sequenceDiagram
     IPC->>UI: show connected state
 ```
 
+#### Dual-Path Operation Architecture
+
+The strategy router (`router.ts`) determines whether to use the OAuth or browser path for each operation. The preferred strategy is read from the `twitterOperationStrategy` config field (default: `auto`).
+
+```mermaid
+flowchart TD
+    CLI["vellum x post / reply"] --> Router["Strategy Router (router.ts)"]
+    Router --> StratCheck{Preferred strategy?}
+
+    StratCheck -->|oauth| OAuthOnly["OAuth Client (oauth-client.ts)"]
+    OAuthOnly --> XAPI["X API v2 POST /tweets"]
+
+    StratCheck -->|browser| BrowserOnly["Browser Client (client.ts)"]
+    BrowserOnly --> CDP["Chrome CDP GraphQL mutation"]
+
+    StratCheck -->|auto| AutoCheck{"OAuth available &\noperation supported?"}
+    AutoCheck -->|yes| TryOAuth["Try OAuth Client"]
+    TryOAuth -->|success| XAPI
+    TryOAuth -->|failure| Fallback["Fallback to Browser Client"]
+    Fallback --> CDP
+    AutoCheck -->|no| BrowserOnly
+```
+
+- **`auto`** (default): Checks `oauthIsAvailable()` (access token stored) and `oauthSupportsOperation()` (currently `post` and `reply`). If both pass, tries OAuth first. On OAuth failure, falls back to browser. If OAuth is not available or the operation is unsupported, uses browser directly.
+- **`oauth`**: Uses OAuth exclusively. Fails with an actionable error if credentials are not configured.
+- **`browser`**: Uses CDP exclusively. Fails with an actionable error if the browser session has expired.
+
+The strategy is persisted in the Vellum config file as `twitterOperationStrategy` and can be changed via `vellum x strategy set <oauth|browser|auto>`.
+
 #### Twitter OAuth2 Specifics
 
 | Aspect | Detail |
@@ -2531,17 +2560,31 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
 }
 ```
 
-#### Twitter CDP Posting Path
+#### Twitter Operation Paths
 
-The `vellum x post` CLI command is the sole posting mechanism. It connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes a `CreateTweet` GraphQL mutation through the browser's session cookies. It does not use OAuth2 tokens for posting. Session management is handled by Ride Shotgun recordings (`vellum x refresh`).
+**OAuth path** (`oauth-client.ts`): The `oauthPostTweet` function calls X API v2 (`POST https://api.x.com/2/tweets`) with a Bearer token obtained via `withValidToken('integration:twitter', ...)`. The token manager handles automatic refresh if the stored token is expired. Supports `post` and `reply` (by including `reply.in_reply_to_tweet_id` in the request body). All other operations (timeline, search, etc.) throw `UnsupportedOAuthOperationError` and are not available via this path.
+
+**Browser path** (`client.ts`): Connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes GraphQL mutations/queries through the browser's session cookies. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Session management is handled by Ride Shotgun recordings (`vellum x refresh`).
 
 #### Available Twitter Tools
 
-| Tool | Mechanism | Description |
-|------|-----------|-------------|
-| `twitter_post` | CDP | Post a tweet. Available via the `X` bundled skill (`vellum x post`). |
+| Tool / Command | Mechanism | Description |
+|----------------|-----------|-------------|
+| `vellum x post` | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default). |
+| `vellum x reply` | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
+| `vellum x timeline` | CDP | Fetch a user's recent tweets. Browser path only. |
+| `vellum x search` | CDP | Search tweets. Browser path only. |
+| `vellum x home` | CDP | Fetch home timeline. Browser path only. |
+| `vellum x notifications` | CDP | Fetch notifications. Browser path only. |
+| `vellum x bookmarks` | CDP | Fetch bookmarks. Browser path only. |
+| `vellum x likes` | CDP | Fetch a user's liked tweets. Browser path only. |
+| `vellum x followers` | CDP | Fetch a user's followers. Browser path only. |
+| `vellum x following` | CDP | Fetch who a user follows. Browser path only. |
+| `vellum x media` | CDP | Fetch a user's media tweets. Browser path only. |
+| `vellum x strategy` | Config | Get or set the operation strategy (`oauth`, `browser`, `auto`). |
+| `vellum x status` | IPC + local | Check browser session, OAuth connection, and strategy status. |
 
-Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow for identity verification. Posting is handled exclusively via CDP, not through the OAuth2 tokens.
+Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow. The `post` and `reply` operations use these tokens when the OAuth path is selected. Read operations require the browser path.
 
 ### Key Design Decisions
 
@@ -2550,7 +2593,8 @@ Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`
 | PKCE by default, optional client_secret | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh |
 | Gateway callback transport | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments. |
 | Unified `MessagingProvider` interface | All platforms implement the same contract; generic tools work immediately for new providers |
-| Twitter outside unified messaging | Twitter is a broadcast platform (post-only), not a conversation platform — it doesn't fit the `MessagingProvider` contract |
+| Twitter outside unified messaging | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract |
+| Dual-path Twitter strategy | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
 | Provider auto-selection | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX |
 | Token expiry in credential metadata | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer |
 | Confidence scores on medium-risk tools | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution |
@@ -2575,9 +2619,11 @@ Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`
 | `assistant/src/watcher/providers/slack.ts` | Slack watcher for DMs, mentions, thread replies |
 | `assistant/src/watcher/providers/gmail.ts` | Gmail watcher using History API |
 | `assistant/src/daemon/handlers/twitter-auth.ts` | Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`) |
-| `assistant/src/twitter/client.ts` | Twitter CDP client: GraphQL mutations via Chrome DevTools Protocol |
+| `assistant/src/twitter/client.ts` | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol |
+| `assistant/src/twitter/oauth-client.ts` | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()` |
+| `assistant/src/twitter/router.ts` | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config |
 | `assistant/src/twitter/session.ts` | Twitter browser session persistence (cookie import/export) |
-| `assistant/src/cli/twitter.ts` | `vellum x` CLI command group (post, refresh, status, login, logout) |
+| `assistant/src/cli/twitter.ts` | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
 | `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions |
 
 ---

--- a/README.md
+++ b/README.md
@@ -211,15 +211,19 @@ Connect via the Settings UI or `integration_connect` IPC message. OAuth2 tokens 
 
 ### Twitter (X)
 
-Twitter integration has two components: an OAuth2 identity flow and a CDP-based posting path.
+Twitter integration supports two operation paths: **OAuth** (X API v2) and **Browser** (CDP). A strategy router selects which path is used for each operation.
 
-- **OAuth2 PKCE flow** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. This flow is used for **identity verification only** (`GET /2/users/me`) — it confirms the user's Twitter account and stores credentials in the vault, but is not used for posting. Connect via the Settings UI or `twitter_auth_start` IPC message.
+- **OAuth path**: Uses stored OAuth2 tokens via `withValidToken('integration:twitter', ...)` to call the X API v2 directly. Supports `post` and `reply`. Most reliable when developer credentials are configured — no browser session needed for these operations.
 
-- **Browser session posting** (CDP): The `vellum x post` CLI command posts via Chrome DevTools Protocol, executing GraphQL mutations through an authenticated x.com browser tab. This is the **only posting mechanism**. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
+- **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
 
-**Available tool**: `twitter_post` — posts a tweet via CDP. OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow, but posting is handled exclusively through the browser session.
+- **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
 
-**Setup**: Store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`). Optionally store a Client Secret. Initiate the OAuth2 flow from the Settings UI to verify your identity. For posting, ensure Chrome is running with remote debugging enabled and an authenticated x.com tab.
+**OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
+
+**Available tools**: `twitter_post` — posts a tweet via the strategy router (OAuth or CDP depending on configuration). Read operations (timeline, search, etc.) use the browser path.
+
+**Setup**: For OAuth posting, store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`), optionally store a Client Secret, and initiate the OAuth2 flow from the Settings UI. For browser operations, ensure Chrome is running with remote debugging enabled and an authenticated x.com tab.
 
 ## Dynamic Skill Authoring
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -189,6 +189,9 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
       'runtime/http-server.ts',         // HTTP server credential lookup
       'daemon/handlers/twitter-auth.ts', // Twitter OAuth token storage
+      'twitter/oauth-client.ts',         // Twitter OAuth API client (reads access token for API calls)
+      'calls/elevenlabs-config.ts',      // ElevenLabs credential lookup
+      'cli/config-commands.ts',          // CLI config management
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -715,4 +715,138 @@ describe('Twitter integration config handler', () => {
     expect(responseStr).not.toContain('secret-client-secret-xyz789');
     expect(responseStr).not.toContain('secret-access-token-def456');
   });
+
+  // --- Strategy tests ---
+
+  test('get_strategy returns auto by default', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get_strategy',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(true);
+    expect(res.strategy).toBe('auto');
+  });
+
+  test('set_strategy persists and can be read back', () => {
+    // Set strategy to oauth
+    const setMsg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+      strategy: 'oauth',
+    };
+    const { ctx: ctx1, sent: sent1 } = createTestContext();
+    handleMessage(setMsg, {} as net.Socket, ctx1);
+
+    expect(sent1).toHaveLength(1);
+    const setRes = sent1[0] as { type: string; success: boolean; strategy: string };
+    expect(setRes.success).toBe(true);
+    expect(setRes.strategy).toBe('oauth');
+
+    // Read it back with get_strategy
+    const getMsg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get_strategy',
+    };
+    const { ctx: ctx2, sent: sent2 } = createTestContext();
+    handleMessage(getMsg, {} as net.Socket, ctx2);
+
+    expect(sent2).toHaveLength(1);
+    const getRes = sent2[0] as { type: string; success: boolean; strategy: string };
+    expect(getRes.success).toBe(true);
+    expect(getRes.strategy).toBe('oauth');
+
+    // Verify persistence via saveRawConfig
+    expect(saveRawConfigCalls.length).toBeGreaterThan(0);
+    const lastSaved = saveRawConfigCalls[saveRawConfigCalls.length - 1]!;
+    expect(lastSaved.twitterOperationStrategy).toBe('oauth');
+  });
+
+  test('set_strategy with invalid value returns error', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+      strategy: 'invalid_value',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Invalid strategy value');
+    expect(res.error).toContain('invalid_value');
+  });
+
+  test('set_strategy without value returns error', () => {
+    const msg = {
+      type: 'twitter_integration_config',
+      action: 'set_strategy',
+    } as unknown as TwitterIntegrationConfigRequest;
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Invalid strategy value');
+  });
+
+  test('get action includes strategy field', () => {
+    // Set a specific strategy first
+    rawConfigStore = { twitterOperationStrategy: 'browser' };
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string; mode: string };
+    expect(res.type).toBe('twitter_integration_config_response');
+    expect(res.success).toBe(true);
+    expect(res.strategy).toBe('browser');
+  });
+
+  test('get action returns auto strategy by default', () => {
+    const msg: TwitterIntegrationConfigRequest = {
+      type: 'twitter_integration_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    expect(res.strategy).toBe('auto');
+  });
+
+  test('set_strategy cycles through all valid values', () => {
+    for (const value of ['oauth', 'browser', 'auto'] as const) {
+      const msg: TwitterIntegrationConfigRequest = {
+        type: 'twitter_integration_config',
+        action: 'set_strategy',
+        strategy: value,
+      };
+      const { ctx, sent } = createTestContext();
+      handleMessage(msg, {} as net.Socket, ctx);
+      expect(sent).toHaveLength(1);
+      const res = sent[0] as { type: string; success: boolean; strategy: string };
+      expect(res.success).toBe(true);
+      expect(res.strategy).toBe(value);
+    }
+  });
 });

--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -1,0 +1,251 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mocks (must be declared before importing the module under test) ---
+
+let mockStrategy: string | undefined = undefined;
+let mockOauthAvailable = false;
+let mockOauthPostResult: { tweetId: string; text: string; url?: string } | null = null;
+let mockOauthPostError: Error | null = null;
+let mockBrowserPostResult: { tweetId: string; text: string; url: string } | null = null;
+let mockBrowserPostError: Error | null = null;
+
+// Mock the config loader to return a controllable strategy
+mock.module('../config/loader.js', () => ({
+  loadRawConfig: () => {
+    if (mockStrategy !== undefined) {
+      return { twitterOperationStrategy: mockStrategy };
+    }
+    return {};
+  },
+  loadConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+}));
+
+// Mock the OAuth client
+mock.module('../twitter/oauth-client.js', () => ({
+  oauthIsAvailable: () => mockOauthAvailable,
+  oauthSupportsOperation: (op: string) => op === 'post' || op === 'reply',
+  oauthPostTweet: async (_text: string, _opts?: { inReplyToTweetId?: string }) => {
+    if (mockOauthPostError) throw mockOauthPostError;
+    if (mockOauthPostResult) return mockOauthPostResult;
+    throw new Error('OAuth mock not configured');
+  },
+  UnsupportedOAuthOperationError: class UnsupportedOAuthOperationError extends Error {
+    public readonly suggestFallback = true;
+    public readonly fallbackPath = 'browser' as const;
+    public readonly operation: string;
+    constructor(operation: string) {
+      super(`The "${operation}" operation is not available via the OAuth API.`);
+      this.name = 'UnsupportedOAuthOperationError';
+      this.operation = operation;
+    }
+  },
+}));
+
+// Create a SessionExpiredError class that matches the real one
+class MockSessionExpiredError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+// Mock the browser client
+mock.module('../twitter/client.js', () => ({
+  postTweet: async (_text: string, _opts?: { inReplyToTweetId?: string }) => {
+    if (mockBrowserPostError) throw mockBrowserPostError;
+    if (mockBrowserPostResult) return mockBrowserPostResult;
+    throw new Error('Browser mock not configured');
+  },
+  SessionExpiredError: MockSessionExpiredError,
+}));
+
+// Mock the logger to silence output
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { routedPostTweet } from '../twitter/router.js';
+
+beforeEach(() => {
+  mockStrategy = undefined;
+  mockOauthAvailable = false;
+  mockOauthPostResult = null;
+  mockOauthPostError = null;
+  mockBrowserPostResult = null;
+  mockBrowserPostError = null;
+});
+
+describe('Twitter strategy router', () => {
+  describe('auto strategy', () => {
+    test('uses OAuth when available and supported', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '111', text: 'hello', url: 'https://x.com/u/status/111' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('111');
+      expect(result.text).toBe('hello');
+      expect(result.url).toBe('https://x.com/u/status/111');
+    });
+
+    test('falls back to browser when OAuth is unavailable', async () => {
+      mockOauthAvailable = false;
+      mockBrowserPostResult = { tweetId: '222', text: 'hello', url: 'https://x.com/u/status/222' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('222');
+    });
+
+    test('falls back to browser when OAuth fails', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostError = new Error('OAuth token expired');
+      mockBrowserPostResult = { tweetId: '333', text: 'hello', url: 'https://x.com/u/status/333' };
+
+      const { result, pathUsed } = await routedPostTweet('hello');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('333');
+    });
+
+    test('constructs URL from tweetId when OAuth result has no url', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '444', text: 'no url' };
+
+      const { result, pathUsed } = await routedPostTweet('no url');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.url).toBe('https://x.com/i/status/444');
+    });
+
+    test('throws combined error when both OAuth and browser fail with SessionExpiredError', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostError = new Error('OAuth failed');
+      mockBrowserPostError = new MockSessionExpiredError('Browser session expired');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain('Browser session expired and OAuth was already tried');
+        expect(e.pathUsed).toBe('auto');
+      }
+    });
+  });
+
+  describe('explicit oauth strategy', () => {
+    test('fails with helpful error when OAuth is not configured', async () => {
+      mockStrategy = 'oauth';
+      mockOauthAvailable = false;
+
+      try {
+        await routedPostTweet('hello');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string; suggestAlternative: string };
+        expect(e.message).toContain('OAuth is not configured');
+        expect(e.message).toContain('vellum x strategy set browser');
+        expect(e.pathUsed).toBe('oauth');
+        expect(e.suggestAlternative).toBe('browser');
+      }
+    });
+
+    test('uses OAuth when available', async () => {
+      mockStrategy = 'oauth';
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '555', text: 'oauth post' };
+
+      const { result, pathUsed } = await routedPostTweet('oauth post');
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('555');
+    });
+  });
+
+  describe('explicit browser strategy', () => {
+    test('uses browser directly, ignoring OAuth availability', async () => {
+      mockStrategy = 'browser';
+      mockOauthAvailable = true; // available but should be ignored
+      mockBrowserPostResult = { tweetId: '666', text: 'browser post', url: 'https://x.com/u/status/666' };
+
+      const { result, pathUsed } = await routedPostTweet('browser post');
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('666');
+    });
+
+    test('provides OAuth hint on SessionExpiredError', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostError = new MockSessionExpiredError('Session expired');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & { pathUsed: string; suggestAlternative: string };
+        expect(e.message).toContain('Browser session expired');
+        expect(e.message).toContain('vellum x refresh');
+        expect(e.message).toContain('vellum x strategy set oauth');
+        expect(e.pathUsed).toBe('browser');
+        expect(e.suggestAlternative).toBe('oauth');
+      }
+    });
+
+    test('re-throws non-session errors without wrapping', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostError = new Error('Network failure');
+
+      try {
+        await routedPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect((err as Error).message).toBe('Network failure');
+      }
+    });
+  });
+
+  describe('reply routing', () => {
+    test('auto strategy routes reply through OAuth when available', async () => {
+      mockOauthAvailable = true;
+      mockOauthPostResult = { tweetId: '777', text: 'reply text', url: 'https://x.com/u/status/777' };
+
+      const { result, pathUsed } = await routedPostTweet('reply text', { inReplyToTweetId: '100' });
+
+      expect(pathUsed).toBe('oauth');
+      expect(result.tweetId).toBe('777');
+    });
+
+    test('browser strategy routes reply through browser', async () => {
+      mockStrategy = 'browser';
+      mockBrowserPostResult = { tweetId: '888', text: 'reply text', url: 'https://x.com/u/status/888' };
+
+      const { result, pathUsed } = await routedPostTweet('reply text', { inReplyToTweetId: '200' });
+
+      expect(pathUsed).toBe('browser');
+      expect(result.tweetId).toBe('888');
+    });
+  });
+});

--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -149,10 +149,11 @@ describe('Twitter strategy router', () => {
         await routedPostTweet('will fail');
         expect(true).toBe(false); // should not reach
       } catch (err) {
-        const e = err as Error & { pathUsed: string };
+        const e = err as Error & { pathUsed: string; oauthError?: string };
         expect(e).toBeInstanceOf(MockSessionExpiredError);
         expect(e.message).toBe('Browser session expired');
         expect(e.pathUsed).toBe('auto');
+        expect(e.oauthError).toBe('OAuth failed');
       }
     });
   });

--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -150,7 +150,8 @@ describe('Twitter strategy router', () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & { pathUsed: string };
-        expect(e.message).toContain('Browser session expired and OAuth was already tried');
+        expect(e).toBeInstanceOf(MockSessionExpiredError);
+        expect(e.message).toBe('Browser session expired');
         expect(e.pathUsed).toBe('auto');
       }
     });
@@ -197,7 +198,7 @@ describe('Twitter strategy router', () => {
       expect(result.tweetId).toBe('666');
     });
 
-    test('provides OAuth hint on SessionExpiredError', async () => {
+    test('preserves SessionExpiredError type with router metadata', async () => {
       mockStrategy = 'browser';
       mockBrowserPostError = new MockSessionExpiredError('Session expired');
 
@@ -206,9 +207,8 @@ describe('Twitter strategy router', () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & { pathUsed: string; suggestAlternative: string };
-        expect(e.message).toContain('Browser session expired');
-        expect(e.message).toContain('vellum x refresh');
-        expect(e.message).toContain('vellum x strategy set oauth');
+        expect(e).toBeInstanceOf(MockSessionExpiredError);
+        expect(e.message).toBe('Session expired');
         expect(e.pathUsed).toBe('browser');
         expect(e.suggestAlternative).toBe('oauth');
       }

--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -57,11 +57,11 @@ import {
 // --- Global fetch mock ---
 
 const originalFetch = globalThis.fetch;
-let fetchMock: ReturnType<typeof mock> | null = null;
+let _fetchMock: ReturnType<typeof mock> | null = null;
 
 beforeEach(() => {
   secureKeyStore = {};
-  fetchMock = null;
+  _fetchMock = null;
 });
 
 afterEach(() => {
@@ -78,7 +78,7 @@ function mockFetch(response: { ok: boolean; status: number; json?: unknown; text
     }),
   );
   globalThis.fetch = fn as unknown as typeof fetch;
-  fetchMock = fn;
+  _fetchMock = fn;
   return fn;
 }
 

--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -98,7 +98,7 @@ describe('Twitter OAuth client', () => {
 
       // Verify the request was made correctly
       expect(fn).toHaveBeenCalledTimes(1);
-      const [url, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const [url, opts] = fn.mock.calls[0] as unknown as [string, RequestInit];
       expect(url).toBe('https://api.x.com/2/tweets');
       expect(opts.method).toBe('POST');
       expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer fake-oauth-token');
@@ -121,7 +121,7 @@ describe('Twitter OAuth client', () => {
       expect(result.tweetId).toBe('67890');
       expect(result.text).toBe('My reply');
 
-      const [, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const [, opts] = fn.mock.calls[0] as unknown as [string, RequestInit];
       const body = JSON.parse(opts.body as string);
       expect(body.text).toBe('My reply');
       expect(body.reply).toEqual({ in_reply_to_tweet_id: '11111' });

--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// --- Mocks (must be declared before importing the module under test) ---
+
+let secureKeyStore: Record<string, string> = {};
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: () => true,
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+// withValidToken: call the callback directly with a fake token.
+mock.module('../security/token-manager.js', () => ({
+  withValidToken: async (_service: string, cb: (token: string) => Promise<unknown>) =>
+    cb('fake-oauth-token'),
+  TokenExpiredError: class TokenExpiredError extends Error {
+    constructor(public readonly service: string, message?: string) {
+      super(message ?? `Token expired for "${service}".`);
+      this.name = 'TokenExpiredError';
+    }
+  },
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import {
+  oauthPostTweet,
+  oauthIsAvailable,
+  oauthSupportsOperation,
+  UnsupportedOAuthOperationError,
+} from '../twitter/oauth-client.js';
+
+// --- Global fetch mock ---
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof mock> | null = null;
+
+beforeEach(() => {
+  secureKeyStore = {};
+  fetchMock = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockFetch(response: { ok: boolean; status: number; json?: unknown; text?: string }) {
+  const fn = mock(() =>
+    Promise.resolve({
+      ok: response.ok,
+      status: response.status,
+      json: () => Promise.resolve(response.json),
+      text: () => Promise.resolve(response.text ?? ''),
+    }),
+  );
+  globalThis.fetch = fn as unknown as typeof fetch;
+  fetchMock = fn;
+  return fn;
+}
+
+describe('Twitter OAuth client', () => {
+  describe('oauthPostTweet', () => {
+    test('successfully posts and returns tweet ID', async () => {
+      const fn = mockFetch({
+        ok: true,
+        status: 200,
+        json: { data: { id: '12345', text: 'Hello world' } },
+      });
+
+      const result = await oauthPostTweet('Hello world');
+
+      expect(result.tweetId).toBe('12345');
+      expect(result.text).toBe('Hello world');
+
+      // Verify the request was made correctly
+      expect(fn).toHaveBeenCalledTimes(1);
+      const [url, opts] = fn.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.x.com/2/tweets');
+      expect(opts.method).toBe('POST');
+      expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer fake-oauth-token');
+      expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(opts.body as string);
+      expect(body.text).toBe('Hello world');
+      expect(body.reply).toBeUndefined();
+    });
+
+    test('with reply returns correct result', async () => {
+      const fn = mockFetch({
+        ok: true,
+        status: 200,
+        json: { data: { id: '67890', text: 'My reply' } },
+      });
+
+      const result = await oauthPostTweet('My reply', { inReplyToTweetId: '11111' });
+
+      expect(result.tweetId).toBe('67890');
+      expect(result.text).toBe('My reply');
+
+      const [, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(opts.body as string);
+      expect(body.text).toBe('My reply');
+      expect(body.reply).toEqual({ in_reply_to_tweet_id: '11111' });
+    });
+
+    test('throws on API error', async () => {
+      mockFetch({
+        ok: false,
+        status: 429,
+        text: 'Rate limit exceeded',
+      });
+
+      await expect(oauthPostTweet('will fail')).rejects.toThrow(
+        /Twitter API error \(429\)/,
+      );
+    });
+
+    test('attaches status to thrown error for token manager retry', async () => {
+      mockFetch({
+        ok: false,
+        status: 401,
+        text: 'Unauthorized',
+      });
+
+      try {
+        await oauthPostTweet('will fail');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect((err as Error & { status: number }).status).toBe(401);
+      }
+    });
+  });
+
+  describe('oauthIsAvailable', () => {
+    test('returns true when access token exists', () => {
+      secureKeyStore['credential:integration:twitter:access_token'] = 'some-token';
+      expect(oauthIsAvailable()).toBe(true);
+    });
+
+    test('returns false when no access token', () => {
+      expect(oauthIsAvailable()).toBe(false);
+    });
+  });
+
+  describe('oauthSupportsOperation', () => {
+    test('returns true for post', () => {
+      expect(oauthSupportsOperation('post')).toBe(true);
+    });
+
+    test('returns true for reply', () => {
+      expect(oauthSupportsOperation('reply')).toBe(true);
+    });
+
+    test('returns false for unsupported operations', () => {
+      const unsupported = [
+        'timeline',
+        'search',
+        'bookmarks',
+        'home',
+        'notifications',
+        'likes',
+        'followers',
+        'following',
+        'media',
+        'tweet',
+      ];
+      for (const op of unsupported) {
+        expect(oauthSupportsOperation(op)).toBe(false);
+      }
+    });
+  });
+
+  describe('UnsupportedOAuthOperationError', () => {
+    test('has correct properties', () => {
+      const err = new UnsupportedOAuthOperationError('search');
+      expect(err.name).toBe('UnsupportedOAuthOperationError');
+      expect(err.operation).toBe('search');
+      expect(err.suggestFallback).toBe(true);
+      expect(err.fallbackPath).toBe('browser');
+      expect(err.message).toContain('search');
+      expect(err.message).toContain('not available via the OAuth API');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -13,7 +13,6 @@ import {
   clearSession,
 } from '../twitter/session.js';
 import {
-  postTweet,
   getUserByScreenName,
   getUserTweets,
   getTweetDetail,
@@ -27,6 +26,7 @@ import {
   getUserMedia,
   SessionExpiredError,
 } from '../twitter/client.js';
+import { routedPostTweet } from '../twitter/router.js';
 import { getSocketPath, readSessionToken } from '../util/platform.js';
 import {
   serialize,
@@ -270,11 +270,12 @@ export function registerTwitterCommand(program: Command): void {
     .argument('<text>', 'Tweet text')
     .action(async (text: string, _opts: unknown, cmd: Command) => {
       await run(cmd, async () => {
-        const result = await postTweet(text);
+        const { result, pathUsed } = await routedPostTweet(text);
         return {
           tweetId: result.tweetId,
           text: result.text,
           url: result.url,
+          pathUsed,
         };
       });
     });
@@ -294,12 +295,13 @@ export function registerTwitterCommand(program: Command): void {
           throw new Error(`Could not extract tweet ID from: ${tweetUrl}`);
         }
         const inReplyToTweetId = idMatch[1];
-        const result = await postTweet(text, { inReplyToTweetId });
+        const { result, pathUsed } = await routedPostTweet(text, { inReplyToTweetId });
         return {
           tweetId: result.tweetId,
           text: result.text,
           url: result.url,
           inReplyToTweetId,
+          pathUsed,
         };
       });
     });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -502,8 +502,8 @@ function sendDaemonMessage(
           continue;
         }
 
-        // Skip auth_result echoes and daemon_status broadcasts
-        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong') {
+        // Skip auth_result echoes, daemon_status broadcasts, and session_info
+        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong' || m.type === 'session_info') {
           continue;
         }
 

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -172,25 +172,93 @@ export function registerTwitterCommand(program: Command): void {
     });
 
   // =========================================================================
-  // status — check session status
+  // status — check session status + OAuth and strategy info
   // =========================================================================
   tw.command('status')
-    .description('Check if a Twitter session is active')
-    .action((_opts: unknown, cmd: Command) => {
+    .description('Check Twitter session, OAuth, and strategy status')
+    .action(async (_opts: unknown, cmd: Command) => {
       const session = loadSession();
-      if (session) {
-        output(
-          {
-            ok: true,
-            loggedIn: true,
+      const browserInfo: Record<string, unknown> = session
+        ? {
+            browserSessionActive: true,
             cookieCount: session.cookies.length,
             importedAt: session.importedAt,
             recordingId: session.recordingId,
-          },
-          getJson(cmd),
-        );
-      } else {
-        output({ ok: true, loggedIn: false }, getJson(cmd));
+          }
+        : { browserSessionActive: false };
+
+      // Query daemon for OAuth / strategy config
+      let oauthInfo: Record<string, unknown> = {};
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'get',
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        oauthInfo = {
+          oauthConnected: r.connected ?? false,
+          oauthAccount: r.accountInfo ?? undefined,
+          preferredStrategy: r.strategy ?? 'auto',
+        };
+      } catch {
+        // Daemon may not be running; report what we can from the local session
+        oauthInfo = {
+          oauthConnected: undefined,
+          oauthAccount: undefined,
+          preferredStrategy: undefined,
+        };
+      }
+
+      output(
+        {
+          ok: true,
+          loggedIn: !!session,
+          ...browserInfo,
+          ...oauthInfo,
+        },
+        getJson(cmd),
+      );
+    });
+
+  // =========================================================================
+  // strategy — get or set the Twitter operation strategy
+  // =========================================================================
+  const strategyCli = tw.command('strategy')
+    .description('Get or set the Twitter operation strategy (oauth, browser, auto)')
+    .action(async (_opts: unknown, cmd: Command) => {
+      const json = getJson(cmd);
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'get_strategy',
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        output({ ok: true, strategy: r.strategy ?? 'auto' }, json);
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  strategyCli.command('set')
+    .description('Set the Twitter operation strategy')
+    .argument('<value>', 'Strategy value: oauth, browser, or auto')
+    .action(async (value: string, _opts: unknown, cmd: Command) => {
+      const json = getJson(cmd);
+      try {
+        const daemonResponse = await sendDaemonMessage({
+          type: 'twitter_integration_config',
+          action: 'set_strategy',
+          strategy: value,
+        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        const r = daemonResponse as Record<string, unknown>;
+        if (r.success) {
+          output({ ok: true, strategy: r.strategy }, json);
+        } else {
+          output({ ok: false, error: r.error ?? 'Failed to set strategy' }, json);
+          process.exitCode = 1;
+        }
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
       }
     });
 
@@ -380,6 +448,84 @@ export function registerTwitterCommand(program: Command): void {
         return { user, tweets };
       });
     });
+}
+
+// ---------------------------------------------------------------------------
+// Daemon IPC helper — send a message and wait for the first response
+// ---------------------------------------------------------------------------
+
+function sendDaemonMessage(
+  message: import('../daemon/ipc-protocol.js').ClientMessage,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const socketPath = getSocketPath();
+    const sessionToken = readSessionToken();
+    const socket = net.createConnection(socketPath);
+    const parser = createMessageParser();
+
+    const timeoutHandle = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('Daemon request timed out after 10s'));
+    }, 10_000);
+    timeoutHandle.unref();
+
+    let authenticated = !sessionToken;
+    let messageSent = false;
+
+    const sendPayload = () => {
+      if (messageSent) return;
+      messageSent = true;
+      socket.write(serialize(message));
+    };
+
+    socket.on('error', (err) => {
+      clearTimeout(timeoutHandle);
+      reject(new Error(`Cannot connect to daemon: ${err.message}. Is the daemon running?`));
+    });
+
+    socket.on('data', (chunk) => {
+      const messages = parser.feed(chunk.toString('utf-8'));
+      for (const msg of messages) {
+        const m = msg as unknown as Record<string, unknown>;
+
+        if (!authenticated && m.type === 'auth_result') {
+          if ((m as { success: boolean }).success) {
+            authenticated = true;
+            sendPayload();
+          } else {
+            clearTimeout(timeoutHandle);
+            socket.destroy();
+            reject(new Error('Daemon authentication failed'));
+          }
+          continue;
+        }
+
+        // Skip auth_result echoes and daemon_status broadcasts
+        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong') {
+          continue;
+        }
+
+        // First substantive response — return it
+        clearTimeout(timeoutHandle);
+        socket.destroy();
+        resolve(m);
+        return;
+      }
+    });
+
+    socket.on('connect', () => {
+      if (sessionToken) {
+        socket.write(
+          serialize({
+            type: 'auth',
+            token: sessionToken,
+          } as unknown as import('../daemon/ipc-protocol.js').ClientMessage),
+        );
+      } else {
+        sendPayload();
+      }
+    });
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -193,7 +193,7 @@ export function registerTwitterCommand(program: Command): void {
         const daemonResponse = await sendDaemonMessage({
           type: 'twitter_integration_config',
           action: 'get',
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         oauthInfo = {
           oauthConnected: r.connected ?? false,
@@ -231,7 +231,7 @@ export function registerTwitterCommand(program: Command): void {
         const daemonResponse = await sendDaemonMessage({
           type: 'twitter_integration_config',
           action: 'get_strategy',
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         output({ ok: true, strategy: r.strategy ?? 'auto' }, json);
       } catch (err) {
@@ -249,7 +249,7 @@ export function registerTwitterCommand(program: Command): void {
           type: 'twitter_integration_config',
           action: 'set_strategy',
           strategy: value,
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         if (r.success) {
           output({ ok: true, strategy: r.strategy }, json);
@@ -458,6 +458,7 @@ export function registerTwitterCommand(program: Command): void {
 
 function sendDaemonMessage(
   message: import('../daemon/ipc-protocol.js').ClientMessage,
+  expectedResponseType: string,
 ): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const socketPath = getSocketPath();
@@ -502,16 +503,14 @@ function sendDaemonMessage(
           continue;
         }
 
-        // Skip auth_result echoes, daemon_status broadcasts, and session_info
-        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong' || m.type === 'session_info') {
-          continue;
+        // Only resolve on the expected response type; skip everything else
+        if (m.type === expectedResponseType) {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          resolve(m);
+          return;
         }
-
-        // First substantive response — return it
-        clearTimeout(timeoutHandle);
-        socket.destroy();
-        resolve(m);
-        return;
+        // Skip all other message types (auth_result, daemon_status, pong, session_info, tasks_changed, etc.)
       }
     });
 

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -121,7 +121,7 @@ Like `post`, the `reply` command routes through the strategy router and returns 
 
 ## Reading
 
-Read-only operations currently only work via the browser path. When the strategy is set to `auto` or `browser`, these work as expected. When the strategy is set to `oauth`, these operations will fail because OAuth does not yet support them — suggest switching to `auto` or `browser` if this happens.
+Read-only operations always use the browser path directly, regardless of the strategy setting. They work the same whether the strategy is `oauth`, `browser`, or `auto` — the strategy only affects `post` and `reply` commands.
 
 ### User timeline
 ```bash

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -7,13 +7,107 @@ metadata: {"vellum": {"emoji": "𝕏"}}
 
 You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `vellum x` CLI commands.
 
+## Connection Options
+
+There are two supported ways to connect to X. Both are fully functional; choose whichever fits the user's situation.
+
+### OAuth (recommended with X developer credentials)
+
+OAuth uses the official X API v2. It is the most reliable connection method and does not depend on browser sessions.
+
+- Supports: **post** and **reply**
+- Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) are not yet available via OAuth; they use the browser path automatically when the strategy is set to `auto`.
+- Setup: The user connects OAuth credentials through the Settings UI or the `twitter_auth_start` IPC flow.
+- Set the strategy: `vellum x strategy set oauth`
+
+### Browser session (no developer credentials needed)
+
+The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X.
+
+- Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
+- Setup: Run `vellum x refresh` to open Chrome and capture session cookies automatically.
+- Set the strategy: `vellum x strategy set browser`
+
+### Auto mode (default)
+
+When the strategy is `auto` (the default), the router tries OAuth first for supported operations if credentials are available, then falls back to the browser path. This gives the best of both worlds without requiring manual switching.
+
+- Set auto mode: `vellum x strategy set auto`
+
+## First-Use Decision Flow
+
+When the user triggers a Twitter operation and no strategy has been configured yet, follow these steps:
+
+1. **Check current status:**
+   ```bash
+   vellum x status --json
+   ```
+   Look at `oauthConnected`, `browserSessionActive`, and `preferredStrategy` in the response.
+
+2. **Present both options with trade-offs:**
+   - **OAuth**: Most reliable and official. Requires X developer app credentials (API key and secret). Supports posting and replying. Set up through Settings UI.
+   - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh`.
+
+3. **Ask the user which they prefer.** Do not choose for them.
+
+4. **Execute setup for the chosen path:**
+   - If OAuth: Guide the user to the Settings UI to connect their X developer credentials, or initiate the `twitter_auth_start` IPC flow.
+   - If browser: Run `vellum x refresh` to capture session cookies from Chrome.
+
+5. **Set the preferred strategy:**
+   ```bash
+   vellum x strategy set <oauth|browser|auto>
+   ```
+
+## Failure Recovery Flow
+
+When a Twitter operation fails, follow these steps:
+
+1. **Detect the failure type from the error output:**
+   - `session_expired` or `SessionExpiredError` — the browser session cookies have expired.
+   - `OAuth is not configured` — the user chose OAuth but credentials are not set up.
+   - `Twitter API error (401)` — OAuth token may be expired or revoked.
+   - `UnsupportedOAuthOperationError` — the requested operation is not available via OAuth (e.g., timeline, search).
+   - `Cannot connect to daemon` — the Vellum daemon is not running.
+
+2. **Explain the likely cause clearly** to the user.
+
+3. **Suggest trying the other path as an alternative:**
+   - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `vellum x refresh`.
+   - If OAuth failed or is not configured: suggest using the browser path with `vellum x strategy set browser` and `vellum x refresh`.
+   - If the operation is unsupported via OAuth: explain that this specific operation requires the browser path, and run it via browser. No strategy change is needed if the user is on `auto`.
+
+4. **Offer concrete steps to switch:**
+   ```bash
+   # Switch to the other strategy
+   vellum x strategy set <oauth|browser|auto>
+
+   # If switching to browser, refresh the session
+   vellum x refresh
+   ```
+
+## Strategy Management Commands
+
+```bash
+# Check current strategy
+vellum x strategy
+
+# Set strategy to OAuth, browser, or auto
+vellum x strategy set <oauth|browser|auto>
+
+# Check full status (session, OAuth, and strategy info)
+vellum x status --json
+```
+
 ## Posting
 
 ```bash
 vellum x post "The post text here"
 ```
 
-Returns JSON with `ok`, `tweetId`, `text`, and `url` fields. Share the URL with the user so they can verify the post.
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. The `pathUsed` field indicates whether the post was sent via `oauth` or `browser`. Share the URL with the user so they can verify the post.
+
+The `post` command routes through the strategy router: it uses OAuth if configured and available, otherwise falls back to the browser path.
 
 ## Replying
 
@@ -23,7 +117,11 @@ vellum x reply <tweetUrl> "The reply text here"
 
 The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID.
 
+Like `post`, the `reply` command routes through the strategy router and returns a `pathUsed` field.
+
 ## Reading
+
+Read-only operations currently only work via the browser path. When the strategy is set to `auto` or `browser`, these work as expected. When the strategy is set to `oauth`, these operations will fail because OAuth does not yet support them — suggest switching to `auto` or `browser` if this happens.
 
 ### User timeline
 ```bash
@@ -76,20 +174,6 @@ vellum x media <screenName> [--count N]
 ```
 Returns tweets that contain media from the user's profile.
 
-## Session Management
-
-Check if a session exists:
-```bash
-vellum x status --json
-```
-
-If there is no session or the session has expired, refresh it:
-```bash
-vellum x refresh
-```
-
-This opens Chrome, navigates through x.com automatically, and captures auth cookies. Do NOT tell the user to run this manually — run it yourself.
-
 ## Workflows
 
 ### Check Mentions
@@ -131,4 +215,6 @@ When the user wants to see how their posts are performing:
 - All commands return JSON with an `ok` field
 - When drafting replies, match the tone of the conversation — casual threads get casual replies
 - Always show the user what you're about to post and get approval before sending
-- If a session is expired, refresh it silently with `vellum x refresh` before retrying
+- If a browser session is expired, refresh it with `vellum x refresh` before retrying, or suggest switching to OAuth for post/reply operations
+- If an operation fails, check `vellum x status --json` to diagnose the issue before retrying
+- The `post` and `reply` commands include a `pathUsed` field in their response so you can tell the user which connection method was used

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -546,6 +546,7 @@ export function handleTwitterIntegrationConfig(
     if (msg.action === 'get') {
       const raw = loadRawConfig();
       const mode = (raw.twitterIntegrationMode as 'local_byo' | 'managed' | undefined) ?? 'local_byo';
+      const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
       const localClientConfigured = !!getSecureKey('credential:integration:twitter:oauth_client_id');
       const connected = !!getSecureKey('credential:integration:twitter:access_token');
       const meta = getCredentialMetadata('integration:twitter', 'access_token');
@@ -557,6 +558,43 @@ export function handleTwitterIntegrationConfig(
         localClientConfigured,
         connected,
         accountInfo: meta?.accountInfo ?? undefined,
+        strategy,
+      });
+    } else if (msg.action === 'get_strategy') {
+      const raw = loadRawConfig();
+      const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
+      ctx.send(socket, {
+        type: 'twitter_integration_config_response',
+        success: true,
+        managedAvailable: false,
+        localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
+        connected: !!getSecureKey('credential:integration:twitter:access_token'),
+        strategy,
+      });
+    } else if (msg.action === 'set_strategy') {
+      const valid = ['oauth', 'browser', 'auto'];
+      const value = msg.strategy;
+      if (!value || !valid.includes(value)) {
+        ctx.send(socket, {
+          type: 'twitter_integration_config_response',
+          success: false,
+          managedAvailable: false,
+          localClientConfigured: false,
+          connected: false,
+          error: `Invalid strategy value: ${String(value)}. Must be one of: ${valid.join(', ')}`,
+        });
+        return;
+      }
+      const raw = loadRawConfig();
+      raw.twitterOperationStrategy = value;
+      saveRawConfig(raw);
+      ctx.send(socket, {
+        type: 'twitter_integration_config_response',
+        success: true,
+        managedAvailable: false,
+        localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
+        connected: !!getSecureKey('credential:integration:twitter:access_token'),
+        strategy: value as 'oauth' | 'browser' | 'auto',
       });
     } else if (msg.action === 'set_mode') {
       const raw = loadRawConfig();

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -494,10 +494,11 @@ export interface VercelApiConfigResponse {
 
 export interface TwitterIntegrationConfigRequest {
   type: 'twitter_integration_config';
-  action: 'get' | 'set_mode' | 'set_local_client' | 'clear_local_client' | 'disconnect';
+  action: 'get' | 'set_mode' | 'set_local_client' | 'clear_local_client' | 'disconnect' | 'get_strategy' | 'set_strategy';
   mode?: 'local_byo' | 'managed';
   clientId?: string;
   clientSecret?: string;
+  strategy?: string;
 }
 
 export interface TwitterIntegrationConfigResponse {
@@ -508,6 +509,7 @@ export interface TwitterIntegrationConfigResponse {
   localClientConfigured: boolean;
   connected: boolean;
   accountInfo?: string;
+  strategy?: 'oauth' | 'browser' | 'auto';
   error?: string;
 }
 

--- a/assistant/src/twitter/oauth-client.ts
+++ b/assistant/src/twitter/oauth-client.ts
@@ -1,0 +1,102 @@
+/**
+ * OAuth-backed Twitter API client.
+ *
+ * Uses stored OAuth2 Bearer tokens (via the token manager) to execute
+ * Twitter API v2 operations directly, without requiring a browser session.
+ * Currently supports post and reply; all other operations fall back to the
+ * browser-based CDP client.
+ */
+
+import { withValidToken } from '../security/token-manager.js';
+import { getSecureKey } from '../security/secure-keys.js';
+
+const TWITTER_API_BASE = 'https://api.x.com/2';
+const SERVICE = 'integration:twitter';
+
+/** Operations that the OAuth client can handle natively. */
+const SUPPORTED_OPERATIONS = new Set(['post', 'reply']);
+
+export interface OAuthPostResult {
+  tweetId: string;
+  text: string;
+  url?: string;
+}
+
+export interface OAuthOperationError {
+  message: string;
+  suggestFallback: boolean;
+  fallbackPath: 'browser';
+  operation: string;
+}
+
+export class UnsupportedOAuthOperationError extends Error {
+  public readonly suggestFallback = true;
+  public readonly fallbackPath = 'browser' as const;
+  public readonly operation: string;
+  constructor(operation: string) {
+    super(`The "${operation}" operation is not available via the OAuth API. Use the browser path instead.`);
+    this.name = 'UnsupportedOAuthOperationError';
+    this.operation = operation;
+  }
+}
+
+/**
+ * Post a tweet (or reply) using OAuth2 Bearer token authentication.
+ *
+ * The token manager handles refresh transparently — if the stored token
+ * is expired it will be refreshed before (or after a 401) calling the API.
+ */
+export async function oauthPostTweet(
+  text: string,
+  opts?: { inReplyToTweetId?: string },
+): Promise<OAuthPostResult> {
+  return withValidToken(SERVICE, async (token) => {
+    const body: Record<string, unknown> = { text };
+    if (opts?.inReplyToTweetId) {
+      body.reply = { in_reply_to_tweet_id: opts.inReplyToTweetId };
+    }
+
+    const res = await fetch(`${TWITTER_API_BASE}/tweets`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text().catch(() => '');
+      const err = new Error(
+        `Twitter API error (${res.status}): ${errorBody.slice(0, 500)}`,
+      );
+      // Attach status so the token manager's 401-retry logic can detect it.
+      (err as Error & { status: number }).status = res.status;
+      throw err;
+    }
+
+    const json = (await res.json()) as { data: { id: string; text: string } };
+    return {
+      tweetId: json.data.id,
+      text: json.data.text,
+    };
+  });
+}
+
+/**
+ * Check whether OAuth credentials are available for the Twitter integration.
+ * Returns true if an access token has been stored (the token manager will
+ * handle refresh if it's expired).
+ */
+export function oauthIsAvailable(): boolean {
+  return getSecureKey('credential:integration:twitter:access_token') !== undefined;
+}
+
+/**
+ * Check whether a given operation is supported via the OAuth API path.
+ * Only `post` and `reply` are currently supported; everything else
+ * (timeline, search, bookmarks, etc.) requires the browser path.
+ */
+export function oauthSupportsOperation(operation: string): boolean {
+  return SUPPORTED_OPERATIONS.has(operation);
+}

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -67,12 +67,14 @@ export async function routedPostTweet(
   }
 
   // auto strategy: try OAuth first if available and supported, fallback to browser
+  let oauthError: Error | undefined;
   if (oauthIsAvailable() && oauthSupportsOperation(operation)) {
     try {
       const result = await oauthPostTweet(text, opts);
       return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
-    } catch {
-      // OAuth failed, fall through to browser
+    } catch (err) {
+      oauthError = err instanceof Error ? err : new Error(String(err));
+      // Fall through to browser
     }
   }
 
@@ -81,9 +83,17 @@ export async function routedPostTweet(
     const result = await browserPostTweet(text, opts);
     return { result, pathUsed: 'browser' };
   } catch (err) {
-    if (err instanceof SessionExpiredError && oauthIsAvailable()) {
+    if (err instanceof SessionExpiredError) {
       throw Object.assign(err, {
         pathUsed: 'auto' as const,
+        oauthError: oauthError?.message,
+      });
+    }
+    if (oauthError) {
+      const browserError = err instanceof Error ? err : new Error(String(err));
+      throw Object.assign(browserError, {
+        pathUsed: 'auto' as const,
+        oauthError: oauthError.message,
       });
     }
     throw err;

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -1,0 +1,91 @@
+/**
+ * Strategy router for Twitter operations.
+ * Selects OAuth or browser path based on persisted preference and capability.
+ */
+
+import { loadRawConfig } from '../config/loader.js';
+import { oauthPostTweet, oauthIsAvailable, oauthSupportsOperation } from './oauth-client.js';
+import { postTweet as browserPostTweet, SessionExpiredError } from './client.js';
+import type { PostTweetResult } from './client.js';
+
+export type TwitterStrategy = 'oauth' | 'browser' | 'auto';
+
+export interface RoutedResult<T> {
+  result: T;
+  pathUsed: TwitterStrategy;
+}
+
+export interface RoutedError {
+  message: string;
+  pathUsed: TwitterStrategy;
+  suggestAlternative?: TwitterStrategy;
+  alternativeSetupHint?: string;
+}
+
+function getPreferredStrategy(): TwitterStrategy {
+  try {
+    const raw = loadRawConfig();
+    const strategy = raw.twitterOperationStrategy as string | undefined;
+    if (strategy === 'oauth' || strategy === 'browser') return strategy;
+  } catch { /* fall through */ }
+  return 'auto';
+}
+
+export async function routedPostTweet(
+  text: string,
+  opts?: { inReplyToTweetId?: string },
+): Promise<RoutedResult<PostTweetResult>> {
+  const strategy = getPreferredStrategy();
+  const operation = opts?.inReplyToTweetId ? 'reply' : 'post';
+
+  if (strategy === 'oauth') {
+    // User explicitly wants OAuth
+    if (!oauthIsAvailable()) {
+      throw Object.assign(new Error('OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy: `vellum x strategy set browser`.'), {
+        pathUsed: 'oauth' as const,
+        suggestAlternative: 'browser' as const,
+      });
+    }
+    const result = await oauthPostTweet(text, opts);
+    return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
+  }
+
+  if (strategy === 'browser') {
+    // User explicitly wants browser
+    try {
+      const result = await browserPostTweet(text, opts);
+      return { result, pathUsed: 'browser' };
+    } catch (err) {
+      if (err instanceof SessionExpiredError) {
+        throw Object.assign(new Error(`Browser session expired. Refresh with \`vellum x refresh\`, or switch to OAuth: \`vellum x strategy set oauth\`.`), {
+          pathUsed: 'browser' as const,
+          suggestAlternative: 'oauth' as const,
+        });
+      }
+      throw err;
+    }
+  }
+
+  // auto strategy: try OAuth first if available and supported, fallback to browser
+  if (oauthIsAvailable() && oauthSupportsOperation(operation)) {
+    try {
+      const result = await oauthPostTweet(text, opts);
+      return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
+    } catch {
+      // OAuth failed, fall through to browser
+    }
+  }
+
+  // Fallback to browser
+  try {
+    const result = await browserPostTweet(text, opts);
+    return { result, pathUsed: 'browser' };
+  } catch (err) {
+    if (err instanceof SessionExpiredError && oauthIsAvailable()) {
+      throw Object.assign(new Error(`Browser session expired and OAuth was already tried. Refresh browser session with \`vellum x refresh\` or check OAuth credentials.`), {
+        pathUsed: 'auto' as const,
+      });
+    }
+    throw err;
+  }
+}

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -57,7 +57,7 @@ export async function routedPostTweet(
       return { result, pathUsed: 'browser' };
     } catch (err) {
       if (err instanceof SessionExpiredError) {
-        throw Object.assign(new Error(`Browser session expired. Refresh with \`vellum x refresh\`, or switch to OAuth: \`vellum x strategy set oauth\`.`), {
+        throw Object.assign(err, {
           pathUsed: 'browser' as const,
           suggestAlternative: 'oauth' as const,
         });
@@ -82,7 +82,7 @@ export async function routedPostTweet(
     return { result, pathUsed: 'browser' };
   } catch (err) {
     if (err instanceof SessionExpiredError && oauthIsAvailable()) {
-      throw Object.assign(new Error(`Browser session expired and OAuth was already tried. Refresh browser session with \`vellum x refresh\` or check OAuth credentials.`), {
+      throw Object.assign(err, {
         pathUsed: 'auto' as const,
       });
     }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1739,6 +1739,7 @@ public struct IPCTwitterIntegrationConfigRequest: Codable, Sendable {
     public let mode: String?
     public let clientId: String?
     public let clientSecret: String?
+    public let strategy: String?
 }
 
 public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
@@ -1749,6 +1750,7 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let localClientConfigured: Bool
     public let connected: Bool
     public let accountInfo: String?
+    public let strategy: String?
     public let error: String?
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1763,8 +1763,8 @@ public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
 public typealias TwitterIntegrationConfigRequestMessage = IPCTwitterIntegrationConfigRequest
 
 extension IPCTwitterIntegrationConfigRequest {
-    public init(action: String, mode: String? = nil, clientId: String? = nil, clientSecret: String? = nil) {
-        self.init(type: "twitter_integration_config", action: action, mode: mode, clientId: clientId, clientSecret: clientSecret)
+    public init(action: String, mode: String? = nil, clientId: String? = nil, clientSecret: String? = nil, strategy: String? = nil) {
+        self.init(type: "twitter_integration_config", action: action, mode: mode, clientId: clientId, clientSecret: clientSecret, strategy: strategy)
     }
 }
 


### PR DESCRIPTION
## Summary
Enable the assistant to perform Twitter/X operations using two supported connection paths: OAuth-based (X API v2, recommended when developer credentials are available) and browser-session-based (CDP, quick start without developer credentials). The assistant presents both options on first use, persists the user's preference, and suggests switching paths when failures occur.

## Changes
- **Strategy config & status** (M1): Added `twitterOperationStrategy` config field (`oauth`/`browser`/`auto`), extended IPC with `get_strategy`/`set_strategy`, added `vellum x strategy` CLI subcommand, enriched `vellum x status` with OAuth readiness
- **OAuth operation client** (M2): Created `oauth-client.ts` for X API v2 post/reply using `withValidToken()` for automatic token refresh
- **Strategy router** (M3): Created `router.ts` that selects OAuth or browser path based on config — `auto` prefers OAuth when available, falls back to browser
- **Skill rewrite** (M4): Rewrote SKILL.md with dual-path connection options, first-use decision flow, failure-recovery guidance, and strategy management
- **Documentation** (M5): Updated README.md and ARCHITECTURE.md with dual-path architecture, Mermaid diagrams, and new source file references
- **Feedback fixes**: Fixed `sendDaemonMessage` to filter `session_info` messages; preserved `SessionExpiredError` type through the strategy router

## Milestone PRs (merged into feature branch)
- #6246: M1 — Strategy state, config, and status foundation
- #6243: M2 — OAuth operation client for core commands
- #6249: M3 — Strategy router for command execution
- #6251: M4 — Twitter skill rewrite with dual-path UX
- #6252: M5 — Documentation and architecture updates
- #6253: Fix sendDaemonMessage to filter session_info messages
- #6254: Fix router to preserve SessionExpiredError for CLI contract

## Project issue
Closes #6232

## Test plan
- [ ] Verify `vellum x strategy` reports current strategy (default: `auto`)
- [ ] Verify `vellum x strategy set oauth` persists across restarts
- [ ] Verify `vellum x status --json` includes OAuth readiness and strategy info
- [ ] Verify `vellum x post` routes through OAuth when configured, browser otherwise
- [ ] Verify browser-only operations (timeline, search, etc.) still work
- [ ] Verify session expiry produces structured `session_expired` error
- [ ] Review SKILL.md for dual-path connection options and failure recovery guidance
- [ ] Review ARCHITECTURE.md Mermaid diagrams for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
