### PR TITLE
Fix caller_identity_source for assistant_number and throw on partial Twilio failures

### DIFF
--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -282,7 +282,7 @@ describe('TwilioConversationRelayProvider', () => {
       );
     });
 
-    test('returns ineligible (not throws) when only one API call fails but the other succeeds with no match', async () => {
+    test('throws when only one API call fails but the other succeeds with no match', async () => {
       const provider = new TwilioConversationRelayProvider();
 
       globalThis.fetch = (async (url: RequestInfo | URL): Promise<Response> => {
@@ -299,9 +299,9 @@ describe('TwilioConversationRelayProvider', () => {
         return new Response('Not found', { status: 404 });
       }) as typeof fetch;
 
-      const result = await provider.checkCallerIdEligibility('+15550001111');
-      expect(result.eligible).toBe(false);
-      expect(result.reason).toContain('not owned by or verified');
+      await expect(provider.checkCallerIdEligibility('+15550001111')).rejects.toThrow(
+        'Unable to verify caller ID eligibility',
+      );
     });
 
     test('passes correct phone number as query parameter', async () => {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -110,8 +110,8 @@ export async function resolveCallerIdentity(
 
   if (mode === 'assistant_number') {
     const twilioConfig = getTwilioConfig();
-    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
-    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
+    log.info({ mode, source: 'twilio_config', fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source: 'twilio_config' };
   }
 
   // user_number mode: resolve from config or secure key, tracking where the number came from

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -202,11 +202,15 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
       );
     }
 
-    // If neither API call succeeded, the eligibility check is inconclusive —
+    // If any API call failed, the eligibility check is inconclusive —
     // propagate as an error rather than returning a false negative.
-    if (!incomingOk && !outgoingOk) {
+    if (!incomingOk || !outgoingOk) {
+      const failedEndpoints = [
+        ...(!incomingOk ? [`IncomingPhoneNumbers: ${incomingRes.status}`] : []),
+        ...(!outgoingOk ? [`OutgoingCallerIds: ${outgoingRes.status}`] : []),
+      ].join(', ');
       throw new Error(
-        `Unable to verify caller ID eligibility for ${phoneNumber}: both Twilio API calls failed (IncomingPhoneNumbers: ${incomingRes.status}, OutgoingCallerIds: ${outgoingRes.status}). This may indicate a network issue, auth error, or Twilio outage.`,
+        `Unable to verify caller ID eligibility for ${phoneNumber}: Twilio API error (${failedEndpoints}). The number may be eligible but could not be confirmed. Please check your Twilio credentials and try again.`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Set caller_identity_source to twilio_config for assistant_number mode (was incorrectly per_call_override/config_default)
- Throw on any Twilio API failure during eligibility check (was only throwing when both failed)
- Updated tests to match new partial-failure behavior

## Original prompt
Address feedback on final PR #6250: Fix source tracking for assistant_number and handle partial Twilio API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
