### PR TITLE
Fix CI + address Codex feedback on final PR

### DIFF
--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -149,10 +149,11 @@ describe('Twitter strategy router', () => {
         await routedPostTweet('will fail');
         expect(true).toBe(false); // should not reach
       } catch (err) {
-        const e = err as Error & { pathUsed: string };
+        const e = err as Error & { pathUsed: string; oauthError?: string };
         expect(e).toBeInstanceOf(MockSessionExpiredError);
         expect(e.message).toBe('Browser session expired');
         expect(e.pathUsed).toBe('auto');
+        expect(e.oauthError).toBe('OAuth failed');
       }
     });
   });

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -193,7 +193,7 @@ export function registerTwitterCommand(program: Command): void {
         const daemonResponse = await sendDaemonMessage({
           type: 'twitter_integration_config',
           action: 'get',
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         oauthInfo = {
           oauthConnected: r.connected ?? false,
@@ -231,7 +231,7 @@ export function registerTwitterCommand(program: Command): void {
         const daemonResponse = await sendDaemonMessage({
           type: 'twitter_integration_config',
           action: 'get_strategy',
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         output({ ok: true, strategy: r.strategy ?? 'auto' }, json);
       } catch (err) {
@@ -249,7 +249,7 @@ export function registerTwitterCommand(program: Command): void {
           type: 'twitter_integration_config',
           action: 'set_strategy',
           strategy: value,
-        } as import('../daemon/ipc-protocol.js').ClientMessage);
+        } as import('../daemon/ipc-protocol.js').ClientMessage, 'twitter_integration_config_response');
         const r = daemonResponse as Record<string, unknown>;
         if (r.success) {
           output({ ok: true, strategy: r.strategy }, json);
@@ -458,6 +458,7 @@ export function registerTwitterCommand(program: Command): void {
 
 function sendDaemonMessage(
   message: import('../daemon/ipc-protocol.js').ClientMessage,
+  expectedResponseType: string,
 ): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const socketPath = getSocketPath();
@@ -502,16 +503,14 @@ function sendDaemonMessage(
           continue;
         }
 
-        // Skip auth_result echoes, daemon_status broadcasts, and session_info
-        if (m.type === 'auth_result' || m.type === 'daemon_status' || m.type === 'pong' || m.type === 'session_info') {
-          continue;
+        // Only resolve on the expected response type; skip everything else
+        if (m.type === expectedResponseType) {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          resolve(m);
+          return;
         }
-
-        // First substantive response — return it
-        clearTimeout(timeoutHandle);
-        socket.destroy();
-        resolve(m);
-        return;
+        // Skip all other message types (auth_result, daemon_status, pong, session_info, tasks_changed, etc.)
       }
     });
 

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -121,7 +121,7 @@ Like `post`, the `reply` command routes through the strategy router and returns 
 
 ## Reading
 
-Read-only operations currently only work via the browser path. When the strategy is set to `auto` or `browser`, these work as expected. When the strategy is set to `oauth`, these operations will fail because OAuth does not yet support them — suggest switching to `auto` or `browser` if this happens.
+Read-only operations always use the browser path directly, regardless of the strategy setting. They work the same whether the strategy is `oauth`, `browser`, or `auto` — the strategy only affects `post` and `reply` commands.
 
 ### User timeline
 ```bash

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -67,12 +67,14 @@ export async function routedPostTweet(
   }
 
   // auto strategy: try OAuth first if available and supported, fallback to browser
+  let oauthError: Error | undefined;
   if (oauthIsAvailable() && oauthSupportsOperation(operation)) {
     try {
       const result = await oauthPostTweet(text, opts);
       return { result: { tweetId: result.tweetId, text: result.text, url: result.url ?? `https://x.com/i/status/${result.tweetId}` }, pathUsed: 'oauth' };
-    } catch {
-      // OAuth failed, fall through to browser
+    } catch (err) {
+      oauthError = err instanceof Error ? err : new Error(String(err));
+      // Fall through to browser
     }
   }
 
@@ -81,9 +83,17 @@ export async function routedPostTweet(
     const result = await browserPostTweet(text, opts);
     return { result, pathUsed: 'browser' };
   } catch (err) {
-    if (err instanceof SessionExpiredError && oauthIsAvailable()) {
+    if (err instanceof SessionExpiredError) {
       throw Object.assign(err, {
         pathUsed: 'auto' as const,
+        oauthError: oauthError?.message,
+      });
+    }
+    if (oauthError) {
+      const browserError = err instanceof Error ? err : new Error(String(err));
+      throw Object.assign(browserError, {
+        pathUsed: 'auto' as const,
+        oauthError: oauthError.message,
       });
     }
     throw err;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1739,6 +1739,7 @@ public struct IPCTwitterIntegrationConfigRequest: Codable, Sendable {
     public let mode: String?
     public let clientId: String?
     public let clientSecret: String?
+    public let strategy: String?
 }
 
 public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
@@ -1749,6 +1750,7 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let localClientConfigured: Bool
     public let connected: Bool
     public let accountInfo: String?
+    public let strategy: String?
     public let error: String?
 }
 


### PR DESCRIPTION
Fixes 4 issues: (1) regenerate IPC Swift types after M1 contract changes, (2) sendDaemonMessage now matches by expected response type instead of skip-list, (3) SKILL.md corrects incorrect guidance about reads failing under oauth strategy, (4) router surfaces OAuth error in auto mode when both paths fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
