### PR TITLE
Fix Telegram isConnected to require webhook_secret

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -58,9 +58,13 @@ export const telegramBotMessagingProvider: MessagingProvider = {
    * credential:telegram:access_token, but the Telegram bot token is
    * stored as credential:telegram:bot_token. This method lets the
    * registry detect that Telegram credentials exist.
+   *
+   * Both bot_token and webhook_secret are required — the gateway's
+   * /deliver/telegram endpoint rejects requests without the webhook
+   * secret, so partial credentials would cause every send to fail.
    */
   isConnected(): boolean {
-    return getBotToken() !== undefined;
+    return getBotToken() !== undefined && !!getSecureKey('credential:telegram:webhook_secret');
   },
 
   async testConnection(_token: string): Promise<ConnectionInfo> {


### PR DESCRIPTION
Codex P2 feedback on #6247: isConnected() only checked bot_token but outbound delivery also requires webhook_secret. Now validates both credentials exist before reporting as connected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
