### PR TITLE
Fix TypeScript errors in OAuth client tests

### DIFF
--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -98,7 +98,7 @@ describe('Twitter OAuth client', () => {
 
       // Verify the request was made correctly
       expect(fn).toHaveBeenCalledTimes(1);
-      const [url, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const [url, opts] = fn.mock.calls[0] as unknown as [string, RequestInit];
       expect(url).toBe('https://api.x.com/2/tweets');
       expect(opts.method).toBe('POST');
       expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer fake-oauth-token');
@@ -121,7 +121,7 @@ describe('Twitter OAuth client', () => {
       expect(result.tweetId).toBe('67890');
       expect(result.text).toBe('My reply');
 
-      const [, opts] = fn.mock.calls[0] as [string, RequestInit];
+      const [, opts] = fn.mock.calls[0] as unknown as [string, RequestInit];
       const body = JSON.parse(opts.body as string);
       expect(body.text).toBe('My reply');
       expect(body.reply).toEqual({ in_reply_to_tweet_id: '11111' });


### PR DESCRIPTION
Fixes TS2352 errors where empty array mock.calls couldn't be directly cast to [string, RequestInit] tuple. Casts through unknown first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
