### PR TITLE
Fix routing default to only apply in single-assistant mode

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -4,7 +4,7 @@ import { createRequire } from "module";
 import { homedir } from "os";
 import { dirname, join } from "path";
 
-import { loadLatestAssistant } from "./assistant-config.js";
+import { loadAllAssistants, loadLatestAssistant } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 
 const _require = createRequire(import.meta.url);
@@ -287,21 +287,32 @@ export async function startGateway(): Promise<string> {
 
   console.log("🌐 Starting gateway...");
   const gatewayDir = resolveGatewayDir();
-  // Auto-configure routing for single-assistant local deployments so that
-  // inbound Telegram messages are forwarded without manual env var setup.
-  const defaultAssistantId =
-    process.env.GATEWAY_DEFAULT_ASSISTANT_ID
-    || loadLatestAssistant()?.assistantId
-    || "default";
+  // Only auto-configure default routing when the workspace has exactly one
+  // assistant.  In multi-assistant deployments, falling back to "default"
+  // would silently deliver unmapped Telegram chats to whichever assistant was
+  // most recently hatched — keep the "reject" policy instead.
+  const assistants = loadAllAssistants();
+  const isSingleAssistant = assistants.length === 1;
 
   const gatewayEnv: Record<string, string> = {
     ...process.env as Record<string, string>,
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
     GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
-    GATEWAY_UNMAPPED_POLICY: process.env.GATEWAY_UNMAPPED_POLICY || "default",
-    GATEWAY_DEFAULT_ASSISTANT_ID: defaultAssistantId,
   };
+
+  if (process.env.GATEWAY_UNMAPPED_POLICY) {
+    gatewayEnv.GATEWAY_UNMAPPED_POLICY = process.env.GATEWAY_UNMAPPED_POLICY;
+  } else if (isSingleAssistant) {
+    gatewayEnv.GATEWAY_UNMAPPED_POLICY = "default";
+  }
+
+  if (process.env.GATEWAY_DEFAULT_ASSISTANT_ID) {
+    gatewayEnv.GATEWAY_DEFAULT_ASSISTANT_ID = process.env.GATEWAY_DEFAULT_ASSISTANT_ID;
+  } else if (isSingleAssistant) {
+    gatewayEnv.GATEWAY_DEFAULT_ASSISTANT_ID =
+      assistants[0].assistantId || loadLatestAssistant()?.assistantId || "default";
+  }
   const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
   const ingressPublicBaseUrl =
     workspaceIngressPublicBaseUrl


### PR DESCRIPTION
Codex P1 feedback on #6247: startGateway() was unconditionally setting GATEWAY_UNMAPPED_POLICY=default which could route messages to the wrong assistant in multi-assistant workspaces. Now only applies when the workspace has exactly one assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
