### PR TITLE
Add call-domain.ts to credential security allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -185,6 +185,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'email/providers/index.ts',      // email provider API key lookup
       'tools/network/script-proxy/session-manager.ts', // proxy credential injection at runtime
       'messaging/registry.ts',          // checks stored credentials for connected providers
+      'calls/call-domain.ts',            // caller identity resolution (user phone number lookup)
       'calls/twilio-config.ts',         // call infrastructure credential lookup
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
       'runtime/http-server.ts',         // HTTP server credential lookup


### PR DESCRIPTION
## Summary
- Added calls/call-domain.ts to the ALLOWED_IMPORTERS set in credential-security-invariants.test.ts
- This file imports getSecureKey for user phone number resolution in caller identity feature
- Fixes CI test failure: Invariant 2 (getSecureKey only imported by authorized modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
