### PR TITLE
fix: correct stale function name and inaccurate JSDoc

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3118,7 +3118,7 @@ Bounded recurrence is supported via `COUNT` (e.g., `RRULE:FREQ=DAILY;COUNT=30`) 
 
 ### Syntax Detection
 
-The `detectScheduleSyntax()` function auto-detects which syntax an expression uses by checking for RRULE markers (`RRULE:`, `DTSTART`, `FREQ=`). When creating or updating a schedule, the caller can explicitly specify `syntax: 'cron' | 'rrule'`, or the system infers it from the expression string via `resolveScheduleSpec()`.
+The `detectScheduleSyntax()` function auto-detects which syntax an expression uses by checking for RRULE markers (`RRULE:`, `DTSTART`, `FREQ=`). When creating or updating a schedule, the caller can explicitly specify `syntax: 'cron' | 'rrule'`, or the system infers it from the expression string via `normalizeScheduleSyntax()`.
 
 ### Legacy Compatibility
 
@@ -3128,7 +3128,7 @@ The database column is named `cron_expression` and the Drizzle table is `cronJob
 
 | File | Responsibility |
 |------|---------------|
-| `assistant/src/schedule/recurrence-types.ts` | `ScheduleSyntax` type, `detectScheduleSyntax()`, `resolveScheduleSpec()` |
+| `assistant/src/schedule/recurrence-types.ts` | `ScheduleSyntax` type, `detectScheduleSyntax()`, `normalizeScheduleSyntax()` |
 | `assistant/src/schedule/recurrence-engine.ts` | Validation (`isValidScheduleExpression`), next-run computation, RRULE set detection |
 | `assistant/src/schedule/schedule-store.ts` | CRUD operations, claim-based polling, legacy `cronExpression` field support |
 | `assistant/src/schedule/scheduler.ts` | 15-second tick loop, fires due schedules and reminders |

--- a/assistant/src/tasks/task-scheduler.ts
+++ b/assistant/src/tasks/task-scheduler.ts
@@ -1,7 +1,8 @@
 import { createSchedule } from '../schedule/schedule-store.js';
 
 /**
- * Create a recurrence schedule that runs a task on a cron or RRULE expression.
+ * Create a cron schedule that runs a task on a recurring cron expression.
+ * RRULE syntax is supported at the store layer but this helper currently defaults to cron.
  * The scheduler detects the `run_task:<taskId>` message format
  * and delegates to runTask() instead of processMessage().
  */


### PR DESCRIPTION
## Summary

- **ARCHITECTURE.md**: Two references to `resolveScheduleSpec()` corrected to `normalizeScheduleSyntax()` (the actual exported function name in `recurrence-types.ts`)
- **task-scheduler.ts**: JSDoc updated from "cron or RRULE expression" to accurately reflect that this helper only creates cron schedules (RRULE is supported at the store layer but not by this function)

## Test plan

- [x] Pure documentation/comment changes -- no runtime behavior affected
- [x] Verified edits match actual code exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
