### PR TITLE
fix: auto-detect schedule syntax in update fallback path

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -420,6 +420,41 @@ describe('schedule_update with RRULE', () => {
     expect(result.content).toContain('Syntax: rrule');
     expect(result.content).toContain('RRULE:FREQ=DAILY');
   });
+
+  test('auto-detects rrule syntax when updating expression without explicit syntax', async () => {
+    await executeScheduleCreate({
+      name: 'Auto-detect on update',
+      cron_expression: '0 9 * * *',
+      message: 'test',
+    }, ctx);
+
+    const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
+    const result = await executeScheduleUpdate({
+      job_id: row.id,
+      expression: 'DTSTART:20250601T120000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Syntax: rrule');
+    expect(result.content).toContain('RRULE:FREQ=WEEKLY');
+  });
+
+  test('auto-detects cron syntax when updating expression without explicit syntax', async () => {
+    await executeScheduleCreate({
+      name: 'Cron auto-detect',
+      cron_expression: '0 9 * * *',
+      message: 'test',
+    }, ctx);
+
+    const row = getRawDb().query('SELECT id FROM cron_jobs LIMIT 1').get() as { id: string };
+    const result = await executeScheduleUpdate({
+      job_id: row.id,
+      expression: '30 17 * * 1-5',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Syntax: cron');
+  });
 });
 
 describe('schedule_list with RRULE', () => {

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,6 +1,6 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { updateSchedule, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
-import { normalizeScheduleSyntax, type ScheduleSyntax } from '../../schedule/recurrence-types.js';
+import { normalizeScheduleSyntax, detectScheduleSyntax, type ScheduleSyntax } from '../../schedule/recurrence-types.js';
 import { validateRruleSetLines } from '../../schedule/recurrence-engine.js';
 
 export async function executeScheduleUpdate(
@@ -31,6 +31,8 @@ export async function executeScheduleUpdate(
       updates.expression = resolved.expression;
     } else if (input.expression !== undefined) {
       updates.expression = input.expression;
+      const detected = detectScheduleSyntax(input.expression as string);
+      if (detected) updates.syntax = detected;
     } else if (input.cron_expression !== undefined) {
       updates.cronExpression = input.cron_expression;
     }


### PR DESCRIPTION
## Summary
- When `normalizeScheduleSyntax()` returns null during `schedule_update`, the fallback branch now calls `detectScheduleSyntax()` to infer syntax from the expression string
- Fixes cron-to-rrule updates failing when no explicit `syntax` parameter is passed, matching the TOOLS.json contract that syntax is auto-detected when expression changes
- Adds two tests verifying auto-detection for both RRULE and cron expressions during update

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/schedule-tools.test.ts` — all 40 tests pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
