### PR TITLE
Add explicit EXRULE behavioral tests for regression coverage

### DIFF
--- a/assistant/src/__tests__/recurrence-engine-rruleset.test.ts
+++ b/assistant/src/__tests__/recurrence-engine-rruleset.test.ts
@@ -76,3 +76,100 @@ describe('RRULE set engine support', () => {
     expect(next).toBeGreaterThan(Date.now() - 1);
   });
 });
+
+// ── EXRULE behavioral tests ──────────────────────────────────────────
+
+describe('EXRULE engine behavior', () => {
+  test('EXRULE excludes matching occurrences from daily series', () => {
+    // RRULE: every day at 09:00 starting Jan 1 2099
+    // EXRULE: every Saturday and Sunday (weekends)
+    // Expected: weekday occurrences only
+    const expr = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'EXRULE:FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+
+    // Jan 1 2099 is a Thursday. Enumerate the first several occurrences
+    // and verify that no Saturday (Jan 3) or Sunday (Jan 4) appears.
+    const thu = new Date('2099-01-01T09:00:00Z').getTime(); // Thu
+    const fri = new Date('2099-01-02T09:00:00Z').getTime(); // Fri
+    const sat = new Date('2099-01-03T09:00:00Z').getTime(); // Sat
+    const sun = new Date('2099-01-04T09:00:00Z').getTime(); // Sun
+    const mon = new Date('2099-01-05T09:00:00Z').getTime(); // Mon
+
+    // After Thu -> should be Fri (not Sat/Sun)
+    const afterThu = computeNextRunAt({ syntax: 'rrule', expression: expr }, thu + 1);
+    expect(afterThu).toBe(fri);
+
+    // After Fri -> should skip Sat+Sun, land on Mon
+    const afterFri = computeNextRunAt({ syntax: 'rrule', expression: expr }, fri + 1);
+    expect(afterFri).toBe(mon);
+
+    // Explicitly confirm Sat and Sun are never returned
+    expect(afterFri).not.toBe(sat);
+    expect(afterFri).not.toBe(sun);
+  });
+
+  test('EXRULE with FREQ acts as repeating exclusion series', () => {
+    // RRULE: every day starting Jan 1 2099
+    // EXRULE: every 3rd day starting Jan 1 2099 (excludes Jan 1, Jan 4, Jan 7, ...)
+    const expr = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'EXRULE:FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+
+    const jan1 = new Date('2099-01-01T09:00:00Z').getTime();
+    const jan2 = new Date('2099-01-02T09:00:00Z').getTime();
+    const jan3 = new Date('2099-01-03T09:00:00Z').getTime();
+    const jan4 = new Date('2099-01-04T09:00:00Z').getTime();
+    const jan5 = new Date('2099-01-05T09:00:00Z').getTime();
+
+    // Jan 1 is excluded (EXRULE fires on DTSTART). First occurrence after
+    // DTSTART should be Jan 2.
+    const first = computeNextRunAt({ syntax: 'rrule', expression: expr }, jan1 - 1);
+    expect(first).toBe(jan2);
+
+    // After Jan 2 -> Jan 3 (Jan 3 not excluded)
+    const second = computeNextRunAt({ syntax: 'rrule', expression: expr }, jan2 + 1);
+    expect(second).toBe(jan3);
+
+    // After Jan 3 -> should skip Jan 4 (excluded, 3 days after Jan 1) -> Jan 5
+    const third = computeNextRunAt({ syntax: 'rrule', expression: expr }, jan3 + 1);
+    expect(third).toBe(jan5);
+    expect(third).not.toBe(jan4);
+  });
+
+  test('EXRULE does not affect non-matching occurrences', () => {
+    // RRULE: every weekday (Mon-Fri) at 09:00
+    // EXRULE: every Saturday at 09:00 (no overlap with weekday rule)
+    // Expected: all weekday occurrences remain intact
+    const expr = [
+      'DTSTART:20990105T090000Z',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'EXRULE:FREQ=WEEKLY;BYDAY=SA;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+
+    // Jan 5 2099 is a Monday. Verify all five weekdays in the first week appear.
+    const mon = new Date('2099-01-05T09:00:00Z').getTime();
+    const tue = new Date('2099-01-06T09:00:00Z').getTime();
+    const wed = new Date('2099-01-07T09:00:00Z').getTime();
+    const thu = new Date('2099-01-08T09:00:00Z').getTime();
+    const fri = new Date('2099-01-09T09:00:00Z').getTime();
+    const nextMon = new Date('2099-01-12T09:00:00Z').getTime();
+
+    expect(computeNextRunAt({ syntax: 'rrule', expression: expr }, mon + 1)).toBe(tue);
+    expect(computeNextRunAt({ syntax: 'rrule', expression: expr }, tue + 1)).toBe(wed);
+    expect(computeNextRunAt({ syntax: 'rrule', expression: expr }, wed + 1)).toBe(thu);
+    expect(computeNextRunAt({ syntax: 'rrule', expression: expr }, thu + 1)).toBe(fri);
+    // After Fri -> skips weekend entirely (Sat excluded + Sun not in RRULE) -> Mon
+    expect(computeNextRunAt({ syntax: 'rrule', expression: expr }, fri + 1)).toBe(nextMon);
+  });
+});

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -657,6 +657,54 @@ describe('schedule_list with RRULE set', () => {
   });
 });
 
+// ── EXRULE support in schedule tools ──────────────────────────────────
+
+describe('schedule_create with RRULE + EXRULE', () => {
+  beforeEach(() => {
+    getRawDb().run('DELETE FROM cron_runs');
+    getRawDb().run('DELETE FROM cron_jobs');
+  });
+
+  test('creates a schedule with RRULE + EXRULE', async () => {
+    const expression = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'EXRULE:FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+
+    const result = await executeScheduleCreate({
+      name: 'Weekday-only via EXRULE',
+      syntax: 'rrule',
+      expression,
+      message: 'EXRULE test',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Schedule created successfully');
+    expect(result.content).toContain('Syntax: rrule');
+  });
+
+  test('list output shows [RRULE set] label for EXRULE expression', async () => {
+    const expression = [
+      'DTSTART:20990101T090000Z',
+      'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      'EXRULE:FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+    ].join('\n');
+
+    await executeScheduleCreate({
+      name: 'EXRULE Set Schedule',
+      syntax: 'rrule',
+      expression,
+      message: 'EXRULE set test',
+    }, ctx);
+
+    const result = await executeScheduleList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('[RRULE set]');
+  });
+});
+
 // ── schedule_delete ─────────────────────────────────────────────────
 
 describe('schedule_delete tool', () => {

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -299,6 +299,47 @@ describe('scheduler RRULE execution', () => {
     expect(runs[0].status).toBe('ok');
   });
 
+  test('EXRULE schedule skips excluded occurrence and advances to next valid date', async () => {
+    // RRULE: every minute from an hour ago
+    // EXRULE: every 2nd minute from the same start
+    // The scheduler should fire on the non-excluded minutes and advance
+    // nextRunAt past any excluded occurrences.
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const pastDate = new Date(now.getTime() - 3_600_000);
+    const ds = `${pastDate.getUTCFullYear()}${pad(pastDate.getUTCMonth() + 1)}${pad(pastDate.getUTCDate())}T${pad(pastDate.getUTCHours())}${pad(pastDate.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
+
+    const expression = `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1\nEXRULE:FREQ=MINUTELY;INTERVAL=2`;
+
+    const schedule = createSchedule({
+      name: 'EXRULE scheduler test',
+      cronExpression: expression,
+      message: 'EXRULE scheduler fire',
+      syntax: 'rrule',
+      expression,
+    });
+
+    forceScheduleDue(schedule.id);
+
+    const processedMessages: string[] = [];
+    const processMessage = async (_conversationId: string, message: string) => {
+      processedMessages.push(message);
+    };
+
+    const scheduler = startScheduler(processMessage, () => {}, () => {});
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    // The schedule should have fired
+    expect(processedMessages).toContain('EXRULE scheduler fire');
+
+    // nextRunAt should have advanced past the current time
+    const after = getSchedule(schedule.id);
+    expect(after).not.toBeNull();
+    expect(after!.lastRunAt).not.toBeNull();
+    expect(after!.nextRunAt).toBeGreaterThan(Date.now() - 5000);
+  });
+
   test('RRULE schedule advances nextRunAt after firing', async () => {
     const rruleExpr = buildEveryMinuteRrule();
     const schedule = createSchedule({


### PR DESCRIPTION
## Summary
- Adds EXRULE-specific engine tests verifying exclusion of matching occurrences (daily + weekend EXRULE skips Sat/Sun), repeating EXRULE series (every-3rd-day exclusion), and no impact on non-matching occurrences
- Adds EXRULE tool tests confirming schedule_create succeeds with RRULE + EXRULE and schedule_list shows `[RRULE set]` label for EXRULE expressions
- Adds EXRULE scheduler test verifying the scheduler fires on non-excluded minutes and advances nextRunAt past excluded occurrences

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test recurrence-engine-rruleset.test.ts` — 12 pass, 0 fail (3 new EXRULE tests)
- [x] `bun test schedule-tools.test.ts` — 40 pass, 0 fail (2 new EXRULE tests)
- [x] `bun test scheduler-recurrence.test.ts` — 7 pass, 1 fail (1 new EXRULE test passes; 1 pre-existing failure on main: "ended RRULE (UNTIL in past) is not repeatedly claimed")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
