### PR TITLE
fix: use strict less-than for suffix length guard in truncate

### DIFF
--- a/assistant/src/util/truncate.ts
+++ b/assistant/src/util/truncate.ts
@@ -1,6 +1,6 @@
 /** Truncate a string to `maxLen` characters, appending `suffix` if truncated. */
 export function truncate(str: string, maxLen: number, suffix = '...'): string {
   if (str.length <= maxLen) return str;
-  if (maxLen <= suffix.length) return str.slice(0, maxLen);
+  if (maxLen < suffix.length) return str.slice(0, maxLen);
   return str.slice(0, maxLen - suffix.length) + suffix;
 }


### PR DESCRIPTION
Address Codex review feedback on PR #5594: change maxLen <= suffix.length to maxLen < suffix.length so that truncate('abcdef', 3) returns '...' instead of 'abc' when maxLen equals suffix length.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
