### PR TITLE
fix: use atomic file replacement for video save to prevent data loss

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -291,8 +291,17 @@ struct InlineVideoAttachmentView: View {
         isSaving = true
         if let sourceURL = cachedFileURL {
             Task.detached {
-                try? FileManager.default.removeItem(at: destURL)
-                try? FileManager.default.copyItem(at: sourceURL, to: destURL)
+                do {
+                    // Copy to a temp location first, then atomically replace the destination so the
+                    // original file is never removed before we have a working replacement in hand.
+                    let tempURL = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(UUID().uuidString)
+                        .appendingPathExtension(destURL.pathExtension)
+                    try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+                    _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
+                } catch {
+                    print("Failed to save video: \(error)")
+                }
                 await MainActor.run { isSaving = false }
             }
         } else if attachment.isLazyLoad {


### PR DESCRIPTION
Address Codex and Devin review feedback on PR #5595: replace delete-then-copy with atomic replaceItemAt or do/catch to prevent data loss if copy fails after destination is removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
