### PR TITLE
fix: clear ffmpeg timeout timer after process exits in video-thumbnail

### DIFF
--- a/assistant/src/daemon/video-thumbnail.ts
+++ b/assistant/src/daemon/video-thumbnail.ts
@@ -35,11 +35,13 @@ export async function generateVideoThumbnail(dataBase64: string): Promise<string
       outputPath,
     ], { stderr: 'pipe' });
 
-    // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg
+    // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg.
+    // The timer handle is cleared via finally() so it doesn't leak when ffmpeg exits normally.
+    let timer: ReturnType<typeof setTimeout>;
     const exitCode = await Promise.race([
-      proc.exited,
+      proc.exited.finally(() => clearTimeout(timer)),
       new Promise<never>((_, reject) =>
-        setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
+        timer = setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
       ),
     ]);
 


### PR DESCRIPTION
Address Codex and Devin review feedback on PR #5597: store the setTimeout handle and clear it via proc.exited.finally() to prevent timer leaks and unhandled promise rejections. Mirrors the existing pattern in browser-manager.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
