### PR TITLE
fix: remove full CRLF when trimming directive-only lines

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -320,8 +320,10 @@ export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDra
       // streaming mode more data may arrive in the next chunk — eagerly
       // trimming would merge words across the directive boundary.
       const nextChar = buffer[end + 2];
-      if (emitText.endsWith('\n') && (nextChar === '\n' || nextChar === '\r')) {
-        emitText = emitText.slice(0, -1);
+      if (emitText.endsWith('\r\n') && nextChar === '\r') {
+        emitText = emitText.slice(0, -2); // trim full \r\n
+      } else if (emitText.endsWith('\n') && nextChar === '\n') {
+        emitText = emitText.slice(0, -1); // trim \n
       }
     }
 


### PR DESCRIPTION
Address Codex and Devin review feedback on PR #5598: fix the CRLF trim logic to remove both \r\n instead of just \n, preventing stray \r characters in streamed text with Windows-style line endings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
