### PR TITLE
fix: update test name to reflect 50% tolerance in memory-retrieval benchmark

### DIFF
--- a/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
@@ -398,7 +398,7 @@ describe('Memory retrieval benchmark', () => {
     }
   });
 
-  test('recall.latencyMs tracks wall-clock within 20% tolerance', async () => {
+  test('recall.latencyMs tracks wall-clock within 50% tolerance', async () => {
     const conversationId = 'conv-bench-wallclock';
     const now = 1_700_500_000_000;
     seedMemoryItems(conversationId, 500, now);


### PR DESCRIPTION
Address Devin review feedback on PR #5622: the test description said '20% tolerance' but the actual assertions use 50% tolerance (0.5–1.5 ratio). Updated the test name to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
