### PR TITLE
fix: relax nextRunAt assertion tolerance to 65s for MINUTELY recurrence

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -322,8 +322,8 @@ describe('scheduler RRULE execution', () => {
     expect(after).not.toBeNull();
     // nextRunAt must have moved forward from the forced-due value
     expect(after!.nextRunAt).toBeGreaterThan(forcedDueAt);
-    // It should be at or near the original computed value (within a few seconds tolerance)
-    expect(Math.abs(after!.nextRunAt - originalNextRunAt)).toBeLessThan(5000);
+    // After claiming, MINUTELY recurrence advances nextRunAt by ~60s, so allow up to 65s tolerance
+    expect(Math.abs(after!.nextRunAt - originalNextRunAt)).toBeLessThan(65000);
     expect(after!.lastRunAt).not.toBeNull();
   });
 });


### PR DESCRIPTION
Address Codex and Devin review feedback on PR #5629: the nextRunAt assertion used a 5s tolerance but MINUTELY recurrence advances by ~60s after claiming. Widened to 65s to prevent nondeterministic test failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
