### PR TITLE
fix: restore front-app focus after Chrome restart prompt dismissal

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -439,9 +439,13 @@ final class ComputerUseSession: ObservableObject {
                         return await buildObservation(executionResult: executionResult, executionError: executionError)
                     } else {
                         log.error("\(browserName) restart failed — continuing with limited AX tree")
+                        // Reactivate the original app so subsequent HID events target the correct window
+                        frontApp.activate()
                     }
                 } else {
                     log.info("User declined \(browserName) restart — continuing with limited AX tree")
+                    // Reactivate the original app so subsequent HID events target the correct window
+                    frontApp.activate()
                 }
             }
             didChromeAccessibilityCheck = true


### PR DESCRIPTION
Address Codex review feedback on PR #5605: reactivate the original frontApp in cancel and restart-failed paths so subsequent HID events target the correct application.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
