### PR TITLE
fix: preserve explicit syntax updates when expression is absent in schedule_update

### DIFF
--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -36,6 +36,11 @@ export async function executeScheduleUpdate(
     } else if (input.cron_expression !== undefined) {
       updates.cronExpression = input.cron_expression;
     }
+    // When only syntax is provided (no expression), normalizeScheduleSyntax returns null
+    // but we still need to persist the explicit syntax value.
+    if (input.syntax !== undefined && updates.syntax === undefined) {
+      updates.syntax = input.syntax;
+    }
   }
 
   if (Object.keys(updates).length === 0) {


### PR DESCRIPTION
Address Codex and Devin review feedback on PR #5633: add fallback to set updates.syntax = input.syntax when normalizeScheduleSyntax returns null but syntax was explicitly provided, restoring the previous behavior for syntax-only updates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
