### PR TITLE
fix: handle terminal RRULE occurrence on exact boundary in computeNextRunAt

### DIFF
--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -129,6 +129,14 @@ export function computeNextRunAt(spec: ScheduleSpec, nowMs?: number): number {
       : rrulestr(normalized, { tzid });
     const next = parsed.after(new Date(now));
     if (!next) {
+      // When after() (exclusive) returns null the rule may still have a
+      // terminal occurrence that lands exactly on `now` — e.g. COUNT=1 or the
+      // final UNTIL instance.  Treat that as "due right now" so claimDueSchedules
+      // doesn't silently skip the last run.
+      const exactMatch = parsed.before(new Date(now), true);
+      if (exactMatch && exactMatch.getTime() === now) {
+        return now;
+      }
       throw new Error(`RRULE expression has no upcoming runs after ${new Date(now).toISOString()}`);
     }
     return next.getTime();


### PR DESCRIPTION
Address Codex review feedback on PR #5632: when the exclusive after() lookup returns null for a finite RRULE, check if the current time matches an occurrence exactly to avoid silently skipping the final scheduled run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
