### PR TITLE
fix: narrow exhaustion catch to no-future-run errors, use future date in test

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -435,8 +435,12 @@ describe('claimDueSchedules', () => {
   });
 
   test('claims exhausted RRULE schedule and disables it', () => {
-    // COUNT=1 means only one occurrence — the DTSTART itself
-    const rrule = 'DTSTART:20250101T000000Z\nRRULE:FREQ=DAILY;COUNT=1';
+    // COUNT=1 means only one occurrence — the DTSTART itself.
+    // Use a far-future DTSTART so createSchedule succeeds (it validates that at
+    // least one run exists from now). We then force next_run_at into the past
+    // via SQL to simulate the schedule becoming due after its only occurrence.
+    const futureYear = new Date().getFullYear() + 5;
+    const rrule = `DTSTART:${futureYear}0101T000000Z\nRRULE:FREQ=DAILY;COUNT=1`;
     const job = createSchedule({
       name: 'Finite RRULE',
       cronExpression: rrule,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -216,7 +216,12 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
         expression: row.cronExpression,
         timezone: row.timezone,
       });
-    } catch {
+    } catch (err) {
+      // Only treat "no upcoming runs" as exhaustion — rethrow other failures
+      // (e.g. invalid RRULE lines, unsupported syntax) so they surface instead
+      // of silently disabling a schedule that has a configuration bug.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('no upcoming runs')) throw err;
       // Finite schedule with no future runs — still claim the current due
       // run but disable the schedule so it doesn't fire again.
       newNextRunAt = null;


### PR DESCRIPTION
Address Codex review feedback on PR #5634: (1) only treat 'no upcoming runs' errors as exhaustion in the catch block, rethrow other exceptions; (2) use a future DTSTART date in the exhausted RRULE test to prevent createSchedule from rejecting a past date.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
