### PR TITLE
Add missing entries to credential security allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -186,8 +186,10 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'tools/network/script-proxy/session-manager.ts', // proxy credential injection at runtime
       'messaging/registry.ts',          // checks stored credentials for connected providers
       'calls/call-domain.ts',            // caller identity resolution (user phone number lookup)
+      'calls/elevenlabs-config.ts',     // ElevenLabs voice quality API key lookup
       'calls/twilio-config.ts',         // call infrastructure credential lookup
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
+      'cli/config-commands.ts',         // CLI credential management commands
       'runtime/http-server.ts',         // HTTP server credential lookup
       'daemon/handlers/twitter-auth.ts', // Twitter OAuth token storage
       'messaging/providers/telegram-bot/adapter.ts', // Telegram bot token lookup for connectivity check


### PR DESCRIPTION
## Summary
- Added calls/elevenlabs-config.ts and cli/config-commands.ts to ALLOWED_IMPORTERS in credential-security-invariants.test.ts
- Both files import getSecureKey and were introduced by recent main merges but not added to the allowlist
- Fixes CI test failure for Invariant 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
