### PR TITLE
Fix credential-security-invariants test: add missing ALLOWED_IMPORTERS

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -189,6 +189,9 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'calls/twilio-provider.ts',       // call infrastructure credential lookup
       'runtime/http-server.ts',         // HTTP server credential lookup
       'daemon/handlers/twitter-auth.ts', // Twitter OAuth token storage
+      'twitter/oauth-client.ts',         // Twitter OAuth API client (reads access token for API calls)
+      'calls/elevenlabs-config.ts',      // ElevenLabs credential lookup
+      'cli/config-commands.ts',          // CLI config management
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Adds twitter/oauth-client.ts, calls/elevenlabs-config.ts, and cli/config-commands.ts to the ALLOWED_IMPORTERS set in credential-security-invariants.test.ts. The first was introduced by our feature; the latter two are pre-existing omissions also failing on main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
