### PR TITLE
Fix expired RRULE test to match fire-then-disable policy

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -156,7 +156,7 @@ describe('scheduler RRULE execution', () => {
     expect(runs.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('ended RRULE (UNTIL in past) is not repeatedly claimed', async () => {
+  test('expired RRULE fires one final due run then is disabled', async () => {
     const endedExpr = buildEndedRrule();
 
     // Insert directly via raw SQL because createSchedule would throw when
@@ -167,7 +167,7 @@ describe('scheduler RRULE execution', () => {
     getRawDb().run(
       `INSERT INTO cron_jobs (id, name, enabled, cron_expression, schedule_syntax, timezone, message, next_run_at, last_run_at, last_status, retry_count, created_by, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [id, 'Ended RRULE', 1, endedExpr, 'rrule', null, 'Should not fire', now - 1000, null, null, 0, 'agent', now, now],
+      [id, 'Ended RRULE', 1, endedExpr, 'rrule', null, 'Final expired run', now - 1000, null, null, 0, 'agent', now, now],
     );
 
     const processedMessages: string[] = [];
@@ -175,16 +175,35 @@ describe('scheduler RRULE execution', () => {
       processedMessages.push(message);
     };
 
-    const scheduler = startScheduler(processMessage, () => {}, () => {});
+    // First tick: the expired schedule should fire its final due run
+    const scheduler1 = startScheduler(processMessage, () => {}, () => {});
     await new Promise(resolve => setTimeout(resolve, 500));
-    scheduler.stop();
+    scheduler1.stop();
 
-    // The ended RRULE should NOT have fired
-    expect(processedMessages).not.toContain('Should not fire');
+    // The message IS delivered once
+    expect(processedMessages).toContain('Final expired run');
 
-    // No runs should have been created
+    // One run record IS created with status 'ok'
     const runs = getScheduleRuns(id);
-    expect(runs.length).toBe(0);
+    expect(runs.length).toBe(1);
+    expect(runs[0].status).toBe('ok');
+
+    // After firing, the schedule is disabled with nextRunAt=0
+    const afterSchedule = getSchedule(id);
+    expect(afterSchedule).not.toBeNull();
+    expect(afterSchedule!.enabled).toBe(false);
+    expect(afterSchedule!.nextRunAt).toBe(0);
+
+    // Second tick: the disabled schedule must NOT fire again
+    processedMessages.length = 0;
+    const scheduler2 = startScheduler(processMessage, () => {}, () => {});
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler2.stop();
+
+    expect(processedMessages).not.toContain('Final expired run');
+    // No additional runs
+    const runsAfter = getScheduleRuns(id);
+    expect(runsAfter.length).toBe(1);
   });
 
   test('existing cron schedule behavior is unchanged', async () => {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -222,8 +222,8 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
       // of silently disabling a schedule that has a configuration bug.
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('no upcoming runs')) throw err;
-      // Finite schedule with no future runs — still claim the current due
-      // run but disable the schedule so it doesn't fire again.
+      // Expired schedules fire their final pending due run then auto-disable,
+      // ensuring no due run is silently dropped.
       newNextRunAt = null;
       exhausted = true;
     }


### PR DESCRIPTION
## Summary
- Updated the `ended RRULE` test in `scheduler-recurrence.test.ts` to align with the actual runtime behavior: expired RRULE schedules fire one final due run before auto-disabling, rather than silently skipping the due run.
- The test now asserts: message is delivered once, a run record is created with status `ok`, the schedule is disabled (`enabled=false`, `nextRunAt=0`), and a second scheduler tick does not fire again.
- Clarified the inline comment in `schedule-store.ts` to document the fire-then-disable policy.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/scheduler-recurrence.test.ts` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
