### PR TITLE
feat: show pattern label + description in always-allow menu

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -711,7 +711,8 @@ public struct ToolConfirmationBubble: View {
                     // Pattern selection step
                     ForEach(Array(confirmation.allowlistOptions.enumerated()), id: \.element.pattern) { index, option in
                         AlwaysAllowRow(
-                            label: option.description,
+                            title: option.label,
+                            subtitle: option.description,
                             isKeyboardSelected: popoverKeyboardModel?.mode == .patterns && popoverKeyboardModel?.selectedIndex == index
                         ) {
                             if option.pattern.isEmpty {
@@ -824,7 +825,8 @@ public struct ToolConfirmationBubble: View {
 // MARK: - Always Allow Row
 
 private struct AlwaysAllowRow: View {
-    let label: String
+    let title: String
+    let subtitle: String
     var isKeyboardSelected: Bool = false
     let action: () -> Void
 
@@ -832,21 +834,28 @@ private struct AlwaysAllowRow: View {
 
     var body: some View {
         Button(action: action) {
-            Text(label)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, VSpacing.sm)
-                .padding(.horizontal, VSpacing.sm)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(isHovered || isKeyboardSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(isKeyboardSelected ? VColor.accent : .clear, lineWidth: 2)
-                )
-                .contentShape(Rectangle())
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(VFont.monoSmall)
+                    .foregroundColor(VColor.textPrimary)
+                if !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, VSpacing.sm)
+            .padding(.horizontal, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(isHovered || isKeyboardSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .stroke(isKeyboardSelected ? VColor.accent : .clear, lineWidth: 2)
+            )
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         #if os(macOS)


### PR DESCRIPTION
## Summary

- Updated `AlwaysAllowRow` to display a two-line layout with the pattern label (e.g. `git *`) as the title in monospace font, and the human-readable description (e.g. "Any git command") as a muted subtitle beneath it
- Changed the struct's properties from a single `label: String` to `title: String` + `subtitle: String`
- Updated the call site to pass `option.label` (the pattern) as `title` and `option.description` as `subtitle`

## Test plan

- [ ] Open the macOS app and trigger a tool confirmation with multiple allowlist options
- [ ] Click "Always Allow" to open the dropdown
- [ ] Verify each row shows the pattern in monospace (e.g. `npm install express`) with the description below it (e.g. "This exact command")
- [ ] Verify rows without a description only show the title
- [ ] Verify keyboard navigation still highlights rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
