### PR TITLE
feat: expose item kinds in PendingConflictDetail

### DIFF
--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -233,6 +233,8 @@ describe('conflict-store', () => {
     expect(details).toHaveLength(1);
     expect(details[0].existingStatement).toBe('Existing statement details');
     expect(details[0].candidateStatement).toBe('Candidate statement details');
+    expect(details[0].existingKind).toBe('fact');
+    expect(details[0].candidateKind).toBe('fact');
   });
 
   test('applyConflictResolution keeps candidate and resolves conflict row', () => {

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -50,6 +50,8 @@ export interface ResolveConflictInput {
 export interface PendingConflictDetail extends MemoryItemConflict {
   existingStatement: string;
   candidateStatement: string;
+  existingKind: string;
+  candidateKind: string;
 }
 
 export type ConflictResolutionAction = 'keep_existing' | 'keep_candidate' | 'merge';
@@ -170,7 +172,9 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
       c.created_at,
       c.updated_at,
       existing_item.statement AS existing_statement,
-      candidate_item.statement AS candidate_statement
+      candidate_item.statement AS candidate_statement,
+      existing_item.kind AS existing_kind,
+      candidate_item.kind AS candidate_kind
     FROM memory_item_conflicts c
     INNER JOIN memory_items existing_item ON existing_item.id = c.existing_item_id
     INNER JOIN memory_items candidate_item ON candidate_item.id = c.candidate_item_id
@@ -193,6 +197,8 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
     updated_at: number;
     existing_statement: string;
     candidate_statement: string;
+    existing_kind: string;
+    candidate_kind: string;
   }>;
 
   return rows.map((row) => ({
@@ -210,6 +216,8 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
     updatedAt: row.updated_at,
     existingStatement: row.existing_statement,
     candidateStatement: row.candidate_statement,
+    existingKind: row.existing_kind,
+    candidateKind: row.candidate_kind,
   }));
 }
 


### PR DESCRIPTION
PR 04 of memory conflict resolution rollout. Adds existingKind and candidateKind fields to PendingConflictDetail, enabling downstream policy to make kind-aware decisions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
