### PR TITLE
feat: add askOnIrrelevantTurns config knob (no behavior change)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -139,12 +139,20 @@ describe('AssistantConfigSchema', () => {
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
+      askOnIrrelevantTurns: true,
     });
   });
 
   test('rejects invalid memory.conflicts.relevanceThreshold', () => {
     const result = AssistantConfigSchema.safeParse({
       memory: { conflicts: { relevanceThreshold: 2 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid memory.conflicts.askOnIrrelevantTurns', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { conflicts: { askOnIrrelevantTurns: 123 } },
     });
     expect(result.success).toBe(false);
   });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -117,6 +117,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
+      askOnIrrelevantTurns: true,
     },
     profile: {
       enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -550,6 +550,9 @@ export const MemoryConflictsConfigSchema = z.object({
     .min(0, 'memory.conflicts.relevanceThreshold must be >= 0')
     .max(1, 'memory.conflicts.relevanceThreshold must be <= 1')
     .default(0.3),
+  askOnIrrelevantTurns: z
+    .boolean({ error: 'memory.conflicts.askOnIrrelevantTurns must be a boolean' })
+    .default(true),
 });
 
 export const MemoryProfileConfigSchema = z.object({
@@ -669,6 +672,7 @@ export const MemoryConfigSchema = z.object({
     reaskCooldownTurns: 3,
     resolverLlmTimeoutMs: 12000,
     relevanceThreshold: 0.3,
+    askOnIrrelevantTurns: true,
   }),
   profile: MemoryProfileConfigSchema.default({
     enabled: true,
@@ -1160,6 +1164,7 @@ export const AssistantConfigSchema = z.object({
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
+      askOnIrrelevantTurns: true,
     },
     profile: {
       enabled: true,


### PR DESCRIPTION
PR 01 of memory conflict resolution rollout. Adds a boolean config knob `memory.conflicts.askOnIrrelevantTurns` (default: true) that will control whether irrelevant conflicts prompt the user. No runtime behavior change in this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
