### PR TITLE
fix: honor explicit syntax hint in legacyCronExpression fallback

### DIFF
--- a/assistant/src/__tests__/recurrence-types.test.ts
+++ b/assistant/src/__tests__/recurrence-types.test.ts
@@ -56,6 +56,14 @@ describe('normalizeScheduleSyntax', () => {
     expect(result).toEqual({ syntax: 'cron', expression: '0 9 * * *' });
   });
 
+  test('honors explicit syntax hint in legacyCronExpression fallback', () => {
+    const result = normalizeScheduleSyntax({
+      syntax: 'rrule',
+      legacyCronExpression: '0 9 * * *',
+    });
+    expect(result).toEqual({ syntax: 'rrule', expression: '0 9 * * *' });
+  });
+
   test('returns null when nothing is provided', () => {
     expect(normalizeScheduleSyntax({})).toBeNull();
   });

--- a/assistant/src/schedule/recurrence-types.ts
+++ b/assistant/src/schedule/recurrence-types.ts
@@ -60,7 +60,7 @@ export function normalizeScheduleSyntax(input: {
 
   // Legacy cron_expression fallback
   if (input.legacyCronExpression) {
-    return { syntax: 'cron', expression: input.legacyCronExpression };
+    return { syntax: input.syntax ?? 'cron', expression: input.legacyCronExpression };
   }
 
   return null;


### PR DESCRIPTION
Address Codex review feedback on PR #5431: when legacyCronExpression is provided alongside an explicit syntax hint, respect the syntax instead of hardcoding cron.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
