### PR TITLE
fix: handle missing destination in atomic video save

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -298,7 +298,11 @@ struct InlineVideoAttachmentView: View {
                         .appendingPathComponent(UUID().uuidString)
                         .appendingPathExtension(destURL.pathExtension)
                     try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-                    _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
+                    if FileManager.default.fileExists(atPath: destURL.path) {
+                        _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
+                    } else {
+                        try FileManager.default.moveItem(at: tempURL, to: destURL)
+                    }
                 } catch {
                     print("Failed to save video: \(error)")
                 }


### PR DESCRIPTION
Address Codex + Devin feedback on PR #6268: check if destination exists before choosing replaceItemAt vs moveItem, so saving to a new filename works correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
