### PR TITLE
fix: handle mixed LF/CRLF in directive line trimming

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -322,7 +322,7 @@ export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDra
       const nextChar = buffer[end + 2];
       if (emitText.endsWith('\r\n') && nextChar === '\r') {
         emitText = emitText.slice(0, -2); // trim full \r\n
-      } else if (emitText.endsWith('\n') && nextChar === '\n') {
+      } else if (emitText.endsWith('\n') && (nextChar === '\n' || nextChar === '\r')) {
         emitText = emitText.slice(0, -1); // trim \n
       }
     }


### PR DESCRIPTION
Address Codex feedback on PR #6270: restore handling of the case where text ends with LF and the next char after the directive is CR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
