### PR TITLE
fix: use frontmostApplication fallback when Chrome restart fails

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -439,8 +439,10 @@ final class ComputerUseSession: ObservableObject {
                         return await buildObservation(executionResult: executionResult, executionError: executionError)
                     } else {
                         log.error("\(browserName) restart failed — continuing with limited AX tree")
-                        // Reactivate the original app so subsequent HID events target the correct window
-                        frontApp.activate()
+                        // frontApp was terminated, so activate whatever is currently frontmost
+                        if let currentFront = NSWorkspace.shared.frontmostApplication {
+                            currentFront.activate()
+                        }
                     }
                 } else {
                     log.info("User declined \(browserName) restart — continuing with limited AX tree")


### PR DESCRIPTION
Address Devin feedback on PR #6273: replace frontApp.activate() with NSWorkspace.shared.frontmostApplication in the restart-failed path, since the original frontApp reference is terminated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
