### PR TITLE
fix: preserve TZID parameter values when uppercasing RRULE property names

### DIFF
--- a/assistant/src/__tests__/recurrence-engine.test.ts
+++ b/assistant/src/__tests__/recurrence-engine.test.ts
@@ -59,6 +59,15 @@ describe('recurrence engine — rrule', () => {
     expect(() => computeNextRunAt({ syntax: 'rrule', expression: 'RRULE:FREQ=DAILY' })).toThrow(/DTSTART/);
   });
 
+  test('preserves TZID parameter values when normalizing lowercase prefixes', () => {
+    // TZID contains case-sensitive timezone names (e.g. America/New_York)
+    // that must not be uppercased during prefix normalization.
+    const expr = 'dtstart;TZID=America/New_York:20990601T090000\nrrule:FREQ=DAILY';
+    expect(isValidScheduleExpression({ syntax: 'rrule', expression: expr })).toBe(true);
+    const next = computeNextRunAt({ syntax: 'rrule', expression: expr });
+    expect(next).toBeGreaterThan(Date.now());
+  });
+
   test('computes next run for RRULE with EXDATE set construct', () => {
     const expr = 'DTSTART:20990101T090000Z\nRRULE:FREQ=DAILY\nEXDATE:20990101T090000Z';
     const next = computeNextRunAt({ syntax: 'rrule', expression: expr });

--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -12,18 +12,21 @@ const SUPPORTED_RRULE_PREFIXES = ['DTSTART', 'RRULE:', 'RDATE', 'EXDATE', 'EXRUL
 
 function normalizeRruleExpression(expression: string): string {
   // Handle escaped newlines from JSON transport, then uppercase property name
-  // prefixes (before the colon) on each line so rrulestr() receives the
-  // canonical uppercase form regardless of what the caller provided. We only
-  // uppercase up to the first colon to preserve case-sensitive parameter
-  // values such as timezone names in DTSTART;TZID=America/New_York:...
+  // prefixes (before the first ';' or ':') on each line so rrulestr() receives
+  // the canonical uppercase form regardless of what the caller provided. We
+  // stop at the earliest delimiter to preserve case-sensitive parameter values
+  // such as timezone names in DTSTART;TZID=America/New_York:...
   return expression
     .replace(/\\n/g, '\n')
     .trim()
     .split(/\r?\n/)
     .map(line => {
       const colonIdx = line.indexOf(':');
-      if (colonIdx === -1) return line;
-      return line.slice(0, colonIdx).toUpperCase() + line.slice(colonIdx);
+      const semiIdx = line.indexOf(';');
+      if (colonIdx === -1 && semiIdx === -1) return line;
+      // Uppercase only the property name (before the first ';' or ':')
+      const nameEnd = semiIdx !== -1 && (colonIdx === -1 || semiIdx < colonIdx) ? semiIdx : colonIdx;
+      return line.slice(0, nameEnd).toUpperCase() + line.slice(nameEnd);
     })
     .join('\n');
 }


### PR DESCRIPTION
Address Codex + Devin feedback on PR #6274: only uppercase the property name before the first semicolon or colon, preserving case-sensitive parameter values like timezone names.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
