### PR TITLE
feat: add conflictableKinds config knob (no behavior change)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -140,6 +140,7 @@ describe('AssistantConfigSchema', () => {
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: true,
+      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
     });
   });
 
@@ -153,6 +154,20 @@ describe('AssistantConfigSchema', () => {
   test('rejects invalid memory.conflicts.askOnIrrelevantTurns', () => {
     const result = AssistantConfigSchema.safeParse({
       memory: { conflicts: { askOnIrrelevantTurns: 123 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid memory.conflicts.conflictableKinds entry', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { conflicts: { conflictableKinds: ['invalid_kind'] } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects empty memory.conflicts.conflictableKinds', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { conflicts: { conflictableKinds: [] } },
     });
     expect(result.success).toBe(false);
   });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -118,6 +118,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: true,
+      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
     },
     profile: {
       enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -12,6 +12,10 @@ const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
 export const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ['Deepgram', 'Google'] as const;
+const VALID_MEMORY_ITEM_KINDS = [
+  'preference', 'profile', 'project', 'decision', 'todo',
+  'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -554,6 +558,14 @@ export const MemoryConflictsConfigSchema = z.object({
   askOnIrrelevantTurns: z
     .boolean({ error: 'memory.conflicts.askOnIrrelevantTurns must be a boolean' })
     .default(true),
+  conflictableKinds: z
+    .array(
+      z.enum(VALID_MEMORY_ITEM_KINDS, {
+        error: `memory.conflicts.conflictableKinds entries must be one of: ${VALID_MEMORY_ITEM_KINDS.join(', ')}`,
+      }),
+    )
+    .nonempty({ message: 'memory.conflicts.conflictableKinds must not be empty' })
+    .default([...VALID_MEMORY_ITEM_KINDS]),
 });
 
 export const MemoryProfileConfigSchema = z.object({
@@ -674,6 +686,7 @@ export const MemoryConfigSchema = z.object({
     resolverLlmTimeoutMs: 12000,
     relevanceThreshold: 0.3,
     askOnIrrelevantTurns: true,
+    conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
   }),
   profile: MemoryProfileConfigSchema.default({
     enabled: true,
@@ -1184,6 +1197,7 @@ export const AssistantConfigSchema = z.object({
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: true,
+      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
     },
     profile: {
       enabled: true,


### PR DESCRIPTION
PR 03 of memory conflict resolution rollout. Adds `memory.conflicts.conflictableKinds` config (default: all memory item kinds) to restrict which kinds can generate conflicts. No behavior change with default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
