### PR TITLE
feat: add conflict-policy primitive (kind eligibility)

### DIFF
--- a/assistant/src/__tests__/conflict-policy.test.ts
+++ b/assistant/src/__tests__/conflict-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { isConflictKindEligible, isConflictKindPairEligible } from '../memory/conflict-policy.js';
+
+describe('conflict-policy', () => {
+  const config = { conflictableKinds: ['preference', 'profile', 'constraint'] };
+
+  describe('isConflictKindEligible', () => {
+    test('returns true for eligible kind', () => {
+      expect(isConflictKindEligible('preference', config)).toBe(true);
+      expect(isConflictKindEligible('profile', config)).toBe(true);
+      expect(isConflictKindEligible('constraint', config)).toBe(true);
+    });
+
+    test('returns false for ineligible kind', () => {
+      expect(isConflictKindEligible('project', config)).toBe(false);
+      expect(isConflictKindEligible('todo', config)).toBe(false);
+      expect(isConflictKindEligible('fact', config)).toBe(false);
+    });
+  });
+
+  describe('isConflictKindPairEligible', () => {
+    test('returns true when both kinds are eligible', () => {
+      expect(isConflictKindPairEligible('preference', 'profile', config)).toBe(true);
+    });
+
+    test('returns false when existing kind is ineligible', () => {
+      expect(isConflictKindPairEligible('project', 'preference', config)).toBe(false);
+    });
+
+    test('returns false when candidate kind is ineligible', () => {
+      expect(isConflictKindPairEligible('preference', 'todo', config)).toBe(false);
+    });
+
+    test('returns false when both kinds are ineligible', () => {
+      expect(isConflictKindPairEligible('project', 'todo', config)).toBe(false);
+    });
+  });
+});

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure, deterministic policy helpers for memory conflict eligibility.
+ * Used by contradiction checker, session conflict gate, and background resolver.
+ */
+
+export interface ConflictPolicyConfig {
+  conflictableKinds: readonly string[];
+}
+
+/**
+ * Returns true when the given memory item kind is eligible to participate
+ * in conflict detection according to the current policy.
+ */
+export function isConflictKindEligible(kind: string, config: ConflictPolicyConfig): boolean {
+  return config.conflictableKinds.includes(kind);
+}
+
+/**
+ * Returns true when both sides of a potential conflict pair are kind-eligible.
+ */
+export function isConflictKindPairEligible(
+  existingKind: string,
+  candidateKind: string,
+  config: ConflictPolicyConfig,
+): boolean {
+  return isConflictKindEligible(existingKind, config) && isConflictKindEligible(candidateKind, config);
+}


### PR DESCRIPTION
PR 05 of memory conflict resolution rollout. Creates reusable conflict-policy.ts with isConflictKindEligible and isConflictKindPairEligible helpers. No production call-sites changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
