### PR TITLE
fix: reorder scope options to least-privilege-first

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1168,11 +1168,28 @@ describe('Permission Checker', () => {
       expect(options[1].label).toBe('/var/data/*');
     });
 
-    test('host tools prioritize everywhere scope first', () => {
+    test('host tools use project → parent → everywhere ordering (same as non-host)', () => {
       const options = generateScopeOptions('/var/data/app', 'host_file_read');
-      expect(options[0]).toEqual({ label: 'everywhere', scope: 'everywhere' });
-      expect(options[1].scope).toBe('/var/data/app');
-      expect(options[2].scope).toBe('/var/data');
+      expect(options[0].scope).toBe('/var/data/app');
+      expect(options[1].scope).toBe('/var/data');
+      expect(options[2]).toEqual({ label: 'everywhere', scope: 'everywhere' });
+    });
+
+    test('scope options are always project → parent → everywhere regardless of tool', () => {
+      const workingDir = join(homedir(), 'projects', 'myapp');
+
+      // Non-host tool
+      const nonHostOpts = generateScopeOptions(workingDir, 'bash');
+      expect(nonHostOpts[0].scope).toBe(workingDir);
+      expect(nonHostOpts[nonHostOpts.length - 1].scope).toBe('everywhere');
+
+      // Host tool — same order now
+      const hostOpts = generateScopeOptions(workingDir, 'host_bash');
+      expect(hostOpts[0].scope).toBe(workingDir);
+      expect(hostOpts[hostOpts.length - 1].scope).toBe('everywhere');
+
+      // Same ordering for both
+      expect(nonHostOpts.map(o => o.scope)).toEqual(hostOpts.map(o => o.scope));
     });
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -626,11 +626,5 @@ export function generateScopeOptions(workingDir: string, toolName?: string): Sco
   // Everywhere
   options.push({ label: 'everywhere', scope: 'everywhere' });
 
-  if (!toolName?.startsWith('host_')) {
-    return options;
-  }
-
-  const everywhere = options.find((option) => option.scope === 'everywhere');
-  const scoped = options.filter((option) => option.scope !== 'everywhere');
-  return everywhere ? [everywhere, ...scoped] : options;
+  return options;
 }


### PR DESCRIPTION
## Summary

- Remove host-tool special-casing in `generateScopeOptions` that moved "everywhere" to the front of scope options for `host_*` tools
- All tools now consistently use project -> parent -> everywhere ordering, presenting the narrowest (least-privilege) scope first
- Updated existing test assertion and added new invariant test confirming uniform ordering across host and non-host tools

## Test plan

- [x] `bun test src/__tests__/checker.test.ts` passes (333 tests, 0 failures)
- [x] Existing test updated: `host tools use project -> parent -> everywhere ordering (same as non-host)` 
- [x] New test added: `scope options are always project -> parent -> everywhere regardless of tool`
- [x] Type-check passes (pre-existing errors in unrelated files only)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
