### PR TITLE
feat: apply kind eligibility in contradiction checker

### DIFF
--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -51,9 +51,19 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+let mockConflictableKinds: string[] = [
+  'preference', 'profile', 'project', 'decision', 'todo',
+  'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+];
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
     apiKeys: { anthropic: 'test-key' },
+    memory: {
+      conflicts: {
+        conflictableKinds: mockConflictableKinds,
+      },
+    },
   }),
 }));
 
@@ -67,6 +77,10 @@ beforeAll(() => {
 
 beforeEach(() => {
   classifyCallCount = 0;
+  mockConflictableKinds = [
+    'preference', 'profile', 'project', 'decision', 'todo',
+    'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+  ];
   const db = getDb();
   db.run('DELETE FROM memory_item_conflicts');
   db.run('DELETE FROM memory_item_sources');
@@ -88,12 +102,13 @@ function insertMemoryItem(params: {
   statement: string;
   scopeId?: string;
   status?: 'active' | 'pending_clarification';
+  kind?: string;
 }): void {
   const now = Date.now();
   const db = getDb();
   db.insert(memoryItems).values({
     id: params.id,
-    kind: 'preference',
+    kind: params.kind ?? 'preference',
     subject: 'framework preference',
     statement: params.statement,
     status: params.status ?? 'active',
@@ -211,6 +226,27 @@ describe('checkContradictions', () => {
 
     expect(classifyCallCount).toBe(0);
     expect(candidate?.status).toBe('active');
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test('skips classification when item kind is not in conflictableKinds', async () => {
+    mockConflictableKinds = ['instruction', 'style'];
+    nextRelationship = 'ambiguous_contradiction';
+
+    insertMemoryItem({
+      id: 'item-existing-ineligible',
+      statement: 'User prefers React for frontend work.',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-ineligible',
+      statement: 'User prefers Vue for frontend work.',
+    });
+
+    await checkContradictions('item-candidate-ineligible');
+
+    expect(classifyCallCount).toBe(0);
+    const db = getDb();
+    const conflicts = db.select().from(memoryItemConflicts).all();
     expect(conflicts).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
+import { isConflictKindEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
 import { getDb } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
@@ -58,6 +59,11 @@ export async function checkContradictions(newItemId: string): Promise<void> {
   const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     log.debug('No Anthropic API key available for contradiction checking');
+    return;
+  }
+
+  if (!isConflictKindEligible(newItem.kind, config.memory.conflicts)) {
+    log.debug({ newItemId, kind: newItem.kind }, 'Skipping contradiction check — kind not eligible for conflicts');
     return;
   }
 


### PR DESCRIPTION
PR 06 of memory conflict resolution rollout. Skips contradiction classification for items whose kind is not in conflictableKinds. No behavior change with default config (all kinds eligible).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
