### PR TITLE
feat: add transient statement classifier in conflict policy

### DIFF
--- a/assistant/src/__tests__/conflict-policy.test.ts
+++ b/assistant/src/__tests__/conflict-policy.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { isConflictKindEligible, isConflictKindPairEligible } from '../memory/conflict-policy.js';
+import {
+  isConflictKindEligible,
+  isConflictKindPairEligible,
+  isTransientTrackingStatement,
+  isDurableInstructionStatement,
+  isStatementConflictEligible,
+} from '../memory/conflict-policy.js';
 
 describe('conflict-policy', () => {
   const config = { conflictableKinds: ['preference', 'profile', 'constraint'] };
@@ -33,6 +39,68 @@ describe('conflict-policy', () => {
 
     test('returns false when both kinds are ineligible', () => {
       expect(isConflictKindPairEligible('project', 'todo', config)).toBe(false);
+    });
+  });
+
+  describe('isTransientTrackingStatement', () => {
+    test('detects PR URLs', () => {
+      expect(isTransientTrackingStatement('Track https://github.com/org/repo/pull/5526')).toBe(true);
+    });
+
+    test('detects issue/ticket references', () => {
+      expect(isTransientTrackingStatement('Track PR #5526 and #5525')).toBe(true);
+      expect(isTransientTrackingStatement('See issue #42 for details')).toBe(true);
+      expect(isTransientTrackingStatement('Filed ticket 1234')).toBe(true);
+    });
+
+    test('detects tracking language', () => {
+      expect(isTransientTrackingStatement('While we wait for CI to pass')).toBe(true);
+      expect(isTransientTrackingStatement('This PR needs review')).toBe(true);
+    });
+
+    test('does not flag durable statements', () => {
+      expect(isTransientTrackingStatement('Always answer with concise bullet points')).toBe(false);
+      expect(isTransientTrackingStatement('User prefers dark mode')).toBe(false);
+    });
+
+    test('does not false-positive on non-PR URLs', () => {
+      expect(isTransientTrackingStatement('Visit https://example.com for docs')).toBe(false);
+    });
+  });
+
+  describe('isDurableInstructionStatement', () => {
+    test('detects durable instruction cues', () => {
+      expect(isDurableInstructionStatement('Always answer with concise bullet points')).toBe(true);
+      expect(isDurableInstructionStatement('Never use semicolons in JavaScript')).toBe(true);
+      expect(isDurableInstructionStatement('Use concise format for status updates')).toBe(true);
+      expect(isDurableInstructionStatement('The default database is Postgres')).toBe(true);
+    });
+
+    test('rejects statements without durable cues', () => {
+      expect(isDurableInstructionStatement('Check the build output')).toBe(false);
+      expect(isDurableInstructionStatement('Run the migration script')).toBe(false);
+    });
+  });
+
+  describe('isStatementConflictEligible', () => {
+    test('rejects transient statements for any kind', () => {
+      expect(isStatementConflictEligible('preference', 'Track PR #5526')).toBe(false);
+      expect(isStatementConflictEligible('instruction', 'This PR needs review')).toBe(false);
+    });
+
+    test('accepts durable instruction statements', () => {
+      expect(isStatementConflictEligible('instruction', 'Always use TypeScript strict mode')).toBe(true);
+      expect(isStatementConflictEligible('style', 'Default to concise format')).toBe(true);
+    });
+
+    test('rejects non-durable instruction statements', () => {
+      expect(isStatementConflictEligible('instruction', 'Run the build first')).toBe(false);
+      expect(isStatementConflictEligible('style', 'Check the output')).toBe(false);
+    });
+
+    test('accepts non-transient statements for non-instruction kinds', () => {
+      expect(isStatementConflictEligible('preference', 'User prefers dark mode')).toBe(true);
+      expect(isStatementConflictEligible('fact', 'User works at Acme Corp')).toBe(true);
     });
   });
 });

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -25,3 +25,47 @@ export function isConflictKindPairEligible(
 ): boolean {
   return isConflictKindEligible(existingKind, config) && isConflictKindEligible(candidateKind, config);
 }
+
+// ── Transient statement classification ─────────────────────────────────
+
+const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/i;
+const ISSUE_TICKET_PATTERN = /\b(?:issue|pr|ticket|pull request)\s*#?\d+/i;
+const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|today|right now|currently tracking)\b/i;
+
+/**
+ * Returns true when a statement looks like a transient tracking note
+ * (PR URLs, issue references, short-lived progress notes) rather than
+ * a durable user preference or instruction.
+ */
+export function isTransientTrackingStatement(statement: string): boolean {
+  if (PR_URL_PATTERN.test(statement)) return true;
+  if (ISSUE_TICKET_PATTERN.test(statement)) return true;
+  if (TRACKING_LANGUAGE_PATTERN.test(statement)) return true;
+  return false;
+}
+
+const DURABLE_INSTRUCTION_CUES = /\b(?:always|never|default|every time|by default|style|format|tone|convention|standard)\b/i;
+
+/**
+ * Returns true when a statement contains strong durable instruction cues,
+ * suggesting it represents a persistent user preference or style rule.
+ */
+export function isDurableInstructionStatement(statement: string): boolean {
+  return DURABLE_INSTRUCTION_CUES.test(statement);
+}
+
+/**
+ * Returns true when a statement of the given kind is eligible to participate
+ * in conflict detection at the statement level. This combines kind eligibility
+ * with statement-level durability heuristics.
+ *
+ * For instruction/style kinds: requires positive durable cues and no transient cues.
+ * For other eligible kinds: rejects if transient tracking cues dominate.
+ */
+export function isStatementConflictEligible(kind: string, statement: string): boolean {
+  if (isTransientTrackingStatement(statement)) return false;
+  if (kind === 'instruction' || kind === 'style') {
+    return isDurableInstructionStatement(statement);
+  }
+  return true;
+}


### PR DESCRIPTION
PR 08 of memory conflict resolution rollout. Adds isTransientTrackingStatement, isDurableInstructionStatement, and isStatementConflictEligible helpers for filtering non-durable tracking statements from conflict detection. No production call-sites changed yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
