### PR TITLE
feat: change default conflictableKinds to durable subset

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -140,7 +140,7 @@ describe('AssistantConfigSchema', () => {
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: false,
-      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
+      conflictableKinds: ['preference', 'profile', 'constraint', 'instruction', 'style'],
     });
   });
 

--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -52,8 +52,7 @@ mock.module('../util/logger.js', () => ({
 }));
 
 let mockConflictableKinds: string[] = [
-  'preference', 'profile', 'project', 'decision', 'todo',
-  'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+  'preference', 'profile', 'constraint', 'instruction', 'style',
 ];
 
 mock.module('../config/loader.js', () => ({
@@ -78,8 +77,7 @@ beforeAll(() => {
 beforeEach(() => {
   classifyCallCount = 0;
   mockConflictableKinds = [
-    'preference', 'profile', 'project', 'decision', 'todo',
-    'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
+    'preference', 'profile', 'constraint', 'instruction', 'style',
   ];
   const db = getDb();
   db.run('DELETE FROM memory_item_conflicts');
@@ -226,6 +224,29 @@ describe('checkContradictions', () => {
 
     expect(classifyCallCount).toBe(0);
     expect(candidate?.status).toBe('active');
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test('project kind ambiguous contradiction does not generate pending conflict with default config', async () => {
+    nextRelationship = 'ambiguous_contradiction';
+    nextExplanation = 'Project items may conflict but are not durable.';
+
+    insertMemoryItem({
+      id: 'item-existing-project',
+      statement: 'The backend uses Node.js.',
+      kind: 'project',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-project',
+      statement: 'The backend uses Deno.',
+      kind: 'project',
+    });
+
+    await checkContradictions('item-candidate-project');
+
+    expect(classifyCallCount).toBe(0);
+    const db = getDb();
+    const conflicts = db.select().from(memoryItemConflicts).all();
     expect(conflicts).toHaveLength(0);
   });
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -118,7 +118,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: false,
-      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
+      conflictableKinds: ['preference', 'profile', 'constraint', 'instruction', 'style'],
     },
     profile: {
       enabled: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -17,6 +17,10 @@ const VALID_MEMORY_ITEM_KINDS = [
   'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style',
 ] as const;
 
+const DEFAULT_CONFLICTABLE_KINDS = [
+  'preference', 'profile', 'constraint', 'instruction', 'style',
+] as const;
+
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
     .number({ error: 'timeouts.shellMaxTimeoutSec must be a number' })
@@ -565,7 +569,7 @@ export const MemoryConflictsConfigSchema = z.object({
       }),
     )
     .nonempty({ message: 'memory.conflicts.conflictableKinds must not be empty' })
-    .default([...VALID_MEMORY_ITEM_KINDS]),
+    .default([...DEFAULT_CONFLICTABLE_KINDS]),
 });
 
 export const MemoryProfileConfigSchema = z.object({
@@ -686,7 +690,7 @@ export const MemoryConfigSchema = z.object({
     resolverLlmTimeoutMs: 12000,
     relevanceThreshold: 0.3,
     askOnIrrelevantTurns: false,
-    conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
+    conflictableKinds: ['preference', 'profile', 'constraint', 'instruction', 'style'],
   }),
   profile: MemoryProfileConfigSchema.default({
     enabled: true,
@@ -1197,7 +1201,7 @@ export const AssistantConfigSchema = z.object({
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
       askOnIrrelevantTurns: false,
-      conflictableKinds: ['preference', 'profile', 'project', 'decision', 'todo', 'fact', 'constraint', 'relationship', 'event', 'opinion', 'instruction', 'style'],
+      conflictableKinds: ['preference', 'profile', 'constraint', 'instruction', 'style'],
     },
     profile: {
       enabled: true,


### PR DESCRIPTION
PR 07 of memory conflict resolution rollout. Narrows the default conflictableKinds to preference, profile, constraint, instruction, and style. Transient kinds (project, decision, todo, fact, etc.) no longer generate pending conflicts by default. Still overrideable via config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
