### PR TITLE
feat: apply transient filter in contradiction creation path

### DIFF
--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -270,4 +270,45 @@ describe('checkContradictions', () => {
     const conflicts = db.select().from(memoryItemConflicts).all();
     expect(conflicts).toHaveLength(0);
   });
+
+  test('skips classification when candidate statement contains PR-tracking content', async () => {
+    nextRelationship = 'ambiguous_contradiction';
+
+    insertMemoryItem({
+      id: 'item-existing-pr-tracking',
+      statement: 'Track PR #5526 for review.',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-pr-tracking',
+      statement: 'Track PR #5525 for review.',
+    });
+
+    await checkContradictions('item-candidate-pr-tracking');
+
+    expect(classifyCallCount).toBe(0);
+    const db = getDb();
+    const conflicts = db.select().from(memoryItemConflicts).all();
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test('durable preference contradiction still runs normal flow', async () => {
+    nextRelationship = 'ambiguous_contradiction';
+    nextExplanation = 'Both are valid preferences that conflict.';
+
+    insertMemoryItem({
+      id: 'item-existing-durable',
+      statement: 'User prefers React for frontend work.',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-durable',
+      statement: 'User prefers Vue for frontend work.',
+    });
+
+    await checkContradictions('item-candidate-durable');
+
+    expect(classifyCallCount).toBe(1);
+    const db = getDb();
+    const conflicts = db.select().from(memoryItemConflicts).all();
+    expect(conflicts).toHaveLength(1);
+  });
 });

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { isConflictKindEligible } from './conflict-policy.js';
+import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
 import { getDb } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
@@ -67,7 +67,19 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     return;
   }
 
+  // Skip if the new item's statement is transient/non-durable
+  if (!isStatementConflictEligible(newItem.kind, newItem.statement)) {
+    log.debug({ newItemId, kind: newItem.kind }, 'Skipping contradiction check — statement is transient or non-durable');
+    return;
+  }
+
   for (const existing of candidates) {
+    // Skip candidate if its statement is transient/non-durable
+    if (!isStatementConflictEligible(existing.kind, existing.statement)) {
+      log.debug({ existingId: existing.id }, 'Skipping candidate — statement is transient or non-durable');
+      continue;
+    }
+
     try {
       const result = await classifyRelationship(apiKey, existing, newItem);
       await handleRelationship(result, existing, newItem);


### PR DESCRIPTION
PR 09 of memory conflict resolution rollout. Prevents transient tracking statements (PR URLs, issue references, etc.) from entering the pending conflict flow. Durable preference/instruction contradictions still function normally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
