### PR TITLE
feat: dismiss non-actionable conflicts in background resolver

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -1216,6 +1216,105 @@ describe('Memory regressions', () => {
     }
   });
 
+  test('background conflict resolver dismisses transient/non-durable conflicts without LLM call', async () => {
+    const db = getDb();
+    const now = 1_700_001_500_000;
+    const originalConflictsEnabled = TEST_CONFIG.memory.conflicts.enabled;
+    TEST_CONFIG.memory.conflicts.enabled = true;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-conflicts-transient',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values({
+        id: 'msg-conflicts-transient',
+        conversationId: 'conv-conflicts-transient',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        createdAt: now + 1,
+      }).run();
+
+      // Create a transient conflict: PR tracking statements should be dismissed
+      db.insert(memoryItems).values([
+        {
+          id: 'item-conflict-existing-transient',
+          kind: 'preference',
+          subject: 'pr-tracking',
+          statement: 'Currently tracking PR #42 for review.',
+          status: 'active',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-existing-transient',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-transient',
+          firstSeenAt: now - 10_000,
+          lastSeenAt: now - 5_000,
+          validFrom: now - 10_000,
+          invalidAt: null,
+        },
+        {
+          id: 'item-conflict-candidate-transient',
+          kind: 'preference',
+          subject: 'pr-tracking',
+          statement: 'Currently tracking PR #99 for review.',
+          status: 'pending_clarification',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-candidate-transient',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-transient',
+          firstSeenAt: now - 9_000,
+          lastSeenAt: now - 4_000,
+          validFrom: now - 9_000,
+          invalidAt: null,
+        },
+      ]).run();
+
+      const conflict = createOrUpdatePendingConflict({
+        scopeId: 'scope-conflicts-transient',
+        existingItemId: 'item-conflict-existing-transient',
+        candidateItemId: 'item-conflict-candidate-transient',
+        relationship: 'ambiguous_contradiction',
+      });
+      db.update(memoryItemConflicts)
+        .set({ createdAt: now, updatedAt: now })
+        .where(eq(memoryItemConflicts.id, conflict.id))
+        .run();
+
+      enqueueResolvePendingConflictsForMessageJob('msg-conflicts-transient', 'scope-conflicts-transient');
+      const processed = await runMemoryJobsOnce();
+      expect(processed).toBe(1);
+
+      const updatedConflict = getConflictById(conflict.id);
+      expect(updatedConflict?.status).toBe('dismissed');
+      expect(updatedConflict?.resolutionNote).toContain('conflict policy');
+
+      // Memory items should remain untouched (no LLM resolution was attempted)
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-existing-transient'))
+        .get();
+      const candidate = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-candidate-transient'))
+        .get();
+      expect(existing?.status).toBe('active');
+      expect(candidate?.status).toBe('pending_clarification');
+    } finally {
+      TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
+    }
+  });
+
   test('cleanup job enqueue is deduped and retention overrides upgrade payload', () => {
     const db = getDb();
 

--- a/assistant/src/memory/job-handlers/conflict.ts
+++ b/assistant/src/memory/job-handlers/conflict.ts
@@ -6,9 +6,10 @@ import {
   looksLikeClarificationReply,
   shouldAttemptConflictResolution,
 } from '../conflict-intent.js';
+import { isConflictKindPairEligible, isStatementConflictEligible } from '../conflict-policy.js';
 import { getDb } from '../db.js';
 import { resolveConflictClarification } from '../clarification-resolver.js';
-import { applyConflictResolution, listPendingConflictDetails } from '../conflict-store.js';
+import { applyConflictResolution, listPendingConflictDetails, resolveConflict } from '../conflict-store.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asPositiveMs, asString } from '../job-utils.js';
 import { extractTextFromStoredMessageContent } from '../message-content.js';
@@ -43,7 +44,26 @@ export async function resolvePendingConflictsForMessageJob(job: MemoryJob, confi
   if (!clarificationReply) return;
 
   const pending = listPendingConflictDetails(scopeId, 25);
-  const eligible = pending.filter((conflict) => conflict.createdAt <= message.createdAt);
+
+  // Dismiss non-actionable conflicts (kind or statement policy)
+  const conflictableKinds = config.memory.conflicts.conflictableKinds;
+  for (const conflict of pending) {
+    const kindEligible = isConflictKindPairEligible(
+      conflict.existingKind, conflict.candidateKind, { conflictableKinds },
+    );
+    if (!kindEligible
+      || !isStatementConflictEligible(conflict.existingKind, conflict.existingStatement)
+      || !isStatementConflictEligible(conflict.candidateKind, conflict.candidateStatement)) {
+      resolveConflict(conflict.id, {
+        status: 'dismissed',
+        resolutionNote: 'Dismissed by conflict policy (transient/non-durable).',
+      });
+    }
+  }
+
+  // Re-fetch after dismissal
+  const actionablePending = listPendingConflictDetails(scopeId, 25);
+  const eligible = actionablePending.filter((conflict) => conflict.createdAt <= message.createdAt);
   if (eligible.length === 0) return;
   const candidates = eligible.filter((conflict) => {
     const askedAt = conflict.lastAskedAt;


### PR DESCRIPTION
PR 11 of memory conflict resolution rollout. Background resolver now dismisses pending conflicts that fail kind or statement policy, keeping the backlog clean and consistent with the session gate.

## Changes

- **`assistant/src/memory/job-handlers/conflict.ts`**: Added a dismissal pass before the eligible/candidate filtering in `resolvePendingConflictsForMessageJob`. Non-actionable conflicts (ineligible kind pairs or transient/non-durable statements) are dismissed via `resolveConflict` with status `dismissed` before re-fetching the actionable pending list.

- **`assistant/src/__tests__/memory-regressions.test.ts`**: Added test verifying that transient tracking conflicts (e.g., PR tracking statements) are automatically dismissed by the background resolver without triggering an LLM call.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
