### PR TITLE
Flip default permissions mode to workspace + docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1861,7 +1861,7 @@ graph TB
 
 ## Permission and Trust Security Model
 
-The permission system controls which tool actions the agent can execute without explicit user approval. It supports two operating modes, principal-aware trust rules, and risk-based escalation to provide defense-in-depth against unintended or malicious tool execution.
+The permission system controls which tool actions the agent can execute without explicit user approval. It supports three operating modes (`workspace`, `strict`, and `legacy`), principal-aware trust rules, and risk-based escalation to provide defense-in-depth against unintended or malicious tool execution.
 
 ### Permission Evaluation Flow
 
@@ -1883,30 +1883,41 @@ graph TB
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
-    NO_MATCH -->|"legacy mode (non-default)"| RISK_FALLBACK{"Risk level?"}
+    NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
+    WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
+    WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
+    RISK_FALLBACK_WS -->|"Low"| PROMPT_WS_LOW["decision: prompt"]
+    RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
+    RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
+    NO_MATCH -->|"legacy mode"| RISK_FALLBACK{"Risk level?"}
     RISK_FALLBACK -->|"Low"| AUTO_LOW["decision: allow<br/>Low risk auto-allow"]
     RISK_FALLBACK -->|"Medium"| PROMPT_MED["decision: prompt"]
     RISK_FALLBACK -->|"High"| PROMPT_HIGH2["decision: prompt"]
 ```
 
-### Strict Mode vs Legacy Mode
+### Permission Modes: Workspace, Strict, and Legacy
 
-The `permissions.mode` config option (`legacy` or `strict`) controls the default behavior when no trust rule matches a tool invocation.
+The `permissions.mode` config option (`workspace`, `strict`, or `legacy`) controls the default behavior when no trust rule matches a tool invocation. The default is `workspace`.
 
-| Behavior | Legacy mode | Strict mode (default) |
-|---|---|---|
-| Low-risk tools with no matching rule | Auto-allowed | Prompted |
-| Medium-risk tools with no matching rule | Prompted | Prompted |
-| High-risk tools with no matching rule | Prompted | Prompted |
-| `skill_load` with no matching rule | Auto-allowed (low risk) | Prompted (explicit rule required) |
-| `skill_load` with system default rule | Auto-allowed (`skill_load:*` at priority 100) | Auto-allowed (`skill_load:*` at priority 100) |
-| `browser_*` skill tools with system default rules | Auto-allowed (priority 100 allow rules) | Auto-allowed (priority 100 allow rules) |
-| Skill-origin tools with no matching rule | Prompted | Prompted |
-| Allow rules for non-high-risk tools | Auto-allowed | Auto-allowed |
-| Allow rules with `allowHighRisk: true` | Auto-allowed (even high risk) | Auto-allowed (even high risk) |
-| Deny rules | Blocked | Blocked |
+| Behavior | Workspace mode (default) | Strict mode | Legacy mode |
+|---|---|---|---|
+| Workspace-scoped ops with no matching rule | Auto-allowed | Prompted | Auto-allowed (low risk) |
+| Non-workspace low-risk tools with no matching rule | Prompted | Prompted | Auto-allowed |
+| Medium-risk tools with no matching rule | Prompted | Prompted | Prompted |
+| High-risk tools with no matching rule | Prompted | Prompted | Prompted |
+| `skill_load` with no matching rule | Prompted | Prompted | Auto-allowed (low risk) |
+| `skill_load` with system default rule | Auto-allowed (`skill_load:*` at priority 100) | Auto-allowed (`skill_load:*` at priority 100) | Auto-allowed (`skill_load:*` at priority 100) |
+| `browser_*` skill tools with system default rules | Auto-allowed (priority 100 allow rules) | Auto-allowed (priority 100 allow rules) | Auto-allowed (priority 100 allow rules) |
+| Skill-origin tools with no matching rule | Prompted | Prompted | Prompted |
+| Allow rules for non-high-risk tools | Auto-allowed | Auto-allowed | Auto-allowed |
+| Allow rules with `allowHighRisk: true` | Auto-allowed (even high risk) | Auto-allowed (even high risk) | Auto-allowed (even high risk) |
+| Deny rules | Blocked | Blocked | Blocked |
 
-Strict mode is designed for security-conscious deployments where every tool action must have an explicit matching rule in the trust store. It eliminates implicit auto-allow for any risk level, ensuring the user has consciously approved each class of tool usage.
+**Workspace mode** (default) auto-allows operations scoped to the workspace (file reads/writes/edits within the workspace directory, sandboxed bash) without prompting. Host operations, network requests, and operations outside the workspace still follow the normal approval flow. Explicit deny and ask rules override auto-allow.
+
+**Strict mode** is designed for security-conscious deployments where every tool action must have an explicit matching rule in the trust store. It eliminates implicit auto-allow for any risk level, ensuring the user has consciously approved each class of tool usage.
+
+**Legacy mode** auto-allows all low-risk tools regardless of scope. It is deprecated and will be removed in a future release.
 
 ### Trust Rules (v3 Schema)
 
@@ -2048,7 +2059,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 | `assistant/src/permissions/defaults.ts` | Default rule templates (system ask rules for host tools, CU, etc.) |
 | `assistant/src/skills/version-hash.ts` | `computeSkillVersionHash()` — deterministic SHA-256 of skill source files |
 | `assistant/src/skills/path-classifier.ts` | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection |
-| `assistant/src/config/schema.ts` | `PermissionsConfigSchema` — `permissions.mode` (`legacy` / `strict`) |
+| `assistant/src/config/schema.ts` | `PermissionsConfigSchema` — `permissions.mode` (`workspace` / `strict` / `legacy`) |
 | `assistant/src/tools/executor.ts` | `ToolExecutor` — orchestrates risk classification, permission check, and execution |
 
 ---

--- a/README.md
+++ b/README.md
@@ -306,13 +306,26 @@ All `browser_*` tools are declared as low-risk. The system seeds default trust r
 
 The assistant uses a permission system to control which tool actions the agent can execute without explicit user approval. Permission behavior is configured via `permissions.mode`:
 
+| Mode | Default? | Behavior |
+|---|---|---|
+| `workspace` | Yes | Workspace-scoped operations (file reads/writes/edits within workspace, sandboxed bash) are auto-allowed without prompting. Host operations, network requests, and operations outside the workspace still follow the normal approval flow. Explicit deny and ask rules override auto-allow. |
+| `strict` | No | Every tool invocation without an explicit matching trust rule prompts the user. No implicit auto-allow for any risk level. |
+| `legacy` | No | Low-risk tools auto-allowed, medium/high prompted. Deprecated in a future release. |
+
+To switch modes:
+
 ```bash
-# Default — ALL tools require an explicit trust rule, no implicit auto-allow
+# Workspace mode (default) — workspace-scoped ops auto-allowed, others follow risk-based policy
+vellum config set permissions.mode '"workspace"'
+
+# Strict — ALL tools require an explicit trust rule, no implicit auto-allow
 vellum config set permissions.mode '"strict"'
 
-# Legacy — low-risk tools auto-allowed, medium/high prompted
+# Legacy — low-risk tools auto-allowed, medium/high prompted (deprecated)
 vellum config set permissions.mode '"legacy"'
 ```
+
+Existing users with `permissions.mode: "strict"` or `permissions.mode: "legacy"` explicitly in their config will continue to use those modes unchanged.
 
 ### Trust rules
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -497,9 +497,9 @@ describe('AssistantConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  test('defaults permissions.mode to strict', () => {
+  test('defaults permissions.mode to workspace', () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.permissions).toEqual({ mode: 'strict' });
+    expect(result.permissions).toEqual({ mode: 'workspace' });
   });
 
   test('accepts explicit permissions.mode strict', () => {
@@ -1293,10 +1293,10 @@ describe('loadConfig with schema validation', () => {
     expect(config.auditLog.retentionDays).toBe(0);
   });
 
-  test('defaults permissions.mode to strict when not specified', () => {
+  test('defaults permissions.mode to workspace when not specified', () => {
     writeConfig({});
     const config = loadConfig();
-    expect(config.permissions).toEqual({ mode: 'strict' });
+    expect(config.permissions).toEqual({ mode: 'workspace' });
   });
 
   test('loads explicit permissions.mode strict', () => {
@@ -1308,7 +1308,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back for invalid permissions.mode', () => {
     writeConfig({ permissions: { mode: 'yolo' } });
     const config = loadConfig();
-    expect(config.permissions.mode).toBe('strict');
+    expect(config.permissions.mode).toBe('workspace');
   });
 
   test('does not mutate default apiKeys when fallback config is overridden by env keys', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -161,7 +161,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     blockIngress: true,
   },
   permissions: {
-    mode: 'strict',
+    mode: 'workspace',
   },
   auditLog: {
     retentionDays: 0,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -137,7 +137,7 @@ export const PermissionsConfigSchema = z.object({
     .enum(VALID_PERMISSIONS_MODES, {
       error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(', ')}`,
     })
-    .default('strict'),
+    .default('workspace'),
 });
 
 export const AuditLogConfigSchema = z.object({
@@ -1242,7 +1242,7 @@ export const AssistantConfigSchema = z.object({
     blockIngress: true,
   }),
   permissions: PermissionsConfigSchema.default({
-    mode: 'strict',
+    mode: 'workspace',
   }),
   auditLog: AuditLogConfigSchema.default({
     retentionDays: 0,


### PR DESCRIPTION
## Summary
- Sets the default `permissions.mode` from `strict` to `workspace` so workspace-scoped operations (file reads/writes/edits within workspace, sandboxed bash) auto-allow without prompting
- Updates README.md with a behavior matrix table showing all three modes, mode switching examples, and notes on backward compatibility
- Updates ARCHITECTURE.md permission evaluation flow diagram to include the workspace mode decision branch, and rewrites the mode comparison section to cover all three modes

## Test plan
- [x] `bun test src/__tests__/config-schema.test.ts` — 119 tests pass (default mode assertions updated)
- [x] `bun test src/__tests__/checker.test.ts` — 347 tests pass (permission logic unchanged)

PR 4 of workspace-default-permissions rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
