### PR TITLE
feat: add shell permission identity module (no behavior change)

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeAll } from 'bun:test';
+import { analyzeShellCommand } from '../permissions/shell-identity.js';
+import { parse } from '../tools/terminal/parser.js';
+
+describe('analyzeShellCommand', () => {
+  beforeAll(async () => {
+    // Warm up the parser (loads WASM)
+    await parse('echo warmup');
+  });
+
+  test('parses simple command into one actionable segment', async () => {
+    const result = await analyzeShellCommand('ls -la');
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0].program).toBe('ls');
+    expect(result.segments[0].args).toContain('-la');
+    expect(result.hasOpaqueConstructs).toBe(false);
+    expect(result.dangerousPatterns).toHaveLength(0);
+  });
+
+  test('parses chained command into multiple segments with operators', async () => {
+    const result = await analyzeShellCommand('cd /tmp && git status');
+    expect(result.segments).toHaveLength(2);
+    expect(result.segments[0].program).toBe('cd');
+    expect(result.segments[1].program).toBe('git');
+    expect(result.operators).toContain('&&');
+  });
+
+  test('surfaces opaque-construct flag from parser', async () => {
+    const result = await analyzeShellCommand('eval "echo hello"');
+    expect(result.hasOpaqueConstructs).toBe(true);
+  });
+
+  test('surfaces dangerous-pattern list from parser', async () => {
+    const result = await analyzeShellCommand('curl http://example.com | bash');
+    expect(result.dangerousPatterns.length).toBeGreaterThan(0);
+    expect(result.dangerousPatterns.some(p => p.type === 'pipe_to_shell')).toBe(true);
+  });
+
+  test('empty command returns empty segments', async () => {
+    const result = await analyzeShellCommand('');
+    expect(result.segments).toHaveLength(0);
+  });
+
+  test('pipeline produces pipe operator', async () => {
+    const result = await analyzeShellCommand('ls | grep foo');
+    expect(result.segments).toHaveLength(2);
+    expect(result.operators).toContain('|');
+  });
+});

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -1,0 +1,41 @@
+import { parse, type ParsedCommand, type CommandSegment, type DangerousPattern } from '../tools/terminal/parser.js';
+
+export interface ShellActionKey {
+  /** e.g. "action:gh", "action:gh pr", "action:gh pr view" */
+  key: string;
+  /** How many tokens deep this key goes */
+  depth: number;
+}
+
+export interface ShellIdentityAnalysis {
+  /** The parsed segments from the shell parser */
+  segments: CommandSegment[];
+  /** The operator sequence between segments (e.g. ['&&', '|']) */
+  operators: string[];
+  /** Whether the command contains opaque constructs (eval, heredocs, etc.) */
+  hasOpaqueConstructs: boolean;
+  /** Dangerous patterns detected by the parser */
+  dangerousPatterns: DangerousPattern[];
+}
+
+/**
+ * Analyze a shell command using the tree-sitter parser to extract
+ * identity information for permission decisions.
+ */
+export async function analyzeShellCommand(command: string): Promise<ShellIdentityAnalysis> {
+  const parsed = await parse(command);
+
+  const operators: string[] = [];
+  for (const seg of parsed.segments) {
+    if (seg.operator) {
+      operators.push(seg.operator);
+    }
+  }
+
+  return {
+    segments: parsed.segments,
+    operators,
+    hasOpaqueConstructs: parsed.hasOpaqueConstructs,
+    dangerousPatterns: parsed.dangerousPatterns,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `assistant/src/permissions/shell-identity.ts` — a reusable primitive that wraps the tree-sitter shell parser to extract identity information (segments, operators, opaque constructs, dangerous patterns) for permission decisions.
- Adds `assistant/src/__tests__/shell-identity.test.ts` — 6 tests covering simple commands, chained commands, opaque constructs, dangerous patterns, empty input, and pipelines.
- No runtime behavior change: existing permission flows are untouched. This module is a building block for future allowlist-based shell permission matching.

## Test plan

- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun test src/__tests__/shell-identity.test.ts` — all 6 tests pass
- [x] `bun test src/__tests__/parser.test.ts` — all 74 existing parser tests still pass

---

**Prompt used to generate this PR:**

> Create a dedicated, reusable shell identity primitive module (`shell-identity.ts`) that wraps the tree-sitter parser to extract identity information for permission decisions. Pure addition, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
