### PR TITLE
feat: add explicit scope selection for always-allow

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -38,7 +38,7 @@ public struct ToolConfirmationBubble: View {
     }
 
     private var needsScopeChoice: Bool {
-        confirmation.scopeOptions.count > 1
+        !confirmation.scopeOptions.isEmpty
     }
 
     private var isDecided: Bool {


### PR DESCRIPTION
## Summary

- Always show the scope picker in the always-allow flow, even when there is only a single scope option. Previously, a single scope was silently auto-applied without the user seeing or confirming it.
- Changes `needsScopeChoice` from `count > 1` to `!isEmpty`, so the scope confirmation step appears whenever scope options exist.

## Test plan

- [ ] With a tool confirmation that has 1 scope option: verify the scope picker popover is shown (previously it was skipped)
- [ ] With 2+ scope options: verify the scope picker still works as before
- [ ] With 0 scope options: verify it falls through to one-time allow (no scope picker shown)
- [ ] In the dropdown (multi-option) path: verify scope step still appears after selecting a pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
