### PR TITLE
feat: add action-key derivation + fixtures (no wiring)

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from 'bun:test';
-import { analyzeShellCommand } from '../permissions/shell-identity.js';
+import { analyzeShellCommand, deriveShellActionKeys } from '../permissions/shell-identity.js';
 import { parse } from '../tools/terminal/parser.js';
 
 describe('analyzeShellCommand', () => {
@@ -45,5 +45,87 @@ describe('analyzeShellCommand', () => {
     const result = await analyzeShellCommand('ls | grep foo');
     expect(result.segments).toHaveLength(2);
     expect(result.operators).toContain('|');
+  });
+});
+
+describe('deriveShellActionKeys', () => {
+  test('cd repo && gh pr view 5525 --json ... derives gh action keys', async () => {
+    const analysis = await analyzeShellCommand('cd repo && gh pr view 5525 --json title');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([
+      { key: 'action:gh pr view', depth: 3 },
+      { key: 'action:gh pr', depth: 2 },
+      { key: 'action:gh', depth: 1 },
+    ]);
+  });
+
+  test('flags and paths are excluded from key growth', async () => {
+    const analysis = await analyzeShellCommand('git log --oneline -n 10 ./src');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([
+      { key: 'action:git log', depth: 2 },
+      { key: 'action:git', depth: 1 },
+    ]);
+  });
+
+  test('pipelines are marked non-simple', async () => {
+    const analysis = await analyzeShellCommand('git log | grep fix');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
+  test('complex chains with multiple actions are non-simple', async () => {
+    const analysis = await analyzeShellCommand('git add . && git commit -m "fix"');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
+  test('empty/invalid commands return no action keys', async () => {
+    const analysis = await analyzeShellCommand('');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
+  test('single program command produces single key', async () => {
+    const analysis = await analyzeShellCommand('ls -la');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([
+      { key: 'action:ls', depth: 1 },
+    ]);
+  });
+
+  test('setup-prefix handling identifies primary action', async () => {
+    const analysis = await analyzeShellCommand('export PATH="/usr/bin:$PATH" && npm install');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([
+      { key: 'action:npm install', depth: 2 },
+      { key: 'action:npm', depth: 1 },
+    ]);
+  });
+
+  test('numeric arguments are excluded from keys', async () => {
+    const analysis = await analyzeShellCommand('gh pr view 5525');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([
+      { key: 'action:gh pr view', depth: 3 },
+      { key: 'action:gh pr', depth: 2 },
+      { key: 'action:gh', depth: 1 },
+    ]);
   });
 });

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -18,6 +18,20 @@ export interface ShellIdentityAnalysis {
   dangerousPatterns: DangerousPattern[];
 }
 
+export interface ActionKeyResult {
+  /** The derived action keys from narrowest to broadest */
+  keys: ShellActionKey[];
+  /** Whether this command has a "simple action" shape (setup prefix + single action) */
+  isSimpleAction: boolean;
+  /** The primary action segment (the non-setup-prefix action command) */
+  primarySegment?: CommandSegment;
+}
+
+/** Programs that are considered setup prefixes (not the main action) */
+const SETUP_PREFIX_PROGRAMS = new Set(['cd', 'pushd', 'export', 'unset', 'set']);
+
+const MAX_ACTION_KEY_DEPTH = 3;
+
 /**
  * Analyze a shell command using the tree-sitter parser to extract
  * identity information for permission decisions.
@@ -38,4 +52,70 @@ export async function analyzeShellCommand(command: string): Promise<ShellIdentit
     hasOpaqueConstructs: parsed.hasOpaqueConstructs,
     dangerousPatterns: parsed.dangerousPatterns,
   };
+}
+
+/**
+ * Derive canonical action keys from a shell command analysis.
+ *
+ * Action keys identify the "family" of a command for allowlist purposes.
+ * For example, `cd repo && gh pr view 5525 --json title` derives:
+ *   - action:gh pr view
+ *   - action:gh pr
+ *   - action:gh
+ *
+ * Only "simple action" commands (optional setup prefix + one action) get
+ * action keys. Pipelines and complex chains are marked non-simple.
+ */
+export function deriveShellActionKeys(analysis: ShellIdentityAnalysis): ActionKeyResult {
+  const { segments, operators } = analysis;
+
+  if (segments.length === 0) {
+    return { keys: [], isSimpleAction: false };
+  }
+
+  // Pipelines are never simple
+  if (operators.includes('|')) {
+    return { keys: [], isSimpleAction: false };
+  }
+
+  // Separate setup-prefix segments from action segments
+  const actionSegments: CommandSegment[] = [];
+  let foundNonPrefix = false;
+
+  for (const seg of segments) {
+    if (!foundNonPrefix && SETUP_PREFIX_PROGRAMS.has(seg.program)) {
+      continue;
+    }
+    foundNonPrefix = true;
+    actionSegments.push(seg);
+  }
+
+  // Simple action: exactly one non-prefix action segment
+  if (actionSegments.length !== 1) {
+    return { keys: [], isSimpleAction: false };
+  }
+
+  const primarySegment = actionSegments[0];
+  const tokens: string[] = [primarySegment.program];
+
+  // Add non-flag, non-path stable subcommand tokens (up to MAX_ACTION_KEY_DEPTH)
+  for (const arg of primarySegment.args) {
+    if (tokens.length >= MAX_ACTION_KEY_DEPTH) break;
+    if (arg.startsWith('-')) continue;
+    if (arg.includes('/') || arg.startsWith('.')) continue;
+    if (/^\d+$/.test(arg)) continue;
+    if (arg.includes('$') || arg.includes('"') || arg.includes("'")) continue;
+    tokens.push(arg);
+  }
+
+  // Build action keys from narrowest to broadest
+  const keys: ShellActionKey[] = [];
+  for (let depth = tokens.length; depth >= 1; depth--) {
+    keys.push({
+      key: `action:${tokens.slice(0, depth).join(' ')}`,
+      depth,
+    });
+  }
+
+  return { keys, isSimpleAction: true, primarySegment };
 }


### PR DESCRIPTION
## Summary

- Add `deriveShellActionKeys()` function to `shell-identity.ts` that extracts canonical action keys from parsed shell commands for allowlist matching
- Setup-prefix programs (cd, export, pushd, unset, set) are skipped to identify the primary action segment
- Flags, paths, numeric args, and variable expansions are excluded from key tokens to keep keys stable
- Pipelines and multi-action chains are classified as non-simple (no action keys derived)
- 8 new test cases covering simple commands, prefixed commands, pipelines, chains, empty input, and edge cases

## Test plan

- [x] All 14 tests pass (6 existing + 8 new) in `shell-identity.test.ts`
- [x] Type-checking passes (no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
