### PR TITLE
fix: harden persist flow — remove silent fallback scope

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -495,14 +495,10 @@ public struct ToolConfirmationBubble: View {
                         itemCount: confirmation.scopeOptions.count
                     )
                 } else {
+                    // No scope options available — fall back to one-time allow
                     showAlwaysAllowMenu = false
                     popoverKeyboardModel = nil
-                    let scope = confirmation.scopeOptions.first?.scope ?? ""
-                    if !scope.isEmpty {
-                        onAlwaysAllow(confirmation.requestId, option.pattern, scope, alwaysAllowDecision)
-                    } else {
-                        onAllow()
-                    }
+                    onAllow()
                 }
             }
         } else if showScopePickerMenu {
@@ -597,12 +593,8 @@ public struct ToolConfirmationBubble: View {
                 itemCount: confirmation.scopeOptions.count
             )
         } else {
-            let scope = confirmation.scopeOptions.first?.scope ?? ""
-            if !scope.isEmpty {
-                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
-            } else {
-                onAllow()
-            }
+            // No scope options — fall back to one-time allow
+            onAllow()
         }
     }
 
@@ -726,14 +718,10 @@ public struct ToolConfirmationBubble: View {
                                     itemCount: confirmation.scopeOptions.count
                                 )
                             } else {
+                                // No scope options available — fall back to one-time allow
                                 showAlwaysAllowMenu = false
                                 popoverKeyboardModel = nil
-                                let scope = confirmation.scopeOptions.first?.scope ?? ""
-                                if !scope.isEmpty {
-                                    onAlwaysAllow(confirmation.requestId, option.pattern, scope, alwaysAllowDecision)
-                                } else {
-                                    onAllow()
-                                }
+                                onAllow()
                             }
                         }
 


### PR DESCRIPTION
## Summary

- Remove three fallback paths in `ToolConfirmationBubble.swift` that attempted to use `scopeOptions.first?.scope` as a default scope when no explicit scope selection was made
- After PR 09 changed `needsScopeChoice` to `!confirmation.scopeOptions.isEmpty`, these `else` branches only execute when `scopeOptions` is empty, so the fallback always resolved to `onAllow()` anyway
- Replacing the conditional with a direct `onAllow()` call makes the intent explicit and prevents future regressions

## Locations changed

1. `activatePopoverSelection()` — keyboard handler path (else branch when `!needsScopeChoice`)
2. `handleSingleOptionAlwaysAllow()` — single-option always-allow path
3. `alwaysAllowDropdown` view — dropdown pattern selection path

## Test plan

- [ ] Verify that "Always Allow" with a single scope option still navigates to the scope picker
- [ ] Verify that "Always Allow" with multiple scope options shows the dropdown then scope picker
- [ ] Verify that when no scope options are available, clicking "Always Allow" falls back to one-time allow
- [ ] Verify keyboard navigation (Enter on pattern row) follows the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
