### PR TITLE
feat: add shell candidate builder utility (no wiring)

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from 'bun:test';
-import { analyzeShellCommand, deriveShellActionKeys } from '../permissions/shell-identity.js';
+import { analyzeShellCommand, deriveShellActionKeys, buildShellCommandCandidates } from '../permissions/shell-identity.js';
 import { parse } from '../tools/terminal/parser.js';
 
 describe('analyzeShellCommand', () => {
@@ -127,5 +127,53 @@ describe('deriveShellActionKeys', () => {
       { key: 'action:gh pr', depth: 2 },
       { key: 'action:gh', depth: 1 },
     ]);
+  });
+});
+
+describe('buildShellCommandCandidates', () => {
+  test('raw candidate is always present', async () => {
+    const candidates = await buildShellCommandCandidates('ls -la');
+    expect(candidates[0]).toBe('ls -la');
+  });
+
+  test('simple action adds canonical and action candidates', async () => {
+    const candidates = await buildShellCommandCandidates('cd repo && gh pr view 5525 --json title');
+    expect(candidates[0]).toBe('cd repo && gh pr view 5525 --json title');
+    // Should include the canonical primary command
+    expect(candidates).toContain('gh pr view 5525 --json title');
+    // Should include action keys
+    expect(candidates).toContain('action:gh pr view');
+    expect(candidates).toContain('action:gh pr');
+    expect(candidates).toContain('action:gh');
+  });
+
+  test('complex command returns raw-only', async () => {
+    const candidates = await buildShellCommandCandidates('git add . && git commit -m "fix"');
+    expect(candidates).toEqual(['git add . && git commit -m "fix"']);
+  });
+
+  test('pipeline returns raw-only', async () => {
+    const candidates = await buildShellCommandCandidates('git log | grep fix');
+    expect(candidates).toEqual(['git log | grep fix']);
+  });
+
+  test('candidate order is stable', async () => {
+    const c1 = await buildShellCommandCandidates('npm install express');
+    const c2 = await buildShellCommandCandidates('npm install express');
+    expect(c1).toEqual(c2);
+  });
+
+  test('empty command returns raw', async () => {
+    const candidates = await buildShellCommandCandidates('');
+    expect(candidates).toEqual(['']);
+  });
+
+  test('deduplication preserves order', async () => {
+    // Single command — raw and canonical are the same
+    const candidates = await buildShellCommandCandidates('git status');
+    // raw is 'git status', canonical would also be 'git status' (same segment)
+    // so it should be deduped to just once
+    const gitStatusCount = candidates.filter(c => c === 'git status').length;
+    expect(gitStatusCount).toBe(1);
   });
 });

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -119,3 +119,39 @@ export function deriveShellActionKeys(analysis: ShellIdentityAnalysis): ActionKe
 
   return { keys, isSimpleAction: true, primarySegment };
 }
+
+/**
+ * Build an ordered list of command candidates for trust-rule matching.
+ *
+ * Candidate ordering:
+ *   1. Raw command (backward compatibility — existing rules match as before)
+ *   2. Canonical primary command (if simple action) — the full primary segment text
+ *   3. Action keys from narrowest to broadest (if simple action)
+ *
+ * Complex commands (pipelines, multi-action chains) only return the raw candidate.
+ */
+export async function buildShellCommandCandidates(command: string): Promise<string[]> {
+  const trimmed = command.trim();
+  if (!trimmed) return [trimmed];
+
+  const analysis = await analyzeShellCommand(trimmed);
+  const actionResult = deriveShellActionKeys(analysis);
+
+  const candidates: string[] = [trimmed];
+
+  if (actionResult.isSimpleAction && actionResult.primarySegment) {
+    // Add canonical primary command text (the actual segment, not the full command with setup prefixes)
+    const canonical = actionResult.primarySegment.command;
+    if (canonical !== trimmed) {
+      candidates.push(canonical);
+    }
+
+    // Add action keys
+    for (const actionKey of actionResult.keys) {
+      candidates.push(actionKey.key);
+    }
+  }
+
+  // Deduplicate while preserving order
+  return [...new Set(candidates)];
+}


### PR DESCRIPTION
## Summary

- Adds `buildShellCommandCandidates()` to `assistant/src/permissions/shell-identity.ts` — a standalone helper that produces an ordered list of trust-rule matching candidates from a shell command
- Candidate ordering: raw command (backward compat) -> canonical primary command -> action keys (narrowest to broadest)
- Complex commands (pipelines, multi-action chains) only return the raw candidate
- 7 new tests covering all candidate generation scenarios

## Test plan

- [x] All existing shell-identity tests still pass (14 tests)
- [x] New `buildShellCommandCandidates` tests pass (7 tests)
- [x] Type-checking passes (pre-existing errors only in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
