### PR TITLE
Legacy permission mode cleanup/deprecation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1899,7 +1899,7 @@ graph TB
 
 The `permissions.mode` config option (`workspace`, `strict`, or `legacy`) controls the default behavior when no trust rule matches a tool invocation. The default is `workspace`.
 
-| Behavior | Workspace mode (default) | Strict mode | Legacy mode |
+| Behavior | Workspace mode (default) | Strict mode | Legacy mode (deprecated) |
 |---|---|---|---|
 | Workspace-scoped ops with no matching rule | Auto-allowed | Prompted | Auto-allowed (low risk) |
 | Non-workspace low-risk tools with no matching rule | Prompted | Prompted | Auto-allowed |
@@ -1917,7 +1917,7 @@ The `permissions.mode` config option (`workspace`, `strict`, or `legacy`) contro
 
 **Strict mode** is designed for security-conscious deployments where every tool action must have an explicit matching rule in the trust store. It eliminates implicit auto-allow for any risk level, ensuring the user has consciously approved each class of tool usage.
 
-**Legacy mode** auto-allows all low-risk tools regardless of scope. It is deprecated and will be removed in a future release.
+**Legacy mode** (deprecated) auto-allows all low-risk tools regardless of scope. It is deprecated and will be removed in a future release. A one-time runtime warning is emitted when legacy mode is active. Users should migrate to `workspace` (default) or `strict`.
 
 ### Trust Rules (v3 Schema)
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ The assistant uses a permission system to control which tool actions the agent c
 |---|---|---|
 | `workspace` | Yes | Workspace-scoped operations (file reads/writes/edits within workspace, sandboxed bash) are auto-allowed without prompting. Host operations, network requests, and operations outside the workspace still follow the normal approval flow. Explicit deny and ask rules override auto-allow. |
 | `strict` | No | Every tool invocation without an explicit matching trust rule prompts the user. No implicit auto-allow for any risk level. |
-| `legacy` | No | Low-risk tools auto-allowed, medium/high prompted. Deprecated in a future release. |
+| `legacy` (deprecated) | No | Low-risk tools auto-allowed, medium/high prompted. **Deprecated — will be removed in a future release.** |
 
 To switch modes:
 
@@ -324,6 +324,8 @@ vellum config set permissions.mode '"strict"'
 # Legacy — low-risk tools auto-allowed, medium/high prompted (deprecated)
 vellum config set permissions.mode '"legacy"'
 ```
+
+> **Note:** Legacy mode is deprecated. If your config uses `permissions.mode: "legacy"`, switch to `workspace` or `strict`. A runtime warning is emitted on first use.
 
 Existing users with `permissions.mode: "strict"` or `permissions.mode: "legacy"` explicitly in their config will continue to use those modes unchanged.
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -24,9 +24,16 @@ mock.module('../util/platform.js', () => ({
   ensureDataDir: () => {},
 }));
 
+// Capture logger.warn() calls so tests can assert on deprecation warnings.
+const loggerWarnCalls: string[] = [];
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
-    get: () => () => {},
+    get: (_target: Record<string, unknown>, prop: string) => {
+      if (prop === 'warn') {
+        return (...args: unknown[]) => { loggerWarnCalls.push(String(args[0])); };
+      }
+      return () => {};
+    },
   }),
 }));
 
@@ -49,7 +56,7 @@ mock.module('../config/loader.js', () => ({
   setNestedValue: () => {},
 }));
 
-import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
+import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions, _resetLegacyDeprecationWarning } from '../permissions/checker.js';
 import { RiskLevel, type PolicyContext } from '../permissions/types.js';
 import { addRule, clearCache, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
@@ -125,6 +132,9 @@ describe('Permission Checker', () => {
     // Reset permissions mode to legacy so existing tests are not affected
     testConfig.permissions = { mode: 'legacy' };
     testConfig.skills = { load: { extraDirs: [] } };
+    // Reset the one-time legacy deprecation warning flag and captured log calls
+    _resetLegacyDeprecationWarning();
+    loggerWarnCalls.length = 0;
     try { rmSync(join(checkerTestDir, 'protected', 'trust.json')); } catch { /* may not exist */ }
     try { rmSync(join(checkerTestDir, 'skills'), { recursive: true, force: true }); } catch { /* may not exist */ }
     try { rmSync(join(checkerTestDir, 'workspace', 'skills'), { recursive: true, force: true }); } catch { /* may not exist */ }
@@ -4090,6 +4100,63 @@ describe('workspace mode — auto-allow workspace-scoped operations', () => {
 
   test('network_request → prompt (Medium risk, not workspace-scoped)', async () => {
     const result = await check('network_request', { url: 'https://api.example.com/data' }, workspaceDir);
+    expect(result.decision).toBe('prompt');
+    expect(result.reason).toContain('risk');
+  });
+});
+
+// ── legacy mode deprecation warning ─────────────────────────────────────
+
+describe('legacy mode — deprecation warning', () => {
+  beforeEach(() => {
+    clearCache();
+    _resetLegacyDeprecationWarning();
+    loggerWarnCalls.length = 0;
+    testConfig.permissions = { mode: 'legacy' };
+    testConfig.skills = { load: { extraDirs: [] } };
+    try { rmSync(join(checkerTestDir, 'protected', 'trust.json')); } catch { /* may not exist */ }
+  });
+
+  afterEach(() => {
+    testConfig.permissions = { mode: 'legacy' };
+  });
+
+  test('emits deprecation warning on first check() call in legacy mode', async () => {
+    await check('file_read', { file_path: '/tmp/test.txt' }, '/tmp');
+    expect(loggerWarnCalls.some(m => m.includes('deprecated'))).toBe(true);
+    expect(loggerWarnCalls.some(m => m.includes('legacy'))).toBe(true);
+  });
+
+  test('deprecation warning fires only once per process', async () => {
+    await check('file_read', { file_path: '/tmp/a.txt' }, '/tmp');
+    const firstCount = loggerWarnCalls.filter(m => m.includes('deprecated')).length;
+    expect(firstCount).toBe(1);
+
+    await check('file_read', { file_path: '/tmp/b.txt' }, '/tmp');
+    const secondCount = loggerWarnCalls.filter(m => m.includes('deprecated')).length;
+    expect(secondCount).toBe(1);
+  });
+
+  test('no deprecation warning in workspace mode', async () => {
+    testConfig.permissions = { mode: 'workspace' };
+    await check('file_read', { file_path: '/tmp/test.txt' }, '/tmp');
+    expect(loggerWarnCalls.some(m => m.includes('deprecated'))).toBe(false);
+  });
+
+  test('no deprecation warning in strict mode', async () => {
+    testConfig.permissions = { mode: 'strict' };
+    await check('file_read', { file_path: '/tmp/test.txt' }, '/tmp');
+    expect(loggerWarnCalls.some(m => m.includes('deprecated'))).toBe(false);
+  });
+
+  test('legacy mode still produces correct decisions (low risk auto-allowed)', async () => {
+    const result = await check('file_read', { file_path: '/tmp/test.txt' }, '/tmp');
+    expect(result.decision).toBe('allow');
+    expect(result.reason).toContain('Low risk');
+  });
+
+  test('legacy mode still prompts for medium risk', async () => {
+    const result = await check('file_write', { file_path: '/tmp/test.txt' }, '/tmp');
     expect(result.decision).toBe('prompt');
     expect(result.reason).toContain('risk');
   });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -5,11 +5,20 @@ import { resolveSkillSelector } from '../config/skills.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
 import { getTool } from '../tools/registry.js';
 import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
 import { dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 import { normalizeFilePath, isSkillSourcePath } from '../skills/path-classifier.js';
 import { isWorkspaceScopedInvocation } from './workspace-policy.js';
+
+// Ensures the legacy mode deprecation warning fires at most once per process.
+let _legacyDeprecationWarned = false;
+
+/** @internal — exposed only for tests to reset the one-time warning flag. */
+export function _resetLegacyDeprecationWarning(): void {
+  _legacyDeprecationWarned = false;
+}
 
 // Low-risk shell programs that are read-only / informational
 const LOW_RISK_PROGRAMS = new Set([
@@ -400,6 +409,12 @@ export async function check(
   // agent new capabilities, so in strict mode users must approve each
   // skill load via an exact-version or wildcard trust rule.
   const permissionsMode = getConfig().permissions.mode;
+
+  if (permissionsMode === 'legacy' && !_legacyDeprecationWarned) {
+    _legacyDeprecationWarned = true;
+    getLogger().warn('Permissions mode "legacy" is deprecated and will be removed in a future release. Switch to "workspace" (default) or "strict".');
+  }
+
   if (permissionsMode === 'strict' && !matchedRule) {
     return { decision: 'prompt', reason: `Strict mode: no matching rule, requires approval` };
   }


### PR DESCRIPTION
PR 5 (final) of workspace-default-permissions rollout. Soft-deprecates legacy permission mode with a one-time runtime warning directing users to workspace or strict. Marks legacy as deprecated in README and ARCHITECTURE docs. Legacy mode still works — no behavior changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
