### PR TITLE
feat: wire parser-derived candidates for bash/host_bash matching

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4161,3 +4161,38 @@ describe('legacy mode — deprecation warning', () => {
     expect(result.reason).toContain('risk');
   });
 });
+
+describe('shell command candidates wiring (PR 04)', () => {
+  test('existing raw shell rule still matches', async () => {
+    clearCache();
+    addRule('bash', 'git status', 'everywhere');
+    const result = await check('bash', { command: 'git status' }, '/tmp');
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRule).toBeDefined();
+  });
+
+  test('action key rule matches simple shell command', async () => {
+    clearCache();
+    addRule('bash', 'action:gh pr view', 'everywhere');
+    const result = await check('bash', { command: 'gh pr view 5525 --json title' }, '/tmp');
+    expect(result.decision).toBe('allow');
+    expect(result.matchedRule).toBeDefined();
+  });
+
+  test('action key rule does not match complex chain with additional action', async () => {
+    // Disable sandbox so the default allow-bash-global rule is not emitted;
+    // otherwise the catch-all "**" pattern auto-allows every bash command.
+    testConfig.sandbox.enabled = false;
+    clearCache();
+    try {
+      addRule('bash', 'action:gh pr view', 'everywhere');
+      // Multi-action chain should NOT match because it's not a simple action
+      const result = await check('bash', { command: 'gh pr view 123 && rm -rf /' }, '/tmp');
+      // Should still prompt because the action key candidate isn't generated for complex chains
+      expect(result.decision).toBe('prompt');
+    } finally {
+      testConfig.sandbox.enabled = true;
+      clearCache();
+    }
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 import { normalizeFilePath, isSkillSourcePath } from '../skills/path-classifier.js';
 import { isWorkspaceScopedInvocation } from './workspace-policy.js';
+import { buildShellCommandCandidates } from './shell-identity.js';
 
 // Ensures the legacy mode deprecation warning fires at most once per process.
 let _legacyDeprecationWarned = false;
@@ -153,9 +154,9 @@ function escapeMinimatchLiteral(value: string): string {
   return value.replace(/([\\*?[\]{}()!+@|])/g, '\\$1');
 }
 
-function buildCommandCandidates(toolName: string, input: Record<string, unknown>, workingDir: string): string[] {
+async function buildCommandCandidates(toolName: string, input: Record<string, unknown>, workingDir: string): Promise<string[]> {
   if (toolName === 'bash' || toolName === 'host_bash') {
-    return [getStringField(input, 'command')];
+    return buildShellCommandCandidates(getStringField(input, 'command'));
   }
 
   if (toolName === 'skill_load') {
@@ -354,7 +355,7 @@ export async function check(
   const risk = await classifyRisk(toolName, input, workingDir);
 
   // Build command string candidates for rule matching
-  const commandCandidates = buildCommandCandidates(toolName, input, workingDir);
+  const commandCandidates = await buildCommandCandidates(toolName, input, workingDir);
 
   // Find the highest-priority matching rule across all candidates
   const matchedRule = findHighestPriorityRule(toolName, commandCandidates, workingDir, policyContext);


### PR DESCRIPTION
## Summary

- Make `buildCommandCandidates()` in `checker.ts` async and delegate bash/host_bash handling to `buildShellCommandCandidates()` from `shell-identity.ts`
- This enables parser-derived action-key candidates (e.g. `action:gh pr view`) for trust-rule matching alongside the existing raw-command matching
- Add tests verifying raw rule backward compatibility, action-key matching for simple commands, and non-matching for complex chains

## Test plan

- [x] All 350 existing checker tests pass
- [x] All 21 shell-identity tests pass
- [x] New test: raw shell rule still matches (`git status`)
- [x] New test: action key rule matches simple command (`gh pr view 5525 --json title` matches `action:gh pr view`)
- [x] New test: action key rule does not match complex chain (`gh pr view 123 && rm -rf /` does not match `action:gh pr view`)

---

**Original prompt:**

Wire `buildShellCommandCandidates()` for bash/host_bash. Use parser-derived candidates for shell rule matching while preserving legacy raw matching. Make `buildCommandCandidates` async and delegate to `buildShellCommandCandidates()` from `shell-identity.ts` for bash/host_bash tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
