### PR TITLE
feat: parser-based allowlist option generator for shell

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -650,7 +650,7 @@ describe('Permission Checker', () => {
     });
 
     test('web_fetch exact allowlist pattern matches query urls literally', async () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'https://example.com/search?q=test' });
+      const options = await generateAllowlistOptions('web_fetch', { url: 'https://example.com/search?q=test' });
       addRule('web_fetch', options[0].pattern, '/tmp');
 
       const allowed = await check(
@@ -930,30 +930,51 @@ describe('Permission Checker', () => {
   // ── generateAllowlistOptions ───────────────────────────────────
 
   describe('generateAllowlistOptions', () => {
-    test('shell: generates exact, subcommand wildcard, and program wildcard', () => {
-      const options = generateAllowlistOptions('bash', { command: 'npm install express' });
-      expect(options).toHaveLength(3);
+    test('shell: generates exact and action-key options via parser', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'npm install express' });
       expect(options[0]).toEqual({ label: 'npm install express', description: 'This exact command', pattern: 'npm install express' });
-      expect(options[1]).toEqual({ label: 'npm install *', description: 'Any "npm install" command', pattern: 'npm install *' });
-      expect(options[2]).toEqual({ label: 'npm *', description: 'Any npm command', pattern: 'npm *' });
+      // Action keys from narrowest to broadest
+      expect(options.some(o => o.pattern === 'action:npm install')).toBe(true);
+      expect(options.some(o => o.pattern === 'action:npm')).toBe(true);
     });
 
-    test('shell: single-word command deduplicates', () => {
-      const options = generateAllowlistOptions('bash', { command: 'make' });
+    test('shell: single-word command deduplicates', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'make' });
       const patterns = options.map((o) => o.pattern);
       expect(new Set(patterns).size).toBe(patterns.length);
     });
 
-    test('shell: two-word command deduplicates program wildcard', () => {
-      const options = generateAllowlistOptions('bash', { command: 'git push' });
-      // exact: 'git push', subcommand: 'git *', program: 'git *' → last two deduplicate
-      expect(options).toHaveLength(2);
+    test('shell: two-word command produces action keys', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'git push' });
       expect(options[0].pattern).toBe('git push');
-      expect(options[1].pattern).toBe('git *');
+      expect(options.some(o => o.pattern === 'action:git push')).toBe(true);
+      expect(options.some(o => o.pattern === 'action:git')).toBe(true);
     });
 
-    test('file_write: generates prefixed file, ancestor directory wildcards, and tool wildcard', () => {
-      const options = generateAllowlistOptions('file_write', { path: '/home/user/project/file.ts' });
+    test('shell allowlist uses parser-based options for simple command', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'gh pr view 5525 --json title' });
+      // Should have exact + action key options, not whitespace-split options
+      expect(options[0].description).toBe('This exact command');
+      expect(options.some(o => o.pattern.startsWith('action:'))).toBe(true);
+      // Action key options should NOT contain numeric args (only the exact match does)
+      const actionOptions = options.filter(o => o.pattern.startsWith('action:'));
+      expect(actionOptions.some(o => o.pattern.includes('5525'))).toBe(false);
+    });
+
+    test('shell allowlist for complex command offers exact only', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'git add . && git commit -m "fix"' });
+      expect(options).toHaveLength(1);
+      expect(options[0].description).toContain('compound');
+    });
+
+    test('shell allowlist for single-word command produces action key', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'ls -la' });
+      expect(options[0].label).toBe('ls -la');
+      expect(options.some(o => o.pattern === 'action:ls')).toBe(true);
+    });
+
+    test('file_write: generates prefixed file, ancestor directory wildcards, and tool wildcard', async () => {
+      const options = await generateAllowlistOptions('file_write', { path: '/home/user/project/file.ts' });
       expect(options).toHaveLength(5);
       // Patterns are prefixed with tool name to match check()'s "tool:path" format
       expect(options[0].pattern).toBe('file_write:/home/user/project/file.ts');
@@ -966,79 +987,78 @@ describe('Permission Checker', () => {
       expect(options[1].label).toBe('/home/user/project/**');
     });
 
-    test('file_read: generates prefixed file, directory, and tool wildcard', () => {
-      const options = generateAllowlistOptions('file_read', { path: '/tmp/data.json' });
+    test('file_read: generates prefixed file, directory, and tool wildcard', async () => {
+      const options = await generateAllowlistOptions('file_read', { path: '/tmp/data.json' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('file_read:/tmp/data.json');
       expect(options[1].pattern).toBe('file_read:/tmp/**');
       expect(options[2].pattern).toBe('file_read:*');
     });
 
-    test('host_file_read: generates prefixed file, directory, and tool wildcard', () => {
-      const options = generateAllowlistOptions('host_file_read', { path: '/etc/hosts' });
+    test('host_file_read: generates prefixed file, directory, and tool wildcard', async () => {
+      const options = await generateAllowlistOptions('host_file_read', { path: '/etc/hosts' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('host_file_read:/etc/hosts');
       expect(options[1].pattern).toBe('host_file_read:/etc/**');
       expect(options[2].pattern).toBe('host_file_read:*');
     });
 
-    test('host_file_write with file_path key', () => {
-      const options = generateAllowlistOptions('host_file_write', { file_path: '/tmp/out.txt' });
+    test('host_file_write with file_path key', async () => {
+      const options = await generateAllowlistOptions('host_file_write', { file_path: '/tmp/out.txt' });
       expect(options[0].pattern).toBe('host_file_write:/tmp/out.txt');
       expect(options[1].pattern).toBe('host_file_write:/tmp/**');
       expect(options[2].pattern).toBe('host_file_write:*');
     });
 
-    test('host_bash: generates exact, subcommand wildcard, and program wildcard', () => {
-      const options = generateAllowlistOptions('host_bash', { command: 'npm install express' });
-      expect(options).toHaveLength(3);
+    test('host_bash: generates exact and action-key options via parser', async () => {
+      const options = await generateAllowlistOptions('host_bash', { command: 'npm install express' });
       expect(options[0].pattern).toBe('npm install express');
-      expect(options[1].pattern).toBe('npm install *');
-      expect(options[2].pattern).toBe('npm *');
+      expect(options.some(o => o.pattern === 'action:npm install')).toBe(true);
+      expect(options.some(o => o.pattern === 'action:npm')).toBe(true);
     });
 
-    test('file_write with file_path key', () => {
-      const options = generateAllowlistOptions('file_write', { file_path: '/tmp/out.txt' });
+    test('file_write with file_path key', async () => {
+      const options = await generateAllowlistOptions('file_write', { file_path: '/tmp/out.txt' });
       expect(options[0].pattern).toBe('file_write:/tmp/out.txt');
     });
 
-    test('unknown tool returns wildcard', () => {
-      const options = generateAllowlistOptions('other_tool', { foo: 'bar' });
+    test('unknown tool returns wildcard', async () => {
+      const options = await generateAllowlistOptions('other_tool', { foo: 'bar' });
       expect(options).toHaveLength(1);
       expect(options[0].pattern).toBe('*');
     });
 
-    test('web_fetch: generates exact url, origin wildcard, and tool wildcard', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'https://example.com/docs/page' });
+    test('web_fetch: generates exact url, origin wildcard, and tool wildcard', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: 'https://example.com/docs/page' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
       expect(options[2].pattern).toBe('**');
     });
 
-    test('web_fetch: strips fragments when generating allowlist options', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'https://example.com/docs/page#section-1' });
+    test('web_fetch: strips fragments when generating allowlist options', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: 'https://example.com/docs/page#section-1' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
       expect(options[2].pattern).toBe('**');
     });
 
-    test('web_fetch: strips trailing-dot hostnames when generating allowlist options', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'https://example.com./docs/page' });
+    test('web_fetch: strips trailing-dot hostnames when generating allowlist options', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: 'https://example.com./docs/page' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
       expect(options[2].pattern).toBe('**');
     });
 
-    test('web_fetch: strips userinfo when generating allowlist options', () => {
+    test('web_fetch: strips userinfo when generating allowlist options', async () => {
       const username = 'demo';
       const credential = ['c', 'r', 'e', 'd', '1', '2', '3'].join('');
       const credentialedUrl = new URL('https://example.com/docs/page');
       credentialedUrl.username = username;
       credentialedUrl.password = credential;
-      const options = generateAllowlistOptions('web_fetch', { url: credentialedUrl.href });
+      const options = await generateAllowlistOptions('web_fetch', { url: credentialedUrl.href });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com/*');
@@ -1046,23 +1066,23 @@ describe('Permission Checker', () => {
       expect(options[0].pattern).not.toContain('demo:cred123@');
     });
 
-    test('web_fetch: normalizes scheme-less host:port for allowlist options', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'example.com:8443/docs/page' });
+    test('web_fetch: normalizes scheme-less host:port for allowlist options', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: 'example.com:8443/docs/page' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('web_fetch:https://example.com:8443/docs/page');
       expect(options[1].pattern).toBe('web_fetch:https://example.com:8443/*');
       expect(options[2].pattern).toBe('**');
     });
 
-    test('web_fetch: does not coerce path-only urls to https hostnames in allowlist options', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: '/docs/getting-started' });
+    test('web_fetch: does not coerce path-only urls to https hostnames in allowlist options', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: '/docs/getting-started' });
       expect(options).toHaveLength(2);
       expect(options[0].pattern).toBe('web_fetch:/docs/getting-started');
       expect(options[1].pattern).toBe('**');
     });
 
-    test('scaffold_managed_skill: generates per-skill and wildcard options', () => {
-      const options = generateAllowlistOptions('scaffold_managed_skill', { skill_id: 'my-tool' });
+    test('scaffold_managed_skill: generates per-skill and wildcard options', async () => {
+      const options = await generateAllowlistOptions('scaffold_managed_skill', { skill_id: 'my-tool' });
       expect(options).toHaveLength(2);
       expect(options[0].label).toBe('my-tool');
       expect(options[0].pattern).toBe('scaffold_managed_skill:my-tool');
@@ -1072,22 +1092,22 @@ describe('Permission Checker', () => {
       expect(options[1].description).toBe('All managed skill scaffolds');
     });
 
-    test('delete_managed_skill: generates per-skill and wildcard options', () => {
-      const options = generateAllowlistOptions('delete_managed_skill', { skill_id: 'doomed' });
+    test('delete_managed_skill: generates per-skill and wildcard options', async () => {
+      const options = await generateAllowlistOptions('delete_managed_skill', { skill_id: 'doomed' });
       expect(options).toHaveLength(2);
       expect(options[0].pattern).toBe('delete_managed_skill:doomed');
       expect(options[1].pattern).toBe('delete_managed_skill:*');
       expect(options[1].description).toBe('All managed skill deletes');
     });
 
-    test('scaffold_managed_skill with empty skill_id: only wildcard option', () => {
-      const options = generateAllowlistOptions('scaffold_managed_skill', { skill_id: '' });
+    test('scaffold_managed_skill with empty skill_id: only wildcard option', async () => {
+      const options = await generateAllowlistOptions('scaffold_managed_skill', { skill_id: '' });
       expect(options).toHaveLength(1);
       expect(options[0].pattern).toBe('scaffold_managed_skill:*');
     });
 
-    test('web_fetch: escapes minimatch metacharacters in generated exact and origin patterns', () => {
-      const options = generateAllowlistOptions('web_fetch', { url: 'https://[2001:db8::1]/search?q=test' });
+    test('web_fetch: escapes minimatch metacharacters in generated exact and origin patterns', async () => {
+      const options = await generateAllowlistOptions('web_fetch', { url: 'https://[2001:db8::1]/search?q=test' });
       expect(options).toHaveLength(3);
       expect(options[0].label).toBe('https://[2001:db8::1]/search?q=test');
       expect(options[0].pattern).toBe('web_fetch:https://\\[2001:db8::1\\]/search\\?q=test');
@@ -1097,8 +1117,8 @@ describe('Permission Checker', () => {
 
     // ── network_request allowlist options ─────────────────────────
 
-    test('network_request: generates exact url, origin wildcard, and tool wildcard', () => {
-      const options = generateAllowlistOptions('network_request', { url: 'https://api.example.com/v1/data' });
+    test('network_request: generates exact url, origin wildcard, and tool wildcard', async () => {
+      const options = await generateAllowlistOptions('network_request', { url: 'https://api.example.com/v1/data' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://api.example.com/v1/data');
       expect(options[1].pattern).toBe('network_request:https://api.example.com/*');
@@ -1107,41 +1127,41 @@ describe('Permission Checker', () => {
       expect(options[2].description).toBe('All network requests');
     });
 
-    test('network_request: origin wildcard uses friendly hostname', () => {
-      const options = generateAllowlistOptions('network_request', { url: 'https://www.example.com/path' });
+    test('network_request: origin wildcard uses friendly hostname', async () => {
+      const options = await generateAllowlistOptions('network_request', { url: 'https://www.example.com/path' });
       expect(options[1].description).toBe('Any page on example.com');
     });
 
-    test('network_request: normalizes scheme-less host:port input', () => {
-      const options = generateAllowlistOptions('network_request', { url: 'api.example.com:8443/v1/data' });
+    test('network_request: normalizes scheme-less host:port input', async () => {
+      const options = await generateAllowlistOptions('network_request', { url: 'api.example.com:8443/v1/data' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://api.example.com:8443/v1/data');
       expect(options[1].pattern).toBe('network_request:https://api.example.com:8443/*');
       expect(options[2].pattern).toBe('**');
     });
 
-    test('network_request: strips fragments and userinfo', () => {
+    test('network_request: strips fragments and userinfo', async () => {
       const username = 'demo';
       const credential = ['c', 'r', 'e', 'd', '1', '2', '3'].join('');
       const credentialedUrl = new URL('https://api.example.com/v1/data#section');
       credentialedUrl.username = username;
       credentialedUrl.password = credential;
-      const options = generateAllowlistOptions('network_request', { url: credentialedUrl.href });
+      const options = await generateAllowlistOptions('network_request', { url: credentialedUrl.href });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://api.example.com/v1/data');
       expect(options[0].pattern).not.toContain('demo:cred123@');
       expect(options[0].pattern).not.toContain('#section');
     });
 
-    test('network_request: escapes minimatch metacharacters', () => {
-      const options = generateAllowlistOptions('network_request', { url: 'https://[2001:db8::1]/api?key=val' });
+    test('network_request: escapes minimatch metacharacters', async () => {
+      const options = await generateAllowlistOptions('network_request', { url: 'https://[2001:db8::1]/api?key=val' });
       expect(options).toHaveLength(3);
       expect(options[0].pattern).toBe('network_request:https://\\[2001:db8::1\\]/api\\?key=val');
       expect(options[1].pattern).toBe('network_request:https://\\[2001:db8::1\\]/*');
     });
 
-    test('network_request: empty url produces only tool wildcard', () => {
-      const options = generateAllowlistOptions('network_request', { url: '' });
+    test('network_request: empty url produces only tool wildcard', async () => {
+      const options = await generateAllowlistOptions('network_request', { url: '' });
       expect(options).toHaveLength(1);
       expect(options[0].pattern).toBe('**');
     });
@@ -2587,11 +2607,11 @@ describe('Permission Checker', () => {
 
     // ── generateAllowlistOptions for skill_load ──
 
-    test('allowlist options only include version-specific option when hash is available', () => {
+    test('allowlist options only include version-specific option when hash is available', async () => {
       ensureSkillsDir();
       writeSkill('test-opts-skill', 'Test Options Skill');
 
-      const options = generateAllowlistOptions('skill_load', { skill: 'test-opts-skill' });
+      const options = await generateAllowlistOptions('skill_load', { skill: 'test-opts-skill' });
 
       // Should have only the version-specific option
       expect(options).toHaveLength(1);
@@ -2599,13 +2619,13 @@ describe('Permission Checker', () => {
       expect(options[0].description).toBe('This exact version');
     });
 
-    test('allowlist options ignore input version_hash and use disk-computed hash (regression)', () => {
+    test('allowlist options ignore input version_hash and use disk-computed hash (regression)', async () => {
       ensureSkillsDir();
       writeSkill('test-opts-explicit', 'Test Opts Explicit');
 
       // Even when a version_hash is supplied in the input, allowlist
       // options must use the disk-computed hash, not the input value.
-      const options = generateAllowlistOptions('skill_load', {
+      const options = await generateAllowlistOptions('skill_load', {
         skill: 'test-opts-explicit',
         version_hash: 'v1:customhash123',
       });
@@ -2617,10 +2637,10 @@ describe('Permission Checker', () => {
       expect(options[0].description).toBe('This exact version');
     });
 
-    test('allowlist options for unresolvable skill fall back to raw selector', () => {
+    test('allowlist options for unresolvable skill fall back to raw selector', async () => {
       ensureSkillsDir();
 
-      const options = generateAllowlistOptions('skill_load', { skill: 'no-such-skill' });
+      const options = await generateAllowlistOptions('skill_load', { skill: 'no-such-skill' });
 
       // Should have only the raw selector
       expect(options).toHaveLength(1);
@@ -2628,8 +2648,8 @@ describe('Permission Checker', () => {
       expect(options[0].description).toBe('This skill');
     });
 
-    test('allowlist options for empty skill selector only has wildcard', () => {
-      const options = generateAllowlistOptions('skill_load', { skill: '' });
+    test('allowlist options for empty skill selector only has wildcard', async () => {
+      const options = await generateAllowlistOptions('skill_load', { skill: '' });
 
       expect(options).toHaveLength(1);
       expect(options[0].pattern).toBe('skill_load:*');

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -51,7 +51,7 @@ export async function approveHostAttachmentRead(
     toolName,
     input,
     await classifyRisk(toolName, input, workingDir),
-    generateAllowlistOptions(toolName, input),
+    await generateAllowlistOptions(toolName, input),
     generateScopeOptions(workingDir, toolName),
     undefined,
     undefined,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -433,7 +433,7 @@ export function createProxyApprovalCallback(
     }
 
     // Use the checker's built-in allowlist generation for network_request
-    const allowlistOptions = generateAllowlistOptions('network_request', { url });
+    const allowlistOptions = await generateAllowlistOptions('network_request', { url });
 
     const scopeOptions = generateScopeOptions(ctx.workingDir);
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 import { normalizeFilePath, isSkillSourcePath } from '../skills/path-classifier.js';
 import { isWorkspaceScopedInvocation } from './workspace-policy.js';
-import { buildShellCommandCandidates } from './shell-identity.js';
+import { buildShellCommandCandidates, buildShellAllowlistOptions } from './shell-identity.js';
 
 // Ensures the legacy mode deprecation warning fires at most once per process.
 let _legacyDeprecationWarned = false;
@@ -473,38 +473,10 @@ function friendlyHostname(url: URL): string {
   return url.hostname.replace(/^www\./, '');
 }
 
-export function generateAllowlistOptions(toolName: string, input: Record<string, unknown>): AllowlistOption[] {
+export async function generateAllowlistOptions(toolName: string, input: Record<string, unknown>): Promise<AllowlistOption[]> {
   if (toolName === 'bash' || toolName === 'host_bash') {
     const command = ((input.command as string) ?? '').trim();
-    const parts = command.split(/\s+/);
-    const program = parts[0] ?? command;
-    const options: AllowlistOption[] = [];
-
-    // Exact match
-    options.push({ label: command, description: 'This exact command', pattern: command });
-
-    if (parts.length >= 2) {
-      // Subcommand wildcard: "npm install *"
-      const sub = parts.slice(0, -1).join(' ');
-      options.push({
-        label: `${sub} *`,
-        description: `Any "${sub}" command`,
-        pattern: `${sub} *`,
-      });
-    }
-
-    if (parts.length >= 1) {
-      // Program wildcard: "npm *"
-      options.push({ label: `${program} *`, description: `Any ${program} command`, pattern: `${program} *` });
-    }
-
-    // Deduplicate
-    const seen = new Set<string>();
-    return options.filter((o) => {
-      if (seen.has(o.pattern)) return false;
-      seen.add(o.pattern);
-      return true;
-    });
+    return buildShellAllowlistOptions(command);
   }
 
   if (

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -1,4 +1,5 @@
 import { parse, type ParsedCommand, type CommandSegment, type DangerousPattern } from '../tools/terminal/parser.js';
+import type { AllowlistOption } from './types.js';
 
 export interface ShellActionKey {
   /** e.g. "action:gh", "action:gh pr", "action:gh pr view" */
@@ -154,4 +155,52 @@ export async function buildShellCommandCandidates(command: string): Promise<stri
 
   // Deduplicate while preserving order
   return [...new Set(candidates)];
+}
+
+/**
+ * Build allowlist options for shell commands using parser-derived identity.
+ *
+ * For simple actions (optional setup prefix + one action), options are:
+ *   1. Exact canonical primary command
+ *   2. Deepest action key (e.g. "action:gh pr view")
+ *   3. Broader action keys (e.g. "action:gh pr", "action:gh")
+ *
+ * For complex commands (pipelines, multi-action chains), only the exact
+ * command is offered (no broad options).
+ */
+export async function buildShellAllowlistOptions(command: string): Promise<AllowlistOption[]> {
+  const trimmed = command.trim();
+  if (!trimmed) return [];
+
+  const analysis = await analyzeShellCommand(trimmed);
+  const actionResult = deriveShellActionKeys(analysis);
+
+  if (!actionResult.isSimpleAction || !actionResult.primarySegment) {
+    // Complex command — exact only
+    return [{ label: trimmed, description: 'This exact command (compound)', pattern: trimmed }];
+  }
+
+  const options: AllowlistOption[] = [];
+
+  // Exact canonical primary command
+  const canonical = actionResult.primarySegment.command;
+  options.push({ label: canonical, description: 'This exact command', pattern: canonical });
+
+  // Action keys from narrowest to broadest
+  for (const actionKey of actionResult.keys) {
+    const keyTokens = actionKey.key.replace(/^action:/, '');
+    options.push({
+      label: `${keyTokens} *`,
+      description: `Any "${keyTokens}" command`,
+      pattern: actionKey.key,
+    });
+  }
+
+  // Deduplicate by pattern
+  const seen = new Set<string>();
+  return options.filter((o) => {
+    if (seen.has(o.pattern)) return false;
+    seen.add(o.pattern);
+    return true;
+  });
 }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -196,7 +196,7 @@ export class ToolExecutor {
         }
 
         // Need user approval
-        const allowlistOptions = generateAllowlistOptions(name, input);
+        const allowlistOptions = await generateAllowlistOptions(name, input);
         const scopeOptions = generateScopeOptions(context.workingDir, name);
 
         // Compute preview diff for file tools so the user sees what will change


### PR DESCRIPTION
## Summary

- Adds `buildShellAllowlistOptions()` to `shell-identity.ts` that uses the tree-sitter parser to generate allowlist options based on command identity rather than naive whitespace splitting
- Simple commands get exact match + action-key options from narrowest to broadest (e.g. `action:gh pr view`, `action:gh pr`, `action:gh`)
- Complex commands (pipelines, multi-action chains) get only the exact command with a "compound" label
- Makes `generateAllowlistOptions` async since it now delegates to the parser; all call sites updated with `await`

## Test plan

- [x] Updated existing shell allowlist tests to expect parser-based output (action keys instead of whitespace-split patterns)
- [x] Added new tests: simple command with subcommands, complex compound command, single-word command
- [x] All 359 checker tests pass
- [x] All 21 shell-identity tests pass

**Original prompt:** Switch shell allowlist suggestions from whitespace-split logic to parser identity logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
