### PR TITLE
test: restrict complex shell commands to exact-only persistence

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -967,6 +967,19 @@ describe('Permission Checker', () => {
       expect(options[0].description).toContain('compound');
     });
 
+    test('compound command via pipeline yields exact-only allowlist option', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'git log | grep fix' });
+      expect(options).toHaveLength(1);
+      expect(options[0].description).toContain('compound');
+      expect(options[0].pattern).toBe('git log | grep fix');
+    });
+
+    test('compound command via && yields exact-only allowlist option', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'git add . && git push' });
+      expect(options).toHaveLength(1);
+      expect(options[0].description).toContain('compound');
+    });
+
     test('shell allowlist for single-word command produces action key', async () => {
       const options = await generateAllowlistOptions('bash', { command: 'ls -la' });
       expect(options[0].label).toBe('ls -la');

--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from 'bun:test';
-import { analyzeShellCommand, deriveShellActionKeys, buildShellCommandCandidates } from '../permissions/shell-identity.js';
+import { analyzeShellCommand, deriveShellActionKeys, buildShellCommandCandidates, buildShellAllowlistOptions } from '../permissions/shell-identity.js';
 import { parse } from '../tools/terminal/parser.js';
 
 describe('analyzeShellCommand', () => {
@@ -175,5 +175,35 @@ describe('buildShellCommandCandidates', () => {
     // so it should be deduped to just once
     const gitStatusCount = candidates.filter(c => c === 'git status').length;
     expect(gitStatusCount).toBe(1);
+  });
+});
+
+describe('buildShellAllowlistOptions — complex command restrictions', () => {
+  test('chain with && offers exact only', async () => {
+    const options = await buildShellAllowlistOptions('gh pr view 123 && rm -rf /');
+    expect(options).toHaveLength(1);
+    expect(options[0].pattern).toBe('gh pr view 123 && rm -rf /');
+    expect(options[0].description).toContain('compound');
+  });
+
+  test('pipeline offers exact only', async () => {
+    const options = await buildShellAllowlistOptions('cat file.txt | grep error | wc -l');
+    expect(options).toHaveLength(1);
+    expect(options[0].pattern).toBe('cat file.txt | grep error | wc -l');
+    expect(options[0].description).toContain('compound');
+  });
+
+  test('setup-prefix + single-action still gets action-key options', async () => {
+    const options = await buildShellAllowlistOptions('cd /repo && npm install express');
+    expect(options.length).toBeGreaterThan(1);
+    expect(options.some(o => o.pattern.startsWith('action:'))).toBe(true);
+  });
+
+  test('simple single command gets action-key options', async () => {
+    const options = await buildShellAllowlistOptions('npm install express');
+    expect(options.length).toBeGreaterThan(1);
+    expect(options[0].pattern).toBe('npm install express');
+    expect(options.some(o => o.pattern === 'action:npm install')).toBe(true);
+    expect(options.some(o => o.pattern === 'action:npm')).toBe(true);
   });
 });

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -177,7 +177,7 @@ export async function buildShellAllowlistOptions(command: string): Promise<Allow
 
   if (!actionResult.isSimpleAction || !actionResult.primarySegment) {
     // Complex command — exact only
-    return [{ label: trimmed, description: 'This exact command (compound)', pattern: trimmed }];
+    return [{ label: trimmed, description: 'This exact compound command', pattern: trimmed }];
   }
 
   const options: AllowlistOption[] = [];


### PR DESCRIPTION
## Summary

- Adds explicit tests in `shell-identity.test.ts` to lock the behavior where complex commands (pipelines, multi-action `&&` chains) yield only exact-match allowlist options, while simple actions and setup-prefix + single-action commands continue to get action-key options
- Adds explicit tests in `checker.test.ts` confirming `generateAllowlistOptions` produces compound-only results for pipeline and chain commands
- Improves the compound command description from "This exact command (compound)" to the clearer "This exact compound command"

## Test plan

- [x] All 25 tests pass in `shell-identity.test.ts` (including 4 new tests)
- [x] All 361 tests pass in `checker.test.ts` (including 2 new tests)
- [x] Type-check passes (pre-existing errors in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
