### PR TITLE
fix: clear focus ring on microphone button after click

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -339,7 +339,7 @@ struct ComposerView: View {
                     MicrophoneButton(
                         isRecording: isRecording,
                         iconSize: composerActionIconSize,
-                        action: onMicrophoneToggle
+                        action: { onMicrophoneToggle(); focusedComposerAction = nil }
                     )
                         .buttonStyle(ComposerActionButtonStyle(
                             isHovered: isMicrophoneHovered,


### PR DESCRIPTION
## Summary
- Clear `focusedComposerAction` after `onMicrophoneToggle()` so the blue focus ring doesn't persist on the mic button

## Original prompt
can we remove the blue when we click on voice mode? why do we have that?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
