### PR TITLE
docs: sync README + ARCHITECTURE for new allowlist behavior

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2026,6 +2026,21 @@ In addition to the opt-in starter bundle, the permission system seeds unconditio
 
 These rules are emitted by `getDefaultRuleTemplates()` in `assistant/src/permissions/defaults.ts`. Because they use priority 100 (equal to user rules), they take effect in both strict and legacy modes. The `skill_load` rule means skill activation never prompts; the `browser_*` rules mean the browser skill's tools behave identically to the old core `headless-browser` tool from a permission standpoint.
 
+### Shell Command Identity and Allowlist Options
+
+For `bash` and `host_bash` tool invocations, the permission system uses parser-derived action keys (via `shell-identity.ts`) instead of raw whitespace-split patterns. This produces more meaningful allowlist options that reflect the actual command structure.
+
+**Candidate building** (`buildShellCommandCandidates`): The shell parser (`tools/terminal/parser.ts`) produces segments and operators. `analyzeShellCommand()` extracts segments, operators, opaque-construct flags, and dangerous patterns. `deriveShellActionKeys()` then classifies the command:
+
+- **Simple action** (optional setup-prefix segments like `cd`, `export`, `pushd` + exactly one action segment): Produces hierarchical `action:` keys. For example, `cd /repo && gh pr view 5525 --json title` yields candidates: the raw command, the canonical primary command (`gh pr view 5525 --json title`), and action keys `action:gh pr view`, `action:gh pr`, `action:gh` (narrowest to broadest, max depth 3).
+- **Complex command** (pipelines with `|`, or multiple non-prefix action segments): Only the raw command is returned as a candidate — no action keys.
+
+**Allowlist option ranking** (`buildShellAllowlistOptions`): For simple actions, the prompt offers options ordered from most specific to broadest: exact canonical command, then action keys from deepest to shallowest. For complex commands, only the exact compound command is offered. This prevents over-generalization of pipelines into permissive rules.
+
+**Trust rule pattern format**: Action keys use the `action:` prefix in trust rules (e.g., `action:gh pr view`). The trust store matches these via `findHighestPriorityRule()` against the candidate list produced by `buildShellCommandCandidates()`.
+
+**Scope ordering**: Scope options for all tools (including shell) are ordered from narrowest to broadest: project > parent directories > everywhere. The macOS chat UI uses a two-step flow for persistent rules: the user first selects the allowlist pattern, then selects the scope. This explicit scope selection replaces any silent auto-selection, ensuring the user always knows where the rule will apply.
+
 ### Prompt UX
 
 When a permission prompt is sent to the client (via `confirmation_request` IPC message), it includes:
@@ -2054,6 +2069,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 |---|---|
 | `assistant/src/permissions/types.ts` | `TrustRule`, `PolicyContext`, `ToolPrincipal`, `RiskLevel`, `UserDecision` types |
 | `assistant/src/permissions/checker.ts` | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation |
+| `assistant/src/permissions/shell-identity.ts` | `analyzeShellCommand()`, `deriveShellActionKeys()`, `buildShellCommandCandidates()`, `buildShellAllowlistOptions()` — parser-based shell command identity and action key derivation |
 | `assistant/src/permissions/trust-store.ts` | Rule persistence, `findHighestPriorityRule()`, principal/version matching, starter bundle |
 | `assistant/src/permissions/prompter.ts` | IPC prompt flow: `confirmation_request` → `confirmation_response` |
 | `assistant/src/permissions/defaults.ts` | Default rule templates (system ask rules for host tools, CU, etc.) |

--- a/README.md
+++ b/README.md
@@ -338,6 +338,23 @@ User approval decisions are persisted as trust rules in `~/.vellum/protected/tru
 - **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
 - **High-risk override**: Rules with `allowHighRisk: true` auto-allow even high-risk tool invocations.
 
+### Shell command allowlist options
+
+When you approve a shell command (`host_bash` or `bash`), the permission prompt offers parser-derived allowlist options based on the command's structure. The shell parser extracts "action keys" — hierarchical identifiers that represent the command family — instead of using whitespace-split patterns.
+
+For example, `cd /repo && gh pr view 5525 --json title` generates these allowlist options:
+
+- `gh pr view 5525 --json title` — this exact command
+- `gh pr view *` — any `gh pr view` command (trust rule pattern: `action:gh pr view`)
+- `gh pr *` — any `gh pr` command (trust rule pattern: `action:gh pr`)
+- `gh *` — any `gh` command (trust rule pattern: `action:gh`)
+
+Setup prefixes (`cd`, `export`, `pushd`, etc.) are stripped before deriving action keys, so the allowlist options focus on the actual action being performed.
+
+**Compound commands** (with `&&`, `||`, `|`) that contain multiple non-prefix actions only offer an exact-command option — no broad action-family patterns. This prevents a complex pipeline from being over-generalized into a permissive rule.
+
+**Scope ordering**: When persisting a rule, scope options are always ordered from narrowest to broadest: project > parent directories > everywhere. The macOS app shows an explicit scope picker (two-step flow: select pattern, then select scope) so users always see where the rule will apply.
+
 ### Version-bound skill approvals
 
 When you approve a skill-originated action, the trust rule can record the skill's version hash. If the skill's source files change, the hash changes and the old rule no longer matches — you are re-prompted. This prevents modified skills from silently inheriting previous approvals.


### PR DESCRIPTION
## Summary

- Document parser-based shell allowlist options in README.md: action keys, setup-prefix stripping, compound command safety, scope ordering, and explicit scope selection
- Document shell command identity system in ARCHITECTURE.md: `buildShellCommandCandidates`, `buildShellAllowlistOptions`, `action:` prefix format, two-step scope picker flow
- Add `shell-identity.ts` to the ARCHITECTURE.md key source files table

## Test plan

- [ ] Verify README.md renders correctly on GitHub (no broken markdown)
- [ ] Verify ARCHITECTURE.md renders correctly on GitHub (no broken markdown)
- [ ] Confirm new sections match the existing doc style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
