### PR TITLE
Fix relative path resolution in workspace-scoped invocation check

### DIFF
--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -133,6 +133,24 @@ describe('isWorkspaceScopedInvocation', () => {
         isWorkspaceScopedInvocation('file_write', { file_path: 123 }, workspaceRoot),
       ).toBe(false);
     });
+
+    test('resolves relative path inside workspace against workspaceRoot', () => {
+      expect(
+        isWorkspaceScopedInvocation('file_read', { path: 'src/index.ts' }, workspaceRoot),
+      ).toBe(true);
+    });
+
+    test('resolves relative path with ../ that escapes workspace as outside', () => {
+      expect(
+        isWorkspaceScopedInvocation('file_read', { file_path: '../outside/secret.txt' }, workspaceRoot),
+      ).toBe(false);
+    });
+
+    test('absolute path inside workspace still works', () => {
+      expect(
+        isWorkspaceScopedInvocation('file_edit', { file_path: join(workspaceRoot, 'src', 'main.ts') }, workspaceRoot),
+      ).toBe(true);
+    });
   });
 
   // ── Bash ───────────────────────────────────────────────────────────

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -95,11 +95,13 @@ export function isWorkspaceScopedInvocation(
   if (HOST_TOOLS.has(toolName)) return false;
 
   if (PATH_SCOPED_TOOLS.has(toolName)) {
-    const filePath = typeof toolInput.file_path === 'string'
+    const rawPath = typeof toolInput.file_path === 'string'
       ? toolInput.file_path
       : typeof toolInput.path === 'string'
         ? toolInput.path
         : '';
+    // Resolve relative paths against workspaceRoot (not process.cwd())
+    const filePath = rawPath !== '' && !rawPath.startsWith('/') ? resolve(workspaceRoot, rawPath) : rawPath;
     return filePath !== '' && isPathWithinWorkspaceRoot(filePath, workspaceRoot);
   }
 


### PR DESCRIPTION
Addresses review feedback from #6293. Resolves relative file paths against workspaceRoot instead of process.cwd() in isWorkspaceScopedInvocation, preventing misclassification of workspace-scoped file operations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
