### PR TITLE
Fix workspace mode docs in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1886,7 +1886,7 @@ graph TB
     NO_MATCH -->|"workspace mode (default)"| WS_CHECK{"Workspace-scoped<br/>invocation?"}
     WS_CHECK -->|"yes"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
     WS_CHECK -->|"no"| RISK_FALLBACK_WS{"Risk level?"}
-    RISK_FALLBACK_WS -->|"Low"| PROMPT_WS_LOW["decision: prompt"]
+    RISK_FALLBACK_WS -->|"Low"| AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]
     RISK_FALLBACK_WS -->|"Medium"| PROMPT_WS_MED["decision: prompt"]
     RISK_FALLBACK_WS -->|"High"| PROMPT_WS_HIGH["decision: prompt"]
     NO_MATCH -->|"legacy mode"| RISK_FALLBACK{"Risk level?"}
@@ -1902,7 +1902,7 @@ The `permissions.mode` config option (`workspace`, `strict`, or `legacy`) contro
 | Behavior | Workspace mode (default) | Strict mode | Legacy mode (deprecated) |
 |---|---|---|---|
 | Workspace-scoped ops with no matching rule | Auto-allowed | Prompted | Auto-allowed (low risk) |
-| Non-workspace low-risk tools with no matching rule | Prompted | Prompted | Auto-allowed |
+| Non-workspace low-risk tools with no matching rule | Auto-allowed | Prompted | Auto-allowed |
 | Medium-risk tools with no matching rule | Prompted | Prompted | Prompted |
 | High-risk tools with no matching rule | Prompted | Prompted | Prompted |
 | `skill_load` with no matching rule | Prompted | Prompted | Auto-allowed (low risk) |


### PR DESCRIPTION
Addresses review feedback from #6306. Fixes Mermaid diagram to correctly show Low-risk non-workspace ops as auto-allowed (not prompted) in workspace mode. Fixes behavior table accordingly.

## Changes

1. **Mermaid diagram**: Changed workspace mode non-workspace fallback for Low risk from `PROMPT_WS_LOW["decision: prompt"]` to `AUTO_WS_LOW["decision: allow<br/>Low risk auto-allow"]`
2. **Behavior table**: Changed "Non-workspace low-risk tools with no matching rule" workspace mode column from "Prompted" to "Auto-allowed"

These changes align the documentation with the actual code behavior, where low-risk operations fall through to the general risk-based fallback which auto-allows them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
