### PR TITLE
feat: custom dialog for skill deletion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -55,21 +55,17 @@ struct AgentPanelContent: View {
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()
         }
-        .alert("Delete Skill", isPresented: Binding(
-            get: { skillToDelete != nil },
-            set: { if !$0 { skillToDelete = nil } }
-        )) {
-            Button("Cancel", role: .cancel) { skillToDelete = nil }
-            Button("Delete", role: .destructive) {
-                if let skill = skillToDelete {
+        .sheet(item: $skillToDelete) { skill in
+            SkillDeleteConfirmView(
+                skillName: skill.name,
+                onDelete: {
                     skillsManager.uninstallSkill(id: skill.id)
                     skillToDelete = nil
+                },
+                onCancel: {
+                    skillToDelete = nil
                 }
-            }
-        } message: {
-            if let skill = skillToDelete {
-                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/workspace/skills/.")
-            }
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct SkillDeleteConfirmView: View {
+    let skillName: String
+    var onDelete: () -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            VStack(spacing: VSpacing.md) {
+                Text("Delete Skill")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Are you sure you want to delete \"\(skillName)\"? This will remove it from ~/.vellum/workspace/skills/.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            HStack(spacing: VSpacing.md) {
+                VButton(label: "Cancel", style: .ghost) {
+                    onCancel()
+                }
+
+                VButton(label: "Delete", style: .danger) {
+                    onDelete()
+                }
+            }
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 340)
+        .background(VColor.background)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -303,21 +303,17 @@ struct SkillsSettingsView: View {
         .onAppear {
             viewModel.loadSkills()
         }
-        .alert("Delete Skill", isPresented: Binding(
-            get: { skillToDelete != nil },
-            set: { if !$0 { skillToDelete = nil } }
-        )) {
-            Button("Cancel", role: .cancel) { skillToDelete = nil }
-            Button("Delete", role: .destructive) {
-                if let skill = skillToDelete {
+        .sheet(item: $skillToDelete) { skill in
+            SkillDeleteConfirmView(
+                skillName: skill.name,
+                onDelete: {
                     viewModel.uninstallSkill(id: skill.id)
                     skillToDelete = nil
+                },
+                onCancel: {
+                    skillToDelete = nil
                 }
-            }
-        } message: {
-            if let skill = skillToDelete {
-                Text("Are you sure you want to delete \"\(skill.name)\"? This will remove it from ~/.vellum/workspace/skills/.")
-            }
+            )
         }
         .sheet(item: $inspectingSkill) { skill in
             SkillInspectSheet(


### PR DESCRIPTION
## Summary
- Replace native SwiftUI `.alert()` with a custom `SkillDeleteConfirmView` for skill delete confirmation
- Uses the app's design system (VFont, VColor, VSpacing, VButton) for consistent look and feel
- Applied in both `AgentPanel` and `SkillsSettingsView`

## Test plan
- [ ] Open Skills panel, click Delete on a managed skill — verify custom dialog appears (not native alert)
- [ ] Click Cancel — verify dialog dismisses without deleting
- [ ] Click Delete — verify skill is removed
- [ ] Test in Settings > Skills Manager as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
