### PR TITLE
Gate workspace bash auto-allow on sandbox enabled

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4078,6 +4078,49 @@ describe('workspace mode — auto-allow workspace-scoped operations', () => {
     expect(result.matchedRule?.id).toBe('default:allow-bash-global');
   });
 
+  // ── bash sandbox gate — workspace auto-allow depends on sandbox being enabled ──
+
+  test('bash with sandbox disabled in workspace mode → falls through to risk-based policy (not auto-allowed)', async () => {
+    const origSandbox = testConfig.sandbox.enabled;
+    testConfig.sandbox.enabled = false;
+    try {
+      const result = await check('bash', { command: 'echo hello' }, workspaceDir);
+      // Should NOT be auto-allowed via workspace mode
+      expect(result.reason).not.toContain('Workspace mode');
+      // With sandbox disabled, no default bash allow rule either, so it falls through to risk-based policy
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toContain('Low risk');
+    } finally {
+      testConfig.sandbox.enabled = origSandbox;
+    }
+  });
+
+  test('bash with sandbox enabled in workspace mode → auto-allowed via default rule', async () => {
+    const origSandbox = testConfig.sandbox.enabled;
+    testConfig.sandbox.enabled = true;
+    try {
+      const result = await check('bash', { command: 'echo hello' }, workspaceDir);
+      expect(result.decision).toBe('allow');
+      // With sandbox enabled, the default bash allow rule matches before workspace mode
+      expect(result.matchedRule?.id).toBe('default:allow-bash-global');
+    } finally {
+      testConfig.sandbox.enabled = origSandbox;
+    }
+  });
+
+  test('bash with sandbox disabled in workspace mode — medium risk command → prompt (not auto-allowed)', async () => {
+    const origSandbox = testConfig.sandbox.enabled;
+    testConfig.sandbox.enabled = false;
+    try {
+      // An unknown program is medium risk; without sandbox, workspace auto-allow is blocked
+      const result = await check('bash', { command: 'some-unknown-program --flag' }, workspaceDir);
+      expect(result.reason).not.toContain('Workspace mode');
+      expect(result.decision).toBe('prompt');
+    } finally {
+      testConfig.sandbox.enabled = origSandbox;
+    }
+  });
+
   // ── proxied bash — prompt takes precedence over workspace mode ──
 
   test('bash with network_mode=proxied → prompt (proxied check before workspace mode)', async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -423,7 +423,11 @@ export async function check(
   // Workspace mode: auto-allow workspace-scoped operations that don't have
   // an explicit rule. Non-workspace operations fall through to risk-based policy.
   if (permissionsMode === 'workspace' && !matchedRule) {
-    if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
+    // When sandbox is disabled, bash runs on the host — don't auto-allow
+    const sandboxEnabled = getConfig().sandbox.enabled;
+    if (toolName === 'bash' && !sandboxEnabled) {
+      // Fall through to risk-based policy below
+    } else if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
       return { decision: 'allow', reason: 'Workspace mode: workspace-scoped operation auto-allowed' };
     }
   }


### PR DESCRIPTION
Addresses review feedback from #6298. When sandbox is disabled, bash commands in workspace mode now fall through to risk-based policy instead of being auto-allowed, preventing potential host-level command execution without approval.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
