### PR TITLE
Daemon sends single ⚠️ error message

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -18,7 +18,7 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import type { TraceEmitter } from './trace-emitter.js';
-import { classifySessionError, isUserCancellation, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
+import { classifySessionError, isUserCancellation, isContextTooLarge, toWarningAssistantMessage } from './session-error.js';
 import type { ToolProfiler } from '../events/tool-profiling-listener.js';
 import type { ContextWindowManager } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
@@ -420,8 +420,7 @@ export async function runAgentLoopImpl(
             contextTooLargeDetected = true;
           } else {
             const classified = classifySessionError(event.error, { phase: 'agent_loop' });
-            onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
-            providerErrorUserMessage = classified.userMessage;
+            providerErrorUserMessage = toWarningAssistantMessage(classified.userMessage);
           }
           break;
         case 'message_complete': {
@@ -672,13 +671,13 @@ export async function runAgentLoopImpl(
           new Error('context_length_exceeded'),
           { phase: 'agent_loop' },
         );
-        onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+        providerErrorUserMessage = toWarningAssistantMessage(classified.userMessage);
       }
     }
 
     if (deferredOrderingError) {
       const classified = classifySessionError(new Error(deferredOrderingError), { phase: 'agent_loop' });
-      onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      providerErrorUserMessage = toWarningAssistantMessage(classified.userMessage);
     }
 
     // Reconcile synthesized cancellation tool_results
@@ -830,9 +829,24 @@ export async function runAgentLoopImpl(
         status: 'error',
         attributes: { errorClass, message: truncate(message, 500, '') },
       });
-      onEvent({ type: 'error', message: `Failed to process message: ${message}` });
       const classified = classifySessionError(err, errorCtx);
-      onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      const warningMessage = toWarningAssistantMessage(classified.userMessage);
+      const assistantMsg = createAssistantMessage(warningMessage);
+      conversationStore.addMessage(
+        ctx.conversationId,
+        'assistant',
+        JSON.stringify(assistantMsg.content),
+      );
+      ctx.messages.push(assistantMsg);
+      onEvent({
+        type: 'assistant_text_delta',
+        text: warningMessage,
+        sessionId: ctx.conversationId,
+      });
+      onEvent({
+        type: 'message_complete',
+        sessionId: ctx.conversationId,
+      });
       void getHookManager().trigger('on-error', {
         error: err instanceof Error ? err.name : 'Error',
         message,

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -11,6 +11,11 @@ export interface ClassifiedSessionError {
   debugDetails?: string;
 }
 
+/**
+ * Prefix for inline assistant warning messages emitted for user-facing errors.
+ */
+export const SESSION_WARNING_PREFIX = '⚠️ ';
+
 // Network-level error patterns (connection refused, timeout, DNS, reset)
 const NETWORK_PATTERNS = [
   /ECONNREFUSED/i,
@@ -287,4 +292,13 @@ export function buildSessionErrorMessage(
     retryable: classified.retryable,
     debugDetails: classified.debugDetails,
   };
+}
+
+/**
+ * Convert a user-facing error message to a warning-style assistant response.
+ */
+export function toWarningAssistantMessage(message: string): string {
+  const trimmed = message.trim();
+  if (trimmed.startsWith(SESSION_WARNING_PREFIX)) return trimmed;
+  return `${SESSION_WARNING_PREFIX}${trimmed}`;
 }


### PR DESCRIPTION
This updates daemon session error handling to emit one inline assistant warning message instead of duplicating error channels for the same failure. Provider, context-too-large, ordering, and catch-path failures in the agent loop now flow through a single ⚠️-prefixed assistant response path. It also adds a shared helper in assistant/src/daemon/session-error.ts to format warning messages consistently. The goal is cross-platform parity so desktop, Slack, Telegram, and CLI receive the same user-facing error text from the daemon.