### PR TITLE
fix: gate irrelevant conflict asks to prevent unrelated auto-resolves

### DIFF
--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -86,10 +86,14 @@ export class ConflictGate {
       .filter((entry) => entry.relevance >= threshold)
       .find((entry) => this.shouldAsk(entry.conflict.id, cooldownTurns));
 
-    // If no relevant conflict to ask and askOnIrrelevantTurns is enabled, try irrelevant ones
+    // If no relevant conflict to ask and askOnIrrelevantTurns is enabled, try ones
+    // below the threshold but with at least some topical overlap (relevance > 0).
+    // Completely unrelated conflicts (relevance === 0) are excluded because marking
+    // them as asked would let wasRecentlyAsked trigger heuristic resolution on
+    // a subsequent unrelated short imperative turn.
     const candidateToAsk = askable
       ?? (conflictConfig.askOnIrrelevantTurns
-        ? scored.find((entry) => entry.relevance < threshold && this.shouldAsk(entry.conflict.id, cooldownTurns))
+        ? scored.find((entry) => entry.relevance > 0 && entry.relevance < threshold && this.shouldAsk(entry.conflict.id, cooldownTurns))
         : undefined);
 
     if (!candidateToAsk) return null;


### PR DESCRIPTION
Address Codex feedback on #6294: prevent irrelevant conflicts (relevance=0) from being marked as asked, which could trigger heuristic resolution on subsequent unrelated turns. The fallback path now requires at least minimal topical overlap (relevance > 0) before asking about a conflict.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
