### PR TITLE
fix: reject non-AND setup chains in action-key derivation

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -117,6 +117,22 @@ describe('deriveShellActionKeys', () => {
     ]);
   });
 
+  test('OR chains (||) are marked non-simple', async () => {
+    const analysis = await analyzeShellCommand('cd repo || gh pr view 123');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
+  test('semicolon chains (;) are marked non-simple', async () => {
+    const analysis = await analyzeShellCommand('cd repo; gh pr view 123');
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
   test('numeric arguments are excluded from keys', async () => {
     const analysis = await analyzeShellCommand('gh pr view 5525');
     const result = deriveShellActionKeys(analysis);

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -79,6 +79,11 @@ export function deriveShellActionKeys(analysis: ShellIdentityAnalysis): ActionKe
     return { keys: [], isSimpleAction: false };
   }
 
+  // Only && is a valid setup-prefix chain; || and ; change control flow semantics
+  if (operators.some(op => op === '||' || op === ';')) {
+    return { keys: [], isSimpleAction: false };
+  }
+
   // Separate setup-prefix segments from action segments
   const actionSegments: CommandSegment[] = [];
   let foundNonPrefix = false;


### PR DESCRIPTION
Address Codex feedback on #6309: commands chained with || or ; should not be classified as simple actions. Only && chains are valid setup-prefix patterns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
