### PR TITLE
fix: use full command text for exact shell allowlist option

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -986,6 +986,23 @@ describe('Permission Checker', () => {
       expect(options.some(o => o.pattern === 'action:ls')).toBe(true);
     });
 
+    test('shell allowlist exact option includes full command with setup prefixes', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'cd /tmp && rm -rf build' });
+      // The exact option must use the full command text, not just the primary segment
+      expect(options[0]).toEqual({
+        label: 'cd /tmp && rm -rf build',
+        description: 'This exact command',
+        pattern: 'cd /tmp && rm -rf build',
+      });
+    });
+
+    test('shell allowlist exact option includes full command with export prefix', async () => {
+      const options = await generateAllowlistOptions('bash', { command: 'export PATH="/usr/bin:$PATH" && npm install' });
+      expect(options[0].label).toBe('export PATH="/usr/bin:$PATH" && npm install');
+      expect(options[0].pattern).toBe('export PATH="/usr/bin:$PATH" && npm install');
+      expect(options[0].description).toBe('This exact command');
+    });
+
     test('file_write: generates prefixed file, ancestor directory wildcards, and tool wildcard', async () => {
       const options = await generateAllowlistOptions('file_write', { path: '/home/user/project/file.ts' });
       expect(options).toHaveLength(5);

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -182,9 +182,8 @@ export async function buildShellAllowlistOptions(command: string): Promise<Allow
 
   const options: AllowlistOption[] = [];
 
-  // Exact canonical primary command
-  const canonical = actionResult.primarySegment.command;
-  options.push({ label: canonical, description: 'This exact command', pattern: canonical });
+  // Full original command text — "this exact command" means exactly what the user approved
+  options.push({ label: trimmed, description: 'This exact command', pattern: trimmed });
 
   // Action keys from narrowest to broadest
   for (const actionKey of actionResult.keys) {


### PR DESCRIPTION
Address Codex P1 feedback on #6314: the 'exact command' allowlist option was using primarySegment.command which drops setup prefixes, silently broadening the approval. Now uses the full command text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
