### PR TITLE
fix: narrow transient classifier and wire kind eligibility in statement gate

### DIFF
--- a/assistant/src/__tests__/conflict-policy.test.ts
+++ b/assistant/src/__tests__/conflict-policy.test.ts
@@ -58,6 +58,11 @@ describe('conflict-policy', () => {
       expect(isTransientTrackingStatement('This PR needs review')).toBe(true);
     });
 
+    test('does not flag generic time words as transient', () => {
+      expect(isTransientTrackingStatement('The deadline is today')).toBe(false);
+      expect(isTransientTrackingStatement('I need this right now')).toBe(false);
+    });
+
     test('does not flag durable statements', () => {
       expect(isTransientTrackingStatement('Always answer with concise bullet points')).toBe(false);
       expect(isTransientTrackingStatement('User prefers dark mode')).toBe(false);
@@ -100,6 +105,16 @@ describe('conflict-policy', () => {
 
     test('accepts non-transient statements for non-instruction kinds', () => {
       expect(isStatementConflictEligible('preference', 'User prefers dark mode')).toBe(true);
+      expect(isStatementConflictEligible('fact', 'User works at Acme Corp')).toBe(true);
+    });
+
+    test('rejects kinds not in conflictableKinds when config is provided', () => {
+      const policyConfig = { conflictableKinds: ['preference', 'profile'] };
+      expect(isStatementConflictEligible('fact', 'User works at Acme Corp', policyConfig)).toBe(false);
+      expect(isStatementConflictEligible('preference', 'User prefers dark mode', policyConfig)).toBe(true);
+    });
+
+    test('skips kind check when config is omitted', () => {
       expect(isStatementConflictEligible('fact', 'User works at Acme Corp')).toBe(true);
     });
   });

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -146,10 +146,10 @@ export class ConflictGate {
     if (!isConflictKindPairEligible(conflict.existingKind, conflict.candidateKind, { conflictableKinds })) {
       return false;
     }
-    if (!isStatementConflictEligible(conflict.existingKind, conflict.existingStatement)) {
+    if (!isStatementConflictEligible(conflict.existingKind, conflict.existingStatement, { conflictableKinds })) {
       return false;
     }
-    if (!isStatementConflictEligible(conflict.candidateKind, conflict.candidateStatement)) {
+    if (!isStatementConflictEligible(conflict.candidateKind, conflict.candidateStatement, { conflictableKinds })) {
       return false;
     }
     return true;

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -30,7 +30,7 @@ export function isConflictKindPairEligible(
 
 const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/i;
 const ISSUE_TICKET_PATTERN = /\b(?:issue|pr|ticket|pull request)\s*#?\d+/i;
-const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|today|right now|currently tracking)\b/i;
+const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|currently tracking)\b/i;
 
 /**
  * Returns true when a statement looks like a transient tracking note
@@ -62,7 +62,8 @@ export function isDurableInstructionStatement(statement: string): boolean {
  * For instruction/style kinds: requires positive durable cues and no transient cues.
  * For other eligible kinds: rejects if transient tracking cues dominate.
  */
-export function isStatementConflictEligible(kind: string, statement: string): boolean {
+export function isStatementConflictEligible(kind: string, statement: string, config?: ConflictPolicyConfig): boolean {
+  if (config && !isConflictKindEligible(kind, config)) return false;
   if (isTransientTrackingStatement(statement)) return false;
   if (kind === 'instruction' || kind === 'style') {
     return isDurableInstructionStatement(statement);

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -68,14 +68,14 @@ export async function checkContradictions(newItemId: string): Promise<void> {
   }
 
   // Skip if the new item's statement is transient/non-durable
-  if (!isStatementConflictEligible(newItem.kind, newItem.statement)) {
+  if (!isStatementConflictEligible(newItem.kind, newItem.statement, config.memory.conflicts)) {
     log.debug({ newItemId, kind: newItem.kind }, 'Skipping contradiction check — statement is transient or non-durable');
     return;
   }
 
   for (const existing of candidates) {
     // Skip candidate if its statement is transient/non-durable
-    if (!isStatementConflictEligible(existing.kind, existing.statement)) {
+    if (!isStatementConflictEligible(existing.kind, existing.statement, config.memory.conflicts)) {
       log.debug({ existingId: existing.id }, 'Skipping candidate — statement is transient or non-durable');
       continue;
     }

--- a/assistant/src/memory/job-handlers/conflict.ts
+++ b/assistant/src/memory/job-handlers/conflict.ts
@@ -52,8 +52,8 @@ export async function resolvePendingConflictsForMessageJob(job: MemoryJob, confi
       conflict.existingKind, conflict.candidateKind, { conflictableKinds },
     );
     if (!kindEligible
-      || !isStatementConflictEligible(conflict.existingKind, conflict.existingStatement)
-      || !isStatementConflictEligible(conflict.candidateKind, conflict.candidateStatement)) {
+      || !isStatementConflictEligible(conflict.existingKind, conflict.existingStatement, { conflictableKinds })
+      || !isStatementConflictEligible(conflict.candidateKind, conflict.candidateStatement, { conflictableKinds })) {
       resolveConflict(conflict.id, {
         status: 'dismissed',
         resolutionNote: 'Dismissed by conflict policy (transient/non-durable).',


### PR DESCRIPTION
Address Codex feedback on #6300: (1) remove overly broad 'today'/'right now' from transient tracking pattern, (2) add optional config parameter to isStatementConflictEligible to honor conflictableKinds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
