### PR TITLE
fix: scope zero-relevance tracking skip to askOnIrrelevantTurns fallback path only

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -1017,6 +1017,46 @@ describe('ConflictGate askOnIrrelevantTurns knob', () => {
     expect(result2).toBeNull();
   });
 
+  test('zero-relevance conflict on primary askable path (relevanceThreshold=0) is tracked as asked', async () => {
+    pendingConflicts = [{
+      id: 'conflict-zero-threshold',
+      scopeId: 'default',
+      existingItemId: 'existing-zt',
+      candidateItemId: 'candidate-zt',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+      existingKind: 'preference',
+      candidateKind: 'preference',
+    }];
+
+    const gate = new ConflictGate();
+    // relevanceThreshold=0 means zero-relevance conflicts pass the primary askable filter
+    const result1 = await gate.evaluate(
+      'How do I set up pre-commit hooks?',
+      { ...baseConfig, relevanceThreshold: 0, askOnIrrelevantTurns: false },
+    );
+
+    expect(result1).not.toBeNull();
+    expect(result1!.relevant).toBe(true);
+    // Should be tracked as asked since it came through the primary askable path
+    expect(markAskedCalls).toEqual(['conflict-zero-threshold']);
+
+    // Second turn within cooldown: the conflict should NOT be re-asked
+    const result2 = await gate.evaluate(
+      'Another unrelated question',
+      { ...baseConfig, relevanceThreshold: 0, askOnIrrelevantTurns: false },
+    );
+    expect(result2).toBeNull();
+  });
+
   test('relevant conflict is asked regardless of askOnIrrelevantTurns value', async () => {
     pendingConflicts = [{
       id: 'conflict-rel-knob',

--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -97,7 +97,7 @@ export class ConflictGate {
 
     if (!candidateToAsk) return null;
 
-    if (candidateToAsk.relevance > 0) {
+    if (askable || candidateToAsk.relevance > 0) {
       this.lastAskedTurn.set(candidateToAsk.conflict.id, this.turnCounter);
       markConflictAsked(candidateToAsk.conflict.id);
     }


### PR DESCRIPTION
Addresses review feedback on #6333. Changes the tracking guard from `candidateToAsk.relevance > 0` to `askable || candidateToAsk.relevance > 0`, ensuring candidates from the primary askable path are always tracked (even when relevanceThreshold=0), while still skipping tracking for zero-relevance conflicts on the askOnIrrelevantTurns fallback path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
