### PR TITLE
docs: fix exact-option description to match implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2032,10 +2032,10 @@ For `bash` and `host_bash` tool invocations, the permission system uses parser-d
 
 **Candidate building** (`buildShellCommandCandidates`): The shell parser (`tools/terminal/parser.ts`) produces segments and operators. `analyzeShellCommand()` extracts segments, operators, opaque-construct flags, and dangerous patterns. `deriveShellActionKeys()` then classifies the command:
 
-- **Simple action** (optional setup-prefix segments like `cd`, `export`, `pushd` + exactly one action segment): Produces hierarchical `action:` keys. For example, `cd /repo && gh pr view 5525 --json title` yields candidates: the raw command, the canonical primary command (`gh pr view 5525 --json title`), and action keys `action:gh pr view`, `action:gh pr`, `action:gh` (narrowest to broadest, max depth 3).
-- **Complex command** (pipelines with `|`, or multiple non-prefix action segments): Only the raw command is returned as a candidate — no action keys.
+- **Simple action** (optional setup-prefix segments like `cd`, `export`, `pushd` + exactly one action segment): Produces hierarchical `action:` keys. For example, `cd /repo && gh pr view 5525 --json title` yields candidates: the full original command text (`cd /repo && gh pr view 5525 --json title`), and action keys `action:gh pr view`, `action:gh pr`, `action:gh` (narrowest to broadest, max depth 3).
+- **Complex command** (pipelines with `|`, or multiple non-prefix action segments): Only the full original command text is returned as a candidate — no action keys.
 
-**Allowlist option ranking** (`buildShellAllowlistOptions`): For simple actions, the prompt offers options ordered from most specific to broadest: exact canonical command, then action keys from deepest to shallowest. For complex commands, only the exact compound command is offered. This prevents over-generalization of pipelines into permissive rules.
+**Allowlist option ranking** (`buildShellAllowlistOptions`): For simple actions, the prompt offers options ordered from most specific to broadest: the full original command text (exact match), then action keys from deepest to shallowest. For complex commands, only the full original command text is offered. This prevents over-generalization of pipelines into permissive rules.
 
 **Trust rule pattern format**: Action keys use the `action:` prefix in trust rules (e.g., `action:gh pr view`). The trust store matches these via `findHighestPriorityRule()` against the candidate list produced by `buildShellCommandCandidates()`.
 

--- a/README.md
+++ b/README.md
@@ -344,12 +344,12 @@ When you approve a shell command (`host_bash` or `bash`), the permission prompt 
 
 For example, `cd /repo && gh pr view 5525 --json title` generates these allowlist options:
 
-- `gh pr view 5525 --json title` — this exact command
+- `cd /repo && gh pr view 5525 --json title` — the full original command text (exactly what will be approved)
 - `gh pr view *` — any `gh pr view` command (trust rule pattern: `action:gh pr view`)
 - `gh pr *` — any `gh pr` command (trust rule pattern: `action:gh pr`)
 - `gh *` — any `gh` command (trust rule pattern: `action:gh`)
 
-Setup prefixes (`cd`, `export`, `pushd`, etc.) are stripped before deriving action keys, so the allowlist options focus on the actual action being performed.
+Setup prefixes (`cd`, `export`, `pushd`, etc.) are stripped before deriving action keys for the broader pattern options, but the exact option always uses the full original command text.
 
 **Compound commands** (with `&&`, `||`, `|`) that contain multiple non-prefix actions only offer an exact-command option — no broad action-family patterns. This prevents a complex pipeline from being over-generalized into a permissive rule.
 


### PR DESCRIPTION
## Summary

- Updates `README.md` and `ARCHITECTURE.md` to correctly describe the "exact" shell allowlist option as using the full original command text (including setup prefixes like `cd /repo &&`), not a stripped canonical primary command
- The implementation already uses the full original command text for exact matching; only the docs were inaccurate

## Test plan

- [ ] Verify `README.md` shell allowlist section accurately describes the exact option behavior
- [ ] Verify `ARCHITECTURE.md` shell command identity section matches implementation

## Original prompt

Fix docs-implementation mismatch: the docs described the "exact" shell allowlist option as using the canonical primary command (stripped of setup prefixes), but the implementation uses the full original command text. The implementation is correct; the docs needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
