### PR TITLE
fix: add missing logger name argument in checker

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -422,7 +422,7 @@ export async function check(
 
   if (permissionsMode === 'legacy' && !_legacyDeprecationWarned) {
     _legacyDeprecationWarned = true;
-    getLogger().warn('Permissions mode "legacy" is deprecated and will be removed in a future release. Switch to "workspace" (default) or "strict".');
+    getLogger('checker').warn('Permissions mode "legacy" is deprecated and will be removed in a future release. Switch to "workspace" (default) or "strict".');
   }
 
   if (permissionsMode === 'strict' && !matchedRule) {


### PR DESCRIPTION
## Summary

- Fix TypeScript compile error (TS2554) in `assistant/src/permissions/checker.ts` where `getLogger()` was called without the required `name` argument
- Changed `getLogger()` to `getLogger('checker')` on line 425

## Test plan

- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun test src/__tests__/checker.test.ts` — all 372 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
