### PR TITLE
fix: harden compound-command detection for ;, newline, and & separators

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -133,6 +133,20 @@ describe('deriveShellActionKeys', () => {
     expect(result.keys).toHaveLength(0);
   });
 
+  test('newline-separated commands are marked non-simple', async () => {
+    const analysis = await analyzeShellCommand('cd repo\ngh pr view 123');
+    const result = deriveShellActionKeys(analysis);
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
+  test('background operator (&) chains are marked non-simple', async () => {
+    const analysis = await analyzeShellCommand('sleep 5 & echo done');
+    const result = deriveShellActionKeys(analysis);
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toHaveLength(0);
+  });
+
   test('numeric arguments are excluded from keys', async () => {
     const analysis = await analyzeShellCommand('gh pr view 5525');
     const result = deriveShellActionKeys(analysis);
@@ -184,6 +198,11 @@ describe('buildShellCommandCandidates', () => {
     expect(candidates).toEqual(['']);
   });
 
+  test('semicolon chain returns raw-only', async () => {
+    const candidates = await buildShellCommandCandidates('cd repo; gh pr view 123');
+    expect(candidates).toHaveLength(1);
+  });
+
   test('deduplication preserves order', async () => {
     // Single command — raw and canonical are the same
     const candidates = await buildShellCommandCandidates('git status');
@@ -206,6 +225,18 @@ describe('buildShellAllowlistOptions — complex command restrictions', () => {
     const options = await buildShellAllowlistOptions('cat file.txt | grep error | wc -l');
     expect(options).toHaveLength(1);
     expect(options[0].pattern).toBe('cat file.txt | grep error | wc -l');
+    expect(options[0].description).toContain('compound');
+  });
+
+  test('semicolon chain offers exact only', async () => {
+    const options = await buildShellAllowlistOptions('cd repo; gh pr view 123');
+    expect(options).toHaveLength(1);
+    expect(options[0].description).toContain('compound');
+  });
+
+  test('newline-separated commands offer exact only', async () => {
+    const options = await buildShellAllowlistOptions('cd repo\ngh pr view 123');
+    expect(options).toHaveLength(1);
     expect(options[0].description).toContain('compound');
   });
 

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -76,14 +76,29 @@ export function deriveShellActionKeys(analysis: ShellIdentityAnalysis): ActionKe
     return { keys: [], isSimpleAction: false };
   }
 
-  // Pipelines are never simple
-  if (operators.includes('|')) {
-    return { keys: [], isSimpleAction: false };
-  }
-
-  // Only && is a valid setup-prefix chain; || and ; change control flow semantics
-  if (operators.some(op => op === '||' || op === ';')) {
-    return { keys: [], isSimpleAction: false };
+  // For multi-segment commands, only allow simple-action classification if
+  // ALL inter-segment operators are explicitly &&. Any other operator (|, ||,
+  // ;, &, empty/missing) means the separator is unknown or unsafe.
+  // This safely handles cases where the parser doesn't capture certain
+  // separators (;, newline, &) and leaves them as empty operators.
+  if (segments.length > 1) {
+    for (const seg of segments) {
+      const op = seg.operator;
+      // Non-empty operator that isn't && → definitely complex
+      if (op && op !== '&&') {
+        return { keys: [], isSimpleAction: false };
+      }
+    }
+    // Also check: if there are multiple segments but no operators at all
+    // between them (e.g. newline-separated), that's suspicious.
+    // The first segment always has operator '' (no preceding operator).
+    // If any non-first segment also has operator '', the separator was
+    // not captured — treat as complex for safety.
+    for (let i = 1; i < segments.length; i++) {
+      if (!segments[i].operator) {
+        return { keys: [], isSimpleAction: false };
+      }
+    }
   }
 
   // Separate setup-prefix segments from action segments


### PR DESCRIPTION
## Summary

- Replaces individual operator checks (`|`, `||`, `;`) in `deriveShellActionKeys` with a defensive approach: for multi-segment commands, only classify as "simple" if ALL non-first segments have `&&` as their operator
- Empty/missing operators on non-first segments (which occur when the parser doesn't capture `;`, newline, or `&` separators) are now treated as unsafe, preventing broad `action:*` allowlist options
- Adds regression tests for semicolon chains, newline-separated commands, and background operator (`&`) chains across `deriveShellActionKeys`, `buildShellCommandCandidates`, and `buildShellAllowlistOptions`

## Test plan

- [x] All 32 shell-identity tests pass (including the previously-failing semicolon test at line 128)
- [x] All 372 checker tests pass
- [x] New regression tests cover: newline-separated commands, `&` chains, semicolon chains in candidates and allowlist options

> Prompt used to create this PR:
> Fix safety gap in shell command classification where `;`, newline, and `&` separators are not captured by the parser and commands slip through as "simple" with broad action:* options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
