### PR TITLE
test: strengthen prompt-lifecycle integration coverage

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4396,4 +4396,64 @@ describe('integration regressions (PR 11)', () => {
 
     expect(bashOptions).toEqual(hostBashOptions);
   });
+
+  // ── prompt-lifecycle integration (real parser) ──────────────────
+
+  describe('prompt-lifecycle integration (real parser)', () => {
+    test('allowlist options for shell use real parser output with action keys', async () => {
+      // Verify the real parser produces correct allowlist options
+      const options = await generateAllowlistOptions('bash', { command: 'cd /repo && gh pr view 5525 --json title' });
+
+      // Must have exact command as first option
+      expect(options[0].pattern).toBe('cd /repo && gh pr view 5525 --json title');
+      expect(options[0].description).toBe('This exact command');
+
+      // Must have action keys (not whitespace-split patterns)
+      expect(options.some(o => o.pattern === 'action:gh pr view')).toBe(true);
+      expect(options.some(o => o.pattern === 'action:gh pr')).toBe(true);
+      expect(options.some(o => o.pattern === 'action:gh')).toBe(true);
+
+      // Must NOT have whitespace-split patterns
+      expect(options.some(o => o.pattern === 'cd *')).toBe(false);
+      // Action key options must NOT contain numeric args (only the exact match does)
+      const actionOptions = options.filter(o => o.pattern.startsWith('action:'));
+      expect(actionOptions.some(o => o.pattern.includes('5525'))).toBe(false);
+    });
+
+    test('allowlist option patterns are valid for rule matching', async () => {
+      clearCache();
+
+      // Generate allowlist options for a command
+      const options = await generateAllowlistOptions('bash', { command: 'npm install express' });
+
+      // Each non-exact option pattern should work as a trust rule
+      for (const option of options) {
+        if (option.pattern.startsWith('action:')) {
+          clearCache();
+          addRule('bash', option.pattern, 'everywhere', 'allow');
+          const result = await check('bash', { command: 'npm install express' }, '/tmp');
+          expect(result.decision).toBe('allow');
+        }
+      }
+    });
+
+    test('scope options are always least-privilege-first in prompt payload', () => {
+      const scopes = generateScopeOptions('/Users/test/project', 'host_bash');
+      expect(scopes[0].scope).toBe('/Users/test/project');
+      expect(scopes[scopes.length - 1].scope).toBe('everywhere');
+
+      // Verify no reordering for host tools
+      const nonHostScopes = generateScopeOptions('/Users/test/project', 'bash');
+      expect(scopes.map(s => s.scope)).toEqual(nonHostScopes.map(s => s.scope));
+    });
+
+    test('compound command prompt offers only exact persistence', async () => {
+      const options = await generateAllowlistOptions('host_bash', { command: 'git add . && git commit -m "fix" && git push' });
+      expect(options).toHaveLength(1);
+      expect(options[0].description).toContain('compound');
+
+      // The exact pattern should be the full command
+      expect(options[0].pattern).toBe('git add . && git commit -m "fix" && git push');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `prompt-lifecycle integration (real parser)` describe block in `checker.test.ts` with 4 new integration tests that validate the full composed pipeline end-to-end using the real parser (not mocked)
- Tests verify: action key generation for setup-prefixed commands, action key patterns work as trust rules for rule matching, scope options are always least-privilege-first, and compound commands offer only exact persistence
- Fixes an assertion from the original spec that checked `options.some(o => o.pattern.includes('5525'))` against all options (including the exact match which naturally contains the number) by scoping to action key options only

## Test plan

- [x] All 376 tests pass in `checker.test.ts` (including 4 new ones)
- [x] Pre-existing TSC errors only (unrelated `ipc-validate.ts` and `seed.ts`)

---

**Original prompt:**
> Add integration tests in `checker.test.ts` that validate the full composed behavior — parse -> analyze -> derive action keys -> build candidates -> match rules, AND parse -> build allowlist options — works together correctly with the real parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
