### PR TITLE
fix: filter dismissed conflicts from resolver candidates in session conflict gate

### DIFF
--- a/assistant/src/daemon/session-conflict-gate.ts
+++ b/assistant/src/daemon/session-conflict-gate.ts
@@ -50,17 +50,20 @@ export class ConflictGate {
     const pendingBeforeResolve = listPendingConflictDetails(scopeId, 50);
 
     // Dismiss non-actionable conflicts (kind or statement policy)
+    const dismissedIds = new Set<string>();
     for (const conflict of pendingBeforeResolve) {
       if (!this.isConflictActionable(conflict, conflictConfig.conflictableKinds)) {
         resolveConflict(conflict.id, {
           status: 'dismissed',
           resolutionNote: 'Dismissed by conflict policy (transient/non-durable).',
         });
+        dismissedIds.add(conflict.id);
       }
     }
 
+    const actionablePending = pendingBeforeResolve.filter((c) => !dismissedIds.has(c.id));
     const clarificationReply = looksLikeClarificationReply(userMessage);
-    const candidatesBeforeResolve = pendingBeforeResolve.filter((conflict) => {
+    const candidatesBeforeResolve = actionablePending.filter((conflict) => {
       const relevance = computeConflictRelevance(userMessage, conflict);
       return shouldAttemptConflictResolution({
         clarificationReply,


### PR DESCRIPTION
## Summary
- Fix a snapshot bug in `ConflictGate.evaluate()` where dismissed conflicts were still passed to the LLM resolver because `candidatesBeforeResolve` was derived from the unfiltered `pendingBeforeResolve` array.
- After the dismissal loop, filter out dismissed conflict IDs before building the resolver candidate list, matching the pattern already used by the background resolver in `conflict.ts`.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 29 tests in `session-conflict-gate.test.ts` pass

---

**Prompt:** Fix a snapshot bug in `session-conflict-gate.ts` where dismissed conflicts could still be passed to the LLM resolver, wasting resources. Collect dismissed IDs and filter them out before deriving `candidatesBeforeResolve`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
