### PR TITLE
fix: exclude URL/numeric/tracking noise tokens from conflict relevance tokenizer

### DIFF
--- a/assistant/src/__tests__/conflict-intent-tokenization.test.ts
+++ b/assistant/src/__tests__/conflict-intent-tokenization.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { computeConflictRelevance } from '../memory/conflict-intent.js';
+
+describe('tokenizeForConflictRelevance hardening', () => {
+  test('excludes numeric-only tokens from relevance', () => {
+    const relevance = computeConflictRelevance(
+      'Check PR 5526',
+      { existingStatement: 'Track PR 5525 for review.', candidateStatement: 'Track PR 5526 for review.' },
+    );
+    // Numeric tokens "5526" and "5525" should be excluded, so overlap is minimal
+    expect(relevance).toBeLessThan(0.5);
+  });
+
+  test('excludes URL boilerplate tokens from relevance', () => {
+    const relevance = computeConflictRelevance(
+      'Check https://github.com/org/repo/pull/123',
+      {
+        existingStatement: 'Review https://github.com/org/repo/pull/456',
+        candidateStatement: 'Review https://github.com/org/repo/pull/789',
+      },
+    );
+    // URL tokens like "https", "github", "pull" should be excluded;
+    // only real content tokens like "repo" remain, keeping relevance low
+    expect(relevance).toBeLessThanOrEqual(0.5);
+  });
+
+  test('excludes generic tracking tokens from relevance', () => {
+    const relevance = computeConflictRelevance(
+      'Check issue #42',
+      { existingStatement: 'Track issue #10 for review.', candidateStatement: 'Track issue #11 for review.' },
+    );
+    // "issue" should be excluded as a noise token
+    expect(relevance).toBeLessThan(0.5);
+  });
+
+  test('still computes meaningful relevance for real content tokens', () => {
+    const relevance = computeConflictRelevance(
+      'Should I use React for frontend?',
+      {
+        existingStatement: 'Use React for frontend work.',
+        candidateStatement: 'Use Vue for frontend work.',
+      },
+    );
+    // Real content tokens like "react", "frontend" should still match
+    expect(relevance).toBeGreaterThan(0);
+  });
+});

--- a/assistant/src/memory/conflict-intent.ts
+++ b/assistant/src/memory/conflict-intent.ts
@@ -22,12 +22,19 @@ export function computeConflictRelevance(
   );
 }
 
+const NOISE_TOKENS = new Set([
+  'http', 'https', 'github', 'gitlab', 'www', 'com', 'org',
+  'pull', 'issue', 'ticket',
+]);
+
 function tokenizeForConflictRelevance(input: string): Set<string> {
   const tokens = input
     .toLowerCase()
     .split(/[^a-z0-9]+/g)
     .map((token) => token.trim())
-    .filter((token) => token.length >= 4);
+    .filter((token) => token.length >= 4)
+    .filter((token) => !/^\d+$/.test(token))
+    .filter((token) => !NOISE_TOKENS.has(token));
   return new Set(tokens);
 }
 


### PR DESCRIPTION
## Summary

- Hardens `tokenizeForConflictRelevance` in `conflict-intent.ts` to exclude numeric-only tokens, URL boilerplate (`http`, `https`, `github`, `gitlab`, `www`, `com`, `org`), and generic tracking tokens (`pull`, `issue`, `ticket`) from the relevance overlap computation.
- Adds dedicated test file `conflict-intent-tokenization.test.ts` verifying that noise tokens no longer inflate relevance scores while real content tokens still produce meaningful matches.

## Test plan

- [x] New `conflict-intent-tokenization.test.ts` tests pass (4/4)
- [x] Existing `session-conflict-gate.test.ts` tests pass (29/29)
- [x] `bunx tsc --noEmit` passes cleanly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
