### PR TITLE
fix: use medium-risk command in action-key rule matching test (#6339)

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4423,15 +4423,16 @@ describe('integration regressions (PR 11)', () => {
     test('allowlist option patterns are valid for rule matching', async () => {
       clearCache();
 
-      // Generate allowlist options for a command
-      const options = await generateAllowlistOptions('bash', { command: 'npm install express' });
+      // Use a medium-risk command (unknown program) so the allow decision
+      // actually depends on the trust rule, not low-risk auto-allow.
+      const options = await generateAllowlistOptions('bash', { command: 'mycli install express' });
 
       // Each non-exact option pattern should work as a trust rule
       for (const option of options) {
         if (option.pattern.startsWith('action:')) {
           clearCache();
           addRule('bash', option.pattern, 'everywhere', 'allow');
-          const result = await check('bash', { command: 'npm install express' }, '/tmp');
+          const result = await check('bash', { command: 'mycli install express' }, '/tmp');
           expect(result.decision).toBe('allow');
         }
       }


### PR DESCRIPTION
Address reviewer feedback from PR #6339: the test 'allowlist option patterns are valid for rule matching' used npm (a low-risk auto-allowed command), so the test passed regardless of whether the action key rule actually matched. Changed to use an unknown program (mycli) which is medium-risk and requires a matching rule to be allowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
