### PR TITLE
fix: scope noise-token filtering to URL contexts in conflict relevance tokenizer (#6342)

### DIFF
--- a/assistant/src/__tests__/conflict-intent-tokenization.test.ts
+++ b/assistant/src/__tests__/conflict-intent-tokenization.test.ts
@@ -24,13 +24,26 @@ describe('tokenizeForConflictRelevance hardening', () => {
     expect(relevance).toBeLessThanOrEqual(0.5);
   });
 
-  test('excludes generic tracking tokens from relevance', () => {
-    const relevance = computeConflictRelevance(
-      'Check issue #42',
-      { existingStatement: 'Track issue #10 for review.', candidateStatement: 'Track issue #11 for review.' },
+  test('URL-embedded tracking tokens are stripped, standalone usage preserved', () => {
+    // URLs containing "issue", "pull", etc. are stripped entirely before tokenizing
+    const urlRelevance = computeConflictRelevance(
+      'Check https://github.com/org/repo/issues/42',
+      {
+        existingStatement: 'Review https://github.com/org/repo/issues/10',
+        candidateStatement: 'Review https://github.com/org/repo/issues/11',
+      },
     );
-    // "issue" should be excluded as a noise token
-    expect(relevance).toBeLessThan(0.5);
+    expect(urlRelevance).toBeLessThanOrEqual(0.5);
+
+    // Standalone "issue" is preserved as a meaningful token
+    const standaloneRelevance = computeConflictRelevance(
+      'should I file an issue?',
+      {
+        existingStatement: 'File an issue when bugs are found.',
+        candidateStatement: 'Skip filing an issue for minor bugs.',
+      },
+    );
+    expect(standaloneRelevance).toBeGreaterThan(0);
   });
 
   test('still computes meaningful relevance for real content tokens', () => {

--- a/assistant/src/memory/conflict-intent.ts
+++ b/assistant/src/memory/conflict-intent.ts
@@ -24,11 +24,13 @@ export function computeConflictRelevance(
 
 const NOISE_TOKENS = new Set([
   'http', 'https', 'github', 'gitlab', 'www', 'com', 'org',
-  'pull', 'issue', 'ticket',
 ]);
 
+const URL_PATTERN = /https?:\/\/[^\s)>\]]+/gi;
+
 function tokenizeForConflictRelevance(input: string): Set<string> {
-  const tokens = input
+  const stripped = input.replace(URL_PATTERN, ' ');
+  const tokens = stripped
     .toLowerCase()
     .split(/[^a-z0-9]+/g)
     .map((token) => token.trim())


### PR DESCRIPTION
Address reviewer feedback from PR #6342: pull/issue/ticket were globally added to NOISE_TOKENS which created false negatives when those words were the actual conflict topic. Now strips URLs before tokenizing and keeps NOISE_TOKENS to only URL protocol/domain terms (http, https, github, etc). Standalone uses of pull/issue/ticket are preserved for proper relevance scoring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
