### PR TITLE
Align proactive attachment contract for ID-only payloads (#6354)

### DIFF
--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -187,6 +187,129 @@ describe("sendTelegramAttachments", () => {
     expect(calls[1]).toContain("sendPhoto");
   });
 
+  test("ID-only attachment hydrates metadata from downloaded payload", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-id-only")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-id-only",
+            filename: "downloaded.png",
+            mimeType: "image/png",
+            sizeBytes: 120,
+            kind: "generated_image",
+            data: "iVBORw0KGgo=",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    // Only provide `id` — no filename, mimeType, sizeBytes, or kind
+    const meta: RuntimeAttachmentMeta = { id: "att-id-only" };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("/attachments/att-id-only");
+    // Should use mimeType from downloaded payload to determine it's an image
+    expect(calls[1]).toContain("sendPhoto");
+  });
+
+  test("ID-only attachment falls back to defaults when download payload also lacks metadata", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-bare")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-bare",
+            data: "AQID", // 3 bytes base64
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = { id: "att-bare" };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("/attachments/att-bare");
+    // With default mime type (application/octet-stream), should send as document
+    expect(calls[1]).toContain("sendDocument");
+  });
+
+  test("ID-only attachment skipped when hydrated size exceeds limit", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-big")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-big",
+            filename: "big.bin",
+            mimeType: "application/octet-stream",
+            sizeBytes: 200,
+            kind: "filesystem",
+            data: "AQID",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig({ maxAttachmentBytes: 50 });
+    // No sizeBytes in meta — will be hydrated from download payload (200 > 50 limit)
+    const meta: RuntimeAttachmentMeta = { id: "att-big" };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    // Should download, discover size exceeds limit, skip, then send failure notice
+    expect(calls.filter((u) => u.includes("/attachments/att-big"))).toHaveLength(1);
+    expect(calls.filter((u) => u.includes("sendMessage"))).toHaveLength(1);
+    expect(calls.filter((u) => u.includes("sendPhoto"))).toHaveLength(0);
+    expect(calls.filter((u) => u.includes("sendDocument"))).toHaveLength(0);
+  });
+
+  test("ID-only attachment uses id as filename fallback", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    const origMockFetch = mock(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.includes("/attachments/my-attachment-id")) {
+        return new Response(
+          JSON.stringify({
+            id: "my-attachment-id",
+            mimeType: "application/pdf",
+            sizeBytes: 50,
+            data: "JVBER",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+    Object.assign(origMockFetch, { preconnect: () => {} });
+    globalThis.fetch = origMockFetch as unknown as typeof fetch;
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = { id: "my-attachment-id" };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    expect(calls).toHaveLength(2);
+    // Second call is the Telegram API call with FormData
+    const telegramCall = calls[1];
+    expect(telegramCall.url).toContain("sendDocument");
+  });
+
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -40,10 +40,10 @@ export type RuntimeInboundPayload = {
 
 export type RuntimeAttachmentMeta = {
   id: string;
-  filename: string;
-  mimeType: string;
-  sizeBytes: number;
-  kind: string;
+  filename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  kind?: string;
 };
 
 export type RuntimeAttachmentPayload = RuntimeAttachmentMeta & {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -704,6 +704,8 @@ export function buildSchema(): Record<string, unknown> {
         },
         RuntimeAttachmentMeta: {
           type: "object",
+          required: ["id"],
+          description: "Attachment metadata. Only `id` is required; missing fields are hydrated from the downloaded attachment data.",
           properties: {
             id: { type: "string" },
             filename: { type: "string" },

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -54,9 +54,10 @@ export async function sendTelegramAttachments(
   const failures: string[] = [];
 
   for (const meta of attachments) {
-    if (meta.sizeBytes > config.maxAttachmentBytes) {
+    // When size is known upfront, skip oversized attachments before downloading.
+    if (meta.sizeBytes !== undefined && meta.sizeBytes > config.maxAttachmentBytes) {
       log.warn({ attachmentId: meta.id, sizeBytes: meta.sizeBytes }, "Skipping oversized outbound attachment");
-      failures.push(meta.filename);
+      failures.push(meta.filename ?? meta.id);
       continue;
     }
 
@@ -66,25 +67,39 @@ export async function sendTelegramAttachments(
       const payload = assistantId
         ? await downloadAttachment(config, assistantId, meta.id)
         : await downloadAttachmentById(config, meta.id);
+
+      // Hydrate missing metadata from the downloaded payload so that
+      // ID-only attachment payloads work correctly.
+      const mimeType = meta.mimeType ?? payload.mimeType ?? "application/octet-stream";
+      const filename = meta.filename ?? payload.filename ?? meta.id;
+      const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? Math.ceil((payload.data.length * 3) / 4);
+
+      // Check size after hydration for ID-only payloads where size was unknown.
+      if (sizeBytes > config.maxAttachmentBytes) {
+        log.warn({ attachmentId: meta.id, sizeBytes }, "Skipping oversized outbound attachment (detected after download)");
+        failures.push(filename);
+        continue;
+      }
+
       const buffer = Buffer.from(payload.data, "base64");
-      const blob = new Blob([buffer], { type: meta.mimeType });
+      const blob = new Blob([buffer], { type: mimeType });
 
       const form = new FormData();
       form.set("chat_id", chatId);
 
-      const isImage = IMAGE_MIME_PREFIXES.some((p) => meta.mimeType.startsWith(p));
+      const isImage = IMAGE_MIME_PREFIXES.some((p) => mimeType.startsWith(p));
       if (isImage) {
-        form.set("photo", blob, meta.filename);
+        form.set("photo", blob, filename);
         await callTelegramApiMultipart(config, "sendPhoto", form);
       } else {
-        form.set("document", blob, meta.filename);
+        form.set("document", blob, filename);
         await callTelegramApiMultipart(config, "sendDocument", form);
       }
 
-      log.debug({ chatId, attachmentId: meta.id, filename: meta.filename }, "Attachment sent to Telegram");
+      log.debug({ chatId, attachmentId: meta.id, filename }, "Attachment sent to Telegram");
     } catch (err) {
       log.error({ err, attachmentId: meta.id, filename: meta.filename }, "Failed to send attachment to Telegram");
-      failures.push(meta.filename);
+      failures.push(meta.filename ?? meta.id);
     }
   }
 


### PR DESCRIPTION
## Summary
- Make RuntimeAttachmentMeta metadata fields optional (only id required)
- Hydrate missing metadata from downloaded attachment data in sendTelegramAttachments
- Update deliver route validation to accept ID-only attachment payloads
- Update OpenAPI schema to reflect optional metadata fields
- Add tests for ID-only attachment handling

Closes #6354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
