### PR TITLE
Decouple Telegram delivery from localhost + /new rejection parity (#6352)

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -27,8 +27,11 @@ import { getSecureKey } from '../../../security/secure-keys.js';
 import { readHttpToken } from '../../../util/platform.js';
 import * as telegram from './client.js';
 
-/** Resolve the local gateway base URL from GATEWAY_PORT (default 7830). */
+/** Resolve the gateway base URL from GATEWAY_BASE_URL env var, falling back to localhost. */
 function getGatewayUrl(): string {
+  if (process.env.GATEWAY_BASE_URL) {
+    return process.env.GATEWAY_BASE_URL;
+  }
   const port = Number(process.env.GATEWAY_PORT) || 7830;
   return `http://127.0.0.1:${port}`;
 }

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -14,6 +14,7 @@ export type RoutingEntry = {
 export type GatewayConfig = {
   assistantRuntimeBaseUrl: string;
   defaultAssistantId: string | undefined;
+  gatewayInternalBaseUrl: string;
   logFile: LogFileConfig;
   maxAttachmentBytes: number;
   maxAttachmentConcurrency: number;
@@ -122,6 +123,9 @@ export function loadConfig(): GatewayConfig {
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error("GATEWAY_PORT must be a valid port number");
   }
+
+  const gatewayInternalBaseUrl =
+    process.env.GATEWAY_INTERNAL_BASE_URL || `http://127.0.0.1:${port}`;
 
   const proxyEnabledRaw = process.env.GATEWAY_RUNTIME_PROXY_ENABLED;
   if (proxyEnabledRaw !== undefined && proxyEnabledRaw !== "true" && proxyEnabledRaw !== "false") {
@@ -243,6 +247,7 @@ export function loadConfig(): GatewayConfig {
     {
       telegramApiBaseUrl,
       assistantRuntimeBaseUrl,
+      gatewayInternalBaseUrl,
       routingEntryCount: routingEntries.length,
       unmappedPolicy,
       hasDefaultAssistant: !!defaultAssistantId,
@@ -259,6 +264,7 @@ export function loadConfig(): GatewayConfig {
   return {
     assistantRuntimeBaseUrl,
     defaultAssistantId,
+    gatewayInternalBaseUrl,
     logFile,
     maxAttachmentBytes,
     maxAttachmentConcurrency,

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+import { createTelegramWebhookHandler } from "./telegram-webhook.js";
+
+// ---- Mocks ----
+
+// Track calls to sendTelegramReply
+let sendTelegramReplyCalls: Array<{ chatId: string; text: string }> = [];
+
+mock.module("../../telegram/send.js", () => ({
+  sendTelegramReply: async (_config: unknown, chatId: string, text: string) => {
+    sendTelegramReplyCalls.push({ chatId, text });
+  },
+  sendTelegramAttachments: async () => {},
+  sendTypingIndicator: async () => true,
+}));
+
+mock.module("../../telegram/verify.js", () => ({
+  verifyWebhookSecret: () => true,
+}));
+
+mock.module("../../runtime/client.js", () => ({
+  resetConversation: async () => {},
+  forwardToRuntime: async () => ({ eventId: "evt-1", duplicate: false }),
+  uploadAttachment: async () => ({ id: "att-1" }),
+  AttachmentValidationError: class extends Error {},
+}));
+
+mock.module("../../telegram/download.js", () => ({
+  downloadTelegramFile: async () => ({
+    data: Buffer.from("fake"),
+    fileName: "test.txt",
+    mimeType: "text/plain",
+  }),
+}));
+
+// ---- Helpers ----
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: "test-bot-token",
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: "test-secret",
+    twilioAuthToken: undefined,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "reject",
+    ...overrides,
+  };
+}
+
+function makeTelegramPayload(text: string, updateId = 1, chatId = 12345) {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: 100,
+      text,
+      chat: { id: chatId, type: "private" },
+      from: { id: 99, is_bot: false, username: "testuser", first_name: "Test" },
+    },
+  };
+}
+
+function makeRequest(body: object): Request {
+  const json = JSON.stringify(body);
+  return new Request("http://localhost:7830/webhook/telegram", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-telegram-bot-api-secret-token": "test-secret",
+    },
+    body: json,
+  });
+}
+
+// ---- Tests ----
+
+describe("telegram-webhook /new rejection", () => {
+  beforeEach(() => {
+    sendTelegramReplyCalls = [];
+  });
+
+  it("sends a rejection notice when /new is routed to an unmapped chat", async () => {
+    // No routing entries + unmappedPolicy "reject" means every chat is rejected
+    const config = makeConfig({ unmappedPolicy: "reject", routingEntries: [] });
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("/new", 1000, 55555);
+    const req = makeRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+
+    // The handler should have sent a rejection notice to the chat
+    const rejectionReply = sendTelegramReplyCalls.find((c) =>
+      c.text.includes("could not be routed"),
+    );
+    expect(rejectionReply).toBeDefined();
+    expect(rejectionReply!.chatId).toBe("55555");
+  });
+
+  it("does not send a rejection notice when /new routing succeeds", async () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      routingEntries: [{ type: "chat_id", key: "55555", assistantId: "asst-1" }],
+    });
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("/new", 1001, 55555);
+    const req = makeRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+
+    // Should get the success confirmation, not a rejection notice
+    const rejectionReply = sendTelegramReplyCalls.find((c) =>
+      c.text.includes("could not be routed"),
+    );
+    expect(rejectionReply).toBeUndefined();
+
+    const confirmReply = sendTelegramReplyCalls.find((c) =>
+      c.text.includes("Starting a new conversation"),
+    );
+    expect(confirmReply).toBeDefined();
+  });
+
+  it("rate-limits rejection notices for the same chat on /new", async () => {
+    const config = makeConfig({ unmappedPolicy: "reject", routingEntries: [] });
+    const handler = createTelegramWebhookHandler(config);
+
+    // First /new — should produce a notice
+    const req1 = makeRequest(makeTelegramPayload("/new", 2000, 77777));
+    await handler(req1);
+
+    // Second /new from the same chat — should be rate-limited (no notice)
+    const req2 = makeRequest(makeTelegramPayload("/new", 2001, 77777));
+    await handler(req2);
+
+    const rejectionReplies = sendTelegramReplyCalls.filter(
+      (c) => c.chatId === "77777" && c.text.includes("could not be routed"),
+    );
+    expect(rejectionReplies.length).toBe(1);
+  });
+});

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -155,7 +155,21 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         normalized.sender.externalUserId,
       );
 
-      if (!isRejection(routing)) {
+      if (isRejection(routing)) {
+        log.warn(
+          { chatId: normalized.message.externalChatId, reason: routing.reason },
+          "Routing rejected /new command",
+        );
+        if (shouldSendRejectionNotice(normalized.message.externalChatId)) {
+          sendTelegramReply(
+            config,
+            normalized.message.externalChatId,
+            "\u26a0\ufe0f This message could not be routed to an assistant. Please check your gateway routing configuration.",
+          ).catch((err) => {
+            log.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /new routing rejection notice");
+          });
+        }
+      } else {
         try {
           await resetConversation(
             config,
@@ -252,7 +266,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       const result = await handleInbound(config, normalized, {
         attachmentIds,
         transportMetadata: buildTelegramTransportMetadata(),
-        replyCallbackUrl: `http://127.0.0.1:${config.port}/deliver/telegram`,
+        replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/telegram`,
       });
 
       if (result.rejected) {


### PR DESCRIPTION
## Summary
- Add GATEWAY_INTERNAL_BASE_URL config to gateway for configurable internal base URL (fallback to localhost)
- Replace hardcoded 127.0.0.1 in telegram-webhook.ts replyCallbackUrl with config-driven URL
- Replace hardcoded localhost in assistant telegram adapter with GATEWAY_BASE_URL env var
- Add /new rejection notice parity — routing rejection on /new now emits the same rate-limited notice as normal inbound messages

Closes #6352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
