### PR TITLE
fix: always kill and restart source gateway in /update command

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,17 +1,16 @@
 # Update — Pull Latest and Restart Vellum
 
-Pull the latest changes from main, restart the backend daemon, and rebuild/launch the macOS app.
+Pull the latest changes from main, restart the backend daemon, rebuild/launch the macOS app, and start the source gateway.
 
 ## Steps
 
-1. Kill app + daemon processes only (do **not** kill a manually run source gateway):
+1. Kill app, daemon, and **all** gateway processes. There must only ever be one gateway running, and it must always be started from source:
    ```bash
    pkill -x "Vellum" || true
    pkill -x "vellum-assistant" || true
    vellum daemon stop || true
+   pkill -f "dev:proxy" || true
    ```
-
-   If a source gateway is already running (for example `cd gateway && bun run dev:proxy`), leave it running.
 
 2. Switch to main and pull latest:
    ```bash
@@ -29,15 +28,14 @@ Pull the latest changes from main, restart the backend daemon, and rebuild/launc
    cd assistant && bun run daemon:restart:http && cd ..
    ```
 
-5. Build and launch the macOS app from source. Pin gateway resolution to the repo `gateway/` directory so local gateway changes are used instead of a packaged fallback. Run this in the background since `build.sh run` enters a watch loop:
+5. Build and launch the macOS app from source **and** start the source gateway. These can run in parallel. Pin gateway resolution to the repo `gateway/` directory so local gateway changes are used instead of a packaged fallback. Run both in the background since `build.sh run` enters a watch loop:
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-6. If no gateway is running yet and you need ingress/webhook testing, start gateway from source in a separate terminal:
    ```bash
-   cd gateway && bun run dev:proxy
+   cd gateway && bun run dev:proxy &
    ```
 
-Report what was pulled (new commits), whether an existing source gateway was preserved or started, and confirm daemon + app are running.
+Report what was pulled (new commits), and confirm daemon, app, and source gateway are all running.


### PR DESCRIPTION
## Summary
- Changed `/update` to always kill existing gateway processes and restart from source, instead of optionally leaving them running
- Ensures there is only ever one gateway running, always from source (`cd gateway && bun run dev:proxy`)
- Gateway start runs in parallel with the macOS app build

## Original prompt
Update the /update command (.claude/commands/update.md) to change the gateway behavior: Instead of optionally starting the gateway only when needed, always ensure exactly one source gateway is running. Specifically: (1) Kill any existing gateway processes (both source and non-source) before restarting, (2) Always start the gateway from source (`cd gateway && bun run dev:proxy`) as part of the update flow, (3) Make it clear there should only ever be one gateway running and it should always be from source. The gateway start should happen after the daemon is running but can be in parallel with the macOS app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
