### PR TITLE
M2: Attachment contract alignment

### DIFF
--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -157,6 +157,117 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
   });
 });
 
+describe("/deliver/telegram ID-only attachment validation", () => {
+  test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      calls.push(urlStr);
+      if (urlStr.includes("/v1/attachments/att-id-only")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-id-only",
+            filename: "hydrated.png",
+            mimeType: "image/png",
+            sizeBytes: 80,
+            kind: "generated_image",
+            data: "iVBORw0KGgo=",
+          }),
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chatId: "789",
+        attachments: [{ id: "att-id-only" }],
+      }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Should have downloaded the attachment and sent it to Telegram
+    const downloadCall = calls.find((u) => u.includes("/attachments/att-id-only"));
+    expect(downloadCall).toBeDefined();
+    const telegramCall = calls.find((u) => u.includes("sendPhoto"));
+    expect(telegramCall).toBeDefined();
+  });
+
+  test("rejects attachment missing id with 400", async () => {
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chatId: "789",
+        attachments: [{ filename: "no-id.png", mimeType: "image/png" }],
+      }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must have an id");
+  });
+
+  test("full-metadata attachments still accepted (backward compatibility)", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      calls.push(urlStr);
+      if (urlStr.includes("/v1/attachments/att-compat")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-compat",
+            filename: "doc.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 150,
+            kind: "filesystem",
+            data: "JVBER",
+          }),
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createTelegramDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+    );
+    const req = new Request("http://localhost:7830/deliver/telegram", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chatId: "789",
+        attachments: [
+          { id: "att-compat", filename: "doc.pdf", mimeType: "application/pdf", sizeBytes: 150, kind: "filesystem" },
+        ],
+      }),
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});
+
 describe("/deliver/telegram bearer auth enforcement", () => {
   test("rejects request without Authorization header with 401", async () => {
     const handler = createTelegramDeliverHandler(makeConfig());

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -310,6 +310,42 @@ describe("sendTelegramAttachments", () => {
     expect(telegramCall.url).toContain("sendDocument");
   });
 
+  test("full-metadata payload still works (backward compatibility)", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-full")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-full",
+            filename: "photo.jpg",
+            mimeType: "image/jpeg",
+            sizeBytes: 100,
+            kind: "generated_image",
+            data: "/9j/4AAQ",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = {
+      id: "att-full",
+      filename: "photo.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 100,
+      kind: "generated_image",
+    };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("/attachments/att-full");
+    expect(calls[1]).toContain("sendPhoto");
+  });
+
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -56,6 +56,15 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "text or attachments required" }, { status: 400 });
     }
 
+    // Validate that each attachment has at least an id
+    if (attachments) {
+      for (const att of attachments) {
+        if (!att.id || typeof att.id !== "string") {
+          return Response.json({ error: "each attachment must have an id" }, { status: 400 });
+        }
+      }
+    }
+
     try {
       if (text) {
         await sendTelegramReply(config, chatId, text);

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -711,6 +711,7 @@ export function buildSchema(): Record<string, unknown> {
             filename: { type: "string" },
             mimeType: { type: "string" },
             sizeBytes: { type: "integer" },
+            kind: { type: "string" },
           },
         },
       },

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -69,10 +69,12 @@ export async function sendTelegramAttachments(
         : await downloadAttachmentById(config, meta.id);
 
       // Hydrate missing metadata from the downloaded payload so that
-      // ID-only attachment payloads work correctly.
+      // ID-only attachment payloads work correctly. Explicit meta fields
+      // take precedence over downloaded values.
       const mimeType = meta.mimeType ?? payload.mimeType ?? "application/octet-stream";
       const filename = meta.filename ?? payload.filename ?? meta.id;
-      const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? Math.ceil((payload.data.length * 3) / 4);
+      const buffer = Buffer.from(payload.data, "base64");
+      const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? buffer.length;
 
       // Check size after hydration for ID-only payloads where size was unknown.
       if (sizeBytes > config.maxAttachmentBytes) {
@@ -81,7 +83,6 @@ export async function sendTelegramAttachments(
         continue;
       }
 
-      const buffer = Buffer.from(payload.data, "base64");
       const blob = new Blob([buffer], { type: mimeType });
 
       const form = new FormData();
@@ -98,13 +99,14 @@ export async function sendTelegramAttachments(
 
       log.debug({ chatId, attachmentId: meta.id, filename }, "Attachment sent to Telegram");
     } catch (err) {
-      log.error({ err, attachmentId: meta.id, filename: meta.filename }, "Failed to send attachment to Telegram");
-      failures.push(meta.filename ?? meta.id);
+      const displayName = meta.filename ?? meta.id;
+      log.error({ err, attachmentId: meta.id, filename: displayName }, "Failed to send attachment to Telegram");
+      failures.push(displayName);
     }
   }
 
   if (failures.length > 0) {
-    const notice = `⚠️ ${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
+    const notice = `\u26a0\ufe0f ${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
     try {
       await sendTelegramReply(config, chatId, notice);
     } catch (err) {


### PR DESCRIPTION
Part of #6349. Closes #6354.

- Make RuntimeAttachmentMeta metadata fields optional (only id required)
- Hydrate missing metadata from downloaded attachment in send path
- Update OpenAPI schema and request validation for ID-only attachments
- Add tests for ID-only and full-metadata attachment handling
- Maintain backward compatibility for existing full-metadata payloads
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
