### PR TITLE
Documentation alignment for Telegram post-gap finalization (#6356)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -305,13 +305,14 @@ graph TB
     GW_VERIFY --> GW_NORMALIZE
     GW_NORMALIZE --> GW_ROUTE
     GW_ROUTE --> GW_FORWARD
-    GW_FORWARD -->|"HTTP"| HTTP_SERVER
+    GW_FORWARD -->|"HTTP + replyCallbackUrl"| HTTP_SERVER
     HTTP_SERVER -->|"channels/inbound transport<br/>channelId + hints + uxBrief"| PLAYBOOK_MGR
     GW_REPLY -->|"Telegram API"| GW_WEBHOOK
     GW_ATTACH -->|"download from runtime<br/>+ upload to Telegram"| GW_WEBHOOK
 
     %% Gateway flow — Telegram deliver (runtime → gateway → Telegram)
-    HTTP_SERVER -->|"POST /deliver/telegram"| GW_TG_DELIVER
+    %% replyCallbackUrl is built from gatewayInternalBaseUrl (GATEWAY_INTERNAL_BASE_URL env var)
+    HTTP_SERVER -->|"POST /deliver/telegram<br/>(via gatewayInternalBaseUrl)"| GW_TG_DELIVER
     GW_TG_DELIVER --> GW_REPLY
     GW_TG_DELIVER --> GW_ATTACH
 
@@ -3517,6 +3518,7 @@ Telegram messages follow three paths through the system:
 Inbound (user → assistant):
   Telegram → Gateway POST /webhooks/telegram → verify secret → normalize → route
     → Runtime POST /v1/assistants/:id/channels/inbound
+    (replyCallbackUrl = ${gatewayInternalBaseUrl}/deliver/telegram)
 
 Outbound reply (assistant → user, triggered by inbound):
   Runtime callback → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendPhoto/sendDocument
@@ -3525,7 +3527,11 @@ Outbound proactive (assistant → user, initiated by messaging provider):
   Runtime messaging provider → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage
 ```
 
+The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which defaults to `http://127.0.0.1:${GATEWAY_PORT}` and can be overridden via the `GATEWAY_INTERNAL_BASE_URL` environment variable. This allows distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts).
+
 The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-closed). If no bearer token is configured and the dev-only bypass flag (`GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS`) is not set, the endpoint returns 503 rather than allowing unauthenticated access.
+
+**Bot-account limitations:** The Telegram Bot API only supports sending messages to chats that have previously interacted with the bot. Bots cannot enumerate chats, read message history, or search messages. A future MTProto user-account session track may lift some of these restrictions.
 
 ### Webhook Reconciliation
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -34,6 +34,7 @@ bun run dev
 | `GATEWAY_DEFAULT_ASSISTANT_ID` | No | — | Default assistant ID for unmapped users |
 | `GATEWAY_UNMAPPED_POLICY` | No | `reject` | Policy for unmapped users: `reject` or `default` |
 | `GATEWAY_PORT` | No | `7830` | Port for the gateway HTTP server |
+| `GATEWAY_INTERNAL_BASE_URL` | No | `http://127.0.0.1:${PORT}` | Base URL for runtime→gateway callbacks (e.g., reply delivery). Defaults to `http://127.0.0.1:${GATEWAY_PORT}`. Set this when gateway and runtime are not co-located (e.g., separate containers or hosts). |
 | `INGRESS_PUBLIC_BASE_URL` | No | — | Public URL where the gateway is reachable (e.g. `https://abc123.ngrok-free.app`). Used by the assistant runtime to construct webhook and OAuth callback URLs. Set this to your tunnel's public URL. |
 | `GATEWAY_RUNTIME_PROXY_ENABLED` | No | `false` | Enable runtime proxy for non-Telegram requests |
 | `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
@@ -226,6 +227,8 @@ docker run --rm -p 7830:7830 \
 ```
 
 The image runs as non-root user `gateway` (uid 1001) and exposes port `7830`.
+
+When the runtime and gateway run in separate containers or hosts, set `GATEWAY_INTERNAL_BASE_URL` so the runtime can reach the gateway for callbacks (e.g., Telegram reply delivery). By default it points to `http://127.0.0.1:${GATEWAY_PORT}`, which only works when both services share the same host.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Add GATEWAY_INTERNAL_BASE_URL to gateway README config table
- Update ARCHITECTURE.md Telegram flow to reflect config-driven callback URLs
- Review SKILL.md for gateway connectivity references

Closes #6356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
