### PR TITLE
Fix gateway TypeScript errors and test failures (#6355)

### DIFF
--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -30,6 +30,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -29,6 +29,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   ...overrides,
 });
 

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -30,6 +30,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -36,6 +36,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   ...overrides,
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -32,6 +32,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -30,6 +30,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -32,6 +32,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }
@@ -44,7 +45,7 @@ afterEach(() => {
 
 function mockTelegramApi() {
   globalThis.fetch = mock(async () => {
-    return new Response(JSON.stringify({ ok: true }), {
+    return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -30,6 +30,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   ...overrides,
 });
 

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -30,7 +30,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxAttachmentConcurrency: 3,
     twilioAuthToken: undefined,
     ingressPublicBaseUrl: "https://example.ngrok.io",
-    publicUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
 }
@@ -52,7 +52,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request) => {
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -63,8 +63,7 @@ describe("reconcileTelegramWebhook", () => {
         });
       }
       if (url.includes("/setWebhook")) {
-        const req = typeof input === "object" && "json" in input ? input : null;
-        const body = req ? await (req as Request).json() : null;
+        const body = init?.body ? JSON.parse(init.body as string) : null;
         calls.push({ method: "setWebhook", body });
         return makeTelegramResponse(true);
       }
@@ -111,7 +110,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request) => {
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -122,8 +121,7 @@ describe("reconcileTelegramWebhook", () => {
         });
       }
       if (url.includes("/setWebhook")) {
-        const req = typeof input === "object" && "json" in input ? input : null;
-        const body = req ? await (req as Request).json() : null;
+        const body = init?.body ? JSON.parse(init.body as string) : null;
         calls.push({ method: "setWebhook", body });
         return makeTelegramResponse(true);
       }

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -44,6 +44,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: undefined,
   ingressPublicBaseUrl: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   ...overrides,
 });
 
@@ -76,7 +77,7 @@ function createFakeUpstreamWs() {
   const sent: unknown[] = [];
   const closes: { code?: number; reason?: string }[] = [];
   return {
-    readyState: WS_CONNECTING,
+    readyState: WS_CONNECTING as number,
     sent,
     closes,
     listeners,
@@ -106,7 +107,7 @@ describe("createTwilioRelayWebsocketHandler", () => {
   test("returns 400 when callSessionId is missing", () => {
     const handler = createTwilioRelayWebsocketHandler(makeConfig());
     const req = new Request("http://localhost:7830/ws/twilio/relay");
-    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server;
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeInstanceOf(Response);
@@ -120,7 +121,7 @@ describe("createTwilioRelayWebsocketHandler", () => {
     const req = new Request(
       "http://localhost:7830/ws/twilio/relay?callSessionId=sess-42",
     );
-    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server;
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeUndefined();
@@ -139,7 +140,7 @@ describe("createTwilioRelayWebsocketHandler", () => {
     const req = new Request(
       "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1",
     );
-    const fakeServer = { upgrade: mock(() => false) } as unknown as import("bun").Server;
+    const fakeServer = { upgrade: mock(() => false) } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeInstanceOf(Response);
@@ -197,7 +198,7 @@ describe("getRelayWebsocketHandlers", () => {
     });
     handlers.open(ws as never);
 
-    const ctorCall = (globalThis.WebSocket as ReturnType<typeof mock>).mock.calls[0] as unknown[];
+    const ctorCall = (globalThis.WebSocket as unknown as ReturnType<typeof mock>).mock.calls[0] as unknown[];
     const url = ctorCall[0] as string;
     expect(url).toBe("ws://runtime:8000/v1/calls/relay?callSessionId=s%26id%3D1");
   });

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -34,6 +34,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   maxAttachmentConcurrency: 3,
   twilioAuthToken: AUTH_TOKEN,
   ingressPublicBaseUrl: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   ...overrides,
 });
 

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -6,12 +6,19 @@ const log = getLogger("twilio-relay-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
+type RelaySocketData = {
+  callSessionId: string;
+  config: GatewayConfig;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
 /**
  * Create a WebSocket upgrade handler that proxies Twilio ConversationRelay
  * frames between Twilio and the runtime's /v1/calls/relay endpoint.
  */
 export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
-  return function handleUpgrade(req: Request, server: import("bun").Server): Response | undefined {
+  return function handleUpgrade(req: Request, server: import("bun").Server<RelaySocketData>): Response | undefined {
     const url = new URL(req.url);
     const callSessionId = url.searchParams.get("callSessionId");
 
@@ -32,13 +39,6 @@ export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
     return undefined;
   };
 }
-
-type RelaySocketData = {
-  callSessionId: string;
-  config: GatewayConfig;
-  upstream?: WebSocket;
-  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
-};
 
 /**
  * WebSocket handler config for Bun.serve() that proxies frames to runtime.


### PR DESCRIPTION
## Summary
- Fix Bun Server generic type argument in twilio-relay-websocket.ts and its test file
- Fix publicUrl → ingressPublicBaseUrl in telegram-webhook-manager test
- Fix WebSocket readyState type assignments in twilio-relay-websocket tests
- Fix fetch mock intercepts in telegram-deliver-auth tests
- Fix Request body reading in telegram-webhook-manager tests
- Ensure all test config helpers include gatewayInternalBaseUrl

Closes #6355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
