### PR TITLE
Fix attachment validation in telegram-deliver

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+import { createTelegramDeliverHandler } from "./telegram-deliver.js";
+
+// ---- Mocks ----
+
+mock.module("../../telegram/send.js", () => ({
+  sendTelegramReply: async () => {},
+  sendTelegramAttachments: async () => {},
+}));
+
+// ---- Helpers ----
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: "test-bot-token",
+    telegramDeliverAuthBypass: true,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: "test-secret",
+    twilioAuthToken: undefined,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "reject",
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:7830/deliver/telegram", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---- Tests ----
+
+describe("telegram-deliver attachment validation", () => {
+  const config = makeConfig();
+  const handler = createTelegramDeliverHandler(config);
+
+  it("returns 400 when attachments contains a null element", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [null],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("returns 400 when attachments contains a number", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [42],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("returns 400 when attachments contains a string", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: ["not-an-object"],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("returns 400 when attachments contains a nested array", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [["nested"]],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("returns 400 when attachments contains a boolean", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [true],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("returns 400 when an attachment object is missing an id", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [{ filename: "test.txt" }],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must have an id");
+  });
+
+  it("returns 400 when attachment id is not a string", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [{ id: 123 }],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must have an id");
+  });
+
+  it("returns 400 for a mix of valid and invalid elements", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [{ id: "att-1" }, null, { id: "att-2" }],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each attachment must be an object");
+  });
+
+  it("accepts valid attachments with string ids", async () => {
+    const req = makeRequest({
+      chatId: "123",
+      attachments: [{ id: "att-1" }, { id: "att-2", filename: "test.txt" }],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -56,9 +56,17 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "text or attachments required" }, { status: 400 });
     }
 
-    // Validate that each attachment has at least an id
+    // Validate attachment array shape and element types before accessing properties.
+    // Without these checks, null or non-object elements would throw a TypeError
+    // outside the delivery try/catch, producing an unhandled 500 instead of a 400.
     if (attachments) {
+      if (!Array.isArray(attachments)) {
+        return Response.json({ error: "attachments must be an array" }, { status: 400 });
+      }
       for (const att of attachments) {
+        if (att === null || typeof att !== "object" || Array.isArray(att)) {
+          return Response.json({ error: "each attachment must be an object" }, { status: 400 });
+        }
         if (!att.id || typeof att.id !== "string") {
           return Response.json({ error: "each attachment must have an id" }, { status: 400 });
         }


### PR DESCRIPTION
Addresses Codex P2 feedback on #6366.

- Add type/shape check for attachment elements before accessing .id
- Return 400 for malformed attachment items (null, non-object, missing id)
- Add test coverage for malformed attachment elements
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
