### PR TITLE
Handle daemon error frames in CLI twitter message helper

### DIFF
--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -503,6 +503,15 @@ function sendDaemonMessage(
           continue;
         }
 
+        // Reject immediately on daemon error frames so the CLI surfaces the
+        // real failure reason instead of hanging until the timeout fires.
+        if (m.type === 'error') {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          reject(new Error((m as { message?: string }).message ?? 'Daemon returned an error'));
+          return;
+        }
+
         // Only resolve on the expected response type; skip everything else
         if (m.type === expectedResponseType) {
           clearTimeout(timeoutHandle);


### PR DESCRIPTION
## Summary
- Reject immediately on daemon error frames instead of silently dropping them
- Prevents CLI from hanging on full timeout when daemon sends error responses

## Original PR
Addresses feedback from #6258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
