### PR TITLE
Normalize trailing slashes in gateway URL composition

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -30,7 +30,7 @@ import * as telegram from './client.js';
 /** Resolve the gateway base URL from GATEWAY_BASE_URL env var, falling back to localhost. */
 function getGatewayUrl(): string {
   if (process.env.GATEWAY_BASE_URL) {
-    return process.env.GATEWAY_BASE_URL;
+    return process.env.GATEWAY_BASE_URL.replace(/\/+$/, "");
   }
   const port = Number(process.env.GATEWAY_PORT) || 7830;
   return `http://127.0.0.1:${port}`;

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -124,8 +124,9 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_PORT must be a valid port number");
   }
 
-  const gatewayInternalBaseUrl =
-    process.env.GATEWAY_INTERNAL_BASE_URL || `http://127.0.0.1:${port}`;
+  const gatewayInternalBaseUrl = (
+    process.env.GATEWAY_INTERNAL_BASE_URL || `http://127.0.0.1:${port}`
+  ).replace(/\/+$/, "");
 
   const proxyEnabledRaw = process.env.GATEWAY_RUNTIME_PROXY_ENABLED;
   if (proxyEnabledRaw !== undefined && proxyEnabledRaw !== "true" && proxyEnabledRaw !== "false") {


### PR DESCRIPTION
## Summary
- Trim trailing slashes from gatewayInternalBaseUrl before composing callback URLs
- Trim trailing slashes from GATEWAY_BASE_URL in telegram adapter
- Prevents double-slash paths that would 404 on the gateway router

## Original PR
Addresses feedback from #6362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
