### PR TITLE
Fix /update command: kill all gateway modes and install gateway deps

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -10,6 +10,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    pkill -x "vellum-assistant" || true
    vellum daemon stop || true
    pkill -f "dev:proxy" || true
+   lsof -ti :7830 | xargs kill -9 2>/dev/null || true
    ```
 
 2. Switch to main and pull latest:
@@ -21,6 +22,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
 3. Install any new dependencies:
    ```bash
    cd assistant && bun install && cd ..
+   cd gateway && bun install && cd ..
    ```
 
 4. Start the daemon fresh with runtime HTTP enabled (required for gateway/Twilio/OAuth ingress):


### PR DESCRIPTION
## Summary
- Broaden gateway process kill to cover all launch modes (not just dev:proxy)
- Add gateway dependency installation step before starting gateway

## Original PR
Addresses feedback from #6364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
