### PR TITLE
Fix Twilio webhook signature URL candidate fallback logic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3724,8 +3724,8 @@ All webhook paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhoo
 
 For **inbound Twilio signature validation** at the gateway, URL reconstruction now supports multiple candidates in order:
 1. `config.ingressPublicBaseUrl` (if configured)
-2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`, with `X-Original-*`/`Host` fallbacks)
-3. Raw request URL fallback when no public candidates are available
+2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`/`X-Original-Host` fallbacks)
+3. Raw request URL (always included as the final fallback)
 
 This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating even before a gateway restart.
 

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -40,13 +40,15 @@ function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): strin
     firstHeaderValue(req.headers.get("x-original-proto"));
   const forwardedHost =
     firstHeaderValue(req.headers.get("x-forwarded-host")) ??
-    firstHeaderValue(req.headers.get("x-original-host")) ??
-    firstHeaderValue(req.headers.get("host"));
+    firstHeaderValue(req.headers.get("x-original-host"));
   if (forwardedProto && forwardedHost) {
     addBase(`${forwardedProto}://${forwardedHost}`);
   }
 
-  if (candidates.length === 0) {
+  // Always include the raw request URL as the final fallback candidate so
+  // valid signatures are not rejected when the other candidates are stale or
+  // incorrectly reconstructed (e.g. mixed proxy/tunnel setups).
+  if (!candidates.includes(req.url)) {
     candidates.push(req.url);
   }
 


### PR DESCRIPTION
## Summary
- Removed `Host` header fallback from the forwarded host resolution chain. The `Host` header represents the local server address in proxied setups, not the original public host, so using it as a fallback for `X-Forwarded-Host` could construct incorrect candidate URLs and suppress the `req.url` fallback.
- Changed `req.url` from a conditional last-resort (only when no other candidates exist) to always being appended as the final candidate. This ensures valid Twilio signatures are not rejected when other candidates are stale or incorrectly reconstructed.
- Updated ARCHITECTURE.md to reflect these changes.

## Original PR
Addresses feedback from #6051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
