### PR TITLE
fix: exclude system permission requests from keyboard focus selector

### DIFF
--- a/clients/shared/Features/Chat/PendingConfirmationFocusSelector.swift
+++ b/clients/shared/Features/Chat/PendingConfirmationFocusSelector.swift
@@ -2,14 +2,21 @@
 /// list of chat messages. Only the first pending confirmation in display order
 /// should own keyboard focus; lower ones wait until promoted.
 public enum PendingConfirmationFocusSelector {
-    /// Returns the `requestId` of the first message whose confirmation is
-    /// `.pending`, or `nil` if no pending confirmation exists.
+    /// Returns the `requestId` of the first keyboard-capable pending
+    /// confirmation, or `nil` if none exists.
+    ///
+    /// System-permission requests (`request_system_permission`) are excluded
+    /// because they render via a dedicated card without keyboard shortcut
+    /// support. Including them would block keyboard focus for tool-confirmation
+    /// bubbles stacked below.
     ///
     /// - Parameter messages: The ordered messages as rendered in the chat
     ///   (after any display filters have been applied).
     public static func activeRequestId(from messages: [ChatMessage]) -> String? {
         for message in messages {
-            if let confirmation = message.confirmation, confirmation.state == .pending {
+            if let confirmation = message.confirmation,
+               confirmation.state == .pending,
+               !confirmation.isSystemPermissionRequest {
                 return confirmation.requestId
             }
         }

--- a/clients/shared/Tests/PendingConfirmationFocusSelectorTests.swift
+++ b/clients/shared/Tests/PendingConfirmationFocusSelectorTests.swift
@@ -6,13 +6,13 @@ struct PendingConfirmationFocusSelectorTests {
 
     // MARK: - Helpers
 
-    private func makeConfirmationMessage(requestId: String, state: ToolConfirmationState) -> ChatMessage {
+    private func makeConfirmationMessage(requestId: String, state: ToolConfirmationState, toolName: String = "host_bash") -> ChatMessage {
         ChatMessage(
             role: .assistant,
             text: "",
             confirmation: ToolConfirmationData(
                 requestId: requestId,
-                toolName: "host_bash",
+                toolName: toolName,
                 input: [:],
                 riskLevel: "medium",
                 state: state
@@ -71,5 +71,37 @@ struct PendingConfirmationFocusSelectorTests {
         ]
         let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
         #expect(result == "req-4")
+    }
+
+    @Test("Skips pending system permission requests")
+    func skipsSystemPermissionRequests() {
+        let messages = [
+            makeConfirmationMessage(requestId: "req-perm", state: .pending, toolName: "request_system_permission"),
+            makeConfirmationMessage(requestId: "req-bash", state: .pending),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == "req-bash")
+    }
+
+    @Test("Returns nil when only system permission requests are pending")
+    func onlySystemPermissionsPending() {
+        let messages = [
+            makeConfirmationMessage(requestId: "req-perm-1", state: .pending, toolName: "request_system_permission"),
+            makeConfirmationMessage(requestId: "req-perm-2", state: .pending, toolName: "request_system_permission"),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == nil)
+    }
+
+    @Test("System permission before tool confirmation does not block focus handoff")
+    func systemPermissionDoesNotBlockFocusHandoff() {
+        let messages = [
+            makeConfirmationMessage(requestId: "req-1", state: .approved),
+            makeConfirmationMessage(requestId: "req-perm", state: .pending, toolName: "request_system_permission"),
+            makeConfirmationMessage(requestId: "req-3", state: .pending),
+            makeConfirmationMessage(requestId: "req-4", state: .pending),
+        ]
+        let result = PendingConfirmationFocusSelector.activeRequestId(from: messages)
+        #expect(result == "req-3")
     }
 }


### PR DESCRIPTION
## Summary
Fixed a bug where a pending `request_system_permission` confirmation could block keyboard shortcuts for tool-confirmation bubbles stacked below it. System permission cards render via a dedicated card UI without keyboard shortcut support, so they should not participate in focus selection. The `PendingConfirmationFocusSelector.activeRequestId` now skips `request_system_permission` confirmations.

Added three new test cases covering the exclusion behavior.

## Original PR
Addresses feedback from #6058

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
