### PR TITLE
fix: restore secure credential_store prompt for ngrok authtoken in public-ingress skill

### DIFF
--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -68,9 +68,21 @@ ngrok config check
 If not authenticated:
 
 1. Tell the user: "You need an ngrok account to create tunnels. If you don't have one, sign up at https://dashboard.ngrok.com/signup — it's free."
-2. Once they have an account, ask them to paste their auth token directly in chat. They can find it at https://dashboard.ngrok.com/get-started/your-authtoken.
+2. Once they have an account, use `credential_store` to securely collect their auth token. **Never ask the user to paste the token directly in chat.**
 
-3. Once the user provides the token, configure ngrok with it immediately:
+   Use `credential_store` with:
+   - action: `prompt`
+   - service: `ngrok`
+   - field: `authtoken`
+   - label: `ngrok Auth Token`
+   - description: `Get your auth token from https://dashboard.ngrok.com/get-started/your-authtoken`
+   - usage_description: `ngrok authentication token for creating public tunnels`
+
+3. Once the credential is stored, retrieve it and configure ngrok:
+```
+credential_store action=get service=ngrok field=authtoken
+```
+Then use the retrieved value:
 ```bash
 ngrok config add-authtoken <token>
 ```


### PR DESCRIPTION
## Summary
Restores the secure `credential_store` prompt flow for collecting the ngrok auth token in the public-ingress skill. PR #6053 replaced this with asking users to paste their token directly in chat, which exposes a long-lived credential in conversation history and any downstream logging/telemetry. This change:

- Restores `credential_store` with `action: prompt` to securely collect the ngrok authtoken via the OS keychain
- Adds an explicit `credential_store action=get` step to retrieve the stored token before configuring ngrok
- Adds a clear warning: **Never ask the user to paste the token directly in chat**
- Follows the same pattern used by other skills (agentmail, phone-calls, telegram-setup)

## Original PR
Addresses feedback from #6053

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
