### PR TITLE
Fix ingress toggle backward compat and env var clearing

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1056,11 +1056,18 @@ export const SkillsConfigSchema = z.object({
 export const IngressConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'ingress.enabled must be a boolean' })
-    .default(false),
+    .optional(),
   publicBaseUrl: z
     .string({ error: 'ingress.publicBaseUrl must be a string' })
     .default(''),
-});
+}).transform((val) => ({
+  ...val,
+  // Backward compatibility: if `enabled` was never explicitly set (undefined),
+  // infer it from whether a publicBaseUrl is configured. Existing users who
+  // have a URL but predate the `enabled` field should not have their webhooks
+  // silently disabled on upgrade.
+  enabled: val.enabled ?? (val.publicBaseUrl ? true : false),
+}));
 
 export const AssistantConfigSchema = z.object({
   provider: z
@@ -1334,7 +1341,6 @@ export const AssistantConfigSchema = z.object({
     },
   }),
   ingress: IngressConfigSchema.default({
-    enabled: false,
     publicBaseUrl: '',
   }),
 }).superRefine((config, ctx) => {

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -420,7 +420,10 @@ export function handleIngressConfig(
       const raw = loadRawConfig();
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       const publicBaseUrl = (ingress.publicBaseUrl as string) ?? '';
-      const enabled = (ingress.enabled as boolean) ?? false;
+      // Backward compatibility: if `enabled` was never explicitly set,
+      // infer from whether a publicBaseUrl is configured so existing users
+      // who predate the toggle aren't silently disabled.
+      const enabled = (ingress.enabled as boolean | undefined) ?? (publicBaseUrl ? true : false);
       ctx.send(socket, { type: 'ingress_config_response', enabled, publicBaseUrl, localGatewayTarget, success: true });
     } else if (msg.action === 'set') {
       const value = (msg.publicBaseUrl ?? '').trim().replace(/\/+$/, '');
@@ -456,7 +459,10 @@ export function handleIngressConfig(
       // so updating process.env here ensures the value is visible when the
       // gateway is restarted (e.g. by the self-upgrade skill or a manual
       // `pkill -f gateway`).
-      if (value) {
+      // Only export the URL when ingress is enabled; clearing it when
+      // disabled ensures the gateway stops accepting inbound webhooks.
+      const isEnabled = (ingress.enabled as boolean | undefined) ?? (value ? true : false);
+      if (value && isEnabled) {
         process.env.INGRESS_PUBLIC_BASE_URL = value;
       } else if (ORIGINAL_INGRESS_ENV !== undefined) {
         process.env.INGRESS_PUBLIC_BASE_URL = ORIGINAL_INGRESS_ENV;
@@ -464,8 +470,7 @@ export function handleIngressConfig(
         delete process.env.INGRESS_PUBLIC_BASE_URL;
       }
 
-      const enabled = (ingress.enabled as boolean) ?? false;
-      ctx.send(socket, { type: 'ingress_config_response', enabled, publicBaseUrl: value, localGatewayTarget, success: true });
+      ctx.send(socket, { type: 'ingress_config_response', enabled: isEnabled, publicBaseUrl: value, localGatewayTarget, success: true });
     } else {
       ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }


### PR DESCRIPTION
## Summary
- Fix backward compatibility regression where existing users with a configured `publicBaseUrl` but no explicit `enabled` field would have their webhooks silently disabled on upgrade. The Zod schema now uses a transform to infer `enabled: true` when a URL is present and `enabled` was not explicitly set.
- Fix the config handler's `get` action to apply the same backward-compat logic when reading raw config.
- Fix `INGRESS_PUBLIC_BASE_URL` env var to only be exported when ingress is both configured and enabled, so toggling ingress off actually stops the gateway from accepting webhooks.

## Original PR
Addresses feedback from #6060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
