### PR TITLE
fix: restrict Tab and Escape to unmodified keys in tool confirmation monitor

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -420,8 +420,8 @@ public struct ToolConfirmationBubble: View {
                 // Shift+Tab — move left
                 keyboardModel?.moveLeft()
                 return nil
-            case 48:
-                // Tab — move right
+            case 48 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
+                // Plain Tab — move right (modified Tab passes through)
                 keyboardModel?.moveRight()
                 return nil
             case 36, 76 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
@@ -430,8 +430,8 @@ public struct ToolConfirmationBubble: View {
                     activateAction(action)
                 }
                 return nil
-            case 53:
-                // Escape — deny
+            case 53 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
+                // Plain Escape — deny (modified Escape passes through)
                 activateAction(.dontAllow)
                 return nil
             default:


### PR DESCRIPTION
## Summary
Extends the modifier-flag guard (already applied to Return in #6035) to Tab and Escape key handling in the tool confirmation keyboard monitor. Modified Tab (e.g., Ctrl+Tab, Option+Tab) and modified Escape (e.g., Ctrl+Escape) now pass through instead of being consumed by the confirmation bubble's key monitor.

This completes the pattern established by the Codex review on PR #5999 which flagged that modified key events were being consumed unintentionally.

## Original PR
Addresses feedback from #5999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
