### PR TITLE
fix: strip scheme-less URLs in conflict relevance tokenizer (#6345)

### DIFF
--- a/assistant/src/__tests__/conflict-intent-tokenization.test.ts
+++ b/assistant/src/__tests__/conflict-intent-tokenization.test.ts
@@ -46,6 +46,19 @@ describe('tokenizeForConflictRelevance hardening', () => {
     expect(standaloneRelevance).toBeGreaterThan(0);
   });
 
+  test('strips scheme-less bare domain URLs from relevance', () => {
+    const relevance = computeConflictRelevance(
+      'Check github.com/org/repo/pull/123',
+      {
+        existingStatement: 'Review gitlab.com/org/repo/issues/456',
+        candidateStatement: 'Review github.com/org/repo/pull/789',
+      },
+    );
+    // Bare URLs should be stripped entirely; tokens like "pull", "issues"
+    // embedded in paths must not contribute to overlap
+    expect(relevance).toBeLessThanOrEqual(0.5);
+  });
+
   test('still computes meaningful relevance for real content tokens', () => {
     const relevance = computeConflictRelevance(
       'Should I use React for frontend?',

--- a/assistant/src/memory/conflict-intent.ts
+++ b/assistant/src/memory/conflict-intent.ts
@@ -26,7 +26,10 @@ const NOISE_TOKENS = new Set([
   'http', 'https', 'github', 'gitlab', 'www', 'com', 'org',
 ]);
 
-const URL_PATTERN = /https?:\/\/[^\s)>\]]+/gi;
+// Matches full URLs (http(s)://...) and scheme-less bare domain URLs
+// (e.g. github.com/org/repo/pull/123) so embedded path segments like
+// "pull", "issue", "ticket" don't leak into relevance scoring.
+const URL_PATTERN = /https?:\/\/[^\s)>\]]+|[a-z0-9-]+\.[a-z]{2,}\/[^\s)>\]]*/gi;
 
 function tokenizeForConflictRelevance(input: string): Set<string> {
   const stripped = input.replace(URL_PATTERN, ' ');


### PR DESCRIPTION
Address reviewer feedback from PR #6345: the URL stripping regex only matched http(s):// URLs, so bare links like github.com/org/repo/pull/123 still leaked tracking tokens (pull/issue/ticket) into relevance scoring. Extended the regex to also strip scheme-less URLs (domain.tld/path patterns).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
