### PR TITLE
calls: enforce assistant-number implicit default; require explicit user-number mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3801,13 +3801,13 @@ Call behavior is controlled via the `calls` config block in the assistant config
 
 ### Caller Identity Resolution
 
-When a call is initiated, the system resolves the caller identity (which phone number to show as the caller ID). By default, the assistant's Twilio number is used (`assistant_number` mode). Users can opt into `user_number` mode, which uses their own verified phone number. The identity mode is validated against Twilio's eligible caller IDs before the call is placed. The resolved identity mode and source are persisted in the `call_sessions` table for auditability.
+When a call is initiated, the system resolves the caller identity (which phone number to show as the caller ID). **Implicit calls (no explicit `callerIdentityMode`) always use `assistant_number`** — the assistant's Twilio number. `user_number` mode is only used when explicitly requested per call. The identity mode is validated against Twilio's eligible caller IDs before the call is placed. The resolved identity mode and source are persisted in the `call_sessions` table for auditability.
 
 The resolution is performed by `resolveCallerIdentity()` in `call-domain.ts`:
 
 1. **Per-call override** — If `callerIdentityMode` is provided in the call input and `calls.callerIdentity.allowPerCallOverride` is enabled, the requested mode is used (source: `per_call_override`).
-2. **Config default** — Otherwise, the configured `calls.callerIdentity.defaultMode` is used (source: `config_default`).
-3. **User number lookup** — For `user_number` mode, the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`), `TWILIO_USER_PHONE_NUMBER` environment variable (source: `env_var`), or the `credential:twilio:user_phone_number` secure key (source: `secure_key`).
+2. **Implicit default** — Otherwise, `assistant_number` is always used (source: `implicit_default`). There is no configurable default mode — this is a strict policy.
+3. **User number lookup** — For `user_number` mode (explicit only), the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`), `TWILIO_USER_PHONE_NUMBER` environment variable (source: `env_var`), or the `credential:twilio:user_phone_number` secure key (source: `secure_key`).
 4. **Eligibility check** — User numbers are verified against the Twilio API to confirm they can be used as an outbound caller ID.
 
 Both the resolved mode and source are logged at info level on success, and rejections are logged at warn level.

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for caller identity resolution in call-domain.ts.
+ *
+ * Validates the strict implicit-default policy:
+ * - Implicit calls (no explicit mode) always use assistant_number.
+ * - Explicit user_number calls succeed when eligible.
+ * - Explicit user_number calls fail clearly when missing/ineligible.
+ * - Explicit override rejected when allowPerCallOverride=false.
+ */
+import { describe, test, expect, mock } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'call-domain-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../calls/twilio-config.js', () => ({
+  getTwilioConfig: () => ({
+    accountSid: 'AC_test',
+    authToken: 'test_token',
+    phoneNumber: '+15550001111',
+    webhookBaseUrl: 'https://test.example.com',
+    wssBaseUrl: 'wss://test.example.com',
+  }),
+}));
+
+mock.module('../calls/twilio-provider.js', () => ({
+  TwilioConversationRelayProvider: class {
+    async checkCallerIdEligibility(number: string) {
+      // Simulate: +15550002222 is eligible, others are not
+      if (number === '+15550002222') return { eligible: true };
+      return { eligible: false, reason: `${number} is not eligible as a caller ID` };
+    }
+  },
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => null,
+}));
+
+import { resolveCallerIdentity } from '../calls/call-domain.js';
+import type { AssistantConfig } from '../config/types.js';
+
+function makeConfig(overrides: {
+  allowPerCallOverride?: boolean;
+  userNumber?: string;
+} = {}): AssistantConfig {
+  return {
+    calls: {
+      callerIdentity: {
+        allowPerCallOverride: overrides.allowPerCallOverride ?? true,
+        userNumber: overrides.userNumber,
+      },
+    },
+  } as unknown as AssistantConfig;
+}
+
+describe('resolveCallerIdentity — strict implicit-default policy', () => {
+  test('implicit call defaults to assistant_number', async () => {
+    const result = await resolveCallerIdentity(makeConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('assistant_number');
+      expect(result.fromNumber).toBe('+15550001111');
+      expect(result.source).toBe('implicit_default');
+    }
+  });
+
+  test('implicit call uses assistant_number even when userNumber is configured', async () => {
+    const result = await resolveCallerIdentity(
+      makeConfig({ userNumber: '+15550002222' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('assistant_number');
+      expect(result.fromNumber).toBe('+15550001111');
+      expect(result.source).toBe('implicit_default');
+    }
+  });
+
+  test('explicit user_number succeeds when eligible', async () => {
+    const result = await resolveCallerIdentity(
+      makeConfig({ userNumber: '+15550002222' }),
+      'user_number',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('user_number');
+      expect(result.fromNumber).toBe('+15550002222');
+      expect(result.source).toBe('user_config');
+    }
+  });
+
+  test('explicit user_number fails when no user phone configured', async () => {
+    const result = await resolveCallerIdentity(makeConfig(), 'user_number');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('user_number');
+      expect(result.error).toContain('user phone number');
+    }
+  });
+
+  test('explicit user_number fails when number is ineligible', async () => {
+    const result = await resolveCallerIdentity(
+      makeConfig({ userNumber: '+15559999999' }),
+      'user_number',
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('not eligible');
+    }
+  });
+
+  test('explicit override rejected when allowPerCallOverride=false', async () => {
+    const result = await resolveCallerIdentity(
+      makeConfig({ allowPerCallOverride: false, userNumber: '+15550002222' }),
+      'user_number',
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('override is disabled');
+    }
+  });
+
+  test('explicit assistant_number override succeeds when allowed', async () => {
+    const result = await resolveCallerIdentity(makeConfig(), 'assistant_number');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('assistant_number');
+      expect(result.source).toBe('per_call_override');
+    }
+  });
+
+  test('invalid mode returns error', async () => {
+    const result = await resolveCallerIdentity(
+      makeConfig(),
+      'custom_number' as 'assistant_number',
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Invalid callerIdentityMode');
+    }
+  });
+});

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -39,7 +39,6 @@ const mockCallsConfig = {
   disclosure: { enabled: false, text: '' },
   safety: { denyCategories: [] },
   callerIdentity: {
-    defaultMode: 'assistant_number' as const,
     allowPerCallOverride: true,
   },
 };

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -704,7 +704,6 @@ describe('AssistantConfigSchema', () => {
         },
       },
       callerIdentity: {
-        defaultMode: 'assistant_number',
         allowPerCallOverride: true,
       },
     });
@@ -903,7 +902,6 @@ describe('AssistantConfigSchema', () => {
   test('applies calls.callerIdentity defaults', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.calls.callerIdentity).toEqual({
-      defaultMode: 'assistant_number',
       allowPerCallOverride: true,
     });
   });
@@ -912,37 +910,25 @@ describe('AssistantConfigSchema', () => {
     const result = AssistantConfigSchema.parse({
       calls: {
         callerIdentity: {
-          defaultMode: 'user_number',
           allowPerCallOverride: false,
           userNumber: '+14155559999',
         },
       },
     });
-    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
     expect(result.calls.callerIdentity.allowPerCallOverride).toBe(false);
     expect(result.calls.callerIdentity.userNumber).toBe('+14155559999');
   });
 
-  test('accepts partial calls.callerIdentity with defaults for missing fields', () => {
+  test('legacy defaultMode field is silently stripped by schema', () => {
+    // Backward compatibility: existing configs with defaultMode should parse
+    // without error — Zod strips unrecognized keys by default.
     const result = AssistantConfigSchema.parse({
       calls: {
-        callerIdentity: { defaultMode: 'user_number' },
+        callerIdentity: { defaultMode: 'user_number', allowPerCallOverride: true },
       },
     });
-    expect(result.calls.callerIdentity.defaultMode).toBe('user_number');
+    expect((result.calls.callerIdentity as Record<string, unknown>).defaultMode).toBeUndefined();
     expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
-    expect(result.calls.callerIdentity.userNumber).toBeUndefined();
-  });
-
-  test('rejects invalid calls.callerIdentity.defaultMode', () => {
-    const result = AssistantConfigSchema.safeParse({
-      calls: { callerIdentity: { defaultMode: 'custom_number' } },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const msgs = result.error.issues.map(i => i.message);
-      expect(msgs.some(m => m.includes('calls.callerIdentity.defaultMode'))).toBe(true);
-    }
   });
 
   test('rejects non-boolean calls.callerIdentity.allowPerCallOverride', () => {
@@ -956,7 +942,6 @@ describe('AssistantConfigSchema', () => {
     const result = AssistantConfigSchema.parse({
       calls: { enabled: true },
     });
-    expect(result.calls.callerIdentity.defaultMode).toBe('assistant_number');
     expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
   });
 });
@@ -1369,7 +1354,6 @@ describe('loadConfig with schema validation', () => {
     expect(config.calls.voice.elevenlabs.voiceId).toBe('');
     expect(config.calls.model).toBeUndefined();
     expect(config.calls.callerIdentity).toEqual({
-      defaultMode: 'assistant_number',
       allowPerCallOverride: true,
     });
   });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -66,7 +66,7 @@ export type AnswerCallInput = {
 
 // ── Caller identity resolution ───────────────────────────────────────
 
-export type CallerIdentitySource = 'per_call_override' | 'config_default' | 'twilio_config' | 'user_config' | 'secure_key' | 'env_var';
+export type CallerIdentitySource = 'per_call_override' | 'implicit_default' | 'user_config' | 'secure_key' | 'env_var';
 
 export type CallerIdentityResult =
   | { ok: true; mode: 'assistant_number' | 'user_number'; fromNumber: string; source: CallerIdentitySource }
@@ -75,9 +75,12 @@ export type CallerIdentityResult =
 /**
  * Resolve which phone number to use as the caller ID for an outbound call.
  *
+ * Policy: implicit calls (no explicit mode) always use `assistant_number`.
+ * `user_number` is only used when explicitly requested per call.
+ *
  * - If `requestedMode` is provided and per-call overrides are allowed, use it.
  * - If `requestedMode` is provided but overrides are disabled, return an error.
- * - Otherwise fall through to the configured default mode.
+ * - Otherwise, always use `assistant_number` (implicit default).
  *
  * For `assistant_number`: uses the Twilio phone number from `getTwilioConfig()`.
  *   No eligibility check is performed — this is a fast path.
@@ -104,14 +107,15 @@ export async function resolveCallerIdentity(
     mode = requestedMode;
     source = 'per_call_override';
   } else {
-    mode = identityConfig.defaultMode;
-    source = 'config_default';
+    // Implicit calls always use assistant_number regardless of config
+    mode = 'assistant_number';
+    source = 'implicit_default';
   }
 
   if (mode === 'assistant_number') {
     const twilioConfig = getTwilioConfig();
-    log.info({ mode, source: 'twilio_config', fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
-    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source: 'twilio_config' };
+    log.info({ mode, source, fromNumber: twilioConfig.phoneNumber }, 'Resolved caller identity');
+    return { ok: true, mode, fromNumber: twilioConfig.phoneNumber, source };
   }
 
   // user_number mode: resolve from config or secure key, tracking where the number came from

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -27,7 +27,7 @@ Three voice quality modes are available:
 
 You can keep using Twilio only — no changes needed. Enabling ElevenLabs can improve naturalness and quality.
 
-The user's assistant gets its own personal phone number through Twilio. By default, all outbound calls are placed from this assistant number. Optionally, users can call from their own phone number if it's authorized with the Twilio account — this is called "caller identity mode" and can be configured as a default or selected per-call.
+The user's assistant gets its own personal phone number through Twilio. All implicit calls (without an explicit mode) always use this assistant number. Optionally, users can call from their own phone number if it's authorized with the Twilio account — this must be explicitly requested per call via `caller_identity_mode="user_number"`.
 
 ## Step 1: Check Current Configuration
 
@@ -149,11 +149,11 @@ If they agree, ask for their personal phone number and place a test call with a 
 
 ## Caller Identity
 
-By default, calls are placed from the assistant's Twilio phone number (the one stored as service `twilio`, field `phone_number`). This is the number that appears on the recipient's caller ID.
+All implicit calls (calls without an explicit `caller_identity_mode`) always use the assistant's Twilio phone number. This is the number that appears on the recipient's caller ID.
 
-### User-number mode
+### User-number mode (per-call only)
 
-If the user wants calls to appear as coming from their own phone number instead, they can enable **user-number mode**. The user's phone number must be either owned by or verified with the same Twilio account.
+If the user wants a specific call to appear as coming from their own phone number, they must explicitly pass `caller_identity_mode: 'user_number'` on that call. The user's phone number must be either owned by or verified with the same Twilio account.
 
 **To configure a user phone number:**
 
@@ -161,29 +161,14 @@ If the user wants calls to appear as coming from their own phone number instead,
 credential_store action=store service=twilio field=user_phone_number value=+14155559999
 ```
 
-**To set user-number mode as the default:**
-
-```bash
-vellum config set calls.callerIdentity.defaultMode user_number
-```
-
-**To use it for a single call** (without changing the default), pass `caller_identity_mode: 'user_number'` when calling `call_start` — see the Making Calls section for examples.
+**To use it for a specific call**, pass `caller_identity_mode: 'user_number'` when calling `call_start` — see the Making Calls section for examples. User-number mode cannot be set as a global default; it must be requested explicitly per call.
 
 ### Configuration reference
 
 | Setting | Description | Default |
 |---|---|---|
-| `calls.callerIdentity.defaultMode` | Which number to use as caller ID: `assistant_number` or `user_number` | `assistant_number` |
 | `calls.callerIdentity.allowPerCallOverride` | Whether per-call mode selection is allowed | `true` |
 | `calls.callerIdentity.userNumber` | Optional E.164 phone number for user-number mode (alternative to storing via `credential_store`) | *(empty)* |
-
-### Reverting to assistant number
-
-To switch back to the default:
-
-```bash
-vellum config set calls.callerIdentity.defaultMode assistant_number
-```
 
 ## Optional: Higher Quality Voice with ElevenLabs
 
@@ -278,7 +263,7 @@ call_start phone_number="+12125551234" task="Confirm the dentist appointment sch
 
 ### Caller identity in calls
 
-By default, calls use the configured default caller identity mode (see `calls.callerIdentity.defaultMode` — defaults to `assistant_number`). Only specify `caller_identity_mode` when you need to override the configured default for a specific call.
+Implicit calls always use the assistant's Twilio number (`assistant_number`). Only specify `caller_identity_mode` when the user explicitly requests a different identity for a specific call.
 
 **Default call (assistant number):**
 ```
@@ -290,7 +275,7 @@ call_start phone_number="+14155551234" task="Check store hours for today"
 call_start phone_number="+14155551234" task="Check store hours for today" caller_identity_mode="user_number"
 ```
 
-**Decision rule:** Use the configured default mode (`calls.callerIdentity.defaultMode`) unless the user explicitly requests a different mode for this call. When the configured default is `assistant_number`, the assistant's Twilio number is used. When configured as `user_number`, the user's verified number is used.
+**Decision rule:** Implicit calls (no explicit mode) always use the assistant's Twilio number. Only use `caller_identity_mode="user_number"` when the user explicitly requests it for a specific call.
 
 ### Phone number format
 
@@ -413,7 +398,6 @@ All call-related settings can be managed via `vellum config`:
 | `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
 | `calls.disclosure.text` | The disclosure message spoken at call start | `"I should let you know that I'm an AI assistant calling on behalf of my user."` |
 | `calls.model` | Override LLM model for call orchestration | *(uses default model)* |
-| `calls.callerIdentity.defaultMode` | Default caller ID mode: `assistant_number` or `user_number` | `assistant_number` |
 | `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection | `true` |
 | `calls.callerIdentity.userNumber` | E.164 phone number for user-number mode | *(empty)* |
 | `calls.voice.mode` | Voice quality mode (`twilio_standard`, `twilio_elevenlabs_tts`, `elevenlabs_agent`) | `twilio_standard` |
@@ -464,7 +448,7 @@ Run the **public-ingress** skill to set up ngrok and configure `ingress.publicBa
 The user's phone number is not owned by or verified with the Twilio account. The number must be either purchased through Twilio or added as a verified caller ID at https://console.twilio.com/us1/develop/phone-numbers/manage/verified.
 
 ### "Per-call caller identity override is disabled"
-The setting `calls.callerIdentity.allowPerCallOverride` is set to `false`, so per-call `caller_identity_mode` selection is not allowed. Either change the default mode with `vellum config set calls.callerIdentity.defaultMode user_number`, or re-enable overrides with `vellum config set calls.callerIdentity.allowPerCallOverride true`.
+The setting `calls.callerIdentity.allowPerCallOverride` is set to `false`, so per-call `caller_identity_mode` selection is not allowed. Re-enable overrides with `vellum config set calls.callerIdentity.allowPerCallOverride true`.
 
 ### Caller identity call fails on trial account
 Twilio trial accounts can only place calls to verified numbers, regardless of caller identity mode. The user's phone number must also be verified with Twilio. Upgrade to a paid account or verify both the source and destination numbers.

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -247,7 +247,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     },
     model: undefined,
     callerIdentity: {
-      defaultMode: 'assistant_number' as const,
       allowPerCallOverride: true,
     },
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -979,11 +979,6 @@ export const CallsVoiceConfigSchema = z.object({
 });
 
 export const CallerIdentityConfigSchema = z.object({
-  defaultMode: z
-    .enum(VALID_CALLER_IDENTITY_MODES, {
-      error: `calls.callerIdentity.defaultMode must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}`,
-    })
-    .default('assistant_number'),
   allowPerCallOverride: z
     .boolean({ error: 'calls.callerIdentity.allowPerCallOverride must be a boolean' })
     .default(true),
@@ -1041,7 +1036,6 @@ export const CallsConfigSchema = z.object({
     .string({ error: 'calls.model must be a string' })
     .optional(),
   callerIdentity: CallerIdentityConfigSchema.default({
-    defaultMode: 'assistant_number',
     allowPerCallOverride: true,
   }),
 });
@@ -1336,7 +1330,6 @@ export const AssistantConfigSchema = z.object({
       },
     },
     callerIdentity: {
-      defaultMode: 'assistant_number',
       allowPerCallOverride: true,
     },
   }),


### PR DESCRIPTION
## Summary
- Remove `calls.callerIdentity.defaultMode` from schema, defaults, and runtime — implicit calls always use `assistant_number`
- `user_number` mode now requires explicit per-call `callerIdentityMode` parameter; cannot be set as a global default
- Add `call-domain.test.ts` with 8 regression tests for the strict implicit-default policy
- Update SKILL.md and ARCHITECTURE.md to reflect the new policy unambiguously

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/calls-caller-identity-strict-default-one-pr-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
