### PR TITLE
fix(twitter): preserve dual-path recovery signals and clarify OAuth/browser setup guidance

### DIFF
--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -718,7 +718,7 @@ describe('Twitter integration config handler', () => {
 
   // --- Strategy tests ---
 
-  test('get_strategy returns auto by default', () => {
+  test('get_strategy returns auto by default with strategyConfigured=false', () => {
     const msg: TwitterIntegrationConfigRequest = {
       type: 'twitter_integration_config',
       action: 'get_strategy',
@@ -728,13 +728,14 @@ describe('Twitter integration config handler', () => {
     handleMessage(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
-    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    const res = sent[0] as { type: string; success: boolean; strategy: string; strategyConfigured: boolean };
     expect(res.type).toBe('twitter_integration_config_response');
     expect(res.success).toBe(true);
     expect(res.strategy).toBe('auto');
+    expect(res.strategyConfigured).toBe(false);
   });
 
-  test('set_strategy persists and can be read back', () => {
+  test('set_strategy persists and can be read back with strategyConfigured=true', () => {
     // Set strategy to oauth
     const setMsg: TwitterIntegrationConfigRequest = {
       type: 'twitter_integration_config',
@@ -745,9 +746,10 @@ describe('Twitter integration config handler', () => {
     handleMessage(setMsg, {} as net.Socket, ctx1);
 
     expect(sent1).toHaveLength(1);
-    const setRes = sent1[0] as { type: string; success: boolean; strategy: string };
+    const setRes = sent1[0] as { type: string; success: boolean; strategy: string; strategyConfigured: boolean };
     expect(setRes.success).toBe(true);
     expect(setRes.strategy).toBe('oauth');
+    expect(setRes.strategyConfigured).toBe(true);
 
     // Read it back with get_strategy
     const getMsg: TwitterIntegrationConfigRequest = {
@@ -758,9 +760,10 @@ describe('Twitter integration config handler', () => {
     handleMessage(getMsg, {} as net.Socket, ctx2);
 
     expect(sent2).toHaveLength(1);
-    const getRes = sent2[0] as { type: string; success: boolean; strategy: string };
+    const getRes = sent2[0] as { type: string; success: boolean; strategy: string; strategyConfigured: boolean };
     expect(getRes.success).toBe(true);
     expect(getRes.strategy).toBe('oauth');
+    expect(getRes.strategyConfigured).toBe(true);
 
     // Verify persistence via saveRawConfig
     expect(saveRawConfigCalls.length).toBeGreaterThan(0);
@@ -801,7 +804,7 @@ describe('Twitter integration config handler', () => {
     expect(res.error).toContain('Invalid strategy value');
   });
 
-  test('get action includes strategy field', () => {
+  test('get action includes strategy field with strategyConfigured=true when set', () => {
     // Set a specific strategy first
     rawConfigStore = { twitterOperationStrategy: 'browser' };
 
@@ -814,13 +817,14 @@ describe('Twitter integration config handler', () => {
     handleMessage(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
-    const res = sent[0] as { type: string; success: boolean; strategy: string; mode: string };
+    const res = sent[0] as { type: string; success: boolean; strategy: string; strategyConfigured: boolean; mode: string };
     expect(res.type).toBe('twitter_integration_config_response');
     expect(res.success).toBe(true);
     expect(res.strategy).toBe('browser');
+    expect(res.strategyConfigured).toBe(true);
   });
 
-  test('get action returns auto strategy by default', () => {
+  test('get action returns auto strategy by default with strategyConfigured=false', () => {
     const msg: TwitterIntegrationConfigRequest = {
       type: 'twitter_integration_config',
       action: 'get',
@@ -830,8 +834,9 @@ describe('Twitter integration config handler', () => {
     handleMessage(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
-    const res = sent[0] as { type: string; success: boolean; strategy: string };
+    const res = sent[0] as { type: string; success: boolean; strategy: string; strategyConfigured: boolean };
     expect(res.strategy).toBe('auto');
+    expect(res.strategyConfigured).toBe(false);
   });
 
   test('set_strategy cycles through all valid values', () => {

--- a/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
+++ b/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for CLI error-shaping logic in the `run()` helper of twitter.ts.
+ *
+ * These tests verify that structured router metadata (pathUsed,
+ * suggestAlternative, oauthError) is preserved in CLI output while
+ * maintaining backward-compatible error codes.
+ */
+import { describe, test, expect } from 'bun:test';
+import { SessionExpiredError } from '../twitter/client.js';
+
+// ---------------------------------------------------------------------------
+// We test the error-shaping logic directly by reproducing the branching in
+// the CLI `run()` function. The actual `run()` function writes to stdout and
+// sets process.exitCode, which makes it awkward to test in isolation. Instead
+// we extract the payload-building logic into a pure helper and verify its
+// output here.
+// ---------------------------------------------------------------------------
+
+const SESSION_EXPIRED_MSG =
+  'Your Twitter session has expired. Please sign in to Twitter in Chrome — ' +
+  'run `vellum twitter refresh` to capture your session automatically.';
+
+/**
+ * Replicates the error-to-payload logic from `run()` in twitter.ts.
+ * Returns the JSON payload that would be written to stdout.
+ */
+function buildErrorPayload(err: unknown): Record<string, unknown> | null {
+  const meta = err as Record<string, unknown>;
+
+  if (err instanceof SessionExpiredError) {
+    const payload: Record<string, unknown> = {
+      ok: false,
+      error: 'session_expired',
+      message: SESSION_EXPIRED_MSG,
+    };
+    if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
+    if (meta.suggestAlternative !== undefined) payload.suggestAlternative = meta.suggestAlternative;
+    if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+    return payload;
+  }
+
+  if (err instanceof Error && meta.suggestAlternative !== undefined) {
+    const payload: Record<string, unknown> = {
+      ok: false,
+      error: err.message,
+    };
+    if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
+    payload.suggestAlternative = meta.suggestAlternative;
+    if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+    return payload;
+  }
+
+  // Generic fallback
+  return { ok: false, error: err instanceof Error ? err.message : String(err) };
+}
+
+describe('CLI error shaping', () => {
+  test('plain SessionExpiredError preserves backward-compatible error code', () => {
+    const err = new SessionExpiredError('No Twitter session found.');
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'session_expired',
+      message: SESSION_EXPIRED_MSG,
+    });
+  });
+
+  test('SessionExpiredError from browser path preserves pathUsed and suggestAlternative', () => {
+    const err = Object.assign(new SessionExpiredError('Session cookies expired'), {
+      pathUsed: 'browser' as const,
+      suggestAlternative: 'oauth' as const,
+    });
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'session_expired',
+      message: SESSION_EXPIRED_MSG,
+      pathUsed: 'browser',
+      suggestAlternative: 'oauth',
+    });
+  });
+
+  test('SessionExpiredError from auto path preserves pathUsed and oauthError', () => {
+    const err = Object.assign(new SessionExpiredError('Session cookies expired'), {
+      pathUsed: 'auto' as const,
+      oauthError: 'Token revoked',
+    });
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'session_expired',
+      message: SESSION_EXPIRED_MSG,
+      pathUsed: 'auto',
+      oauthError: 'Token revoked',
+    });
+  });
+
+  test('routed non-session error with suggestAlternative emits structured JSON', () => {
+    const err = Object.assign(
+      new Error('OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy.'),
+      {
+        pathUsed: 'oauth' as const,
+        suggestAlternative: 'browser' as const,
+      },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy.',
+      pathUsed: 'oauth',
+      suggestAlternative: 'browser',
+    });
+  });
+
+  test('routed auto-mode error with oauthError and suggestAlternative', () => {
+    const err = Object.assign(
+      new Error('Both OAuth and browser paths failed'),
+      {
+        pathUsed: 'auto' as const,
+        suggestAlternative: 'browser' as const,
+        oauthError: 'Twitter API error (401)',
+      },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'Both OAuth and browser paths failed',
+      pathUsed: 'auto',
+      suggestAlternative: 'browser',
+      oauthError: 'Twitter API error (401)',
+    });
+  });
+
+  test('generic error without router metadata falls back to plain error', () => {
+    const err = new Error('Network connection failed');
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'Network connection failed',
+    });
+  });
+
+  test('non-Error value falls back to stringified error', () => {
+    const payload = buildErrorPayload('some string error');
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'some string error',
+    });
+  });
+
+  test('backward compatibility: session_expired error code is always preserved', () => {
+    // Even with metadata, the error code stays 'session_expired'
+    const err = Object.assign(new SessionExpiredError('expired'), {
+      pathUsed: 'auto' as const,
+      suggestAlternative: 'oauth' as const,
+      oauthError: 'token expired',
+    });
+    const payload = buildErrorPayload(err);
+
+    expect(payload!.error).toBe('session_expired');
+    expect(payload!.ok).toBe(false);
+    expect(payload!.pathUsed).toBe('auto');
+    expect(payload!.suggestAlternative).toBe('oauth');
+    expect(payload!.oauthError).toBe('token expired');
+  });
+});

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -69,11 +69,31 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       getJson(cmd),
     );
   } catch (err) {
+    const meta = err as Record<string, unknown>;
     if (err instanceof SessionExpiredError) {
-      output(
-        { ok: false, error: 'session_expired', message: SESSION_EXPIRED_MSG },
-        getJson(cmd),
-      );
+      // Preserve backward-compatible error code while surfacing router metadata
+      const payload: Record<string, unknown> = {
+        ok: false,
+        error: 'session_expired',
+        message: SESSION_EXPIRED_MSG,
+      };
+      if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
+      if (meta.suggestAlternative !== undefined) payload.suggestAlternative = meta.suggestAlternative;
+      if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+      output(payload, getJson(cmd));
+      process.exitCode = 1;
+      return;
+    }
+    // For routed errors with suggestAlternative, emit structured JSON
+    if (err instanceof Error && meta.suggestAlternative !== undefined) {
+      const payload: Record<string, unknown> = {
+        ok: false,
+        error: err.message,
+      };
+      if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
+      payload.suggestAlternative = meta.suggestAlternative;
+      if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+      output(payload, getJson(cmd));
       process.exitCode = 1;
       return;
     }
@@ -90,7 +110,7 @@ export function registerTwitterCommand(program: Command): void {
     .command('x')
     .alias('twitter')
     .description(
-      'Post on X and manage sessions. Requires a session imported from a Ride Shotgun recording.',
+      'Post on X and manage connections. Supports OAuth (official API) and browser session paths.',
     )
     .option('--json', 'Machine-readable JSON output');
 
@@ -199,6 +219,7 @@ export function registerTwitterCommand(program: Command): void {
           oauthConnected: r.connected ?? false,
           oauthAccount: r.accountInfo ?? undefined,
           preferredStrategy: r.strategy ?? 'auto',
+          strategyConfigured: r.strategyConfigured ?? false,
         };
       } catch {
         // Daemon may not be running; report what we can from the local session
@@ -206,6 +227,7 @@ export function registerTwitterCommand(program: Command): void {
           oauthConnected: undefined,
           oauthAccount: undefined,
           preferredStrategy: undefined,
+          strategyConfigured: undefined,
         };
       }
 

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "X"
-description: "Read and post on X (formerly Twitter) using your authenticated session"
+description: "Read and post on X (formerly Twitter) via OAuth or browser session"
 user-invocable: true
 metadata: {"vellum": {"emoji": "𝕏"}}
 ---
@@ -42,10 +42,10 @@ When the user triggers a Twitter operation and no strategy has been configured y
    ```bash
    vellum x status --json
    ```
-   Look at `oauthConnected`, `browserSessionActive`, and `preferredStrategy` in the response.
+   Look at `oauthConnected`, `browserSessionActive`, `preferredStrategy`, and `strategyConfigured` in the response. If `strategyConfigured` is `false`, the user has not yet chosen a strategy and should be guided through setup.
 
 2. **Present both options with trade-offs:**
-   - **OAuth**: Most reliable and official. Requires X developer app credentials (API key and secret). Supports posting and replying. Set up through Settings UI.
+   - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up through Settings UI.
    - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh`.
 
 3. **Ask the user which they prefer.** Do not choose for them.

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -552,6 +552,7 @@ export function handleTwitterIntegrationConfig(
       const raw = loadRawConfig();
       const mode = (raw.twitterIntegrationMode as 'local_byo' | 'managed' | undefined) ?? 'local_byo';
       const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
+      const strategyConfigured = Object.prototype.hasOwnProperty.call(raw, 'twitterOperationStrategy');
       const localClientConfigured = !!getSecureKey('credential:integration:twitter:oauth_client_id');
       const connected = !!getSecureKey('credential:integration:twitter:access_token');
       const meta = getCredentialMetadata('integration:twitter', 'access_token');
@@ -564,10 +565,12 @@ export function handleTwitterIntegrationConfig(
         connected,
         accountInfo: meta?.accountInfo ?? undefined,
         strategy,
+        strategyConfigured,
       });
     } else if (msg.action === 'get_strategy') {
       const raw = loadRawConfig();
       const strategy = (raw.twitterOperationStrategy as 'oauth' | 'browser' | 'auto' | undefined) ?? 'auto';
+      const strategyConfigured = Object.prototype.hasOwnProperty.call(raw, 'twitterOperationStrategy');
       ctx.send(socket, {
         type: 'twitter_integration_config_response',
         success: true,
@@ -575,6 +578,7 @@ export function handleTwitterIntegrationConfig(
         localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
         connected: !!getSecureKey('credential:integration:twitter:access_token'),
         strategy,
+        strategyConfigured,
       });
     } else if (msg.action === 'set_strategy') {
       const valid = ['oauth', 'browser', 'auto'];
@@ -600,6 +604,7 @@ export function handleTwitterIntegrationConfig(
         localClientConfigured: !!getSecureKey('credential:integration:twitter:oauth_client_id'),
         connected: !!getSecureKey('credential:integration:twitter:access_token'),
         strategy: value as 'oauth' | 'browser' | 'auto',
+        strategyConfigured: true,
       });
     } else if (msg.action === 'set_mode') {
       const raw = loadRawConfig();

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -510,6 +510,8 @@ export interface TwitterIntegrationConfigResponse {
   connected: boolean;
   accountInfo?: string;
   strategy?: 'oauth' | 'browser' | 'auto';
+  /** Whether the user has explicitly set a strategy (vs. relying on the default 'auto'). */
+  strategyConfigured?: boolean;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
- Preserves structured recovery metadata in CLI failures (pathUsed, suggestAlternative, oauthError) while keeping backward-compatible error codes
- Adds explicit strategyConfigured state to Twitter integration config responses and vellum x status
- Fixes residual user-facing copy that implied session-only behavior or incorrect OAuth credential wording
- Adds focused tests for new status and error-shaping behavior

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/twitter-dual-path-followup-pr-draft.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
