### PR TITLE
fix: restrict scheme-less URL matching to known hosting domains (#6382)

### DIFF
--- a/assistant/src/__tests__/conflict-intent-tokenization.test.ts
+++ b/assistant/src/__tests__/conflict-intent-tokenization.test.ts
@@ -59,6 +59,18 @@ describe('tokenizeForConflictRelevance hardening', () => {
     expect(relevance).toBeLessThanOrEqual(0.5);
   });
 
+  test('preserves dotted identifiers that look like file paths', () => {
+    const relevance = computeConflictRelevance(
+      'Use index.ts/runtime parser',
+      {
+        existingStatement: 'Keep index.ts/runtime approach.',
+        candidateStatement: 'Switch to config.ts/runtime approach.',
+      },
+    );
+    // File-like identifiers should NOT be stripped as URLs
+    expect(relevance).toBeGreaterThan(0);
+  });
+
   test('still computes meaningful relevance for real content tokens', () => {
     const relevance = computeConflictRelevance(
       'Should I use React for frontend?',

--- a/assistant/src/memory/conflict-intent.ts
+++ b/assistant/src/memory/conflict-intent.ts
@@ -26,10 +26,12 @@ const NOISE_TOKENS = new Set([
   'http', 'https', 'github', 'gitlab', 'www', 'com', 'org',
 ]);
 
-// Matches full URLs (http(s)://...) and scheme-less bare domain URLs
-// (e.g. github.com/org/repo/pull/123) so embedded path segments like
-// "pull", "issue", "ticket" don't leak into relevance scoring.
-const URL_PATTERN = /https?:\/\/[^\s)>\]]+|[a-z0-9-]+\.[a-z]{2,}\/[^\s)>\]]*/gi;
+// Matches full URLs (http(s)://...) and scheme-less bare domain URLs for known
+// code hosting sites (e.g. github.com/org/repo/pull/123) so embedded path
+// segments like "pull", "issue", "ticket" don't leak into relevance scoring.
+// The scheme-less branch is restricted to known hosting domains to avoid
+// stripping dotted identifiers like "index.ts/runtime".
+const URL_PATTERN = /https?:\/\/[^\s)>\]]+|(?:github|gitlab|bitbucket)\.(?:com|org|io)\/[^\s)>\]]*/gi;
 
 function tokenizeForConflictRelevance(input: string): Set<string> {
   const stripped = input.replace(URL_PATTERN, ' ');


### PR DESCRIPTION
Address reviewer feedback from PR #6382: the scheme-less URL regex was too broad and matched dotted identifiers like index.ts/runtime. Restricted to known code hosting domains (github.com, gitlab.com, bitbucket.org/io). Added test to verify file-like identifiers are preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
