### PR TITLE
M2: Gateway baseline stabilization

### DIFF
--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -45,10 +45,11 @@ function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): strin
     addBase(`${forwardedProto}://${forwardedHost}`);
   }
 
-  // Always include the raw request URL as the final fallback candidate so
-  // valid signatures are not rejected when the other candidates are stale or
-  // incorrectly reconstructed (e.g. mixed proxy/tunnel setups).
-  if (!candidates.includes(req.url)) {
+  // Include the raw request URL as a fallback only when no canonical public
+  // URL is configured. When ingressPublicBaseUrl is set, we enforce that the
+  // signature matches the public URL (or forwarded headers) to prevent
+  // accepting signatures computed against the local/internal URL.
+  if (!config.ingressPublicBaseUrl && !candidates.includes(req.url)) {
     candidates.push(req.url);
   }
 


### PR DESCRIPTION
Fix gateway test failures and typecheck errors to restore green baseline. Closes #6386.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
