### PR TITLE
M3: Assistant validation + docs finalization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3538,11 +3538,10 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 On startup, the gateway automatically reconciles the Telegram webhook registration:
 
 1. Reads `INGRESS_PUBLIC_BASE_URL` and Telegram credentials (bot token, webhook secret)
-2. Calls `getWebhookInfo` to check the current registration
-3. Compares the URL, secret, and allowed updates against the expected values
-4. If any differ, calls `setWebhook` to update the registration
+2. Calls `getWebhookInfo` to log the current registration state
+3. Unconditionally calls `setWebhook` with the expected URL, secret, and allowed updates (idempotent — Telegram does not expose the current secret via `getWebhookInfo`, so a compare-then-set approach would miss secret rotations)
 
-This also runs when the credential watcher detects changes to Telegram credentials. Manual webhook registration is no longer required.
+This also runs when the credential watcher detects changes to Telegram credentials. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required. Manual webhook registration is no longer required.
 
 ### Routing Auto-Configuration
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -37,7 +37,7 @@ Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** s
    - Then call `skill_load` with `skill: "telegram-setup"`.
    - Tell the user: *"I've loaded a setup guide for Telegram. It will walk you through connecting a Telegram bot to your assistant."*
 
-The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering the webhook with Telegram, registering bot commands, and storing credentials securely.
+The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering bot commands, and storing credentials securely. Webhook registration with Telegram is handled automatically by the gateway on startup and whenever credentials change.
 
 ## Platform Selection
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1334,6 +1334,7 @@ export const AssistantConfigSchema = z.object({
     },
   }),
   ingress: IngressConfigSchema.default({
+    enabled: false,
     publicBaseUrl: '',
   }),
 }).superRefine((config, ctx) => {

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -47,7 +47,7 @@ Save this value for the next steps.
 
 Manual webhook registration is no longer required. The gateway automatically reconciles the Telegram webhook on startup and whenever credentials change. It compares the current webhook URL against `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` and updates it if needed, including the webhook secret and allowed updates.
 
-If the ingress URL or webhook secret changes (e.g., tunnel restart, secret rotation), the gateway will detect the drift and re-register the webhook automatically.
+If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL and re-register.
 
 You can skip directly to storing credentials.
 
@@ -96,7 +96,7 @@ Summarize what was done:
 - Credentials stored securely in the vault
 - Routing configuration validated
 
-The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the ingress URL or secret changes later, the gateway will automatically re-register the webhook.
+The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL.
 
 ## Bot-Account Limitations
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -69,7 +69,7 @@ v1 uses deterministic settings-based routing (no database):
 
 ## Setting up the Telegram webhook
 
-Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by comparing the current registration against `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram`. If the URL, secret, or allowed updates differ, the gateway re-registers the webhook automatically. This also runs whenever credentials change (e.g., tunnel restart, secret rotation).
+Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by registering it at `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` with the configured secret and allowed updates. This also runs whenever the credential watcher detects changes to the bot token or webhook secret (e.g., secret rotation). If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL.
 
 For manual setup (or reference), register the webhook with Telegram using the `setWebhook` API method. Pass:
 - `url` — your gateway URL, e.g. `https://your-host/webhooks/telegram`


### PR DESCRIPTION
Fix assistant typecheck blocker (IngressConfigSchema.default type mismatch) and align documentation with actual Telegram webhook reconciliation behavior. Closes #6387.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
