### PR TITLE
M1: Live ingress reconcile trigger

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -8,6 +8,7 @@ import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secu
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { postToSlackWebhook } from '../../slack/slack-webhook.js';
 import { getApp } from '../../memory/app-store.js';
+import { readHttpToken } from '../../util/platform.js';
 import type {
   ModelSetRequest,
   ImageGenModelSetRequest,
@@ -409,6 +410,43 @@ function computeLocalGatewayTarget(): string {
   return `http://127.0.0.1:${port}`;
 }
 
+/**
+ * Best-effort call to the gateway's internal reconcile endpoint so that
+ * Telegram webhook registration is updated immediately when the ingress
+ * URL changes, without requiring a gateway restart.
+ */
+function triggerGatewayReconcile(ingressPublicBaseUrl: string | undefined): void {
+  const gatewayBase = computeLocalGatewayTarget();
+  const token = readHttpToken();
+  if (!token) {
+    log.debug('Skipping gateway reconcile trigger: no HTTP bearer token available');
+    return;
+  }
+
+  const url = `${gatewayBase}/internal/telegram/reconcile`;
+  const body = ingressPublicBaseUrl
+    ? JSON.stringify({ ingressPublicBaseUrl })
+    : '{}';
+
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body,
+    signal: AbortSignal.timeout(5_000),
+  }).then((res) => {
+    if (res.ok) {
+      log.info('Gateway Telegram webhook reconcile triggered successfully');
+    } else {
+      log.warn({ status: res.status }, 'Gateway Telegram webhook reconcile returned non-OK status');
+    }
+  }).catch((err) => {
+    log.debug({ err }, 'Gateway Telegram webhook reconcile failed (gateway may not be running)');
+  });
+}
+
 export function handleIngressConfig(
   msg: IngressConfigRequest,
   socket: net.Socket,
@@ -471,6 +509,12 @@ export function handleIngressConfig(
       }
 
       ctx.send(socket, { type: 'ingress_config_response', enabled: isEnabled, publicBaseUrl: value, localGatewayTarget, success: true });
+
+      // Trigger immediate Telegram webhook reconcile on the gateway so
+      // that changing the ingress URL takes effect without a restart.
+      if (value && isEnabled) {
+        triggerGatewayReconcile(value);
+      }
     } else {
       ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
+import type { GatewayConfig } from "../config.js";
+
+// Mock reconcileTelegramWebhook so tests don't call the real Telegram API
+const mockReconcile = mock(() => Promise.resolve());
+mock.module("../telegram/webhook-manager.js", () => ({
+  reconcileTelegramWebhook: mockReconcile,
+}));
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: "test-token",
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: "bot-token",
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: "webhook-secret",
+    twilioAuthToken: undefined,
+    ingressPublicBaseUrl: "https://example.com",
+    unmappedPolicy: "reject",
+    ...overrides,
+  };
+}
+
+function makeRequest(
+  method: string,
+  token?: string,
+  body?: Record<string, unknown>,
+): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token) {
+    headers["authorization"] = `Bearer ${token}`;
+  }
+  return new Request("http://localhost:7830/internal/telegram/reconcile", {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /internal/telegram/reconcile", () => {
+  beforeEach(() => {
+    mockReconcile.mockClear();
+  });
+
+  test("rejects non-POST methods", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(
+      new Request("http://localhost:7830/internal/telegram/reconcile", {
+        method: "GET",
+      }),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("returns 503 when no bearer token is configured", async () => {
+    const config = makeConfig({ runtimeProxyBearerToken: undefined });
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(makeRequest("POST", "any-token"));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("bearer token required");
+  });
+
+  test("returns 401 for missing auth header", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(makeRequest("POST"));
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 401 for wrong token", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(makeRequest("POST", "wrong-token"));
+    expect(res.status).toBe(401);
+  });
+
+  test("triggers reconcile with correct auth", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(makeRequest("POST", "test-token"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    expect(mockReconcile).toHaveBeenCalledWith(config);
+  });
+
+  test("updates ingressPublicBaseUrl when provided", async () => {
+    const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(
+      makeRequest("POST", "test-token", {
+        ingressPublicBaseUrl: "https://new.example.com/",
+      }),
+    );
+    expect(res.status).toBe(200);
+    // Trailing slash should be normalized
+    expect(config.ingressPublicBaseUrl).toBe("https://new.example.com");
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears ingressPublicBaseUrl when empty string is provided", async () => {
+    const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(
+      makeRequest("POST", "test-token", {
+        ingressPublicBaseUrl: "",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(config.ingressPublicBaseUrl).toBeUndefined();
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test("works with empty body (no URL update)", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(config.ingressPublicBaseUrl).toBe("https://example.com");
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 502 when reconcile throws", async () => {
+    mockReconcile.mockImplementationOnce(() =>
+      Promise.reject(new Error("Telegram API error")),
+    );
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const res = await handler(makeRequest("POST", "test-token"));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("Reconciliation failed");
+  });
+
+  test("returns 400 for invalid JSON body", async () => {
+    const config = makeConfig();
+    const handler = createTelegramReconcileHandler(config);
+    const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: "not-json{",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/gateway/src/http/routes/telegram-reconcile.ts
+++ b/gateway/src/http/routes/telegram-reconcile.ts
@@ -1,0 +1,62 @@
+import type { GatewayConfig } from "../../config.js";
+import { validateBearerToken } from "../auth/bearer.js";
+import { getLogger } from "../../logger.js";
+import { reconcileTelegramWebhook } from "../../telegram/webhook-manager.js";
+
+const log = getLogger("telegram-reconcile");
+
+/**
+ * Internal endpoint that triggers Telegram webhook reconciliation.
+ * Called by the assistant daemon after an ingress URL change so that
+ * the webhook re-registers immediately without a gateway restart.
+ */
+export function createTelegramReconcileHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    // Fail-closed: require a bearer token to be configured.
+    if (!config.runtimeProxyBearerToken) {
+      return Response.json(
+        { error: "Service not configured: bearer token required" },
+        { status: 503 },
+      );
+    }
+
+    const authResult = validateBearerToken(
+      req.headers.get("authorization"),
+      config.runtimeProxyBearerToken,
+    );
+    if (!authResult.authorized) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: { ingressPublicBaseUrl?: string } = {};
+    try {
+      const text = await req.text();
+      if (text) {
+        body = JSON.parse(text) as typeof body;
+      }
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // If a new ingress URL is provided, update the in-memory config so that
+    // reconcile uses the latest value without requiring a gateway restart.
+    if (typeof body.ingressPublicBaseUrl === "string") {
+      const normalized = body.ingressPublicBaseUrl.trim().replace(/\/+$/, "");
+      config.ingressPublicBaseUrl = normalized || undefined;
+      log.info({ ingressPublicBaseUrl: config.ingressPublicBaseUrl }, "Updated in-memory ingress URL");
+    }
+
+    try {
+      await reconcileTelegramWebhook(config);
+      log.info("Telegram webhook reconciled via internal endpoint");
+      return Response.json({ ok: true });
+    } catch (err) {
+      log.error({ err }, "Failed to reconcile Telegram webhook via internal endpoint");
+      return Response.json({ error: "Reconciliation failed" }, { status: 502 });
+    }
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
+import { createTelegramReconcileHandler } from "./http/routes/telegram-reconcile.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
 import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
@@ -25,6 +26,7 @@ function main() {
 
   const handleTelegramWebhook = createTelegramWebhookHandler(config);
   const handleTelegramDeliver = createTelegramDeliverHandler(config);
+  const handleTelegramReconcile = createTelegramReconcileHandler(config);
 
   const isTelegramConfigured = () =>
     !!(config.telegramBotToken && config.telegramWebhookSecret);
@@ -58,6 +60,10 @@ function main() {
           return Response.json({ status: "draining" }, { status: 503 });
         }
         return Response.json({ status: "ok" });
+      }
+
+      if (url.pathname === "/internal/telegram/reconcile") {
+        return handleTelegramReconcile(req);
       }
 
       if (url.pathname === "/webhooks/telegram") {


### PR DESCRIPTION
Add authenticated internal gateway endpoint to trigger Telegram webhook reconcile when ingress URL changes. Assistant calls this endpoint after ingress config updates. Closes #6385.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
