### PR TITLE
Fix: treat whitespace-only ingressPublicBaseUrl as unset

### DIFF
--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -49,7 +49,7 @@ function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): strin
   // URL is configured. When ingressPublicBaseUrl is set, we enforce that the
   // signature matches the public URL (or forwarded headers) to prevent
   // accepting signatures computed against the local/internal URL.
-  if (!config.ingressPublicBaseUrl && !candidates.includes(req.url)) {
+  if (!config.ingressPublicBaseUrl?.trim() && !candidates.includes(req.url)) {
     candidates.push(req.url);
   }
 


### PR DESCRIPTION
Address Codex feedback on #6391. Use .trim() to treat whitespace-only ingressPublicBaseUrl values as effectively unset, preserving the req.url fallback for signature validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
