### PR TITLE
Fix: preserve env-only ingress fallback in config default

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1047,21 +1047,25 @@ export const SkillsConfigSchema = z.object({
   allowBundled: z.array(z.string()).nullable().default(null),
 });
 
-export const IngressConfigSchema = z.object({
+const IngressBaseSchema = z.object({
   enabled: z
     .boolean({ error: 'ingress.enabled must be a boolean' })
     .optional(),
   publicBaseUrl: z
     .string({ error: 'ingress.publicBaseUrl must be a string' })
     .default(''),
-}).transform((val) => ({
-  ...val,
-  // Backward compatibility: if `enabled` was never explicitly set (undefined),
-  // infer it from whether a publicBaseUrl is configured. Existing users who
-  // have a URL but predate the `enabled` field should not have their webhooks
-  // silently disabled on upgrade.
-  enabled: val.enabled ?? (val.publicBaseUrl ? true : false),
-}));
+});
+
+export const IngressConfigSchema = IngressBaseSchema
+  .default({ publicBaseUrl: '' })
+  .transform((val) => ({
+    ...val,
+    // Backward compatibility: if `enabled` was never explicitly set (undefined),
+    // infer it from whether a publicBaseUrl is configured. Existing users who
+    // have a URL but predate the `enabled` field should not have their webhooks
+    // silently disabled on upgrade.
+    enabled: val.enabled ?? (val.publicBaseUrl ? true : false),
+  }));
 
 export const AssistantConfigSchema = z.object({
   provider: z
@@ -1320,9 +1324,9 @@ export const AssistantConfigSchema = z.object({
       elevenlabs: {
         voiceId: '',
         voiceModelId: 'turbo_v2_5',
+        speed: 1.0,
         stability: 0.5,
         similarityBoost: 0.75,
-        style: 0.0,
         useSpeakerBoost: true,
         agentId: '',
         apiBaseUrl: 'https://api.elevenlabs.io',
@@ -1333,10 +1337,7 @@ export const AssistantConfigSchema = z.object({
       allowPerCallOverride: true,
     },
   }),
-  ingress: IngressConfigSchema.default({
-    enabled: false,
-    publicBaseUrl: '',
-  }),
+  ingress: IngressConfigSchema,
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({


### PR DESCRIPTION
Address Codex P1 feedback on #6392. The IngressConfigSchema default no longer explicitly disables ingress, preserving the env-var fallback path for getPublicBaseUrl().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
