### PR TITLE
fix(twitter): preserve router metadata for auto-routed failures

### DIFF
--- a/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
+++ b/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
@@ -39,13 +39,13 @@ function buildErrorPayload(err: unknown): Record<string, unknown> | null {
     return payload;
   }
 
-  if (err instanceof Error && meta.suggestAlternative !== undefined) {
+  if (err instanceof Error && (meta.pathUsed !== undefined || meta.suggestAlternative !== undefined || meta.oauthError !== undefined)) {
     const payload: Record<string, unknown> = {
       ok: false,
       error: err.message,
     };
     if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
-    payload.suggestAlternative = meta.suggestAlternative;
+    if (meta.suggestAlternative !== undefined) payload.suggestAlternative = meta.suggestAlternative;
     if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
     return payload;
   }
@@ -133,6 +133,41 @@ describe('CLI error shaping', () => {
       pathUsed: 'auto',
       suggestAlternative: 'browser',
       oauthError: 'Twitter API error (401)',
+    });
+  });
+
+  test('auto-mode error with pathUsed and oauthError but no suggestAlternative preserves metadata', () => {
+    // This is the scenario flagged by Codex: routedPostTweet in auto mode tries
+    // OAuth (fails), then browser (fails with non-SessionExpiredError). The thrown
+    // error has pathUsed and oauthError but no suggestAlternative.
+    const err = Object.assign(
+      new Error('Browser automation failed: element not found'),
+      {
+        pathUsed: 'auto' as const,
+        oauthError: 'Twitter API error (401)',
+      },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'Browser automation failed: element not found',
+      pathUsed: 'auto',
+      oauthError: 'Twitter API error (401)',
+    });
+  });
+
+  test('error with only pathUsed (no oauthError or suggestAlternative) preserves metadata', () => {
+    const err = Object.assign(
+      new Error('Something went wrong'),
+      { pathUsed: 'browser' as const },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'Something went wrong',
+      pathUsed: 'browser',
     });
   });
 

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -84,14 +84,15 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    // For routed errors with suggestAlternative, emit structured JSON
-    if (err instanceof Error && meta.suggestAlternative !== undefined) {
+    // For routed errors with any router metadata, emit structured JSON
+    // so callers can see dual-path diagnostics (pathUsed, oauthError, etc.)
+    if (err instanceof Error && (meta.pathUsed !== undefined || meta.suggestAlternative !== undefined || meta.oauthError !== undefined)) {
       const payload: Record<string, unknown> = {
         ok: false,
         error: err.message,
       };
       if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
-      payload.suggestAlternative = meta.suggestAlternative;
+      if (meta.suggestAlternative !== undefined) payload.suggestAlternative = meta.suggestAlternative;
       if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
       output(payload, getJson(cmd));
       process.exitCode = 1;


### PR DESCRIPTION
Address Codex feedback on PR #6388: ensure auto-strategy failures with pathUsed/oauthError but no suggestAlternative still preserve recovery metadata in CLI output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
