### PR TITLE
fix: address review feedback on public ingress toggle PR #6060

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -502,9 +502,13 @@ export function handleIngressConfig(
       const isEnabled = (ingress.enabled as boolean | undefined) ?? (value ? true : false);
       if (value && isEnabled) {
         process.env.INGRESS_PUBLIC_BASE_URL = value;
-      } else if (ORIGINAL_INGRESS_ENV !== undefined) {
+      } else if (isEnabled && ORIGINAL_INGRESS_ENV !== undefined) {
+        // Ingress is enabled but the user cleared the URL — fall back to the
+        // env var that was present when the process started.
         process.env.INGRESS_PUBLIC_BASE_URL = ORIGINAL_INGRESS_ENV;
       } else {
+        // Ingress is disabled or no URL is configured and no startup env var
+        // exists — remove the env var so the gateway stops accepting webhooks.
         delete process.env.INGRESS_PUBLIC_BASE_URL;
       }
 


### PR DESCRIPTION
Address reviewer feedback from PR #6060 (toggle enable/disable public ingress).

When ingress is toggled off, the env var `INGRESS_PUBLIC_BASE_URL` must be deleted rather than restored to the startup value (`ORIGINAL_INGRESS_ENV`). The previous logic would restore the original env var even when the user explicitly disabled ingress, defeating the toggle in Docker/CI deployments where the env var was pre-set.

The fix gates the `ORIGINAL_INGRESS_ENV` restoration on `isEnabled`, so that path is only taken when ingress is enabled but the user cleared the URL (fall back to startup env). When ingress is disabled, the env var is always deleted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
