### PR TITLE
fix: address review feedback on /update gateway restart PR #6364

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -10,6 +10,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    pkill -x "vellum-assistant" || true
    vellum daemon stop || true
    pkill -f "dev:proxy" || true
+   pkill -f "gateway/src/index" || true
    lsof -ti :7830 | xargs kill -9 2>/dev/null || true
    ```
 


### PR DESCRIPTION
Address reviewer feedback from PR #6364 (kill/restart source gateway in /update).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
