### PR TITLE
fix: address review feedback on IngressConfigSchema PR #6392

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1060,7 +1060,11 @@ export const IngressConfigSchema = z.object({
   // infer it from whether a publicBaseUrl is configured. Existing users who
   // have a URL but predate the `enabled` field should not have their webhooks
   // silently disabled on upgrade.
-  enabled: val.enabled ?? (val.publicBaseUrl ? true : false),
+  //
+  // When publicBaseUrl is empty and enabled is unset, leave enabled as
+  // undefined so getPublicBaseUrl() can still fall through to the
+  // INGRESS_PUBLIC_BASE_URL env-var fallback (env-only setups).
+  enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
 }));
 
 export const AssistantConfigSchema = z.object({
@@ -1334,7 +1338,6 @@ export const AssistantConfigSchema = z.object({
     },
   }),
   ingress: IngressConfigSchema.default({
-    enabled: false,
     publicBaseUrl: '',
   }),
 }).superRefine((config, ctx) => {


### PR DESCRIPTION
Address reviewer feedback from PR #6392 (IngressConfigSchema type mismatch and docs alignment).

## Changes

- Remove explicit `enabled: false` from the IngressConfigSchema default — when the config file omits `ingress`, `enabled` should remain `undefined` (not be explicitly set to `false`) so the transform's backward-compatibility logic can handle it correctly.

- Change the transform's fallback from `false` to `undefined` when both `enabled` and `publicBaseUrl` are unset. This ensures `getPublicBaseUrl()` does not throw on `enabled === false` before checking the `INGRESS_PUBLIC_BASE_URL` env-var fallback, preserving env-only setups (e.g., direct gateway deployments without a config file ingress section).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
