### PR TITLE
fix: address review feedback on NSEvent keyboard nav PR #5999

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -452,12 +452,12 @@ public struct ToolConfirmationBubble: View {
             // Down arrow
             popoverKeyboardModel?.moveDown()
             return nil
-        case 36, 76:
-            // Return / numpad Enter — activate selected row
+        case 36, 76 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
+            // Plain Return / numpad Enter — activate selected row (modified Enter passes through)
             activatePopoverSelection()
             return nil
-        case 53:
-            // Escape — back or close
+        case 53 where event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty:
+            // Plain Escape — back or close (modified Escape passes through)
             handlePopoverEscape()
             return nil
         default:


### PR DESCRIPTION
Address reviewer feedback from PR #5999 (replace focus-based keyboard nav with NSEvent local monitor). Restricts Return/Enter and Escape to unmodified keys in the popover key handler, matching the same fix already applied to the top-level key monitor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
