### PR TITLE
fix: serialize reconcile requests and clear stale ingress URL on disable

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -516,9 +516,10 @@ export function handleIngressConfig(
 
       // Trigger immediate Telegram webhook reconcile on the gateway so
       // that changing the ingress URL takes effect without a restart.
-      if (value && isEnabled) {
-        triggerGatewayReconcile(value);
-      }
+      // Called unconditionally so the gateway clears its in-memory URL
+      // when ingress is disabled, preventing stale re-registration on
+      // credential rotation.
+      triggerGatewayReconcile(value && isEnabled ? value : undefined);
     } else {
       ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -177,4 +177,43 @@ describe("POST /internal/telegram/reconcile", () => {
     const res = await handler(req);
     expect(res.status).toBe(400);
   });
+
+  test("serializes concurrent requests so the last URL wins", async () => {
+    const callOrder: string[] = [];
+    // Make reconcile slow enough that the first call is still in-flight
+    // when the second one arrives.
+    mockReconcile.mockImplementation(async (cfg: GatewayConfig) => {
+      callOrder.push(cfg.ingressPublicBaseUrl ?? "undefined");
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    const config = makeConfig({ ingressPublicBaseUrl: "https://original.com" });
+    const handler = createTelegramReconcileHandler(config);
+
+    // Fire two requests concurrently — without serialization the second
+    // would mutate config.ingressPublicBaseUrl while the first reconcile
+    // is still running, leaving Telegram pointed at the first URL.
+    const [res1, res2] = await Promise.all([
+      handler(
+        makeRequest("POST", "test-token", {
+          ingressPublicBaseUrl: "https://first.com",
+        }),
+      ),
+      handler(
+        makeRequest("POST", "test-token", {
+          ingressPublicBaseUrl: "https://second.com",
+        }),
+      ),
+    ]);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(mockReconcile).toHaveBeenCalledTimes(2);
+
+    // The first reconcile should see "first" and the second should see
+    // "second" — proving that config mutation + reconcile are atomic.
+    expect(callOrder).toEqual(["https://first.com", "https://second.com"]);
+    // After both complete, the config should reflect the last write.
+    expect(config.ingressPublicBaseUrl).toBe("https://second.com");
+  });
 });

--- a/gateway/src/http/routes/telegram-reconcile.ts
+++ b/gateway/src/http/routes/telegram-reconcile.ts
@@ -11,6 +11,12 @@ const log = getLogger("telegram-reconcile");
  * the webhook re-registers immediately without a gateway restart.
  */
 export function createTelegramReconcileHandler(config: GatewayConfig) {
+  // Serialize reconcile operations so that concurrent requests don't race.
+  // Without this, overlapping calls could each mutate config.ingressPublicBaseUrl
+  // and then call reconcileTelegramWebhook independently, leaving Telegram
+  // pointed at a stale URL from an earlier request.
+  let reconcileChain: Promise<void> = Promise.resolve();
+
   return async (req: Request): Promise<Response> => {
     if (req.method !== "POST") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
@@ -42,21 +48,33 @@ export function createTelegramReconcileHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    // If a new ingress URL is provided, update the in-memory config so that
-    // reconcile uses the latest value without requiring a gateway restart.
-    if (typeof body.ingressPublicBaseUrl === "string") {
-      const normalized = body.ingressPublicBaseUrl.trim().replace(/\/+$/, "");
-      config.ingressPublicBaseUrl = normalized || undefined;
-      log.info({ ingressPublicBaseUrl: config.ingressPublicBaseUrl }, "Updated in-memory ingress URL");
-    }
+    // Chain this reconcile after any in-flight one so config mutation +
+    // webhook registration are atomic with respect to other requests.
+    const result = new Promise<Response>((resolve) => {
+      reconcileChain = reconcileChain
+        .then(async () => {
+          // If a new ingress URL is provided, update the in-memory config so that
+          // reconcile uses the latest value without requiring a gateway restart.
+          if (typeof body.ingressPublicBaseUrl === "string") {
+            const normalized = body.ingressPublicBaseUrl.trim().replace(/\/+$/, "");
+            config.ingressPublicBaseUrl = normalized || undefined;
+            log.info({ ingressPublicBaseUrl: config.ingressPublicBaseUrl }, "Updated in-memory ingress URL");
+          }
 
-    try {
-      await reconcileTelegramWebhook(config);
-      log.info("Telegram webhook reconciled via internal endpoint");
-      return Response.json({ ok: true });
-    } catch (err) {
-      log.error({ err }, "Failed to reconcile Telegram webhook via internal endpoint");
-      return Response.json({ error: "Reconciliation failed" }, { status: 502 });
-    }
+          try {
+            await reconcileTelegramWebhook(config);
+            log.info("Telegram webhook reconciled via internal endpoint");
+            resolve(Response.json({ ok: true }));
+          } catch (err) {
+            log.error({ err }, "Failed to reconcile Telegram webhook via internal endpoint");
+            resolve(Response.json({ error: "Reconciliation failed" }, { status: 502 }));
+          }
+        })
+        // Swallow errors so the chain never rejects and subsequent requests
+        // are not blocked by a previous failure.
+        .catch(() => {});
+    });
+
+    return result;
   };
 }


### PR DESCRIPTION
Address review feedback on PR #6393:\n\n1. Serialize concurrent reconcile requests in the gateway handler to prevent race conditions where overlapping updates could leave Telegram pointed at a stale URL.\n2. Call triggerGatewayReconcile unconditionally when ingress config changes, passing undefined when disabled, so the gateway clears its in-memory URL and avoids stale re-registration on credential rotation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
