### PR TITLE
fix: address review feedback on gateway restart in update PR #6364

### DIFF
--- a/.claude/gh-review
+++ b/.claude/gh-review
@@ -63,7 +63,7 @@ cmd_resolve_threads() {
   thread_ids=$(echo "$threads_json" | jq -r '
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false)
-    | select(.comments.nodes[0].author.login == "chatgpt-codex-connector[bot]" or .comments.nodes[0].author.login == "devin-ai-integration[bot]")
+    | select(.comments.nodes[0].author.login == "chatgpt-codex-connector[bot]" or .comments.nodes[0].author.login == "chatgpt-codex-connector" or .comments.nodes[0].author.login == "devin-ai-integration[bot]" or .comments.nodes[0].author.login == "devin-ai-integration")
     | .id
   ')
 


### PR DESCRIPTION
Address review feedback from PR #6364. The substantive fixes (install gateway deps, kill all gateway launch modes) were already addressed by PRs #6375 and #6398. This PR fixes a bug in the gh-review script where bot author logins from the GraphQL API don't include the [bot] suffix, preventing thread resolution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
