### PR TITLE
fix: address review feedback on ingress toggle PR #6060

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -77,6 +77,40 @@ describe('getPublicBaseUrl', () => {
     expect(() => getPublicBaseUrl({})).toThrow(/No public base URL configured/);
   });
 
+  test('throws when ingress is explicitly disabled', () => {
+    expect(() => getPublicBaseUrl({
+      ingress: { enabled: false, publicBaseUrl: 'https://example.com' },
+    })).toThrow(/Public ingress is disabled/);
+  });
+
+  test('throws when ingress is explicitly disabled with no URL', () => {
+    expect(() => getPublicBaseUrl({
+      ingress: { enabled: false, publicBaseUrl: '' },
+    })).toThrow(/Public ingress is disabled/);
+  });
+
+  test('returns URL when enabled is undefined (backward compat)', () => {
+    const result = getPublicBaseUrl({
+      ingress: { enabled: undefined, publicBaseUrl: 'https://example.com' },
+    });
+    expect(result).toBe('https://example.com');
+  });
+
+  test('returns URL when enabled is true', () => {
+    const result = getPublicBaseUrl({
+      ingress: { enabled: true, publicBaseUrl: 'https://example.com' },
+    });
+    expect(result).toBe('https://example.com');
+  });
+
+  test('falls back to env var when enabled is undefined and no publicBaseUrl', () => {
+    process.env.INGRESS_PUBLIC_BASE_URL = 'https://env-fallback.example.com';
+    const result = getPublicBaseUrl({
+      ingress: { enabled: undefined, publicBaseUrl: '' },
+    });
+    expect(result).toBe('https://env-fallback.example.com');
+  });
+
   test('normalizes trailing slashes from ingress.publicBaseUrl', () => {
     const result = getPublicBaseUrl({
       ingress: { publicBaseUrl: 'https://example.com///' },

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -251,7 +251,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     },
   },
   ingress: {
-    enabled: false,
+    enabled: undefined,
     publicBaseUrl: '',
   },
 };


### PR DESCRIPTION
Address review feedback from PR #6060.

## Changes

- **defaults.ts**: Change `DEFAULT_CONFIG.ingress.enabled` from `false` to `undefined` so that the default config correctly represents 'never explicitly set' rather than 'explicitly disabled'. This prevents confusing 'Public ingress is disabled' errors when no ingress has ever been configured (e.g. during config loader re-entrancy fallback).

- **public-ingress-urls.test.ts**: Add comprehensive tests for the `enabled` toggle behavior in `getPublicBaseUrl()`:
  - Verify `enabled: false` throws 'disabled' (with and without URL)
  - Verify `enabled: undefined` allows URL passthrough (backward compat)
  - Verify `enabled: true` works normally
  - Verify env var fallback works with `enabled: undefined`

## Context

PR #6060 added an ingress enabled/disabled toggle. Reviews from Devin and Codex identified that defaulting `enabled` to `false` silently breaks existing users who have a `publicBaseUrl` configured but never set the new `enabled` field. Prior fixes (#6397, #6399) addressed the Zod schema transform and env var export logic, but the `DEFAULT_CONFIG` constant and test coverage were still missing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
