### PR TITLE
fix: address review feedback on public-ingress skill PR #6053

### DIFF
--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -78,14 +78,19 @@ If not authenticated:
    - description: `Get your auth token from https://dashboard.ngrok.com/get-started/your-authtoken`
    - usage_description: `ngrok authentication token for creating public tunnels`
 
-3. Once the credential is stored, retrieve it and configure ngrok:
-```
-credential_store action=get service=ngrok field=authtoken
-```
-Then use the retrieved value:
-```bash
-ngrok config add-authtoken <token>
-```
+3. Once the credential is stored, configure ngrok by reading the token directly from the OS keychain and piping it to ngrok so the plaintext never enters the conversation:
+
+   **macOS:**
+   ```bash
+   ngrok config add-authtoken "$(security find-generic-password -s vellum-assistant -a credential:ngrok:authtoken -w)"
+   ```
+
+   **Linux:**
+   ```bash
+   ngrok config add-authtoken "$(secret-tool lookup service vellum-assistant account credential:ngrok:authtoken)"
+   ```
+
+   If the keychain command fails (e.g., headless environment without a keyring), fall back to asking the user to re-enter the token via `credential_store prompt` and then paste it into `ngrok config add-authtoken` manually as a last resort.
 
 Verify authentication succeeded by checking `ngrok config check` again.
 


### PR DESCRIPTION
Address review feedback from PR #6053. Fixes the broken credential_store action=get call (which doesn't exist) by replacing it with OS keychain commands that read the stored ngrok authtoken and pipe it directly to ngrok config add-authtoken, keeping the plaintext out of the conversation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
