### PR TITLE
fix: send empty-string URL to gateway when ingress is disabled

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -424,9 +424,7 @@ function triggerGatewayReconcile(ingressPublicBaseUrl: string | undefined): void
   }
 
   const url = `${gatewayBase}/internal/telegram/reconcile`;
-  const body = ingressPublicBaseUrl
-    ? JSON.stringify({ ingressPublicBaseUrl })
-    : '{}';
+  const body = JSON.stringify({ ingressPublicBaseUrl: ingressPublicBaseUrl ?? '' });
 
   fetch(url, {
     method: 'POST',


### PR DESCRIPTION
When ingress is disabled, triggerGatewayReconcile was sending an empty JSON body '{}' to the gateway, which didn't actually clear the in-memory URL. Now sends { ingressPublicBaseUrl: '' } so the gateway properly clears its stored URL and avoids stale webhook re-registration.

Addresses feedback from PR #6403.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
