### PR TITLE
feat: add IPC contract types for tool permission simulation

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -830,6 +830,23 @@ exports[`IPC message snapshots ClientMessage types identity_get serializes to ex
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types tool_permission_simulate serializes to expected JSON 1`] = `
+{
+  "executionTarget": "host",
+  "forcePromptSideEffects": false,
+  "input": {
+    "command": "rm -rf /tmp/test",
+  },
+  "isInteractive": true,
+  "principalId": "my-skill",
+  "principalKind": "skill",
+  "principalVersion": "sha256:abc123",
+  "toolName": "bash",
+  "type": "tool_permission_simulate",
+  "workingDir": "/projects/my-app",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -2312,5 +2329,31 @@ exports[`IPC message snapshots ServerMessage types identity_get_response seriali
   "personality": "Friendly",
   "role": "AI assistant",
   "type": "identity_get_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_permission_simulate_response serializes to expected JSON 1`] = `
+{
+  "decision": "prompt",
+  "promptPayload": {
+    "allowlistOptions": [
+      {
+        "description": "Allow rm commands",
+        "label": "Allow rm commands",
+        "pattern": "bash:rm *",
+      },
+    ],
+    "persistentDecisionsAllowed": true,
+    "scopeOptions": [
+      {
+        "label": "In /projects/my-app",
+        "scope": "/projects/my-app",
+      },
+    ],
+  },
+  "reason": "No matching trust rule; tool requires approval",
+  "riskLevel": "high",
+  "success": true,
+  "type": "tool_permission_simulate_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -516,6 +516,18 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   identity_get: {
     type: 'identity_get',
   },
+  tool_permission_simulate: {
+    type: 'tool_permission_simulate',
+    toolName: 'bash',
+    input: { command: 'rm -rf /tmp/test' },
+    workingDir: '/projects/my-app',
+    isInteractive: true,
+    forcePromptSideEffects: false,
+    principalKind: 'skill',
+    principalId: 'my-skill',
+    principalVersion: 'sha256:abc123',
+    executionTarget: 'host',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1489,6 +1501,23 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     personality: 'Friendly',
     emoji: '✨',
     home: '~/workspace',
+  },
+  tool_permission_simulate_response: {
+    type: 'tool_permission_simulate_response',
+    success: true,
+    decision: 'prompt',
+    riskLevel: 'high',
+    reason: 'No matching trust rule; tool requires approval',
+    promptPayload: {
+      allowlistOptions: [
+        { label: 'Allow rm commands', description: 'Allow rm commands', pattern: 'bash:rm *' },
+      ],
+      scopeOptions: [
+        { label: 'In /projects/my-app', scope: '/projects/my-app' },
+      ],
+      persistentDecisionsAllowed: true,
+    },
+    matchedRuleId: undefined,
   },
 };
 

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -86,6 +86,15 @@ const inlineHandlers = defineHandlers({
     });
   },
   integration_disconnect: () => { /* no-op — integration registry removed */ },
+
+  // Stub: runtime behavior wired in a later PR
+  tool_permission_simulate: (_msg, socket, ctx) => {
+    ctx.send(socket, {
+      type: 'tool_permission_simulate_response',
+      success: false,
+      error: 'Not implemented yet',
+    });
+  },
 });
 
 const handlers = {

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -105,6 +105,7 @@
     "WorkItemRunTaskRequest",
     "WorkItemUpdateRequest",
     "WorkItemsListRequest",
+    "ToolPermissionSimulateRequest",
     "WorkspaceFileReadRequest",
     "WorkspaceFilesListRequest"
   ],
@@ -227,6 +228,7 @@
     "WorkItemStatusChanged",
     "WorkItemUpdateResponse",
     "WorkItemsListResponse",
+    "ToolPermissionSimulateResponse",
     "WorkspaceFileReadResponse",
     "WorkspaceFilesListResponse"
   ],
@@ -313,6 +315,7 @@
     "subagent_status",
     "suggestion_request",
     "task_submit",
+    "tool_permission_simulate",
     "trust_rules_list",
     "twitter_auth_start",
     "twitter_auth_status",
@@ -426,6 +429,7 @@
     "tasks_changed",
     "tool_input_delta",
     "tool_output_chunk",
+    "tool_permission_simulate_response",
     "tool_result",
     "tool_use_start",
     "trace_event",

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -896,6 +896,26 @@ export interface IdentityGetRequest {
   type: 'identity_get';
 }
 
+export interface ToolPermissionSimulateRequest {
+  type: 'tool_permission_simulate';
+  /** Tool name to simulate (e.g. 'bash', 'file_write'). */
+  toolName: string;
+  /** Tool input record to simulate. */
+  input: Record<string, unknown>;
+  /** Working directory context; defaults to daemon cwd when omitted. */
+  workingDir?: string;
+  /** Whether the simulated context is interactive (default true). */
+  isInteractive?: boolean;
+  /** When true, side-effect tools that would normally be auto-allowed get promoted to prompt. */
+  forcePromptSideEffects?: boolean;
+  /** Optional principal context overrides. */
+  principalKind?: 'core' | 'skill' | 'task';
+  principalId?: string;
+  principalVersion?: string;
+  /** Optional execution target override. */
+  executionTarget?: 'host' | 'sandbox';
+}
+
 export type ClientMessage =
   | AuthMessage
   | UserMessage
@@ -1003,7 +1023,8 @@ export type ClientMessage =
   | SubagentDetailRequest
   | WorkspaceFilesListRequest
   | WorkspaceFileReadRequest
-  | IdentityGetRequest;
+  | IdentityGetRequest
+  | ToolPermissionSimulateRequest;
 
 export interface IntegrationListRequest {
   type: 'integration_list';
@@ -2164,6 +2185,27 @@ export interface IdentityGetResponse {
   originSystem?: string;
 }
 
+export interface ToolPermissionSimulateResponse {
+  type: 'tool_permission_simulate_response';
+  success: boolean;
+  /** The simulated permission decision. */
+  decision?: 'allow' | 'deny' | 'prompt';
+  /** Risk level of the simulated tool invocation. */
+  riskLevel?: string;
+  /** Human-readable reason for the decision. */
+  reason?: string;
+  /** When decision is 'prompt', the data needed to render a ToolConfirmationBubble. */
+  promptPayload?: {
+    allowlistOptions: Array<{ label: string; description: string; pattern: string }>;
+    scopeOptions: Array<{ label: string; scope: string }>;
+    persistentDecisionsAllowed: boolean;
+  };
+  /** ID of the trust rule that matched (if any). */
+  matchedRuleId?: string;
+  /** Error message when success is false. */
+  error?: string;
+}
+
 export type ServerMessage =
   | AuthResult
   | UserMessageEcho
@@ -2284,7 +2326,8 @@ export type ServerMessage =
   | SubagentDetailResponse
   | WorkspaceFilesListResponse
   | WorkspaceFileReadResponse
-  | IdentityGetResponse;
+  | IdentityGetResponse
+  | ToolPermissionSimulateResponse;
 
 // === Subagent IPC ─────────────────────────────────────────────────────
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1665,6 +1665,60 @@ public struct IPCToolOutputChunk: Codable, Sendable {
     public let subToolId: String?
 }
 
+public struct IPCToolPermissionSimulateRequest: Codable, Sendable {
+    public let type: String
+    /// Tool name to simulate (e.g. 'bash', 'file_write').
+    public let toolName: String
+    /// Tool input record to simulate.
+    public let input: [String: AnyCodable]
+    /// Working directory context; defaults to daemon cwd when omitted.
+    public let workingDir: String?
+    /// Whether the simulated context is interactive (default true).
+    public let isInteractive: Bool?
+    /// When true, side-effect tools that would normally be auto-allowed get promoted to prompt.
+    public let forcePromptSideEffects: Bool?
+    /// Optional principal context overrides.
+    public let principalKind: String?
+    public let principalId: String?
+    public let principalVersion: String?
+    /// Optional execution target override.
+    public let executionTarget: String?
+}
+
+public struct IPCToolPermissionSimulateResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    /// The simulated permission decision.
+    public let decision: String?
+    /// Risk level of the simulated tool invocation.
+    public let riskLevel: String?
+    /// Human-readable reason for the decision.
+    public let reason: String?
+    /// When decision is 'prompt', the data needed to render a ToolConfirmationBubble.
+    public let promptPayload: IPCToolPermissionSimulateResponsePromptPayload?
+    /// ID of the trust rule that matched (if any).
+    public let matchedRuleId: String?
+    /// Error message when success is false.
+    public let error: String?
+}
+
+public struct IPCToolPermissionSimulateResponsePromptPayload: Codable, Sendable {
+    public let allowlistOptions: [IPCToolPermissionSimulateResponsePromptPayloadAllowlistOption]
+    public let scopeOptions: [IPCToolPermissionSimulateResponsePromptPayloadScopeOption]
+    public let persistentDecisionsAllowed: Bool
+}
+
+public struct IPCToolPermissionSimulateResponsePromptPayloadAllowlistOption: Codable, Sendable {
+    public let label: String
+    public let description: String
+    public let pattern: String
+}
+
+public struct IPCToolPermissionSimulateResponsePromptPayloadScopeOption: Codable, Sendable {
+    public let label: String
+    public let scope: String
+}
+
 public struct IPCToolResult: Codable, Sendable {
     public let type: String
     public let toolName: String
@@ -1751,6 +1805,8 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let connected: Bool
     public let accountInfo: String?
     public let strategy: String?
+    /// Whether the user has explicitly set a strategy (vs. relying on the default 'auto').
+    public let strategyConfigured: Bool?
     public let error: String?
 }
 


### PR DESCRIPTION
## Summary

- Adds `ToolPermissionSimulateRequest` and `ToolPermissionSimulateResponse` interfaces to the IPC contract, enabling dry-run permission checks without executing tools
- Adds stub handler in the dispatch map (returns "not implemented" until wired in a later PR)
- Adds snapshot test fixtures for both new message types and updates the contract inventory JSON
- Regenerates Swift IPC bindings

This is PR 01 of the Tool Permission Simulator rollout plan — types only, no runtime behavior yet.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` passes (247 tests, 229 snapshots)
- [x] Generated Swift IPC bindings are up to date

---

**Prompt used to generate this PR:**

> Implement PR 01 of the Tool Permission Simulator rollout plan: add `ToolPermissionSimulateRequest` and `ToolPermissionSimulateResponse` IPC contract types, update the `ClientMessage`/`ServerMessage` unions, add snapshot test fixtures, and regenerate Swift bindings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
