### PR TITLE
Fix: lazily capture INGRESS_PUBLIC_BASE_URL after dotenv loads (PR #6012 feedback)

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -27,9 +27,19 @@ import type {
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
-// Snapshot the env-provided value at module load time so we can restore it
-// when the user clears a Settings-set override.
-const ORIGINAL_INGRESS_ENV = process.env.INGRESS_PUBLIC_BASE_URL;
+// Lazily capture the env-provided INGRESS_PUBLIC_BASE_URL on first access
+// rather than at module load time. The daemon loads ~/.vellum/.env inside
+// runDaemon() (see lifecycle.ts), which runs AFTER static ES module imports
+// resolve. A module-level snapshot would miss dotenv-provided values.
+let _originalIngressEnvCaptured = false;
+let _originalIngressEnv: string | undefined;
+function getOriginalIngressEnv(): string | undefined {
+  if (!_originalIngressEnvCaptured) {
+    _originalIngressEnv = process.env.INGRESS_PUBLIC_BASE_URL;
+    _originalIngressEnvCaptured = true;
+  }
+  return _originalIngressEnv;
+}
 
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
@@ -500,10 +510,10 @@ export function handleIngressConfig(
       const isEnabled = (ingress.enabled as boolean | undefined) ?? (value ? true : false);
       if (value && isEnabled) {
         process.env.INGRESS_PUBLIC_BASE_URL = value;
-      } else if (isEnabled && ORIGINAL_INGRESS_ENV !== undefined) {
+      } else if (isEnabled && getOriginalIngressEnv() !== undefined) {
         // Ingress is enabled but the user cleared the URL — fall back to the
         // env var that was present when the process started.
-        process.env.INGRESS_PUBLIC_BASE_URL = ORIGINAL_INGRESS_ENV;
+        process.env.INGRESS_PUBLIC_BASE_URL = getOriginalIngressEnv()!;
       } else {
         // Ingress is disabled or no URL is configured and no startup env var
         // exists — remove the env var so the gateway stops accepting webhooks.


### PR DESCRIPTION
## Summary
- Change ORIGINAL_INGRESS_ENV from a module-level constant to a lazily-initialized value captured on first access
- The daemon loads ~/.vellum/.env inside runDaemon() (lifecycle.ts), which runs AFTER static ES module imports resolve
- A module-level snapshot would miss dotenv-provided values, causing the env fallback to be lost when clearing ingress settings
- Now the original env var is captured on first call to handleIngressConfig, which is at runtime after dotenv has loaded

Addresses feedback on #6012 (via #6037).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
