### PR TITLE
fix: position overflow menu dots next to bubble content

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -82,6 +82,14 @@ struct ChatBubble: View {
             .overlay {
                 bubbleBorderOverlay
             }
+            .overlay(alignment: isUser ? .topLeading : .topTrailing) {
+                if hasOverflowActions {
+                    overflowMenuButton
+                        .opacity(showOverflowMenu ? 1 : 0)
+                        .animation(VAnimation.fast, value: showOverflowMenu)
+                        .offset(x: isUser ? -(24 + VSpacing.sm) : (24 + VSpacing.sm))
+                }
+            }
             .frame(maxWidth: 520, alignment: isUser ? .trailing : .leading)
     }
 
@@ -141,12 +149,6 @@ struct ChatBubble: View {
                         .padding(.top, 2)
                 }
 
-                if isUser && hasOverflowActions {
-                    overflowMenuButton
-                        .opacity(showOverflowMenu ? 1 : 0)
-                        .animation(VAnimation.fast, value: showOverflowMenu)
-                }
-
                 VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
                     if !isUser && hasInterleavedContent {
                         interleavedContent
@@ -191,11 +193,6 @@ struct ChatBubble: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .contextMenu {}
 
-                if !isUser && hasOverflowActions {
-                    overflowMenuButton
-                        .opacity(showOverflowMenu ? 1 : 0)
-                        .animation(VAnimation.fast, value: showOverflowMenu)
-                }
             }
 
             if !isUser { Spacer(minLength: 0) }


### PR DESCRIPTION
## Summary
- Move the three-dots overflow menu from a sibling in the HStack to an overlay on the bubble chrome
- Overlay is anchored before the `maxWidth: 520` frame, so it tracks the actual bubble edge
- Dots appear immediately adjacent to the bubble regardless of message length (both user and assistant)

## Test plan
- [ ] Send short user message — dots appear right next to bubble on hover
- [ ] Send long user message — dots still adjacent, bubble respects 520pt max
- [ ] Hover assistant message — dots appear next to bubble, not at edge of frame
- [ ] Verify no layout overflow or clipping issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
