### PR TITLE
feat: add Swift IPC message aliases and decoder for tool permission simulation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -57,8 +57,10 @@ declare -a PATTERNS=(
 )
 
 # Ignore deterministic checksum/hash fixtures that are not credentials.
+# Also ignore Swift/TS function-parameter declarations (e.g. `clientSecret: String?`).
 declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
+    "client[Ss]ecret:[[:space:]]*(String|client[Ss]ecret)"
 )
 
 matches_safe_line_pattern() {
@@ -114,6 +116,8 @@ if [ "${1:-}" = "--self-test" ]; then
     # False-positive lines that must NOT match (plain identifiers, not secrets)
     SAFE_CACHE_KEY_LINE='redis.get("user_session_key_prefix")'
     SAFE_CLIENT_SECRET_DOC='- **PKCE or client_secret flows** — Desktop apps use PKCE by default (S256).'
+    SAFE_SWIFT_PARAM_LINE='public init(action: String, mode: String? = nil, clientId: String? = nil, clientSecret: String? = nil)'
+    SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -197,6 +201,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_CLIENT_SECRET_DOC"; then
         echo -e "${RED}Self-test failed:${NC} client_secret in documentation context still matches"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_PARAM_LINE" && ! matches_safe_line_pattern "$SAFE_SWIFT_PARAM_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} Swift clientSecret param false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_CALL_LINE" && ! matches_safe_line_pattern "$SAFE_SWIFT_CALL_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} Swift clientSecret call-site false positive"
         exit 1
     fi
     if ! matches_secret_pattern "$REAL_CLIENT_SECRET_LINE"; then

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1480,6 +1480,20 @@ extension IPCUpdateTrustRule {
     }
 }
 
+/// Simulate a tool permission check without executing the tool.
+/// Backed by generated `IPCToolPermissionSimulateRequest`.
+public typealias ToolPermissionSimulateMessage = IPCToolPermissionSimulateRequest
+
+extension IPCToolPermissionSimulateRequest {
+    public init(toolName: String, input: [String: AnyCodable], workingDir: String? = nil, isInteractive: Bool? = nil, forcePromptSideEffects: Bool? = nil, principalKind: String? = nil, principalId: String? = nil, principalVersion: String? = nil, executionTarget: String? = nil) {
+        self.init(type: "tool_permission_simulate", toolName: toolName, input: input, workingDir: workingDir, isInteractive: isInteractive, forcePromptSideEffects: forcePromptSideEffects, principalKind: principalKind, principalId: principalId, principalVersion: principalVersion, executionTarget: executionTarget)
+    }
+}
+
+/// Response from a tool permission simulation.
+/// Backed by generated `IPCToolPermissionSimulateResponse`.
+public typealias ToolPermissionSimulateResponseMessage = IPCToolPermissionSimulateResponse
+
 /// Response from opening and scanning a .vellumapp bundle.
 /// Backed by generated `IPCOpenBundleResponse`.
 public typealias OpenBundleResponseMessage = IPCOpenBundleResponse
@@ -1940,6 +1954,7 @@ public enum ServerMessage: Decodable, Sendable {
     case watchCompleteRequest(WatchCompleteRequestMessage)
     case traceEvent(TraceEventMessage)
     case trustRulesListResponse(TrustRulesListResponseMessage)
+    case toolPermissionSimulateResponse(ToolPermissionSimulateResponseMessage)
     case acceptStarterBundleResponse(IPCAcceptStarterBundleResponse)
     case remindersListResponse(RemindersListResponseMessage)
     case schedulesListResponse(SchedulesListResponseMessage)
@@ -2162,6 +2177,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "trust_rules_list_response":
             let message = try TrustRulesListResponseMessage(from: decoder)
             self = .trustRulesListResponse(message)
+        case "tool_permission_simulate_response":
+            let message = try ToolPermissionSimulateResponseMessage(from: decoder)
+            self = .toolPermissionSimulateResponse(message)
         case "accept_starter_bundle_response":
             let message = try IPCAcceptStarterBundleResponse(from: decoder)
             self = .acceptStarterBundleResponse(message)


### PR DESCRIPTION
## Summary
- Add `ToolPermissionSimulateMessage` typealias and convenience init for the client-to-server request
- Add `ToolPermissionSimulateResponseMessage` typealias for the server-to-client response
- Add `ServerMessage.toolPermissionSimulateResponse` enum case and decoder switch case
- Fix pre-commit hook false positive on Swift `clientSecret` parameter names

## Test plan
- [x] `bun run check:ipc-generated` passes
- [x] Pre-commit hook self-test passes
- [x] Swift decoder switch case matches wire type `"tool_permission_simulate_response"`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
