### PR TITLE
feat: add DaemonClient send/callback plumbing for tool permission simulation

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -182,6 +182,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `trust_rules_list_response` message.
     public var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
 
+    /// Called when the daemon sends a `tool_permission_simulate_response` message.
+    public var onToolPermissionSimulateResponse: ((ToolPermissionSimulateResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `schedules_list_response` message.
     public var onSchedulesListResponse: (([ScheduleItem]) -> Void)?
 
@@ -632,6 +635,25 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             scope: scope,
             decision: decision,
             priority: priority
+        ))
+    }
+
+    // MARK: - Tool Permission Simulation
+
+    /// Simulate a tool permission check without executing the tool.
+    public func sendToolPermissionSimulate(
+        toolName: String,
+        input: [String: AnyCodable],
+        workingDir: String? = nil,
+        isInteractive: Bool? = nil,
+        forcePromptSideEffects: Bool? = nil
+    ) throws {
+        try send(ToolPermissionSimulateMessage(
+            toolName: toolName,
+            input: input,
+            workingDir: workingDir,
+            isInteractive: isInteractive,
+            forcePromptSideEffects: forcePromptSideEffects
         ))
     }
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -81,6 +81,8 @@ extension DaemonClient {
             onScheduleComplete?(msg)
         case .trustRulesListResponse(let msg):
             onTrustRulesListResponse?(msg.rules)
+        case .toolPermissionSimulateResponse(let msg):
+            onToolPermissionSimulateResponse?(msg)
         case .schedulesListResponse(let msg):
             onSchedulesListResponse?(msg.schedules)
         case .remindersListResponse(let msg):


### PR DESCRIPTION
## Summary
- Add `onToolPermissionSimulateResponse` callback in `DaemonClient.swift` for receiving simulation results
- Add `sendToolPermissionSimulate(...)` convenience method for sending simulation requests
- Route `tool_permission_simulate_response` server message to the callback in `DaemonMessageRouter.swift`

## Test plan
- [x] Follows existing callback and routing patterns
- [x] No UI usage yet -- plumbing only for later PRs to consume

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
