### PR TITLE
feat: move tool_permission_simulate handler to config.ts

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -23,6 +23,7 @@ import type {
   IngressConfigRequest,
   VercelApiConfigRequest,
   TwitterIntegrationConfigRequest,
+  ToolPermissionSimulateRequest,
 } from '../ipc-protocol.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
@@ -789,6 +790,18 @@ export function handleEnvVarsRequest(socket: net.Socket, ctx: HandlerContext): v
   ctx.send(socket, { type: 'env_vars_response', vars });
 }
 
+export function handleToolPermissionSimulate(
+  _msg: ToolPermissionSimulateRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  ctx.send(socket, {
+    type: 'tool_permission_simulate_response',
+    success: false,
+    error: 'Not implemented',
+  });
+}
+
 export const configHandlers = defineHandlers({
   model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
   model_set: handleModelSet,
@@ -809,4 +822,5 @@ export const configHandlers = defineHandlers({
   vercel_api_config: handleVercelApiConfig,
   twitter_integration_config: handleTwitterIntegrationConfig,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
+  tool_permission_simulate: handleToolPermissionSimulate,
 });

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -87,14 +87,6 @@ const inlineHandlers = defineHandlers({
   },
   integration_disconnect: () => { /* no-op — integration registry removed */ },
 
-  // Stub: runtime behavior wired in a later PR
-  tool_permission_simulate: (_msg, socket, ctx) => {
-    ctx.send(socket, {
-      type: 'tool_permission_simulate_response',
-      success: false,
-      error: 'Not implemented yet',
-    });
-  },
 });
 
 const handlers = {


### PR DESCRIPTION
## Summary
- Move the `tool_permission_simulate` stub handler from inline handlers in `index.ts` to a proper `handleToolPermissionSimulate` function in `config.ts`
- Register it in the `configHandlers` map where it belongs alongside other config-related handlers
- Handler currently returns a deterministic `{ success: false, error: 'Not implemented' }` response — core logic comes in subsequent PRs

## Test plan
- [x] `bunx tsc --noEmit` passes cleanly
- [x] Existing tests unaffected (pre-existing failures only)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
