### PR TITLE
fix: pass effective ingress URL to gateway reconcile instead of raw value

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -527,7 +527,10 @@ export function handleIngressConfig(
       // Called unconditionally so the gateway clears its in-memory URL
       // when ingress is disabled, preventing stale re-registration on
       // credential rotation.
-      triggerGatewayReconcile(value && isEnabled ? value : undefined);
+      // Use the effective URL from process.env (which accounts for the
+      // fallback branch above) rather than the raw `value` from the UI.
+      const effectiveUrl = isEnabled ? process.env.INGRESS_PUBLIC_BASE_URL : undefined;
+      triggerGatewayReconcile(effectiveUrl);
     } else {
       ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }


### PR DESCRIPTION
## Summary
- Fixes the issue where triggerGatewayReconcile received undefined when the fallback env var branch was used
- Now passes the effective URL (including fallback) to the gateway reconcile call
- Ensures the gateway stays in sync with the daemon's actual ingress URL

Addresses feedback from PR #6408.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
