### PR TITLE
feat: add private-thread and non-interactive overrides in simulation handler

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -3,6 +3,7 @@ import { getConfig, loadRawConfig, saveRawConfig } from '../../config/loader.js'
 import { initializeProviders } from '../../providers/registry.js';
 import { addRule, removeRule, updateRule, getAllRules, acceptStarterBundle } from '../../permissions/trust-store.js';
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../../permissions/checker.js';
+import { isSideEffectTool } from '../../tools/executor.js';
 import { listSchedules, updateSchedule, deleteSchedule, describeCronExpression } from '../../schedule/schedule-store.js';
 import { listReminders, cancelReminder } from '../../tools/reminder/reminder-store.js';
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secure-keys.js';
@@ -832,6 +833,22 @@ export async function handleToolPermissionSimulate(
 
     const riskLevel = await classifyRisk(msg.toolName, msg.input, workingDir);
     const result = await check(msg.toolName, msg.input, workingDir, policyContext);
+
+    // Private-thread override: promote allow → prompt for side-effect tools
+    if (
+      msg.forcePromptSideEffects
+      && result.decision === 'allow'
+      && isSideEffectTool(msg.toolName, msg.input)
+    ) {
+      result.decision = 'prompt';
+      result.reason = 'Private thread: side-effect tools require explicit approval';
+    }
+
+    // Non-interactive override: convert prompt → deny
+    if (msg.isInteractive === false && result.decision === 'prompt') {
+      result.decision = 'deny';
+      result.reason = 'Non-interactive session: no client to approve prompt';
+    }
 
     // When decision is prompt, generate the full payload the UI needs
     let promptPayload: {


### PR DESCRIPTION
## Summary
- Apply context-dependent decision overrides matching the real executor's behavior:
  - `forcePromptSideEffects=true`: promote `allow` to `prompt` for side-effect tools (file writes, bash, web_fetch, etc.)
  - `isInteractive=false`: convert `prompt` to `deny` with explicit reason
- Reuse the existing `isSideEffectTool()` classifier from the executor module

## Test plan
- [x] `bunx tsc --noEmit` passes cleanly
- [x] Side-effect tools promoted to prompt when `forcePromptSideEffects=true`
- [x] Prompt decisions converted to deny when `isInteractive=false`
- [x] Non-side-effect tools unaffected by `forcePromptSideEffects`

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
