### PR TITLE
fix: capture original ingress env before any mutation in handleIngressConfig

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -475,6 +475,8 @@ export function handleIngressConfig(
       ctx.send(socket, { type: 'ingress_config_response', enabled, publicBaseUrl, localGatewayTarget, success: true });
     } else if (msg.action === 'set') {
       const value = (msg.publicBaseUrl ?? '').trim().replace(/\/+$/, '');
+      // Ensure we capture the original env value before any mutation below
+      getOriginalIngressEnv();
       const raw = loadRawConfig();
 
       // Update ingress.publicBaseUrl — this is the single source of truth for


### PR DESCRIPTION
## Summary
- Calls getOriginalIngressEnv() before the branching logic that may mutate process.env.INGRESS_PUBLIC_BASE_URL
- Ensures the lazy capture always snapshots the pre-mutation dotenv value
- Prevents the fallback from restoring a user-set URL instead of the original dotenv URL

Addresses feedback from PR #6410.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
