### PR TITLE
feat: improve /update command with gateway env injection and health checks

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -4,6 +4,11 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
 
 ## Steps
 
+0. Ensure Bun is on PATH:
+   ```bash
+   export PATH="$HOME/.bun/bin:$PATH"
+   ```
+
 1. Kill app, daemon, and **all** gateway processes. There must only ever be one gateway running, and it must always be started from source:
    ```bash
    pkill -x "Vellum" || true
@@ -31,14 +36,64 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    cd assistant && bun run daemon:restart:http && cd ..
    ```
 
-5. Build and launch the macOS app from source **and** start the source gateway. These can run in parallel. Pin gateway resolution to the repo `gateway/` directory so local gateway changes are used instead of a packaged fallback. Run both in the background since `build.sh run` enters a watch loop:
+5. Resolve gateway ingress and Twilio auth env from local config/credential store:
+   ```bash
+   INGRESS_PUBLIC_BASE_URL="$(
+     python3 - <<'PY'
+import json, os
+cfg_path = os.path.expanduser("~/.vellum/workspace/config.json")
+try:
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    ingress = (cfg.get("ingress") or {}).get("publicBaseUrl") or ""
+    print(str(ingress).strip())
+except Exception:
+    print("")
+PY
+   )"
+   TWILIO_AUTH_TOKEN="$(
+     cd assistant
+     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:auth_token") ?? "")'
+     cd ..
+   )"
+   if [ -z "$INGRESS_PUBLIC_BASE_URL" ]; then
+     echo "WARNING: INGRESS_PUBLIC_BASE_URL is empty (Twilio signature validation may fail)."
+   fi
+   if [ -z "$TWILIO_AUTH_TOKEN" ]; then
+     echo "WARNING: TWILIO_AUTH_TOKEN is empty (Twilio webhooks will be rejected)."
+   fi
+   ```
+
+6. Start the source gateway first (so the app connects to this instance). Run in background with logs:
+   ```bash
+   cd gateway
+   mkdir -p "${HOME}/.vellum"
+   nohup env \
+     GATEWAY_RUNTIME_PROXY_ENABLED=true \
+     GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false \
+     INGRESS_PUBLIC_BASE_URL="$INGRESS_PUBLIC_BASE_URL" \
+     TWILIO_AUTH_TOKEN="$TWILIO_AUTH_TOKEN" \
+     bun run dev:proxy \
+     > "${HOME}/.vellum/gateway-dev.log" 2>&1 &
+   cd ..
+   ```
+
+7. Build and launch the macOS app from source with gateway pinned to local `gateway/`:
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
+   cd ..
    ```
 
+8. Verify health:
    ```bash
-   cd gateway && bun run dev:proxy &
+   curl -sS http://127.0.0.1:7821/healthz
+   curl -sS http://127.0.0.1:7830/healthz
    ```
 
-Report what was pulled (new commits), and confirm daemon, app, and source gateway are all running.
+Report:
+
+1. What was pulled (new commits).
+2. Daemon health and gateway health results.
+3. Whether ingress and Twilio auth env were non-empty at startup.
+4. The gateway log path: `~/.vellum/gateway-dev.log`.

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon/app, preserve any source-run gateway process, and launch app with `VELLUM_GATEWAY_DIR` pinned to local `gateway/`. |
+| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env injected from local config/credentials, then launch app pinned to local `gateway/`. |
 
 
 ### Review


### PR DESCRIPTION
## Summary
- Ensures Bun is on PATH before running update steps
- Resolves INGRESS_PUBLIC_BASE_URL and TWILIO_AUTH_TOKEN from local config/credential store before starting gateway
- Starts gateway with proper env vars injected, adds health check verification, and updates README description

## Original prompt
ship my staged and unstaged changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
