### PR TITLE
fix: show avatar next to thinking indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -495,10 +495,20 @@ struct ChatView: View {
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
                     let hasActiveToolCall = lastVisible?.toolCalls.contains(where: { !$0.isComplete }) == true
                     if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
-                        RunningIndicator(
-                            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
-                            showIcon: false
-                        )
+                        HStack(alignment: .top, spacing: VSpacing.sm) {
+                            Image(nsImage: appearance.chatAvatarImage)
+                                .interpolation(.none)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 28, height: 28)
+                                .clipShape(Circle())
+                                .padding(.top, 2)
+
+                            RunningIndicator(
+                                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
+                                showIcon: false
+                            )
+                        }
                         .frame(maxWidth: 520, alignment: .leading)
                         .id("thinking-indicator")
                         .transition(.opacity.combined(with: .move(edge: .bottom)))


### PR DESCRIPTION
## Summary
- The "Thinking ● ● ●" indicator was missing the assistant avatar that regular messages display
- Wrapped the `RunningIndicator` in the same avatar + HStack layout used by `ChatBubble`

## Test plan
- [ ] Send a message and verify the thinking indicator shows the avatar to its left
- [ ] Verify "Waking up..." also shows the avatar on first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
