### PR TITLE
fix: address review feedback on app git history PR #6318

### DIFF
--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -153,13 +153,14 @@ export async function commitAppChange(message: string): Promise<void> {
  */
 export async function getAppHistory(appId: string, limit = 50): Promise<AppVersion[]> {
   validateAppId(appId);
+  const safeLimit = Math.max(1, Math.min(Math.floor(limit), 500));
   const appsDir = getAppsDir();
   const gitService = getWorkspaceGitService(appsDir);
 
   // Format: hash<TAB>unix-seconds<TAB>subject line
   const { stdout } = await gitService.runReadOnlyGit([
     'log',
-    `--max-count=${limit}`,
+    `--max-count=${safeLimit}`,
     '--format=%H\t%at\t%s',
     '--',
     `${appId}.json`,
@@ -258,7 +259,8 @@ export async function restoreAppVersion(appId: string, commitHash: string): Prom
       `${appId}/`,
     ]);
 
-    // Read the app name for the commit message
+    // Read the app name and refresh updatedAt so the restored app
+    // doesn't appear stale in recency ordering.
     let appName = appId;
     const jsonPath = join(appsDir, `${appId}.json`);
     if (existsSync(jsonPath)) {
@@ -266,6 +268,8 @@ export async function restoreAppVersion(appId: string, commitHash: string): Prom
         const raw = readFileSync(jsonPath, 'utf-8');
         const app = JSON.parse(raw);
         if (app.name) appName = app.name;
+        app.updatedAt = Date.now();
+        writeFileSync(jsonPath, JSON.stringify(app, null, 2) + '\n', 'utf-8');
       } catch {
         // fall back to id
       }


### PR DESCRIPTION
## Summary
- Clamp `getAppHistory()` limit to a bounded positive integer [1, 500] to prevent invalid git args
- Refresh `updatedAt` to current time in `restoreAppVersion()` so restored apps don't appear stale in recency ordering

## Original prompt
In assistant/src/memory/app-git-service.ts, fix two issues from PR #6318 review feedback:

1. **Refresh updatedAt after restore** (line ~257): In `restoreAppVersion()`, after checking out the old `{appId}.json` and reading the app name, also update the `updatedAt` field to `Date.now()` before committing. The restored JSON has the old `updatedAt` which makes the app appear stale in recency ordering. Read the JSON, parse it, set `app.updatedAt = Date.now()`, and write it back before staging.

2. **Validate/clamp the history limit** (line ~162): In `getAppHistory()`, clamp `limit` to a bounded positive integer before passing to git. Use something like `const safeLimit = Math.max(1, Math.min(Math.floor(limit), 500))` to prevent negative, non-integer, or excessively large values.

Addresses review feedback from #6318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
