### PR TITLE
fix: restore overflow menu for assistant messages without a bubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -192,6 +192,14 @@ struct ChatBubble: View {
                 // trailing tool-chip to overlap long text content.
                 .fixedSize(horizontal: false, vertical: true)
                 .contextMenu {}
+                .overlay(alignment: .topTrailing) {
+                    if !isUser && !shouldShowBubble && hasOverflowActions {
+                        overflowMenuButton
+                            .opacity(showOverflowMenu ? 1 : 0)
+                            .animation(VAnimation.fast, value: showOverflowMenu)
+                            .offset(x: 24 + VSpacing.sm)
+                    }
+                }
 
             }
 


### PR DESCRIPTION
## Summary
- Add fallback overflow menu overlay on the VStack for assistant messages where `shouldShowBubble` is false
- Only renders when no bubble is shown (avoids doubling up with the one in `bubbleChrome`)
- Restores access to "Copy message" and "Export response for diagnostics" for tool-call-only messages and messages with active inline surfaces
- Addresses review feedback from #6411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
