### PR TITLE
feat: extend add_trust_rule contract with optional metadata

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -318,8 +318,13 @@ exports[`IPC message snapshots ClientMessage types suggestion_request serializes
 
 exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to expected JSON 1`] = `
 {
+  "allowHighRisk": true,
   "decision": "allow",
+  "executionTarget": "host",
   "pattern": "git *",
+  "principalId": "my-skill",
+  "principalKind": "skill",
+  "principalVersion": "sha256:abc123",
   "scope": "/projects/my-app",
   "toolName": "bash",
   "type": "add_trust_rule",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -218,6 +218,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     pattern: 'git *',
     scope: '/projects/my-app',
     decision: 'allow',
+    allowHighRisk: true,
+    principalKind: 'skill',
+    principalId: 'my-skill',
+    principalVersion: 'sha256:abc123',
+    executionTarget: 'host',
   },
   trust_rules_list: {
     type: 'trust_rules_list',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -318,6 +318,16 @@ export interface AddTrustRule {
   pattern: string;
   scope: string;
   decision: 'allow' | 'deny' | 'ask';
+  /** When true, the rule also covers high-risk invocations. */
+  allowHighRisk?: boolean;
+  /** Principal kind that this rule applies to (e.g. 'core', 'skill', 'task'). */
+  principalKind?: 'core' | 'skill' | 'task';
+  /** Skill/task ID when principalKind is 'skill' or 'task'. */
+  principalId?: string;
+  /** Content-hash of the skill source for version pinning. */
+  principalVersion?: string;
+  /** Execution target override for this rule. */
+  executionTarget?: 'host' | 'sandbox';
 }
 
 export interface TrustRulesList {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -27,6 +27,16 @@ public struct IPCAddTrustRule: Codable, Sendable {
     public let pattern: String
     public let scope: String
     public let decision: String
+    /// When true, the rule also covers high-risk invocations.
+    public let allowHighRisk: Bool?
+    /// Principal kind that this rule applies to (e.g. 'core', 'skill', 'task').
+    public let principalKind: String?
+    /// Skill/task ID when principalKind is 'skill' or 'task'.
+    public let principalId: String?
+    /// Content-hash of the skill source for version pinning.
+    public let principalVersion: String?
+    /// Execution target override for this rule.
+    public let executionTarget: String?
 }
 
 public struct IPCAgentHeartbeatAlert: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add optional metadata fields to `AddTrustRule` IPC interface: `allowHighRisk`, `principalKind`, `principalId`, `principalVersion`, `executionTarget`
- Update snapshot test fixture to include the new fields
- Regenerate Swift IPC models

## Test plan
- [x] Snapshot tests updated and passing (247 tests, 0 failures)
- [x] Swift IPC generation verified in sync
- [x] Backward compatible — all fields are optional
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
