### PR TITLE
feat: plumb trust rule metadata through handleAddTrustRule

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -184,7 +184,30 @@ export function handleAddTrustRule(
   _ctx: HandlerContext,
 ): void {
   try {
-    addRule(msg.toolName, msg.pattern, msg.scope, msg.decision);
+    // Forward optional metadata fields when present so the persisted rule
+    // captures principal-scoping, high-risk coverage, and execution target.
+    const hasMetadata = msg.allowHighRisk != null
+      || msg.principalKind != null
+      || msg.principalId != null
+      || msg.principalVersion != null
+      || msg.executionTarget != null;
+
+    addRule(
+      msg.toolName,
+      msg.pattern,
+      msg.scope,
+      msg.decision,
+      undefined, // priority — use default
+      hasMetadata
+        ? {
+            allowHighRisk: msg.allowHighRisk,
+            principalKind: msg.principalKind,
+            principalId: msg.principalId,
+            principalVersion: msg.principalVersion,
+            executionTarget: msg.executionTarget,
+          }
+        : undefined,
+    );
     log.info({ toolName: msg.toolName, pattern: msg.pattern, scope: msg.scope, decision: msg.decision }, 'Trust rule added via client');
   } catch (err) {
     log.error({ err, toolName: msg.toolName, pattern: msg.pattern, scope: msg.scope }, 'Failed to add trust rule via client');


### PR DESCRIPTION
## Summary
- Forward optional metadata fields (`allowHighRisk`, `principalKind`, `principalId`, `principalVersion`, `executionTarget`) from `AddTrustRule` IPC message to `addRule()` in the trust store
- Legacy requests without metadata fields continue to work unchanged (backward compatible)

## Test plan
- [x] Type-check passes (no new errors)
- [x] IPC snapshot tests pass (247/247)
- [x] Backward compatible: metadata is only forwarded when at least one field is present
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
