### PR TITLE
fix: remove stray cd .. after backgrounded build in update command

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -82,7 +82,6 @@ PY
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
-   cd ..
    ```
 
 8. Verify health:


### PR DESCRIPTION
Remove the stray `cd ..` after the backgrounded macOS app build in step 7 of the /update command. When a command is backgrounded with `&`, the `cd clients/macos` runs in a subshell and doesn't affect the parent shell, so the `cd ..` incorrectly moves the shell above the repo root.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
