### PR TITLE
test: add daemon tests for add_trust_rule metadata plumbing

### DIFF
--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as net from 'node:net';
+import { mock } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'trust-rule-metadata-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => join(testDir, 'data'),
+  getWorkspaceSkillsDir: () => join(testDir, 'skills'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getIpcBlobDir: () => join(testDir, 'ipc-blobs'),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+const testConfig: Record<string, any> = {
+  permissions: { mode: 'legacy' as 'legacy' | 'strict' | 'workspace' },
+  skills: { load: { extraDirs: [] as string[] } },
+  sandbox: { enabled: true },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => testConfig,
+  loadConfig: () => testConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+import { handleAddTrustRule } from '../daemon/handlers/config.js';
+import { getAllRules, clearAllRules, clearCache } from '../permissions/trust-store.js';
+import type { AddTrustRule } from '../daemon/ipc-contract.js';
+import type { HandlerContext } from '../daemon/handlers.js';
+import type { ServerMessage } from '../daemon/ipc-contract.js';
+
+function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new Map(),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+describe('handleAddTrustRule metadata plumbing', () => {
+  beforeEach(() => {
+    clearAllRules();
+    clearCache();
+  });
+
+  test('persists allowHighRisk and principal fields when provided', () => {
+    const { ctx } = createTestContext();
+    const msg: AddTrustRule = {
+      type: 'add_trust_rule',
+      toolName: 'bash',
+      pattern: 'git *',
+      scope: '/projects/my-app',
+      decision: 'allow',
+      allowHighRisk: true,
+      principalKind: 'skill',
+      principalId: 'my-skill',
+      principalVersion: 'sha256:abc123',
+      executionTarget: 'host',
+    };
+
+    handleAddTrustRule(msg, {} as net.Socket, ctx);
+
+    const rules = getAllRules();
+    const userRule = rules.find((r) => r.tool === 'bash' && r.pattern === 'git *');
+    expect(userRule).toBeDefined();
+    expect(userRule!.allowHighRisk).toBe(true);
+    expect(userRule!.principalKind).toBe('skill');
+    expect(userRule!.principalId).toBe('my-skill');
+    expect(userRule!.principalVersion).toBe('sha256:abc123');
+    expect(userRule!.executionTarget).toBe('host');
+  });
+
+  test('backward compatibility: rules work without any metadata fields', () => {
+    const { ctx } = createTestContext();
+    const msg: AddTrustRule = {
+      type: 'add_trust_rule',
+      toolName: 'file_write',
+      pattern: '**',
+      scope: 'everywhere',
+      decision: 'allow',
+    };
+
+    handleAddTrustRule(msg, {} as net.Socket, ctx);
+
+    const rules = getAllRules();
+    const userRule = rules.find((r) => r.tool === 'file_write' && r.pattern === '**');
+    expect(userRule).toBeDefined();
+    expect(userRule!.decision).toBe('allow');
+    // Metadata fields should be absent
+    expect(userRule!.allowHighRisk).toBeUndefined();
+    expect(userRule!.principalKind).toBeUndefined();
+    expect(userRule!.principalId).toBeUndefined();
+    expect(userRule!.principalVersion).toBeUndefined();
+    expect(userRule!.executionTarget).toBeUndefined();
+  });
+
+  test('rule can be retrieved after being added with metadata', () => {
+    const { ctx } = createTestContext();
+    const msg: AddTrustRule = {
+      type: 'add_trust_rule',
+      toolName: 'bash',
+      pattern: 'npm install *',
+      scope: '/projects/web',
+      decision: 'allow',
+      allowHighRisk: false,
+      principalKind: 'task',
+      principalId: 'task-42',
+      executionTarget: 'sandbox',
+    };
+
+    handleAddTrustRule(msg, {} as net.Socket, ctx);
+
+    // Force re-read from disk to verify persistence
+    clearCache();
+    const rules = getAllRules();
+    const userRule = rules.find((r) => r.tool === 'bash' && r.pattern === 'npm install *');
+    expect(userRule).toBeDefined();
+    expect(userRule!.scope).toBe('/projects/web');
+    expect(userRule!.decision).toBe('allow');
+    expect(userRule!.allowHighRisk).toBe(false);
+    expect(userRule!.principalKind).toBe('task');
+    expect(userRule!.principalId).toBe('task-42');
+    // principalVersion was not set
+    expect(userRule!.principalVersion).toBeUndefined();
+    expect(userRule!.executionTarget).toBe('sandbox');
+  });
+
+  test('partial metadata: only allowHighRisk is forwarded when others are absent', () => {
+    const { ctx } = createTestContext();
+    const msg: AddTrustRule = {
+      type: 'add_trust_rule',
+      toolName: 'bash',
+      pattern: 'docker *',
+      scope: 'everywhere',
+      decision: 'allow',
+      allowHighRisk: true,
+    };
+
+    handleAddTrustRule(msg, {} as net.Socket, ctx);
+
+    const rules = getAllRules();
+    const userRule = rules.find((r) => r.tool === 'bash' && r.pattern === 'docker *');
+    expect(userRule).toBeDefined();
+    expect(userRule!.allowHighRisk).toBe(true);
+    expect(userRule!.principalKind).toBeUndefined();
+    expect(userRule!.principalId).toBeUndefined();
+    expect(userRule!.principalVersion).toBeUndefined();
+    expect(userRule!.executionTarget).toBeUndefined();
+  });
+
+  test('partial metadata: only executionTarget is forwarded when others are absent', () => {
+    const { ctx } = createTestContext();
+    const msg: AddTrustRule = {
+      type: 'add_trust_rule',
+      toolName: 'bash',
+      pattern: 'curl *',
+      scope: 'everywhere',
+      decision: 'allow',
+      executionTarget: 'sandbox',
+    };
+
+    handleAddTrustRule(msg, {} as net.Socket, ctx);
+
+    const rules = getAllRules();
+    const userRule = rules.find((r) => r.tool === 'bash' && r.pattern === 'curl *');
+    expect(userRule).toBeDefined();
+    expect(userRule!.executionTarget).toBe('sandbox');
+    expect(userRule!.allowHighRisk).toBeUndefined();
+    expect(userRule!.principalKind).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add targeted tests for `handleAddTrustRule` metadata persistence behavior
- Tests cover: full metadata, backward compatibility (no metadata), disk persistence after cache clear, partial metadata (allowHighRisk only, executionTarget only)

## Test plan
- [x] All 5 new tests pass
- [x] IPC snapshot tests still pass (247/247)
- [x] No regressions in existing test suite
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
