### PR TITLE
fix: resolve gateway test failures, decouple reconcile from localhost, align docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3541,7 +3541,7 @@ On startup, the gateway automatically reconciles the Telegram webhook registrati
 2. Calls `getWebhookInfo` to log the current registration state
 3. Unconditionally calls `setWebhook` with the expected URL, secret, and allowed updates (idempotent — Telegram does not expose the current secret via `getWebhookInfo`, so a compare-then-set approach would miss secret rotations)
 
-This also runs when the credential watcher detects changes to Telegram credentials. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required. Manual webhook registration is no longer required.
+This also runs when the credential watcher detects changes to Telegram credentials. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile via `POST /internal/telegram/reconcile`, so the webhook re-registers automatically without a gateway restart. Manual webhook registration is no longer required.
 
 ### Routing Auto-Configuration
 
@@ -3732,7 +3732,7 @@ For **inbound Twilio signature validation** at the gateway, URL reconstruction n
 2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`/`X-Original-Host` fallbacks)
 3. Raw request URL (always included as the final fallback)
 
-This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating even before a gateway restart.
+This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating immediately. For Telegram, ingress URL changes trigger an immediate internal reconcile, so neither channel requires a gateway restart.
 
 ### Runtime HTTP Endpoints
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -47,7 +47,7 @@ Save this value for the next steps.
 
 Manual webhook registration is no longer required. The gateway automatically reconciles the Telegram webhook on startup and whenever credentials change. It compares the current webhook URL against `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` and updates it if needed, including the webhook secret and allowed updates.
 
-If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL and re-register.
+If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
 You can skip directly to storing credentials.
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -417,7 +417,10 @@ export function handleSlackWebhookConfig(
   }
 }
 
-function computeLocalGatewayTarget(): string {
+function computeGatewayTarget(): string {
+  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
+    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
+  }
   const portRaw = process.env.GATEWAY_PORT || '7830';
   const port = Number(portRaw) || 7830;
   return `http://127.0.0.1:${port}`;
@@ -429,7 +432,7 @@ function computeLocalGatewayTarget(): string {
  * URL changes, without requiring a gateway restart.
  */
 function triggerGatewayReconcile(ingressPublicBaseUrl: string | undefined): void {
-  const gatewayBase = computeLocalGatewayTarget();
+  const gatewayBase = computeGatewayTarget();
   const token = readHttpToken();
   if (!token) {
     log.debug('Skipping gateway reconcile trigger: no HTTP bearer token available');
@@ -463,7 +466,7 @@ export function handleIngressConfig(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const localGatewayTarget = computeLocalGatewayTarget();
+  const localGatewayTarget = computeGatewayTarget();
   try {
     if (msg.action === 'get') {
       const raw = loadRawConfig();

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -69,7 +69,7 @@ v1 uses deterministic settings-based routing (no database):
 
 ## Setting up the Telegram webhook
 
-Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by registering it at `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` with the configured secret and allowed updates. This also runs whenever the credential watcher detects changes to the bot token or webhook secret (e.g., secret rotation). If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL.
+Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by registering it at `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` with the configured secret and allowed updates. This also runs whenever the credential watcher detects changes to the bot token or webhook secret (e.g., secret rotation). If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
 For manual setup (or reference), register the webhook with Telegram using the `setWebhook` API method. Pass:
 - `url` — your gateway URL, e.g. `https://your-host/webhooks/telegram`

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,12 +1,19 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
 import type { GatewayConfig } from "../config.js";
 
-// Mock reconcileTelegramWebhook so tests don't call the real Telegram API
-const mockReconcile = mock(() => Promise.resolve());
-mock.module("../telegram/webhook-manager.js", () => ({
-  reconcileTelegramWebhook: mockReconcile,
-}));
+// Instead of mock.module("../telegram/webhook-manager.js", ...) — which leaks
+// across Bun test files (process-global module mocks) — we mock globalThis.fetch
+// so that the real reconcileTelegramWebhook runs but API calls are intercepted.
+
+const originalFetch = globalThis.fetch;
+
+function makeTelegramResponse(result: unknown) {
+  return new Response(JSON.stringify({ ok: true, result }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return {
@@ -31,7 +38,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     telegramBotToken: "bot-token",
     telegramDeliverAuthBypass: false,
     telegramInitialBackoffMs: 1000,
-    telegramMaxRetries: 3,
+    telegramMaxRetries: 0,
     telegramTimeoutMs: 15000,
     telegramWebhookSecret: "webhook-secret",
     twilioAuthToken: undefined,
@@ -59,9 +66,36 @@ function makeRequest(
   });
 }
 
+/** Default fetch mock that handles Telegram API calls with success responses. */
+function installDefaultFetchMock() {
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    if (url.includes("/getWebhookInfo")) {
+      return makeTelegramResponse({
+        url: "",
+        has_custom_certificate: false,
+        pending_update_count: 0,
+      });
+    }
+    if (url.includes("/setWebhook")) {
+      return makeTelegramResponse(true);
+    }
+    return new Response("Not found", { status: 404 });
+  }) as any;
+}
+
 describe("POST /internal/telegram/reconcile", () => {
   beforeEach(() => {
-    mockReconcile.mockClear();
+    installDefaultFetchMock();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   test("rejects non-POST methods", async () => {
@@ -105,8 +139,8 @@ describe("POST /internal/telegram/reconcile", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(mockReconcile).toHaveBeenCalledTimes(1);
-    expect(mockReconcile).toHaveBeenCalledWith(config);
+    // Fetch was called (getWebhookInfo + setWebhook) proving reconcile ran.
+    expect(globalThis.fetch).toHaveBeenCalled();
   });
 
   test("updates ingressPublicBaseUrl when provided", async () => {
@@ -120,7 +154,6 @@ describe("POST /internal/telegram/reconcile", () => {
     expect(res.status).toBe(200);
     // Trailing slash should be normalized
     expect(config.ingressPublicBaseUrl).toBe("https://new.example.com");
-    expect(mockReconcile).toHaveBeenCalledTimes(1);
   });
 
   test("clears ingressPublicBaseUrl when empty string is provided", async () => {
@@ -133,7 +166,6 @@ describe("POST /internal/telegram/reconcile", () => {
     );
     expect(res.status).toBe(200);
     expect(config.ingressPublicBaseUrl).toBeUndefined();
-    expect(mockReconcile).toHaveBeenCalledTimes(1);
   });
 
   test("works with empty body (no URL update)", async () => {
@@ -148,13 +180,12 @@ describe("POST /internal/telegram/reconcile", () => {
     const res = await handler(req);
     expect(res.status).toBe(200);
     expect(config.ingressPublicBaseUrl).toBe("https://example.com");
-    expect(mockReconcile).toHaveBeenCalledTimes(1);
   });
 
   test("returns 502 when reconcile throws", async () => {
-    mockReconcile.mockImplementationOnce(() =>
-      Promise.reject(new Error("Telegram API error")),
-    );
+    globalThis.fetch = mock(async () => {
+      throw new Error("Telegram API error");
+    }) as any;
     const config = makeConfig();
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "test-token"));
@@ -179,13 +210,34 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("serializes concurrent requests so the last URL wins", async () => {
-    const callOrder: string[] = [];
+    const setWebhookUrls: string[] = [];
+
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
-    mockReconcile.mockImplementation(async (cfg: GatewayConfig) => {
-      callOrder.push(cfg.ingressPublicBaseUrl ?? "undefined");
-      await new Promise((r) => setTimeout(r, 50));
-    });
+    globalThis.fetch = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/getWebhookInfo")) {
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : {};
+          setWebhookUrls.push(body.url);
+          await new Promise((r) => setTimeout(r, 50));
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    ) as any;
 
     const config = makeConfig({ ingressPublicBaseUrl: "https://original.com" });
     const handler = createTelegramReconcileHandler(config);
@@ -208,11 +260,13 @@ describe("POST /internal/telegram/reconcile", () => {
 
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
-    expect(mockReconcile).toHaveBeenCalledTimes(2);
 
-    // The first reconcile should see "first" and the second should see
+    // The first reconcile should register with "first" and the second with
     // "second" — proving that config mutation + reconcile are atomic.
-    expect(callOrder).toEqual(["https://first.com", "https://second.com"]);
+    expect(setWebhookUrls).toEqual([
+      "https://first.com/webhooks/telegram",
+      "https://second.com/webhooks/telegram",
+    ]);
     // After both complete, the config should reflect the last write.
     expect(config.ingressPublicBaseUrl).toBe("https://second.com");
   });


### PR DESCRIPTION
## Summary
- Fix 4 failing gateway tests caused by `mock.module()` leaking across test files (Bun process-global module mocks). Replaced with scoped `globalThis.fetch` mocking.
- Decouple assistant's `triggerGatewayReconcile` from localhost by supporting `GATEWAY_INTERNAL_BASE_URL` env var, enabling non-co-located gateway/runtime topologies.
- Update 3 doc files to replace stale "gateway restart required" statements with accurate "immediate internal reconcile" behavior.

## Test plan
- [x] `cd gateway && bunx tsc --noEmit` passes
- [x] `cd gateway && bun test` passes (211/211, 0 fail) — deterministic across 2 runs
- [x] `cd assistant && bunx tsc --noEmit` passes
- [x] Assistant test suite has pre-existing baseline failures (unrelated `getTool` export issue)

## Original prompt
.private/plans/telegram-remaining-closeout-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
