### PR TITLE
fix: handle NaN in getAppHistory limit clamping

### DIFF
--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -153,7 +153,7 @@ export async function commitAppChange(message: string): Promise<void> {
  */
 export async function getAppHistory(appId: string, limit = 50): Promise<AppVersion[]> {
   validateAppId(appId);
-  const safeLimit = Math.max(1, Math.min(Math.floor(limit), 500));
+  const safeLimit = Math.max(1, Math.min(Math.floor(limit) || 50, 500));
   const appsDir = getAppsDir();
   const gitService = getWorkspaceGitService(appsDir);
 


### PR DESCRIPTION
## Summary
- Add `|| 50` fallback to `Math.floor(limit)` so NaN inputs fall back to the default limit instead of propagating through the Math chain
- Prevents `--max-count=NaN` being passed to git
- Addresses review feedback from #6423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
