### PR TITLE
fix: prevent duplicate overflow menu on interleaved assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -193,7 +193,7 @@ struct ChatBubble: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .contextMenu {}
                 .overlay(alignment: .topTrailing) {
-                    if !isUser && !shouldShowBubble && hasOverflowActions {
+                    if !isUser && !shouldShowBubble && !hasInterleavedContent && hasOverflowActions {
                         overflowMenuButton
                             .opacity(showOverflowMenu ? 1 : 0)
                             .animation(VAnimation.fast, value: showOverflowMenu)


### PR DESCRIPTION
## Summary
- Add `!hasInterleavedContent` guard to the fallback overflow menu overlay to prevent it from rendering when interleaved text bubbles already provide their own overflow menus via `bubbleChrome`
- Addresses review feedback from #6424

## Original prompt
In clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift, fix a duplicate overflow menu bug from PR #6424 review feedback.

The fallback overflow menu overlay (around line 195-196) needs an additional `!hasInterleavedContent` guard so it doesn't double up with the per-bubble overflow menus from `bubbleChrome`. Addresses feedback from #6424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
