### PR TITLE
feat: default to bare voiceId for ElevenLabs ConversationRelay

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -693,7 +693,7 @@ describe('AssistantConfigSchema', () => {
         fallbackToStandardOnError: true,
         elevenlabs: {
           voiceId: '',
-          voiceModelId: 'turbo_v2_5',
+          voiceModelId: '',
           speed: 1.0,
           stability: 0.5,
           similarityBoost: 0.75,
@@ -806,7 +806,7 @@ describe('AssistantConfigSchema', () => {
     expect(result.calls.voice.transcriptionProvider).toBe('Deepgram');
     expect(result.calls.voice.fallbackToStandardOnError).toBe(true);
     expect(result.calls.voice.elevenlabs.voiceId).toBe('');
-    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('turbo_v2_5');
+    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('');
     expect(result.calls.voice.elevenlabs.speed).toBe(1.0);
     expect(result.calls.voice.elevenlabs.stability).toBe(0.5);
     expect(result.calls.voice.elevenlabs.similarityBoost).toBe(0.75);
@@ -860,7 +860,7 @@ describe('AssistantConfigSchema', () => {
     expect(result.calls.voice.elevenlabs.voiceId).toBe('abc123');
     expect(result.calls.voice.elevenlabs.stability).toBe(0.8);
     // Defaults preserved for unset fields
-    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('turbo_v2_5');
+    expect(result.calls.voice.elevenlabs.voiceModelId).toBe('');
     expect(result.calls.voice.elevenlabs.similarityBoost).toBe(0.75);
   });
 
@@ -996,7 +996,7 @@ describe('resolveVoiceQualityProfile', () => {
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.mode).toBe('twilio_elevenlabs_tts');
     expect(profile.ttsProvider).toBe('ElevenLabs');
-    expect(profile.voice).toBe('test-voice-id-turbo_v2_5-1_0.5_0.75');
+    expect(profile.voice).toBe('test-voice-id');
     expect(profile.validationErrors).toEqual([]);
   });
 
@@ -1046,7 +1046,7 @@ describe('resolveVoiceQualityProfile', () => {
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.mode).toBe('elevenlabs_agent');
     expect(profile.ttsProvider).toBe('ElevenLabs');
-    expect(profile.voice).toBe('v1-turbo_v2_5-1_0.5_0.75');
+    expect(profile.voice).toBe('v1');
     expect(profile.agentId).toBe('agent-123');
     expect(profile.validationErrors).toEqual([]);
   });
@@ -1122,7 +1122,7 @@ describe('buildElevenLabsVoiceSpec', () => {
     expect(spec).toBe('myVoice-eleven_multilingual_v2-0.9_0.8_0.9');
   });
 
-  test('default config produces valid speed (not below 0.7)', () => {
+  test('default config uses a bare voiceId when no model override is set', () => {
     const config = AssistantConfigSchema.parse({
       calls: {
         voice: {
@@ -1132,12 +1132,7 @@ describe('buildElevenLabsVoiceSpec', () => {
       },
     });
     const spec = buildElevenLabsVoiceSpec(config.calls.voice.elevenlabs);
-    // speed=1, stability=0.5, similarity=0.75
-    expect(spec).toBe('test-turbo_v2_5-1_0.5_0.75');
-    // The first numeric value (speed) must be >= 0.7 for Twilio
-    const parts = spec.split('-');
-    const tuning = parts[2].split('_');
-    expect(Number(tuning[0])).toBeGreaterThanOrEqual(0.7);
+    expect(spec).toBe('test');
   });
 });
 

--- a/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
+++ b/assistant/src/__tests__/twilio-routes-elevenlabs.test.ts
@@ -55,7 +55,7 @@ mock.module('../config/loader.js', () => ({
         fallbackToStandardOnError: true,
         elevenlabs: {
           voiceId: '',
-          voiceModelId: 'turbo_v2_5',
+          voiceModelId: '',
           speed: 1.0,
           stability: 0.5,
           similarityBoost: 0.75,

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -14,25 +14,33 @@ export interface VoiceQualityProfile {
 /**
  * Build a Twilio-compatible ElevenLabs voice string.
  *
- * Twilio ConversationRelay expects the format:
- *   voiceId-model-speed_stability_similarity
+ * Twilio ConversationRelay accepts:
+ *   - bare voiceId
+ *   - voiceId-model-speed_stability_similarity
  *
- * Where:
- *   - speed:      0.7 – 1.2  (playback speed)
- *   - stability:  0.0 – 1.0
- *   - similarity: 0.0 – 1.0
+ * We default to bare voiceId unless a model is explicitly configured.
+ * This avoids forcing model/tuning suffixes that may be rejected for some
+ * voice + model combinations.
  *
  * See: https://www.twilio.com/docs/voice/conversationrelay/voice-configuration
  */
 export function buildElevenLabsVoiceSpec(config: {
   voiceId: string;
-  voiceModelId: string;
-  speed: number;
-  stability: number;
-  similarityBoost: number;
+  voiceModelId?: string;
+  speed?: number;
+  stability?: number;
+  similarityBoost?: number;
 }): string {
-  if (!config.voiceId) return '';
-  return `${config.voiceId}-${config.voiceModelId}-${config.speed}_${config.stability}_${config.similarityBoost}`;
+  const voiceId = config.voiceId?.trim();
+  if (!voiceId) return '';
+
+  const voiceModelId = config.voiceModelId?.trim();
+  if (!voiceModelId) return voiceId;
+
+  const speed = config.speed ?? 1.0;
+  const stability = config.stability ?? 0.5;
+  const similarityBoost = config.similarityBoost ?? 0.75;
+  return `${voiceId}-${voiceModelId}-${speed}_${stability}_${similarityBoost}`;
 }
 
 /**

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -176,17 +176,33 @@ ElevenLabs integration is entirely optional. The standard Twilio-only setup work
 
 ### Mode: `twilio_elevenlabs_tts`
 
-Uses ElevenLabs voices through Twilio's ConversationRelay. Speech is more natural-sounding than the default Google TTS voices. No ElevenLabs API key is needed for this mode — just a voice ID.
+Uses ElevenLabs voices through Twilio's ConversationRelay. Speech is more natural-sounding than the default Google TTS voices.
 
-**Setup:**
+**Recommended user-friendly workflow (no technical IDs required):**
 
-1. Browse ElevenLabs voices at https://elevenlabs.io/voice-library and pick a voice ID
-2. Set the voice mode and voice ID:
+1. Ask what kind of voice the user wants (examples: "warm", "professional", "playful", "calm", "deeper", "brighter")
+2. If the user doesn't care, keep `twilio_standard` (simplest path)
+3. If they want higher-quality voice, switch to `twilio_elevenlabs_tts` and choose a matching ElevenLabs voice on their behalf
+
+The user should not need to know what a `voiceId` is unless they explicitly want advanced/manual control.
+
+**Manual/advanced setup (optional):**
 
 ```bash
 vellum config set calls.voice.mode twilio_elevenlabs_tts
 vellum config set calls.voice.elevenlabs.voiceId "<your-voice-id>"
 ```
+
+By default, the system sends a **bare** `voiceId` to Twilio ConversationRelay (no model/tuning suffix). This is the safest default across voice IDs.
+
+If you want to force Twilio's extended voice spec, you can optionally set a model ID:
+
+```bash
+vellum config set calls.voice.elevenlabs.voiceModelId "flash_v2_5"
+```
+
+When `voiceModelId` is set, the emitted voice string becomes:
+`voiceId-model-speed_stability_similarity`.
 
 ### Mode: `elevenlabs_agent` (experimental/restricted)
 
@@ -404,7 +420,8 @@ All call-related settings can be managed via `vellum config`:
 | `calls.voice.language` | Language code for TTS and transcription | `en-US` |
 | `calls.voice.transcriptionProvider` | Speech-to-text provider (`Deepgram`, `Google`) | `Deepgram` |
 | `calls.voice.fallbackToStandardOnError` | Auto-fallback to standard Twilio TTS on ElevenLabs errors | `true` |
-| `calls.voice.elevenlabs.voiceId` | ElevenLabs voice ID (for `twilio_elevenlabs_tts` mode) | *(empty)* |
+| `calls.voice.elevenlabs.voiceId` | Advanced/internal ElevenLabs voice identifier. Usually set by the assistant based on requested voice style | *(empty)* |
+| `calls.voice.elevenlabs.voiceModelId` | Optional Twilio ConversationRelay model suffix. Leave empty to send bare `voiceId` | *(empty)* |
 | `calls.voice.elevenlabs.agentId` | ElevenLabs agent ID (for `elevenlabs_agent` mode) | *(empty)* |
 | `calls.voice.elevenlabs.speed` | Playback speed (`0.7` – `1.2`) | `1.0` |
 | `calls.voice.elevenlabs.stability` | Voice stability (`0.0` – `1.0`) | `0.5` |
@@ -471,8 +488,15 @@ The system has a 30-second silence timeout. If nobody speaks for 30 seconds, the
 
 ### Call quality didn't improve after enabling ElevenLabs
 - Verify `calls.voice.mode` is set to `twilio_elevenlabs_tts` or `elevenlabs_agent` (not still `twilio_standard`)
-- Check that `calls.voice.elevenlabs.voiceId` contains a valid ElevenLabs voice ID
+- Ask for the desired voice style again and try a different voice selection
+- If configuring manually: check that `calls.voice.elevenlabs.voiceId` contains a valid ElevenLabs voice ID
 - If mode is `elevenlabs_agent`, ensure `calls.voice.elevenlabs.agentId` is also set
+
+### Twilio says "application error" right after answer
+- This often means ConversationRelay rejected voice configuration after TwiML fetch
+- Keep `calls.voice.elevenlabs.voiceModelId` empty first (bare `voiceId` mode)
+- If you set `voiceModelId`, try clearing it and retesting:
+  `vellum config set calls.voice.elevenlabs.voiceModelId ""`
 
 ### ElevenLabs mode falls back to standard
 When `calls.voice.fallbackToStandardOnError` is `true` (the default), the system silently falls back to standard Twilio TTS if ElevenLabs encounters an error or restriction. Check:

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -235,7 +235,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       fallbackToStandardOnError: true,
       elevenlabs: {
         voiceId: '',
-        voiceModelId: 'turbo_v2_5',
+        voiceModelId: '',
         speed: 1.0,
         stability: 0.5,
         similarityBoost: 0.75,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -915,7 +915,7 @@ export const CallsElevenLabsConfigSchema = z.object({
     .default(''),
   voiceModelId: z
     .string({ error: 'calls.voice.elevenlabs.voiceModelId must be a string' })
-    .default('turbo_v2_5'),
+    .default(''),
   speed: z
     .number({ error: 'calls.voice.elevenlabs.speed must be a number' })
     .min(0.7, 'calls.voice.elevenlabs.speed must be >= 0.7')
@@ -967,7 +967,7 @@ export const CallsVoiceConfigSchema = z.object({
     .default(true),
   elevenlabs: CallsElevenLabsConfigSchema.default({
     voiceId: '',
-    voiceModelId: 'turbo_v2_5',
+    voiceModelId: '',
     speed: 1.0,
     stability: 0.5,
     similarityBoost: 0.75,
@@ -1022,7 +1022,7 @@ export const CallsConfigSchema = z.object({
     fallbackToStandardOnError: true,
     elevenlabs: {
       voiceId: '',
-      voiceModelId: 'turbo_v2_5',
+      voiceModelId: '',
       speed: 1.0,
       stability: 0.5,
       similarityBoost: 0.75,
@@ -1327,7 +1327,7 @@ export const AssistantConfigSchema = z.object({
       fallbackToStandardOnError: true,
       elevenlabs: {
         voiceId: '',
-        voiceModelId: 'turbo_v2_5',
+        voiceModelId: '',
         speed: 1.0,
         stability: 0.5,
         similarityBoost: 0.75,


### PR DESCRIPTION
## Summary
- Default `voiceModelId` to empty string instead of `turbo_v2_5`, so the voice spec sent to Twilio ConversationRelay is a bare `voiceId` unless a model is explicitly configured
- Update `buildElevenLabsVoiceSpec` to return just the voiceId when no model override is set, avoiding model/tuning suffixes that may be rejected for some voice + model combinations
- Update phone-calls SKILL.md with user-friendly workflow guidance and troubleshooting for the new bare voiceId default

## Original prompt
ship my staged and unstaged changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
