### PR TITLE
feat: render prompt preview with ToolConfirmationBubble in simulator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -210,7 +210,38 @@ struct ToolPermissionTesterView: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                // Local override label
+                // Prompt preview: reuse the ToolConfirmationBubble from chat
+                if result.decision == "prompt",
+                   result.localOverrideLabel == nil,
+                   let payload = result.promptPayload {
+                    let parsed = (try? model.parseInputJSON(model.inputJSON)) ?? [:]
+                    let confirmation = ToolConfirmationData.fromSimulation(
+                        toolName: model.toolName,
+                        input: parsed,
+                        riskLevel: result.riskLevel,
+                        executionTarget: model.executionTarget.isEmpty ? nil : model.executionTarget,
+                        promptPayload: payload
+                    )
+
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        ToolConfirmationBubble(
+                            confirmation: confirmation,
+                            isKeyboardActive: false,
+                            onAllow: { model.allowOnce() },
+                            onDeny: { model.denyOnce() },
+                            onAlwaysAllow: { _, pattern, scope, decision in
+                                model.alwaysAllow(pattern: pattern, scope: scope, decision: decision)
+                            }
+                        )
+
+                        Text("This is a simulation \u{2014} Allow Once and Don\u{2019}t Allow do not affect real permissions.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .italic()
+                    }
+                }
+
+                // Local override label (shown after allowOnce / denyOnce)
                 if let label = result.localOverrideLabel {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "info.circle")

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -308,6 +308,38 @@ public struct ToolConfirmationData: Equatable {
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
         self.state = state
     }
+
+    /// Build a `ToolConfirmationData` from a tool permission simulation response.
+    /// Maps the simulation-specific prompt payload types to the confirmation types
+    /// used by `ToolConfirmationBubble`.
+    public static func fromSimulation(
+        toolName: String,
+        input: [String: AnyCodable],
+        riskLevel: String,
+        executionTarget: String?,
+        promptPayload: IPCToolPermissionSimulateResponsePromptPayload
+    ) -> ToolConfirmationData {
+        let allowlistOptions = promptPayload.allowlistOptions.map { opt in
+            IPCConfirmationRequestAllowlistOption(
+                label: opt.label,
+                description: opt.description,
+                pattern: opt.pattern
+            )
+        }
+        let scopeOptions = promptPayload.scopeOptions.map { opt in
+            IPCConfirmationRequestScopeOption(label: opt.label, scope: opt.scope)
+        }
+        return ToolConfirmationData(
+            requestId: "simulation",
+            toolName: toolName,
+            input: input,
+            riskLevel: riskLevel,
+            allowlistOptions: allowlistOptions,
+            scopeOptions: scopeOptions,
+            executionTarget: executionTarget,
+            persistentDecisionsAllowed: promptPayload.persistentDecisionsAllowed
+        )
+    }
 }
 
 /// A single sub-tool invocation within a claude_code tool call.


### PR DESCRIPTION
## Summary

- When the permission simulator returns a `prompt` decision, renders an interactive `ToolConfirmationBubble` preview showing exactly what the user would see during a real tool invocation
- Adds `ToolConfirmationData.fromSimulation()` factory method in the shared module to map simulation payload types to confirmation types (solving cross-module init access)
- Includes a disclaimer note clarifying that Allow Once / Don't Allow in the simulator don't affect real permissions

## Test plan

- [ ] Build the macOS app — verify no compiler errors
- [ ] Open Settings > Trust tab > Permission Simulator
- [ ] Enter a tool name and simulate — verify prompt decisions show the ToolConfirmationBubble
- [ ] Verify Allow Once / Don't Allow buttons work within the simulation context
- [ ] Verify the disclaimer note appears below the bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
