### PR TITLE
feat: forward simulation metadata when persisting Always Allow rules

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -113,6 +113,9 @@ final class ToolPermissionTesterModel: ObservableObject {
     }
 
     /// Persist a trust rule via IPC, then re-simulate to show updated decision.
+    ///
+    /// Forwards the simulation's metadata (execution target, principal) so the
+    /// persisted rule matches the context that was being tested.
     func alwaysAllow(pattern: String, scope: String, decision: String) {
         guard let dc = daemonClient as? DaemonClient else {
             lastError = "Cannot add trust rule: daemon client unavailable"
@@ -120,7 +123,8 @@ final class ToolPermissionTesterModel: ObservableObject {
         }
 
         let riskLevel = lastResult?.riskLevel ?? ""
-        let effectiveDecision = riskLevel.lowercased() == "high"
+        let isHighRisk = riskLevel.lowercased() == "high"
+        let effectiveDecision = isHighRisk
             ? "always_allow_high_risk"
             : decision
 
@@ -129,7 +133,12 @@ final class ToolPermissionTesterModel: ObservableObject {
                 toolName: toolName,
                 pattern: pattern,
                 scope: scope,
-                decision: effectiveDecision
+                decision: effectiveDecision,
+                allowHighRisk: isHighRisk ? true : nil,
+                principalKind: principalKind.isEmpty ? nil : principalKind,
+                principalId: principalId.isEmpty ? nil : principalId,
+                principalVersion: principalVersion.isEmpty ? nil : principalVersion,
+                executionTarget: executionTarget.isEmpty ? nil : executionTarget
             )
             // Re-simulate to show the updated outcome with the new rule in effect.
             simulate()

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -234,7 +234,7 @@ struct ToolPermissionTesterView: View {
                             }
                         )
 
-                        Text("This is a simulation \u{2014} Allow Once and Don\u{2019}t Allow do not affect real permissions.")
+                        Text("Allow Once and Don\u{2019}t Allow are simulation-only. Always Allow persists a real trust rule.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                             .italic()


### PR DESCRIPTION
## Summary

- Forwards execution target and principal context (kind, id, version) from the simulator form to `sendAddTrustRule` when the user clicks Always Allow, so the persisted trust rule matches the simulation context
- Sets `allowHighRisk: true` when the simulated risk level is high
- Updates the prompt preview disclaimer to clarify that Always Allow persists real trust rules while Allow Once / Don't Allow remain simulation-only

## Test plan

- [ ] Build the macOS app — verify no compiler errors
- [ ] Open Settings > Trust tab > Permission Simulator
- [ ] Set a principal kind and execution target, simulate a tool that returns `prompt`
- [ ] Click Always Allow — verify the new trust rule appears in the rules list with the correct metadata
- [ ] Re-simulate — verify the decision now shows `allow` with the matched rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
