### PR TITLE
fix: make sidebar always push content instead of floating overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -459,17 +459,10 @@ struct MainWindowView: View {
 
                     Divider().background(VColor.surfaceBorder)
 
-                    // Content area with sidebar drawer overlay.
-                    // On panel routes the sidebar pushes content via leading padding
-                    // so the panel view is never obscured. On chat routes the sidebar
-                    // floats as an overlay.
+                    // Content area with sidebar pushing content
                     ZStack(alignment: .leading) {
                         let sidebarVisible = sidebarOpen && windowState.layoutConfig.left.visible
-                        let sidebarPushesContent: Bool = {
-                            if case .panel = windowState.selection { return true }
-                            return false
-                        }()
-                        let sidebarInset = sidebarVisible && sidebarPushesContent
+                        let sidebarInset = sidebarVisible
                             ? threadDrawerWidth + VSpacing.xs : 0
 
                         chatContentView(geometry: geometry)
@@ -477,22 +470,10 @@ struct MainWindowView: View {
 
                         // Sidebar drawer
                         if sidebarVisible {
-                            // Click-outside-to-dismiss scrim (overlay mode only)
-                            if !sidebarPushesContent {
-                                Color.clear
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
-                                        withAnimation(.easeInOut(duration: 0.35)) {
-                                            sidebarOpen = false
-                                        }
-                                    }
-                            }
                             HStack(spacing: 0) {
                                 sidebarView
                                 drawerDragDivider(availableWidth: geometry.size.width / zoomManager.zoomLevel)
                             }
-                            .shadow(color: sidebarPushesContent ? .clear : .black.opacity(0.2),
-                                    radius: 8, x: 2, y: 0)
                             .transition(.move(edge: .leading))
                             .animation(nil, value: threadDrawerWidth)
                         }
@@ -839,9 +820,6 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "plus.circle", label: "New chat") {
                 windowState.selection = nil
                 threadManager.createThread()
-                withAnimation(.easeInOut(duration: 0.35)) {
-                    sidebarOpen = false
-                }
             }
 
             Spacer().frame(height: VSpacing.lg)


### PR DESCRIPTION
## Summary
- Sidebar now always pushes the main content area via leading padding, regardless of whether you're on a chat or panel route
- Removes the conditional overlay mode (click-outside-to-dismiss scrim, shadow) since push mode makes these unnecessary
- Removes auto-close sidebar on new chat creation

## Test plan
- [ ] Open sidebar on a chat thread — verify it pushes content to the right
- [ ] Open sidebar on a panel route — verify same push behavior
- [ ] Create a new chat while sidebar is open — verify sidebar stays open
- [ ] Resize sidebar drag handle — verify content adjusts smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
