### PR TITLE
fix: reduce sidebar subheader padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1115,7 +1115,8 @@ private struct SidebarSubheader: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 20)
             .padding(.trailing, VSpacing.md)
-            .padding(.vertical, 20)
+            .padding(.top, VSpacing.md)
+            .padding(.bottom, VSpacing.md)
     }
 }
 


### PR DESCRIPTION
## Summary
- Reduced "Recent Chats" subheader vertical padding from 20pt to 12pt (VSpacing.md) to tighten the gap

## Test plan
- [ ] Verify the spacing between "Recent Chats" label and the first chat item looks tighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
