### PR TITLE
fix: use canonical decision values in permission tester Always Allow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -124,16 +124,13 @@ final class ToolPermissionTesterModel: ObservableObject {
 
         let riskLevel = lastResult?.riskLevel ?? ""
         let isHighRisk = riskLevel.lowercased() == "high"
-        let effectiveDecision = isHighRisk
-            ? "always_allow_high_risk"
-            : decision
 
         do {
             try dc.sendAddTrustRule(
                 toolName: toolName,
                 pattern: pattern,
                 scope: scope,
-                decision: effectiveDecision,
+                decision: "allow",  // Always use canonical "allow" — metadata handles high-risk
                 allowHighRisk: isHighRisk ? true : nil,
                 principalKind: principalKind.isEmpty ? nil : principalKind,
                 principalId: principalId.isEmpty ? nil : principalId,

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -272,7 +272,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         XCTAssertEqual(trustRuleMsg?.toolName, "host_bash")
         XCTAssertEqual(trustRuleMsg?.pattern, "echo *")
         XCTAssertEqual(trustRuleMsg?.scope, "project")
-        XCTAssertEqual(trustRuleMsg?.decision, "always_allow")
+        XCTAssertEqual(trustRuleMsg?.decision, "allow")
         XCTAssertEqual(trustRuleMsg?.executionTarget, "host")
         XCTAssertEqual(trustRuleMsg?.principalKind, "skill")
         XCTAssertEqual(trustRuleMsg?.principalId, "my-skill")
@@ -295,7 +295,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
 
         let trustRuleMsg = sentMessages[0] as? AddTrustRuleMessage
         XCTAssertNotNil(trustRuleMsg)
-        XCTAssertEqual(trustRuleMsg?.decision, "always_allow_high_risk")
+        XCTAssertEqual(trustRuleMsg?.decision, "allow")
         XCTAssertEqual(trustRuleMsg?.allowHighRisk, true)
     }
 
@@ -311,7 +311,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
 
         let trustRuleMsg = sentMessages[0] as? AddTrustRuleMessage
         XCTAssertNotNil(trustRuleMsg)
-        XCTAssertEqual(trustRuleMsg?.decision, "always_allow")
+        XCTAssertEqual(trustRuleMsg?.decision, "allow")
         XCTAssertNil(trustRuleMsg?.allowHighRisk)
     }
 


### PR DESCRIPTION
## Summary

- Fixed `alwaysAllow()` in `ToolPermissionTesterModel` to send the canonical `"allow"` decision value instead of non-canonical `"always_allow"` / `"always_allow_high_risk"` in the `add_trust_rule` IPC message
- The IPC contract requires `decision` to be one of `allow | deny | ask`; high-risk cases are already handled via the `allowHighRisk` metadata field
- Updated test assertions to expect `"allow"` instead of the old non-canonical values

## Test plan

- [x] Verified all three test assertion changes match the new canonical decision value
- [x] Confirmed `allowHighRisk: true` is still set correctly for high-risk scenarios
- [x] Confirmed `allowHighRisk: nil` for non-high-risk scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
