### PR TITLE
fix: add daemon-side validation for add_trust_rule decision field

### DIFF
--- a/assistant/src/__tests__/ipc-validate.test.ts
+++ b/assistant/src/__tests__/ipc-validate.test.ts
@@ -295,6 +295,55 @@ describe('IPC Validate', () => {
       if (!result.valid) expect(result.reason).toContain('non-empty string "actionId"');
     });
 
+    // ─── High-risk: add_trust_rule ──────────────────────────────────────
+
+    test('accepts valid add_trust_rule', () => {
+      const result = validateClientMessage({
+        type: 'add_trust_rule',
+        toolName: 'Bash',
+        pattern: '*',
+        scope: 'global',
+        decision: 'allow',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts all valid add_trust_rule decisions', () => {
+      for (const decision of ['allow', 'deny', 'ask']) {
+        const result = validateClientMessage({
+          type: 'add_trust_rule',
+          toolName: 'Bash',
+          pattern: '*',
+          scope: 'global',
+          decision,
+        });
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    test('rejects add_trust_rule without toolName', () => {
+      const result = validateClientMessage({
+        type: 'add_trust_rule',
+        pattern: '*',
+        scope: 'global',
+        decision: 'allow',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "toolName"');
+    });
+
+    test('rejects add_trust_rule with invalid decision', () => {
+      const result = validateClientMessage({
+        type: 'add_trust_rule',
+        toolName: 'Bash',
+        pattern: '*',
+        scope: 'global',
+        decision: 'always_allow',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"decision" must be one of');
+    });
+
     // ─── Extra properties are tolerated ─────────────────────────────────
 
     test('allows extra properties on known types', () => {
@@ -335,6 +384,7 @@ describe('IPC Validate', () => {
       secret_response: { requestId: 'r1' },
       ui_surface_action: { sessionId: 's1', surfaceId: 'sf1', actionId: 'a1' },
       ipc_blob_probe: { probeId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', nonceSha256: 'abc123' },
+      add_trust_rule: { toolName: 'Bash', pattern: '*', scope: 'global', decision: 'allow' },
       document_save: { surfaceId: 'doc1', conversationId: 'c1', title: 'Doc', content: 'text', wordCount: 1 },
       document_load: { surfaceId: 'doc1' },
       document_list: {},

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -150,6 +150,23 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     return null;
   },
 
+  add_trust_rule: (obj) => {
+    if (typeof obj.toolName !== 'string' || obj.toolName === '') {
+      return 'add_trust_rule requires a non-empty string "toolName"';
+    }
+    if (typeof obj.pattern !== 'string') {
+      return 'add_trust_rule requires a string "pattern"';
+    }
+    if (typeof obj.scope !== 'string') {
+      return 'add_trust_rule requires a string "scope"';
+    }
+    const validDecisions = ['allow', 'deny', 'ask'];
+    if (typeof obj.decision !== 'string' || !validDecisions.includes(obj.decision)) {
+      return `add_trust_rule "decision" must be one of: ${validDecisions.join(', ')}`;
+    }
+    return null;
+  },
+
   ui_surface_action: (obj) => {
     if (typeof obj.sessionId !== 'string' || obj.sessionId === '') {
       return 'ui_surface_action requires a non-empty string "sessionId"';


### PR DESCRIPTION
## Summary
- Adds an `add_trust_rule` validator to `HIGH_RISK_VALIDATORS` in `ipc-validate.ts` that ensures `decision` is one of the canonical values: `allow`, `deny`, `ask`
- Also validates `toolName` (non-empty string), `pattern` (string), and `scope` (string)
- Adds corresponding test cases and a fixture for the contract parity test

## Test plan
- [x] `bun test src/__tests__/ipc-validate.test.ts` passes (45/45 tests)
- [x] New tests cover valid decisions, invalid decisions, and missing required fields

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
