### PR TITLE
docs: add Tool Permission Tester mention to macOS README

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -234,6 +234,10 @@ Users can send multiple messages while the assistant is busy. Messages are queue
 
 **Current limitations:** Text-only messages, no conversation history browser.
 
+### Tool Permission Tester
+
+In Settings > Trust, engineers can simulate whether a tool invocation would be allowed, denied, or prompted. The tester shows the same `ToolConfirmationBubble` UI used in chat. "Allow Once" and "Don't Allow" are simulation-only; "Always Allow" persists a real trust rule.
+
 ## Xcode Previews
 
 The package is split into a library target (`VellumAssistantLib`) and a thin executable target (`vellum-assistant`). This lets you preview SwiftUI views live in Xcode without building and running the whole app.


### PR DESCRIPTION
## Summary
- Adds a brief "Tool Permission Tester" subsection to the macOS README under Usage
- Documents the Settings > Trust simulation feature: engineers can test whether a tool invocation would be allowed, denied, or prompted
- Notes the distinction between simulation-only actions (Allow Once, Don't Allow) and the persistent action (Always Allow)

## Test plan
- [x] README renders correctly with the new section

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
