### PR TITLE
fix: hide 'Thinking' indicator once text is streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -276,8 +276,9 @@ struct ChatBubble: View {
         /// True when there is at least one tool call that hasn't finished yet.
         let hasActuallyRunningTool = !hideToolCalls && message.toolCalls.contains(where: { !$0.isComplete })
         /// All individual tool calls done but message still streaming (model generating next tool call).
+        /// Hide once text is being streamed so the user doesn't see "Thinking" alongside the response.
         let toolsCompleteButStillStreaming = !hideToolCalls && !message.toolCalls.isEmpty
-            && message.toolCalls.allSatisfy({ $0.isComplete }) && message.isStreaming
+            && message.toolCalls.allSatisfy({ $0.isComplete }) && message.isStreaming && !hasText
         let hasInProgressTools = !message.toolCalls.isEmpty && !hideToolCalls && !allToolCallsComplete
         let hasPermission = decidedConfirmation != nil
         let hasStreamingCode = message.isStreaming && message.streamingCodePreview != nil && !(message.streamingCodePreview?.isEmpty ?? true)


### PR DESCRIPTION
## Summary
- Hide the "Thinking" indicator in `trailingStatus` once the message has text content
- Previously, after all tool calls completed but while `isStreaming` was still true, the user would see "Thinking" alongside the streaming response text
- Added `!hasText` guard to `toolsCompleteButStillStreaming` so it only shows in the gap between tool completion and first text chunk

## Original prompt
when its streaming, why we are still seeing additional thinking????

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
