### PR TITLE
test: add app version history IPC snapshots and refactor gateway tests

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2362,3 +2362,80 @@ exports[`IPC message snapshots ServerMessage types tool_permission_simulate_resp
   "type": "tool_permission_simulate_response",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types app_history_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "limit": 25,
+  "type": "app_history_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_diff_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "fromCommit": "abc123def456",
+  "toCommit": "789abc123def",
+  "type": "app_diff_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_file_at_version_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "commitHash": "abc123def456",
+  "path": "index.html",
+  "type": "app_file_at_version_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_restore_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "commitHash": "abc123def456",
+  "type": "app_restore_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_history_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_history_response",
+  "versions": [
+    {
+      "commitHash": "abc123def456",
+      "message": "Initial app commit",
+      "timestamp": 1700000000,
+    },
+    {
+      "commitHash": "789abc123def",
+      "message": "Update landing page",
+      "timestamp": 1700001000,
+    },
+  ],
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_diff_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "diff": "diff --git a/index.html b/index.html",
+  "type": "app_diff_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_file_at_version_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "content": "<html><body>Hello</body></html>",
+  "path": "index.html",
+  "type": "app_file_at_version_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_restore_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "app_restore_response",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -332,6 +332,28 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'app_preview_request',
     appId: 'app-001',
   },
+  app_history_request: {
+    type: 'app_history_request',
+    appId: 'app-001',
+    limit: 25,
+  },
+  app_diff_request: {
+    type: 'app_diff_request',
+    appId: 'app-001',
+    fromCommit: 'abc123def456',
+    toCommit: '789abc123def',
+  },
+  app_file_at_version_request: {
+    type: 'app_file_at_version_request',
+    appId: 'app-001',
+    path: 'index.html',
+    commitHash: 'abc123def456',
+  },
+  app_restore_request: {
+    type: 'app_restore_request',
+    appId: 'app-001',
+    commitHash: 'abc123def456',
+  },
   share_app_cloud: {
     type: 'share_app_cloud',
     appId: 'app-001',
@@ -1211,6 +1233,37 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'app_preview_response',
     appId: 'app-001',
     preview: 'base64-png-data',
+  },
+  app_history_response: {
+    type: 'app_history_response',
+    appId: 'app-001',
+    versions: [
+      {
+        commitHash: 'abc123def456',
+        message: 'Initial app commit',
+        timestamp: 1700000000,
+      },
+      {
+        commitHash: '789abc123def',
+        message: 'Update landing page',
+        timestamp: 1700001000,
+      },
+    ],
+  },
+  app_diff_response: {
+    type: 'app_diff_response',
+    appId: 'app-001',
+    diff: 'diff --git a/index.html b/index.html',
+  },
+  app_file_at_version_response: {
+    type: 'app_file_at_version_response',
+    appId: 'app-001',
+    path: 'index.html',
+    content: '<html><body>Hello</body></html>',
+  },
+  app_restore_response: {
+    type: 'app_restore_response',
+    success: true,
   },
   ui_surface_undo_result: {
     type: 'ui_surface_undo_result',

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -26,32 +26,28 @@ const handleTelegramWebhook = createTelegramWebhookHandler(config);
 
 let draining = false;
 
-const server = Bun.serve({
-  port: 0,
-  async fetch(req) {
-    const url = new URL(req.url);
+async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url);
 
-    if (url.pathname === "/healthz") {
-      return Response.json({ status: "ok" });
+  if (url.pathname === "/healthz") {
+    return Response.json({ status: "ok" });
+  }
+
+  if (url.pathname === "/readyz") {
+    if (draining) {
+      return Response.json({ status: "draining" }, { status: 503 });
     }
+    return Response.json({ status: "ok" });
+  }
 
-    if (url.pathname === "/readyz") {
-      if (draining) {
-        return Response.json({ status: "draining" }, { status: 503 });
-      }
-      return Response.json({ status: "ok" });
-    }
+  if (url.pathname === "/webhooks/telegram") {
+    return handleTelegramWebhook(req);
+  }
 
-    if (url.pathname === "/webhooks/telegram") {
-      return handleTelegramWebhook(req);
-    }
-
-    return Response.json({ error: "Not found" }, { status: 404 });
-  },
-});
+  return Response.json({ error: "Not found" }, { status: 404 });
+}
 
 afterAll(() => {
-  server.stop(true);
   for (const [k, v] of Object.entries(saved)) {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
@@ -60,7 +56,7 @@ afterAll(() => {
 
 describe("/healthz", () => {
   test("returns 200 with ok status", async () => {
-    const res = await fetch(`http://localhost:${server.port}/healthz`);
+    const res = await handleRequest(new Request("http://gateway.test/healthz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
@@ -69,7 +65,7 @@ describe("/healthz", () => {
 
 describe("/readyz", () => {
   test("returns 200 when not draining", async () => {
-    const res = await fetch(`http://localhost:${server.port}/readyz`);
+    const res = await handleRequest(new Request("http://gateway.test/readyz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
@@ -78,7 +74,7 @@ describe("/readyz", () => {
   test("returns 503 when draining", async () => {
     draining = true;
     try {
-      const res = await fetch(`http://localhost:${server.port}/readyz`);
+      const res = await handleRequest(new Request("http://gateway.test/readyz"));
       expect(res.status).toBe(503);
       const body = await res.json();
       expect(body.status).toBe("draining");

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -69,7 +69,7 @@ const successBody = {
   },
 };
 
-function mockFetch(fn: () => Promise<Response>) {
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
   const m = mock(fn);
   Object.assign(m, { preconnect: () => {} });
   globalThis.fetch = m as unknown as typeof fetch;
@@ -111,10 +111,21 @@ describe("forwardToRuntime", () => {
   });
 
   test("5xx error retries and eventually succeeds", async () => {
-    let callCount = 0;
-    mockFetch(() => {
-      callCount++;
-      if (callCount <= 2) {
+    const config = makeConfig();
+    const expectedUrl = `${config.assistantRuntimeBaseUrl}/v1/assistants/assistant-a/channels/inbound`;
+    let inboundCallCount = 0;
+    const fetchMock = mockFetch((input) => {
+      const calledUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (calledUrl === expectedUrl) {
+        inboundCallCount++;
+      }
+
+      if (inboundCallCount <= 2) {
         return Promise.resolve(
           new Response("Internal error", { status: 500 }),
         );
@@ -124,10 +135,13 @@ describe("forwardToRuntime", () => {
       );
     });
 
-    const config = makeConfig();
     const result = await forwardToRuntime(config, "assistant-a", payload);
     expect(result.accepted).toBe(true);
-    expect(callCount).toBe(3);
+    const callsToInboundRoute = fetchMock.mock.calls.filter((call) => {
+      const calledUrl = call[0];
+      return typeof calledUrl === "string" && calledUrl === expectedUrl;
+    });
+    expect(callsToInboundRoute).toHaveLength(3);
   });
 
   test("5xx error exhausts retries and throws", async () => {

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -1,22 +1,15 @@
-import { describe, test, expect, afterAll } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { buildSchema } from "../schema.js";
 
-const server = Bun.serve({
-  port: 0,
-  fetch(req) {
-    const url = new URL(req.url);
+function handleRequest(req: Request): Response {
+  const url = new URL(req.url);
 
-    if (url.pathname === "/schema") {
-      return Response.json(buildSchema());
-    }
+  if (url.pathname === "/schema") {
+    return Response.json(buildSchema());
+  }
 
-    return Response.json({ error: "Not found" }, { status: 404 });
-  },
-});
-
-afterAll(() => {
-  server.stop(true);
-});
+  return Response.json({ error: "Not found" }, { status: 404 });
+}
 
 describe("/schema route", () => {
   test("returns valid OpenAPI 3.1 schema via HTTP", async () => {
@@ -28,7 +21,7 @@ describe("/schema route", () => {
     // GIVEN a running gateway server
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${server.port}/schema`);
+    const res = handleRequest(new Request("http://gateway.test/schema"));
 
     // THEN we receive a 200 with valid JSON
     expect(res.status).toBe(200);
@@ -54,7 +47,7 @@ describe("/schema route", () => {
     // GIVEN a running gateway server
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${server.port}/schema`);
+    const res = handleRequest(new Request("http://gateway.test/schema"));
     const body = await res.json();
 
     // THEN the paths include every gateway endpoint
@@ -80,7 +73,7 @@ describe("/schema route", () => {
     const pkg = (await import("../../package.json")).default;
 
     // WHEN we request the schema endpoint
-    const res = await fetch(`http://localhost:${server.port}/schema`);
+    const res = handleRequest(new Request("http://gateway.test/schema"));
     const body = await res.json();
 
     // THEN the schema version matches the package version

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -45,33 +45,29 @@ const handleRuntimeProxy = config.runtimeProxyEnabled
   ? createRuntimeProxyHandler(config)
   : null;
 
-const server = Bun.serve({
-  port: 0,
-  async fetch(req) {
-    const url = new URL(req.url);
+async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url);
 
-    if (url.pathname === "/healthz") {
-      return Response.json({ status: "ok" });
-    }
+  if (url.pathname === "/healthz") {
+    return Response.json({ status: "ok" });
+  }
 
-    if (url.pathname === "/readyz") {
-      return Response.json({ status: "ok" });
-    }
+  if (url.pathname === "/readyz") {
+    return Response.json({ status: "ok" });
+  }
 
-    if (url.pathname === "/webhooks/telegram") {
-      return handleTelegramWebhook(req);
-    }
+  if (url.pathname === "/webhooks/telegram") {
+    return handleTelegramWebhook(req);
+  }
 
-    if (handleRuntimeProxy) {
-      return handleRuntimeProxy(req);
-    }
+  if (handleRuntimeProxy) {
+    return handleRuntimeProxy(req);
+  }
 
-    return Response.json({ error: "Not found" }, { status: 404 });
-  },
-});
+  return Response.json({ error: "Not found" }, { status: 404 });
+}
 
 afterAll(() => {
-  server.stop(true);
   for (const [k, v] of Object.entries(saved)) {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
@@ -80,28 +76,30 @@ afterAll(() => {
 
 describe("Telegram-only default: non-Telegram requests return 404", () => {
   test("GET / returns 404", async () => {
-    const res = await fetch(`http://localhost:${server.port}/`);
+    const res = await handleRequest(new Request("http://gateway.test/"));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("Not found");
   });
 
   test("GET /v1/health returns 404", async () => {
-    const res = await fetch(`http://localhost:${server.port}/v1/health`);
+    const res = await handleRequest(new Request("http://gateway.test/v1/health"));
     expect(res.status).toBe(404);
   });
 
   test("POST /v1/assistants/foo/chat returns 404", async () => {
-    const res = await fetch(`http://localhost:${server.port}/v1/assistants/foo/chat`, {
-      method: "POST",
-      body: "{}",
-      headers: { "content-type": "application/json" },
-    });
+    const res = await handleRequest(
+      new Request("http://gateway.test/v1/assistants/foo/chat", {
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      }),
+    );
     expect(res.status).toBe(404);
   });
 
   test("GET /random-path returns 404", async () => {
-    const res = await fetch(`http://localhost:${server.port}/random-path`);
+    const res = await handleRequest(new Request("http://gateway.test/random-path"));
     expect(res.status).toBe(404);
   });
 
@@ -114,14 +112,14 @@ describe("Telegram-only default: non-Telegram requests return 404", () => {
   });
 
   test("GET /healthz returns 200 (infrastructure routes still work)", async () => {
-    const res = await fetch(`http://localhost:${server.port}/healthz`);
+    const res = await handleRequest(new Request("http://gateway.test/healthz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
   });
 
   test("GET /readyz returns 200 (infrastructure routes still work)", async () => {
-    const res = await fetch(`http://localhost:${server.port}/readyz`);
+    const res = await handleRequest(new Request("http://gateway.test/readyz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");


### PR DESCRIPTION
## Summary
- Add IPC snapshot tests for new app version history message types (app_history, app_diff, app_file_at_version, app_restore request/response)
- Refactor gateway tests (probes, schema, telegram-only-default, runtime-client) to call request handlers directly instead of spinning up Bun.serve() servers, eliminating port binding and improving test speed
- Fix runtime-client retry test to track only inbound route calls instead of all fetch calls

## Original prompt
ship my staged and unstaged changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
