### PR TITLE
security: harden Telegram credential collection and add bot token detection

### DIFF
--- a/assistant/src/__tests__/secret-ingress-handler.test.ts
+++ b/assistant/src/__tests__/secret-ingress-handler.test.ts
@@ -27,6 +27,7 @@ const { checkIngressForSecrets } = await import('../security/secret-ingress.js')
 // These are well-known fake AWS/GitHub patterns used across the test suite.
 const AWS_KEY = ['AKIA', 'IOSFODNN7', 'REALKEY'].join('');
 const GH_TOKEN = ['ghp_', 'ABCDEFghijklMN01234567', '89abcdefghijkl'].join('');
+const TG_TOKEN = ['123456789', ':', 'ABCDefGHIJklmnopQRSTuvwxyz012345678'].join('');
 
 describe('secret ingress handler', () => {
   beforeEach(() => {
@@ -82,6 +83,13 @@ describe('secret ingress handler', () => {
     const result = checkIngressForSecrets(msg);
     expect(result.blocked).toBe(true);
     expect(result.detectedTypes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('blocks message containing a Telegram bot token', () => {
+    const result = checkIngressForSecrets(`Here is my bot token: ${TG_TOKEN}`);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain('Telegram Bot Token');
+    expect(result.userNotice).not.toContain(TG_TOKEN);
   });
 
   test('empty content passes through', () => {

--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -131,6 +131,43 @@ describe('Slack tokens', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Telegram
+// ---------------------------------------------------------------------------
+describe('Telegram bot tokens', () => {
+  // Build test token at runtime to avoid tripping pre-commit secret hook
+  const BOT_TOKEN = ['123456789', ':', 'ABCDefGHIJklmnopQRSTuvwxyz012345678'].join('');
+
+  test('detects Telegram bot token', () => {
+    expectMatch(`token=${BOT_TOKEN}`, 'Telegram Bot Token');
+  });
+
+  test('detects bot token in surrounding text', () => {
+    expectMatch(`My bot token is ${BOT_TOKEN} please save it`, 'Telegram Bot Token');
+  });
+
+  test('does not flag short numeric:alpha strings', () => {
+    // Too few digits in bot ID (only 5)
+    const matches = scanText('12345:ABCDefGHIJklmnopQRSTuvwxyz012345678');
+    const telegram = matches.filter((m) => m.type === 'Telegram Bot Token');
+    expect(telegram).toHaveLength(0);
+  });
+
+  test('does not flag token with wrong secret length', () => {
+    // Secret part is only 10 chars (needs 35)
+    const matches = scanText('123456789:ABCDefGHIJ');
+    const telegram = matches.filter((m) => m.type === 'Telegram Bot Token');
+    expect(telegram).toHaveLength(0);
+  });
+
+  test('does not flag token with too-long secret part', () => {
+    // Secret part is 40 chars (needs exactly 35)
+    const matches = scanText('123456789:ABCDefGHIJklmnopQRSTuvwxyz0123456789AB');
+    const telegram = matches.filter((m) => m.type === 'Telegram Bot Token');
+    expect(telegram).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Anthropic
 // ---------------------------------------------------------------------------
 describe('Anthropic keys', () => {

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -37,7 +37,7 @@ Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** s
    - Then call `skill_load` with `skill: "telegram-setup"`.
    - Tell the user: *"I've loaded a setup guide for Telegram. It will walk you through connecting a Telegram bot to your assistant."*
 
-The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering bot commands, and storing credentials securely. Webhook registration with Telegram is handled automatically by the gateway on startup and whenever credentials change.
+The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering bot commands, and storing credentials securely via the secure credential prompt flow. **Never accept a Telegram bot token pasted in plaintext chat — always use the secure prompt.** Webhook registration with Telegram is handled automatically by the gateway on startup and whenever credentials change.
 
 ## Platform Selection
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -13,13 +13,16 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 1. **Bot token** from Telegram's @BotFather (the user provides this)
 2. **Gateway webhook URL** — derived from the canonical ingress setting: `${ingress.publicBaseUrl}/webhooks/telegram`. The gateway is the only publicly reachable endpoint; Telegram sends webhooks to the gateway, which validates and forwards them to the assistant runtime internally. If `ingress.publicBaseUrl` is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 
-If the user has already provided the bot token in the conversation, use it directly. Otherwise, ask for it.
+**IMPORTANT — Secure credential collection only:** Never use a bot token that was pasted in plaintext chat. Always collect the bot token through the secure credential prompt flow using `credential_store` with `action: "prompt"` and `service: "telegram"`, `field: "bot_token"`. If the user has already pasted a token in the conversation, inform them that for security reasons you cannot use tokens shared in chat and must collect it through the secure prompt instead.
 
 ## Setup Steps
 
-### Step 1: Verify the Bot Token
+### Step 1: Collect and Verify the Bot Token
 
-Use `evaluate_typescript_code` to call the Telegram `getMe` API and confirm the token is valid:
+First, collect the bot token securely using the credential prompt:
+- Call `credential_store` with `action: "prompt"`, `service: "telegram"`, `field: "bot_token"`, and `prompt: "Enter your Telegram bot token from @BotFather"`.
+
+Then verify the token by calling the Telegram `getMe` API using `evaluate_typescript_code`:
 
 ```typescript
 export default async (input: { token: string }) => {

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -81,6 +81,13 @@ const PATTERNS: SecretPattern[] = [
     regex: /(https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+)/g,
   },
 
+  // -- Telegram --
+  {
+    type: 'Telegram Bot Token',
+    // Format: <bot_id>:<secret> where bot_id is 8-10 digits and secret is 35 alphanumeric/dash/underscore chars
+    regex: /\b([0-9]{8,10}:[A-Za-z0-9_-]{35})\b/g,
+  },
+
   // -- Anthropic --
   {
     type: 'Anthropic API Key',


### PR DESCRIPTION
## Summary
- Updated Telegram setup skill instructions to require secure credential prompt flow, removing the path that allowed using tokens pasted in plaintext chat
- Added Telegram bot token pattern (`<bot_id>:<secret>`) to the secret scanner so pasted tokens are blocked at ingress
- Added comprehensive tests for the new scanner pattern and ingress blocking behavior

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/telegram-credential-security-hardening-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
