### PR TITLE
fix: include executionTarget in simulator policy context

### DIFF
--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -275,4 +275,68 @@ describe('tool_permission_simulate handler', () => {
     expect(res.decision).toBe('allow');
     expect(res.matchedRuleId).toBeDefined();
   });
+
+  test('executionTarget: sandbox-scoped rule matches when simulated with sandbox target', async () => {
+    addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
+      executionTarget: 'sandbox',
+    });
+
+    const { ctx, sent } = createTestContext();
+    const msg: ToolPermissionSimulateRequest = {
+      type: 'tool_permission_simulate',
+      toolName: 'file_write',
+      input: { path: '/tmp/test.txt', content: 'hello' },
+      executionTarget: 'sandbox',
+    };
+    await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
+
+    const res = getResponse(sent);
+    expect(res.success).toBe(true);
+    expect(res.decision).toBe('allow');
+    expect(res.matchedRuleId).toBeDefined();
+  });
+
+  test('executionTarget: sandbox-scoped rule does NOT match when simulated with host target', async () => {
+    addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
+      executionTarget: 'sandbox',
+    });
+
+    const { ctx, sent } = createTestContext();
+    const msg: ToolPermissionSimulateRequest = {
+      type: 'tool_permission_simulate',
+      toolName: 'file_write',
+      input: { path: '/tmp/test.txt', content: 'hello' },
+      executionTarget: 'host',
+    };
+    await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
+
+    const res = getResponse(sent);
+    expect(res.success).toBe(true);
+    // The sandbox-scoped rule should not match a host target, so it falls
+    // through to the default prompt decision for medium-risk file_write.
+    expect(res.decision).toBe('prompt');
+    expect(res.matchedRuleId).toBeUndefined();
+  });
+
+  test('executionTarget: sandbox-scoped rule does not match without a target in context', async () => {
+    addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
+      executionTarget: 'sandbox',
+    });
+
+    const { ctx, sent } = createTestContext();
+    const msg: ToolPermissionSimulateRequest = {
+      type: 'tool_permission_simulate',
+      toolName: 'file_write',
+      input: { path: '/tmp/test.txt', content: 'hello' },
+      // no executionTarget — context.executionTarget will be undefined
+    };
+    await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
+
+    const res = getResponse(sent);
+    expect(res.success).toBe(true);
+    // A rule with executionTarget='sandbox' requires ctx.executionTarget='sandbox'.
+    // Without a target in the context, the rule should NOT match.
+    expect(res.decision).toBe('prompt');
+    expect(res.matchedRuleId).toBeUndefined();
+  });
 });

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -848,14 +848,21 @@ export async function handleToolPermissionSimulate(
 
     const workingDir = msg.workingDir ?? process.cwd();
 
-    // Build policy context from optional principal fields
-    const policyContext = msg.principalKind
+    // Build policy context from optional principal / execution-target fields
+    const hasPrincipal = !!msg.principalKind;
+    const hasTarget = !!msg.executionTarget;
+    const policyContext = (hasPrincipal || hasTarget)
       ? {
-          principal: {
-            kind: msg.principalKind as 'core' | 'skill' | 'task',
-            id: msg.principalId,
-            version: msg.principalVersion,
-          },
+          ...(hasPrincipal && {
+            principal: {
+              kind: msg.principalKind as 'core' | 'skill' | 'task',
+              id: msg.principalId,
+              version: msg.principalVersion,
+            },
+          }),
+          ...(hasTarget && {
+            executionTarget: msg.executionTarget as 'host' | 'sandbox',
+          }),
         }
       : undefined;
 


### PR DESCRIPTION
## Summary

- The tool permission simulator accepted `executionTarget` via IPC but never forwarded it into the `policyContext` passed to `check()`. This meant target-scoped trust rules (e.g. `executionTarget: 'sandbox'`) silently failed to match during simulation.
- Now builds `policyContext` when either `principalKind` or `executionTarget` is present, forwarding both fields correctly.
- Adds three tests covering sandbox-scoped rule matching: matching target, mismatched target, and absent target.

## Test plan

- [x] `bun test src/__tests__/tool-permission-simulate-handler.test.ts` — 14/14 pass (3 new)
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing `ipc-snapshot.test.ts` errors only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
