### PR TITLE
fix: remove unused decision parameter from alwaysAllow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -116,7 +116,7 @@ final class ToolPermissionTesterModel: ObservableObject {
     ///
     /// Forwards the simulation's metadata (execution target, principal) so the
     /// persisted rule matches the context that was being tested.
-    func alwaysAllow(pattern: String, scope: String, decision: String) {
+    func alwaysAllow(pattern: String, scope: String) {
         guard let dc = daemonClient as? DaemonClient else {
             lastError = "Cannot add trust rule: daemon client unavailable"
             return

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -229,8 +229,8 @@ struct ToolPermissionTesterView: View {
                             isKeyboardActive: false,
                             onAllow: { model.allowOnce() },
                             onDeny: { model.denyOnce() },
-                            onAlwaysAllow: { _, pattern, scope, decision in
-                                model.alwaysAllow(pattern: pattern, scope: scope, decision: decision)
+                            onAlwaysAllow: { _, pattern, scope, _ in
+                                model.alwaysAllow(pattern: pattern, scope: scope)
                             }
                         )
 

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -262,7 +262,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             matchedRuleId: nil, promptPayload: nil
         )
 
-        model.alwaysAllow(pattern: "echo *", scope: "project", decision: "always_allow")
+        model.alwaysAllow(pattern: "echo *", scope: "project")
 
         // Should have sent AddTrustRuleMessage + ToolPermissionSimulateMessage (re-simulate)
         XCTAssertEqual(sentMessages.count, 2)
@@ -291,7 +291,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             matchedRuleId: nil, promptPayload: nil
         )
 
-        model.alwaysAllow(pattern: "rm -rf *", scope: "global", decision: "always_allow")
+        model.alwaysAllow(pattern: "rm -rf *", scope: "global")
 
         let trustRuleMsg = sentMessages[0] as? AddTrustRuleMessage
         XCTAssertNotNil(trustRuleMsg)
@@ -307,7 +307,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             matchedRuleId: nil, promptPayload: nil
         )
 
-        model.alwaysAllow(pattern: "echo *", scope: "project", decision: "always_allow")
+        model.alwaysAllow(pattern: "echo *", scope: "project")
 
         let trustRuleMsg = sentMessages[0] as? AddTrustRuleMessage
         XCTAssertNotNil(trustRuleMsg)
@@ -325,7 +325,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             matchedRuleId: nil, promptPayload: nil
         )
 
-        model.alwaysAllow(pattern: "*", scope: "global", decision: "always_allow")
+        model.alwaysAllow(pattern: "*", scope: "global")
 
         let trustRuleMsg = sentMessages[0] as? AddTrustRuleMessage
         XCTAssertNotNil(trustRuleMsg)


### PR DESCRIPTION
## Summary
- Removed the unused `decision` parameter from `ToolPermissionTesterModel.alwaysAllow(pattern:scope:)` — the method always hardcodes `"allow"` internally, making the parameter vestigial.
- Updated the call site in `ToolPermissionTesterView` to stop passing the decision value through.
- Updated all 4 test call sites in `ToolPermissionTesterModelTests`.

## Test plan
- [ ] `./build.sh test` passes (all `ToolPermissionTesterModelTests` still pass without the parameter)
- [ ] `./build.sh lint` passes (no unused variable warnings)

Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
