### PR TITLE
feat: add Telegram bot token settings to macOS Settings UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -26,6 +26,7 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
+    @State private var telegramBotTokenText: String = ""
     @State private var ingressUrlText: String = ""
     @FocusState private var isIngressUrlFocused: Bool
     @State private var checkingGateway: Bool = false
@@ -92,6 +93,7 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
+            store.refreshTelegramStatus()
             store.refreshIngressConfig()
             ingressUrlText = store.ingressPublicBaseUrl
             setupIntegrationCallbacks()
@@ -644,6 +646,9 @@ struct SettingsPanel: View {
             // TWITTER / X section
             twitterSection
 
+            // TELEGRAM section
+            telegramSection
+
             // PUBLIC INGRESS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 HStack {
@@ -919,6 +924,86 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textMuted)
                     }
                 }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Telegram Section
+
+    private var telegramSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Telegram")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            if store.telegramHasBotToken {
+                // Connected / configured state
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                        .font(.system(size: 14))
+                    if let username = store.telegramBotUsername {
+                        Text("@\(username)")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    } else {
+                        Text("Bot token configured")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    Spacer()
+                    VButton(label: "Clear", style: .danger) {
+                        store.clearTelegramCredentials()
+                        telegramBotTokenText = ""
+                    }
+                }
+            } else {
+                // Not configured — show SecureField for token entry
+                HStack(spacing: VSpacing.xs) {
+                    Text("Enter Bot Token")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                SecureField("Telegram bot token", text: $telegramBotTokenText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                Text("Get your bot token from @BotFather on Telegram")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+
+                if store.telegramSaveInProgress {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Saving...")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                } else {
+                    VButton(label: "Save", style: .primary) {
+                        store.saveTelegramToken(botToken: telegramBotTokenText)
+                        telegramBotTokenText = ""
+                    }
+                    .disabled(telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+
+            if let error = store.telegramError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
             }
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -82,6 +82,15 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthError: String?
 
+    // MARK: - Telegram Integration State
+
+    @Published var telegramHasBotToken: Bool = false
+    @Published var telegramBotUsername: String?
+    @Published var telegramConnected: Bool = false
+    @Published var telegramHasWebhookSecret: Bool = false
+    @Published var telegramSaveInProgress: Bool = false
+    @Published var telegramError: String?
+
     // MARK: - Ingress Config State
 
     @Published var ingressEnabled: Bool = false
@@ -241,6 +250,21 @@ public final class SettingsStore: ObservableObject {
             self.refreshTwitterStatus()
         }
 
+        // Wire up Telegram config IPC response
+        daemonClient?.onTelegramConfigResponse = { [weak self] response in
+            guard let self else { return }
+            self.telegramSaveInProgress = false
+            if response.success {
+                self.telegramHasBotToken = response.hasBotToken
+                self.telegramBotUsername = response.botUsername
+                self.telegramConnected = response.connected
+                self.telegramHasWebhookSecret = response.hasWebhookSecret
+                self.telegramError = nil
+            } else {
+                self.telegramError = response.error
+            }
+        }
+
         // Refresh Vercel key state on init
         refreshVercelKeyState()
 
@@ -253,6 +277,9 @@ public final class SettingsStore: ObservableObject {
 
         // Refresh Twitter integration status on init
         refreshTwitterStatus()
+
+        // Refresh Telegram integration status on init
+        refreshTelegramStatus()
 
         // Ingress config is refreshed by onAppear in SettingsPanel /
         // SettingsView, not here, to avoid duplicate get requests whose
@@ -482,6 +509,37 @@ public final class SettingsStore: ObservableObject {
             try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
         } catch {
             log.error("Failed to send Twitter disconnect: \(error)")
+        }
+    }
+
+    // MARK: - Telegram Integration Actions
+
+    func refreshTelegramStatus() {
+        do {
+            try daemonClient?.sendTelegramConfig(action: "get")
+        } catch {
+            log.error("Failed to send Telegram config get: \(error)")
+        }
+    }
+
+    func saveTelegramToken(botToken: String) {
+        let trimmed = botToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        telegramSaveInProgress = true
+        telegramError = nil
+        do {
+            try daemonClient?.sendTelegramConfig(action: "set", botToken: trimmed)
+        } catch {
+            telegramSaveInProgress = false
+            log.error("Failed to send Telegram config set: \(error)")
+        }
+    }
+
+    func clearTelegramCredentials() {
+        do {
+            try daemonClient?.sendTelegramConfig(action: "clear")
+        } catch {
+            log.error("Failed to send Telegram config clear: \(error)")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ public struct SettingsView: View {
     @State private var vercelKeyText = ""
     @State private var twitterClientId = ""
     @State private var twitterClientSecret = ""
+    @State private var telegramBotTokenText = ""
     @State private var ingressUrlText = ""
     @FocusState private var isIngressUrlFocused: Bool
     @State private var accessibilityGranted = false
@@ -358,6 +359,54 @@ public struct SettingsView: View {
                 }
             }
 
+            Section("Telegram") {
+                if store.telegramHasBotToken {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
+                        if let username = store.telegramBotUsername {
+                            Text("@\(username)")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Bot token configured")
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Clear") {
+                            store.clearTelegramCredentials()
+                            telegramBotTokenText = ""
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    SecureField("Enter bot token", text: $telegramBotTokenText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your bot token from @BotFather on Telegram")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        if store.telegramSaveInProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Button("Save") {
+                                store.saveTelegramToken(botToken: telegramBotTokenText)
+                                telegramBotTokenText = ""
+                            }
+                            .disabled(telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                }
+
+                if let error = store.telegramError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+
             Section("Public Ingress") {
                 Toggle("Enable Public Ingress", isOn: Binding(
                     get: { store.ingressEnabled },
@@ -616,6 +665,7 @@ public struct SettingsView: View {
             store.refreshAPIKeyState()
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
+            store.refreshTelegramStatus()
             store.refreshIngressConfig()
             ingressUrlText = store.ingressPublicBaseUrl
             checkPermissions()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -245,6 +245,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `vercel_api_config_response` message.
     public var onVercelApiConfigResponse: ((VercelApiConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `telegram_config_response` message.
+    public var onTelegramConfigResponse: ((TelegramConfigResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `twitter_integration_config_response` message.
     public var onTwitterIntegrationConfigResponse: ((TwitterIntegrationConfigResponseMessage) -> Void)?
 
@@ -901,6 +904,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Get, set, or delete the Vercel API token configuration.
     public func sendVercelApiConfig(action: String, apiToken: String? = nil) throws {
         try send(VercelApiConfigRequestMessage(action: action, apiToken: apiToken))
+    }
+
+    /// Get, set, or clear Telegram bot token configuration.
+    public func sendTelegramConfig(action: String, botToken: String? = nil) throws {
+        try send(TelegramConfigRequestMessage(action: action, botToken: botToken))
     }
 
     /// Publish a static page to Vercel.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -125,6 +125,8 @@ extension DaemonClient {
             onIngressConfigResponse?(msg)
         case .vercelApiConfigResponse(let msg):
             onVercelApiConfigResponse?(msg)
+        case .telegramConfigResponse(let msg):
+            onTelegramConfigResponse?(msg)
         case .twitterIntegrationConfigResponse(let msg):
             onTwitterIntegrationConfigResponse?(msg)
         case .twitterAuthResult(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1791,6 +1791,22 @@ extension IPCVercelApiConfigRequest {
 /// Backed by generated `IPCVercelApiConfigResponse`.
 public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
 
+// MARK: - Telegram Config Messages
+
+/// Sent to get/set/clear Telegram bot config.
+/// Backed by generated `IPCTelegramConfigRequest`.
+public typealias TelegramConfigRequestMessage = IPCTelegramConfigRequest
+
+extension IPCTelegramConfigRequest {
+    public init(action: String, botToken: String? = nil) {
+        self.init(type: "telegram_config", action: action, botToken: botToken)
+    }
+}
+
+/// Response from Telegram config operations.
+/// Backed by generated `IPCTelegramConfigResponse`.
+public typealias TelegramConfigResponseMessage = IPCTelegramConfigResponse
+
 // MARK: - Twitter Integration Config Messages
 
 /// Sent to get/set Twitter integration config.
@@ -1997,6 +2013,7 @@ public enum ServerMessage: Decodable, Sendable {
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
     case ingressConfigResponse(IngressConfigResponseMessage)
     case vercelApiConfigResponse(VercelApiConfigResponseMessage)
+    case telegramConfigResponse(TelegramConfigResponseMessage)
     case twitterIntegrationConfigResponse(TwitterIntegrationConfigResponseMessage)
     case twitterAuthResult(TwitterAuthResultMessage)
     case twitterAuthStatusResponse(TwitterAuthStatusResponseMessage)
@@ -2268,6 +2285,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "vercel_api_config_response":
             let message = try VercelApiConfigResponseMessage(from: decoder)
             self = .vercelApiConfigResponse(message)
+        case "telegram_config_response":
+            let message = try TelegramConfigResponseMessage(from: decoder)
+            self = .telegramConfigResponse(message)
         case "twitter_integration_config_response":
             let message = try TwitterIntegrationConfigResponseMessage(from: decoder)
             self = .twitterIntegrationConfigResponse(message)


### PR DESCRIPTION
## Summary
- Wired Telegram config IPC routing in DaemonMessageRouter and DaemonClient
- Added Telegram state properties and methods to SettingsStore
- Added Telegram section to both SettingsPanel and SettingsView
- SecureField for token entry, never displays raw token
- Bot username visible when connected, with clear/save controls

Part of #6450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
