### PR TITLE
fix: prevent in-flight Telegram dedup from returning early 200s

### DIFF
--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -99,7 +99,7 @@ Summarize what was done:
 - Credentials stored securely in the vault
 - Routing configuration validated
 
-The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), a gateway restart is required to pick up the new URL.
+The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
 ## Bot-Account Limitations
 

--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -62,12 +62,11 @@ describe("DedupCache", () => {
     expect(cache.size).toBe(2);
   });
 
-  test("reserve returns true for unseen update_id and populates cache", () => {
+  test("reserve returns true for unseen update_id and creates processing entry", () => {
     expect(cache.reserve(50)).toBe(true);
     expect(cache.size).toBe(1);
-    const hit = cache.get(50);
-    expect(hit).toBeDefined();
-    expect(hit!.status).toBe(200);
+    // get() returns undefined for processing entries (not yet finalized)
+    expect(cache.get(50)).toBeUndefined();
   });
 
   test("reserve returns false for already-reserved update_id", () => {
@@ -80,11 +79,39 @@ describe("DedupCache", () => {
     expect(cache.reserve(70)).toBe(false);
   });
 
-  test("set overwrites a reserved entry with the final response", () => {
+  test("get returns undefined while entry is still processing", () => {
+    cache.reserve(75);
+    // Entry is reserved (processing) — get() should not return it
+    expect(cache.get(75)).toBeUndefined();
+    // But the entry does occupy a slot
+    expect(cache.size).toBe(1);
+  });
+
+  test("set finalizes a reserved entry and makes it available via get", () => {
     cache.reserve(80);
+    // Still processing — not visible
+    expect(cache.get(80)).toBeUndefined();
+    // Finalize with actual response
     cache.set(80, '{"final":true}', 201);
     const hit = cache.get(80);
     expect(hit).toEqual({ body: '{"final":true}', status: 201 });
+  });
+
+  test("unreserve allows re-reservation after processing failure", () => {
+    cache.reserve(85);
+    expect(cache.reserve(85)).toBe(false);
+    // Simulate processing failure — unreserve so Telegram can retry
+    cache.unreserve(85);
+    expect(cache.size).toBe(0);
+    // Now re-reserve should succeed
+    expect(cache.reserve(85)).toBe(true);
+  });
+
+  test("unreserve does not remove finalized entries", () => {
+    cache.set(86, '{"ok":true}', 200);
+    cache.unreserve(86);
+    // Finalized entry should still be present
+    expect(cache.get(86)).toEqual({ body: '{"ok":true}', status: 200 });
   });
 
   test("reserve succeeds after a reserved entry expires", () => {

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -224,3 +224,143 @@ describe("telegram webhook handler: /new rejection", () => {
     expect(resetCall).toBeUndefined();
   });
 });
+
+describe("telegram webhook handler: in-flight dedup", () => {
+  test("second request with same update_id returns 503 while first is still processing", async () => {
+    // Simulate a slow runtime: the first request hangs until we resolve
+    let resolveFirst!: () => void;
+    const firstBlocks = new Promise<void>((r) => { resolveFirst = r; });
+
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+
+    // Install a fetch mock where the runtime inbound call blocks on the first
+    // invocation and responds immediately on subsequent ones.
+    let inboundCallCount = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
+      let body: unknown;
+      try {
+        if (init?.body) body = JSON.parse(String(init.body));
+        else if (typeof input === "object" && "json" in input) body = await (input as Request).clone().json();
+      } catch { /* not JSON */ }
+      fetchCalls.push({ url, method, body });
+
+      if (url.includes("/v1/assistants/") && url.includes("/inbound")) {
+        inboundCallCount++;
+        if (inboundCallCount === 1) {
+          await firstBlocks; // hang until test releases
+        }
+        return new Response(JSON.stringify({ eventId: "evt-1", duplicate: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("api.telegram.org")) {
+        return new Response(JSON.stringify({ ok: true, result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    }) as any;
+
+    const handler = createTelegramWebhookHandler(config);
+    const payload = makeTelegramPayload("hello", 9001);
+
+    // Fire first request (will block on runtime call)
+    const first = handler(makeWebhookRequest(payload));
+
+    // Fire second request with same update_id while first is in-flight
+    const second = await handler(makeWebhookRequest(payload));
+    expect(second.status).toBe(503);
+    expect(second.headers.get("Retry-After")).toBe("1");
+
+    // Let the first request finish
+    resolveFirst();
+    const firstRes = await first;
+    expect(firstRes.status).toBe(200);
+
+    // Third request after processing completed — should get cached 200
+    const third = await handler(makeWebhookRequest(payload));
+    expect(third.status).toBe(200);
+    const thirdBody = await third.json();
+    expect(thirdBody.ok).toBe(true);
+  });
+
+  test("failed processing unreserves, allowing retry to be processed normally", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+      runtimeMaxRetries: 0,
+    });
+
+    let callCount = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
+      let body: unknown;
+      try {
+        if (init?.body) body = JSON.parse(String(init.body));
+        else if (typeof input === "object" && "json" in input) body = await (input as Request).clone().json();
+      } catch { /* not JSON */ }
+      fetchCalls.push({ url, method, body });
+
+      if (url.includes("/v1/assistants/") && url.includes("/inbound")) {
+        callCount++;
+        if (callCount === 1) {
+          // First call fails
+          return new Response("Internal error", { status: 500 });
+        }
+        // Subsequent calls succeed
+        return new Response(JSON.stringify({ eventId: "evt-2", duplicate: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("api.telegram.org")) {
+        return new Response(JSON.stringify({ ok: true, result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    }) as any;
+
+    const handler = createTelegramWebhookHandler(config);
+    const payload = makeTelegramPayload("hello", 9002);
+
+    // First attempt fails — should return 500 and unreserve
+    const first = await handler(makeWebhookRequest(payload));
+    expect(first.status).toBe(500);
+
+    // Retry with same update_id — should be processed (not permanently deduped)
+    const retry = await handler(makeWebhookRequest(payload));
+    expect(retry.status).toBe(200);
+    const retryBody = await retry.json();
+    expect(retryBody.ok).toBe(true);
+  });
+
+  test("after successful processing, duplicates return cached success", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+    const payload = makeTelegramPayload("hello", 9003);
+
+    // Process successfully
+    const first = await handler(makeWebhookRequest(payload));
+    expect(first.status).toBe(200);
+
+    // Duplicate returns cached response without hitting the runtime again
+    const beforeCount = fetchCalls.length;
+    const dup = await handler(makeWebhookRequest(payload));
+    expect(dup.status).toBe(200);
+    const dupBody = await dup.json();
+    expect(dupBody.ok).toBe(true);
+    // No new fetch calls should have been made (response came from cache)
+    expect(fetchCalls.length).toBe(beforeCount);
+  });
+});

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -25,7 +25,11 @@ export class DedupCache {
     this.maxSize = maxSize;
   }
 
-  /** Returns the cached response body+status if the update_id was already seen. */
+  /**
+   * Returns the cached response body+status if the update_id was already seen
+   * and processing has completed. Returns `undefined` for entries still being
+   * processed (reserved but not yet finalized).
+   */
   get(updateId: number): { body: string; status: number } | undefined {
     const entry = this.cache.get(updateId);
     if (!entry) return undefined;
@@ -33,6 +37,7 @@ export class DedupCache {
       this.cache.delete(updateId);
       return undefined;
     }
+    if (entry.processing) return undefined;
     return { body: entry.body, status: entry.status };
   }
 
@@ -42,6 +47,10 @@ export class DedupCache {
    * concurrent retries are blocked before the handler finishes.
    * Returns true if a new reservation was created (caller should proceed),
    * false if the update_id was already present (caller should short-circuit).
+   *
+   * While the entry is in the "processing" state, {@link get} returns
+   * `undefined` so callers can distinguish an in-flight request from a
+   * finalized cache hit and respond accordingly (e.g. 503 Retry-After).
    */
   reserve(updateId: number): boolean {
     const existing = this.cache.get(updateId);
@@ -50,8 +59,24 @@ export class DedupCache {
     }
     // Clean up expired entry if present
     if (existing) this.cache.delete(updateId);
-    this.set(updateId, '{"ok":true}', 200);
-    this.cache.get(updateId)!.processing = true;
+
+    // Evict if at capacity
+    if (this.cache.size >= this.maxSize) {
+      this.evictExpired();
+    }
+    if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) {
+        this.cache.delete(oldest);
+      }
+    }
+
+    this.cache.set(updateId, {
+      body: "",
+      status: 0,
+      expiresAt: Date.now() + this.ttlMs,
+      processing: true,
+    });
     return true;
   }
 

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -120,11 +120,19 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     if (updateId !== undefined) {
       const reserved = dedupCache.reserve(updateId);
       if (!reserved) {
-        log.info({ updateId }, "Duplicate update_id, returning cached response");
-        const cached = dedupCache.get(updateId)!;
-        return new Response(cached.body, {
-          status: cached.status,
-          headers: { "content-type": "application/json" },
+        const cached = dedupCache.get(updateId);
+        if (cached) {
+          log.info({ updateId }, "Duplicate update_id, returning cached response");
+          return new Response(cached.body, {
+            status: cached.status,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        // Still being processed by the first handler — ask Telegram to retry
+        log.info({ updateId }, "Duplicate update_id while still processing, returning 503");
+        return new Response(JSON.stringify({ error: "Processing in progress" }), {
+          status: 503,
+          headers: { "content-type": "application/json", "Retry-After": "1" },
         });
       }
     }


### PR DESCRIPTION
## Summary
- Fix dedup cache so `reserve()` no longer seeds a 200 response while processing is in-flight — concurrent duplicates now receive 503 with `Retry-After: 1` so Telegram retries naturally
- Failed processing still unreserves the entry, preserving retryability
- Fix SKILL.md Step 7 wording to match Step 3: ingress URL changes trigger immediate reconcile, no gateway restart needed
- Add regression tests proving in-flight dedup returns 503 (not 200), failed processing allows retry, and finalized entries return cached success

## Original prompt
Please make one PR that closes the last Telegram gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
