### PR TITLE
fix: guard against nil daemonClient in Telegram settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -516,7 +516,8 @@ public final class SettingsStore: ObservableObject {
 
     func refreshTelegramStatus() {
         do {
-            try daemonClient?.sendTelegramConfig(action: "get")
+            guard let daemonClient else { return }
+            try daemonClient.sendTelegramConfig(action: "get")
         } catch {
             log.error("Failed to send Telegram config get: \(error)")
         }
@@ -528,16 +529,21 @@ public final class SettingsStore: ObservableObject {
         telegramSaveInProgress = true
         telegramError = nil
         do {
-            try daemonClient?.sendTelegramConfig(action: "set", botToken: trimmed)
+            guard let daemonClient else {
+                telegramSaveInProgress = false
+                return
+            }
+            try daemonClient.sendTelegramConfig(action: "set", botToken: trimmed)
         } catch {
             telegramSaveInProgress = false
-            log.error("Failed to send Telegram config set: \(error)")
+            telegramError = "Failed to save: \(error.localizedDescription)"
         }
     }
 
     func clearTelegramCredentials() {
         do {
-            try daemonClient?.sendTelegramConfig(action: "clear")
+            guard let daemonClient else { return }
+            try daemonClient.sendTelegramConfig(action: "clear")
         } catch {
             log.error("Failed to send Telegram config clear: \(error)")
         }


### PR DESCRIPTION
## Summary
- Added `guard let daemonClient` checks to Telegram settings methods
- Prevents stuck spinner when daemonClient is nil
- Follows the same pattern as the existing Twitter integration

Addresses feedback on #6458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
