### PR TITLE
fix: distinguish keychain errors and fix credential reader tests

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -63,9 +63,11 @@ beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
   logCalls.length = 0;
   execFileSyncMock.mockReset();
-  // Default: execFileSync throws (credential not found in keychain)
+  // Default: execFileSync throws with exit code 44 (errSecItemNotFound)
   execFileSyncMock.mockImplementation(() => {
-    throw new Error("not found");
+    const err = new Error("not found") as Error & { status: number };
+    err.status = 44;
+    throw err;
   });
 });
 
@@ -109,6 +111,10 @@ describe("readTelegramCredentials: encrypted store only (existing behavior)", ()
 });
 
 describe("readTelegramCredentials: keychain on macOS", () => {
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
   test("returns credentials from keychain when available on macOS", () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
@@ -197,6 +203,10 @@ describe("readTelegramCredentials: neither backend has credentials", () => {
 });
 
 describe("readKeychainCredential", () => {
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
   test("returns credential value from keychain on macOS", () => {
     execFileSyncMock.mockImplementation(() => "my-secret-value\n");
 
@@ -204,11 +214,25 @@ describe("readKeychainCredential", () => {
     expect(result).toBe("my-secret-value");
   });
 
-  test("returns undefined when keychain throws", () => {
+  test("returns undefined when keychain item not found (exit code 44)", () => {
     execFileSyncMock.mockImplementation(() => {
-      throw new Error("security: SecKeychainSearchCopyNext: The specified item could not be found");
+      const err = new Error("security: SecKeychainSearchCopyNext: The specified item could not be found") as Error & { status: number };
+      err.status = 44;
+      throw err;
     });
 
+    const result = readKeychainCredential("credential:telegram:bot_token");
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for transient keychain errors (non-44 exit code)", () => {
+    execFileSyncMock.mockImplementation(() => {
+      const err = new Error("security: The user name or passphrase you entered is not correct.") as Error & { status: number };
+      err.status = 51;
+      throw err;
+    });
+
+    // Should still return undefined (graceful fallback), but logs a warning
     const result = readKeychainCredential("credential:telegram:bot_token");
     expect(result).toBeUndefined();
   });
@@ -235,6 +259,10 @@ describe("readKeychainCredential", () => {
 });
 
 describe("log output: no plaintext secrets", () => {
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
   test("log messages never contain secret values", () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -127,6 +127,11 @@ export function getMetadataPath(): string {
  * Read a single credential from the macOS Keychain.
  * Returns `undefined` on non-macOS platforms, when the credential
  * doesn't exist, or on any error.
+ *
+ * Exit code 44 from `security` means errSecItemNotFound — the credential
+ * genuinely doesn't exist. Other non-zero exit codes indicate transient
+ * errors (locked keychain, timeout, etc.) and are logged as warnings so
+ * operators have visibility into keychain health.
  */
 export function readKeychainCredential(account: string): string | undefined {
   if (process.platform !== "darwin") return undefined;
@@ -146,7 +151,12 @@ export function readKeychainCredential(account: string): string | undefined {
     if (!value) return undefined;
     log.debug({ account }, "Credential found in keychain");
     return value;
-  } catch {
+  } catch (err: unknown) {
+    // Exit code 44 = errSecItemNotFound — credential genuinely missing
+    const exitCode = (err as { status?: number }).status;
+    if (exitCode !== 44) {
+      log.warn({ account, exitCode }, "Keychain lookup failed with unexpected error");
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary
- Distinguish keychain not-found (exit 44) from transient errors with appropriate logging
- Added `process.platform = "darwin"` to all keychain-exercising test cases
- Tests now pass on Linux CI runners

Addresses feedback on #6456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
