### PR TITLE
fix: initialize tester model in onAppear instead of during body evaluation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -98,6 +98,9 @@ struct SettingsPanel: View {
             ingressUrlText = store.ingressPublicBaseUrl
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
+            if testerModel == nil, let dc = daemonClient {
+                testerModel = ToolPermissionTesterModel(daemonClient: dc)
+            }
         }
         .onDisappear {
             daemonClient?.onIntegrationListResponse = nil
@@ -1074,8 +1077,8 @@ struct SettingsPanel: View {
             }
 
             // PERMISSION SIMULATOR section
-            if let dc = daemonClient {
-                ToolPermissionTesterView(model: ensureTesterModel(dc))
+            if let model = testerModel {
+                ToolPermissionTesterView(model: model)
             }
 
             // PRIVACY & SECURITY section
@@ -1371,16 +1374,6 @@ struct SettingsPanel: View {
                 }
             }
         }
-    }
-
-    // MARK: - Tester Model
-
-    /// Lazily create and cache the tester model so it survives re-renders.
-    private func ensureTesterModel(_ dc: DaemonClient) -> ToolPermissionTesterModel {
-        if let existing = testerModel { return existing }
-        let model = ToolPermissionTesterModel(daemonClient: dc)
-        DispatchQueue.main.async { testerModel = model }
-        return model
     }
 
     // MARK: - Privacy Bullet


### PR DESCRIPTION
Fixes SwiftUI race condition where ensureTesterModel could create multiple model instances due to deferred @State assignment. Moves initialization to .onAppear for deterministic lifecycle. Addresses review feedback from PR #6435.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
