### PR TITLE
fix: replace Task.sleep with deterministic assertions in permission tester tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -167,14 +167,10 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             error: nil
         ))
 
-        // Give the Task { @MainActor } a chance to run
-        let expectation = XCTestExpectation(description: "Response handled")
-        Task { @MainActor in
-            // Yield once to let the inner Task run
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
+        // Wait for the Task { @MainActor } dispatch to complete
+        let predicate = NSPredicate { _, _ in !self.model.isSimulating }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
 
         XCTAssertFalse(model.isSimulating)
         XCTAssertNotNil(model.lastResult)
@@ -200,12 +196,10 @@ final class ToolPermissionTesterModelTests: XCTestCase {
             error: "Tool not found"
         ))
 
-        let expectation = XCTestExpectation(description: "Response handled")
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
+        // Wait for the Task { @MainActor } dispatch to complete
+        let predicate = NSPredicate { _, _ in !self.model.isSimulating }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
 
         XCTAssertFalse(model.isSimulating)
         XCTAssertEqual(model.lastError, "Tool not found")


### PR DESCRIPTION
Replaces fixed Task.sleep(10_000_000) delays with deterministic expectation-based assertions that wait for the actual model state change, eliminating potential test flakiness on busy CI executors. Addresses review feedback from PR #6438.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
