### PR TITLE
M1: External binding primitive + API surface

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
+import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
@@ -199,14 +200,29 @@ export function handleSecretResponse(
 
 export function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
   const conversations = conversationStore.listConversations(50);
+  const bindings = externalConversationStore.getBindingsForConversations(
+    conversations.map((c) => c.id),
+  );
   ctx.send(socket, {
     type: 'session_list_response',
-    sessions: conversations.map((c) => ({
-      id: c.id,
-      title: c.title ?? 'Untitled',
-      updatedAt: c.updatedAt,
-      threadType: normalizeThreadType(c.threadType),
-    })),
+    sessions: conversations.map((c) => {
+      const binding = bindings.get(c.id);
+      return {
+        id: c.id,
+        title: c.title ?? 'Untitled',
+        updatedAt: c.updatedAt,
+        threadType: normalizeThreadType(c.threadType),
+        ...(binding ? {
+          channelBinding: {
+            sourceChannel: binding.sourceChannel,
+            externalChatId: binding.externalChatId,
+            externalUserId: binding.externalUserId,
+            displayName: binding.displayName,
+            username: binding.username,
+          },
+        } : {}),
+      };
+    }),
   });
 }
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1232,9 +1232,18 @@ export interface SessionInfo {
   threadType?: ThreadType;
 }
 
+/** Channel binding metadata exposed in session/conversation list APIs. */
+export interface ChannelBinding {
+  sourceChannel: string;
+  externalChatId: string;
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+}
+
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; channelBinding?: ChannelBinding }>;
 }
 
 export interface SessionsClearResponse {

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -904,6 +904,26 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_status ON task_runs(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_candidates_promoted ON task_candidates(promoted_task_id)`);
 
+  // ── External Conversation Bindings ──────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS external_conversation_bindings (
+      conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+      source_channel TEXT NOT NULL,
+      external_chat_id TEXT NOT NULL,
+      external_user_id TEXT,
+      display_name TEXT,
+      username TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      last_inbound_at INTEGER,
+      last_outbound_at INTEGER
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat ON external_conversation_bindings(source_channel, external_chat_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel ON external_conversation_bindings(source_channel)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -1,0 +1,164 @@
+/**
+ * Store for external conversation bindings — maps internal conversation IDs
+ * to external channel identifiers (e.g. Telegram chat ID, SMS thread ID).
+ *
+ * This enables the system to track which conversations originated from
+ * external channels and expose channel metadata in session/conversation
+ * list APIs.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { getDb } from './db.js';
+import { externalConversationBindings } from './schema.js';
+
+export interface ExternalConversationBinding {
+  conversationId: string;
+  sourceChannel: string;
+  externalChatId: string;
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+  createdAt: number;
+  updatedAt: number;
+  lastInboundAt?: number | null;
+  lastOutboundAt?: number | null;
+}
+
+export interface UpsertBindingInput {
+  conversationId: string;
+  sourceChannel: string;
+  externalChatId: string;
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+}
+
+/**
+ * Insert or update an external conversation binding on conflict (conversationId).
+ * On conflict, updates channel metadata and timestamps.
+ */
+export function upsertBinding(input: UpsertBindingInput): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.insert(externalConversationBindings)
+    .values({
+      conversationId: input.conversationId,
+      sourceChannel: input.sourceChannel,
+      externalChatId: input.externalChatId,
+      externalUserId: input.externalUserId ?? null,
+      displayName: input.displayName ?? null,
+      username: input.username ?? null,
+      createdAt: now,
+      updatedAt: now,
+      lastInboundAt: now,
+    })
+    .onConflictDoUpdate({
+      target: externalConversationBindings.conversationId,
+      set: {
+        sourceChannel: input.sourceChannel,
+        externalChatId: input.externalChatId,
+        externalUserId: input.externalUserId ?? null,
+        displayName: input.displayName ?? null,
+        username: input.username ?? null,
+        updatedAt: now,
+        lastInboundAt: now,
+      },
+    })
+    .run();
+}
+
+/**
+ * Look up an external binding by conversation ID.
+ */
+export function getBindingByConversation(
+  conversationId: string,
+): ExternalConversationBinding | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(externalConversationBindings)
+    .where(eq(externalConversationBindings.conversationId, conversationId))
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Look up an external binding by channel + external chat ID.
+ */
+export function getBindingByChannelChat(
+  sourceChannel: string,
+  externalChatId: string,
+): ExternalConversationBinding | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(externalConversationBindings)
+    .where(
+      and(
+        eq(externalConversationBindings.sourceChannel, sourceChannel),
+        eq(externalConversationBindings.externalChatId, externalChatId),
+      ),
+    )
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Remove an external binding for a conversation.
+ */
+export function deleteBinding(conversationId: string): void {
+  const db = getDb();
+  db.delete(externalConversationBindings)
+    .where(eq(externalConversationBindings.conversationId, conversationId))
+    .run();
+}
+
+/**
+ * List all external bindings, optionally filtered by sourceChannel.
+ */
+export function listBindings(options?: {
+  sourceChannel?: string;
+}): ExternalConversationBinding[] {
+  const db = getDb();
+  const query = db
+    .select()
+    .from(externalConversationBindings);
+
+  if (options?.sourceChannel) {
+    return query
+      .where(eq(externalConversationBindings.sourceChannel, options.sourceChannel))
+      .all();
+  }
+
+  return query.all();
+}
+
+/**
+ * Get bindings for multiple conversation IDs at once.
+ * Returns a map of conversationId -> binding for efficient lookup.
+ */
+export function getBindingsForConversations(
+  conversationIds: string[],
+): Map<string, ExternalConversationBinding> {
+  if (conversationIds.length === 0) return new Map();
+
+  const db = getDb();
+  const result = new Map<string, ExternalConversationBinding>();
+
+  // Query all bindings and filter in-memory since SQLite doesn't have
+  // efficient IN() with drizzle for large lists
+  const all = db
+    .select()
+    .from(externalConversationBindings)
+    .all();
+
+  const idSet = new Set(conversationIds);
+  for (const row of all) {
+    if (idSet.has(row.conversationId)) {
+      result.set(row.conversationId, row);
+    }
+  }
+
+  return result;
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -588,3 +588,20 @@ export const processedCallbacks = sqliteTable('processed_callbacks', {
   claimId: text('claim_id'),
   createdAt: integer('created_at').notNull(),
 });
+
+// ── External Conversation Bindings ───────────────────────────────────
+
+export const externalConversationBindings = sqliteTable('external_conversation_bindings', {
+  conversationId: text('conversation_id')
+    .primaryKey()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  sourceChannel: text('source_channel').notNull(),
+  externalChatId: text('external_chat_id').notNull(),
+  externalUserId: text('external_user_id'),
+  displayName: text('display_name'),
+  username: text('username'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  lastInboundAt: integer('last_inbound_at'),
+  lastOutboundAt: integer('last_outbound_at'),
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -44,6 +44,7 @@ import {
 } from './routes/channel-routes.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import * as externalConversationStore from '../memory/external-conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { renderHistoryContent } from '../daemon/handlers.js';
 import { deliverChannelReply } from './gateway-client.js';
@@ -616,13 +617,28 @@ export class RuntimeHttpServer {
       if (endpoint === 'conversations' && req.method === 'GET') {
         const limit = Number(url.searchParams.get('limit') ?? 50);
         const conversations = conversationStore.listConversations(limit);
+        const bindings = externalConversationStore.getBindingsForConversations(
+          conversations.map((c) => c.id),
+        );
         return Response.json({
-          sessions: conversations.map((c) => ({
-            id: c.id,
-            title: c.title ?? 'Untitled',
-            updatedAt: c.updatedAt,
-            threadType: c.threadType === 'private' ? 'private' : 'standard',
-          })),
+          sessions: conversations.map((c) => {
+            const binding = bindings.get(c.id);
+            return {
+              id: c.id,
+              title: c.title ?? 'Untitled',
+              updatedAt: c.updatedAt,
+              threadType: c.threadType === 'private' ? 'private' : 'standard',
+              ...(binding ? {
+                channelBinding: {
+                  sourceChannel: binding.sourceChannel,
+                  externalChatId: binding.externalChatId,
+                  externalUserId: binding.externalUserId,
+                  displayName: binding.displayName,
+                  username: binding.username,
+                },
+              } : {}),
+            };
+          }),
         });
       }
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -6,6 +6,7 @@ import { deleteConversationKey } from '../../memory/conversation-key-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
+import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { renderHistoryContent } from '../../daemon/handlers.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
@@ -178,6 +179,16 @@ export async function handleChannelInbound(
     externalMessageId,
     { sourceMessageId },
   );
+
+  // Upsert external conversation binding with sender metadata
+  externalConversationStore.upsertBinding({
+    conversationId: result.conversationId,
+    sourceChannel,
+    externalChatId,
+    externalUserId: body.senderExternalUserId ?? null,
+    displayName: body.senderName ?? null,
+    username: body.senderUsername ?? null,
+  });
 
   const metadataHintsRaw = sourceMetadata?.hints;
   const metadataHints = Array.isArray(metadataHintsRaw)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -349,6 +349,15 @@ public struct IPCCardSurfaceDataMetadata: Codable, Sendable {
     public let value: String
 }
 
+/// Channel binding metadata exposed in session/conversation list APIs.
+public struct IPCChannelBinding: Codable, Sendable {
+    public let sourceChannel: String
+    public let externalChatId: String
+    public let externalUserId: String?
+    public let displayName: String?
+    public let username: String?
+}
+
 public struct IPCConfirmationRequest: Codable, Sendable {
     public let type: String
     public let requestId: String
@@ -1314,6 +1323,8 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let title: String
     public let updatedAt: Int
     public let threadType: String?
+    /// Channel binding metadata exposed in session/conversation list APIs.
+    public let channelBinding: IPCChannelBinding?
 }
 
 public struct IPCSessionsClearRequest: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add externalConversationBindings table with drizzle-orm schema and migration
- Create external-conversation-store with upsert/lookup/delete/list operations
- Integrate binding upsert on inbound channel events in channel-routes
- Expose optional channelBinding metadata in session list APIs (IPC + HTTP)
- Regenerate Swift IPC contract artifacts

Part of #6465
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
