### PR TITLE
M4: Ingress guardrails + docs + architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3483,20 +3483,41 @@ The avatar evolves during onboarding based on conversation and identity choices.
 
 ## Ingress Boundary Architecture — Gateway-Only Public Ingress
 
-All public-facing HTTP callbacks (Twilio webhooks, OAuth authorization callbacks, Telegram webhooks) terminate at the gateway, which validates and forwards them to the assistant runtime. The runtime HTTP server is not directly exposed to the internet.
+All external webhook endpoints (Telegram, Twilio, OAuth, future channels) are handled exclusively by the gateway. The runtime never exposes webhook ingress. The runtime-proxy explicitly blocks forwarding of `/webhooks/*` paths.
+
+This boundary is enforced at three layers:
+
+1. **Gateway routing:** The gateway's `fetch()` handler matches `/webhooks/*` paths to dedicated handlers before the runtime-proxy fallthrough. Webhook traffic is validated (signature checks, payload limits) and forwarded to internal runtime endpoints.
+2. **Runtime-proxy guard:** The runtime-proxy handler rejects any `/webhooks/*` path with a 404, preventing accidental forwarding of webhook traffic to the runtime even if a new webhook path is added to the gateway without a dedicated handler.
+3. **Runtime server:** The runtime HTTP server does not register any `/webhooks/telegram` routes. Direct Twilio webhook routes (`/webhooks/twilio/*`) return 410 with a `GATEWAY_ONLY` error code, and relay WebSocket upgrades are restricted to private network peers.
 
 ```
 Internet
   |
-  +-- Twilio ----------> Gateway POST /webhooks/twilio/*    --> Runtime /v1/calls/*
-  +-- OAuth Provider ---> Gateway GET  /webhooks/oauth/callback --> Runtime /v1/oauth/callback
-  +-- Telegram --------> Gateway POST /webhooks/telegram    --> Runtime /v1/assistants/:id/channels/inbound
+  +-- Twilio ----------> Gateway POST /webhooks/twilio/*    --> Runtime /v1/internal/twilio/*
+  +-- OAuth Provider ---> Gateway GET  /webhooks/oauth/callback --> Runtime /v1/internal/oauth/callback
+  +-- Telegram --------> Gateway POST /webhooks/telegram    --> Runtime /v1/channels/inbound
   |
   +-- Tunnel (ngrok, Cloudflare, etc.)
        |
        v
      Gateway (http://127.0.0.1:7830)
+       |
+       +-- Runtime proxy /v1/* --> Runtime (http://127.0.0.1:7821)
+       +-- /webhooks/* --> BLOCKED (404, never forwarded to runtime)
 ```
+
+### Channel Sync Lifecycle
+
+Channel bindings (e.g., Telegram chat to conversation) follow a four-phase lifecycle:
+
+1. **Bind** — An inbound message from an external channel (e.g., Telegram chat) arrives at the gateway, which normalizes it and forwards it to the runtime's `/v1/channels/inbound` endpoint. The runtime creates or reuses a conversation, establishing the channel binding (`sourceChannel` metadata on the conversation).
+
+2. **Sync** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint, which sends them to the Telegram API. The binding ensures bidirectional message flow stays in sync.
+
+3. **Delete** — When a conversation is deleted (via the UI or API), the channel binding is removed. Future messages from the same external chat will create a new conversation.
+
+4. **Resurrection** — If a message arrives on an external chat whose conversation was previously deleted, the channel inbound handler treats it as a new conversation and establishes a fresh binding. The external chat ID is reused, but the conversation is new. This prevents orphaned external chats from losing the ability to communicate.
 
 ### Configuration
 

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -2,6 +2,7 @@
  * Tests for gateway-only ingress enforcement in the runtime HTTP server.
  *
  * Verifies:
+ * - Runtime does not expose any Telegram webhook ingress routes
  * - Direct Twilio webhook routes return 410
  * - Internal forwarding routes (gateway→runtime) still work
  * - Relay WebSocket upgrade blocked for non-private-network origins (isPrivateNetworkOrigin)
@@ -161,6 +162,36 @@ describe('gateway-only ingress enforcement', () => {
 
   afterEach(async () => {
     await server.stop();
+  });
+
+  // ── Runtime does not expose Telegram webhook ingress ─────────────
+
+  describe('runtime has no Telegram webhook routes', () => {
+
+    test('POST /webhooks/telegram returns 404 (not handled by runtime)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/telegram`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ update_id: 1, message: { text: 'hello' } }),
+      });
+      // The runtime should not have any route matching /webhooks/telegram.
+      // It returns 404 because the path does not match any handler.
+      expect(res.status).toBe(404);
+    });
+
+    test('GET /webhooks/telegram returns 404', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/telegram`);
+      expect(res.status).toBe(404);
+    });
+
+    test('POST /webhooks/telegram/test returns 404', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/telegram/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(404);
+    });
   });
 
   // ── Direct Twilio webhook routes blocked in gateway_only mode ──────

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -278,4 +278,113 @@ describe("runtime proxy handler", () => {
 
     expect(capturedHeaders!.has("host")).toBe(false);
   });
+
+  // ── Webhook path blocking ──────────────────────────────────────────
+
+  describe("webhook path guard", () => {
+    test("blocks /webhooks/telegram from being proxied", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/webhooks/telegram", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ update_id: 1 }),
+      });
+      const res = await handler(req);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.source).toBe("gateway");
+      // Verify fetch was never called — the request was blocked before proxying
+      expect(fetchCalls.length).toBe(0);
+    });
+
+    test("blocks /webhooks/twilio/voice from being proxied", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
+        method: "POST",
+      });
+      const res = await handler(req);
+
+      expect(res.status).toBe(404);
+      expect(fetchCalls.length).toBe(0);
+    });
+
+    test("blocks /webhooks/oauth/callback from being proxied", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/webhooks/oauth/callback");
+      const res = await handler(req);
+
+      expect(res.status).toBe(404);
+      expect(fetchCalls.length).toBe(0);
+    });
+
+    test("blocks /webhooks/any-future-channel from being proxied", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/webhooks/any-future-channel", {
+        method: "POST",
+      });
+      const res = await handler(req);
+
+      expect(res.status).toBe(404);
+      expect(fetchCalls.length).toBe(0);
+    });
+
+    test("allows /v1/channels/inbound to be proxied (non-webhook path)", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/v1/channels/inbound", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "hello" }),
+      });
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      expect(fetchCalls.length).toBe(1);
+    });
+
+    test("allows /v1/health to be proxied (non-webhook path)", async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = mock(async (input: any) => {
+        fetchCalls.push(String(input));
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/v1/health");
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      expect(fetchCalls.length).toBe(1);
+    });
+  });
 });

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -39,10 +39,30 @@ function stripHopByHop(headers: Headers): Headers {
   return cleaned;
 }
 
+/**
+ * Webhook paths are handled exclusively by the gateway's own route handlers
+ * and must never be forwarded to the runtime. This prevents external webhook
+ * traffic from bypassing gateway-level validation (signature checks, rate
+ * limiting, etc.).
+ */
+const WEBHOOK_PATH_RE = /^\/webhooks\//;
+
 export function createRuntimeProxyHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     const start = performance.now();
     const url = new URL(req.url);
+
+    // Block forwarding of /webhooks/* paths — these are gateway-only.
+    if (WEBHOOK_PATH_RE.test(url.pathname)) {
+      log.warn(
+        { method: req.method, path: url.pathname },
+        "Blocked runtime proxy forwarding of webhook path",
+      );
+      return Response.json(
+        { error: "Not found", source: "gateway" },
+        { status: 404 },
+      );
+    }
 
     if (config.runtimeProxyRequireAuth && req.method !== "OPTIONS") {
       if (!config.runtimeProxyBearerToken) {


### PR DESCRIPTION
## Summary
- Add gateway-only enforcement test asserting runtime has no webhook routes
- Add webhook path guard in runtime-proxy to block /webhooks/* forwarding
- Add runtime-proxy tests for webhook blocking
- Update ARCHITECTURE.md with ingress boundary and channel sync lifecycle docs

Part of #6465
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
