### PR TITLE
M2: Desktop visual distinction + read path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -53,6 +53,8 @@ struct ChatView: View {
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
+    /// Label for the synced external channel (e.g. "Telegram"). Nil for local-only threads.
+    var syncedChannelLabel: String?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Sums utf8.count over each segment (O(1) per contiguous segment) instead of joining first,
@@ -85,6 +87,9 @@ struct ChatView: View {
         ZStack {
             VStack(spacing: 0) {
                 apiKeyBanner
+                if let channelLabel = syncedChannelLabel {
+                    SyncedChannelHeaderView(channelLabel: channelLabel)
+                }
                 if messages.isEmpty && !isHistoryLoaded {
                     Spacer()
                     HStack {
@@ -233,6 +238,17 @@ struct ChatView: View {
                     onOpenDoctor: onOpenDoctor,
                     onDismissError: onDismissError
                 )
+            }
+            if let channelLabel = syncedChannelLabel {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 9, weight: .medium))
+                    Text("Replies are sent to \(channelLabel)")
+                        .font(VFont.small)
+                }
+                .foregroundColor(VColor.textMuted)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.bottom, VSpacing.xxs)
             }
             ComposerView(
                 inputText: $inputText,
@@ -690,6 +706,37 @@ private struct ScrollWheelDetector: NSViewRepresentable {
             }
             return nil
         }
+    }
+}
+
+// MARK: - Synced Channel Header
+
+/// Subtle pill badge shown at the top of the chat when the thread is synced to an external channel.
+private struct SyncedChannelHeaderView: View {
+    let channelLabel: String
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Spacer()
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 10, weight: .medium))
+                Text("Synced: \(channelLabel)")
+                    .font(VFont.captionMedium)
+            }
+            .foregroundColor(VColor.textMuted)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .background(VColor.surface)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+            Spacer()
+        }
+        .padding(.vertical, VSpacing.sm)
+        .accessibilityLabel("External chat synced to \(channelLabel)")
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -700,12 +700,25 @@ struct MainWindowView: View {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(VColor.accent.opacity(0.7))
+                } else if thread.isSynced {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
                 }
-                Text(thread.title)
-                    .font(.system(size: 13))
-                    .foregroundColor(VColor.textPrimary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(thread.title)
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if let senderLabel = thread.senderLabel {
+                        Text(senderLabel)
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -318,7 +318,8 @@ extension MainWindowView {
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
                 onMicrophoneToggle: onMicrophoneToggle,
-                isTemporaryChat: threadManager.activeThread?.kind == .private
+                isTemporaryChat: threadManager.activeThread?.kind == .private,
+                syncedChannelLabel: threadManager.activeThread?.isSynced == true ? threadManager.activeThread?.sourceChannel?.capitalized : nil
             )
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
@@ -481,6 +482,7 @@ struct ActiveChatViewWrapper: View {
     @ObservedObject var settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false
+    var syncedChannelLabel: String?
 
     var body: some View {
         ChatView(
@@ -574,7 +576,8 @@ struct ActiveChatViewWrapper: View {
             daemonHttpPort: daemonClient.httpPort,
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
-            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) }
+            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
+            syncedChannelLabel: syncedChannelLabel
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -18,7 +18,32 @@ struct ThreadModel: Identifiable, Hashable {
     var lastInteractedAt: Date
     var kind: ThreadKind
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard) {
+    // MARK: - Channel Binding (external conversation sync)
+
+    /// The source channel for externally-synced threads (e.g. "telegram").
+    var sourceChannel: String?
+    /// Display name of the external user who initiated the conversation.
+    var displayName: String?
+    /// Username of the external user (e.g. Telegram @handle).
+    var username: String?
+    /// External chat identifier for the synced conversation.
+    var externalChatId: String?
+
+    /// Whether this thread is bound to an external channel (e.g. Telegram).
+    var isSynced: Bool { sourceChannel != nil }
+
+    /// Best available label for the external sender: displayName, @username, or truncated chat ID.
+    var senderLabel: String? {
+        if let displayName, !displayName.isEmpty { return displayName }
+        if let username, !username.isEmpty { return "@\(username)" }
+        if let externalChatId, !externalChatId.isEmpty {
+            let suffix = String(externalChatId.suffix(6))
+            return "Telegram \(suffix)"
+        }
+        return nil
+    }
+
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, sourceChannel: String? = nil, displayName: String? = nil, username: String? = nil, externalChatId: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -28,5 +53,9 @@ struct ThreadModel: Identifiable, Hashable {
         self.pinnedOrder = pinnedOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
+        self.sourceChannel = sourceChannel
+        self.displayName = displayName
+        self.username = username
+        self.externalChatId = externalChatId
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -103,12 +103,17 @@ final class ThreadSessionRestorer {
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard
+            let binding = session.channelBinding
             let thread = ThreadModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
-                kind: kind
+                kind: kind,
+                sourceChannel: binding?.sourceChannel,
+                displayName: binding?.displayName,
+                username: binding?.username,
+                externalChatId: binding?.externalChatId
             )
             let viewModel = delegate.makeViewModel()
             viewModel.sessionId = session.id

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -23,6 +23,7 @@ struct ConversationsListResponse: Decodable {
         let title: String
         let updatedAt: Int
         let threadType: String?
+        let channelBinding: IPCChannelBinding?
     }
     let sessions: [Session]
 }
@@ -351,7 +352,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, channelBinding: $0.channelBinding)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions)))
             } catch {


### PR DESCRIPTION
## Summary
- Extend ThreadModel with optional channel binding fields (sourceChannel, displayName, username, externalChatId)
- Parse channelBinding from session list IPC/HTTP responses
- Add Telegram badge in sidebar for synced threads with sender label
- Add 'Synced: Telegram' pill in thread header
- Add 'Replies are sent to Telegram' note in message composer
- All changes are read-only (no delete/reset action)

Part of #6465
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
