### PR TITLE
M3: Delete/reset sync semantics + outbound resurrection

### DIFF
--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -69,6 +69,41 @@ export function upsertBinding(input: UpsertBindingInput): void {
 }
 
 /**
+ * Upsert an external conversation binding for outbound sends.
+ * Similar to upsertBinding but touches lastOutboundAt instead of lastInboundAt,
+ * and only requires channel identifiers (no sender metadata needed).
+ */
+export function upsertOutboundBinding(input: {
+  conversationId: string;
+  sourceChannel: string;
+  externalChatId: string;
+}): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.insert(externalConversationBindings)
+    .values({
+      conversationId: input.conversationId,
+      sourceChannel: input.sourceChannel,
+      externalChatId: input.externalChatId,
+      externalUserId: null,
+      displayName: null,
+      username: null,
+      createdAt: now,
+      updatedAt: now,
+      lastOutboundAt: now,
+    })
+    .onConflictDoUpdate({
+      target: externalConversationBindings.conversationId,
+      set: {
+        updatedAt: now,
+        lastOutboundAt: now,
+      },
+    })
+    .run();
+}
+
+/**
  * Look up an external binding by conversation ID.
  */
 export function getBindingByConversation(
@@ -111,6 +146,25 @@ export function deleteBinding(conversationId: string): void {
   const db = getDb();
   db.delete(externalConversationBindings)
     .where(eq(externalConversationBindings.conversationId, conversationId))
+    .run();
+}
+
+/**
+ * Remove an external binding by channel + external chat ID.
+ * Used when disconnecting a synced thread by its channel identifiers.
+ */
+export function deleteBindingByChannelChat(
+  sourceChannel: string,
+  externalChatId: string,
+): void {
+  const db = getDb();
+  db.delete(externalConversationBindings)
+    .where(
+      and(
+        eq(externalConversationBindings.sourceChannel, sourceChannel),
+        eq(externalConversationBindings.externalChatId, externalChatId),
+      ),
+    )
     .run();
 }
 

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -25,6 +25,8 @@ import type {
 } from '../../provider-types.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
 import { readHttpToken } from '../../../util/platform.js';
+import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
+import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import * as telegram from './client.js';
 
 /** Resolve the gateway base URL, preferring GATEWAY_INTERNAL_BASE_URL if set. */
@@ -117,6 +119,22 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     const bearerToken = getBearerToken();
 
     await telegram.sendMessage(gatewayUrl, bearerToken, conversationId, text);
+
+    // Upsert external conversation binding so deleted/reset syncs are
+    // resurrected when an outbound message is sent. This ensures the
+    // conversation key mapping and binding exist for the next inbound.
+    try {
+      const sourceChannel = 'telegram';
+      const conversationKey = `${sourceChannel}:${conversationId}`;
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      externalConversationStore.upsertOutboundBinding({
+        conversationId: internalId,
+        sourceChannel,
+        externalChatId: conversationId,
+      });
+    } catch {
+      // Best-effort — don't fail the send if binding upsert fails
+    }
 
     return {
       id: `tg-${Date.now()}`,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -36,6 +36,7 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
 
   const conversationKey = `${sourceChannel}:${externalChatId}`;
   deleteConversationKey(conversationKey);
+  externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
 
   return Response.json({ ok: true });
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -802,6 +802,29 @@ struct MainWindowView: View {
             }
         }
         .padding(.horizontal, VSpacing.sm)
+        .contextMenu {
+            if thread.sourceChannel != nil {
+                Button {
+                    threadManager.disconnectSyncedThread(id: thread.id)
+                } label: {
+                    Label("Disconnect Channel", systemImage: "link.badge.minus")
+                }
+            }
+            Button {
+                if thread.isPinned {
+                    threadManager.unpinThread(id: thread.id)
+                } else {
+                    threadManager.pinThread(id: thread.id)
+                }
+            } label: {
+                Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
+            }
+            Button {
+                threadManager.archiveThread(id: thread.id)
+            } label: {
+                Label("Archive", systemImage: "archivebox")
+            }
+        }
         .onHover { hovering in
             if hovering {
                 isHoveredThread = thread.id

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -254,6 +254,39 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Archived thread \(id)")
     }
 
+    /// Disconnect a synced thread's channel binding and archive it locally.
+    /// Calls the runtime's DELETE /v1/channels/conversation endpoint to
+    /// remove the conversation key mapping and external binding, then
+    /// archives the thread in the UI. Does NOT call any external channel
+    /// delete APIs (e.g. Telegram).
+    func disconnectSyncedThread(id: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+        let thread = threads[index]
+        guard let sourceChannel = thread.sourceChannel,
+              let externalChatId = thread.externalChatId else {
+            log.warning("Cannot disconnect thread \(id): missing channel binding")
+            return
+        }
+
+        // Fire the HTTP DELETE in the background; archive immediately in the UI
+        Task { @MainActor in
+            let _ = await daemonClient.deleteChannelConversation(
+                sourceChannel: sourceChannel,
+                externalChatId: externalChatId
+            )
+        }
+
+        // Clear channel binding fields so the thread no longer shows as synced
+        threads[index].sourceChannel = nil
+        threads[index].externalChatId = nil
+        threads[index].displayName = nil
+        threads[index].username = nil
+
+        archiveThread(id: id)
+
+        log.info("Disconnected synced thread \(id) (\(sourceChannel):\(externalChatId))")
+    }
+
     func unarchiveThread(id: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1120,4 +1120,68 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             conversationId: conversationId
         ))
     }
+
+    // MARK: - Channel Management
+
+    /// Delete a channel conversation binding via the runtime HTTP endpoint.
+    /// Removes the conversation key mapping and external binding so the
+    /// sync can be re-established on the next inbound or outbound message.
+    public func deleteChannelConversation(sourceChannel: String, externalChatId: String) async -> Bool {
+        let baseURL: String
+        let bearerToken: String?
+
+        if let httpTransport {
+            baseURL = httpTransport.baseURL
+            bearerToken = httpTransport.bearerToken
+        } else if let port = httpPort {
+            baseURL = "http://localhost:\(port)"
+            let tokenBase: String
+            if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !baseDir.isEmpty {
+                tokenBase = baseDir
+            } else {
+                tokenBase = NSHomeDirectory()
+            }
+            let tokenPath = tokenBase + "/.vellum/http-token"
+            do {
+                bearerToken = try String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                log.error("Failed to read HTTP bearer token from \(tokenPath): \(error)")
+                bearerToken = nil
+            }
+        } else {
+            log.warning("Cannot delete channel conversation: no HTTP transport available")
+            return false
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/channels/conversation") else { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+        if let token = bearerToken, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: String] = [
+            "sourceChannel": sourceChannel,
+            "externalChatId": externalChatId,
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+            if http.statusCode == 200 {
+                log.info("Deleted channel conversation \(sourceChannel):\(externalChatId)")
+                return true
+            } else {
+                log.error("Delete channel conversation failed (\(http.statusCode))")
+                return false
+            }
+        } catch {
+            log.error("Delete channel conversation error: \(error.localizedDescription)")
+            return false
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add 'Disconnect Channel' context menu action for synced threads in desktop
- Wire desktop to call DELETE /v1/channels/conversation for channel unbinding
- Clean up external conversation binding on channel conversation delete
- Add deleteBindingByChannelChat to external-conversation-store
- Add outbound resurrection: upsert binding on Telegram outbound sends
- Archive remains local-only and does not alter sync mappings

Part of #6465
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
