### PR TITLE
fix: use inArray for efficient binding lookups in external-conversation-store

### DIFF
--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -7,7 +7,7 @@
  * list APIs.
  */
 
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { getDb } from './db.js';
 import { externalConversationBindings } from './schema.js';
 
@@ -200,18 +200,14 @@ export function getBindingsForConversations(
   const db = getDb();
   const result = new Map<string, ExternalConversationBinding>();
 
-  // Query all bindings and filter in-memory since SQLite doesn't have
-  // efficient IN() with drizzle for large lists
   const all = db
     .select()
     .from(externalConversationBindings)
+    .where(inArray(externalConversationBindings.conversationId, conversationIds))
     .all();
 
-  const idSet = new Set(conversationIds);
   for (const row of all) {
-    if (idSet.has(row.conversationId)) {
-      result.set(row.conversationId, row);
-    }
+    result.set(row.conversationId, row);
   }
 
   return result;


### PR DESCRIPTION
## Summary
- Replace full table scan with drizzle `inArray` query in `getBindingsForConversations`
- Both Codex and Devin flagged this in PR #6475: the function loaded all rows and filtered in memory instead of querying only the needed conversation IDs

## Test plan
- [x] Verify `inArray` import exists
- [x] Verify query filters at DB level

Addresses review feedback from #6475.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
