### PR TITLE
fix: account for synced channel note in composer reserved height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -199,7 +199,8 @@ struct ChatView: View {
         let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
-        return base + attachments + error
+        let syncNote: CGFloat = syncedChannelLabel != nil ? 18 : 0
+        return base + attachments + error + syncNote
     }
 
     private func modelPickerView(for message: ChatMessage) -> some View {


### PR DESCRIPTION
## Summary
- Add syncNote height term to composerReservedHeight in ChatView.swift
- When syncedChannelLabel is set, the "Replies are sent to..." note adds extra height to the composer overlay that wasn't accounted for in the bottom inset calculation
- Both Codex and Devin flagged this in PR #6479

## Test plan
- [x] Verify composerReservedHeight includes syncNote term
- [x] Verify syncNote only adds height when syncedChannelLabel is non-nil

Addresses review feedback from #6479.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
