### PR TITLE
feat: add runtime owner arbitration and move-sync endpoint for Telegram sync

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for runtime owner arbitration and move-sync for Telegram channel sync.
+ *
+ * Verifies:
+ * - Owner send succeeds without conflict
+ * - Non-owner send returns conflict with ownerConversationId
+ * - Send without senderConversationId skips check (backward compatible)
+ * - Move-sync rebinds ownership atomically
+ * - Inbound after move routes to new owner
+ * - Hide (delete) then recreate works correctly
+ */
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'channel-sync-arb-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getWorkspaceConfigPath: () => join(testDir, 'config.json'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  getHttpTokenPath: () => join(testDir, 'http-token'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+  readHttpToken: () => 'test-bearer-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+  loadConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => {
+    if (key === 'credential:telegram:bot_token') return 'test-bot-token';
+    if (key === 'credential:telegram:webhook_secret') return 'test-secret';
+    return undefined;
+  },
+}));
+
+mock.module('../messaging/providers/telegram-bot/client.js', () => ({
+  sendMessage: async () => ({ ok: true }),
+  getMe: async () => ({ ok: true, result: { id: 1, is_bot: true, first_name: 'Test', username: 'test_bot' } }),
+}));
+
+import { initializeDb } from '../memory/db.js';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+import * as externalConversationStore from '../memory/external-conversation-store.js';
+import { getOrCreateConversation, deleteConversationKey, getConversationByKey } from '../memory/conversation-key-store.js';
+import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
+import { handleMoveSync, handleDeleteConversation } from '../runtime/routes/channel-routes.js';
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+
+initializeDb();
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const ensuredConvIds = new Set<string>();
+
+function ensureConversation(id: string): void {
+  if (ensuredConvIds.has(id)) return;
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title: `Test: ${id}`,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    })
+    .onConflictDoNothing()
+    .run();
+  ensuredConvIds.add(id);
+}
+
+function createBinding(conversationId: string, sourceChannel: string, externalChatId: string): void {
+  ensureConversation(conversationId);
+  externalConversationStore.upsertOutboundBinding({
+    conversationId,
+    sourceChannel,
+    externalChatId,
+  });
+}
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request('http://localhost/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteRequest(body: unknown): Request {
+  return new Request('http://localhost/test', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('channel sync arbitration', () => {
+  const chatId = '12345';
+
+  describe('owner send', () => {
+    test('succeeds without conflict when sender is the owner', async () => {
+      const convA = uuid();
+      createBinding(convA, 'telegram', chatId);
+
+      const result = await telegramBotMessagingProvider.sendMessage(
+        '',
+        chatId,
+        'Hello from owner',
+        { senderConversationId: convA },
+      );
+
+      expect(result.conflict).toBeUndefined();
+      expect(result.conversationId).toBe(chatId);
+    });
+  });
+
+  describe('non-owner send', () => {
+    test('returns conflict with ownerConversationId', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `non-owner-${uuid()}`;
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      const result = await telegramBotMessagingProvider.sendMessage(
+        '',
+        uniqueChatId,
+        'Hello from non-owner',
+        { senderConversationId: convB },
+      );
+
+      expect(result.conflict).toBeDefined();
+      expect(result.conflict!.ownerConversationId).toBe(convA);
+      expect(result.id).toBe('');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    test('send without senderConversationId skips check', async () => {
+      const convA = uuid();
+      const uniqueChatId = `compat-${uuid()}`;
+      createBinding(convA, 'telegram', uniqueChatId);
+
+      const result = await telegramBotMessagingProvider.sendMessage(
+        '',
+        uniqueChatId,
+        'Hello without sender ID',
+      );
+
+      expect(result.conflict).toBeUndefined();
+      expect(result.conversationId).toBe(uniqueChatId);
+    });
+  });
+
+  describe('move-sync', () => {
+    test('rebinds ownership and returns previousOwner', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `move-${uuid()}`;
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      // Also create the conversation key mapping
+      const conversationKey = `telegram:${uniqueChatId}`;
+      getOrCreateConversation(conversationKey);
+
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatId,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      const body = await resp.json() as { ok: boolean; previousOwner: string | null };
+
+      expect(resp.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.previousOwner).toBe(convA);
+
+      // Verify binding now points to conv-B
+      const binding = externalConversationStore.getBindingByChannelChat('telegram', uniqueChatId);
+      expect(binding).not.toBeNull();
+      expect(binding!.conversationId).toBe(convB);
+
+      // Verify conversation key now points to conv-B
+      const keyMapping = getConversationByKey(conversationKey);
+      expect(keyMapping).not.toBeNull();
+      expect(keyMapping!.conversationId).toBe(convB);
+    });
+  });
+
+  describe('inbound after move', () => {
+    test('routes to new owner after move-sync', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `inbound-move-${uuid()}`;
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      // Create initial conversation key mapping
+      const conversationKey = `telegram:${uniqueChatId}`;
+      getOrCreateConversation(conversationKey);
+
+      // Move to conv-B
+      const moveReq = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatId,
+        newConversationId: convB,
+      });
+      await handleMoveSync(moveReq);
+
+      // Simulate a new inbound — recordInbound uses getOrCreateConversation
+      // which should find the key mapping pointing to conv-B now
+      const result = channelDeliveryStore.recordInbound(
+        'telegram',
+        uniqueChatId,
+        `msg-${uuid()}`,
+      );
+
+      expect(result.conversationId).toBe(convB);
+    });
+  });
+
+  describe('hide then recreate', () => {
+    test('delete binding then new inbound creates fresh conversation', async () => {
+      const convA = uuid();
+      const uniqueChatId = `hide-${uuid()}`;
+      createBinding(convA, 'telegram', uniqueChatId);
+
+      // Create conversation key mapping for the binding
+      const conversationKey = `telegram:${uniqueChatId}`;
+      getOrCreateConversation(conversationKey);
+
+      // Delete the binding (simulating hide)
+      const deleteReq = makeDeleteRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatId,
+      });
+      const deleteResp = await handleDeleteConversation(deleteReq);
+      expect(deleteResp.status).toBe(200);
+
+      // Verify old binding is gone
+      const bindingAfterDelete = externalConversationStore.getBindingByChannelChat('telegram', uniqueChatId);
+      expect(bindingAfterDelete).toBeNull();
+
+      // Verify old conversation key is gone
+      const keyAfterDelete = getConversationByKey(conversationKey);
+      expect(keyAfterDelete).toBeNull();
+
+      // New inbound should create a fresh conversation
+      const result = channelDeliveryStore.recordInbound(
+        'telegram',
+        uniqueChatId,
+        `msg-${uuid()}`,
+      );
+
+      // The new conversation should be different from the old one
+      expect(result.conversationId).not.toBe(convA);
+      expect(result.accepted).toBe(true);
+      expect(result.duplicate).toBe(false);
+    });
+  });
+
+  describe('move-sync validation', () => {
+    test('returns 400 when sourceChannel is missing', async () => {
+      const req = makeJsonRequest({
+        externalChatId: '12345',
+        newConversationId: 'conv-1',
+      });
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(400);
+    });
+
+    test('returns 400 when externalChatId is missing', async () => {
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        newConversationId: 'conv-1',
+      });
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(400);
+    });
+
+    test('returns 400 when newConversationId is missing', async () => {
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: '12345',
+      });
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(400);
+    });
+  });
+});

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -53,6 +53,22 @@ export function deleteConversationKey(
 }
 
 /**
+ * Map a conversation key to an existing conversation ID (no creation).
+ * Used by move-sync to rebind a key to a different conversation.
+ */
+export function setConversationKey(conversationKey: string, conversationId: string): void {
+  const db = getDb();
+  db.insert(conversationKeys)
+    .values({
+      id: uuid(),
+      conversationKey,
+      conversationId,
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+/**
  * Get or create a conversation for the given conversationKey.
  *
  * If a mapping already exists, returns the existing conversation ID.

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -44,6 +44,9 @@ export interface SendResult {
   id: string;
   timestamp: number;
   conversationId: string;
+  conflict?: {
+    ownerConversationId: string;
+  };
 }
 
 export interface ConnectionInfo {
@@ -77,4 +80,6 @@ export interface SendOptions {
   subject?: string;
   /** For email: in-reply-to message ID */
   inReplyTo?: string;
+  /** Internal conversation ID of the sender, used for owner arbitration */
+  senderConversationId?: string;
 }

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -115,6 +115,19 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(_token: string, conversationId: string, text: string, _options?: SendOptions): Promise<SendResult> {
+    // Check for owner conflict before sending
+    if (_options?.senderConversationId) {
+      const existingBinding = externalConversationStore.getBindingByChannelChat('telegram', conversationId);
+      if (existingBinding && existingBinding.conversationId !== _options.senderConversationId) {
+        return {
+          id: '',
+          timestamp: Date.now(),
+          conversationId,
+          conflict: { ownerConversationId: existingBinding.conversationId },
+        };
+      }
+    }
+
     const gatewayUrl = getGatewayUrl();
     const bearerToken = getBearerToken();
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -37,6 +37,7 @@ import {
 } from './routes/run-routes.js';
 import {
   handleDeleteConversation,
+  handleMoveSync,
   handleChannelInbound,
   handleChannelDeliveryAck,
   handleListDeadLetters,
@@ -713,6 +714,10 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/conversation' && req.method === 'DELETE') {
         return await handleDeleteConversation(req);
+      }
+
+      if (endpoint === 'channels/move-sync' && req.method === 'POST') {
+        return await handleMoveSync(req);
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for channel inbound messages, delivery acks, and
  * conversation deletion.
  */
-import { deleteConversationKey } from '../../memory/conversation-key-store.js';
+import { deleteConversationKey, setConversationKey } from '../../memory/conversation-key-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
@@ -39,6 +39,45 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
   externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
 
   return Response.json({ ok: true });
+}
+
+export async function handleMoveSync(req: Request): Promise<Response> {
+  const body = await req.json() as {
+    sourceChannel?: string;
+    externalChatId?: string;
+    newConversationId?: string;
+  };
+
+  const { sourceChannel, externalChatId, newConversationId } = body;
+
+  if (!sourceChannel || typeof sourceChannel !== 'string') {
+    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+  }
+  if (!externalChatId || typeof externalChatId !== 'string') {
+    return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+  }
+  if (!newConversationId || typeof newConversationId !== 'string') {
+    return Response.json({ error: 'newConversationId is required' }, { status: 400 });
+  }
+
+  // Get current owner
+  const currentBinding = externalConversationStore.getBindingByChannelChat(sourceChannel, externalChatId);
+  const previousOwner = currentBinding?.conversationId ?? null;
+
+  // Delete old mappings
+  const conversationKey = `${sourceChannel}:${externalChatId}`;
+  deleteConversationKey(conversationKey);
+  externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
+
+  // Create new mappings
+  setConversationKey(conversationKey, newConversationId);
+  externalConversationStore.upsertOutboundBinding({
+    conversationId: newConversationId,
+    sourceChannel,
+    externalChatId,
+  });
+
+  return Response.json({ ok: true, previousOwner });
 }
 
 export async function handleChannelInbound(


### PR DESCRIPTION
## Summary
- Add conflict detection in Telegram adapter: non-owner sends return conflict metadata instead of silently rebinding
- Add `POST /v1/channels/move-sync` endpoint for atomic ownership transfer between threads
- Extend SendResult with optional `conflict` field and SendOptions with `senderConversationId`
- Add `setConversationKey` function in conversation-key-store for explicit key mapping
- Add comprehensive tests for owner arbitration, move-sync, and hide/recreate flows

## Test plan
- [x] Owner send succeeds without conflict
- [x] Non-owner send returns conflict with ownerConversationId
- [x] Send without senderConversationId skips check (backward compatible)
- [x] Move-sync rebinds ownership atomically
- [x] Inbound after move routes to new owner
- [x] Hide then recreate works correctly

Part of Telegram Channel Thread Sync UX Phase 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
