### PR TITLE
feat: simplified Telegram sync UX with conflict detection and hide thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -55,6 +55,13 @@ struct ChatView: View {
     var onDismissDocumentWidget: ((String) -> Void)?
     /// Label for the synced external channel (e.g. "Telegram"). Nil for local-only threads.
     var syncedChannelLabel: String?
+    /// When non-nil, indicates a sync conflict: this thread targets a Telegram chat
+    /// that is owned by a different thread. Contains the canonical thread's info.
+    var syncConflict: SyncConflictInfo?
+    /// Callback when user taps "Continue in Synced Thread"
+    var onContinueInSyncedThread: (() -> Void)?
+    /// Callback when user taps "Move Sync Here"
+    var onMoveSyncHere: (() -> Void)?
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Sums utf8.count over each segment (O(1) per contiguous segment) instead of joining first,
@@ -89,6 +96,13 @@ struct ChatView: View {
                 apiKeyBanner
                 if let channelLabel = syncedChannelLabel {
                     SyncedChannelHeaderView(channelLabel: channelLabel)
+                }
+                if let conflict = syncConflict {
+                    SyncConflictBanner(
+                        info: conflict,
+                        onContinue: { onContinueInSyncedThread?() },
+                        onMove: { onMoveSyncHere?() }
+                    )
                 }
                 if messages.isEmpty && !isHistoryLoaded {
                     Spacer()
@@ -707,6 +721,56 @@ private struct ScrollWheelDetector: NSViewRepresentable {
             }
             return nil
         }
+    }
+}
+
+// MARK: - Sync Conflict
+
+/// Info about a sync conflict when the current thread is not the canonical owner.
+struct SyncConflictInfo {
+    let ownerThreadTitle: String
+    let sourceChannel: String
+    let externalChatId: String
+}
+
+/// Banner shown when the user tries to send from a non-canonical synced thread.
+private struct SyncConflictBanner: View {
+    let info: SyncConflictInfo
+    let onContinue: () -> Void
+    let onMove: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(VColor.warning)
+                Text("This Telegram chat is synced to \"\(info.ownerThreadTitle)\"")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+            }
+            HStack(spacing: VSpacing.sm) {
+                Button(action: onContinue) {
+                    Label("Continue in Synced Thread", systemImage: "arrow.right.circle")
+                        .font(VFont.captionMedium)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(VColor.accent)
+
+                Button(action: onMove) {
+                    Text("Move Sync Here")
+                        .font(VFont.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(VColor.textMuted)
+
+                Spacer()
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.warning.opacity(0.1))
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -807,8 +807,9 @@ struct MainWindowView: View {
                 Button {
                     threadManager.disconnectSyncedThread(id: thread.id)
                 } label: {
-                    Label("Disconnect Channel", systemImage: "link.badge.minus")
+                    Label("Hide Local Thread", systemImage: "eye.slash")
                 }
+                .help("This does not delete Telegram history. The thread reappears on next message.")
             }
             Button {
                 if thread.isPinned {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -311,6 +311,23 @@ extension MainWindowView {
     @ViewBuilder
     var chatView: some View {
         if let viewModel = threadManager.activeViewModel {
+            let activeThread = threadManager.activeThread
+            let syncConflict: SyncConflictInfo? = {
+                guard let thread = activeThread,
+                      let sourceChannel = thread.sourceChannel,
+                      let externalChatId = thread.externalChatId,
+                      let canonical = threadManager.findCanonicalThread(
+                          sourceChannel: sourceChannel,
+                          externalChatId: externalChatId,
+                          excludingThread: thread.id
+                      ) else { return nil }
+                return SyncConflictInfo(
+                    ownerThreadTitle: canonical.title,
+                    sourceChannel: sourceChannel,
+                    externalChatId: externalChatId
+                )
+            }()
+
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
@@ -318,8 +335,32 @@ extension MainWindowView {
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
                 onMicrophoneToggle: onMicrophoneToggle,
-                isTemporaryChat: threadManager.activeThread?.kind == .private,
-                syncedChannelLabel: threadManager.activeThread?.isSynced == true ? threadManager.activeThread?.sourceChannel?.capitalized : nil
+                isTemporaryChat: activeThread?.kind == .private,
+                syncedChannelLabel: activeThread?.isSynced == true ? activeThread?.sourceChannel?.capitalized : nil,
+                syncConflict: syncConflict,
+                onContinueInSyncedThread: syncConflict != nil ? {
+                    if let thread = threadManager.activeThread,
+                       let sourceChannel = thread.sourceChannel,
+                       let externalChatId = thread.externalChatId,
+                       let canonical = threadManager.findCanonicalThread(
+                           sourceChannel: sourceChannel,
+                           externalChatId: externalChatId,
+                           excludingThread: thread.id
+                       ) {
+                        threadManager.activeThreadId = canonical.id
+                    }
+                } : nil,
+                onMoveSyncHere: syncConflict != nil ? {
+                    if let thread = threadManager.activeThread,
+                       let sourceChannel = thread.sourceChannel,
+                       let externalChatId = thread.externalChatId {
+                        threadManager.moveSyncHere(
+                            threadId: thread.id,
+                            sourceChannel: sourceChannel,
+                            externalChatId: externalChatId
+                        )
+                    }
+                } : nil
             )
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
@@ -483,6 +524,9 @@ struct ActiveChatViewWrapper: View {
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false
     var syncedChannelLabel: String?
+    var syncConflict: SyncConflictInfo?
+    var onContinueInSyncedThread: (() -> Void)?
+    var onMoveSyncHere: (() -> Void)?
 
     var body: some View {
         ChatView(
@@ -577,7 +621,10 @@ struct ActiveChatViewWrapper: View {
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
-            syncedChannelLabel: syncedChannelLabel
+            syncedChannelLabel: syncedChannelLabel,
+            syncConflict: syncConflict,
+            onContinueInSyncedThread: onContinueInSyncedThread,
+            onMoveSyncHere: onMoveSyncHere
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -287,6 +287,60 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Disconnected synced thread \(id) (\(sourceChannel):\(externalChatId))")
     }
 
+    /// Move Telegram sync ownership to the specified thread.
+    /// Calls the runtime's move-sync endpoint to atomically transfer the binding,
+    /// then updates the UI: the target thread becomes synced, the old owner loses its binding.
+    func moveSyncHere(threadId: UUID, sourceChannel: String, externalChatId: String) {
+        guard let targetIndex = threads.firstIndex(where: { $0.id == threadId }),
+              let sessionId = threads[targetIndex].sessionId else {
+            log.warning("Cannot move sync: thread \(threadId) not found or has no session")
+            return
+        }
+
+        Task { @MainActor in
+            let success = await daemonClient.moveChannelSync(
+                sourceChannel: sourceChannel,
+                externalChatId: externalChatId,
+                newConversationId: sessionId
+            )
+
+            if success {
+                // Find the old owner and clear its binding
+                for i in threads.indices {
+                    if threads[i].sourceChannel == sourceChannel &&
+                       threads[i].externalChatId == externalChatId &&
+                       threads[i].id != threadId {
+                        threads[i].sourceChannel = nil
+                        threads[i].externalChatId = nil
+                        threads[i].displayName = nil
+                        threads[i].username = nil
+                    }
+                }
+
+                // Set the new thread as synced
+                if let idx = threads.firstIndex(where: { $0.id == threadId }) {
+                    threads[idx].sourceChannel = sourceChannel
+                    threads[idx].externalChatId = externalChatId
+                }
+
+                log.info("Moved sync to thread \(threadId) for \(sourceChannel):\(externalChatId)")
+            } else {
+                log.error("Failed to move sync to thread \(threadId)")
+            }
+        }
+    }
+
+    /// Find the canonical synced thread for a given channel chat, if one exists.
+    /// Returns the thread that owns the sync binding, or nil if no other thread is synced to this chat.
+    func findCanonicalThread(sourceChannel: String, externalChatId: String, excludingThread: UUID) -> ThreadModel? {
+        return threads.first(where: {
+            $0.sourceChannel == sourceChannel &&
+            $0.externalChatId == externalChatId &&
+            $0.id != excludingThread &&
+            !$0.isArchived
+        })
+    }
+
     func unarchiveThread(id: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1184,4 +1184,67 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return false
         }
     }
+
+    /// Move channel sync ownership to a different conversation.
+    /// Calls the runtime's POST /v1/channels/move-sync endpoint to
+    /// atomically transfer the binding from the current owner to the new conversation.
+    public func moveChannelSync(sourceChannel: String, externalChatId: String, newConversationId: String) async -> Bool {
+        let baseURL: String
+        let bearerToken: String?
+
+        if let httpTransport {
+            baseURL = httpTransport.baseURL
+            bearerToken = httpTransport.bearerToken
+        } else if let port = httpPort {
+            baseURL = "http://localhost:\(port)"
+            let tokenBase: String
+            if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !baseDir.isEmpty {
+                tokenBase = baseDir
+            } else {
+                tokenBase = NSHomeDirectory()
+            }
+            let tokenPath = tokenBase + "/.vellum/http-token"
+            do {
+                bearerToken = try String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                log.error("Failed to read HTTP bearer token from \(tokenPath): \(error)")
+                bearerToken = nil
+            }
+        } else {
+            log.warning("Cannot move channel sync: no HTTP transport available")
+            return false
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/channels/move-sync") else { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+        if let token = bearerToken, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: String] = [
+            "sourceChannel": sourceChannel,
+            "externalChatId": externalChatId,
+            "newConversationId": newConversationId,
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+            if http.statusCode == 200 {
+                log.info("Moved channel sync \(sourceChannel):\(externalChatId) to \(newConversationId)")
+                return true
+            } else {
+                log.error("Move channel sync failed (\(http.statusCode))")
+                return false
+            }
+        } catch {
+            log.error("Move channel sync error: \(error.localizedDescription)")
+            return false
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Rename "Disconnect Channel" to "Hide Local Thread" with tooltip explaining behavior
- Add `moveChannelSync` IPC method in DaemonClient for POST /v1/channels/move-sync
- Add `moveSyncHere` and `findCanonicalThread` in ThreadManager for ownership transfer
- Add SyncConflictBanner in ChatView showing "Continue in Synced Thread" (primary) and "Move Sync Here" (secondary) actions
- Wire conflict detection at ChatView instantiation: checks if another visible thread owns the same Telegram chat

## Test plan
- [x] "Hide Local Thread" label appears in context menu for synced threads
- [x] Tooltip shows "This does not delete Telegram history..."
- [x] Conflict banner appears when thread targets a chat owned by another thread
- [x] "Continue in Synced Thread" navigates to canonical thread
- [x] "Move Sync Here" calls runtime endpoint and updates thread bindings

Part of Telegram Channel Thread Sync UX Phase 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
