### PR TITLE
M1: Add instruction primitive to call domain/orchestrator

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -100,6 +100,7 @@ import { conversations } from '../memory/schema.js';
 import {
   createCallSession,
   getCallSession,
+  getCallEvents,
   getPendingQuestion,
   updateCallSession,
 } from '../calls/call-store.js';
@@ -507,6 +508,118 @@ describe('call-orchestrator', () => {
 
     const { orchestrator } = setupOrchestrator();
     await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  // ── handleUserInstruction ─────────────────────────────────────────
+
+  test('handleUserInstruction: injects instruction marker into conversation history and triggers LLM when idle', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const instructionMsg = firstArg.messages.find((m) =>
+        m.role === 'user' && m.content.includes('[USER_INSTRUCTION:'),
+      );
+      expect(instructionMsg).toBeDefined();
+      expect(instructionMsg!.content).toContain('[USER_INSTRUCTION: Ask about their weekend plans]');
+      return createMockStream(['Sure, do you have any weekend plans?']);
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleUserInstruction('Ask about their weekend plans');
+
+    // Should have streamed a response since orchestrator was idle
+    const nonEmptyTokens = relay.sentTokens.filter((t) => t.token.length > 0);
+    expect(nonEmptyTokens.length).toBeGreaterThan(0);
+
+    orchestrator.destroy();
+  });
+
+  test('handleUserInstruction: does not break existing answer flow', async () => {
+    // Step 1: Caller says something, LLM responds normally
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello! How can I help you today?']));
+    const { session, relay, orchestrator } = setupOrchestrator('Book appointment');
+
+    await orchestrator.handleCallerUtterance('Hi there');
+
+    // Step 2: Inject an instruction while idle
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      // Verify the history contains both the original exchange and the instruction
+      const messages = firstArg.messages;
+      expect(messages.length).toBeGreaterThanOrEqual(3); // user utterance + assistant response + instruction
+      const instructionMsg = messages.find((m) =>
+        m.role === 'user' && m.content.includes('[USER_INSTRUCTION:'),
+      );
+      expect(instructionMsg).toBeDefined();
+      return createMockStream(['Of course, let me mention the weekend special.']);
+    });
+
+    await orchestrator.handleUserInstruction('Mention the weekend special');
+
+    // Step 3: Caller speaks again — the flow should continue normally
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Great choice! The weekend special is 20% off.']),
+    );
+
+    await orchestrator.handleCallerUtterance('Tell me more about that');
+
+    // Verify state is idle after the normal flow
+    expect(orchestrator.getState()).toBe('idle');
+
+    // Verify relay received tokens from all exchanges
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('Hello');
+    expect(allText).toContain('weekend special');
+
+    orchestrator.destroy();
+  });
+
+  test('handleUserInstruction: emits user_instruction_relayed event', async () => {
+    mockStreamFn.mockImplementation(() => createMockStream(['Understood, adjusting approach.']));
+
+    const { session, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleUserInstruction('Be more formal in your tone');
+
+    const events = getCallEvents(session.id);
+    const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
+    expect(instructionEvents.length).toBe(1);
+
+    const payload = JSON.parse(instructionEvents[0].payloadJson);
+    expect(payload.instruction).toBe('Be more formal in your tone');
+
+    orchestrator.destroy();
+  });
+
+  test('handleUserInstruction: does not trigger LLM when orchestrator is not idle', async () => {
+    // First, trigger ASK_USER so orchestrator enters waiting_on_user
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Hold on. [ASK_USER: What time?]']),
+    );
+
+    const { session, orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('I need an appointment');
+    expect(orchestrator.getState()).toBe('waiting_on_user');
+
+    // Track how many times the stream mock is called
+    let streamCallCount = 0;
+    mockStreamFn.mockImplementation(() => {
+      streamCallCount++;
+      return createMockStream(['Response after instruction.']);
+    });
+
+    // Inject instruction while in waiting_on_user state
+    await orchestrator.handleUserInstruction('Suggest morning slots');
+
+    // The LLM should NOT have been triggered since we're not idle
+    expect(streamCallCount).toBe(0);
+
+    // But the event should still be recorded
+    const events = getCallEvents(session.id);
+    const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
+    expect(instructionEvents.length).toBe(1);
+
     orchestrator.destroy();
   });
 });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -64,6 +64,11 @@ export type AnswerCallInput = {
   answer: string;
 };
 
+export type RelayInstructionInput = {
+  callSessionId: string;
+  instructionText: string;
+};
+
 // ── Caller identity resolution ───────────────────────────────────────
 
 export type CallerIdentitySource = 'per_call_override' | 'implicit_default' | 'user_config' | 'secure_key' | 'env_var';
@@ -389,4 +394,37 @@ export async function answerCall(input: AnswerCallInput): Promise<{ ok: true; qu
   answerPendingQuestion(question.id, answer);
 
   return { ok: true, questionId: question.id };
+}
+
+/**
+ * Relay a user instruction to an active call's orchestrator.
+ * Validates that the call is active and the instruction is non-empty
+ * before injecting it into the orchestrator's conversation history.
+ */
+export async function relayInstruction(input: RelayInstructionInput): Promise<{ ok: true } | CallError> {
+  const { callSessionId, instructionText } = input;
+
+  if (!instructionText || typeof instructionText !== 'string' || instructionText.trim().length === 0) {
+    return { ok: false, error: 'instructionText is required and must be a non-empty string', status: 400 };
+  }
+
+  const session = getCallSession(callSessionId);
+  if (!session) {
+    return { ok: false, error: `No call session found with ID ${callSessionId}`, status: 404 };
+  }
+
+  if (session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled') {
+    return { ok: false, error: `Call session ${callSessionId} is not active (status: ${session.status})`, status: 409 };
+  }
+
+  const orchestrator = getCallOrchestrator(callSessionId);
+  if (!orchestrator) {
+    return { ok: false, error: 'No active orchestrator for this call', status: 409 };
+  }
+
+  await orchestrator.handleUserInstruction(instructionText);
+
+  log.info({ callSessionId }, 'User instruction relayed to orchestrator');
+
+  return { ok: true };
 }

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -113,6 +113,27 @@ export class CallOrchestrator {
   }
 
   /**
+   * Inject a user instruction into the orchestrator's conversation history.
+   * The instruction is formatted as a dedicated marker that the system prompt
+   * tells the model to treat as high-priority steering input.
+   */
+  async handleUserInstruction(instructionText: string): Promise<void> {
+    this.conversationHistory.push({
+      role: 'user',
+      content: `[USER_INSTRUCTION: ${instructionText}]`,
+    });
+
+    recordCallEvent(this.callSessionId, 'user_instruction_relayed', { instruction: instructionText });
+
+    // If the orchestrator is idle, trigger an LLM turn so the model can
+    // act on the instruction immediately. In other states the instruction
+    // will be picked up on the next LLM invocation.
+    if (this.state === 'idle') {
+      await this.runLlm();
+    }
+  }
+
+  /**
    * Handle caller interrupting the assistant's speech.
    */
   handleInterrupt(): void {
@@ -155,10 +176,11 @@ export class CallOrchestrator {
       '2. Be concise — phone conversations should be brief and natural.',
       '3. If the callee asks something you don\'t know, include [ASK_USER: your question here] in your response along with a hold message like "Let me check on that for you."',
       '4. If the callee provides information preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
-      '5. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
-      '6. Do not make up information — ask the user if unsure.',
-      '7. Keep responses short — 1-3 sentences is ideal for phone conversation.',
-      '8. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
+      '5. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
+      '6. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
+      '7. Do not make up information — ask the user if unsure.',
+      '8. Keep responses short — 1-3 sentences is ideal for phone conversation.',
+      '9. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
     ]
       .filter(Boolean)
       .join('\n');

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -1,5 +1,5 @@
 export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed' | 'cancelled';
-export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'call_ended' | 'call_failed';
+export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed';
 export type PendingQuestionStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 
 export interface CallSession {


### PR DESCRIPTION
## Summary
- Add `handleUserInstruction()` to call orchestrator for mid-call steering
- Add `user_instruction_relayed` event type for observability
- Add domain-level relay function with validation
- Add tests for instruction injection

Closes #6485
Part of #6484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
