### PR TITLE
docs: final Telegram credential docs alignment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3579,22 +3579,27 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 In desktop deployments, Telegram bot tokens are stored in secure storage (macOS Keychain or the encrypted file fallback) and never in plaintext config files. When deploying the gateway standalone, operators may also supply credentials via environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`).
 
 ```
-Settings UI (macOS)
+Secure credential prompt (credential_store action: "prompt")
   → telegram_config IPC (action: set, botToken)
     → Daemon handler validates token via Telegram getMe API
       → setSecureKey("credential:telegram:bot_token", token)
-      → Auto-generates webhook secret if missing
       → upsertCredentialMetadata("telegram", "bot_token", {accountInfo: username})
+      → Auto-generates webhook secret if missing
+        → setSecureKey("credential:telegram:webhook_secret", secret)
+        → upsertCredentialMetadata("telegram", "webhook_secret", {})
+        → On storage failure: rolls back bot_token + metadata, returns error
+      → If webhook secret already exists: upserts metadata anyway (self-heal)
+      → Triggers gateway webhook reconcile
         → Gateway credential reader picks up new credentials
-          → Webhook reconciliation triggers automatically
+          → Webhook reconciliation registers webhook with Telegram
 ```
 
 The `telegram_config` IPC message supports three actions:
 - **`get`** — returns connection status (`hasBotToken`, `botUsername`, `connected`, `hasWebhookSecret`) without exposing secret values
-- **`set`** — validates the bot token against the Telegram API, stores it in secure storage, auto-generates a webhook secret if none exists, and triggers gateway webhook reconciliation
-- **`clear`** — deletes the bot token and webhook secret from both secure storage and credential metadata, then triggers reconciliation to deregister the webhook
+- **`set`** — validates the bot token against the Telegram API, stores it in secure storage, auto-generates a webhook secret if none exists (with rollback on failure), self-heals webhook_secret metadata if it already exists, and triggers gateway webhook reconciliation
+- **`clear`** — deregisters the webhook by calling Telegram's `deleteWebhook` API directly (while the token is still available), then deletes the bot token and webhook secret from both secure storage and credential metadata, and triggers gateway reconciliation
 
-The gateway reads Telegram credentials via its `credential-reader` module (`gateway/src/credential-reader.ts`), which uses a keychain-first fallback strategy on macOS: it tries the macOS Keychain first (via the `security` CLI), then falls back to the encrypted file store (`~/.vellum/protected/keys.enc`). This mirrors the assistant's own `secure-keys.ts` module. On non-macOS platforms, only the encrypted store is used.
+The gateway reads Telegram credentials via its `credential-reader` module (`gateway/src/credential-reader.ts`), which uses a keychain-first fallback strategy on macOS: it tries the macOS Keychain first (via the `security` CLI), then falls back to the encrypted file store (`~/.vellum/protected/keys.enc`). This mirrors the assistant's own `secure-keys.ts` module. On non-macOS platforms, only the encrypted store is used. The keychain reader discriminates exit code 44 (`errSecItemNotFound` — credential genuinely missing) from other non-zero exit codes (transient errors like locked keychain or timeout), logging the latter as warnings for operator visibility.
 
 ### Webhook Reconciliation
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,8 +26,8 @@ bun run dev
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `TELEGRAM_BOT_TOKEN` | No | — | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store (macOS Keychain first, then encrypted file fallback). |
-| `TELEGRAM_WEBHOOK_SECRET` | No | — | Secret for verifying webhook requests (Telegram disabled when unset). Same fallback behavior as `TELEGRAM_BOT_TOKEN`. |
+| `TELEGRAM_BOT_TOKEN` | No | — | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store via the credential reader fallback chain: macOS Keychain first (via `security` CLI), then encrypted file store (`~/.vellum/protected/keys.enc`). The keychain reader discriminates exit code 44 (`errSecItemNotFound` — credential genuinely missing) from other non-zero exit codes (transient errors), logging the latter as warnings. On non-macOS platforms, only the encrypted store is used. |
+| `TELEGRAM_WEBHOOK_SECRET` | No | — | Secret for verifying webhook requests (Telegram disabled when unset). Same credential reader fallback behavior as `TELEGRAM_BOT_TOKEN`. |
 | `TELEGRAM_API_BASE_URL` | No | `https://api.telegram.org` | Override Telegram API base URL |
 | `ASSISTANT_RUNTIME_BASE_URL` | Yes | — | Base URL of the assistant runtime HTTP server |
 | `GATEWAY_ASSISTANT_ROUTING_JSON` | No | `{}` | JSON mapping of Telegram identities to assistant IDs |


### PR DESCRIPTION
## Summary
- Align ARCHITECTURE.md Telegram section with actual post-hardening behavior
- Verify skill instructions match fixed credential flow
- Tighten gateway README keychain fallback documentation

Closes #6493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
