### PR TITLE
M3: Generalize bridge and wire IPC path

### DIFF
--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -101,7 +101,7 @@ import {
   fireCallCompletionNotifier,
 } from '../calls/call-state.js';
 import { CallOrchestrator } from '../calls/call-orchestrator.js';
-import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
+import { tryRouteCallMessage } from '../calls/call-bridge.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import type { RelayConnection } from '../calls/relay-server.js';
 
@@ -177,26 +177,26 @@ describe('call-bridge', () => {
     mockStreamFn.mockImplementation(() => createMockStream(['Hello']));
   });
 
-  // ── tryHandlePendingCallAnswer ──────────────────────────────────
+  // ── tryRouteCallMessage — answer path ───────────────────────
 
   test('returns handled:false when no active call exists', async () => {
     ensureConversation('conv-no-call');
-    const result = await tryHandlePendingCallAnswer('conv-no-call', 'some answer');
+    const result = await tryRouteCallMessage('conv-no-call', 'some answer');
     expect(result.handled).toBe(false);
     expect(result.reason).toBe('no_active_call');
   });
 
-  test('returns handled:false when call exists but no pending question', async () => {
-    ensureConversation('conv-no-question');
+  test('returns instruction_relay_failed when call exists but no orchestrator and no pending question', async () => {
+    ensureConversation('conv-no-orch');
     createCallSession({
-      conversationId: 'conv-no-question',
+      conversationId: 'conv-no-orch',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
     });
-    const result = await tryHandlePendingCallAnswer('conv-no-question', 'some answer');
+    const result = await tryRouteCallMessage('conv-no-orch', 'some instruction');
     expect(result.handled).toBe(false);
-    expect(result.reason).toBe('no_pending_question');
+    expect(result.reason).toBe('instruction_relay_failed');
   });
 
   test('returns handled:false when orchestrator is not found (call still active but no orchestrator)', async () => {
@@ -215,7 +215,7 @@ describe('call-bridge', () => {
     // Create a pending question without an orchestrator
     createPendingQuestion(callSession.id, 'What time?');
 
-    const result = await tryHandlePendingCallAnswer('conv-ended', 'Too late');
+    const result = await tryRouteCallMessage('conv-ended', 'Too late');
     expect(result.handled).toBe(false);
     expect(result.reason).toBe('orchestrator_not_found');
   });
@@ -231,7 +231,7 @@ describe('call-bridge', () => {
     // Mark the call as completed — getActiveCallSessionForConversation will return null
     updateCallSession(callSession.id, { status: 'completed', endedAt: Date.now() });
 
-    const result = await tryHandlePendingCallAnswer('conv-completed', 'Too late');
+    const result = await tryRouteCallMessage('conv-completed', 'Too late');
     expect(result.handled).toBe(false);
     expect(result.reason).toBe('no_active_call');
   });
@@ -252,7 +252,7 @@ describe('call-bridge', () => {
     // Create a pending question in the DB but orchestrator is idle, not waiting_on_user
     createPendingQuestion(callSession.id, 'What time?');
 
-    const result = await tryHandlePendingCallAnswer('conv-not-waiting', 'answer');
+    const result = await tryRouteCallMessage('conv-not-waiting', 'answer');
     expect(result.handled).toBe(false);
     expect(result.reason).toBe('orchestrator_not_waiting');
 
@@ -284,7 +284,7 @@ describe('call-bridge', () => {
     // Now provide the answer — set up mock for the LLM call after answer
     mockStreamFn.mockImplementation(() => createMockStream(['Great, booking for tomorrow.']));
 
-    const result = await tryHandlePendingCallAnswer('conv-bridge', 'Tomorrow at noon');
+    const result = await tryRouteCallMessage('conv-bridge', 'Tomorrow at noon');
     expect(result.handled).toBe(true);
 
     // Wait for the fire-and-forget LLM call
@@ -296,6 +296,89 @@ describe('call-bridge', () => {
     expect(question).toBeNull();
 
     orchestrator.destroy();
+  });
+
+  // ── tryRouteCallMessage — instruction path ────────────────────
+
+  test('routes instruction to orchestrator when active call exists with no pending question', async () => {
+    ensureConversation('conv-instruct');
+    const callSession = createCallSession({
+      conversationId: 'conv-instruct',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const relay = createMockRelay();
+    const orchestrator = new CallOrchestrator(callSession.id, relay as unknown as RelayConnection, 'test task');
+
+    const result = await tryRouteCallMessage('conv-instruct', 'Please ask about pricing');
+    expect(result.handled).toBe(true);
+
+    // Verify acknowledgement was persisted
+    const msgs = getMessagesForConversation('conv-instruct');
+    const ackMsg = msgs.find((m) => m.content.includes('Instruction relayed'));
+    expect(ackMsg).toBeDefined();
+    expect(ackMsg!.role).toBe('assistant');
+
+    orchestrator.destroy();
+  });
+
+  test('prefers answer path over instruction path when pending question exists', async () => {
+    // Setup: trigger ASK_USER to put orchestrator in waiting_on_user state
+    mockStreamFn.mockImplementation(() =>
+      createMockStream(['Hold on. [ASK_USER: Budget range?]']),
+    );
+
+    ensureConversation('conv-prefer-answer');
+    const callSession = createCallSession({
+      conversationId: 'conv-prefer-answer',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    const relay = createMockRelay();
+    const orchestrator = new CallOrchestrator(callSession.id, relay as unknown as RelayConnection, 'test task');
+
+    await orchestrator.handleCallerUtterance('What is your budget?');
+    expect(orchestrator.getState()).toBe('waiting_on_user');
+
+    // Mock the next LLM call
+    mockStreamFn.mockImplementation(() => createMockStream(['Got it, thanks.']));
+
+    // This should route as answer, not instruction
+    const result = await tryRouteCallMessage('conv-prefer-answer', '$500');
+    expect(result.handled).toBe(true);
+
+    // Wait for fire-and-forget LLM call
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should have answered the pending question, not relayed as instruction
+    const question = getPendingQuestion(callSession.id);
+    expect(question).toBeNull();
+
+    // No instruction acknowledgement should be persisted
+    const msgs = getMessagesForConversation('conv-prefer-answer');
+    const ackMsg = msgs.find((m) => m.content.includes('Instruction relayed'));
+    expect(ackMsg).toBeUndefined();
+
+    orchestrator.destroy();
+  });
+
+  test('instruction relay fails gracefully when call has no orchestrator', async () => {
+    ensureConversation('conv-no-orch-instruct');
+    createCallSession({
+      conversationId: 'conv-no-orch-instruct',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+    });
+
+    // No orchestrator registered — relay should fail
+    const result = await tryRouteCallMessage('conv-no-orch-instruct', 'Change the topic');
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('instruction_relay_failed');
   });
 
   // ── Call question notifier ──────────────────────────────────────

--- a/assistant/src/calls/call-bridge.ts
+++ b/assistant/src/calls/call-bridge.ts
@@ -1,11 +1,14 @@
 /**
- * Call-answer bridge: auto-consumes user replies in-thread as answers
- * to pending call questions, routing them to the live call orchestrator.
+ * Call message bridge: intercepts user messages in-thread and routes them
+ * to the live call orchestrator — either as answers to pending questions
+ * or as mid-call steering instructions.
  *
- * When a call has a pending question and the user sends a normal message
- * in the conversation thread, this bridge intercepts the message before
- * the agent loop, forwards the answer to the orchestrator, and returns
- * `{ handled: true }` so the caller can skip agent processing.
+ * Decision priority:
+ * 1. If a pending question exists → answer path (existing behavior).
+ * 2. If no pending question but an active call exists → instruction path.
+ *
+ * When the bridge consumes a message it returns `{ handled: true }` so
+ * the caller can skip agent processing.
  */
 
 import { getLogger } from '../util/logger.js';
@@ -17,6 +20,7 @@ import {
   getCallSession,
 } from './call-store.js';
 import { getCallOrchestrator } from './call-state.js';
+import { relayInstruction } from './call-domain.js';
 import * as conversationStore from '../memory/conversation-store.js';
 
 const log = getLogger('call-bridge');
@@ -27,15 +31,16 @@ export interface CallBridgeResult {
 }
 
 /**
- * Attempt to route a user message as an answer to a pending call question.
+ * Attempt to route a user message to an active call — as an answer to
+ * a pending question (priority) or as a mid-call steering instruction.
  *
  * @param conversationId - The conversation the message belongs to.
  * @param userText - The user's message text.
  * @param _userMessageId - The persisted message ID (reserved for future use).
- * @returns `{ handled: true }` if the answer was consumed by the call system,
+ * @returns `{ handled: true }` if the message was consumed by the call system,
  *          `{ handled: false, reason }` otherwise.
  */
-export async function tryHandlePendingCallAnswer(
+export async function tryRouteCallMessage(
   conversationId: string,
   userText: string,
   _userMessageId?: string,
@@ -46,18 +51,32 @@ export async function tryHandlePendingCallAnswer(
     return { handled: false, reason: 'no_active_call' };
   }
 
-  // 2. Check for a pending question
+  // 2. Check for a pending question — answer path takes priority
   const pendingQuestion = getPendingQuestion(callSession.id);
-  if (!pendingQuestion) {
-    return { handled: false, reason: 'no_pending_question' };
+  if (pendingQuestion) {
+    return handleAnswer(conversationId, callSession.id, pendingQuestion, userText);
   }
 
-  // 3. Check that the orchestrator is alive and waiting
-  const orchestrator = getCallOrchestrator(callSession.id);
+  // 3. No pending question — instruction path
+  return handleInstruction(conversationId, callSession.id, userText);
+}
+
+/** @deprecated Use `tryRouteCallMessage` instead. */
+export const tryHandlePendingCallAnswer = tryRouteCallMessage;
+
+// ── Answer path ─────────────────────────────────────────────────────
+
+async function handleAnswer(
+  conversationId: string,
+  callSessionId: string,
+  pendingQuestion: { id: string; questionText: string },
+  userText: string,
+): Promise<CallBridgeResult> {
+  const orchestrator = getCallOrchestrator(callSessionId);
   if (!orchestrator) {
     // The call may have ended between the question being asked and the
     // user replying. Persist a follow-up message so the user knows.
-    const freshSession = getCallSession(callSession.id);
+    const freshSession = getCallSession(callSessionId);
     const ended = freshSession && (freshSession.status === 'completed' || freshSession.status === 'failed');
     if (ended) {
       conversationStore.addMessage(
@@ -76,19 +95,49 @@ export async function tryHandlePendingCallAnswer(
     return { handled: false, reason: 'orchestrator_not_waiting' };
   }
 
-  // 4. Route the answer through the orchestrator
   const accepted = await orchestrator.handleUserAnswer(userText);
   if (!accepted) {
     return { handled: false, reason: 'orchestrator_rejected' };
   }
 
-  // 5. Persist the answered state
   answerPendingQuestion(pendingQuestion.id, userText);
-  recordCallEvent(callSession.id, 'user_answered', { answer: userText });
+  recordCallEvent(callSessionId, 'user_answered', { answer: userText });
 
   log.info(
-    { conversationId, callSessionId: callSession.id, questionId: pendingQuestion.id },
+    { conversationId, callSessionId, questionId: pendingQuestion.id },
     'User reply routed as call answer via bridge',
+  );
+
+  return { handled: true };
+}
+
+// ── Instruction path ────────────────────────────────────────────────
+
+async function handleInstruction(
+  conversationId: string,
+  callSessionId: string,
+  userText: string,
+): Promise<CallBridgeResult> {
+  const result = await relayInstruction({ callSessionId, instructionText: userText });
+
+  if (!result.ok) {
+    log.warn(
+      { conversationId, callSessionId, error: result.error },
+      'Instruction relay failed via bridge',
+    );
+    return { handled: false, reason: 'instruction_relay_failed' };
+  }
+
+  // Persist a concise acknowledgement so the user sees confirmation
+  conversationStore.addMessage(
+    conversationId,
+    'assistant',
+    JSON.stringify([{ type: 'text', text: 'Instruction relayed to active call.' }]),
+  );
+
+  log.info(
+    { conversationId, callSessionId },
+    'User message routed as call instruction via bridge',
   );
 
   return { handled: true };

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -36,7 +36,7 @@ import { assistantEventHub } from '../runtime/assistant-event-hub.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { SessionEvictor } from './session-evictor.js';
 import { getSubagentManager } from '../subagent/index.js';
-import { tryHandlePendingCallAnswer } from '../calls/call-bridge.js';
+import { tryRouteCallMessage } from '../calls/call-bridge.js';
 import { resolveSlash } from './session-slash.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import { registerDaemonCallbacks } from '../work-items/work-item-runner.js';
@@ -1041,10 +1041,10 @@ export class DaemonServer {
     // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
+      const bridgeResult = await tryRouteCallMessage(conversationId, content, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
-      log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
+      log.warn({ err, conversationId }, 'Call bridge check failed (non-fatal), proceeding with agent loop');
     }
 
     if (bridgeHandled) {
@@ -1052,7 +1052,7 @@ export class DaemonServer {
       resetSessionProcessingState(session);
       // Drain any queued messages that arrived while processing was true.
       session.drainQueue('loop_complete');
-      log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
+      log.info({ conversationId, messageId }, 'User message consumed by call bridge, skipping agent loop');
       return { messageId };
     }
 
@@ -1150,10 +1150,10 @@ export class DaemonServer {
     // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryHandlePendingCallAnswer(conversationId, content, messageId);
+      const bridgeResult = await tryRouteCallMessage(conversationId, content, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
-      log.warn({ err, conversationId }, 'Call-answer bridge check failed (non-fatal), proceeding with agent loop');
+      log.warn({ err, conversationId }, 'Call bridge check failed (non-fatal), proceeding with agent loop');
     }
 
     if (bridgeHandled) {
@@ -1162,7 +1162,7 @@ export class DaemonServer {
       resetSessionProcessingState(session);
       // Drain any queued messages that arrived while processing was true.
       session.drainQueue('loop_complete');
-      log.info({ conversationId, messageId }, 'User message consumed by call-answer bridge, skipping agent loop');
+      log.info({ conversationId, messageId }, 'User message consumed by call bridge, skipping agent loop');
       return { messageId };
     }
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -16,6 +16,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { resolveSlash } from './session-slash.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { tryRouteCallMessage } from '../calls/call-bridge.js';
 
 const log = getLogger('session-process');
 
@@ -177,13 +178,42 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   session.currentPage = next.currentPage;
 
   // Fire-and-forget: persistUserMessage set session.processing = true
-  // so subsequent messages will still be enqueued. runAgentLoop's
-  // finally block will call drainQueue when this run completes.
-  session.runAgentLoop(resolvedContent, userMessageId, next.onEvent).catch((err) => {
+  // so subsequent messages will still be enqueued. Route through the call
+  // bridge first — if consumed, skip agent processing and continue draining.
+  // runAgentLoop's finally block will call drainQueue when this run completes.
+  routeOrProcess(session, resolvedContent, userMessageId, next).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Error processing queued message');
     next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });
   });
+}
+
+/**
+ * Try the call bridge first; if not consumed, run the agent loop.
+ * Used by drainQueue to handle the async bridge check in fire-and-forget mode.
+ */
+async function routeOrProcess(
+  session: ProcessSessionContext,
+  content: string,
+  userMessageId: string,
+  next: { onEvent: (msg: ServerMessage) => void; requestId: string },
+): Promise<void> {
+  try {
+    const bridgeResult = await tryRouteCallMessage(session.conversationId, content, userMessageId);
+    if (bridgeResult.handled) {
+      session.preactivatedSkillIds = undefined;
+      session.processing = false;
+      log.info({ conversationId: session.conversationId, userMessageId }, 'Queued message consumed by call bridge, skipping agent loop');
+      next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      // runAgentLoop never ran so its finally block won't drain — continue manually
+      drainQueue(session);
+      return;
+    }
+  } catch (err) {
+    log.warn({ err, conversationId: session.conversationId }, 'Call bridge check failed (non-fatal), proceeding with agent loop');
+  }
+
+  await session.runAgentLoop(content, userMessageId, next.onEvent);
 }
 
 // ── processMessage ───────────────────────────────────────────────────
@@ -257,6 +287,21 @@ export async function processMessage(
     // runAgentLoop never ran, so its finally block won't clear this
     session.preactivatedSkillIds = undefined;
     return '';
+  }
+
+  // Route through the call bridge before the agent loop. When the bridge
+  // consumes the message (answer or instruction), skip agent processing.
+  try {
+    const bridgeResult = await tryRouteCallMessage(session.conversationId, resolvedContent, userMessageId);
+    if (bridgeResult.handled) {
+      session.preactivatedSkillIds = undefined;
+      session.processing = false;
+      log.info({ conversationId: session.conversationId, userMessageId }, 'IPC message consumed by call bridge, skipping agent loop');
+      onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      return userMessageId;
+    }
+  } catch (err) {
+    log.warn({ err, conversationId: session.conversationId }, 'Call bridge check failed (non-fatal), proceeding with agent loop');
   }
 
   await session.runAgentLoop(resolvedContent, userMessageId, onEvent);


### PR DESCRIPTION
## Summary
- Generalize `tryHandlePendingCallAnswer` to handle both answer and instruction routing
- Route IPC chat messages through bridge before agent loop
- Prevent double-processing of consumed bridge messages
- Persist acknowledgement text on successful instruction relay
- Add tests for instruction routing via bridge

Closes #6487
Part of #6484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
