### PR TITLE
fix: make move-sync transactional and update binding fields on conflict

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -333,4 +333,46 @@ describe('channel sync arbitration', () => {
       expect(resp.status).toBe(400);
     });
   });
+
+  describe('move-sync upsert', () => {
+    test('updates binding fields when newConversationId already has an existing binding', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatIdA = `upsert-a-${uuid()}`;
+      const uniqueChatIdB = `upsert-b-${uuid()}`;
+
+      // conv-A owns chat-A, conv-B owns chat-B
+      createBinding(convA, 'telegram', uniqueChatIdA);
+      createBinding(convB, 'telegram', uniqueChatIdB);
+
+      // Create conversation key mappings
+      getOrCreateConversation(`telegram:${uniqueChatIdA}`);
+      getOrCreateConversation(`telegram:${uniqueChatIdB}`);
+
+      // Move chat-A to conv-B (which already has a binding for chat-B)
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatIdA,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      const body = await resp.json() as { ok: boolean; previousOwner: string | null };
+
+      expect(resp.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.previousOwner).toBe(convA);
+
+      // conv-B's binding should now point to chat-A (sourceChannel/externalChatId updated)
+      const binding = externalConversationStore.getBindingByConversation(convB);
+      expect(binding).not.toBeNull();
+      expect(binding!.sourceChannel).toBe('telegram');
+      expect(binding!.externalChatId).toBe(uniqueChatIdA);
+
+      // Conversation key for chat-A should resolve to conv-B
+      const keyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
+      expect(keyMapping).not.toBeNull();
+      expect(keyMapping!.conversationId).toBe(convB);
+    });
+  });
 });

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -96,6 +96,8 @@ export function upsertOutboundBinding(input: {
     .onConflictDoUpdate({
       target: externalConversationBindings.conversationId,
       set: {
+        sourceChannel: input.sourceChannel,
+        externalChatId: input.externalChatId,
         updatedAt: now,
         lastOutboundAt: now,
       },

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -3,6 +3,7 @@
  * conversation deletion.
  */
 import { deleteConversationKey, setConversationKey } from '../../memory/conversation-key-store.js';
+import { getDb } from '../../memory/db.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
@@ -60,21 +61,22 @@ export async function handleMoveSync(req: Request): Promise<Response> {
     return Response.json({ error: 'newConversationId is required' }, { status: 400 });
   }
 
-  // Get current owner
   const currentBinding = externalConversationStore.getBindingByChannelChat(sourceChannel, externalChatId);
   const previousOwner = currentBinding?.conversationId ?? null;
 
-  // Delete old mappings
   const conversationKey = `${sourceChannel}:${externalChatId}`;
-  deleteConversationKey(conversationKey);
-  externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
 
-  // Create new mappings
-  setConversationKey(conversationKey, newConversationId);
-  externalConversationStore.upsertOutboundBinding({
-    conversationId: newConversationId,
-    sourceChannel,
-    externalChatId,
+  // Wrap in transaction so a failure mid-way rolls back all changes
+  const db = getDb();
+  db.transaction(() => {
+    deleteConversationKey(conversationKey);
+    externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
+    setConversationKey(conversationKey, newConversationId);
+    externalConversationStore.upsertOutboundBinding({
+      conversationId: newConversationId,
+      sourceChannel,
+      externalChatId,
+    });
   });
 
   return Response.json({ ok: true, previousOwner });


### PR DESCRIPTION
## Summary
- Wraps `handleMoveSync` delete+create operations in a database transaction so a mid-way failure rolls back all changes instead of leaving orphaned mappings
- Updates `upsertOutboundBinding` to also set `sourceChannel` and `externalChatId` on conflict, so moving a chat to a conversation that already has a binding correctly updates the channel identifiers
- Adds a test verifying move-sync works when the target conversation already has an existing binding (the upsert case)

Addresses review feedback from PR #6483.

## Test plan
- [x] Existing channel-sync-arbitration tests pass (10/10)
- [x] New `move-sync upsert` test verifies binding fields are updated on conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
