### PR TITLE
fix: await DELETE result before archiving in disconnectSyncedThread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -805,7 +805,9 @@ struct MainWindowView: View {
         .contextMenu {
             if thread.sourceChannel != nil {
                 Button {
-                    threadManager.disconnectSyncedThread(id: thread.id)
+                    Task {
+                        await threadManager.disconnectSyncedThread(id: thread.id)
+                    }
                 } label: {
                     Label("Hide Local Thread", systemImage: "eye.slash")
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -259,7 +259,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// remove the conversation key mapping and external binding, then
     /// archives the thread in the UI. Does NOT call any external channel
     /// delete APIs (e.g. Telegram).
-    func disconnectSyncedThread(id: UUID) {
+    func disconnectSyncedThread(id: UUID) async {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
         let thread = threads[index]
         guard let sourceChannel = thread.sourceChannel,
@@ -268,12 +268,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             return
         }
 
-        // Fire the HTTP DELETE in the background; archive immediately in the UI
-        Task { @MainActor in
-            let _ = await daemonClient.deleteChannelConversation(
-                sourceChannel: sourceChannel,
-                externalChatId: externalChatId
-            )
+        // Await the DELETE so the runtime mapping is removed before we hide locally;
+        // otherwise inbound messages can route to an archived thread.
+        let success = await daemonClient.deleteChannelConversation(
+            sourceChannel: sourceChannel,
+            externalChatId: externalChatId
+        )
+
+        if !success {
+            log.warning("DELETE channel conversation failed for thread \(id) (\(sourceChannel):\(externalChatId)); proceeding with local archive")
         }
 
         // Clear channel binding fields so the thread no longer shows as synced


### PR DESCRIPTION
## Summary

- `disconnectSyncedThread` was firing `deleteChannelConversation` in a background `Task` and immediately clearing local fields and archiving. When the DELETE failed, the runtime mapping stayed active but the thread was hidden locally, causing future inbound messages to route to an archived thread.
- Now awaits the DELETE result before proceeding. On failure, logs a warning but still archives (respecting user intent).
- Updated the caller in `MainWindowView.swift` to wrap the now-async call in a `Task`.

## Test plan

- [ ] Verify hiding a synced Telegram thread successfully removes the runtime mapping and archives the thread
- [ ] Simulate a DELETE failure (e.g., daemon offline) and verify the warning is logged and the thread is still archived locally
- [ ] Verify that after a successful hide, new inbound Telegram messages create a fresh thread rather than routing to the archived one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
