### PR TITLE
fix: telegram config handler token fallback and set_commands action

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -499,40 +499,6 @@ exports[`IPC message snapshots ClientMessage types gallery_install serializes to
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types app_history_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "limit": 10,
-  "type": "app_history_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_diff_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "fromCommit": "abc123",
-  "toCommit": "def456",
-  "type": "app_diff_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_file_at_version_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123",
-  "path": "index.html",
-  "type": "app_file_at_version_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_restore_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123",
-  "type": "app_restore_request",
-}
-`;
-
 exports[`IPC message snapshots ClientMessage types app_update_preview serializes to expected JSON 1`] = `
 {
   "appId": "app-001",
@@ -545,6 +511,40 @@ exports[`IPC message snapshots ClientMessage types app_preview_request serialize
 {
   "appId": "app-001",
   "type": "app_preview_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_history_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "limit": 25,
+  "type": "app_history_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_diff_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "fromCommit": "abc123def456",
+  "toCommit": "789abc123def",
+  "type": "app_diff_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_file_at_version_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "commitHash": "abc123def456",
+  "path": "index.html",
+  "type": "app_file_at_version_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types app_restore_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "commitHash": "abc123def456",
+  "type": "app_restore_request",
 }
 `;
 
@@ -587,6 +587,13 @@ exports[`IPC message snapshots ClientMessage types twitter_integration_config se
 {
   "action": "get",
   "type": "twitter_integration_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types telegram_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "telegram_config",
 }
 `;
 
@@ -1844,50 +1851,6 @@ exports[`IPC message snapshots ServerMessage types gallery_install_response seri
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types app_history_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "type": "app_history_response",
-  "versions": [
-    {
-      "commitHash": "abc123",
-      "message": "Initial commit",
-      "timestamp": 1700000000,
-    },
-  ],
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_diff_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "diff": 
-"--- a/index.html
-+++ b/index.html
-@@ -1 +1 @@
--old
-+new"
-,
-  "type": "app_diff_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_file_at_version_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "content": "<html><body>Hello</body></html>",
-  "path": "index.html",
-  "type": "app_file_at_version_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_restore_response serializes to expected JSON 1`] = `
-{
-  "success": true,
-  "type": "app_restore_response",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types share_app_cloud_response serializes to expected JSON 1`] = `
 {
   "shareToken": "abc123def456",
@@ -1941,6 +1904,17 @@ exports[`IPC message snapshots ServerMessage types twitter_integration_config_re
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types telegram_config_response serializes to expected JSON 1`] = `
+{
+  "botUsername": "my_test_bot",
+  "connected": true,
+  "hasBotToken": true,
+  "hasWebhookSecret": true,
+  "success": true,
+  "type": "telegram_config_response",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types twitter_auth_result serializes to expected JSON 1`] = `
 {
   "accountInfo": "@vellum_test",
@@ -1979,6 +1953,49 @@ exports[`IPC message snapshots ServerMessage types app_preview_response serializ
   "appId": "app-001",
   "preview": "base64-png-data",
   "type": "app_preview_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_history_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_history_response",
+  "versions": [
+    {
+      "commitHash": "abc123def456",
+      "message": "Initial app commit",
+      "timestamp": 1700000000,
+    },
+    {
+      "commitHash": "789abc123def",
+      "message": "Update landing page",
+      "timestamp": 1700001000,
+    },
+  ],
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_diff_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "diff": "diff --git a/index.html b/index.html",
+  "type": "app_diff_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_file_at_version_response serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "content": "<html><body>Hello</body></html>",
+  "path": "index.html",
+  "type": "app_file_at_version_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_restore_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "app_restore_response",
 }
 `;
 
@@ -2438,100 +2455,5 @@ exports[`IPC message snapshots ServerMessage types tool_permission_simulate_resp
   "riskLevel": "high",
   "success": true,
   "type": "tool_permission_simulate_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_history_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "limit": 25,
-  "type": "app_history_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_diff_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "fromCommit": "abc123def456",
-  "toCommit": "789abc123def",
-  "type": "app_diff_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_file_at_version_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123def456",
-  "path": "index.html",
-  "type": "app_file_at_version_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_restore_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123def456",
-  "type": "app_restore_request",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_history_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "type": "app_history_response",
-  "versions": [
-    {
-      "commitHash": "abc123def456",
-      "message": "Initial app commit",
-      "timestamp": 1700000000,
-    },
-    {
-      "commitHash": "789abc123def",
-      "message": "Update landing page",
-      "timestamp": 1700001000,
-    },
-  ],
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_diff_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "diff": "diff --git a/index.html b/index.html",
-  "type": "app_diff_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_file_at_version_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "content": "<html><body>Hello</body></html>",
-  "path": "index.html",
-  "type": "app_file_at_version_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_restore_response serializes to expected JSON 1`] = `
-{
-  "success": true,
-  "type": "app_restore_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types telegram_config serializes to expected JSON 1`] = `
-{
-  "action": "get",
-  "type": "telegram_config",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types telegram_config_response serializes to expected JSON 1`] = `
-{
-  "botUsername": "my_test_bot",
-  "connected": true,
-  "hasBotToken": true,
-  "hasWebhookSecret": true,
-  "success": true,
-  "type": "telegram_config_response",
 }
 `;

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -272,7 +272,7 @@ describe('Telegram config handler', () => {
     expect(secureKeyStore['credential:telegram:bot_token']).toBeUndefined();
   });
 
-  test('set action without botToken returns error', async () => {
+  test('set action without botToken returns error when no token in secure storage', async () => {
     const msg: TelegramConfigRequest = {
       type: 'telegram_config',
       action: 'set',
@@ -285,6 +285,40 @@ describe('Telegram config handler', () => {
     const res = sent[0] as { type: string; success: boolean; error?: string };
     expect(res.success).toBe(false);
     expect(res.error).toContain('botToken is required');
+  });
+
+  test('set action without botToken falls back to secure storage', async () => {
+    // Pre-populate token in secure storage (as credential_store prompt would)
+    secureKeyStore['credential:telegram:bot_token'] = '123456:stored-token';
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.telegram.org') && urlStr.includes('/getMe')) {
+        // Verify the stored token is being used
+        expect(urlStr).toContain('123456:stored-token');
+        return new Response(JSON.stringify({
+          ok: true,
+          result: { id: 123456, is_bot: true, first_name: 'TestBot', username: 'stored_bot' },
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set',
+      // No botToken provided — should fall back to secure storage
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasBotToken: boolean; botUsername: string; connected: boolean };
+    expect(res.success).toBe(true);
+    expect(res.hasBotToken).toBe(true);
+    expect(res.botUsername).toBe('stored_bot');
+    expect(res.connected).toBe(true);
   });
 
   test('clear action removes credentials', async () => {
@@ -651,5 +685,116 @@ describe('Telegram config handler', () => {
     // Credentials should still be cleaned up despite webhook deregistration failure
     expect(secureKeyStore['credential:telegram:bot_token']).toBeUndefined();
     expect(secureKeyStore['credential:telegram:webhook_secret']).toBeUndefined();
+  });
+
+  test('set_commands action registers default commands', async () => {
+    secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
+    secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
+
+    let setCommandsCalled = false;
+    let setCommandsBody: unknown = null;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('/setMyCommands')) {
+        setCommandsCalled = true;
+        setCommandsBody = JSON.parse(init?.body as string);
+        return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set_commands',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasBotToken: boolean; connected: boolean };
+    expect(res.success).toBe(true);
+    expect(res.hasBotToken).toBe(true);
+    expect(res.connected).toBe(true);
+    expect(setCommandsCalled).toBe(true);
+    expect((setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands).toEqual([
+      { command: 'new', description: 'Start a new conversation' },
+    ]);
+  });
+
+  test('set_commands action with custom commands', async () => {
+    secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
+    secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
+
+    let setCommandsBody: unknown = null;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('/setMyCommands')) {
+        setCommandsBody = JSON.parse(init?.body as string);
+        return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set_commands',
+      commands: [
+        { command: 'new', description: 'Start a new conversation' },
+        { command: 'help', description: 'Show help' },
+      ],
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean };
+    expect(res.success).toBe(true);
+    expect((setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands).toEqual([
+      { command: 'new', description: 'Start a new conversation' },
+      { command: 'help', description: 'Show help' },
+    ]);
+  });
+
+  test('set_commands action fails when no bot token is configured', async () => {
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set_commands',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Bot token not configured');
+  });
+
+  test('set_commands action handles Telegram API error', async () => {
+    secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
+    secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('/setMyCommands')) {
+        return new Response(JSON.stringify({ ok: false, description: 'Bad Request' }), { status: 400 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set_commands',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Failed to set bot commands');
   });
 });

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -28,7 +28,7 @@ The token is collected securely via a system-level prompt and is never exposed i
 
 After the token is collected, send it to the daemon's `telegram_config` handler which validates, stores, and configures everything in one step:
 
-- Send the `telegram_config` IPC message with `action: "set"`. The daemon retrieves the token from the credential store internally — you do not need to retrieve it yourself.
+- Send the `telegram_config` IPC message with `action: "set"`. The daemon retrieves the token from secure storage internally when `botToken` is not provided in the message — you do not need to retrieve it yourself.
 
 The daemon's `telegram_config set` handler automatically:
 - Validates the token by calling the Telegram `getMe` API

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -836,7 +836,9 @@ export async function handleTelegramConfig(
         hasWebhookSecret,
       });
     } else if (msg.action === 'set') {
-      if (!msg.botToken) {
+      // Resolve token: prefer explicit msg.botToken, fall back to secure storage
+      const botToken = msg.botToken || getSecureKey('credential:telegram:bot_token');
+      if (!botToken) {
         ctx.send(socket, {
           type: 'telegram_config_response',
           success: false,
@@ -851,7 +853,7 @@ export async function handleTelegramConfig(
       // Validate token via Telegram getMe API
       let botUsername: string;
       try {
-        const res = await fetch(`https://api.telegram.org/bot${msg.botToken}/getMe`);
+        const res = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
         if (!res.ok) {
           const body = await res.text();
           ctx.send(socket, {
@@ -891,7 +893,7 @@ export async function handleTelegramConfig(
       }
 
       // Store bot token securely
-      const stored = setSecureKey('credential:telegram:bot_token', msg.botToken);
+      const stored = setSecureKey('credential:telegram:bot_token', botToken);
       if (!stored) {
         ctx.send(socket, {
           type: 'telegram_config_response',
@@ -984,6 +986,64 @@ export async function handleTelegramConfig(
       if (effectiveUrl) {
         triggerGatewayReconcile(effectiveUrl);
       }
+    } else if (msg.action === 'set_commands') {
+      const storedToken = getSecureKey('credential:telegram:bot_token');
+      if (!storedToken) {
+        ctx.send(socket, {
+          type: 'telegram_config_response',
+          success: false,
+          hasBotToken: false,
+          connected: false,
+          hasWebhookSecret: false,
+          error: 'Bot token not configured. Run set action first.',
+        });
+        return;
+      }
+
+      const commands = msg.commands ?? [
+        { command: 'new', description: 'Start a new conversation' },
+      ];
+
+      try {
+        const res = await fetch(`https://api.telegram.org/bot${storedToken}/setMyCommands`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ commands }),
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          ctx.send(socket, {
+            type: 'telegram_config_response',
+            success: false,
+            hasBotToken: true,
+            connected: !!getSecureKey('credential:telegram:webhook_secret'),
+            hasWebhookSecret: !!getSecureKey('credential:telegram:webhook_secret'),
+            error: `Failed to set bot commands: ${body}`,
+          });
+          return;
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.send(socket, {
+          type: 'telegram_config_response',
+          success: false,
+          hasBotToken: true,
+          connected: !!getSecureKey('credential:telegram:webhook_secret'),
+          hasWebhookSecret: !!getSecureKey('credential:telegram:webhook_secret'),
+          error: `Failed to set bot commands: ${message}`,
+        });
+        return;
+      }
+
+      const hasBotToken = !!getSecureKey('credential:telegram:bot_token');
+      const hasWebhookSecret = !!getSecureKey('credential:telegram:webhook_secret');
+      ctx.send(socket, {
+        type: 'telegram_config_response',
+        success: true,
+        hasBotToken,
+        connected: hasBotToken && hasWebhookSecret,
+        hasWebhookSecret,
+      });
     } else {
       ctx.send(socket, {
         type: 'telegram_config_response',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -539,8 +539,9 @@ export interface TwitterIntegrationConfigRequest {
 
 export interface TelegramConfigRequest {
   type: 'telegram_config';
-  action: 'get' | 'set' | 'clear';
+  action: 'get' | 'set' | 'clear' | 'set_commands';
   botToken?: string;  // Only for action: 'set'
+  commands?: Array<{ command: string; description: string }>;  // Only for action: 'set_commands'
 }
 
 export interface TelegramConfigResponse {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1729,6 +1729,12 @@ public struct IPCTelegramConfigRequest: Codable, Sendable {
     public let type: String
     public let action: String
     public let botToken: String?
+    public let commands: [IPCTelegramConfigRequestCommand]?
+}
+
+public struct IPCTelegramConfigRequestCommand: Codable, Sendable {
+    public let command: String
+    public let description: String
 }
 
 public struct IPCTelegramConfigResponse: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Add secure storage fallback for botToken in `telegram_config set` handler (reads from `getSecureKey` when not provided in message)
- Add `set_commands` action to register bot commands via Telegram API
- Update IPC contract to include `set_commands` action
- Regenerate IPC types

Addresses feedback on #6495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
