### PR TITLE
fix: validate instruction payload shape before field access (#6499)

### DIFF
--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -165,6 +165,10 @@ export async function handleInstructionCall(req: Request, callSessionId: string)
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
 
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+  }
+
   const result = await relayInstruction({
     callSessionId,
     instructionText: body.instruction ?? '',


### PR DESCRIPTION
## Summary
- Add guard to validate request body is a non-null object before accessing instruction field
- Return 400 instead of 500 for malformed JSON payloads (null, string, number, array)

Addresses review feedback on #6499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
