### PR TITLE
fix: clean up target conversation's old key during move-sync

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -375,4 +375,41 @@ describe('channel sync arbitration', () => {
       expect(keyMapping!.conversationId).toBe(convB);
     });
   });
+
+  describe('move-sync cleans up target conversation stale key', () => {
+    test('old target binding conversation key is removed when moving to a conversation that already has a binding', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatIdA = `stale-key-a-${uuid()}`;
+      const uniqueChatIdB = `stale-key-b-${uuid()}`;
+
+      // conv-A owns chat-A, conv-B owns chat-B
+      createBinding(convA, 'telegram', uniqueChatIdA);
+      createBinding(convB, 'telegram', uniqueChatIdB);
+
+      // Create conversation key mappings for both chats
+      getOrCreateConversation(`telegram:${uniqueChatIdA}`);
+      getOrCreateConversation(`telegram:${uniqueChatIdB}`);
+
+      // Move chat-A to conv-B (which already has a binding for chat-B)
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatIdA,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(200);
+
+      // The stale conversation key for chat-B should be cleaned up so
+      // inbound messages on chat-B no longer route to conv-B.
+      const staleKeyMapping = getConversationByKey(`telegram:${uniqueChatIdB}`);
+      expect(staleKeyMapping).toBeNull();
+
+      // chat-A's key should now point to conv-B
+      const chatAKeyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
+      expect(chatAKeyMapping).not.toBeNull();
+      expect(chatAKeyMapping!.conversationId).toBe(convB);
+    });
+  });
 });

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -71,6 +71,17 @@ export async function handleMoveSync(req: Request): Promise<Response> {
   db.transaction(() => {
     deleteConversationKey(conversationKey);
     externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
+
+    // If the target conversation already had a different chat bound, remove
+    // that stale conversation-key so inbound messages on the old chat no
+    // longer route to the target conversation.
+    const existingTargetBinding = externalConversationStore.getBindingByConversation(newConversationId);
+    if (existingTargetBinding &&
+        (existingTargetBinding.sourceChannel !== sourceChannel || existingTargetBinding.externalChatId !== externalChatId)) {
+      const oldTargetKey = `${existingTargetBinding.sourceChannel}:${existingTargetBinding.externalChatId}`;
+      deleteConversationKey(oldTargetKey);
+    }
+
     setConversationKey(conversationKey, newConversationId);
     externalConversationStore.upsertOutboundBinding({
       conversationId: newConversationId,


### PR DESCRIPTION
## Summary

- When `handleMoveSync` rebinds a chat to a `newConversationId` that already has its own binding, the old `conversation_keys` entry for the target conversation was not cleaned up. This caused inbound messages on the previously-bound chat to continue routing to the target conversation even though the binding now pointed to a different chat.
- Added cleanup logic inside the transaction block to detect and remove the stale conversation key before creating the new mappings.
- Added a regression test that verifies the old target binding's conversation key is removed during move-sync.

Addresses review feedback on #6502.

## Test plan

- [x] Existing tests pass (11/11 in `channel-sync-arbitration.test.ts`)
- [x] New test `move-sync cleans up target conversation stale key` verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
