### PR TITLE
fix: re-lookup thread index after await in disconnectSyncedThread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -805,7 +805,9 @@ struct MainWindowView: View {
         .contextMenu {
             if thread.sourceChannel != nil {
                 Button {
-                    threadManager.disconnectSyncedThread(id: thread.id)
+                    Task {
+                        await threadManager.disconnectSyncedThread(id: thread.id)
+                    }
                 } label: {
                     Label("Hide Local Thread", systemImage: "eye.slash")
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -259,24 +259,26 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// remove the conversation key mapping and external binding, then
     /// archives the thread in the UI. Does NOT call any external channel
     /// delete APIs (e.g. Telegram).
-    func disconnectSyncedThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
-        let thread = threads[index]
+    func disconnectSyncedThread(id: UUID) async {
+        guard let thread = threads.first(where: { $0.id == id }) else { return }
         guard let sourceChannel = thread.sourceChannel,
               let externalChatId = thread.externalChatId else {
             log.warning("Cannot disconnect thread \(id): missing channel binding")
             return
         }
 
-        // Fire the HTTP DELETE in the background; archive immediately in the UI
-        Task { @MainActor in
-            let _ = await daemonClient.deleteChannelConversation(
-                sourceChannel: sourceChannel,
-                externalChatId: externalChatId
-            )
+        let success = await daemonClient.deleteChannelConversation(
+            sourceChannel: sourceChannel,
+            externalChatId: externalChatId
+        )
+
+        if !success {
+            log.warning("DELETE channel conversation failed for \(sourceChannel):\(externalChatId), proceeding with local archive")
         }
 
-        // Clear channel binding fields so the thread no longer shows as synced
+        // Re-lookup after await — threads may have changed during suspension
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+
         threads[index].sourceChannel = nil
         threads[index].externalChatId = nil
         threads[index].displayName = nil


### PR DESCRIPTION
## Summary

- Fix stale-index bug in `disconnectSyncedThread` (ThreadManager.swift): the original code captured `index` before firing a background `Task` with an `await`, then mutated `threads[index]` synchronously. Since `@MainActor` is reentrant at suspension points, other code (e.g. `createThread`, `closeThread`) could mutate `threads` during the suspension, causing the stale index to target the wrong thread or crash with out-of-bounds.
- Make the method `async`, capture identifying fields (`sourceChannel`, `externalChatId`) before the `await`, then re-lookup the index by `id` after — matching the pattern already used by `moveSyncHere`.
- Update the call site in `MainWindowView.swift` to wrap the now-async call in a `Task`.

Addresses review feedback on PR #6503.

## Test plan

- [ ] Verify "Hide Local Thread" context menu action on a synced Telegram thread still disconnects and archives correctly.
- [ ] Confirm no crashes when rapidly creating/closing threads while a disconnect is in-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
