### PR TITLE
docs: show both Telegram credential entry points in architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3579,19 +3579,28 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 In desktop deployments, Telegram bot tokens are stored in secure storage (macOS Keychain or the encrypted file fallback) and never in plaintext config files. When deploying the gateway standalone, operators may also supply credentials via environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`).
 
 ```
-Secure credential prompt (credential_store action: "prompt")
-  → telegram_config IPC (action: set, botToken)
-    → Daemon handler validates token via Telegram getMe API
-      → setSecureKey("credential:telegram:bot_token", token)
-      → upsertCredentialMetadata("telegram", "bot_token", {accountInfo: username})
-      → Auto-generates webhook secret if missing
-        → setSecureKey("credential:telegram:webhook_secret", secret)
-        → upsertCredentialMetadata("telegram", "webhook_secret", {})
-        → On storage failure: rolls back bot_token + metadata, returns error
-      → If webhook secret already exists: upserts metadata anyway (self-heal)
-      → Triggers gateway webhook reconcile
-        → Gateway credential reader picks up new credentials
-          → Webhook reconciliation registers webhook with Telegram
+Entry points:
+
+  1. Skill-based setup (chat):
+     credential_store action: "prompt" → token stored in secure storage
+       → telegram_config IPC (action: set) — daemon reads token from secure storage
+
+  2. Desktop Settings UI (macOS):
+     SettingsStore.saveTelegramToken(token)
+       → telegram_config IPC (action: set, botToken: token) — token passed directly
+
+Both paths converge at:
+  → Daemon handler validates token via Telegram getMe API
+    → setSecureKey("credential:telegram:bot_token", token)
+    → upsertCredentialMetadata("telegram", "bot_token", {accountInfo: username})
+    → Auto-generates webhook secret if missing
+      → setSecureKey("credential:telegram:webhook_secret", secret)
+      → upsertCredentialMetadata("telegram", "webhook_secret", {})
+      → On storage failure: rolls back bot_token + metadata, returns error
+    → If webhook secret already exists: upserts metadata anyway (self-heal)
+    → Triggers gateway webhook reconcile
+      → Gateway credential reader picks up new credentials
+        → Webhook reconciliation registers webhook with Telegram
 ```
 
 The `telegram_config` IPC message supports three actions:


### PR DESCRIPTION
## Summary
- Update ARCHITECTURE.md Telegram credential flow to show both entry points:
  1. Skill-based setup via credential_store prompt
  2. Desktop Settings UI via SettingsStore
- Both paths converge at the daemon handler

Addresses feedback on #6500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
