### PR TITLE
fix: clarify steering hint re answer-first priority (#6504)

### DIFF
--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -95,7 +95,7 @@ export function registerSessionNotifiers(
   registerCallQuestionNotifier(conversationId, (callSessionId: string, question: string) => {
     const callSession = getCallSession(callSessionId);
     const callee = callSession?.toNumber ?? 'the caller';
-    const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Reply in this thread to answer. You can also send messages anytime during the call to steer the conversation._`;
+    const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Reply in this thread to answer. Your next message will be treated as the answer to this question. Once answered, you can send messages to steer the conversation._`;
 
     conversationStore.addMessage(
       conversationId,


### PR DESCRIPTION
## Summary
- Update call notification text to clarify that answers to pending questions take priority over steering instructions
- Prevents users from accidentally sending steering text that gets consumed as a question answer

Addresses review feedback on #6504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
