### PR TITLE
fix: address review feedback on bridge and IPC path (#6501)

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1150,7 +1150,7 @@ export class DaemonServer {
     // Now that the processing lock is held, check the call-answer bridge.
     let bridgeHandled = false;
     try {
-      const bridgeResult = await tryRouteCallMessage(conversationId, content, messageId);
+      const bridgeResult = await tryRouteCallMessage(conversationId, resolvedContent, messageId);
       bridgeHandled = bridgeResult.handled;
     } catch (err) {
       log.warn({ err, conversationId }, 'Call bridge check failed (non-fatal), proceeding with agent loop');

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -50,6 +50,8 @@ export interface ProcessSessionContext {
   readonly conversationId: string;
   messages: Message[];
   processing: boolean;
+  abortController: AbortController | null;
+  currentRequestId?: string;
   readonly queue: MessageQueue;
   readonly traceEmitter: TraceEmitter;
   currentActiveSurfaceId?: string;
@@ -203,6 +205,8 @@ async function routeOrProcess(
     if (bridgeResult.handled) {
       session.preactivatedSkillIds = undefined;
       session.processing = false;
+      session.abortController = null;
+      session.currentRequestId = undefined;
       log.info({ conversationId: session.conversationId, userMessageId }, 'Queued message consumed by call bridge, skipping agent loop');
       next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
       // runAgentLoop never ran so its finally block won't drain — continue manually
@@ -296,8 +300,12 @@ export async function processMessage(
     if (bridgeResult.handled) {
       session.preactivatedSkillIds = undefined;
       session.processing = false;
+      session.abortController = null;
+      session.currentRequestId = undefined;
       log.info({ conversationId: session.conversationId, userMessageId }, 'IPC message consumed by call bridge, skipping agent loop');
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      // runAgentLoop never ran so its finally block won't drain — continue manually
+      drainQueue(session);
       return userMessageId;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Drain queued IPC messages after bridge consumes a message to prevent stranded work
- Use resolvedContent instead of content when calling bridge in server.ts
- Reset abortController and currentRequestId in bridge-consumed paths for consistent session state

Addresses review feedback on #6501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
