### PR TITLE
fix: conditional rollback for storage-fallback tokens and Swift init parity

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -623,6 +623,50 @@ describe('Telegram config handler', () => {
     expect(credentialMetadataStore.find((m) => m.service === 'telegram' && m.field === 'bot_token')).toBeUndefined();
   });
 
+  test('set action preserves storage-fallback token when webhook secret storage fails', async () => {
+    // Pre-populate token in secure storage (simulating credential_store prompt)
+    secureKeyStore['credential:telegram:bot_token'] = '123456:stored-token';
+
+    // Let bot token storage succeed but webhook secret storage fail
+    setSecureKeyOverride = (account: string, value: string) => {
+      if (account === 'credential:telegram:webhook_secret') return false;
+      secureKeyStore[account] = value;
+      return true;
+    };
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.telegram.org') && urlStr.includes('/getMe')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          result: { id: 123456, is_bot: true, first_name: 'TestBot', username: 'stored_bot' },
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set',
+      // No botToken — falls back to secure storage
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasBotToken: boolean; connected: boolean; hasWebhookSecret: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('Failed to store webhook secret');
+    // The pre-existing token from storage should NOT be deleted
+    expect(res.hasBotToken).toBe(true);
+    expect(res.connected).toBe(false);
+    expect(res.hasWebhookSecret).toBe(false);
+
+    // Token should still exist in secure storage
+    expect(secureKeyStore['credential:telegram:bot_token']).toBe('123456:stored-token');
+  });
+
   test('clear action deregisters webhook before deleting credentials', async () => {
     secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
     secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -836,7 +836,9 @@ export async function handleTelegramConfig(
         hasWebhookSecret,
       });
     } else if (msg.action === 'set') {
-      // Resolve token: prefer explicit msg.botToken, fall back to secure storage
+      // Resolve token: prefer explicit msg.botToken, fall back to secure storage.
+      // Track provenance so we only rollback tokens that were freshly provided.
+      const isNewToken = !!msg.botToken;
       const botToken = msg.botToken || getSecureKey('credential:telegram:bot_token');
       if (!botToken) {
         ctx.send(socket, {
@@ -921,13 +923,17 @@ export async function handleTelegramConfig(
           upsertCredentialMetadata('telegram', 'webhook_secret', {});
           hasWebhookSecret = true;
         } else {
-          // Roll back bot token to avoid partial configuration
-          deleteSecureKey('credential:telegram:bot_token');
-          deleteCredentialMetadata('telegram', 'bot_token');
+          // Only roll back the bot token if it was freshly provided.
+          // When the token came from secure storage it was already valid
+          // configuration; deleting it would destroy working state.
+          if (isNewToken) {
+            deleteSecureKey('credential:telegram:bot_token');
+            deleteCredentialMetadata('telegram', 'bot_token');
+          }
           ctx.send(socket, {
             type: 'telegram_config_response',
             success: false,
-            hasBotToken: false,
+            hasBotToken: !isNewToken,
             connected: false,
             hasWebhookSecret: false,
             error: 'Failed to store webhook secret',

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -907,8 +907,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Get, set, or clear Telegram bot token configuration.
-    public func sendTelegramConfig(action: String, botToken: String? = nil) throws {
-        try send(TelegramConfigRequestMessage(action: action, botToken: botToken))
+    public func sendTelegramConfig(action: String, botToken: String? = nil, commands: [IPCTelegramConfigRequestCommand]? = nil) throws {
+        try send(TelegramConfigRequestMessage(action: action, botToken: botToken, commands: commands))
     }
 
     /// Publish a static page to Vercel.

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1798,8 +1798,8 @@ public typealias VercelApiConfigResponseMessage = IPCVercelApiConfigResponse
 public typealias TelegramConfigRequestMessage = IPCTelegramConfigRequest
 
 extension IPCTelegramConfigRequest {
-    public init(action: String, botToken: String? = nil) {
-        self.init(type: "telegram_config", action: action, botToken: botToken)
+    public init(action: String, botToken: String? = nil, commands: [IPCTelegramConfigRequestCommand]? = nil) {
+        self.init(type: "telegram_config", action: action, botToken: botToken, commands: commands)
     }
 }
 


### PR DESCRIPTION
## Summary
- Only rollback bot token on webhook secret failure when token was freshly provided (not from storage fallback)
- Fix Swift IPCTelegramConfigRequest init to include optional `commands` parameter
- Update DaemonClient.sendTelegramConfig to accept optional commands

Addresses feedback on #6505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
