### PR TITLE
fix: add body shape guards to handleStartCall and handleAnswerCall (#6507)

### DIFF
--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -38,6 +38,10 @@ export async function handleStartCall(req: Request): Promise<Response> {
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
 
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+  }
+
   if (!body.conversationId) {
     return Response.json({ error: 'conversationId is required' }, { status: 400 });
   }
@@ -138,6 +142,10 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
     body = await req.json() as typeof body;
   } catch {
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
   }
 
   const result = await answerCall({


### PR DESCRIPTION
## Summary
- Add non-object body validation to handleStartCall and handleAnswerCall
- Matches the guard already in handleInstructionCall — returns 400 instead of 500 for null/string/number/array payloads

Addresses review feedback on #6507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
