### PR TITLE
fix: flush pending instructions on consultation timeout (#6510)

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -379,6 +379,7 @@ export class CallOrchestrator {
             this.state = 'idle';
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             expirePendingQuestions(this.callSessionId);
+            this.flushPendingInstructions();
           }
         }, getUserConsultationTimeoutMs());
         return;


### PR DESCRIPTION
## Summary
- Flush queued pending instructions when consultation timeout fires during waiting_on_user state
- Prevents silently dropped user steering directives when users don't answer in time

Addresses review feedback on #6510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
