### PR TITLE
fix: restrict IPC log hygiene regexes to single log call scope

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -286,11 +286,11 @@ describe('Invariant 3: secrets never logged in plaintext', () => {
         // Verify log calls never include raw content fields — only safe
         // metadata like lineLength and errorType are permitted.
         // `trimmed.length` is safe (numeric); `trimmed` alone would leak raw content.
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\(.*[{,]\s*trimmed[^.]/s);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\(.*[{,]\s*line[^L]/s);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\(.*[{,]\s*data\b/s);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\(.*[{,]\s*buffer\b/s);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\(.*err\.message\b/s);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*trimmed[^.]/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*line[^L]/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*data\b/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*buffer\b/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*err\.message\b/);
       });
     } else {
       // PR 25 — secret prompter log hygiene: verify the prompter source


### PR DESCRIPTION
Addresses Devin's review feedback on #6477. The dotall flag caused regexes to match across newlines, creating false positives where a log.warn() call on one line matched a buffer variable assignment 15 lines later. Fixes the regexes to avoid false positive cross-line matches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
