### PR TITLE
fix: verify conversation key ownership before deletion in move-sync

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -78,7 +78,7 @@ import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
 import { conversations } from '../memory/schema.js';
 import * as externalConversationStore from '../memory/external-conversation-store.js';
-import { getOrCreateConversation, deleteConversationKey, getConversationByKey } from '../memory/conversation-key-store.js';
+import { getOrCreateConversation, deleteConversationKey, getConversationByKey, setConversationKey } from '../memory/conversation-key-store.js';
 import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
 import { handleMoveSync, handleDeleteConversation } from '../runtime/routes/channel-routes.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
@@ -407,6 +407,54 @@ describe('channel sync arbitration', () => {
       expect(staleKeyMapping).toBeNull();
 
       // chat-A's key should now point to conv-B
+      const chatAKeyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
+      expect(chatAKeyMapping).not.toBeNull();
+      expect(chatAKeyMapping!.conversationId).toBe(convB);
+    });
+  });
+
+  describe('move-sync preserves conversation key claimed by another conversation', () => {
+    test('does not delete old target key if another conversation has claimed it', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const convC = uuid();
+      const uniqueChatIdA = `claimed-key-a-${uuid()}`;
+      const uniqueChatIdB = `claimed-key-b-${uuid()}`;
+
+      // conv-A owns chat-A, conv-B owns chat-B via external binding
+      createBinding(convA, 'telegram', uniqueChatIdA);
+      createBinding(convB, 'telegram', uniqueChatIdB);
+      ensureConversation(convC);
+
+      // Create conversation key mappings for both chats
+      getOrCreateConversation(`telegram:${uniqueChatIdA}`);
+      getOrCreateConversation(`telegram:${uniqueChatIdB}`);
+
+      // Simulate another conversation (conv-C) claiming chat-B's key via
+      // inbound traffic before the move-sync happens.  This can occur when
+      // the binding and conversation_keys tables diverge.
+      const chatBKey = `telegram:${uniqueChatIdB}`;
+      deleteConversationKey(chatBKey);
+      setConversationKey(chatBKey, convC);
+
+      // Move chat-A to conv-B — conv-B's external binding still points to
+      // chat-B, but the conversation_keys entry for chat-B now belongs to
+      // conv-C.  The guard should prevent deleting conv-C's key.
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatIdA,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(200);
+
+      // The conversation key for chat-B must still point to conv-C
+      const chatBKeyMapping = getConversationByKey(chatBKey);
+      expect(chatBKeyMapping).not.toBeNull();
+      expect(chatBKeyMapping!.conversationId).toBe(convC);
+
+      // chat-A's key should point to conv-B
       const chatAKeyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
       expect(chatAKeyMapping).not.toBeNull();
       expect(chatAKeyMapping!.conversationId).toBe(convB);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for channel inbound messages, delivery acks, and
  * conversation deletion.
  */
-import { deleteConversationKey, setConversationKey } from '../../memory/conversation-key-store.js';
+import { deleteConversationKey, getConversationByKey, setConversationKey } from '../../memory/conversation-key-store.js';
 import { getDb } from '../../memory/db.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
@@ -79,7 +79,14 @@ export async function handleMoveSync(req: Request): Promise<Response> {
     if (existingTargetBinding &&
         (existingTargetBinding.sourceChannel !== sourceChannel || existingTargetBinding.externalChatId !== externalChatId)) {
       const oldTargetKey = `${existingTargetBinding.sourceChannel}:${existingTargetBinding.externalChatId}`;
-      deleteConversationKey(oldTargetKey);
+      // Only delete the old key if it currently maps to the conversation we
+      // are moving into.  Another conversation may have since claimed the key
+      // (e.g. via getOrCreateConversation on inbound traffic), and deleting it
+      // would break routing for that unrelated conversation.
+      const oldTargetMapping = getConversationByKey(oldTargetKey);
+      if (oldTargetMapping && oldTargetMapping.conversationId === newConversationId) {
+        deleteConversationKey(oldTargetKey);
+      }
     }
 
     setConversationKey(conversationKey, newConversationId);


### PR DESCRIPTION
Addresses Codex review feedback on #6508. Adds an ownership check before deleting the old target conversation key during move-sync — only removes the key if it currently maps to the target conversation, preventing accidental deletion of routing entries that may have been claimed by another conversation via inbound traffic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
