### PR TITLE
fix: allow end-of-line clientSecret declarations and fix self-test logic

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -60,7 +60,7 @@ declare -a PATTERNS=(
 # Also ignore Swift/TS function-parameter declarations (e.g. `clientSecret: String?`).
 declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
-    "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*([,)]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
+    "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
 )
 
 matches_safe_line_pattern() {
@@ -121,6 +121,7 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_CLIENT_SECRET_DOC='- **PKCE or client_secret flows** — Desktop apps use PKCE by default (S256).'
     SAFE_SWIFT_PARAM_LINE='public init(action: String, mode: String? = nil, clientId: String? = nil, clientSecret: String? = nil)'
     SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
+    SAFE_SWIFT_DECL_LINE='public let clientSecret: String?'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -218,8 +219,16 @@ if [ "${1:-}" = "--self-test" ]; then
         echo -e "${RED}Self-test failed:${NC} real client_secret assignment did not match"
         exit 1
     fi
-    if matches_secret_pattern "$DANGEROUS_TYPED_SECRET" && matches_safe_line_pattern "$DANGEROUS_TYPED_SECRET"; then
+    if ! matches_secret_pattern "$DANGEROUS_TYPED_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} typed clientSecret assignment was not detected as a secret"
+        exit 1
+    fi
+    if matches_safe_line_pattern "$DANGEROUS_TYPED_SECRET"; then
         echo -e "${RED}Self-test failed:${NC} typed clientSecret assignment incorrectly whitelisted"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_DECL_LINE" && ! matches_safe_line_pattern "$SAFE_SWIFT_DECL_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} Swift clientSecret end-of-line declaration false positive"
         exit 1
     fi
 


### PR DESCRIPTION
Widens the clientSecret safe-line regex to allow end-of-line type declarations (e.g. public let clientSecret: String?) while still catching assignments with string literals. Also splits the DANGEROUS_TYPED_SECRET self-test into two separate assertions to prevent silent passes. Addresses review feedback from PR #6473.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
