### PR TITLE
fix: close mid-call steering gaps — explicit relay failures + live IPC ack

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3767,7 +3767,10 @@ The bridge function `tryRouteCallMessage()` applies the following decision logic
 
 1. **Question emission**: When the LLM emits `[ASK_USER: question]`, the orchestrator creates a pending question in SQLite, fires the question notifier, and transitions to `waiting_on_user` state.
 2. **In-thread display**: The Session's registered question notifier callback persists an assistant message in the conversation thread (via `conversationStore.addMessage()`) and emits `assistant_text_delta` + `message_complete` events to connected clients.
-3. **Auto-consumption**: When the user sends their next message in the same thread, `DaemonServer.processMessage()` and `DaemonServer.persistAndProcessMessage()` call `tryRouteCallMessage()` before launching the agent loop. If there is an active call with a pending question and the orchestrator is in `waiting_on_user` state, the message is routed directly to the orchestrator and the agent loop is skipped.
+3. **Auto-consumption**: `tryRouteCallMessage()` is checked before the agent loop in two entrypoints:
+   - **HTTP path**: `DaemonServer.processMessage()` / `persistAndProcessMessage()` in the daemon server.
+   - **IPC/session path**: `processMessage()` (direct) and `routeOrProcess()` (queued) in `session-process.ts`.
+   In both paths, if the bridge consumes the message the agent loop is skipped. Any `userFacingText` returned by the bridge is emitted as `assistant_text_delta` + `message_complete` so the chat UI shows a live acknowledgement or failure notice.
 4. **Orchestrator resume**: The orchestrator receives the answer via `handleUserAnswer()`, injects `[USER_ANSWERED: answer]` into the LLM context, and resumes the conversation with the callee.
 
 #### Instruction path detail
@@ -3777,18 +3780,19 @@ When no pending question exists but a call is active, the user's message is trea
 1. The bridge calls `relayInstruction()` which validates the call is active and delegates to `handleUserInstruction()` on the orchestrator.
 2. The orchestrator appends `[USER_INSTRUCTION: text]` to its conversation history. The system prompt tells the model to treat this marker as high-priority steering input.
 3. A confirmation message ("Instruction relayed to active call.") is persisted in the conversation thread.
+4. **Failure handling**: If `relayInstruction()` fails (no active orchestrator, terminal session, etc.), a failure notice ("Failed to relay instruction to the active call.") is persisted and the message is still consumed (`handled: true`) so the caller does not fall through to the normal agent loop. The bridge returns `reason: 'instruction_relay_failed'` so callers can distinguish success from failure.
 
 The instruction path is also available via HTTP at `POST /v1/calls/:callSessionId/instruction` for programmatic access (see Runtime HTTP Endpoints).
 
 #### Bridge result reasons
 
-The bridge returns a `{ handled: boolean; reason?: string }` result so callers can determine whether the message was consumed:
+The bridge returns a `{ handled: boolean; reason?: string; userFacingText?: string }` result so callers can determine whether the message was consumed:
 - `no_active_call` — no non-terminal call session exists for this conversation
 - `no_pending_question` — call is active but no question is pending (only returned in legacy answer-only path; current bridge falls through to instruction)
 - `orchestrator_not_found` — the orchestrator was destroyed (call ended between question and answer)
 - `orchestrator_not_waiting` — the orchestrator is not in `waiting_on_user` state
 - `orchestrator_rejected` — the orchestrator's `handleUserAnswer()` returned false
-- `instruction_relay_failed` — the instruction could not be relayed to the orchestrator
+- `instruction_relay_failed` — the instruction could not be relayed to the orchestrator; message is still consumed (`handled: true`) with a failure notice persisted in-thread
 
 ### SQLite Tables
 

--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -186,7 +186,7 @@ describe('call-bridge', () => {
     expect(result.reason).toBe('no_active_call');
   });
 
-  test('returns instruction_relay_failed when call exists but no orchestrator and no pending question', async () => {
+  test('returns instruction_relay_failed (consumed) when call exists but no orchestrator and no pending question', async () => {
     ensureConversation('conv-no-orch');
     createCallSession({
       conversationId: 'conv-no-orch',
@@ -195,8 +195,9 @@ describe('call-bridge', () => {
       toNumber: '+15552222222',
     });
     const result = await tryRouteCallMessage('conv-no-orch', 'some instruction');
-    expect(result.handled).toBe(false);
+    expect(result.handled).toBe(true);
     expect(result.reason).toBe('instruction_relay_failed');
+    expect(result.userFacingText).toBe('Failed to relay instruction to the active call.');
   });
 
   test('returns handled:false when orchestrator is not found (call still active but no orchestrator)', async () => {
@@ -314,6 +315,7 @@ describe('call-bridge', () => {
 
     const result = await tryRouteCallMessage('conv-instruct', 'Please ask about pricing');
     expect(result.handled).toBe(true);
+    expect(result.userFacingText).toBe('Instruction relayed to active call.');
 
     // Verify acknowledgement was persisted
     const msgs = getMessagesForConversation('conv-instruct');
@@ -366,7 +368,7 @@ describe('call-bridge', () => {
     orchestrator.destroy();
   });
 
-  test('instruction relay fails gracefully when call has no orchestrator', async () => {
+  test('instruction relay failure persists notice and is consumed (handled:true)', async () => {
     ensureConversation('conv-no-orch-instruct');
     createCallSession({
       conversationId: 'conv-no-orch-instruct',
@@ -375,10 +377,17 @@ describe('call-bridge', () => {
       toNumber: '+15552222222',
     });
 
-    // No orchestrator registered — relay should fail
+    // No orchestrator registered — relay should fail but still be consumed
     const result = await tryRouteCallMessage('conv-no-orch-instruct', 'Change the topic');
-    expect(result.handled).toBe(false);
+    expect(result.handled).toBe(true);
     expect(result.reason).toBe('instruction_relay_failed');
+    expect(result.userFacingText).toBe('Failed to relay instruction to the active call.');
+
+    // Verify failure notice was persisted in-thread
+    const msgs = getMessagesForConversation('conv-no-orch-instruct');
+    const failMsg = msgs.find((m) => m.content.includes('Failed to relay'));
+    expect(failMsg).toBeDefined();
+    expect(failMsg!.role).toBe('assistant');
   });
 
   // ── Call question notifier ──────────────────────────────────────

--- a/assistant/src/__tests__/session-process-bridge.test.ts
+++ b/assistant/src/__tests__/session-process-bridge.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'session-process-bridge-test-'));
+
+// ── Platform + logger mocks ─────────────────────────────────────────
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { anthropic: 'test-key' },
+    model: 'claude-sonnet-4-20250514',
+    provider: 'anthropic',
+    memory: { enabled: false },
+    calls: { enabled: false },
+  }),
+}));
+
+// ── Mock the call bridge ─────────────────────────────────────────────
+
+import type { CallBridgeResult } from '../calls/call-bridge.js';
+
+const mockTryRouteCallMessage = mock(
+  (_convId: string, _text: string, _msgId?: string): Promise<CallBridgeResult> =>
+    Promise.resolve({ handled: false, reason: 'no_active_call' }),
+);
+
+mock.module('../calls/call-bridge.js', () => ({
+  tryRouteCallMessage: (...args: [string, string, string?]) => mockTryRouteCallMessage(...args),
+}));
+
+// ── Mock slash resolution ────────────────────────────────────────────
+
+mock.module('./session-slash.js', () => ({
+  resolveSlash: (content: string) => ({ kind: 'passthrough' as const, content }),
+}));
+
+// ── Import after mocks ──────────────────────────────────────────────
+
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { ProcessSessionContext } from '../daemon/session-process.js';
+import { processMessage, drainQueue } from '../daemon/session-process.js';
+import { MessageQueue } from '../daemon/session-queue-manager.js';
+
+// ── Session mock factory ─────────────────────────────────────────────
+
+function createMockSession(overrides?: Partial<ProcessSessionContext>): ProcessSessionContext {
+  return {
+    conversationId: 'test-conv',
+    messages: [],
+    processing: false,
+    abortController: null,
+    currentRequestId: undefined,
+    queue: new MessageQueue(),
+    traceEmitter: {
+      emit: () => {},
+    } as unknown as ProcessSessionContext['traceEmitter'],
+    persistUserMessage: mock((_content: string, _attachments: unknown[], _requestId?: string) => 'mock-msg-id'),
+    runAgentLoop: mock(async () => {}),
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('session-process bridge consumption', () => {
+  beforeEach(() => {
+    mockTryRouteCallMessage.mockReset();
+  });
+
+  // ── Direct processMessage path ───────────────────────────────
+
+  test('processMessage emits assistant_text_delta + message_complete when bridge consumes with userFacingText', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: true,
+      userFacingText: 'Instruction relayed to active call.',
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession();
+
+    await processMessage(session, 'ask about pricing', [], onEvent);
+
+    // Should have emitted text delta then message_complete
+    const textDelta = events.find((e) => e.type === 'assistant_text_delta');
+    expect(textDelta).toBeDefined();
+    expect((textDelta as { text: string }).text).toBe('Instruction relayed to active call.');
+
+    const complete = events.find((e) => e.type === 'message_complete');
+    expect(complete).toBeDefined();
+
+    // Should NOT have called runAgentLoop
+    expect(session.runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  test('processMessage emits failure text when bridge consumes with failure userFacingText', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: true,
+      reason: 'instruction_relay_failed',
+      userFacingText: 'Failed to relay instruction to the active call.',
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession();
+
+    await processMessage(session, 'change the topic', [], onEvent);
+
+    const textDelta = events.find((e) => e.type === 'assistant_text_delta');
+    expect(textDelta).toBeDefined();
+    expect((textDelta as { text: string }).text).toBe('Failed to relay instruction to the active call.');
+
+    const complete = events.find((e) => e.type === 'message_complete');
+    expect(complete).toBeDefined();
+
+    // Only one message_complete
+    const completeCount = events.filter((e) => e.type === 'message_complete').length;
+    expect(completeCount).toBe(1);
+
+    expect(session.runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  test('processMessage skips text delta when bridge consumes without userFacingText', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: true,
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession();
+
+    await processMessage(session, 'hello', [], onEvent);
+
+    const textDelta = events.find((e) => e.type === 'assistant_text_delta');
+    expect(textDelta).toBeUndefined();
+
+    const complete = events.find((e) => e.type === 'message_complete');
+    expect(complete).toBeDefined();
+
+    expect(session.runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  test('processMessage falls through to agent loop when bridge does not consume', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: false,
+      reason: 'no_active_call',
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession();
+
+    await processMessage(session, 'normal message', [], onEvent);
+
+    expect(session.runAgentLoop).toHaveBeenCalled();
+  });
+
+  // ── Queued routeOrProcess path ───────────────────────────────
+
+  test('drainQueue emits assistant_text_delta + message_complete for bridge-consumed queued message', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: true,
+      userFacingText: 'Instruction relayed to active call.',
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession({ processing: true });
+
+    // Enqueue a message
+    session.queue.push({
+      content: 'ask about pricing',
+      attachments: [],
+      requestId: 'req-1',
+      onEvent,
+    });
+
+    drainQueue(session);
+
+    // Wait for async routeOrProcess
+    await new Promise((r) => setTimeout(r, 50));
+
+    const textDelta = events.find((e) => e.type === 'assistant_text_delta');
+    expect(textDelta).toBeDefined();
+    expect((textDelta as { text: string }).text).toBe('Instruction relayed to active call.');
+
+    // message_complete (from dequeue + bridge consumption — only one expected for this request)
+    const completeEvents = events.filter((e) => e.type === 'message_complete');
+    expect(completeEvents.length).toBe(1);
+
+    expect(session.runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  test('drainQueue emits failure text for bridge-consumed queued message with relay failure', async () => {
+    mockTryRouteCallMessage.mockResolvedValue({
+      handled: true,
+      reason: 'instruction_relay_failed',
+      userFacingText: 'Failed to relay instruction to the active call.',
+    });
+
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+    const session = createMockSession({ processing: true });
+
+    session.queue.push({
+      content: 'change the topic',
+      attachments: [],
+      requestId: 'req-2',
+      onEvent,
+    });
+
+    drainQueue(session);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const textDelta = events.find((e) => e.type === 'assistant_text_delta');
+    expect(textDelta).toBeDefined();
+    expect((textDelta as { text: string }).text).toBe('Failed to relay instruction to the active call.');
+
+    expect(session.runAgentLoop).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/calls/call-bridge.ts
+++ b/assistant/src/calls/call-bridge.ts
@@ -28,6 +28,8 @@ const log = getLogger('call-bridge');
 export interface CallBridgeResult {
   handled: boolean;
   reason?: string;
+  /** User-facing text persisted in-thread by the bridge (success ack or failure notice). */
+  userFacingText?: string;
 }
 
 /**
@@ -125,14 +127,24 @@ async function handleInstruction(
       { conversationId, callSessionId, error: result.error },
       'Instruction relay failed via bridge',
     );
-    return { handled: false, reason: 'instruction_relay_failed' };
+
+    const failureText = 'Failed to relay instruction to the active call.';
+    conversationStore.addMessage(
+      conversationId,
+      'assistant',
+      JSON.stringify([{ type: 'text', text: failureText }]),
+    );
+
+    // Consumed: caller should NOT fall through to the agent loop
+    return { handled: true, reason: 'instruction_relay_failed', userFacingText: failureText };
   }
 
   // Persist a concise acknowledgement so the user sees confirmation
+  const ackText = 'Instruction relayed to active call.';
   conversationStore.addMessage(
     conversationId,
     'assistant',
-    JSON.stringify([{ type: 'text', text: 'Instruction relayed to active call.' }]),
+    JSON.stringify([{ type: 'text', text: ackText }]),
   );
 
   log.info(
@@ -140,5 +152,5 @@ async function handleInstruction(
     'User message routed as call instruction via bridge',
   );
 
-  return { handled: true };
+  return { handled: true, userFacingText: ackText };
 }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -208,6 +208,9 @@ async function routeOrProcess(
       session.abortController = null;
       session.currentRequestId = undefined;
       log.info({ conversationId: session.conversationId, userMessageId }, 'Queued message consumed by call bridge, skipping agent loop');
+      if (bridgeResult.userFacingText) {
+        next.onEvent({ type: 'assistant_text_delta', text: bridgeResult.userFacingText });
+      }
       next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
       // runAgentLoop never ran so its finally block won't drain — continue manually
       drainQueue(session);
@@ -303,6 +306,9 @@ export async function processMessage(
       session.abortController = null;
       session.currentRequestId = undefined;
       log.info({ conversationId: session.conversationId, userMessageId }, 'IPC message consumed by call bridge, skipping agent loop');
+      if (bridgeResult.userFacingText) {
+        onEvent({ type: 'assistant_text_delta', text: bridgeResult.userFacingText });
+      }
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
       // runAgentLoop never ran so its finally block won't drain — continue manually
       drainQueue(session);


### PR DESCRIPTION
## Summary
- Instruction relay failures in call-bridge now persist a failure notice and return `handled: true` so the caller never silently falls through to the agent loop
- Both IPC session paths (`processMessage` direct + `routeOrProcess` queued) emit `assistant_text_delta` with bridge-provided `userFacingText` before `message_complete`, giving chat UI live feedback for success and failure
- ARCHITECTURE.md documents both HTTP and IPC bridge entrypoints and the new failure-handling behavior

## Original prompt
Implement a **single PR** to close the remaining mid-call steering gaps found in review.

## Goal
Ensure call-steering behavior is faithful to shipped docs/UX:
1. IPC users get a **live visible acknowledgement** when an instruction is relayed.
2. Instruction relay failures do **not silently fall through** to normal agent loop behavior.
3. Architecture docs reflect both HTTP and IPC bridge entrypoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)