### PR TITLE
fix: redact telegram token leakage in error paths

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -542,8 +542,12 @@ describe('Telegram config handler', () => {
   });
 
   test('set action handles network error during getMe', async () => {
-    globalThis.fetch = (async (_url: string | URL | Request) => {
-      throw new Error('Network error: ECONNREFUSED');
+    const tgToken = ['123456789', ':', 'ABCDefGHIJklmnopQRSTuvwxyz012345678'].join('');
+    globalThis.fetch = (async () => {
+      const err = new Error('Network error: ECONNREFUSED') as Error & { path?: string; code?: string };
+      err.path = `https://api.telegram.org/bot${tgToken}/getMe`;
+      err.code = 'ConnectionRefused';
+      throw err;
     }) as unknown as typeof fetch;
 
     const msg: TelegramConfigRequest = {
@@ -560,6 +564,8 @@ describe('Telegram config handler', () => {
     expect(res.success).toBe(false);
     expect(res.error).toContain('Failed to validate bot token');
     expect(res.error).toContain('ECONNREFUSED');
+    expect(res.error).toContain('[REDACTED]');
+    expect(res.error).not.toContain(tgToken);
   });
 
   test('get action reports connected only when both bot_token and webhook_secret exist', async () => {
@@ -706,11 +712,15 @@ describe('Telegram config handler', () => {
   });
 
   test('clear action proceeds even when webhook deregistration fails', async () => {
-    secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
+    const tgToken = ['123456789', ':', 'ABCDefGHIJklmnopQRSTuvwxyz012345678'].join('');
+    secureKeyStore['credential:telegram:bot_token'] = tgToken;
     secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
 
-    globalThis.fetch = (async (_url: string | URL | Request) => {
-      throw new Error('Network error');
+    globalThis.fetch = (async () => {
+      const err = new Error('Network error') as Error & { path?: string; code?: string };
+      err.path = `https://api.telegram.org/bot${tgToken}/deleteWebhook`;
+      err.code = 'ConnectionRefused';
+      throw err;
     }) as unknown as typeof fetch;
 
     const { ctx, sent } = createTestContext();

--- a/assistant/src/__tests__/secret-ingress-handler.test.ts
+++ b/assistant/src/__tests__/secret-ingress-handler.test.ts
@@ -12,6 +12,8 @@ const mockConfig = {
 mock.module('../config/loader.js', () => ({
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
+  loadRawConfig: () => ({ secretDetection: { ...mockConfig.secretDetection } }),
+  saveRawConfig: () => {},
   invalidateConfigCache: () => {},
 }));
 
@@ -19,6 +21,7 @@ mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
   }),
+  isDebug: () => false,
 }));
 
 const { checkIngressForSecrets } = await import('../security/secret-ingress.js');

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -45,6 +45,33 @@ function getOriginalIngressEnv(): string | undefined {
   return _originalIngressEnv;
 }
 
+const TELEGRAM_BOT_TOKEN_IN_URL_PATTERN = /\/bot\d{8,10}:[A-Za-z0-9_-]{30,120}\//g;
+const TELEGRAM_BOT_TOKEN_PATTERN = /\b\d{8,10}:[A-Za-z0-9_-]{30,120}\b/g;
+
+function redactTelegramBotTokens(value: string): string {
+  return value
+    .replace(TELEGRAM_BOT_TOKEN_IN_URL_PATTERN, '/bot[REDACTED]/')
+    .replace(TELEGRAM_BOT_TOKEN_PATTERN, '[REDACTED]');
+}
+
+function summarizeTelegramError(err: unknown): string {
+  const parts: string[] = [];
+  if (err instanceof Error) {
+    parts.push(err.message);
+  } else {
+    parts.push(String(err));
+  }
+  const path = (err as { path?: unknown })?.path;
+  if (typeof path === 'string' && path.length > 0) {
+    parts.push(`path=${path}`);
+  }
+  const code = (err as { code?: unknown })?.code;
+  if (typeof code === 'string' && code.length > 0) {
+    parts.push(`code=${code}`);
+  }
+  return redactTelegramBotTokens(parts.join(' '));
+}
+
 export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
   const configured = Object.keys(config.apiKeys).filter((k) => !!config.apiKeys[k]);
@@ -882,7 +909,7 @@ export async function handleTelegramConfig(
         }
         botUsername = data.result.username;
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = summarizeTelegramError(err);
         ctx.send(socket, {
           type: 'telegram_config_response',
           success: false,
@@ -970,7 +997,10 @@ export async function handleTelegramConfig(
         try {
           await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`);
         } catch (err) {
-          log.warn({ err }, 'Failed to deregister Telegram webhook (proceeding with credential cleanup)');
+          log.warn(
+            { error: summarizeTelegramError(err) },
+            'Failed to deregister Telegram webhook (proceeding with credential cleanup)',
+          );
         }
       }
 
@@ -1029,7 +1059,7 @@ export async function handleTelegramConfig(
           return;
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = summarizeTelegramError(err);
         ctx.send(socket, {
           type: 'telegram_config_response',
           success: false,

--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { callTelegramApi } from "../telegram/api.js";
+
+const originalFetch = globalThis.fetch;
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "test-bot-token",
+    telegramWebhookSecret: "test-webhook-secret",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 0,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    ingressPublicBaseUrl: "https://example.ngrok.io",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+}
+
+describe("callTelegramApi transport error redaction", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("redacts bot token from warning logs and thrown error", async () => {
+    const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
+
+    globalThis.fetch = mock(async () => {
+      const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
+        path?: string;
+        code?: string;
+      };
+      err.path = `https://api.telegram.org/bot${tgToken}/sendMessage`;
+      err.code = "ConnectionRefused";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
+
+    let thrown: Error | null = null;
+    try {
+      await callTelegramApi(config, "sendMessage", { chat_id: "1", text: "hello" });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown?.message).not.toContain(tgToken);
+    expect(thrown?.message).toContain("[REDACTED]");
+  });
+});

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -10,6 +10,36 @@ interface TelegramApiResponse<T> {
   parameters?: { retry_after?: number };
 }
 
+const TELEGRAM_BOT_TOKEN_IN_URL_PATTERN = /\/bot\d{8,10}:[A-Za-z0-9_-]{30,120}\//g;
+const TELEGRAM_BOT_TOKEN_PATTERN = /\b\d{8,10}:[A-Za-z0-9_-]{30,120}\b/g;
+
+function redactTelegramBotTokens(value: string): string {
+  return value
+    .replace(TELEGRAM_BOT_TOKEN_IN_URL_PATTERN, "/bot[REDACTED]/")
+    .replace(TELEGRAM_BOT_TOKEN_PATTERN, "[REDACTED]");
+}
+
+function summarizeFetchError(err: unknown): string {
+  const parts: string[] = [];
+  if (err instanceof Error) {
+    parts.push(err.message);
+  } else {
+    parts.push(String(err));
+  }
+
+  const path = (err as { path?: unknown })?.path;
+  if (typeof path === "string" && path.length > 0) {
+    parts.push(`path=${path}`);
+  }
+
+  const code = (err as { code?: unknown })?.code;
+  if (typeof code === "string" && code.length > 0) {
+    parts.push(`code=${code}`);
+  }
+
+  return redactTelegramBotTokens(parts.join(" "));
+}
+
 function isRetryable(status: number): boolean {
   return status === 429 || status >= 500;
 }
@@ -69,8 +99,9 @@ async function retryableFetch<T>(
     try {
       response = await doFetch();
     } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
-      log.warn({ err: lastError, attempt, method }, "Telegram API fetch failed");
+      const safeError = summarizeFetchError(err);
+      lastError = new Error(`Telegram ${method} request failed: ${safeError}`);
+      log.warn({ error: safeError, attempt, method }, "Telegram API fetch failed");
       continue;
     }
 


### PR DESCRIPTION
## Summary\n- redact Telegram bot token material from assistant Telegram config error handling before logging/responding\n- redact Telegram bot token material from gateway Telegram transport errors before logging/propagating\n- stabilize cross-file assistant test mocks for secret-ingress + telegram handler execution\n- add regression coverage for gateway transport error token redaction\n\n## Validation\n- \n- bun test v1.3.9 (cf6cdbbb)\n- \n- bun test v1.3.9 (cf6cdbbb)
[06:31:01.211] WARN (gateway/48557): Telegram API fetch failed
    module: "telegram-api"
    attempt: 0
    method: "sendMessage"
    error: "Unable to connect. Is the computer able to access the url? path=https://api.telegram.org/bot[REDACTED]/sendMessage code=ConnectionRefused"\n- bun test v1.3.9 (cf6cdbbb)
[06:31:01.280] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:01.287] WARN (gateway/48566): Webhook payload too large
    module: "telegram-webhook"
    contentLength: "311"
[06:31:01.288] WARN (gateway/48566): Webhook payload too large
    module: "telegram-webhook"
    bodyLength: 311
[06:31:01.288] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "1"
    userId: "1"
[06:31:01.288] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "1"
    userId: "1"
[06:31:01.288] INFO (gateway/48566): Inbound event rejected by routing
    module: "handle-inbound"
    externalChatId: "1"
    reason: "No route configured for this chat"
[06:31:01.288] WARN (gateway/48566): Routing rejected inbound Telegram message
    module: "telegram-webhook"
    chatId: "1"
    reason: "No route configured for this chat"
[06:31:01.294] WARN (gateway/48566): Relay WS upgrade without callSessionId
    module: "twilio-relay-ws"
[06:31:01.295] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.295] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "s&id=1"
    upstreamUrl: "ws://runtime:8000/v1/calls/relay?callSessionId=s%26id%3D1"
[06:31:01.295] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.296] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.296] INFO (gateway/48566): Upstream WS connected
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
[06:31:01.296] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.296] INFO (gateway/48566): Upstream WS connected
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
[06:31:01.296] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.296] WARN (gateway/48566): Pending message buffer overflow — closing connection
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
[06:31:01.297] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.297] INFO (gateway/48566): Twilio WS closed
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    code: 1000
    reason: "client gone"
[06:31:01.297] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.297] INFO (gateway/48566): Upstream WS closed
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    code: 1001
[06:31:01.297] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.297] ERROR (gateway/48566): Upstream WS error
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    error: {
      "isTrusted": false
    }
[06:31:01.298] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.298] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.298] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.298] INFO (gateway/48566): Twilio WS closed
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    code: 1000
    reason: "normal"
[06:31:01.298] INFO (gateway/48566): Opening upstream WS to runtime
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    upstreamUrl: "ws://localhost:7821/v1/calls/relay?callSessionId=sess-1"
[06:31:01.298] INFO (gateway/48566): Twilio WS closed
    module: "twilio-relay-ws"
    callSessionId: "sess-1"
    code: 1000
    reason: "done"
[06:31:01.315] WARN (gateway/48566): Telegram credential metadata exists but secrets could not be read from any backend
    module: "credential-reader"
[06:31:01.319] WARN (gateway/48566): Telegram credential metadata exists but secrets could not be read from any backend
    module: "credential-reader"
[06:31:01.321] WARN (gateway/48566): Telegram credential metadata exists but secrets could not be read from any backend
    module: "credential-reader"
[06:31:01.322] WARN (gateway/48566): Keychain lookup failed with unexpected error
    module: "credential-reader"
    account: "credential:telegram:bot_token"
    exitCode: 51
[06:31:01.336] WARN (gateway/48566): Runtime returned client error, not retrying
    module: "runtime-client"
    status: 400
    body: "Bad request"
    assistantId: "assistant-a"
[06:31:01.336] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 0
    assistantId: "assistant-a"
[06:31:01.639] ERROR (gateway/48566): Failed to send routing rejection notice
    module: "telegram-webhook"
    chatId: "1"
    err: {
      "type": "Error",
      "message": "Telegram sendMessage failed: Not Found",
      "stack":
          Error: Telegram sendMessage failed: Not Found
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:110:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:01.837] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 1
    assistantId: "assistant-a"
[06:31:02.839] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 0
    assistantId: "assistant-a"
[06:31:03.341] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 1
    assistantId: "assistant-a"
[06:31:04.342] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 2
    assistantId: "assistant-a"
[06:31:04.350] ERROR (gateway/48566): Failed to send attachment to Telegram
    module: "telegram-send"
    attachmentId: "att-1"
    filename: "photo.png"
    err: {
      "type": "Error",
      "message": "Telegram sendPhoto failed with status 200",
      "stack":
          Error: Telegram sendPhoto failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.351] ERROR (gateway/48566): Failed to send attachment failure notice
    module: "telegram-send"
    chatId: "123"
    err: {
      "type": "Error",
      "message": "Telegram sendMessage failed with status 200",
      "stack":
          Error: Telegram sendMessage failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.351] ERROR (gateway/48566): Failed to send attachment to Telegram
    module: "telegram-send"
    attachmentId: "att-2"
    filename: "doc.pdf"
    err: {
      "type": "Error",
      "message": "Telegram sendDocument failed with status 200",
      "stack":
          Error: Telegram sendDocument failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.351] ERROR (gateway/48566): Failed to send attachment failure notice
    module: "telegram-send"
    chatId: "456"
    err: {
      "type": "Error",
      "message": "Telegram sendMessage failed with status 200",
      "stack":
          Error: Telegram sendMessage failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.351] ERROR (gateway/48566): Failed to send attachment to Telegram
    module: "telegram-send"
    attachmentId: "att-id-only"
    filename: "att-id-only"
    err: {
      "type": "Error",
      "message": "Telegram sendPhoto failed with status 200",
      "stack":
          Error: Telegram sendPhoto failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.351] ERROR (gateway/48566): Failed to send attachment failure notice
    module: "telegram-send"
    chatId: "789"
    err: {
      "type": "Error",
      "message": "Telegram sendMessage failed with status 200",
      "stack":
          Error: Telegram sendMessage failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.352] ERROR (gateway/48566): Failed to send attachment to Telegram
    module: "telegram-send"
    attachmentId: "att-compat"
    filename: "doc.pdf"
    err: {
      "type": "Error",
      "message": "Telegram sendDocument failed with status 200",
      "stack":
          Error: Telegram sendDocument failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.352] ERROR (gateway/48566): Failed to send attachment failure notice
    module: "telegram-send"
    chatId: "789"
    err: {
      "type": "Error",
      "message": "Telegram sendMessage failed with status 200",
      "stack":
          Error: Telegram sendMessage failed with status 200
              at retryableFetch (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/api.ts:138:17)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.355] INFO (gateway/48566): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[06:31:04.355] INFO (gateway/48566): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[06:31:04.355] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "12345"
    userId: "67890"
[06:31:04.356] WARN (gateway/48566): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "12345"
    reason: "No route configured for this chat"
[06:31:04.356] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "12345"
    userId: "67890"
[06:31:04.356] WARN (gateway/48566): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "12345"
    reason: "No route configured for this chat"
[06:31:04.356] INFO (gateway/48566): Duplicate update_id while still processing, returning 503
    module: "telegram-webhook"
    updateId: 9001
[06:31:04.356] INFO (gateway/48566): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[06:31:04.356] INFO (gateway/48566): Duplicate update_id, returning cached response
    module: "telegram-webhook"
    updateId: 9001
[06:31:04.357] WARN (gateway/48566): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 0
    assistantId: "assistant-a"
[06:31:04.357] ERROR (gateway/48566): Failed to forward inbound event to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    err: {
      "type": "Error",
      "message": "Runtime returned 500: Internal error",
      "stack":
          Error: Runtime returned 500: Internal error
              at forwardToRuntime (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/runtime/client.ts:101:25)
              at async handleInbound (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/handlers/handle-inbound.ts:65:28)
              at async <anonymous> (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/http/routes/telegram-webhook.ts:274:28)
              at async <anonymous> (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/__tests__/telegram-webhook-handler.test.ts:335:25)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.357] ERROR (gateway/48566): Failed to forward inbound event
    module: "telegram-webhook"
    updateId: 9002
[06:31:04.357] INFO (gateway/48566): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-2"
    duplicate: false
    hasReply: false
[06:31:04.357] INFO (gateway/48566): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[06:31:04.357] INFO (gateway/48566): Duplicate update_id, returning cached response
    module: "telegram-webhook"
    updateId: 9003
[06:31:04.364] WARN (gateway/48566): Skipping oversized outbound attachment
    module: "telegram-send"
    attachmentId: "att-3"
    sizeBytes: 100
[06:31:04.365] WARN (gateway/48566): Skipping oversized outbound attachment (detected after download)
    module: "telegram-send"
    attachmentId: "att-big"
    sizeBytes: 200
[06:31:04.365] ERROR (gateway/48566): Failed to send attachment to Telegram
    module: "telegram-send"
    attachmentId: "att-fail"
    filename: "bad.png"
    err: {
      "type": "Error",
      "message": "Attachment download failed (404): {\"error\":\"not found\"}",
      "stack":
          Error: Attachment download failed (404): {"error":"not found"}
              at downloadAttachment (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/runtime/client.ts:179:15)
              at async sendTelegramAttachments (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/telegram/send.ts:68:17)
              at async <anonymous> (/private/tmp/vellum-assistant-telegram-log-hardening/gateway/src/__tests__/telegram-send-attachments.test.ts:381:11)
              at processTicksAndRejections (native:7:39)
    }
[06:31:04.368] WARN (gateway/48566): Telegram API fetch failed
    module: "telegram-api"
    attempt: 0
    method: "getWebhookInfo"
    error: "Telegram API error"
[06:31:04.475] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "99001"
    userId: "55001"
[06:31:04.476] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "99001"
    userId: "55001"
[06:31:04.478] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.484] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.484] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.484] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.485] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.485] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: false
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.485] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.485] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.485] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.486] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.486] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: true
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.486] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.486] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.486] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.487] INFO (gateway/48566): Configuration loaded
    module: "config"
    telegramApiBaseUrl: "https://api.telegram.org"
    assistantRuntimeBaseUrl: "http://localhost:7821"
    gatewayInternalBaseUrl: "http://127.0.0.1:7830"
    routingEntryCount: 0
    unmappedPolicy: "reject"
    hasDefaultAssistant: false
    port: 7830
    runtimeProxyEnabled: false
    runtimeProxyRequireAuth: true
    telegramDeliverAuthBypass: false
    hasTwilioAuthToken: false
[06:31:04.490] WARN (gateway/48566): Telegram API fetch failed
    module: "telegram-api"
    attempt: 0
    method: "sendMessage"
    error: "Unable to connect. Is the computer able to access the url? path=https://api.telegram.org/bot[REDACTED]/sendMessage code=ConnectionRefused"
[06:31:04.494] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "55555"
    userId: "99"
[06:31:04.494] WARN (gateway/48566): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "55555"
    reason: "No route configured for this chat"
[06:31:04.494] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "77777"
    userId: "99"
[06:31:04.494] WARN (gateway/48566): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "77777"
    reason: "No route configured for this chat"
[06:31:04.494] INFO (gateway/48566): No route matched, rejecting
    module: "routing"
    chatId: "77777"
    userId: "99"
[06:31:04.494] WARN (gateway/48566): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "77777"
    reason: "No route configured for this chat"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
