### PR TITLE
fix: use statement-boundary regex for IPC log hygiene invariants

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -286,11 +286,15 @@ describe('Invariant 3: secrets never logged in plaintext', () => {
         // Verify log calls never include raw content fields — only safe
         // metadata like lineLength and errorType are permitted.
         // `trimmed.length` is safe (numeric); `trimmed` alone would leak raw content.
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*trimmed[^.]/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*line[^L]/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*data\b/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*[{,]\s*buffer\b/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^)]*err\.message\b/);
+        // Use [^\n]* instead of [^)]* so that inner parentheses (e.g.
+        // helper calls like formatErr(err)) don't terminate the match
+        // early — avoiding false negatives — while still scoping each
+        // pattern to a single line (no cross-statement matching).
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*trimmed[^.]/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*line[^L]/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*data\b/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*buffer\b/);
+        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*err\.message\b/);
       });
     } else {
       // PR 25 — secret prompter log hygiene: verify the prompter source


### PR DESCRIPTION
Addresses Codex feedback on #6517. The [^)]* pattern stopped at the first ), creating false negatives for log calls with inner function calls. Updated to match up to statement boundaries instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
