### PR TITLE
fix: relax conversation key ownership check to allow orphan key cleanup

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -431,11 +431,13 @@ describe('channel sync arbitration', () => {
       getOrCreateConversation(`telegram:${uniqueChatIdB}`);
 
       // Simulate another conversation (conv-C) claiming chat-B's key via
-      // inbound traffic before the move-sync happens.  This can occur when
-      // the binding and conversation_keys tables diverge.
+      // inbound traffic before the move-sync happens.  In a real inbound
+      // flow, getOrCreateConversation + upsertBinding run together, so
+      // conv-C gets both a key mapping and an external binding.
       const chatBKey = `telegram:${uniqueChatIdB}`;
       deleteConversationKey(chatBKey);
       setConversationKey(chatBKey, convC);
+      createBinding(convC, 'telegram', uniqueChatIdB);
 
       // Move chat-A to conv-B — conv-B's external binding still points to
       // chat-B, but the conversation_keys entry for chat-B now belongs to

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -79,13 +79,19 @@ export async function handleMoveSync(req: Request): Promise<Response> {
     if (existingTargetBinding &&
         (existingTargetBinding.sourceChannel !== sourceChannel || existingTargetBinding.externalChatId !== externalChatId)) {
       const oldTargetKey = `${existingTargetBinding.sourceChannel}:${existingTargetBinding.externalChatId}`;
-      // Only delete the old key if it currently maps to the conversation we
-      // are moving into.  Another conversation may have since claimed the key
-      // (e.g. via getOrCreateConversation on inbound traffic), and deleting it
-      // would break routing for that unrelated conversation.
+      // Delete the old key unless it has been claimed by a different
+      // conversation that has its own active external binding.  Keys auto-
+      // created by getOrCreateConversation produce orphan conversation IDs
+      // (no external binding) and are safe to clean up.  Keys owned by a
+      // real, externally-bound conversation must be preserved.
       const oldTargetMapping = getConversationByKey(oldTargetKey);
-      if (oldTargetMapping && oldTargetMapping.conversationId === newConversationId) {
-        deleteConversationKey(oldTargetKey);
+      if (oldTargetMapping) {
+        const isOwnedByTarget = oldTargetMapping.conversationId === newConversationId;
+        const hasOwnBinding = !isOwnedByTarget &&
+          externalConversationStore.getBindingByConversation(oldTargetMapping.conversationId) !== null;
+        if (!hasOwnBinding) {
+          deleteConversationKey(oldTargetKey);
+        }
       }
     }
 


### PR DESCRIPTION
Addresses Devin feedback on #6518. The strict equality check prevented cleanup of auto-created orphan keys. Now checks whether the key belongs to a conversation with an active external binding before protecting it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
