### PR TITLE
feat: outbound conflict arbitration end-to-end (#6526)

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -82,6 +82,10 @@ import { getOrCreateConversation, deleteConversationKey, getConversationByKey, s
 import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
 import { handleMoveSync, handleDeleteConversation } from '../runtime/routes/channel-routes.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+import { registerMessagingProvider } from '../messaging/registry.js';
+import { run as runSend } from '../config/bundled-skills/messaging/tools/messaging-send.js';
+import { run as runReply } from '../config/bundled-skills/messaging/tools/messaging-reply.js';
+import type { ToolContext } from '../tools/types.js';
 
 initializeDb();
 
@@ -458,6 +462,92 @@ describe('channel sync arbitration', () => {
       const chatAKeyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
       expect(chatAKeyMapping).not.toBeNull();
       expect(chatAKeyMapping!.conversationId).toBe(convB);
+    });
+  });
+
+  describe('messaging tool senderConversationId propagation', () => {
+    // Register the Telegram provider so resolveProvider('telegram') works
+    beforeEach(() => {
+      registerMessagingProvider(telegramBotMessagingProvider);
+    });
+
+    function makeToolContext(conversationId: string): ToolContext {
+      return {
+        workingDir: testDir,
+        sessionId: 'test-session',
+        conversationId,
+      };
+    }
+
+    test('messaging-send forwards senderConversationId from context to provider', async () => {
+      const ownerConvId = uuid();
+      const uniqueChatId = `tool-send-fwd-${uuid()}`;
+      createBinding(ownerConvId, 'telegram', uniqueChatId);
+
+      // When the tool's context.conversationId matches the owner, no conflict
+      const ctx = makeToolContext(ownerConvId);
+      const result = await runSend(
+        { platform: 'telegram', conversation_id: uniqueChatId, text: 'Hello' },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Message sent');
+    });
+
+    test('messaging-send returns conflict error when sender is not the owner', async () => {
+      const ownerConvId = uuid();
+      const senderConvId = uuid();
+      const uniqueChatId = `tool-send-conflict-${uuid()}`;
+      createBinding(ownerConvId, 'telegram', uniqueChatId);
+      ensureConversation(senderConvId);
+
+      const ctx = makeToolContext(senderConvId);
+      const result = await runSend(
+        { platform: 'telegram', conversation_id: uniqueChatId, text: 'Hello' },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.error).toBe('conflict');
+      expect(parsed.ownerConversationId).toBe(ownerConvId);
+      expect(parsed.message).toContain('Another thread owns this chat');
+    });
+
+    test('messaging-reply forwards senderConversationId from context to provider', async () => {
+      const ownerConvId = uuid();
+      const uniqueChatId = `tool-reply-fwd-${uuid()}`;
+      createBinding(ownerConvId, 'telegram', uniqueChatId);
+
+      const ctx = makeToolContext(ownerConvId);
+      const result = await runReply(
+        { platform: 'telegram', conversation_id: uniqueChatId, thread_id: 'thread-1', text: 'Reply' },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain('Reply sent');
+    });
+
+    test('messaging-reply returns conflict error when sender is not the owner', async () => {
+      const ownerConvId = uuid();
+      const senderConvId = uuid();
+      const uniqueChatId = `tool-reply-conflict-${uuid()}`;
+      createBinding(ownerConvId, 'telegram', uniqueChatId);
+      ensureConversation(senderConvId);
+
+      const ctx = makeToolContext(senderConvId);
+      const result = await runReply(
+        { platform: 'telegram', conversation_id: uniqueChatId, thread_id: 'thread-1', text: 'Reply' },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.error).toBe('conflict');
+      expect(parsed.ownerConversationId).toBe(ownerConvId);
+      expect(parsed.message).toContain('Another thread owns this chat');
     });
   });
 });

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -1,7 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
 
-export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
   const threadId = input.thread_id as string;
@@ -20,7 +20,19 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = resolveProvider(platform);
     return withProviderToken(provider, async (token) => {
-      const result = await provider.sendMessage(token, conversationId, text, { threadId });
+      const result = await provider.sendMessage(token, conversationId, text, {
+        threadId,
+        senderConversationId: context.conversationId,
+      });
+
+      if (result.conflict) {
+        return err(JSON.stringify({
+          error: 'conflict',
+          ownerConversationId: result.conflict.ownerConversationId,
+          message: "Another thread owns this chat. Use 'Continue in Synced Thread' or 'Move Sync Here'.",
+        }));
+      }
+
       return ok(`Reply sent (ID: ${result.id}).`);
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -1,7 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
 
-export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
   const text = input.text as string;
@@ -18,7 +18,20 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = resolveProvider(platform);
     return withProviderToken(provider, async (token) => {
-      const result = await provider.sendMessage(token, conversationId, text, { subject, inReplyTo });
+      const result = await provider.sendMessage(token, conversationId, text, {
+        subject,
+        inReplyTo,
+        senderConversationId: context.conversationId,
+      });
+
+      if (result.conflict) {
+        return err(JSON.stringify({
+          error: 'conflict',
+          ownerConversationId: result.conflict.ownerConversationId,
+          message: "Another thread owns this chat. Use 'Continue in Synced Thread' or 'Move Sync Here'.",
+        }));
+      }
+
       return ok(`Message sent (ID: ${result.id}).`);
     });
   } catch (e) {


### PR DESCRIPTION
## Summary\n- Propagate senderConversationId from execution context through messaging send/reply tools\n- Handle SendResult.conflict by returning structured error payload\n- Add test coverage for conflict propagation and surfacing\n\nPart of #6524
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
