### PR TITLE
fix: runtime correctness + data invariants for channel sync (#6525)

### DIFF
--- a/assistant/src/__tests__/channel-sync-arbitration.test.ts
+++ b/assistant/src/__tests__/channel-sync-arbitration.test.ts
@@ -76,7 +76,7 @@ mock.module('../messaging/providers/telegram-bot/client.js', () => ({
 import { initializeDb } from '../memory/db.js';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
-import { conversations } from '../memory/schema.js';
+import { conversations, externalConversationBindings } from '../memory/schema.js';
 import * as externalConversationStore from '../memory/external-conversation-store.js';
 import { getOrCreateConversation, deleteConversationKey, getConversationByKey, setConversationKey } from '../memory/conversation-key-store.js';
 import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
@@ -345,9 +345,9 @@ describe('channel sync arbitration', () => {
       createBinding(convA, 'telegram', uniqueChatIdA);
       createBinding(convB, 'telegram', uniqueChatIdB);
 
-      // Create conversation key mappings
-      getOrCreateConversation(`telegram:${uniqueChatIdA}`);
-      getOrCreateConversation(`telegram:${uniqueChatIdB}`);
+      // Create conversation key mappings pointing to the correct conversations
+      setConversationKey(`telegram:${uniqueChatIdA}`, convA);
+      setConversationKey(`telegram:${uniqueChatIdB}`, convB);
 
       // Move chat-A to conv-B (which already has a binding for chat-B)
       const req = makeJsonRequest({
@@ -387,9 +387,9 @@ describe('channel sync arbitration', () => {
       createBinding(convA, 'telegram', uniqueChatIdA);
       createBinding(convB, 'telegram', uniqueChatIdB);
 
-      // Create conversation key mappings for both chats
-      getOrCreateConversation(`telegram:${uniqueChatIdA}`);
-      getOrCreateConversation(`telegram:${uniqueChatIdB}`);
+      // Create conversation key mappings pointing to the correct conversations
+      setConversationKey(`telegram:${uniqueChatIdA}`, convA);
+      setConversationKey(`telegram:${uniqueChatIdB}`, convB);
 
       // Move chat-A to conv-B (which already has a binding for chat-B)
       const req = makeJsonRequest({
@@ -458,6 +458,142 @@ describe('channel sync arbitration', () => {
       const chatAKeyMapping = getConversationByKey(`telegram:${uniqueChatIdA}`);
       expect(chatAKeyMapping).not.toBeNull();
       expect(chatAKeyMapping!.conversationId).toBe(convB);
+    });
+  });
+
+  describe('unique (sourceChannel, externalChatId) constraint', () => {
+    test('inserting a duplicate (sourceChannel, externalChatId) for a different conversation fails', () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `unique-dup-${uuid()}`;
+
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      // Attempting to insert a second binding with the same (sourceChannel, externalChatId)
+      // but a different conversationId should throw due to the unique index.
+      expect(() => {
+        const db = getDb();
+        db.insert(externalConversationBindings)
+          .values({
+            conversationId: convB,
+            sourceChannel: 'telegram',
+            externalChatId: uniqueChatId,
+            externalUserId: null,
+            displayName: null,
+            username: null,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          })
+          .run();
+      }).toThrow();
+    });
+
+    test('upsertOutboundBinding on same conversationId updates in place (no constraint violation)', () => {
+      const convA = uuid();
+      const uniqueChatId = `unique-upsert-${uuid()}`;
+
+      createBinding(convA, 'telegram', uniqueChatId);
+
+      // Upserting the same (conversationId, sourceChannel, externalChatId) should succeed
+      expect(() => {
+        externalConversationStore.upsertOutboundBinding({
+          conversationId: convA,
+          sourceChannel: 'telegram',
+          externalChatId: uniqueChatId,
+        });
+      }).not.toThrow();
+
+      const binding = externalConversationStore.getBindingByChannelChat('telegram', uniqueChatId);
+      expect(binding).not.toBeNull();
+      expect(binding!.conversationId).toBe(convA);
+    });
+
+    test('different channels with same externalChatId are allowed', () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `unique-diff-chan-${uuid()}`;
+
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      // Different sourceChannel should not conflict
+      expect(() => {
+        createBinding(convB, 'sms', uniqueChatId);
+      }).not.toThrow();
+
+      const bindingTelegram = externalConversationStore.getBindingByChannelChat('telegram', uniqueChatId);
+      const bindingSms = externalConversationStore.getBindingByChannelChat('sms', uniqueChatId);
+      expect(bindingTelegram!.conversationId).toBe(convA);
+      expect(bindingSms!.conversationId).toBe(convB);
+    });
+  });
+
+  describe('move-sync with uniqueness constraint', () => {
+    test('move-sync atomically transfers binding without violating unique constraint', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const uniqueChatId = `move-unique-${uuid()}`;
+
+      // conv-A owns the chat
+      createBinding(convA, 'telegram', uniqueChatId);
+      ensureConversation(convB);
+
+      setConversationKey(`telegram:${uniqueChatId}`, convA);
+
+      // Move to conv-B — the old binding is deleted first, then re-created
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: uniqueChatId,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(200);
+
+      // Only conv-B should own the chat now
+      const binding = externalConversationStore.getBindingByChannelChat('telegram', uniqueChatId);
+      expect(binding).not.toBeNull();
+      expect(binding!.conversationId).toBe(convB);
+
+      // conv-A should have no binding
+      const oldBinding = externalConversationStore.getBindingByConversation(convA);
+      expect(oldBinding).toBeNull();
+    });
+
+    test('move-sync with target already bound to a different chat respects uniqueness', async () => {
+      const convA = uuid();
+      const convB = uuid();
+      const chatIdA = `move-unique-a-${uuid()}`;
+      const chatIdB = `move-unique-b-${uuid()}`;
+
+      // conv-A owns chat-A, conv-B owns chat-B
+      createBinding(convA, 'telegram', chatIdA);
+      createBinding(convB, 'telegram', chatIdB);
+
+      setConversationKey(`telegram:${chatIdA}`, convA);
+      setConversationKey(`telegram:${chatIdB}`, convB);
+
+      // Move chat-A to conv-B — conv-B's old binding (chat-B) is replaced
+      const req = makeJsonRequest({
+        sourceChannel: 'telegram',
+        externalChatId: chatIdA,
+        newConversationId: convB,
+      });
+
+      const resp = await handleMoveSync(req);
+      expect(resp.status).toBe(200);
+
+      // conv-B now owns chat-A
+      const binding = externalConversationStore.getBindingByChannelChat('telegram', chatIdA);
+      expect(binding).not.toBeNull();
+      expect(binding!.conversationId).toBe(convB);
+
+      // chat-B should no longer be bound (the old binding for conv-B was replaced)
+      // The upsertOutboundBinding updates conv-B's row to point to chat-A
+      const convBBinding = externalConversationStore.getBindingByConversation(convB);
+      expect(convBBinding).not.toBeNull();
+      expect(convBBinding!.externalChatId).toBe(chatIdA);
     });
   });
 });

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -924,6 +924,8 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat ON external_conversation_bindings(source_channel, external_chat_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel ON external_conversation_bindings(source_channel)`);
 
+  migrateExtConvBindingsChannelChatUnique(database);
+
   migrateMemoryFtsBackfill(database);
 }
 
@@ -1785,6 +1787,61 @@ function migrateLlmUsageEventsDropAssistantId(database: ReturnType<typeof drizzl
     throw e;
   } finally {
     raw.exec('PRAGMA foreign_keys = ON');
+  }
+}
+
+/**
+ * One-shot migration: deduplicate external_conversation_bindings rows that
+ * share the same (source_channel, external_chat_id), then create a unique
+ * index to enforce the invariant at DB level.
+ *
+ * For each duplicate group, the binding with the newest updatedAt (then
+ * createdAt) is kept; older duplicates are deleted.
+ */
+function migrateExtConvBindingsChannelChatUnique(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+
+  // If the unique index already exists, nothing to do.
+  const idxExists = raw.query(
+    `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_ext_conv_bindings_channel_chat_unique'`,
+  ).get();
+  if (idxExists) return;
+
+  // Check if the table exists (first boot edge case).
+  const tableExists = raw.query(
+    `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+  ).get();
+  if (!tableExists) return;
+
+  // Remove duplicates: keep the row with the newest updatedAt, then createdAt.
+  // Since conversation_id is the PK (rowid alias), we use it for ordering ties.
+  try {
+    raw.exec('BEGIN');
+
+    raw.exec(/*sql*/ `
+      DELETE FROM external_conversation_bindings
+      WHERE rowid NOT IN (
+        SELECT rowid FROM (
+          SELECT rowid,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY source_channel, external_chat_id
+                   ORDER BY updated_at DESC, created_at DESC
+                 ) AS rn
+          FROM external_conversation_bindings
+        )
+        WHERE rn = 1
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_unique
+      ON external_conversation_bindings(source_channel, external_chat_id)
+    `);
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
   }
 }
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -590,6 +590,7 @@ export const processedCallbacks = sqliteTable('processed_callbacks', {
 });
 
 // ── External Conversation Bindings ───────────────────────────────────
+// UNIQUE (source_channel, external_chat_id) enforced via idx_ext_conv_bindings_channel_chat_unique in db.ts
 
 export const externalConversationBindings = sqliteTable('external_conversation_bindings', {
   conversationId: text('conversation_id')


### PR DESCRIPTION
## Summary\n- Fix failing stale-key cleanup test by using setConversationKey instead of getOrCreateConversation in test setup\n- Add unique index on (sourceChannel, externalChatId) in external conversation bindings\n- Add migration to clean up duplicate bindings\n- Add test coverage for uniqueness constraint\n\nPart of #6524
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
