### PR TITLE
feat: hide/reappearance semantics + reconnected state (#6529)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -558,6 +558,18 @@ struct MainWindowView: View {
                 windowState.persistentThreadId = activeId
             }
             requestHomeBaseDashboardIfNeeded()
+
+            // Show a brief toast when a previously-hidden thread reappears
+            threadManager.onThreadReconnected = { [weak windowState] title in
+                windowState?.showToast(
+                    message: "Reconnected: \(title)",
+                    style: .success
+                )
+                // Auto-dismiss after 3 seconds
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak windowState] in
+                    windowState?.dismissToast()
+                }
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -55,6 +55,25 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Forwards only message count changes to ThreadManager's objectWillChange.
     private var activeViewModelCancellable: AnyCancellable?
 
+    /// Metadata for sessions whose threads were hidden locally.
+    /// Keyed by daemon session ID so we can detect inbound activity and restore them.
+    struct HiddenSessionInfo {
+        let sessionId: String
+        let title: String
+        let sourceChannel: String?
+        let externalChatId: String?
+        let displayName: String?
+        let username: String?
+    }
+    private(set) var hiddenSessions: [String: HiddenSessionInfo] = [:]
+
+    /// Fired when a previously-hidden thread is restored due to new activity.
+    /// The String parameter is the thread title for display in a toast.
+    var onThreadReconnected: ((String) -> Void)?
+
+    /// Task monitoring daemon messages for activity on hidden sessions.
+    private var hiddenSessionMonitorTask: Task<Void, Never>?
+
     /// Threads that are not archived — used by the UI to populate the sidebar.
     /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
     var visibleThreads: [ThreadModel] {
@@ -263,6 +282,19 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let thread = threads[index]
         let sourceChannel = thread.sourceChannel ?? "?"
         let externalChatId = thread.externalChatId ?? "?"
+
+        // Preserve session metadata so we can restore the thread on next activity
+        if let sessionId = thread.sessionId {
+            hiddenSessions[sessionId] = HiddenSessionInfo(
+                sessionId: sessionId,
+                title: thread.title,
+                sourceChannel: thread.sourceChannel,
+                externalChatId: thread.externalChatId,
+                displayName: thread.displayName,
+                username: thread.username
+            )
+            startHiddenSessionMonitorIfNeeded()
+        }
 
         // Stop any active generation and remove the view model
         chatViewModels[id]?.stopGenerating()
@@ -541,6 +573,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         chatViewModels.removeValue(forKey: threadId)
     }
 
+    func isSessionHidden(_ sessionId: String) -> Bool {
+        hiddenSessions[sessionId] != nil
+    }
+
+    func clearHiddenSession(_ sessionId: String) {
+        hiddenSessions.removeValue(forKey: sessionId)
+        if hiddenSessions.isEmpty {
+            hiddenSessionMonitorTask?.cancel()
+            hiddenSessionMonitorTask = nil
+        }
+    }
+
     /// Called when the user responds to a confirmation via the inline chat UI.
     /// The app layer uses this to dismiss the native notification and resume
     /// the notification service continuation. Receives (requestId, decision).
@@ -693,6 +737,72 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         } catch {
             log.warning("Title generation failed: \(error.localizedDescription)")
             updateThreadTitle(id: threadId, title: fallback)
+        }
+    }
+
+    // MARK: - Hidden Session Restoration
+
+    /// Restore a previously-hidden thread when activity is detected on its session.
+    /// Creates a new thread with the stored metadata and notifies via `onThreadReconnected`.
+    func restoreHiddenThread(sessionId: String) {
+        guard let info = hiddenSessions.removeValue(forKey: sessionId) else { return }
+
+        // Avoid duplicates if the thread was already restored by the session restorer
+        if threads.contains(where: { $0.sessionId == sessionId }) {
+            return
+        }
+
+        let thread = ThreadModel(
+            title: info.title,
+            sessionId: sessionId,
+            sourceChannel: info.sourceChannel,
+            displayName: info.displayName,
+            username: info.username,
+            externalChatId: info.externalChatId
+        )
+        let viewModel = makeViewModel()
+        viewModel.sessionId = sessionId
+        viewModel.startMessageLoop()
+
+        threads.insert(thread, at: 0)
+        chatViewModels[thread.id] = viewModel
+
+        // Stop monitoring if no hidden sessions remain
+        if hiddenSessions.isEmpty {
+            hiddenSessionMonitorTask?.cancel()
+            hiddenSessionMonitorTask = nil
+        }
+
+        onThreadReconnected?(info.title)
+        log.info("Restored hidden thread for session \(sessionId) (\(info.sourceChannel ?? "?"):\(info.externalChatId ?? "?"))")
+    }
+
+    /// Start a daemon message listener to detect activity on hidden sessions.
+    /// Only one monitor task runs at a time; it cancels itself when no hidden sessions remain.
+    private func startHiddenSessionMonitorIfNeeded() {
+        guard hiddenSessionMonitorTask == nil else { return }
+
+        let stream = daemonClient.subscribe()
+        hiddenSessionMonitorTask = Task { @MainActor [weak self] in
+            for await message in stream {
+                guard let self, !Task.isCancelled else { break }
+                guard !self.hiddenSessions.isEmpty else { break }
+
+                // Extract session ID from messages that indicate activity
+                let messageSessionId: String? = {
+                    switch message {
+                    case .assistantTextDelta(let msg): return msg.sessionId
+                    case .userMessageEcho(let msg): return msg.sessionId
+                    case .messageComplete(let msg): return msg.sessionId
+                    default: return nil
+                    }
+                }()
+
+                if let sid = messageSessionId, self.hiddenSessions[sid] != nil {
+                    self.restoreHiddenThread(sessionId: sid)
+                }
+            }
+            self?.hiddenSessionMonitorTask = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -19,6 +19,11 @@ protocol ThreadRestorerDelegate: AnyObject {
     func createThread()
     func isSessionArchived(_ sessionId: String) -> Bool
     func restoreLastActiveThread()
+    /// Returns true if the session was previously hidden locally.
+    func isSessionHidden(_ sessionId: String) -> Bool
+    /// Remove a session from the hidden-sessions tracker (called when the
+    /// session restorer re-creates the thread on daemon reconnect).
+    func clearHiddenSession(_ sessionId: String)
 }
 
 /// Handles daemon session restoration: fetching the session list on connect,
@@ -102,6 +107,13 @@ final class ThreadSessionRestorer {
 
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
+            // If this session was hidden locally, clear the hidden-session
+            // tracker so the monitor stops watching for it. The thread will
+            // be re-created normally (not archived) and remain visible.
+            if delegate.isSessionHidden(session.id) {
+                delegate.clearHiddenSession(session.id)
+            }
+
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard
             let binding = session.channelBinding
             let thread = ThreadModel(

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -52,6 +52,16 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         archivedSessionIds.contains(sessionId)
     }
 
+    var hiddenSessionIds: Set<String> = []
+
+    func isSessionHidden(_ sessionId: String) -> Bool {
+        hiddenSessionIds.contains(sessionId)
+    }
+
+    func clearHiddenSession(_ sessionId: String) {
+        hiddenSessionIds.remove(sessionId)
+    }
+
     func restoreLastActiveThread() {
         // no-op for tests
     }


### PR DESCRIPTION
## Summary\n- Ensure hidden synced threads reliably reappear on next inbound/outbound activity\n- Add subtle Reconnected indicator when a hidden thread reappears\n- Verify product copy matches expected wording\n- Handle hidden threads correctly during session restore\n\nPart of #6524
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
