### PR TITLE
feat: desktop conflict UX — draft carryover and move+resend (#6528)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -347,14 +347,17 @@ extension MainWindowView {
                            externalChatId: externalChatId,
                            excludingThread: thread.id
                        ) {
-                        threadManager.activeThreadId = canonical.id
+                        threadManager.continueInSyncedThread(
+                            targetThreadId: canonical.id,
+                            sourceThreadId: thread.id
+                        )
                     }
                 } : nil,
                 onMoveSyncHere: syncConflict != nil ? {
                     if let thread = threadManager.activeThread,
                        let sourceChannel = thread.sourceChannel,
                        let externalChatId = thread.externalChatId {
-                        threadManager.moveSyncHere(
+                        threadManager.moveSyncHereAndResend(
                             threadId: thread.id,
                             sourceChannel: sourceChannel,
                             externalChatId: externalChatId

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -430,6 +430,109 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         })
     }
 
+    /// Switch to the canonical synced thread, carrying over any draft text and
+    /// attachments from the source thread's composer so the user doesn't lose work.
+    func continueInSyncedThread(targetThreadId: UUID, sourceThreadId: UUID) {
+        guard let sourceVM = chatViewModels[sourceThreadId],
+              let targetVM = chatViewModels[targetThreadId] else {
+            // Fallback: just switch threads without draft carryover
+            activeThreadId = targetThreadId
+            return
+        }
+
+        // Capture draft state from source composer
+        let draftText = sourceVM.inputText
+        let draftAttachments = sourceVM.pendingAttachments
+
+        // Clear the source composer so it doesn't look like unsaved state
+        sourceVM.inputText = ""
+        sourceVM.pendingAttachments = []
+
+        // Switch to the target thread
+        activeThreadId = targetThreadId
+
+        // Place the draft in the target composer
+        if !draftText.isEmpty {
+            targetVM.inputText = draftText
+        }
+        if !draftAttachments.isEmpty {
+            targetVM.pendingAttachments = draftAttachments
+        }
+
+        log.info("Continued in synced thread \(targetThreadId), carried draft (\(draftText.count) chars, \(draftAttachments.count) attachments)")
+    }
+
+    /// Move sync ownership to this thread and automatically resend any pending
+    /// draft text once the move succeeds. If the composer is empty, falls back
+    /// to a plain moveSyncHere without auto-send.
+    func moveSyncHereAndResend(threadId: UUID, sourceChannel: String, externalChatId: String) {
+        guard let vm = chatViewModels[threadId] else {
+            log.warning("Cannot move-sync-and-resend: no view model for thread \(threadId)")
+            return
+        }
+
+        // Capture the draft that should be resent after the move succeeds
+        let draftText = vm.inputText
+        let draftAttachments = vm.pendingAttachments
+
+        guard let targetIndex = threads.firstIndex(where: { $0.id == threadId }),
+              let sessionId = threads[targetIndex].sessionId else {
+            log.warning("Cannot move sync: thread \(threadId) not found or has no session")
+            return
+        }
+
+        Task { @MainActor in
+            let success = await daemonClient.moveChannelSync(
+                sourceChannel: sourceChannel,
+                externalChatId: externalChatId,
+                newConversationId: sessionId
+            )
+
+            if success {
+                // Capture metadata from old owner before clearing
+                let oldOwner = threads.first(where: {
+                    $0.sourceChannel == sourceChannel &&
+                    $0.externalChatId == externalChatId &&
+                    $0.id != threadId
+                })
+                let oldDisplayName = oldOwner?.displayName
+                let oldUsername = oldOwner?.username
+
+                // Clear old owner's binding
+                for i in threads.indices {
+                    if threads[i].sourceChannel == sourceChannel &&
+                       threads[i].externalChatId == externalChatId &&
+                       threads[i].id != threadId {
+                        threads[i].sourceChannel = nil
+                        threads[i].externalChatId = nil
+                        threads[i].displayName = nil
+                        threads[i].username = nil
+                    }
+                }
+
+                // Set the new thread as synced, preserving display metadata
+                if let idx = threads.firstIndex(where: { $0.id == threadId }) {
+                    threads[idx].sourceChannel = sourceChannel
+                    threads[idx].externalChatId = externalChatId
+                    threads[idx].displayName = threads[idx].displayName ?? oldDisplayName
+                    threads[idx].username = threads[idx].username ?? oldUsername
+                }
+
+                log.info("Moved sync to thread \(threadId) for \(sourceChannel):\(externalChatId)")
+
+                // Auto-resend the draft message now that ownership has moved
+                if !draftText.isEmpty {
+                    vm.inputText = draftText
+                    vm.pendingAttachments = draftAttachments
+                    vm.sendMessage()
+                    log.info("Auto-resent draft after move-sync (\(draftText.count) chars)")
+                }
+            } else {
+                log.error("Failed to move sync to thread \(threadId)")
+            }
+        }
+    }
+
     func unarchiveThread(id: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 

--- a/clients/macos/vellum-assistantTests/ThreadManagerSyncConflictTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerSyncConflictTests.swift
@@ -1,0 +1,421 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerSyncConflictTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+    private var capturedMessages: [Any] = []
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        capturedMessages = []
+        daemonClient.sendOverride = { [weak self] msg in
+            guard let self else { return }
+            capturedMessages.append(msg)
+        }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        daemonClient?.sendOverride = nil
+        daemonClient?.moveChannelSyncOverride = nil
+        threadManager = nil
+        capturedMessages = []
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helper: create a synced thread with a session
+
+    /// Creates a thread with a given sourceChannel/externalChatId binding
+    /// and bootstraps a session for it so it has a valid sessionId.
+    private func createSyncedThread(
+        sourceChannel: String = "telegram",
+        externalChatId: String = "chat-123",
+        title: String = "Synced Thread",
+        displayName: String? = nil,
+        username: String? = nil
+    ) -> (thread: ThreadModel, viewModel: ChatViewModel) {
+        let thread = ThreadModel(
+            title: title,
+            sessionId: "session-\(UUID().uuidString.prefix(8))",
+            sourceChannel: sourceChannel,
+            displayName: displayName,
+            username: username,
+            externalChatId: externalChatId
+        )
+        let vm = threadManager.makeViewModel()
+        vm.sessionId = thread.sessionId
+        vm.isHistoryLoaded = true
+        threadManager.threads.insert(thread, at: 0)
+        threadManager.setChatViewModel(vm, for: thread.id)
+        return (thread, vm)
+    }
+
+    // MARK: - continueInSyncedThread: Draft Carryover
+
+    func testContinueInSyncedThreadCarriesDraftText() {
+        let (ownerThread, ownerVM) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        // Activate the non-owner thread and type a draft
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "Hello from non-owner"
+
+        // Continue in the synced (owner) thread
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: nonOwnerThread.id
+        )
+
+        // Verify: active thread switched to owner
+        XCTAssertEqual(threadManager.activeThreadId, ownerThread.id)
+        // Verify: draft text carried to target composer
+        XCTAssertEqual(ownerVM.inputText, "Hello from non-owner")
+        // Verify: source composer cleared
+        XCTAssertEqual(nonOwnerVM.inputText, "")
+    }
+
+    func testContinueInSyncedThreadCarriesAttachments() {
+        let (ownerThread, ownerVM) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "Check this file"
+        let attachment = ChatAttachment(
+            id: "att-1",
+            filename: "test.png",
+            mimeType: "image/png",
+            data: "base64data",
+            thumbnailData: nil,
+            dataLength: 10,
+            thumbnailImage: nil
+        )
+        nonOwnerVM.pendingAttachments = [attachment]
+
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: nonOwnerThread.id
+        )
+
+        // Verify: attachments carried to target
+        XCTAssertEqual(ownerVM.pendingAttachments.count, 1)
+        XCTAssertEqual(ownerVM.pendingAttachments.first?.id, "att-1")
+        // Verify: source attachments cleared
+        XCTAssertTrue(nonOwnerVM.pendingAttachments.isEmpty)
+    }
+
+    func testContinueInSyncedThreadWithEmptyDraft() {
+        let (ownerThread, ownerVM) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, _) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        // No draft text or attachments
+
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: nonOwnerThread.id
+        )
+
+        // Verify: active thread still switched
+        XCTAssertEqual(threadManager.activeThreadId, ownerThread.id)
+        // Verify: target composer unchanged (empty)
+        XCTAssertEqual(ownerVM.inputText, "")
+        XCTAssertTrue(ownerVM.pendingAttachments.isEmpty)
+    }
+
+    func testContinueInSyncedThreadPreservesTargetExistingDraft() {
+        let (ownerThread, ownerVM) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        // Target already has a draft
+        ownerVM.inputText = "Existing draft in owner"
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "New text from non-owner"
+
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: nonOwnerThread.id
+        )
+
+        // Source draft replaces target draft (the user's intent is to continue
+        // their current work in the synced thread)
+        XCTAssertEqual(ownerVM.inputText, "New text from non-owner")
+    }
+
+    func testContinueInSyncedThreadFallsBackOnMissingViewModel() {
+        let (ownerThread, _) = createSyncedThread(title: "Owner Thread")
+        let bogusId = UUID()
+
+        threadManager.activeThreadId = ownerThread.id
+
+        // Call with a bogus source thread ID — should still switch threads
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: bogusId
+        )
+
+        XCTAssertEqual(threadManager.activeThreadId, ownerThread.id)
+    }
+
+    // MARK: - moveSyncHereAndResend: Move + Auto-Resend
+
+    func testMoveSyncHereAndResendSendsMessageOnSuccess() {
+        // Owner thread currently owns "telegram:chat-123"
+        let (ownerThread, _) = createSyncedThread(title: "Owner Thread")
+        // Non-owner is a plain thread (no sync binding) that wants to take over
+        let nonOwnerThread = ThreadModel(
+            title: "Non-Owner",
+            sessionId: "session-nonowner"
+        )
+        let nonOwnerVM = threadManager.makeViewModel()
+        nonOwnerVM.sessionId = nonOwnerThread.sessionId
+        nonOwnerVM.isHistoryLoaded = true
+        threadManager.threads.insert(nonOwnerThread, at: 0)
+        threadManager.setChatViewModel(nonOwnerVM, for: nonOwnerThread.id)
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "Please send this"
+
+        // Mock moveChannelSync to succeed
+        daemonClient.moveChannelSyncOverride = { _, _, _ in true }
+
+        threadManager.moveSyncHereAndResend(
+            threadId: nonOwnerThread.id,
+            sourceChannel: "telegram",
+            externalChatId: "chat-123"
+        )
+
+        // Wait for the async Task to complete
+        let expectation = XCTestExpectation(description: "move-sync completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Verify: non-owner thread now has sync binding
+        let updatedNonOwner = threadManager.threads.first(where: { $0.id == nonOwnerThread.id })!
+        XCTAssertEqual(updatedNonOwner.sourceChannel, "telegram")
+        XCTAssertEqual(updatedNonOwner.externalChatId, "chat-123")
+
+        // Verify: old owner lost sync binding
+        let updatedOwner = threadManager.threads.first(where: { $0.id == ownerThread.id })!
+        XCTAssertNil(updatedOwner.sourceChannel)
+        XCTAssertNil(updatedOwner.externalChatId)
+
+        // Verify: the user message was appended (auto-sent)
+        XCTAssertTrue(nonOwnerVM.messages.contains(where: {
+            $0.role == .user && $0.text == "Please send this"
+        }), "Draft should have been auto-sent after move-sync success")
+
+        // Verify: composer was cleared by sendMessage
+        XCTAssertEqual(nonOwnerVM.inputText, "")
+    }
+
+    func testMoveSyncHereAndResendDoesNotSendOnFailure() {
+        let (_, _) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "Should not be sent"
+
+        // Mock moveChannelSync to fail
+        daemonClient.moveChannelSyncOverride = { _, _, _ in false }
+
+        threadManager.moveSyncHereAndResend(
+            threadId: nonOwnerThread.id,
+            sourceChannel: "telegram",
+            externalChatId: "chat-456"
+        )
+
+        let expectation = XCTestExpectation(description: "move-sync fails")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Verify: no user messages were sent
+        XCTAssertFalse(nonOwnerVM.messages.contains(where: { $0.role == .user }),
+                       "Draft should NOT be sent when move-sync fails")
+    }
+
+    func testMoveSyncHereAndResendWithEmptyDraftSkipsSend() {
+        let (_, _) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        // Empty composer — no draft to resend
+
+        daemonClient.moveChannelSyncOverride = { _, _, _ in true }
+
+        threadManager.moveSyncHereAndResend(
+            threadId: nonOwnerThread.id,
+            sourceChannel: "telegram",
+            externalChatId: "chat-456"
+        )
+
+        let expectation = XCTestExpectation(description: "move-sync completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Verify: sync moved successfully
+        let updatedNonOwner = threadManager.threads.first(where: { $0.id == nonOwnerThread.id })!
+        XCTAssertEqual(updatedNonOwner.sourceChannel, "telegram")
+
+        // Verify: no messages sent (empty draft)
+        XCTAssertFalse(nonOwnerVM.messages.contains(where: { $0.role == .user }))
+    }
+
+    func testMoveSyncHereAndResendPreservesDisplayMetadata() {
+        let (ownerThread, _) = createSyncedThread(
+            title: "Owner Thread",
+            displayName: "Alice",
+            username: "alice_tg"
+        )
+        let (nonOwnerThread, _) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+
+        daemonClient.moveChannelSyncOverride = { _, _, _ in true }
+
+        threadManager.moveSyncHereAndResend(
+            threadId: nonOwnerThread.id,
+            sourceChannel: "telegram",
+            externalChatId: "chat-123"
+        )
+
+        let expectation = XCTestExpectation(description: "move-sync completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Verify: display metadata carried from old owner to new owner
+        let updatedNonOwner = threadManager.threads.first(where: { $0.id == nonOwnerThread.id })!
+        XCTAssertEqual(updatedNonOwner.displayName, "Alice")
+        XCTAssertEqual(updatedNonOwner.username, "alice_tg")
+
+        // Verify: old owner metadata cleared
+        let updatedOwner = threadManager.threads.first(where: { $0.id == ownerThread.id })!
+        XCTAssertNil(updatedOwner.displayName)
+        XCTAssertNil(updatedOwner.username)
+    }
+
+    // MARK: - No Data Loss
+
+    func testDraftNotLostOnContinue() {
+        // Ensures the draft text is faithfully preserved across thread switch
+        let (ownerThread, ownerVM) = createSyncedThread(title: "Owner")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        let longDraft = String(repeating: "test message content ", count: 50)
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = longDraft
+
+        threadManager.continueInSyncedThread(
+            targetThreadId: ownerThread.id,
+            sourceThreadId: nonOwnerThread.id
+        )
+
+        XCTAssertEqual(ownerVM.inputText, longDraft,
+                       "Long draft text must be preserved exactly across thread switch")
+        XCTAssertEqual(ownerVM.inputText.count, longDraft.count)
+    }
+
+    func testDraftNotLostOnMoveFailure() {
+        // When move-sync fails, the draft should remain in the composer
+        let (_, _) = createSyncedThread(title: "Owner")
+        let (nonOwnerThread, nonOwnerVM) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        threadManager.activeThreadId = nonOwnerThread.id
+        nonOwnerVM.inputText = "Important message"
+
+        daemonClient.moveChannelSyncOverride = { _, _, _ in false }
+
+        threadManager.moveSyncHereAndResend(
+            threadId: nonOwnerThread.id,
+            sourceChannel: "telegram",
+            externalChatId: "chat-456"
+        )
+
+        let expectation = XCTestExpectation(description: "move-sync fails")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // The draft is still in inputText since sendMessage was never called
+        // (move failed, so we skip the auto-send)
+        XCTAssertFalse(nonOwnerVM.messages.contains(where: { $0.role == .user }),
+                       "No user message should be sent on failure")
+    }
+
+    // MARK: - findCanonicalThread
+
+    func testFindCanonicalThreadReturnsCorrectThread() {
+        let (ownerThread, _) = createSyncedThread(title: "Owner")
+        let (nonOwnerThread, _) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        let canonical = threadManager.findCanonicalThread(
+            sourceChannel: "telegram",
+            externalChatId: "chat-123",
+            excludingThread: nonOwnerThread.id
+        )
+
+        XCTAssertEqual(canonical?.id, ownerThread.id)
+    }
+
+    func testFindCanonicalThreadExcludesArchived() {
+        let (ownerThread, _) = createSyncedThread(title: "Owner")
+
+        // Archive the owner thread
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == ownerThread.id }) {
+            threadManager.threads[idx].isArchived = true
+        }
+
+        let canonical = threadManager.findCanonicalThread(
+            sourceChannel: "telegram",
+            externalChatId: "chat-123",
+            excludingThread: UUID()
+        )
+
+        XCTAssertNil(canonical, "Archived threads should not be returned as canonical")
+    }
+}

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -69,7 +69,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastError = "previous error"
         model.lastResult = SimulationResult(
             decision: "allow", riskLevel: "low", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.toolName = "host_bash"
@@ -211,7 +212,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
     func testAllowOnce_setsLocalOverrideLabel() {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.allowOnce()
@@ -229,7 +231,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
     func testDenyOnce_setsLocalOverrideLabel() {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.denyOnce()
@@ -253,7 +256,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.principalVersion = "v1"
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.alwaysAllow(pattern: "echo *", scope: "project")
@@ -282,7 +286,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.inputJSON = "{}"
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "high", reason: "dangerous",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.alwaysAllow(pattern: "rm -rf *", scope: "global")
@@ -298,7 +303,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.inputJSON = "{}"
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.alwaysAllow(pattern: "echo *", scope: "project")
@@ -316,7 +322,8 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.principalKind = ""
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "low", reason: "test",
-            matchedRuleId: nil, promptPayload: nil
+            matchedRuleId: nil, promptPayload: nil,
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: "", snapshotPrincipalKind: "", snapshotPrincipalId: "", snapshotPrincipalVersion: ""
         )
 
         model.alwaysAllow(pattern: "*", scope: "global")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -495,6 +495,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Used in tests to avoid needing a live NWConnection.
     internal var sendOverride: ((Any) throws -> Void)?
 
+    /// Closure that, when set, replaces the real moveChannelSync HTTP call.
+    /// Used in tests to simulate success/failure without a live HTTP server.
+    internal var moveChannelSyncOverride: ((String, String, String) async -> Bool)?
+
     /// Send a message to the daemon.
     /// Encodes the message as JSON, appends a newline, and writes to the connection.
     /// Throws `SendError.notConnected` when the connection is nil so callers can
@@ -1189,6 +1193,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Calls the runtime's POST /v1/channels/move-sync endpoint to
     /// atomically transfer the binding from the current owner to the new conversation.
     public func moveChannelSync(sourceChannel: String, externalChatId: String, newConversationId: String) async -> Bool {
+        if let override = moveChannelSyncOverride {
+            return await override(sourceChannel, externalChatId, newConversationId)
+        }
         let baseURL: String
         let bearerToken: String?
 


### PR DESCRIPTION
## Summary

Implements the two conflict-resolution UX flows for Telegram sync conflicts on the macOS desktop app:

1. **Continue in Synced Thread** — switches to the canonical thread while carrying over draft text and attachments from the source composer, so the user doesn't lose their in-progress work
2. **Move Sync Here** — atomically transfers sync ownership to the current thread via `moveChannelSync` and auto-resends the blocked draft message on success

### Changes

- **PanelCoordinator.swift**: Wire up `onContinueInSyncedThread` and `onMoveSyncHere` callbacks to use new ThreadManager methods instead of simple thread switching
- **ThreadManager.swift**: Add `continueInSyncedThread(targetThreadId:sourceThreadId:)` and `moveSyncHereAndResend(threadId:sourceChannel:externalChatId:)` methods with full draft/attachment transfer logic
- **DaemonClient.swift**: Add `moveChannelSyncOverride` closure for test mocking (follows existing `sendOverride` pattern)
- **ThreadManagerSyncConflictTests.swift**: 13 unit tests covering draft carryover, attachment transfer, move+resend success/failure, display metadata preservation, and no-data-loss guarantees
- **ToolPermissionTesterModelTests.swift**: Fix pre-existing compile errors (missing `snapshot*` parameters in `SimulationResult` initializations)

Part of #6528 / #6524

## Test plan

- [x] All 13 new ThreadManagerSyncConflictTests pass
- [x] Pre-existing ToolPermissionTesterModelTests compile errors fixed
- [x] `swift build` passes cleanly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
