### PR TITLE
fix: silence Swift 'where' clause warnings in ToolConfirmationBubble

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -431,7 +431,7 @@ public struct ToolConfirmationBubble: View {
                 // Plain Tab — move right (modified Tab passes through)
                 keyboardModel?.moveRight()
                 return nil
-            case 36, 76 where mods.isEmpty:
+            case 36 where mods.isEmpty, 76 where mods.isEmpty:
                 // Plain Return / numpad Enter — activate (modified Enter passes through, e.g. Shift+Enter for newline)
                 if let action = keyboardModel?.selectedAction {
                     activateAction(action)
@@ -459,7 +459,7 @@ public struct ToolConfirmationBubble: View {
             // Down arrow
             popoverKeyboardModel?.moveDown()
             return nil
-        case 36, 76 where mods.isEmpty:
+        case 36 where mods.isEmpty, 76 where mods.isEmpty:
             // Plain Return / numpad Enter — activate selected row (modified Enter passes through)
             activatePopoverSelection()
             return nil


### PR DESCRIPTION
## Summary
- Duplicate the `where mods.isEmpty` clause on both key code patterns (36, 76) in two `case` statements so Swift applies the guard to both patterns, silencing the compiler warnings.

## Original prompt
fix: Swift build warnings — `'where' only applies to the second pattern match in this 'case'` at ToolConfirmationBubble.swift lines 434 and 462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
