### PR TITLE
fix: silence SendableClosureCaptures warnings in AssistantCli

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -3,6 +3,21 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AssistantCli")
 
+/// Thread-safe one-shot flag for ensuring a continuation is resumed exactly once.
+private final class OnceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var set = false
+
+    /// Returns `true` the first time it's called; `false` on every subsequent call.
+    func trySet() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if set { return false }
+        set = true
+        return true
+    }
+}
+
 /// Manages all daemon lifecycle operations through the bundled CLI binary.
 ///
 /// This is the single entry point for hatching, stopping, and retiring the
@@ -161,17 +176,11 @@ final class AssistantCli {
             }
             proc.environment = env
 
-            var resumed = false
-            let lock = NSLock()
+            let once = OnceFlag()
 
             // Timeout: terminate the process if it takes too long
             let timeoutItem = DispatchWorkItem { [weak proc] in
-                lock.lock()
-                let alreadyResumed = resumed
-                if !alreadyResumed { resumed = true }
-                lock.unlock()
-
-                if !alreadyResumed {
+                if once.trySet() {
                     proc?.terminate()
                     continuation.resume(throwing: CLIError.executionFailed("Retire timed out after 60 seconds"))
                 }
@@ -180,12 +189,7 @@ final class AssistantCli {
 
             proc.terminationHandler = { finished in
                 timeoutItem.cancel()
-                lock.lock()
-                let alreadyResumed = resumed
-                if !alreadyResumed { resumed = true }
-                lock.unlock()
-
-                guard !alreadyResumed else { return }
+                guard once.trySet() else { return }
 
                 let stderrData = stderrPipe.fileHandleForReading.availableData
                 let stderrStr = String(data: stderrData, encoding: .utf8) ?? ""
@@ -196,12 +200,7 @@ final class AssistantCli {
                 try proc.run()
             } catch {
                 timeoutItem.cancel()
-                lock.lock()
-                let alreadyResumed = resumed
-                if !alreadyResumed { resumed = true }
-                lock.unlock()
-
-                if !alreadyResumed {
+                if once.trySet() {
                     continuation.resume(throwing: CLIError.executionFailed("Failed to launch retire: \(error.localizedDescription)"))
                 }
             }


### PR DESCRIPTION
## Summary
- Introduced a private `OnceFlag` class (`@unchecked Sendable`) that encapsulates the lock + boolean test-and-set pattern
- Replaced `var resumed` + manual `NSLock` lock/unlock sequences with `once.trySet()` calls, eliminating Swift 6 `SendableClosureCaptures` warnings
- Same thread-safety guarantees, cleaner code

## Original prompt
fix: Swift 6 SendableClosureCaptures warnings in AssistantCli.swift — captured var `resumed` referenced/mutated in concurrently-executing closures (DispatchWorkItem, terminationHandler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
