### PR TITLE
refactor: split tools/executor.ts into focused modules

### DIFF
--- a/assistant/src/tools/execution-target.ts
+++ b/assistant/src/tools/execution-target.ts
@@ -1,0 +1,21 @@
+import type { ExecutionTarget } from './types.js';
+import { getTool } from './registry.js';
+
+export function resolveExecutionTarget(toolName: string): ExecutionTarget {
+  const tool = getTool(toolName);
+  // Manifest-declared execution target is authoritative — check it first so
+  // skill tools with host_/computer_use_ prefixes aren't mis-classified.
+  if (tool?.executionTarget) {
+    return tool.executionTarget;
+  }
+  // Check the tool's executionMode metadata — proxy tools run on the connected
+  // client (host), not inside the sandbox.
+  if (tool?.executionMode === 'proxy') {
+    return 'host';
+  }
+  // Prefix heuristics for core tools that don't declare an explicit target.
+  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_')) {
+    return 'host';
+  }
+  return 'sandbox';
+}

--- a/assistant/src/tools/execution-timeout.ts
+++ b/assistant/src/tools/execution-timeout.ts
@@ -1,0 +1,49 @@
+import type { ToolExecutionResult } from './types.js';
+
+const TIMEOUT_SENTINEL = Symbol('tool-timeout');
+
+export const DEFAULT_TOOL_TIMEOUT_SEC = 120;
+
+/**
+ * Convert a config-provided seconds value to a safe milliseconds value,
+ * falling back to the default if the input is NaN, non-finite, zero, or negative.
+ */
+export function safeTimeoutMs(sec: unknown): number {
+  const n = Number(sec);
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_TOOL_TIMEOUT_SEC * 1000;
+  }
+  return n * 1000;
+}
+
+/**
+ * Race a tool execution promise against a timeout. Returns a timeout error
+ * result instead of throwing so the agent loop can continue gracefully.
+ */
+export async function executeWithTimeout(
+  promise: Promise<ToolExecutionResult>,
+  timeoutMs: number,
+  toolName: string,
+): Promise<ToolExecutionResult> {
+  // Guard against NaN/invalid values that would cause setTimeout to fire immediately
+  const safeMs = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_TOOL_TIMEOUT_SEC * 1000;
+  let timeoutHandle: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), safeMs);
+  });
+  try {
+    const result = await Promise.race([promise, timeoutPromise]);
+    if (result === TIMEOUT_SENTINEL) {
+      const sec = Math.round(safeMs / 1000);
+      return {
+        content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
+        isError: true,
+      };
+    }
+    return result;
+  } finally {
+    clearTimeout(timeoutHandle!);
+  }
+}

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,8 +1,7 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { getTool, getAllTools } from './registry.js';
-import type { ExecutionTarget, Tool, ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
+import type { ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
-import type { PolicyContext } from '../permissions/types.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
@@ -18,6 +17,9 @@ import { scanText, redactSecrets } from '../security/secret-scanner.js';
 import { redactSensitiveFields } from '../security/redaction.js';
 import { getHookManager } from '../hooks/manager.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
+import { safeTimeoutMs, executeWithTimeout } from './execution-timeout.js';
+import { buildPolicyContext } from './policy-context.js';
+import { resolveExecutionTarget } from './execution-target.js';
 
 const log = getLogger('tool-executor');
 
@@ -754,111 +756,6 @@ export function isSideEffectTool(toolName: string, input?: Record<string, unknow
   }
 
   return false;
-}
-
-const TIMEOUT_SENTINEL = Symbol('tool-timeout');
-
-const DEFAULT_TOOL_TIMEOUT_SEC = 120;
-
-/**
- * Convert a config-provided seconds value to a safe milliseconds value,
- * falling back to the default if the input is NaN, non-finite, zero, or negative.
- */
-function safeTimeoutMs(sec: unknown): number {
-  const n = Number(sec);
-  if (!Number.isFinite(n) || n <= 0) {
-    return DEFAULT_TOOL_TIMEOUT_SEC * 1000;
-  }
-  return n * 1000;
-}
-
-/**
- * Race a tool execution promise against a timeout. Returns a timeout error
- * result instead of throwing so the agent loop can continue gracefully.
- */
-async function executeWithTimeout(
-  promise: Promise<ToolExecutionResult>,
-  timeoutMs: number,
-  toolName: string,
-): Promise<ToolExecutionResult> {
-  // Guard against NaN/invalid values that would cause setTimeout to fire immediately
-  const safeMs = Number.isFinite(timeoutMs) && timeoutMs > 0
-    ? timeoutMs
-    : DEFAULT_TOOL_TIMEOUT_SEC * 1000;
-  let timeoutHandle: ReturnType<typeof setTimeout>;
-  const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-    timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), safeMs);
-  });
-  try {
-    const result = await Promise.race([promise, timeoutPromise]);
-    if (result === TIMEOUT_SENTINEL) {
-      const sec = Math.round(safeMs / 1000);
-      return {
-        content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
-        isError: true,
-      };
-    }
-    return result;
-  } finally {
-    clearTimeout(timeoutHandle!);
-  }
-}
-
-/**
- * Build a PolicyContext from tool metadata and execution context. Skill-origin
- * tools carry a principal identifying the owning skill. When executing within
- * a task run, ephemeral permission rules are included so pre-approved tools
- * are auto-allowed without prompting.
- */
-function buildPolicyContext(tool: Tool, context?: ToolContext): PolicyContext | undefined {
-  const ephemeralRules = context?.taskRunId
-    ? getTaskRunRules(context.taskRunId)
-    : undefined;
-
-  if (tool.origin === 'skill') {
-    return {
-      principal: {
-        kind: 'skill',
-        id: tool.ownerSkillId,
-        version: tool.ownerSkillVersionHash,
-      },
-      executionTarget: tool.executionTarget,
-      ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
-    };
-  }
-
-  // For non-skill tools in a task run, create a context with task principal
-  // and ephemeral rules so pre-approved tools are honored.
-  if (context?.taskRunId && ephemeralRules?.length) {
-    return {
-      principal: {
-        kind: 'task',
-        id: context.taskRunId,
-      },
-      ephemeralRules,
-    };
-  }
-
-  return undefined;
-}
-
-function resolveExecutionTarget(toolName: string): ExecutionTarget {
-  const tool = getTool(toolName);
-  // Manifest-declared execution target is authoritative — check it first so
-  // skill tools with host_/computer_use_ prefixes aren't mis-classified.
-  if (tool?.executionTarget) {
-    return tool.executionTarget;
-  }
-  // Check the tool's executionMode metadata — proxy tools run on the connected
-  // client (host), not inside the sandbox.
-  if (tool?.executionMode === 'proxy') {
-    return 'host';
-  }
-  // Prefix heuristics for core tools that don't declare an explicit target.
-  if (toolName.startsWith('host_') || toolName.startsWith('computer_use_')) {
-    return 'host';
-  }
-  return 'sandbox';
 }
 
 /**

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -1,0 +1,41 @@
+import type { PolicyContext } from '../permissions/types.js';
+import type { Tool, ToolContext } from './types.js';
+import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
+
+/**
+ * Build a PolicyContext from tool metadata and execution context. Skill-origin
+ * tools carry a principal identifying the owning skill. When executing within
+ * a task run, ephemeral permission rules are included so pre-approved tools
+ * are auto-allowed without prompting.
+ */
+export function buildPolicyContext(tool: Tool, context?: ToolContext): PolicyContext | undefined {
+  const ephemeralRules = context?.taskRunId
+    ? getTaskRunRules(context.taskRunId)
+    : undefined;
+
+  if (tool.origin === 'skill') {
+    return {
+      principal: {
+        kind: 'skill',
+        id: tool.ownerSkillId,
+        version: tool.ownerSkillVersionHash,
+      },
+      executionTarget: tool.executionTarget,
+      ephemeralRules: ephemeralRules?.length ? ephemeralRules : undefined,
+    };
+  }
+
+  // For non-skill tools in a task run, create a context with task principal
+  // and ephemeral rules so pre-approved tools are honored.
+  if (context?.taskRunId && ephemeralRules?.length) {
+    return {
+      principal: {
+        kind: 'task',
+        id: context.taskRunId,
+      },
+      ephemeralRules,
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Extract timeout handling, policy context building, and execution target resolution from the monolithic executor.ts (944 lines) into separate modules for improved testability and readability.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
