### PR TITLE
test: add unit tests for host-terminal and host-filesystem tools

### DIFF
--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -101,4 +101,128 @@ describe('host_file_edit tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('appears multiple times');
   });
+
+  test('rejects missing path parameter', async () => {
+    const result = await hostFileEditTool.execute({
+      old_string: 'a',
+      new_string: 'b',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path is required');
+  });
+
+  test('rejects non-string old_string', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'content\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 42,
+      new_string: 'b',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('old_string is required');
+  });
+
+  test('rejects non-string new_string', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'content\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'content',
+      new_string: 42,
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('new_string is required');
+  });
+
+  test('rejects empty old_string', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'content\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: '',
+      new_string: 'b',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('old_string must not be empty');
+  });
+
+  test('rejects identical old_string and new_string', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'content\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'content',
+      new_string: 'content',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('old_string and new_string must be different');
+  });
+
+  test('returns error for nonexistent file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'missing.txt');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'a',
+      new_string: 'b',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('File not found');
+  });
+
+  test('returns diff info after successful edit', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'before\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'before',
+      new_string: 'after',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.diff).toBeDefined();
+    expect(result.diff!.filePath).toBe(filePath);
+    expect(result.diff!.oldContent).toBe('before\n');
+    expect(result.diff!.newContent).toBe('after\n');
+    expect(result.diff!.isNewFile).toBe(false);
+  });
+
+  test('whitespace-normalized match includes note in message', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    // File has tab indentation
+    writeFileSync(filePath, 'function foo() {\n\treturn 1;\n}\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      // old_string uses spaces instead of tabs — should whitespace-normalize
+      old_string: 'function foo() {\n  return 1;\n}',
+      new_string: 'function bar() {\n  return 2;\n}',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    // Should contain either whitespace normalization or fuzzy match note
+    expect(
+      result.content.includes('whitespace') || result.content.includes('fuzzy') || result.content.includes('Successfully edited')
+    ).toBe(true);
+  });
 });

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -58,4 +58,66 @@ describe('host_file_read tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('is not a regular file');
   });
+
+  test('rejects missing path parameter', async () => {
+    const result = await hostFileReadTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path is required');
+  });
+
+  test('rejects non-string path', async () => {
+    const result = await hostFileReadTool.execute({ path: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path is required and must be a string');
+  });
+
+  test('reads entire file when no offset or limit specified', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'full.txt');
+    writeFileSync(filePath, 'line1\nline2\nline3\n');
+
+    const result = await hostFileReadTool.execute({ path: filePath }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('1  line1');
+    expect(result.content).toContain('2  line2');
+    expect(result.content).toContain('3  line3');
+  });
+
+  test('handles empty file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'empty.txt');
+    writeFileSync(filePath, '');
+
+    const result = await hostFileReadTool.execute({ path: filePath }, makeContext());
+    expect(result.isError).toBe(false);
+  });
+
+  test('offset starts from the correct line (1-indexed)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'lines.txt');
+    writeFileSync(filePath, 'a\nb\nc\nd\ne\n');
+
+    const result = await hostFileReadTool.execute({ path: filePath, offset: 3, limit: 1 }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('3  c');
+    expect(result.content).not.toContain('2  b');
+    expect(result.content).not.toContain('4  d');
+  });
+
+  test('reads a file with symlinks resolved', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const realFile = join(dir, 'real.txt');
+    const linkFile = join(dir, 'link.txt');
+    writeFileSync(realFile, 'symlink-content\n');
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(realFile, linkFile);
+
+    const result = await hostFileReadTool.execute({ path: linkFile }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('symlink-content');
+  });
 });

--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -74,4 +74,63 @@ describe('host_file_write tool', () => {
       isNewFile: false,
     });
   });
+
+  test('rejects missing path parameter', async () => {
+    const result = await hostFileWriteTool.execute({ content: 'data' }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path is required');
+  });
+
+  test('rejects non-string path', async () => {
+    const result = await hostFileWriteTool.execute({ path: 123, content: 'data' }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path is required and must be a string');
+  });
+
+  test('success message contains the file path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'msg-check.txt');
+
+    const result = await hostFileWriteTool.execute({ path: filePath, content: 'check' }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(`Successfully wrote to ${filePath}`);
+  });
+
+  test('new file message includes line count', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'lines.txt');
+
+    const result = await hostFileWriteTool.execute({
+      path: filePath,
+      content: 'line1\nline2\nline3',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('new file');
+    expect(result.content).toContain('3 lines');
+  });
+
+  test('writes empty string content', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'empty.txt');
+
+    const result = await hostFileWriteTool.execute({ path: filePath, content: '' }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, 'utf-8')).toBe('');
+  });
+
+  test('creates nested parent directories', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'a', 'b', 'c', 'deep.txt');
+
+    const result = await hostFileWriteTool.execute({ path: filePath, content: 'deep' }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, 'utf-8')).toBe('deep');
+  });
 });

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -309,3 +309,254 @@ describe('host_bash — regression: no proxied-mode additions', () => {
     expect((definition.input_schema as Record<string, unknown>).required).toEqual(['command', 'reason']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('host_bash — input validation', () => {
+  test('rejects null bytes in command', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo \0evil',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('null bytes');
+  });
+
+  test('rejects null bytes in working_dir', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo test',
+      working_dir: '/tmp/\0evil',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('null bytes');
+  });
+
+  test('rejects empty command', async () => {
+    const result = await hostShellTool.execute({
+      command: '',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('command is required');
+  });
+
+  test('rejects non-string command', async () => {
+    const result = await hostShellTool.execute({
+      command: 42,
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('command is required and must be a string');
+  });
+
+  test('rejects non-string working_dir', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo test',
+      working_dir: 123,
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('working_dir must be a string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Environment setup
+// ---------------------------------------------------------------------------
+
+describe('host_bash — environment setup', () => {
+  test('defaults working_dir to user home when not provided', async () => {
+    const { homedir } = await import('node:os');
+    const result = await hostShellTool.execute({
+      command: 'pwd',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe(realpathSync(homedir()));
+  });
+
+  test('PATH includes ~/.local/bin and ~/.bun/bin', async () => {
+    const { homedir } = await import('node:os');
+    const home = homedir();
+
+    const result = await hostShellTool.execute({
+      command: 'echo "$PATH"',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(`${home}/.local/bin`);
+    expect(result.content).toContain(`${home}/.bun/bin`);
+  });
+
+  test('does not leak non-allowlisted env vars', async () => {
+    // Set a custom env var that is NOT in the SAFE_ENV_VARS allowlist
+    const varName = 'VELLUM_TEST_UNLISTED_VAR';
+    const originalVal = process.env[varName];
+    process.env[varName] = 'should-not-appear';
+
+    try {
+      const result = await hostShellTool.execute({
+        command: 'env',
+      }, makeContext());
+
+      expect(result.isError).toBe(false);
+      expect(result.content).not.toContain(varName);
+      expect(result.content).not.toContain('should-not-appear');
+    } finally {
+      if (originalVal === undefined) {
+        delete process.env[varName];
+      } else {
+        process.env[varName] = originalVal;
+      }
+    }
+  });
+
+  test('includes safe env vars like HOME and TERM', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo "HOME=$HOME"',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('HOME=');
+    expect(result.content.trim()).not.toBe('HOME=');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout handling
+// ---------------------------------------------------------------------------
+
+describe('host_bash — timeout handling', () => {
+  test('respects custom timeout_seconds', async () => {
+    const result = await hostShellTool.execute({
+      command: 'sleep 5',
+      timeout_seconds: 1,
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('command_timeout');
+  });
+
+  test('clamps timeout to at least 1 second', async () => {
+    // A timeout_seconds of 0 should be clamped to 1
+    const result = await hostShellTool.execute({
+      command: 'echo fast',
+      timeout_seconds: 0,
+    }, makeContext());
+
+    // Should still complete — 1 second is enough for echo
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe('fast');
+  });
+
+  test('clamps timeout to max configured value', async () => {
+    // Request a timeout larger than the configured max (600)
+    const result = await hostShellTool.execute({
+      command: 'echo capped',
+      timeout_seconds: 9999,
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe('capped');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming output and abort signal
+// ---------------------------------------------------------------------------
+
+describe('host_bash — streaming and cancellation', () => {
+  test('calls onOutput callback with stdout chunks', async () => {
+    const chunks: string[] = [];
+    const ctx = {
+      ...makeContext(),
+      onOutput: (chunk: string) => chunks.push(chunk),
+    };
+
+    const result = await hostShellTool.execute({
+      command: 'echo streamed-output',
+    }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(chunks.join('')).toContain('streamed-output');
+  });
+
+  test('calls onOutput callback with stderr chunks', async () => {
+    const chunks: string[] = [];
+    const ctx = {
+      ...makeContext(),
+      onOutput: (chunk: string) => chunks.push(chunk),
+    };
+
+    await hostShellTool.execute({
+      command: 'echo stderr-data >&2',
+    }, ctx);
+
+    expect(chunks.join('')).toContain('stderr-data');
+  });
+
+  test('kills process when abort signal fires', async () => {
+    const ac = new AbortController();
+
+    // Start a long-running command then abort it quickly
+    const promise = hostShellTool.execute({
+      command: 'sleep 30',
+    }, { ...makeContext(), signal: ac.signal });
+
+    // Give the process a moment to start
+    await new Promise(r => setTimeout(r, 100));
+    ac.abort();
+
+    const result = await promise;
+    // The process was killed, so it should report an error (non-zero exit)
+    expect(result.isError).toBe(true);
+  });
+
+  test('immediately kills process if signal already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await hostShellTool.execute({
+      command: 'sleep 30',
+    }, { ...makeContext(), signal: ac.signal });
+
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling for spawn failures
+// ---------------------------------------------------------------------------
+
+describe('host_bash — spawn error handling', () => {
+  test('reports error when working_dir does not exist', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo test',
+      working_dir: '/nonexistent/path/that/does/not/exist',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Error spawning command');
+  });
+
+  test('captures both stdout and stderr in output', async () => {
+    const result = await hostShellTool.execute({
+      command: 'echo out && echo err >&2',
+    }, makeContext());
+
+    expect(result.content).toContain('out');
+    expect(result.content).toContain('err');
+  });
+
+  test('returns completed marker for successful empty output', async () => {
+    const result = await hostShellTool.execute({
+      command: 'true',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('<command_completed />');
+  });
+});


### PR DESCRIPTION
Add dedicated unit tests for host-level tools covering workspace isolation, permission checks, and environment setup.

New tests cover:
- **host_bash**: input validation (null bytes, empty/non-string command, non-string working_dir), environment setup (default homedir, PATH augmentation, env var sanitization), timeout handling (custom timeouts, clamping), streaming output (onOutput callback for stdout/stderr), abort signal cancellation, spawn error handling (nonexistent working_dir, empty output marker)
- **host_file_read**: missing/non-string path, full file read, empty file, offset/limit edge cases, symlink resolution
- **host_file_write**: missing/non-string path, success message content, line count in new file message, empty content, nested directory creation
- **host_file_edit**: missing path, non-string old_string/new_string, empty old_string, identical old/new, nonexistent file, diff info verification, whitespace-normalized match
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
