### PR TITLE
feat: add structured request tracing to gateway

### DIFF
--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -23,6 +23,7 @@ export type HandleInboundOptions = {
   attachmentIds?: string[];
   transportMetadata?: TransportMetadataOverrides;
   replyCallbackUrl?: string;
+  traceId?: string;
 };
 
 function normalizeTransportHints(hints: string[] | undefined): string[] {
@@ -62,27 +63,32 @@ export async function handleInbound(
   const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
 
   try {
-    const response = await forwardToRuntime(config, routing.assistantId, {
-      sourceChannel: event.sourceChannel,
-      externalChatId: event.message.externalChatId,
-      externalMessageId: event.message.externalMessageId,
-      content: event.message.content,
-      ...(event.message.isEdit ? { isEdit: true } : {}),
-      senderName: displayName,
-      senderExternalUserId: event.sender.externalUserId,
-      senderUsername: event.sender.username,
-      sourceMetadata: {
-        updateId: event.source.updateId,
-        messageId: event.source.messageId,
-        chatType: event.source.chatType,
-        languageCode: event.sender.languageCode,
-        isBot: event.sender.isBot,
-        ...(transportHints.length > 0 ? { hints: transportHints } : {}),
-        ...(transportUxBrief ? { uxBrief: transportUxBrief } : {}),
+    const response = await forwardToRuntime(
+      config,
+      routing.assistantId,
+      {
+        sourceChannel: event.sourceChannel,
+        externalChatId: event.message.externalChatId,
+        externalMessageId: event.message.externalMessageId,
+        content: event.message.content,
+        ...(event.message.isEdit ? { isEdit: true } : {}),
+        senderName: displayName,
+        senderExternalUserId: event.sender.externalUserId,
+        senderUsername: event.sender.username,
+        sourceMetadata: {
+          updateId: event.source.updateId,
+          messageId: event.source.messageId,
+          chatType: event.source.chatType,
+          languageCode: event.sender.languageCode,
+          isBot: event.sender.isBot,
+          ...(transportHints.length > 0 ? { hints: transportHints } : {}),
+          ...(transportUxBrief ? { uxBrief: transportUxBrief } : {}),
+        },
+        ...(options?.attachmentIds?.length ? { attachmentIds: options.attachmentIds } : {}),
+        ...(options?.replyCallbackUrl ? { replyCallbackUrl: options.replyCallbackUrl } : {}),
       },
-      ...(options?.attachmentIds?.length ? { attachmentIds: options.attachmentIds } : {}),
-      ...(options?.replyCallbackUrl ? { replyCallbackUrl: options.replyCallbackUrl } : {}),
-    });
+      { traceId: options?.traceId },
+    );
 
     log.info(
       {

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -8,6 +8,9 @@ const log = getLogger("telegram-deliver");
 
 export function createTelegramDeliverHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
     if (req.method !== "POST") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
@@ -82,10 +85,11 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
         await sendTelegramAttachments(config, chatId, assistantId, attachments);
       }
     } catch (err) {
-      log.error({ err, chatId }, "Failed to deliver Telegram reply");
+      tlog.error({ err, chatId }, "Failed to deliver Telegram reply");
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
 
+    tlog.info({ chatId, hasText: !!text, attachmentCount: attachments?.length ?? 0 }, "Reply sent");
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -78,6 +78,9 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
   const dedupCache = new DedupCache();
 
   return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
     if (req.method !== "POST") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
@@ -85,13 +88,13 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     // Payload size guard
     const contentLength = req.headers.get("content-length");
     if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
-      log.warn({ contentLength }, "Webhook payload too large");
+      tlog.warn({ contentLength }, "Webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
     // Verify webhook secret
     if (!config.telegramWebhookSecret || !verifyWebhookSecret(req.headers, config.telegramWebhookSecret)) {
-      log.warn("Telegram webhook request failed secret verification");
+      tlog.warn("Telegram webhook request failed secret verification");
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -103,7 +106,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     }
 
     if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
-      log.warn({ bodyLength: Buffer.byteLength(rawBody) }, "Webhook payload too large");
+      tlog.warn({ bodyLength: Buffer.byteLength(rawBody) }, "Webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
@@ -122,14 +125,14 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       if (!reserved) {
         const cached = dedupCache.get(updateId);
         if (cached) {
-          log.info({ updateId }, "Duplicate update_id, returning cached response");
+          tlog.info({ updateId }, "Duplicate update_id, returning cached response");
           return new Response(cached.body, {
             status: cached.status,
             headers: { "content-type": "application/json" },
           });
         }
         // Still being processed by the first handler — ask Telegram to retry
-        log.info({ updateId }, "Duplicate update_id while still processing, returning 503");
+        tlog.info({ updateId }, "Duplicate update_id while still processing, returning 503");
         return new Response(JSON.stringify({ error: "Processing in progress" }), {
           status: 503,
           headers: { "content-type": "application/json", "Retry-After": "1" },
@@ -155,6 +158,16 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       return respond({ ok: true });
     }
 
+    tlog.info(
+      {
+        source: "telegram",
+        chatId: normalized.message.externalChatId,
+        messageId: normalized.message.externalMessageId,
+        updateId,
+      },
+      "Webhook received",
+    );
+
     // Handle /new command — reset conversation before it reaches the runtime
     if (normalized.message.content.trim() === "/new") {
       const routing = resolveAssistant(
@@ -164,7 +177,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       );
 
       if (isRejection(routing)) {
-        log.warn(
+        tlog.warn(
           { chatId: normalized.message.externalChatId, reason: routing.reason },
           "Routing rejected /new command",
         );
@@ -174,7 +187,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
             normalized.message.externalChatId,
             "\u26a0\ufe0f This message could not be routed to an assistant. Please check your gateway routing configuration.",
           ).catch((err) => {
-            log.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /new routing rejection notice");
+            tlog.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /new routing rejection notice");
           });
         }
       } else {
@@ -186,12 +199,12 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
             normalized.message.externalChatId,
           );
           sendTelegramReply(config, normalized.message.externalChatId, "Starting a new conversation!").catch((err) => {
-            log.error({ err }, "Failed to send /new confirmation");
+            tlog.error({ err }, "Failed to send /new confirmation");
           });
         } catch (err) {
-          log.error({ err }, "Failed to reset conversation");
+          tlog.error({ err }, "Failed to reset conversation");
           sendTelegramReply(config, normalized.message.externalChatId, "Failed to reset conversation. Please try again.").catch((replyErr) => {
-            log.error({ err: replyErr }, "Failed to send /new error reply");
+            tlog.error({ err: replyErr }, "Failed to send /new error reply");
           });
         }
       }
@@ -221,7 +234,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         // Filter oversized attachments
         const eligible = eventAttachments.filter((att) => {
           if (att.fileSize !== undefined && att.fileSize > config.maxAttachmentBytes) {
-            log.warn(
+            tlog.warn(
               { fileId: att.fileId, fileSize: att.fileSize, limit: config.maxAttachmentBytes },
               "Skipping oversized attachment",
             );
@@ -250,7 +263,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
             if (result.status === 'fulfilled') {
               attachmentIds.push(result.value.id);
             } else if (result.reason instanceof AttachmentValidationError) {
-              log.warn({ err: result.reason }, "Skipping attachment with validation error");
+              tlog.warn({ err: result.reason }, "Skipping attachment with validation error");
             } else {
               // Transient failure — propagate so the webhook returns 500 and
               // Telegram retries the update delivery.
@@ -262,7 +275,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         // Transient attachment failure — return 500 so Telegram retries.
         // Use Response.json() instead of respond() to bypass the dedup cache,
         // otherwise the cached 500 prevents Telegram retries from being processed.
-        log.error({ err }, "Attachment processing failed with transient error");
+        tlog.error({ err }, "Attachment processing failed with transient error");
         if (updateId !== undefined) dedupCache.unreserve(updateId);
         return Response.json({ error: "Attachment processing failed" }, { status: 500 });
       }
@@ -275,10 +288,11 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         attachmentIds,
         transportMetadata: buildTelegramTransportMetadata(),
         replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/telegram`,
+        traceId,
       });
 
       if (result.rejected) {
-        log.warn(
+        tlog.warn(
           { chatId, reason: result.rejectionReason },
           "Routing rejected inbound Telegram message",
         );
@@ -288,19 +302,21 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
             chatId,
             "\u26a0\ufe0f This message could not be routed to an assistant. Please check your gateway routing configuration.",
           ).catch((err) => {
-            log.error({ err, chatId }, "Failed to send routing rejection notice");
+            tlog.error({ err, chatId }, "Failed to send routing rejection notice");
           });
         }
         return respond({ ok: true });
       }
 
       if (!result.forwarded) {
-        log.error({ updateId: payload.update_id }, "Failed to forward inbound event");
+        tlog.error({ updateId: payload.update_id }, "Failed to forward inbound event");
         if (updateId !== undefined) dedupCache.unreserve(updateId);
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
+
+      tlog.info({ status: "forwarded" }, "Forwarded to runtime");
     } catch (err) {
-      log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      tlog.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       if (updateId !== undefined) dedupCache.unreserve(updateId);
       return Response.json({ error: "Internal error" }, { status: 500 });
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { loadConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
@@ -15,6 +16,10 @@ import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 
 const log = getLogger("main");
+
+function generateTraceId(): string {
+  return randomBytes(8).toString("hex");
+}
 
 let draining = false;
 
@@ -62,8 +67,15 @@ function main() {
         return Response.json({ status: "ok" });
       }
 
+      // Attach a trace ID to every non-healthcheck request for
+      // end-to-end correlation across webhook → runtime → reply.
+      const traceId = generateTraceId();
+      const headers = new Headers(req.headers);
+      headers.set("x-trace-id", traceId);
+      const tracedReq = new Request(req, { headers });
+
       if (url.pathname === "/internal/telegram/reconcile") {
-        return handleTelegramReconcile(req);
+        return handleTelegramReconcile(tracedReq);
       }
 
       if (url.pathname === "/webhooks/telegram") {
@@ -73,7 +85,7 @@ function main() {
             { status: 503 },
           );
         }
-        return handleTelegramWebhook(req);
+        return handleTelegramWebhook(tracedReq);
       }
 
       if (url.pathname === "/deliver/telegram") {
@@ -83,43 +95,43 @@ function main() {
             { status: 503 },
           );
         }
-        return handleTelegramDeliver(req);
+        return handleTelegramDeliver(tracedReq);
       }
 
       if (
         url.pathname === "/webhooks/twilio/voice" ||
         url.pathname === "/v1/calls/twilio/voice-webhook"
       ) {
-        return handleTwilioVoiceWebhook(req);
+        return handleTwilioVoiceWebhook(tracedReq);
       }
 
       if (
         url.pathname === "/webhooks/twilio/status" ||
         url.pathname === "/v1/calls/twilio/status"
       ) {
-        return handleTwilioStatusWebhook(req);
+        return handleTwilioStatusWebhook(tracedReq);
       }
 
       if (
         url.pathname === "/webhooks/twilio/connect-action" ||
         url.pathname === "/v1/calls/twilio/connect-action"
       ) {
-        return handleTwilioConnectActionWebhook(req);
+        return handleTwilioConnectActionWebhook(tracedReq);
       }
 
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
-        const upgradeResult = handleTwilioRelayWs(req, server);
+        const upgradeResult = handleTwilioRelayWs(tracedReq, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
         return undefined as unknown as Response;
       }
 
-      if (url.pathname === "/webhooks/oauth/callback" && req.method === "GET") {
-        return handleOAuthCallback(req);
+      if (url.pathname === "/webhooks/oauth/callback" && tracedReq.method === "GET") {
+        return handleOAuthCallback(tracedReq);
       }
 
       if (handleRuntimeProxy) {
-        return handleRuntimeProxy(req);
+        return handleRuntimeProxy(tracedReq);
       }
 
       return Response.json({ error: "Not found", source: "gateway" }, { status: 404 });

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -63,12 +63,22 @@ export type RuntimeInboundResponse = {
   };
 };
 
+export type ForwardOptions = {
+  traceId?: string;
+};
+
 export async function forwardToRuntime(
   config: GatewayConfig,
   assistantId: string,
   payload: RuntimeInboundPayload,
+  options?: ForwardOptions,
 ): Promise<RuntimeInboundResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/inbound`;
+
+  const extraHeaders: Record<string, string> = { "Content-Type": "application/json" };
+  if (options?.traceId) {
+    extraHeaders["X-Trace-Id"] = options.traceId;
+  }
 
   let lastError: Error | null = null;
 
@@ -82,7 +92,7 @@ export async function forwardToRuntime(
     try {
       const response = await fetch(url, {
         method: "POST",
-        headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
+        headers: runtimeHeaders(config, extraHeaders),
         body: JSON.stringify(payload),
         signal: AbortSignal.timeout(config.runtimeTimeoutMs),
       });


### PR DESCRIPTION
Add request trace IDs that flow from webhook receipt through runtime forwarding to reply delivery, enabling production debugging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
