### PR TITLE
refactor: consolidate retry/backoff logic into shared utility

### DIFF
--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,46 +1,21 @@
 import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
 import { ProviderError } from '../util/errors.js';
 import { getLogger, isDebug } from '../util/logger.js';
+import {
+  computeRetryDelay,
+  isRetryableNetworkError,
+  sleep,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_BASE_DELAY_MS,
+} from '../util/retry.js';
 
 const log = getLogger('retry');
 
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 1000;
-
 function isRetryableError(error: unknown): boolean {
-  // Check ProviderError.statusCode for retryable HTTP status codes
   if (error instanceof ProviderError && error.statusCode !== undefined) {
     if (error.statusCode === 429 || error.statusCode >= 500) return true;
   }
-
-  // Check for network errors (direct or wrapped in cause chain)
-  if (error instanceof Error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EPIPE') {
-      return true;
-    }
-
-    if (error.cause instanceof Error) {
-      const causeCode = (error.cause as NodeJS.ErrnoException).code;
-      if (causeCode === 'ECONNRESET' || causeCode === 'ECONNREFUSED' || causeCode === 'ETIMEDOUT' || causeCode === 'EPIPE') {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-function getRetryDelay(attempt: number): number {
-  // Equal jitter: guaranteed floor of cap/2 plus random in [0, cap/2].
-  // Prevents retry storms while ensuring retries never collapse to 0ms.
-  const cap = BASE_DELAY_MS * Math.pow(2, attempt);
-  const half = cap / 2;
-  return half + Math.random() * half;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return isRetryableNetworkError(error);
 }
 
 export class RetryProvider implements Provider {
@@ -67,7 +42,7 @@ export class RetryProvider implements Provider {
       }, 'Provider sendMessage start');
     }
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
       try {
         const start = Date.now();
         const result = await this.inner.sendMessage(messages, tools, systemPrompt, options);
@@ -85,14 +60,14 @@ export class RetryProvider implements Provider {
       } catch (error) {
         lastError = error;
 
-        if (attempt < MAX_RETRIES && isRetryableError(error)) {
-          const delay = getRetryDelay(attempt);
+        if (attempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
+          const delay = computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS);
           const errorType = error instanceof ProviderError && error.statusCode === 429
             ? 'rate_limit'
             : error instanceof ProviderError && error.statusCode !== undefined && error.statusCode >= 500
               ? `server_error_${error.statusCode}`
               : 'network_error';
-          log.warn({ attempt: attempt + 1, maxRetries: MAX_RETRIES, delay, errorType, provider: this.name }, 'Retrying after transient error');
+          log.warn({ attempt: attempt + 1, maxRetries: DEFAULT_MAX_RETRIES, delay, errorType, provider: this.name }, 'Retrying after transient error');
           await sleep(delay);
           continue;
         }

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -5,31 +5,12 @@ import { registerTool } from '../registry.js';
 import { getConfig } from '../../config/loader.js';
 import { getSecureKey } from '../../security/secure-keys.js';
 import { getLogger } from '../../util/logger.js';
+import { getHttpRetryDelay, sleep, DEFAULT_MAX_RETRIES, DEFAULT_BASE_DELAY_MS } from '../../util/retry.js';
 
 const log = getLogger('web-search');
 
 const BRAVE_API_URL = 'https://api.search.brave.com/res/v1/web/search';
 const PERPLEXITY_API_URL = 'https://api.perplexity.ai/chat/completions';
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_BASE_DELAY_MS = 1000;
-
-/**
- * Parse a Retry-After header value into milliseconds.
- * RFC 7231 allows either delta-seconds (e.g. "120") or an HTTP-date
- * (e.g. "Tue, 17 Feb 2026 12:00:00 GMT"). Returns undefined if unparseable.
- */
-function parseRetryAfterMs(value: string): number | undefined {
-  const seconds = Number(value);
-  if (!isNaN(seconds)) {
-    return seconds * 1000;
-  }
-  // Try HTTP-date format — Date.parse handles RFC 2822 / IMF-fixdate
-  const dateMs = Date.parse(value);
-  if (!isNaN(dateMs)) {
-    return Math.max(0, dateMs - Date.now());
-  }
-  return undefined;
-}
 
 type WebSearchProvider = 'perplexity' | 'brave';
 
@@ -148,7 +129,7 @@ async function executeBraveSearch(
 
   const url = `${BRAVE_API_URL}?${params.toString()}`;
 
-  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(url, {
       headers: {
         'Accept': 'application/json',
@@ -169,12 +150,10 @@ async function executeBraveSearch(
       return { content: 'Error: Invalid or expired Brave Search API key', isError: true };
     }
 
-    if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-      const retryAfter = response.headers.get('retry-after');
-      const parsed = retryAfter ? parseRetryAfterMs(retryAfter) : undefined;
-      const delayMs = parsed ?? RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+    if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
+      const delayMs = getHttpRetryDelay(response, attempt, DEFAULT_BASE_DELAY_MS);
       log.warn({ attempt: attempt + 1, delayMs }, 'Brave Search rate limited, retrying');
-      await new Promise(resolve => setTimeout(resolve, delayMs));
+      await sleep(delayMs);
       continue;
     }
 
@@ -192,7 +171,7 @@ async function executePerplexitySearch(
   query: string,
   apiKey: string,
 ): Promise<ToolExecutionResult> {
-  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(PERPLEXITY_API_URL, {
       method: 'POST',
       headers: {
@@ -218,12 +197,10 @@ async function executePerplexitySearch(
       return { content: 'Error: Invalid or expired Perplexity API key', isError: true };
     }
 
-    if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-      const retryAfter = response.headers.get('retry-after');
-      const parsed = retryAfter ? parseRetryAfterMs(retryAfter) : undefined;
-      const delayMs = parsed ?? RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+    if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
+      const delayMs = getHttpRetryDelay(response, attempt, DEFAULT_BASE_DELAY_MS);
       log.warn({ attempt: attempt + 1, delayMs }, 'Perplexity rate limited, retrying');
-      await new Promise(resolve => setTimeout(resolve, delayMs));
+      await sleep(delayMs);
       continue;
     }
 

--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared retry utilities with exponential backoff + jitter.
+ *
+ * Used by both the provider retry layer (exception-based) and the
+ * web-search tool layer (HTTP response-based).
+ */
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default 3). */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff (default 1000). */
+  baseDelayMs?: number;
+}
+
+/**
+ * Compute a retry delay with equal jitter: guaranteed floor of cap/2
+ * plus random in [0, cap/2]. Prevents retry storms while ensuring
+ * retries never collapse to 0ms.
+ */
+export function computeRetryDelay(attempt: number, baseDelayMs = DEFAULT_BASE_DELAY_MS): number {
+  const cap = baseDelayMs * Math.pow(2, attempt);
+  const half = cap / 2;
+  return half + Math.random() * half;
+}
+
+/**
+ * Parse a Retry-After header value into milliseconds.
+ * RFC 7231 allows either delta-seconds (e.g. "120") or an HTTP-date
+ * (e.g. "Tue, 17 Feb 2026 12:00:00 GMT"). Returns undefined if unparseable.
+ */
+export function parseRetryAfterMs(value: string): number | undefined {
+  const seconds = Number(value);
+  if (!isNaN(seconds)) {
+    return seconds * 1000;
+  }
+  // Try HTTP-date format — Date.parse handles RFC 2822 / IMF-fixdate
+  const dateMs = Date.parse(value);
+  if (!isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
+}
+
+/**
+ * Determine the retry delay for an HTTP response. Uses the Retry-After
+ * header if present, otherwise falls back to exponential backoff with jitter.
+ */
+export function getHttpRetryDelay(
+  response: Response,
+  attempt: number,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+): number {
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) {
+    const parsed = parseRetryAfterMs(retryAfter);
+    if (parsed !== undefined) return parsed;
+  }
+  return computeRetryDelay(attempt, baseDelayMs);
+}
+
+/**
+ * Whether an HTTP status code is retryable (429 or 5xx).
+ */
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Whether an error is a retryable network error (ECONNRESET, ECONNREFUSED, etc.).
+ * Checks both the error itself and one level of `cause` chain.
+ */
+export function isRetryableNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const retryableCodes = new Set(['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE']);
+
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code && retryableCodes.has(code)) return true;
+
+  if (error.cause instanceof Error) {
+    const causeCode = (error.cause as NodeJS.ErrnoException).code;
+    if (causeCode && retryableCodes.has(causeCode)) return true;
+  }
+
+  return false;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export { DEFAULT_MAX_RETRIES, DEFAULT_BASE_DELAY_MS };


### PR DESCRIPTION
Extract a shared RetryStrategy utility from duplicated retry logic in web-search.ts and providers/retry.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
