### PR TITLE
perf: cache skill integrity hashes in memory with TTL

### DIFF
--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -80,6 +80,20 @@ function collectFiles(dir: string, base: string, ancestors: Set<string> = new Se
   return entries;
 }
 
+// ---------------------------------------------------------------------------
+// In-memory TTL cache for computed hashes — avoids redundant filesystem I/O
+// when the same skill directory is hashed multiple times within a short window.
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60_000; // 60 seconds
+
+interface CacheEntry {
+  hash: string;
+  expiresAt: number;
+}
+
+const hashCache = new Map<string, CacheEntry>();
+
 /**
  * Compute a deterministic version hash for a skill directory.
  *
@@ -90,8 +104,16 @@ function collectFiles(dir: string, base: string, ancestors: Set<string> = new Se
  *
  * The result is a canonical string in the format `v1:<hex-sha256>`.
  * File traversal order does not affect the result.
+ *
+ * Results are cached in memory for 60 seconds to avoid redundant disk reads.
  */
 export function computeSkillVersionHash(skillDir: string): string {
+  const now = Date.now();
+  const cached = hashCache.get(skillDir);
+  if (cached && now < cached.expiresAt) {
+    return cached.hash;
+  }
+
   const files = collectFiles(skillDir, skillDir);
   const hash = createHash('sha256');
 
@@ -106,5 +128,19 @@ export function computeSkillVersionHash(skillDir: string): string {
     hash.update('\n');
   }
 
-  return `v1:${hash.digest('hex')}`;
+  const result = `v1:${hash.digest('hex')}`;
+  hashCache.set(skillDir, { hash: result, expiresAt: now + CACHE_TTL_MS });
+  return result;
+}
+
+/**
+ * Invalidate the cached hash for a specific skill directory, or clear the
+ * entire cache if no directory is specified.
+ */
+export function invalidateSkillVersionHashCache(skillDir?: string): void {
+  if (skillDir) {
+    hashCache.delete(skillDir);
+  } else {
+    hashCache.clear();
+  }
 }


### PR DESCRIPTION
Add an in-memory cache with TTL for skill version hashes to avoid redundant filesystem I/O on every skill load.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
