### PR TITLE
perf: batch memory indexing jobs for reduced per-job overhead

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -76,6 +76,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     },
     jobs: {
       workerConcurrency: 2,
+      batchSize: 10,
     },
     retention: {
       keepRawForever: true,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -437,6 +437,11 @@ export const MemoryJobsConfigSchema = z.object({
     .int('memory.jobs.workerConcurrency must be an integer')
     .positive('memory.jobs.workerConcurrency must be a positive integer')
     .default(2),
+  batchSize: z
+    .number({ error: 'memory.jobs.batchSize must be a number' })
+    .int('memory.jobs.batchSize must be an integer')
+    .positive('memory.jobs.batchSize must be a positive integer')
+    .default(10),
 });
 
 export const MemoryRetentionConfigSchema = z.object({
@@ -648,6 +653,7 @@ export const MemoryConfigSchema = z.object({
   }),
   jobs: MemoryJobsConfigSchema.default({
     workerConcurrency: 2,
+    batchSize: 10,
   }),
   retention: MemoryRetentionConfigSchema.default({
     keepRawForever: true,
@@ -1168,6 +1174,7 @@ export const AssistantConfigSchema = z.object({
     },
     jobs: {
       workerConcurrency: 2,
+      batchSize: 10,
     },
     retention: {
       keepRawForever: true,

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -85,8 +85,9 @@ export async function runMemoryJobsOnce(
   // Periodic stale item sweep (throttled to at most once per hour)
   sweepStaleItems(config);
 
+  const batchSize = Math.max(1, config.memory.jobs.batchSize);
   const concurrency = Math.max(1, config.memory.jobs.workerConcurrency);
-  const jobs = claimMemoryJobs(concurrency);
+  const jobs = claimMemoryJobs(batchSize);
   if (jobs.length === 0) {
     if (enableScheduledCleanup) {
       maybeEnqueueScheduledCleanupJobs(config);
@@ -94,34 +95,45 @@ export async function runMemoryJobsOnce(
     return 0;
   }
 
+  // Process jobs concurrently (up to workerConcurrency at a time).
+  // Each job is isolated — a failure in one does not affect others.
   let processed = 0;
-  for (const job of jobs) {
-    try {
-      await processJob(job, config);
-      completeMemoryJob(job.id);
-      processed += 1;
-    } catch (err) {
-      if (err instanceof BackendUnavailableError) {
-        // Backend not configured yet -- put the job back with exponential backoff.
-        const result = deferMemoryJob(job.id);
-        if (result === 'failed') {
-          log.warn({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, job exceeded max deferrals');
-        } else {
-          log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
-        }
+  for (let i = 0; i < jobs.length; i += concurrency) {
+    const chunk = jobs.slice(i, i + concurrency);
+    const results = await Promise.allSettled(
+      chunk.map(async (job) => {
+        await processJob(job, config);
+        completeMemoryJob(job.id);
+      }),
+    );
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
+      if (result.status === 'fulfilled') {
+        processed += 1;
       } else {
-        const message = err instanceof Error ? err.message : String(err);
-        const category = classifyError(err);
-        if (category === 'retryable') {
-          const delay = retryDelayForAttempt(job.attempts + 1);
-          failMemoryJob(job.id, message, {
-            retryDelayMs: delay,
-            maxAttempts: RETRY_MAX_ATTEMPTS,
-          });
-          log.warn({ err, jobId: job.id, type: job.type, delay, category }, 'Memory job failed (retryable)');
+        const job = chunk[j];
+        const err = result.reason;
+        if (err instanceof BackendUnavailableError) {
+          const deferResult = deferMemoryJob(job.id);
+          if (deferResult === 'failed') {
+            log.warn({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, job exceeded max deferrals');
+          } else {
+            log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
+          }
         } else {
-          failMemoryJob(job.id, message, { maxAttempts: 1 });
-          log.warn({ err, jobId: job.id, type: job.type, category }, 'Memory job failed (fatal)');
+          const message = err instanceof Error ? err.message : String(err);
+          const category = classifyError(err);
+          if (category === 'retryable') {
+            const delay = retryDelayForAttempt(job.attempts + 1);
+            failMemoryJob(job.id, message, {
+              retryDelayMs: delay,
+              maxAttempts: RETRY_MAX_ATTEMPTS,
+            });
+            log.warn({ err, jobId: job.id, type: job.type, delay, category }, 'Memory job failed (retryable)');
+          } else {
+            failMemoryJob(job.id, message, { maxAttempts: 1 });
+            log.warn({ err, jobId: job.id, type: job.type, category }, 'Memory job failed (fatal)');
+          }
         }
       }
     }


### PR DESCRIPTION
Modify the memory jobs worker to fetch and process multiple pending jobs per poll cycle instead of one at a time. Jobs are now claimed in batches (configurable via memory.jobs.batchSize, default 10) and processed concurrently (up to workerConcurrency at a time) using Promise.allSettled for error isolation — a failure in one job does not affect others in the batch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
