### PR TITLE
fix: secret scanner false positive for doc placeholders

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -57,11 +57,13 @@ declare -a PATTERNS=(
 )
 
 # Ignore deterministic checksum/hash fixtures that are not credentials.
-# Also ignore Swift/TS function-parameter declarations (e.g. `clientSecret: String?`).
+# Also ignore Swift/TS function-parameter declarations (e.g. `clientSecret: String?`)
+# and documentation placeholders (e.g. `oauth2ClientSecret: "<optional>"`).
 declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
     "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
     "private[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
+    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<[^>]+>['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -128,6 +130,7 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_PARAM_LINE='public init(action: String, mode: String? = nil, clientId: String? = nil, clientSecret: String? = nil)'
     SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
     SAFE_SWIFT_DECL_LINE='public let clientSecret: String?'
+    SAFE_DOC_PLACEHOLDER_LINE='  oauth2ClientSecret: "<optional>",'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -247,6 +250,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_SWIFT_DECL_LINE" && ! matches_safe_line_pattern "$SAFE_SWIFT_DECL_LINE"; then
         echo -e "${RED}Self-test failed:${NC} Swift clientSecret end-of-line declaration false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DOC_PLACEHOLDER_LINE" && ! matches_safe_line_pattern "$SAFE_DOC_PLACEHOLDER_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} doc placeholder clientSecret false positive"
         exit 1
     fi
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2573,7 +2573,7 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
   allowedDomains: [],
   oauth2TokenUrl: "https://api.x.com/2/oauth2/token",
   oauth2ClientId: "<user's client ID>",
-  oauth2Credentials: "<optional — PKCE used by default>",
+  oauth2ClientSecret: "<optional>",
   grantedScopes: ["tweet.read", "tweet.write", "users.read", "offline.access"],
   expiresAt: <epoch ms>
 }


### PR DESCRIPTION
## Summary
- Add safe-line pattern to pre-commit hook for documentation placeholder values like `oauth2ClientSecret: "<optional>"` — values wrapped in `<angle brackets>` are clearly not real secrets
- Add self-test case for this false positive
- Restore the original `oauth2ClientSecret` field name in ARCHITECTURE.md (was renamed to work around the false positive in the previous PR)

## Original prompt
fix the false positive you ran into in the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
