### PR TITLE
Rename 'Force Prompt Side Effects' to 'In Temporary Chat'

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -80,7 +80,7 @@ struct ToolPermissionTesterView: View {
                     .foregroundColor(VColor.textSecondary)
                     .toggleStyle(.switch)
 
-                Toggle("Force Prompt Side Effects", isOn: $model.forcePromptSideEffects)
+                Toggle("In Temporary Chat", isOn: $model.forcePromptSideEffects)
                     .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
                     .toggleStyle(.switch)


### PR DESCRIPTION
## Summary
- Renamed the "Force Prompt Side Effects" toggle label to "In Temporary Chat" in the Permission Simulator UI for clarity

## Original prompt
Rename "Force Prompt Side Effects" to "In Temporary Chat"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
