### PR TITLE
refactor: remove Execution Target picker from Permission Simulator

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -875,7 +875,6 @@ exports[`IPC message snapshots ClientMessage types identity_get serializes to ex
 
 exports[`IPC message snapshots ClientMessage types tool_permission_simulate serializes to expected JSON 1`] = `
 {
-  "executionTarget": "host",
   "forcePromptSideEffects": false,
   "input": {
     "command": "rm -rf /tmp/test",
@@ -2426,6 +2425,7 @@ exports[`IPC message snapshots ServerMessage types identity_get_response seriali
 exports[`IPC message snapshots ServerMessage types tool_permission_simulate_response serializes to expected JSON 1`] = `
 {
   "decision": "prompt",
+  "executionTarget": "host",
   "promptPayload": {
     "allowlistOptions": [
       {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -550,7 +550,6 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     workingDir: '/projects/my-app',
     isInteractive: true,
     forcePromptSideEffects: false,
-    executionTarget: 'host',
   },
 };
 
@@ -1577,6 +1576,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       ],
       persistentDecisionsAllowed: true,
     },
+    executionTarget: 'host',
     matchedRuleId: undefined,
   },
 };

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -276,7 +276,8 @@ describe('tool_permission_simulate handler', () => {
     expect(res.matchedRuleId).toBeDefined();
   });
 
-  test('executionTarget: sandbox-scoped rule matches when simulated with sandbox target', async () => {
+  test('executionTarget: sandbox-scoped rule matches when tool resolves to sandbox', async () => {
+    // file_write resolves to 'sandbox' (no host_ prefix)
     addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
       executionTarget: 'sandbox',
     });
@@ -286,7 +287,6 @@ describe('tool_permission_simulate handler', () => {
       type: 'tool_permission_simulate',
       toolName: 'file_write',
       input: { path: '/tmp/test.txt', content: 'hello' },
-      executionTarget: 'sandbox',
     };
     await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
 
@@ -294,49 +294,42 @@ describe('tool_permission_simulate handler', () => {
     expect(res.success).toBe(true);
     expect(res.decision).toBe('allow');
     expect(res.matchedRuleId).toBeDefined();
+    expect(res.executionTarget).toBe('sandbox');
   });
 
-  test('executionTarget: sandbox-scoped rule does NOT match when simulated with host target', async () => {
-    addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
+  test('executionTarget: sandbox-scoped rule does NOT match when tool resolves to host', async () => {
+    // host_file_write resolves to 'host' (host_ prefix)
+    addRule('host_file_write', 'host_file_write:/tmp/**', 'everywhere', 'allow', 100, {
       executionTarget: 'sandbox',
     });
 
     const { ctx, sent } = createTestContext();
     const msg: ToolPermissionSimulateRequest = {
       type: 'tool_permission_simulate',
-      toolName: 'file_write',
+      toolName: 'host_file_write',
       input: { path: '/tmp/test.txt', content: 'hello' },
-      executionTarget: 'host',
     };
     await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
 
     const res = getResponse(sent);
     expect(res.success).toBe(true);
-    // The sandbox-scoped rule should not match a host target, so it falls
-    // through to the default prompt decision for medium-risk file_write.
+    // The sandbox-scoped rule should not match a host tool
     expect(res.decision).toBe('prompt');
     expect(res.matchedRuleId).toBeUndefined();
+    expect(res.executionTarget).toBe('host');
   });
 
-  test('executionTarget: sandbox-scoped rule does not match without a target in context', async () => {
-    addRule('file_write', 'file_write:/tmp/**', 'everywhere', 'allow', 100, {
-      executionTarget: 'sandbox',
-    });
-
+  test('executionTarget: response includes resolved execution target', async () => {
     const { ctx, sent } = createTestContext();
     const msg: ToolPermissionSimulateRequest = {
       type: 'tool_permission_simulate',
-      toolName: 'file_write',
-      input: { path: '/tmp/test.txt', content: 'hello' },
-      // no executionTarget — context.executionTarget will be undefined
+      toolName: 'host_bash',
+      input: { command: 'echo hi' },
     };
     await handleToolPermissionSimulate(msg, {} as net.Socket, ctx);
 
     const res = getResponse(sent);
     expect(res.success).toBe(true);
-    // A rule with executionTarget='sandbox' requires ctx.executionTarget='sandbox'.
-    // Without a target in the context, the rule should NOT match.
-    expect(res.decision).toBe('prompt');
-    expect(res.matchedRuleId).toBeUndefined();
+    expect(res.executionTarget).toBe('host');
   });
 });

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -4,6 +4,7 @@ import { initializeProviders } from '../../providers/registry.js';
 import { addRule, removeRule, updateRule, getAllRules, acceptStarterBundle } from '../../permissions/trust-store.js';
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../../permissions/checker.js';
 import { isSideEffectTool } from '../../tools/executor.js';
+import { resolveExecutionTarget } from '../../tools/execution-target.js';
 import { listSchedules, updateSchedule, deleteSchedule, describeCronExpression } from '../../schedule/schedule-store.js';
 import { listReminders, cancelReminder } from '../../tools/reminder/reminder-store.js';
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secure-keys.js';
@@ -1129,10 +1130,9 @@ export async function handleToolPermissionSimulate(
 
     const workingDir = msg.workingDir ?? process.cwd();
 
-    // Build policy context from optional execution-target field
-    const policyContext = msg.executionTarget
-      ? { executionTarget: msg.executionTarget as 'host' | 'sandbox' }
-      : undefined;
+    // Infer execution target from tool name
+    const executionTarget = resolveExecutionTarget(msg.toolName);
+    const policyContext = { executionTarget };
 
     const riskLevel = await classifyRisk(msg.toolName, msg.input, workingDir);
     const result = await check(msg.toolName, msg.input, workingDir, policyContext);
@@ -1176,6 +1176,7 @@ export async function handleToolPermissionSimulate(
       decision: result.decision,
       riskLevel,
       reason: result.reason,
+      executionTarget,
       matchedRuleId: result.matchedRule?.id,
       promptPayload,
     });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -956,8 +956,6 @@ export interface ToolPermissionSimulateRequest {
   isInteractive?: boolean;
   /** When true, side-effect tools that would normally be auto-allowed get promoted to prompt. */
   forcePromptSideEffects?: boolean;
-  /** Optional execution target override. */
-  executionTarget?: 'host' | 'sandbox';
 }
 
 export type ClientMessage =
@@ -2281,6 +2279,8 @@ export interface ToolPermissionSimulateResponse {
     scopeOptions: Array<{ label: string; scope: string }>;
     persistentDecisionsAllowed: boolean;
   };
+  /** Resolved execution target for the tool. */
+  executionTarget?: 'host' | 'sandbox';
   /** ID of the trust rule that matched (if any). */
   matchedRuleId?: string;
   /** Error message when success is false. */

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -17,7 +17,8 @@ struct SimulationResult: Equatable {
     // rather than whatever the user may have edited since.
     let snapshotToolName: String
     let snapshotInputJSON: String
-    let snapshotExecutionTarget: String
+    /// Execution target resolved by the daemon from the tool name.
+    let snapshotExecutionTarget: String?
 
     static func == (lhs: SimulationResult, rhs: SimulationResult) -> Bool {
         lhs.decision == rhs.decision
@@ -42,7 +43,6 @@ final class ToolPermissionTesterModel: ObservableObject {
     @Published var workingDir: String = ""
     @Published var isInteractive: Bool = true
     @Published var forcePromptSideEffects: Bool = false
-    @Published var executionTarget: String = ""
 
     // MARK: - Result State
 
@@ -59,7 +59,6 @@ final class ToolPermissionTesterModel: ObservableObject {
     // not whatever the user may have edited while the request was in flight.
     private var pendingSnapshotToolName: String = ""
     private var pendingSnapshotInputJSON: String = ""
-    private var pendingSnapshotExecutionTarget: String = ""
 
     init(daemonClient: DaemonClientProtocol) {
         self.daemonClient = daemonClient
@@ -87,7 +86,6 @@ final class ToolPermissionTesterModel: ObservableObject {
         // while the IPC round-trip is in flight).
         pendingSnapshotToolName = toolName
         pendingSnapshotInputJSON = inputJSON
-        pendingSnapshotExecutionTarget = executionTarget
 
         // Wire up the one-shot response callback before sending.
         if let dc = daemonClient as? DaemonClient {
@@ -104,8 +102,7 @@ final class ToolPermissionTesterModel: ObservableObject {
                 input: parsed,
                 workingDir: workingDir.isEmpty ? nil : workingDir,
                 isInteractive: isInteractive,
-                forcePromptSideEffects: forcePromptSideEffects,
-                executionTarget: executionTarget.isEmpty ? nil : executionTarget
+                forcePromptSideEffects: forcePromptSideEffects
             ))
         } catch {
             isSimulating = false
@@ -152,7 +149,7 @@ final class ToolPermissionTesterModel: ObservableObject {
                 scope: scope,
                 decision: "allow",
                 allowHighRisk: isHighRisk ? true : nil,
-                executionTarget: snapshot.snapshotExecutionTarget.isEmpty ? nil : snapshot.snapshotExecutionTarget
+                executionTarget: snapshot.snapshotExecutionTarget
             )
             // Re-simulate to show the updated outcome with the new rule in effect.
             simulate()
@@ -179,7 +176,7 @@ final class ToolPermissionTesterModel: ObservableObject {
             promptPayload: response.promptPayload,
             snapshotToolName: pendingSnapshotToolName,
             snapshotInputJSON: pendingSnapshotInputJSON,
-            snapshotExecutionTarget: pendingSnapshotExecutionTarget
+            snapshotExecutionTarget: response.executionTarget
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -86,19 +86,6 @@ struct ToolPermissionTesterView: View {
                     .toggleStyle(.switch)
             }
 
-            // Execution target
-            HStack(spacing: VSpacing.sm) {
-                fieldLabel("Execution Target")
-                Picker("", selection: $model.executionTarget) {
-                    Text("None").tag("")
-                    Text("Host").tag("host")
-                    Text("Sandbox").tag("sandbox")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .fixedSize()
-            }
-
         }
     }
 
@@ -172,7 +159,7 @@ struct ToolPermissionTesterView: View {
                         toolName: result.snapshotToolName,
                         input: parsed,
                         riskLevel: result.riskLevel,
-                        executionTarget: result.snapshotExecutionTarget.isEmpty ? nil : result.snapshotExecutionTarget,
+                        executionTarget: result.snapshotExecutionTarget,
                         promptPayload: payload
                     )
 

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -70,7 +70,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "allow", riskLevel: "low", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.toolName = "host_bash"
@@ -87,8 +87,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.workingDir = "/tmp"
         model.isInteractive = false
         model.forcePromptSideEffects = true
-        model.executionTarget = "host"
-
         model.simulate()
 
         XCTAssertEqual(sentMessages.count, 1)
@@ -98,14 +96,12 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         XCTAssertEqual(msg?.workingDir, "/tmp")
         XCTAssertEqual(msg?.isInteractive, false)
         XCTAssertEqual(msg?.forcePromptSideEffects, true)
-        XCTAssertEqual(msg?.executionTarget, "host")
     }
 
     func testSimulate_emptyOptionalFieldsSendNil() {
         model.toolName = "host_bash"
         model.inputJSON = "{}"
         model.workingDir = ""
-        model.executionTarget = ""
 
         model.simulate()
 
@@ -113,7 +109,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         let msg = sentMessages[0] as? ToolPermissionSimulateMessage
         XCTAssertNotNil(msg)
         XCTAssertNil(msg?.workingDir)
-        XCTAssertNil(msg?.executionTarget)
     }
 
     func testSimulate_invalidJSON_setsError() {
@@ -203,7 +198,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.allowOnce()
@@ -222,7 +217,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.denyOnce()
@@ -240,11 +235,10 @@ final class ToolPermissionTesterModelTests: XCTestCase {
     func testAlwaysAllow_sendsAddTrustRuleAndResimulates() {
         model.toolName = "host_bash"
         model.inputJSON = "{}"
-        model.executionTarget = "host"
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "host_bash", snapshotInputJSON: "{}", snapshotExecutionTarget: "host"
         )
 
         model.alwaysAllow(pattern: "echo *", scope: "project")
@@ -271,7 +265,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "high", reason: "dangerous",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.alwaysAllow(pattern: "rm -rf *", scope: "global")
@@ -288,7 +282,7 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "medium", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.alwaysAllow(pattern: "echo *", scope: "project")
@@ -302,11 +296,10 @@ final class ToolPermissionTesterModelTests: XCTestCase {
     func testAlwaysAllow_emptyMetadata_doesNotPassNilFields() {
         model.toolName = "host_bash"
         model.inputJSON = "{}"
-        model.executionTarget = ""
         model.lastResult = SimulationResult(
             decision: "prompt", riskLevel: "low", reason: "test",
             matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: ""
+            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
         )
 
         model.alwaysAllow(pattern: "*", scope: "global")
@@ -324,7 +317,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
         XCTAssertEqual(model.workingDir, "")
         XCTAssertTrue(model.isInteractive)
         XCTAssertFalse(model.forcePromptSideEffects)
-        XCTAssertEqual(model.executionTarget, "")
         XCTAssertFalse(model.isSimulating)
         XCTAssertNil(model.lastResult)
         XCTAssertNil(model.lastError)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -657,16 +657,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         input: [String: AnyCodable],
         workingDir: String? = nil,
         isInteractive: Bool? = nil,
-        forcePromptSideEffects: Bool? = nil,
-        executionTarget: String? = nil
+        forcePromptSideEffects: Bool? = nil
     ) throws {
         try send(ToolPermissionSimulateMessage(
             toolName: toolName,
             input: input,
             workingDir: workingDir,
             isInteractive: isInteractive,
-            forcePromptSideEffects: forcePromptSideEffects,
-            executionTarget: executionTarget
+            forcePromptSideEffects: forcePromptSideEffects
         ))
     }
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1766,8 +1766,6 @@ public struct IPCToolPermissionSimulateRequest: Codable, Sendable {
     public let isInteractive: Bool?
     /// When true, side-effect tools that would normally be auto-allowed get promoted to prompt.
     public let forcePromptSideEffects: Bool?
-    /// Optional execution target override.
-    public let executionTarget: String?
 }
 
 public struct IPCToolPermissionSimulateResponse: Codable, Sendable {
@@ -1781,6 +1779,8 @@ public struct IPCToolPermissionSimulateResponse: Codable, Sendable {
     public let reason: String?
     /// When decision is 'prompt', the data needed to render a ToolConfirmationBubble.
     public let promptPayload: IPCToolPermissionSimulateResponsePromptPayload?
+    /// Resolved execution target for the tool.
+    public let executionTarget: String?
     /// ID of the trust rule that matched (if any).
     public let matchedRuleId: String?
     /// Error message when success is false.

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1500,8 +1500,8 @@ extension IPCUpdateTrustRule {
 public typealias ToolPermissionSimulateMessage = IPCToolPermissionSimulateRequest
 
 extension IPCToolPermissionSimulateRequest {
-    public init(toolName: String, input: [String: AnyCodable], workingDir: String? = nil, isInteractive: Bool? = nil, forcePromptSideEffects: Bool? = nil, executionTarget: String? = nil) {
-        self.init(type: "tool_permission_simulate", toolName: toolName, input: input, workingDir: workingDir, isInteractive: isInteractive, forcePromptSideEffects: forcePromptSideEffects, executionTarget: executionTarget)
+    public init(toolName: String, input: [String: AnyCodable], workingDir: String? = nil, isInteractive: Bool? = nil, forcePromptSideEffects: Bool? = nil) {
+        self.init(type: "tool_permission_simulate", toolName: toolName, input: input, workingDir: workingDir, isInteractive: isInteractive, forcePromptSideEffects: forcePromptSideEffects)
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove the Execution Target picker from the Permission Simulator UI — it's redundant since the target is deterministic per tool name
- Daemon handler now infers execution target via `resolveExecutionTarget(toolName)` and always includes it in the simulation response
- Moved `executionTarget` from `ToolPermissionSimulateRequest` to `ToolPermissionSimulateResponse` in the IPC contract

## Original prompt
The Execution Target can be inferred from the Tool Name so we should remove it from here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
