### PR TITLE
feat: include tool input schemas in tool_names_list IPC response

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1193,10 +1193,18 @@ export async function handleToolPermissionSimulate(
 }
 
 export function handleToolNamesList(socket: net.Socket, ctx: HandlerContext): void {
-  const names = getAllTools()
-    .map((t) => t.name)
-    .sort((a, b) => a.localeCompare(b));
-  ctx.send(socket, { type: 'tool_names_list_response', names });
+  const tools = getAllTools();
+  const names = tools.map((t) => t.name).sort((a, b) => a.localeCompare(b));
+  const schemas: Record<string, import('../ipc-contract.js').ToolInputSchema> = {};
+  for (const tool of tools) {
+    try {
+      const def = tool.getDefinition();
+      schemas[tool.name] = def.input_schema as import('../ipc-contract.js').ToolInputSchema;
+    } catch {
+      // Skip tools whose definitions can't be resolved
+    }
+  }
+  ctx.send(socket, { type: 'tool_names_list_response', names, schemas });
 }
 
 export const configHandlers = defineHandlers({

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2292,10 +2292,23 @@ export interface ToolPermissionSimulateResponse {
   error?: string;
 }
 
+export interface ToolInputSchema {
+  type: 'object';
+  properties?: Record<string, {
+    type?: string;
+    description?: string;
+    enum?: string[];
+    [key: string]: unknown;
+  }>;
+  required?: string[];
+}
+
 export interface ToolNamesListResponse {
   type: 'tool_names_list_response';
   /** Sorted list of all registered tool names. */
   names: string[];
+  /** Input schemas keyed by tool name. */
+  schemas: Record<string, ToolInputSchema>;
 }
 
 export type ServerMessage =

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1743,6 +1743,12 @@ public struct IPCToolInputDelta: Codable, Sendable {
     public let sessionId: String?
 }
 
+public struct IPCToolInputSchema: Codable, Sendable {
+    public let type: String
+    public let properties: [String: AnyCodable]?
+    public let required: [String]?
+}
+
 public struct IPCToolNamesListRequest: Codable, Sendable {
     public let type: String
 }
@@ -1751,6 +1757,8 @@ public struct IPCToolNamesListResponse: Codable, Sendable {
     public let type: String
     /// Sorted list of all registered tool names.
     public let names: [String]
+    /// Input schemas keyed by tool name.
+    public let schemas: [String: AnyCodable]
 }
 
 public struct IPCToolOutputChunk: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Adds `ToolInputSchema` type to the IPC contract and extends `ToolNamesListResponse` to include a `schemas` field mapping each tool name to its JSON Schema
- Backend handler now iterates all tools, calls `getDefinition()`, and returns the `input_schema` alongside tool names
- Auto-generated Swift types updated to include the new field

This is backend plumbing for a follow-up PR that will replace the "Input JSON" textarea in the Permission Simulator with dynamic per-argument form fields.

## Original prompt
"Input JSON" is a bad UX since users need to know what all the different arguments to each tool are. Instead, this should be a series of inputs (1 per argument) that depends on the selected tool. Optional arguments should also have a checkbox (unchecked means omitted). If this is nontrivial, break it up into a series of trivial PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
