### PR TITLE
feat: dynamic per-argument fields in Permission Simulator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -29,6 +29,22 @@ struct SimulationResult: Equatable {
     }
 }
 
+/// Describes a single input parameter parsed from a tool's JSON Schema.
+struct ToolFieldDescriptor: Identifiable {
+    let id: String
+    let fieldType: FieldType
+    let description: String?
+    let isRequired: Bool
+
+    enum FieldType {
+        case string
+        case number
+        case integer
+        case boolean
+        case enumeration([String])
+    }
+}
+
 /// View-model for the tool permission simulation tester in Settings.
 ///
 /// Manages form fields, fires simulate requests via DaemonClient,
@@ -39,14 +55,26 @@ final class ToolPermissionTesterModel: ObservableObject {
     // MARK: - Form Fields
 
     @Published var toolName: String = ""
-    @Published var inputJSON: String = "{}"
     @Published var workingDir: String = ""
     @Published var isInteractive: Bool = true
     @Published var forcePromptSideEffects: Bool = false
 
-    // MARK: - Tool Names
+    // MARK: - Dynamic Input Fields
+
+    /// Field descriptors for the currently selected tool, derived from its schema.
+    @Published var fieldDescriptors: [ToolFieldDescriptor] = []
+    /// Current values keyed by field name. String fields, numbers, and enum selections
+    /// are all stored as strings; booleans stored as "true"/"false".
+    @Published var fieldValues: [String: String] = [:]
+    /// Whether each optional field is enabled (checked). Required fields are always enabled.
+    @Published var fieldEnabled: [String: Bool] = [:]
+
+    // MARK: - Tool Names & Schemas
 
     @Published var availableToolNames: [String] = []
+
+    /// Raw schemas keyed by tool name, received from the daemon.
+    private var toolSchemas: [String: Any] = [:]
 
     // MARK: - Result State
 
@@ -57,6 +85,7 @@ final class ToolPermissionTesterModel: ObservableObject {
     // MARK: - Dependencies
 
     private let daemonClient: DaemonClientProtocol
+    private var cancellables = Set<AnyCancellable>()
 
     // Snapshot of form values captured at simulate() time so
     // handleSimulateResponse uses the values that produced the request,
@@ -67,6 +96,14 @@ final class ToolPermissionTesterModel: ObservableObject {
     init(daemonClient: DaemonClientProtocol) {
         self.daemonClient = daemonClient
         fetchToolNames()
+
+        // Rebuild dynamic fields whenever the selected tool changes.
+        $toolName
+            .removeDuplicates()
+            .sink { [weak self] name in
+                self?.updateFieldsForTool(name)
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Tool Names Fetching
@@ -77,7 +114,14 @@ final class ToolPermissionTesterModel: ObservableObject {
 
         dc.onToolNamesListResponse = { [weak self] response in
             Task { @MainActor [weak self] in
-                self?.availableToolNames = response.names
+                guard let self else { return }
+                self.availableToolNames = response.names
+                // Store raw schemas from the response.
+                self.toolSchemas = Self.extractSchemas(from: response.schemas)
+                // Refresh fields if a tool is already selected.
+                if !self.toolName.isEmpty {
+                    self.updateFieldsForTool(self.toolName)
+                }
             }
         }
 
@@ -88,28 +132,156 @@ final class ToolPermissionTesterModel: ObservableObject {
         }
     }
 
+    // MARK: - Schema Parsing
+
+    /// Extract schemas dictionary from the AnyCodable response field.
+    private static func extractSchemas(from raw: [String: AnyCodable]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        for (key, value) in raw {
+            result[key] = value.value
+        }
+        return result
+    }
+
+    /// Rebuild field descriptors and reset values when the selected tool changes.
+    private func updateFieldsForTool(_ name: String) {
+        guard !name.isEmpty,
+              let schemaAny = toolSchemas[name],
+              let schema = schemaAny as? [String: Any],
+              let properties = schema["properties"] as? [String: Any]
+        else {
+            fieldDescriptors = []
+            fieldValues = [:]
+            fieldEnabled = [:]
+            return
+        }
+
+        let requiredNames = Set((schema["required"] as? [String]) ?? [])
+        var descriptors: [ToolFieldDescriptor] = []
+
+        // Sort properties alphabetically, but put required fields first.
+        let sortedKeys = properties.keys.sorted { a, b in
+            let aReq = requiredNames.contains(a)
+            let bReq = requiredNames.contains(b)
+            if aReq != bReq { return aReq }
+            return a < b
+        }
+
+        for key in sortedKeys {
+            guard let propAny = properties[key] else { continue }
+            let prop = propAny as? [String: Any] ?? [:]
+            let isRequired = requiredNames.contains(key)
+            let description = prop["description"] as? String
+
+            let fieldType: ToolFieldDescriptor.FieldType
+            if let enumValues = prop["enum"] as? [String] {
+                fieldType = .enumeration(enumValues)
+            } else {
+                let typeStr = prop["type"] as? String ?? "string"
+                switch typeStr {
+                case "boolean": fieldType = .boolean
+                case "number": fieldType = .number
+                case "integer": fieldType = .integer
+                default: fieldType = .string
+                }
+            }
+
+            descriptors.append(ToolFieldDescriptor(
+                id: key,
+                fieldType: fieldType,
+                description: description,
+                isRequired: isRequired
+            ))
+        }
+
+        fieldDescriptors = descriptors
+
+        // Reset values: keep existing values for fields that still exist,
+        // add defaults for new fields.
+        var newValues: [String: String] = [:]
+        var newEnabled: [String: Bool] = [:]
+        for desc in descriptors {
+            if let existing = fieldValues[desc.id] {
+                newValues[desc.id] = existing
+            } else {
+                switch desc.fieldType {
+                case .boolean:
+                    newValues[desc.id] = "false"
+                default:
+                    newValues[desc.id] = ""
+                }
+            }
+            newEnabled[desc.id] = fieldEnabled[desc.id] ?? desc.isRequired
+        }
+        fieldValues = newValues
+        fieldEnabled = newEnabled
+    }
+
+    // MARK: - Building Input
+
+    /// Build the input dictionary from the dynamic field values.
+    func buildInputFromFields() -> [String: AnyCodable] {
+        var result: [String: AnyCodable] = [:]
+        for field in fieldDescriptors {
+            // Skip disabled optional fields
+            if !field.isRequired && !(fieldEnabled[field.id] ?? false) {
+                continue
+            }
+            let value = fieldValues[field.id] ?? ""
+
+            switch field.fieldType {
+            case .string:
+                result[field.id] = AnyCodable(value)
+            case .number:
+                if let num = Double(value) {
+                    result[field.id] = AnyCodable(num)
+                } else if !value.isEmpty {
+                    result[field.id] = AnyCodable(value)
+                }
+            case .integer:
+                if let num = Int(value) {
+                    result[field.id] = AnyCodable(num)
+                } else if !value.isEmpty {
+                    result[field.id] = AnyCodable(value)
+                }
+            case .boolean:
+                result[field.id] = AnyCodable(value == "true")
+            case .enumeration:
+                if !value.isEmpty {
+                    result[field.id] = AnyCodable(value)
+                }
+            }
+        }
+        return result
+    }
+
+    /// Serialize the current field values to a JSON string for snapshots.
+    private func buildInputJSONString() -> String {
+        let input = buildInputFromFields()
+        guard !input.isEmpty else { return "{}" }
+        do {
+            let data = try JSONEncoder().encode(input)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            return "{}"
+        }
+    }
+
     // MARK: - Actions
 
-    /// Parse inputJSON, send a simulate request via IPC, and update result state.
+    /// Build input from fields, send a simulate request via IPC, and update result state.
     func simulate() {
         lastError = nil
         lastResult = nil
 
-        let parsed: [String: AnyCodable]
-        do {
-            parsed = try parseInputJSON(inputJSON)
-        } catch {
-            lastError = "Invalid JSON: \(error.localizedDescription)"
-            return
-        }
-
+        let parsed = buildInputFromFields()
         isSimulating = true
 
         // Capture form values now so the snapshot reflects the state at
         // request time, not at response time (the user may edit the form
         // while the IPC round-trip is in flight).
         pendingSnapshotToolName = toolName
-        pendingSnapshotInputJSON = inputJSON
+        pendingSnapshotInputJSON = buildInputJSONString()
 
         // Wire up the one-shot response callback before sending.
         if let dc = daemonClient as? DaemonClient {

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -34,20 +34,8 @@ struct ToolPermissionTesterView: View {
             fieldLabel("Tool Name")
             toolNamePicker
 
-            // Input JSON
-            fieldLabel("Input JSON")
-            TextEditor(text: $model.inputJSON)
-                .font(VFont.monoSmall)
-                .foregroundColor(VColor.textPrimary)
-                .scrollContentBackground(.hidden)
-                .padding(VSpacing.xs)
-                .frame(minHeight: 60, maxHeight: 120)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
+            // Dynamic input fields based on schema
+            toolInputFields
 
             // Working directory
             fieldLabel("Working Directory")
@@ -77,6 +65,148 @@ struct ToolPermissionTesterView: View {
             }
 
         }
+    }
+
+    // MARK: - Dynamic Tool Input Fields
+
+    @ViewBuilder
+    private var toolInputFields: some View {
+        if !model.fieldDescriptors.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                fieldLabel("Parameters")
+
+                ForEach(model.fieldDescriptors) { field in
+                    toolFieldRow(field)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func toolFieldRow(_ field: ToolFieldDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            if field.isRequired {
+                // Required fields are always shown
+                fieldNameLabel(field)
+                toolFieldInput(field)
+            } else {
+                // Optional fields have a checkbox
+                HStack(spacing: VSpacing.xs) {
+                    Toggle(isOn: fieldEnabledBinding(for: field.id)) {
+                        fieldNameLabel(field)
+                    }
+                    .toggleStyle(.checkbox)
+                }
+
+                if model.fieldEnabled[field.id] == true {
+                    toolFieldInput(field)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func fieldNameLabel(_ field: ToolFieldDescriptor) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(field.id)
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.textPrimary)
+
+            if field.isRequired {
+                Text("*")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.error)
+            }
+
+            if let desc = field.description {
+                Text(desc)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func toolFieldInput(_ field: ToolFieldDescriptor) -> some View {
+        switch field.fieldType {
+        case .string:
+            TextField("", text: fieldValueBinding(for: field.id))
+                .textFieldStyle(.plain)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.sm)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+
+        case .number, .integer:
+            TextField("", text: fieldValueBinding(for: field.id))
+                .textFieldStyle(.plain)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.sm)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+
+        case .boolean:
+            Toggle("", isOn: fieldBoolBinding(for: field.id))
+                .toggleStyle(.switch)
+                .labelsHidden()
+
+        case .enumeration(let values):
+            Picker("", selection: fieldValueBinding(for: field.id)) {
+                Text("Select\u{2026}")
+                    .foregroundColor(VColor.textMuted)
+                    .tag("")
+                ForEach(values, id: \.self) { value in
+                    Text(value)
+                        .font(VFont.mono)
+                        .tag(value)
+                }
+            }
+            .labelsHidden()
+            .font(VFont.mono)
+            .padding(.vertical, VSpacing.xs)
+            .padding(.horizontal, VSpacing.sm)
+            .background(VColor.surface)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+            )
+        }
+    }
+
+    // MARK: - Bindings
+
+    private func fieldValueBinding(for key: String) -> Binding<String> {
+        Binding(
+            get: { model.fieldValues[key] ?? "" },
+            set: { model.fieldValues[key] = $0 }
+        )
+    }
+
+    private func fieldEnabledBinding(for key: String) -> Binding<Bool> {
+        Binding(
+            get: { model.fieldEnabled[key] ?? false },
+            set: { model.fieldEnabled[key] = $0 }
+        )
+    }
+
+    private func fieldBoolBinding(for key: String) -> Binding<Bool> {
+        Binding(
+            get: { model.fieldValues[key] == "true" },
+            set: { model.fieldValues[key] = $0 ? "true" : "false" }
+        )
     }
 
     // MARK: - Simulate Button


### PR DESCRIPTION
## Summary
- Replaces the "Input JSON" textarea with dynamic form fields that adapt to the selected tool's JSON Schema
- Required parameters are always shown (marked with `*`); optional parameters have a checkbox to enable/disable
- Supports string, number, integer, boolean (toggle), and enum (picker) field types
- Field values are automatically assembled into the correct JSON for the simulation request

## Original prompt
"Input JSON" is a bad UX since users need to know what all the different arguments to each tool are. Instead, this should be a series of inputs (1 per argument) that depends on the selected tool. Optional arguments should also have a checkbox (unchecked means omitted). If this is nontrivial, break it up into a series of trivial PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
