### PR TITLE
fix: assert authorization in credential vault transient test

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -101,6 +101,7 @@ describe('CredentialBroker transient credentials', () => {
 
     // Second authorize + consume should NOT have the transient value
     const auth2 = broker.authorize({ service: 'svc', field: 'key', toolName: 'tool1' });
+    expect(auth2.authorized).toBe(true);
     if (!auth2.authorized) return;
     const result2 = broker.consume(auth2.token.tokenId);
     expect(result2.success).toBe(true);


### PR DESCRIPTION
Address Codex review feedback on PR #6544: replace early return with explicit assertion in transient credential vault test to prevent silent pass on authorization regression.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
