### PR TITLE
fix: preserve trace ID and pass original request for WebSocket upgrades

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -69,7 +69,7 @@ function main() {
 
       // Attach a trace ID to every non-healthcheck request for
       // end-to-end correlation across webhook → runtime → reply.
-      const traceId = generateTraceId();
+      const traceId = req.headers.get("x-trace-id") || generateTraceId();
       const headers = new Headers(req.headers);
       headers.set("x-trace-id", traceId);
       const tracedReq = new Request(req, { headers });
@@ -120,7 +120,7 @@ function main() {
       }
 
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
-        const upgradeResult = handleTwilioRelayWs(tracedReq, server);
+        const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
         return undefined as unknown as Response;


### PR DESCRIPTION
Address review feedback on PR #6549: (1) pass original request object to Twilio relay WebSocket upgrade instead of cloned tracedReq (Codex P1), (2) preserve incoming x-trace-id header for callback correlation instead of always generating a new one (Devin P1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
