### PR TITLE
fix: enforce minimum 1s backoff for 429 retries without Retry-After

### DIFF
--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -58,7 +58,10 @@ export function getHttpRetryDelay(
     const parsed = parseRetryAfterMs(retryAfter);
     if (parsed !== undefined) return parsed;
   }
-  return computeRetryDelay(attempt, baseDelayMs);
+  // Enforce a minimum floor of baseDelayMs when Retry-After is missing.
+  // computeRetryDelay uses equal jitter (cap/2 + random*cap/2) which can
+  // dip to ~500ms on attempt 0 — too aggressive for 429 rate limits.
+  return Math.max(baseDelayMs, computeRetryDelay(attempt, baseDelayMs));
 }
 
 /**


### PR DESCRIPTION
Address Codex review feedback on PR #6551: add minimum 1000ms floor to retry delay for 429 responses when Retry-After header is missing, preventing overly aggressive retries that exhaust rate limit windows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
