### PR TITLE
fix: remove TTL cache from security-critical skill version hash

### DIFF
--- a/assistant/src/skills/version-hash.ts
+++ b/assistant/src/skills/version-hash.ts
@@ -80,20 +80,6 @@ function collectFiles(dir: string, base: string, ancestors: Set<string> = new Se
   return entries;
 }
 
-// ---------------------------------------------------------------------------
-// In-memory TTL cache for computed hashes — avoids redundant filesystem I/O
-// when the same skill directory is hashed multiple times within a short window.
-// ---------------------------------------------------------------------------
-
-const CACHE_TTL_MS = 60_000; // 60 seconds
-
-interface CacheEntry {
-  hash: string;
-  expiresAt: number;
-}
-
-const hashCache = new Map<string, CacheEntry>();
-
 /**
  * Compute a deterministic version hash for a skill directory.
  *
@@ -104,16 +90,8 @@ const hashCache = new Map<string, CacheEntry>();
  *
  * The result is a canonical string in the format `v1:<hex-sha256>`.
  * File traversal order does not affect the result.
- *
- * Results are cached in memory for 60 seconds to avoid redundant disk reads.
  */
 export function computeSkillVersionHash(skillDir: string): string {
-  const now = Date.now();
-  const cached = hashCache.get(skillDir);
-  if (cached && now < cached.expiresAt) {
-    return cached.hash;
-  }
-
   const files = collectFiles(skillDir, skillDir);
   const hash = createHash('sha256');
 
@@ -128,19 +106,5 @@ export function computeSkillVersionHash(skillDir: string): string {
     hash.update('\n');
   }
 
-  const result = `v1:${hash.digest('hex')}`;
-  hashCache.set(skillDir, { hash: result, expiresAt: now + CACHE_TTL_MS });
-  return result;
-}
-
-/**
- * Invalidate the cached hash for a specific skill directory, or clear the
- * entire cache if no directory is specified.
- */
-export function invalidateSkillVersionHashCache(skillDir?: string): void {
-  if (skillDir) {
-    hashCache.delete(skillDir);
-  } else {
-    hashCache.clear();
-  }
+  return `v1:${hash.digest('hex')}`;
 }


### PR DESCRIPTION
Address Codex P1 + Devin P1 review feedback on PR #6552: remove the in-memory TTL cache from computeSkillVersionHash. The cache created a 60-second window where modified skills could bypass version-bound trust checks, which is a security regression. Always compute hash from disk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
