### PR TITLE
fix: use exec in qdrant test fake binaries to prevent orphan processes

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -169,7 +169,7 @@ describe('QdrantManager', () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
 
       // Binary that stays alive. We'll stop it before readyz times out.
-      placeFakeBinary('#!/bin/sh\nsleep 300');
+      placeFakeBinary('#!/bin/sh\nexec sleep 300');
 
       const port = getTestPort();
       const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
@@ -198,7 +198,7 @@ describe('QdrantManager', () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
 
       // Binary that ignores SIGTERM
-      placeFakeBinary('#!/bin/sh\ntrap "" TERM\nsleep 300');
+      placeFakeBinary('#!/bin/sh\ntrap "" TERM\nexec sleep 300');
 
       const port = getTestPort();
       const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
@@ -227,7 +227,7 @@ describe('QdrantManager', () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
 
       // Binary that stays alive but never serves readyz
-      placeFakeBinary('#!/bin/sh\nsleep 300');
+      placeFakeBinary('#!/bin/sh\nexec sleep 300');
 
       const port = getTestPort();
       const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });


### PR DESCRIPTION
Address Codex review feedback on PR #6556: add exec before sleep in fake binary scripts so sleep replaces the shell process and receives SIGTERM/SIGKILL directly, preventing orphaned sleep processes during test runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
