### PR TITLE
fix: serialize same-type memory jobs to prevent checkpoint races

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -95,53 +95,80 @@ export async function runMemoryJobsOnce(
     return 0;
   }
 
-  // Process jobs concurrently (up to workerConcurrency at a time).
-  // Each job is isolated — a failure in one does not affect others.
+  // Group jobs by type so same-type jobs run sequentially (preventing
+  // checkpoint races for backfill, etc.), while different types run concurrently.
+  const jobsByType = new Map<string, MemoryJob[]>();
+  for (const job of jobs) {
+    let group = jobsByType.get(job.type);
+    if (!group) {
+      group = [];
+      jobsByType.set(job.type, group);
+    }
+    group.push(job);
+  }
+
   let processed = 0;
-  for (let i = 0; i < jobs.length; i += concurrency) {
-    const chunk = jobs.slice(i, i + concurrency);
-    const results = await Promise.allSettled(
-      chunk.map(async (job) => {
-        await processJob(job, config);
-        completeMemoryJob(job.id);
-      }),
-    );
-    for (let j = 0; j < results.length; j++) {
-      const result = results[j];
-      if (result.status === 'fulfilled') {
-        processed += 1;
-      } else {
-        const job = chunk[j];
-        const err = result.reason;
-        if (err instanceof BackendUnavailableError) {
-          const deferResult = deferMemoryJob(job.id);
-          if (deferResult === 'failed') {
-            log.warn({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, job exceeded max deferrals');
-          } else {
-            log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
-          }
-        } else {
-          const message = err instanceof Error ? err.message : String(err);
-          const category = classifyError(err);
-          if (category === 'retryable') {
-            const delay = retryDelayForAttempt(job.attempts + 1);
-            failMemoryJob(job.id, message, {
-              retryDelayMs: delay,
-              maxAttempts: RETRY_MAX_ATTEMPTS,
-            });
-            log.warn({ err, jobId: job.id, type: job.type, delay, category }, 'Memory job failed (retryable)');
-          } else {
-            failMemoryJob(job.id, message, { maxAttempts: 1 });
-            log.warn({ err, jobId: job.id, type: job.type, category }, 'Memory job failed (fatal)');
+  const typeGroups = [...jobsByType.values()];
+
+  // Run type groups concurrently (up to workerConcurrency at a time).
+  // Within each group, jobs are processed sequentially.
+  for (let i = 0; i < typeGroups.length; i += concurrency) {
+    const groupChunk = typeGroups.slice(i, i + concurrency);
+    const groupResults = await Promise.allSettled(
+      groupChunk.map(async (group) => {
+        let groupProcessed = 0;
+        for (const job of group) {
+          try {
+            await processJob(job, config);
+            completeMemoryJob(job.id);
+            groupProcessed += 1;
+          } catch (err) {
+            handleJobError(job, err);
           }
         }
+        return groupProcessed;
+      }),
+    );
+    for (const result of groupResults) {
+      if (result.status === 'fulfilled') {
+        processed += result.value;
       }
+      // Errors within groups are already handled per-job above;
+      // a rejected group promise would only come from an unexpected
+      // error in the loop itself, which is unlikely.
     }
   }
   if (enableScheduledCleanup) {
     maybeEnqueueScheduledCleanupJobs(config);
   }
   return processed;
+}
+
+// ── Job error handling ─────────────────────────────────────────────
+
+function handleJobError(job: MemoryJob, err: unknown): void {
+  if (err instanceof BackendUnavailableError) {
+    const result = deferMemoryJob(job.id);
+    if (result === 'failed') {
+      log.warn({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, job exceeded max deferrals');
+    } else {
+      log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
+    }
+  } else {
+    const message = err instanceof Error ? err.message : String(err);
+    const category = classifyError(err);
+    if (category === 'retryable') {
+      const delay = retryDelayForAttempt(job.attempts + 1);
+      failMemoryJob(job.id, message, {
+        retryDelayMs: delay,
+        maxAttempts: RETRY_MAX_ATTEMPTS,
+      });
+      log.warn({ err, jobId: job.id, type: job.type, delay, category }, 'Memory job failed (retryable)');
+    } else {
+      failMemoryJob(job.id, message, { maxAttempts: 1 });
+      log.warn({ err, jobId: job.id, type: job.type, category }, 'Memory job failed (fatal)');
+    }
+  }
 }
 
 // ── Job dispatch ───────────────────────────────────────────────────


### PR DESCRIPTION
Address Codex review feedback on PR #6553: group jobs by type within concurrent chunks and serialize same-type jobs to prevent backfill checkpoint races that could cause duplicate indexing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
