### PR TITLE
fix: guard against non-string patterns when precompiling trust rules

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -28,12 +28,21 @@ let cachedStarterBundleAccepted: boolean | null = null;
  */
 const compiledPatterns = new Map<string, Minimatch>();
 
-/** Get or compile a Minimatch object for the given pattern. */
-function getCompiledPattern(pattern: string): Minimatch {
+/** Get or compile a Minimatch object for the given pattern. Returns null if the pattern is invalid. */
+function getCompiledPattern(pattern: string): Minimatch | null {
   let compiled = compiledPatterns.get(pattern);
   if (!compiled) {
-    compiled = new Minimatch(pattern);
-    compiledPatterns.set(pattern, compiled);
+    if (typeof pattern !== 'string') {
+      log.warn({ pattern }, 'Cannot compile non-string pattern');
+      return null;
+    }
+    try {
+      compiled = new Minimatch(pattern);
+      compiledPatterns.set(pattern, compiled);
+    } catch (err) {
+      log.warn({ pattern, err }, 'Failed to compile pattern');
+      return null;
+    }
   }
   return compiled;
 }
@@ -42,8 +51,16 @@ function getCompiledPattern(pattern: string): Minimatch {
 function rebuildPatternCache(rules: TrustRule[]): void {
   compiledPatterns.clear();
   for (const rule of rules) {
+    if (typeof rule.pattern !== 'string') {
+      log.warn({ ruleId: rule.id, pattern: rule.pattern }, 'Skipping rule with non-string pattern during cache rebuild');
+      continue;
+    }
     if (!compiledPatterns.has(rule.pattern)) {
-      compiledPatterns.set(rule.pattern, new Minimatch(rule.pattern));
+      try {
+        compiledPatterns.set(rule.pattern, new Minimatch(rule.pattern));
+      } catch (err) {
+        log.warn({ ruleId: rule.id, pattern: rule.pattern, err }, 'Skipping rule with invalid pattern during cache rebuild');
+      }
     }
   }
 }
@@ -391,7 +408,8 @@ function findRuleByDecision(tool: string, command: string, scope: string, decisi
   for (const rule of rules) {
     if (rule.tool !== tool) continue;
     if (rule.decision !== decision) continue;
-    if (!getCompiledPattern(rule.pattern).match(command)) continue;
+    const compiled = getCompiledPattern(rule.pattern);
+    if (!compiled || !compiled.match(command)) continue;
     if (!matchesScope(rule.scope, scope)) continue;
     return rule;
   }
@@ -436,6 +454,7 @@ export function findHighestPriorityRule(tool: string, commands: string[], scope:
     if (!matchesScope(rule.scope, scope)) continue;
     if (!matchesExecutionTarget(rule, ctx)) continue;
     const compiled = getCompiledPattern(rule.pattern);
+    if (!compiled) continue;
     for (const command of commands) {
       if (compiled.match(command)) {
         return rule;


### PR DESCRIPTION
Address Codex review feedback on PR #6546: add validation and try-catch around Minimatch precompilation to skip malformed trust rules instead of breaking all permission checks when trust.json is corrupted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
