### PR TITLE
fix: restrict secret scanner allowlist to known placeholder values

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -63,7 +63,7 @@ declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
     "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
     "private[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
-    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<[^>]+>['\"]"
+    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here)>['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -131,6 +131,7 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
     SAFE_SWIFT_DECL_LINE='public let clientSecret: String?'
     SAFE_DOC_PLACEHOLDER_LINE='  oauth2ClientSecret: "<optional>",'
+    UNSAFE_ANGLEBRACKET_SECRET='clientSecret: "<abcDEF1234567890>"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -254,6 +255,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_DOC_PLACEHOLDER_LINE" && ! matches_safe_line_pattern "$SAFE_DOC_PLACEHOLDER_LINE"; then
         echo -e "${RED}Self-test failed:${NC} doc placeholder clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_ANGLEBRACKET_SECRET" && matches_safe_line_pattern "$UNSAFE_ANGLEBRACKET_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} angle-bracket-wrapped real secret was incorrectly whitelisted"
         exit 1
     fi
 


### PR DESCRIPTION
Address Codex review feedback on PR #6558: narrow the safe-line regex for secret placeholders to only match known sentinel values (e.g., optional, required, placeholder, none, your-*-here) instead of any angle-bracket-wrapped value, closing a false-negative path for real secrets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
