### PR TITLE
fix: preserve permission scope boundaries after principal kind removal

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -228,6 +228,22 @@ function loadFromDisk(): TrustRule[] {
         log.info({ ruleCount: rules.length }, 'Migrated v2 trust rules to v3 (principal fields)');
       } else if (data.version === TRUST_FILE_VERSION) {
         rules = rawRules;
+
+        // Strip legacy principal-scoped fields from persisted v3 rules.
+        // Before the principal concept was removed, rules could carry
+        // principalKind/principalId/principalVersion which acted as scope
+        // constraints. Now that matching ignores those fields, leaving them
+        // on loaded rules would silently widen their scope to global
+        // wildcards. Stripping them and re-saving prevents scope escalation.
+        for (const rule of rules) {
+          const r = rule as Record<string, unknown>;
+          if ('principalKind' in r || 'principalId' in r || 'principalVersion' in r) {
+            delete r.principalKind;
+            delete r.principalId;
+            delete r.principalVersion;
+            needsSave = true;
+          }
+        }
       } else if (data.version !== 1) {
         log.warn({ version: data.version }, 'Unknown trust file version, applying defaults in-memory only');
         // Apply default deny rules in-memory so the assistant is still

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -200,7 +200,9 @@ export async function handleAddTrustRule(
   }
 
   try {
-    addRule(confirmation.toolName, pattern, scope, decision);
+    addRule(confirmation.toolName, pattern, scope, decision, undefined, {
+      executionTarget: confirmation.executionTarget,
+    });
     log.info(
       { tool: confirmation.toolName, pattern, scope, decision, runId },
       'Trust rule added via HTTP (bound to pending confirmation)',


### PR DESCRIPTION
Address Codex P1 review feedback on PR #6557: (1) migrate/strip legacy principal-scoped trust rules during loading to prevent scope escalation, (2) persist executionTarget when saving run-scoped trust rules to prevent sandbox approvals becoming unscoped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
