### PR TITLE
fix: preserve execution target for unresolved tools in permission simulator

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -5,7 +5,7 @@ import { addRule, removeRule, updateRule, getAllRules, acceptStarterBundle } fro
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../../permissions/checker.js';
 import { isSideEffectTool } from '../../tools/executor.js';
 import { resolveExecutionTarget } from '../../tools/execution-target.js';
-import { getAllTools } from '../../tools/registry.js';
+import { getAllTools, getTool } from '../../tools/registry.js';
 import { listSchedules, updateSchedule, deleteSchedule, describeCronExpression } from '../../schedule/schedule-store.js';
 import { listReminders, cancelReminder } from '../../tools/reminder/reminder-store.js';
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secure-keys.js';
@@ -1122,9 +1122,11 @@ export async function handleToolPermissionSimulate(
 
     const workingDir = msg.workingDir ?? process.cwd();
 
-    // Infer execution target from tool name
-    const executionTarget = resolveExecutionTarget(msg.toolName);
-    const policyContext = { executionTarget };
+    // Only infer execution target when the tool is actually registered;
+    // for unresolved tools, leave it undefined so trust rules are unscoped.
+    const isRegistered = getTool(msg.toolName) !== undefined;
+    const executionTarget = isRegistered ? resolveExecutionTarget(msg.toolName) : undefined;
+    const policyContext = executionTarget ? { executionTarget } : undefined;
 
     const riskLevel = await classifyRisk(msg.toolName, msg.input, workingDir);
     const result = await check(msg.toolName, msg.input, workingDir, policyContext);


### PR DESCRIPTION
Address Codex review feedback on PR #6560: only infer executionTarget when the tool is actually registered. For unresolved tools, leave it undefined so trust rules are unscoped, preventing mis-scoped sandbox rules for host-backed skill tools.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
