### PR TITLE
fix: move fetchToolNames out of init and fix test pollution

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -95,7 +95,6 @@ final class ToolPermissionTesterModel: ObservableObject {
 
     init(daemonClient: DaemonClientProtocol) {
         self.daemonClient = daemonClient
-        fetchToolNames()
 
         // Rebuild dynamic fields whenever the selected tool changes.
         $toolName
@@ -109,6 +108,10 @@ final class ToolPermissionTesterModel: ObservableObject {
     // MARK: - Tool Names Fetching
 
     /// Request the list of all registered tool names from the daemon.
+    ///
+    /// Call this after init (e.g. from `onAppear`) rather than from init itself
+    /// to avoid polluting test `sentMessages` and to allow connection-state
+    /// retries.
     func fetchToolNames() {
         guard let dc = daemonClient as? DaemonClient else { return }
 
@@ -125,10 +128,23 @@ final class ToolPermissionTesterModel: ObservableObject {
             }
         }
 
+        // Retry when the daemon connection (re)connects, so the dropdown
+        // populates even if the initial send fails.
+        dc.$isConnected
+            .removeDuplicates()
+            .filter { $0 }
+            .sink { [weak self] _ in
+                guard let self,
+                      let dc = self.daemonClient as? DaemonClient else { return }
+                try? dc.sendToolNamesList()
+            }
+            .store(in: &cancellables)
+
+        // Also attempt immediately if already connected.
         do {
             try dc.sendToolNamesList()
         } catch {
-            // Non-critical — the user can still type tool names manually.
+            // Non-critical — the retry subscription above will handle reconnects.
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -23,6 +23,9 @@ struct ToolPermissionTesterView: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+        .onAppear {
+            model.fetchToolNames()
+        }
     }
 
     // MARK: - Form Fields


### PR DESCRIPTION
## Summary
- Move `fetchToolNames()` out of `ToolPermissionTesterModel.init` to prevent test pollution in `sentMessages` (Devin P1 on #6562)
- Add connection-state-aware retry via Combine subscription on `DaemonClient.$isConnected` so the dropdown populates even if the initial fetch fails (Codex P2 on #6562)
- `ToolPermissionTesterView.onAppear` now triggers `fetchToolNames()`

## Test plan
- [ ] Verify tool name dropdown populates when Settings panel opens with an active daemon connection
- [ ] Verify dropdown retries and populates after daemon reconnects
- [ ] Verify existing `ToolPermissionTesterModelTests` pass without `sentMessages` pollution from init
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
