### PR TITLE
fix: make schemas optional in tool_names_list_response for backward compat

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -2308,7 +2308,7 @@ export interface ToolNamesListResponse {
   /** Sorted list of all registered tool names. */
   names: string[];
   /** Input schemas keyed by tool name. */
-  schemas: Record<string, ToolInputSchema>;
+  schemas?: Record<string, ToolInputSchema>;
 }
 
 export type ServerMessage =

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -117,7 +117,7 @@ final class ToolPermissionTesterModel: ObservableObject {
                 guard let self else { return }
                 self.availableToolNames = response.names
                 // Store raw schemas from the response.
-                self.toolSchemas = Self.extractSchemas(from: response.schemas)
+                self.toolSchemas = Self.extractSchemas(from: response.schemas ?? [:])
                 // Refresh fields if a tool is already selected.
                 if !self.toolName.isEmpty {
                     self.updateFieldsForTool(self.toolName)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1758,7 +1758,7 @@ public struct IPCToolNamesListResponse: Codable, Sendable {
     /// Sorted list of all registered tool names.
     public let names: [String]
     /// Input schemas keyed by tool name.
-    public let schemas: [String: AnyCodable]
+    public let schemas: [String: AnyCodable]?
 }
 
 public struct IPCToolOutputChunk: Codable, Sendable {


### PR DESCRIPTION
Address Codex review feedback on PR #6564: make the schemas field optional in ToolNamesListResponse so newer clients can decode responses from older daemons that don't include schemas, preventing UI breakage in mixed-version deployments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
