### PR TITLE
fix: add SSE heartbeats and debug logging for GCP event streaming

### DIFF
--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -148,12 +148,18 @@ describe('SSE assistant-events endpoint', () => {
     await assistantEventHub.publish(event);
 
     // Read the first frame directly from the response body stream.
+    // The first chunk is the ': connected' comment; the event follows.
     const reader = response.body!.getReader();
-    const { value, done } = await reader.read();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    const connectedFrame = new TextDecoder().decode(first.value);
+    expect(connectedFrame).toContain(': connected');
+
+    const second = await reader.read();
     ac.abort();
 
-    expect(done).toBe(false);
-    const frame = new TextDecoder().decode(value);
+    expect(second.done).toBe(false);
+    const frame = new TextDecoder().decode(second.value);
     expect(frame).toContain('event: assistant_event');
     expect(frame).toContain(`"assistantId":"self"`);
     expect(frame).toContain(`"sessionId":"${conversationId}"`);

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -7,6 +7,9 @@
  */
 
 import type { AssistantEvent } from './assistant-event.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('assistant-event-hub');
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -87,17 +90,31 @@ export class AssistantEventHub {
   async publish(event: AssistantEvent): Promise<void> {
     const snapshot = Array.from(this.subscribers);
     const errors: unknown[] = [];
+    let matched = 0;
 
     for (const entry of snapshot) {
       if (!entry.active) continue;
       if (entry.filter.assistantId !== event.assistantId) continue;
       if (entry.filter.sessionId != null && entry.filter.sessionId !== event.sessionId) continue;
+      matched++;
       try {
         await entry.callback(event);
       } catch (err) {
         errors.push(err);
       }
     }
+
+    const msgType = (event.message as { type?: string }).type ?? 'unknown';
+    log.info(
+      {
+        eventAssistantId: event.assistantId,
+        eventSessionId: event.sessionId,
+        msgType,
+        totalSubscribers: snapshot.length,
+        matched,
+      },
+      'Event published to hub',
+    );
 
     if (errors.length > 0) {
       throw new AggregateError(errors, 'One or more assistant-event subscribers threw');

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -11,6 +11,12 @@ import { getOrCreateConversation } from '../../memory/conversation-key-store.js'
 import { assistantEventHub } from '../assistant-event-hub.js';
 import { formatSseFrame } from '../assistant-event.js';
 import type { AssistantEventSubscription } from '../assistant-event-hub.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('events-routes');
+
+/** SSE heartbeat interval in milliseconds. */
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 /**
  * Stream assistant events as Server-Sent Events for a specific conversation.
@@ -28,14 +34,35 @@ export function handleSubscribeAssistantEvents(
   }
 
   const mapping = getOrCreateConversation(conversationKey);
+  log.info(
+    { conversationKey, conversationId: mapping.conversationId },
+    'SSE subscription created',
+  );
   const encoder = new TextEncoder();
   let sub: AssistantEventSubscription | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   // Allow up to 16 queued frames before treating the consumer as stalled.
   // This absorbs normal token-stream bursts without prematurely closing the
   // connection, while still shedding genuinely slow clients.
   const stream = new ReadableStream({
     start(controller) {
+      // Send an initial connection comment immediately. This primes the
+      // HTTP response body so proxies (including the gateway's Bun-based
+      // runtime proxy) begin streaming data to downstream clients.
+      controller.enqueue(encoder.encode(': connected\n\n'));
+
+      // Periodic heartbeats keep the connection alive and help flush
+      // any intermediate proxy buffers (e.g., Bun's chunked-transfer
+      // buffering over loopback connections).
+      heartbeatTimer = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(': heartbeat\n\n'));
+        } catch {
+          // Stream closed — clean up in cancel()
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+
       // 'self' is the assistantId that RunOrchestrator assigns to all HTTP-run events
       // (see buildAssistantEvent('self', ...) in run-orchestrator.ts). This endpoint
       // is part of the HTTP runtime API, so only HTTP-run events are relevant here.
@@ -48,24 +75,32 @@ export function handleSubscribeAssistantEvents(
             // Shed stalled consumers: desiredSize <= 0 means the 16-event buffer
             // is full and the client isn't draining it.
             if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+              log.warn({ conversationKey }, 'SSE consumer stalled, disposing subscription');
               sub?.dispose();
+              if (heartbeatTimer) clearInterval(heartbeatTimer);
               try { controller.close(); } catch { /* already closed */ }
               return;
             }
+            const msgType = (event.message as { type?: string }).type ?? 'unknown';
+            log.info({ conversationKey, msgType }, 'SSE event enqueued');
             controller.enqueue(encoder.encode(formatSseFrame(event)));
           } catch {
             sub?.dispose();
+            if (heartbeatTimer) clearInterval(heartbeatTimer);
           }
         },
       );
 
       req.signal.addEventListener('abort', () => {
+        log.info({ conversationKey }, 'SSE connection aborted by client');
         sub?.dispose();
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
         try { controller.close(); } catch { /* already closed */ }
       }, { once: true });
     },
     cancel() {
       sub?.dispose();
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
     },
   }, new CountQueuingStrategy({ highWaterMark: 16 }));
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -107,6 +107,11 @@ export class RunOrchestrator {
           ? (msgRecord.sessionId as string)
           : undefined;
       const resolvedSessionId = msgSessionId ?? conversationId;
+      const msgType = (msg as { type?: string }).type ?? 'unknown';
+      log.info(
+        { runId: run.id, conversationId, resolvedSessionId, msgType, hubSubscribers: assistantEventHub.subscriberCount() },
+        'publishToHub called',
+      );
       const event = buildAssistantEvent('self', msg, resolvedSessionId);
       hubChain = hubChain
         .then(() => assistantEventHub.publish(event))


### PR DESCRIPTION
## Summary

- Fixes the "Thinking..." hang when sending messages to a GCP-hosted assistant from the desktop app
- The SSE events endpoint (`GET /v1/events`) did not send any initial data when the stream opened. Combined with Bun's documented chunked-transfer buffering over loopback connections (see test comment in `runtime-events-sse.test.ts:127-130`), SSE events published by the `assistantEventHub` never reached clients going through the gateway proxy
- The gateway proxies SSE requests to the runtime via `fetch("http://localhost:7821/...")`, which is a loopback connection subject to Bun's buffering behavior

### Changes
1. **Initial `: connected` comment** — Sent immediately when the SSE stream opens to prime the HTTP response body and trigger proxy streaming
2. **Periodic heartbeats** — Sends `: heartbeat` every 15 seconds to keep the connection alive and help flush intermediate proxy buffers
3. **Debug logging** — Added to `assistant-event-hub.publish()`, SSE subscription creation/delivery, and `run-orchestrator.publishToHub()` to trace event flow through the system

## Test plan
- [x] `runtime-events-sse.test.ts` passes (updated to expect initial `: connected` comment)
- [ ] Deploy to GCP instance and verify SSE events arrive at the desktop app
- [ ] Check runtime logs for `"SSE subscription created"`, `"publishToHub called"`, `"Event published to hub"`, and `"SSE event enqueued"` messages to trace the event flow
- [ ] If heartbeats alone don't fix the buffering, the debug logs will show exactly where events get lost (0 subscribers vs 0 matched vs enqueued-but-not-flushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
