### PR TITLE
fix: skip call bridge relay for empty instruction text to preserve attachment processing

### DIFF
--- a/assistant/src/calls/call-bridge.ts
+++ b/assistant/src/calls/call-bridge.ts
@@ -120,6 +120,12 @@ async function handleInstruction(
   callSessionId: string,
   userText: string,
 ): Promise<CallBridgeResult> {
+  // Empty text (e.g. attachment-only messages) should not be relayed —
+  // fall through to normal processing so attachments are handled.
+  if (!userText.trim()) {
+    return { handled: false, reason: 'empty_instruction_text' };
+  }
+
   const result = await relayInstruction({ callSessionId, instructionText: userText });
 
   if (!result.ok) {


### PR DESCRIPTION
Addresses Codex feedback on #6522. Empty-text messages (attachment-only) during an active call were consumed by the relay failure path, preventing attachment processing. Now returns handled:false for empty text so normal processing continues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
