### PR TITLE
fix: clear hidden session timestamp on manual unarchive to persist across restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -549,6 +549,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             var archived = archivedSessionIds
             archived.remove(sessionId)
             archivedSessionIds = archived
+            // Clear any persisted hidden-timestamp so the thread isn't
+            // re-hidden on restart when no new activity has arrived yet.
+            clearHiddenSession(sessionId)
         }
 
         log.info("Unarchived thread \(id)")


### PR DESCRIPTION
Addresses feedback on #6534. Manually unarchiving a hidden thread now calls clearHiddenSession to remove the persisted timestamp from UserDefaults, preventing the thread from being re-hidden on restart.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
