### PR TITLE
fix: add rowid tiebreaker to dedup migration and handle unique index conflicts in upsertBinding

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1825,7 +1825,7 @@ function migrateExtConvBindingsChannelChatUnique(database: ReturnType<typeof dri
           SELECT rowid,
                  ROW_NUMBER() OVER (
                    PARTITION BY source_channel, external_chat_id
-                   ORDER BY updated_at DESC, created_at DESC
+                   ORDER BY updated_at DESC, created_at DESC, rowid DESC
                  ) AS rn
           FROM external_conversation_bindings
         )

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -41,6 +41,15 @@ export function upsertBinding(input: UpsertBindingInput): void {
   const db = getDb();
   const now = Date.now();
 
+  // If a stale binding exists for this (sourceChannel, externalChatId) under a
+  // different conversationId, remove it first so the unique index is not violated.
+  const existing = getBindingByChannelChat(input.sourceChannel, input.externalChatId);
+  if (existing && existing.conversationId !== input.conversationId) {
+    db.delete(externalConversationBindings)
+      .where(eq(externalConversationBindings.conversationId, existing.conversationId))
+      .run();
+  }
+
   db.insert(externalConversationBindings)
     .values({
       conversationId: input.conversationId,
@@ -80,6 +89,15 @@ export function upsertOutboundBinding(input: {
 }): void {
   const db = getDb();
   const now = Date.now();
+
+  // If a stale binding exists for this (sourceChannel, externalChatId) under a
+  // different conversationId, remove it first so the unique index is not violated.
+  const existing = getBindingByChannelChat(input.sourceChannel, input.externalChatId);
+  if (existing && existing.conversationId !== input.conversationId) {
+    db.delete(externalConversationBindings)
+      .where(eq(externalConversationBindings.conversationId, existing.conversationId))
+      .run();
+  }
 
   db.insert(externalConversationBindings)
     .values({


### PR DESCRIPTION
Addresses feedback on #6533. (1) Added rowid DESC tiebreaker to dedup migration ORDER BY. (2) Updated upsertBinding/upsertOutboundBinding to handle conflicts on the (source_channel, external_chat_id) unique index.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
