### PR TITLE
fix: add authenticated 404 check for telegram subpaths in gateway enforcement tests

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -204,6 +204,17 @@ describe('gateway-only ingress enforcement', () => {
       // route matching — confirming no Telegram webhook handler exists.
       expect(res.status).toBe(404);
     });
+
+    test('POST /webhooks/telegram/test returns 404 when authenticated (no handler exists)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/telegram/test`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      // With valid auth, the request passes the auth middleware and reaches
+      // route matching — confirming no Telegram subpath handler exists.
+      expect(res.status).toBe(404);
+    });
   });
 
   // ── Direct Twilio webhook routes blocked in gateway_only mode ──────


### PR DESCRIPTION
Addresses Codex feedback on #6537. Added authenticated 404 test for /webhooks/telegram/test to verify no handler exists at that subpath (401 checks alone don't prove route absence since auth fires before route matching).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
