### PR TITLE
fix: address review feedback on PR #6535

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -561,13 +561,17 @@ struct MainWindowView: View {
 
             // Show a brief toast when a previously-hidden thread reappears
             threadManager.onThreadReconnected = { [weak windowState] title in
+                let toastMessage = "Reconnected: \(title)"
                 windowState?.showToast(
-                    message: "Reconnected: \(title)",
+                    message: toastMessage,
                     style: .success
                 )
-                // Auto-dismiss after 3 seconds
+                // Auto-dismiss after 3 seconds, but only if this toast is still showing.
+                // Avoids prematurely dismissing an unrelated toast that appeared in the interim.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak windowState] in
-                    windowState?.dismissToast()
+                    if windowState?.toastInfo?.message == toastMessage {
+                        windowState?.dismissToast()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -905,6 +905,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         )
         let viewModel = makeViewModel()
         viewModel.sessionId = sessionId
+        // Do NOT wire onFirstUserMessage — this is a restored thread with an
+        // existing title. Auto-titling would clobber the preserved title.
         viewModel.startMessageLoop()
 
         threads.insert(thread, at: 0)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -108,20 +108,36 @@ final class ThreadSessionRestorer {
 
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
-            // If this session was hidden locally, clear the hidden-session
-            // tracker so the monitor stops watching for it. The thread will
-            // be re-created normally (not archived) and remain visible.
+            // Check hidden state BEFORE clearing so isSessionHidden(_:updatedAt:)
+            // can read the persisted timestamp. If the session has new activity
+            // (updatedAt > hideTime), isSessionHidden returns false and the thread
+            // re-appears as visible.
+            let isHidden = delegate.isSessionHidden(session.id, updatedAt: session.updatedAt)
+
+            // Now that the hidden check is done, clear the in-memory monitor
+            // so the hidden-session monitor task stops watching for this session.
+            // The persisted timestamp was already handled by isSessionHidden above
+            // (it auto-clears when new activity is detected).
             if delegate.isSessionHidden(session.id) {
                 delegate.clearHiddenSession(session.id)
             }
 
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard
             let binding = session.channelBinding
+
+            // Preserve user-set titles: if a thread with this session already
+            // exists locally and has a non-default title, keep it instead of
+            // overwriting with the daemon's auto-generated title.
+            let existingTitle = delegate.threads
+                .first(where: { $0.sessionId == session.id && $0.title != "New Conversation" })?
+                .title
+            let title = existingTitle ?? session.title
+
             let thread = ThreadModel(
-                title: session.title,
+                title: title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id,
-                isArchived: delegate.isSessionArchived(session.id) || delegate.isSessionHidden(session.id, updatedAt: session.updatedAt),
+                isArchived: delegate.isSessionArchived(session.id) || isHidden,
                 kind: kind,
                 sourceChannel: binding?.sourceChannel,
                 displayName: binding?.displayName,


### PR DESCRIPTION
Addresses three review comments on #6535:

1. **clearHiddenSession before isSessionHidden**: Reordered ThreadSessionRestorer.handleSessionListResponse to call isSessionHidden(_:updatedAt:) BEFORE clearHiddenSession, capturing the hidden state first. Previously, clearHiddenSession removed the persisted timestamp, making the subsequent updatedAt check always return false — effectively making the hide feature temporary (lasting only until app restart).

2. **Auto-title clobber**: Added title preservation logic in handleSessionListResponse — if a thread with the same sessionId already exists locally with a non-default title, the existing title is kept instead of being overwritten by the daemon's session title. Also added a defensive comment in restoreHiddenThread clarifying that onFirstUserMessage should not be wired for restored threads.

3. **Toast dismiss timing**: Changed the auto-dismiss timer to capture the toast message and only dismiss if the same toast is still showing, preventing premature dismissal of unrelated toasts that appear within the 3-second window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
