### PR TITLE
fix: hide empty integrations section on settings page

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -625,21 +625,15 @@ struct SettingsPanel: View {
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
 
-            // INTEGRATIONS section
-            if daemonClient != nil {
+            // INTEGRATIONS section (hidden when empty)
+            if daemonClient != nil && !integrations.isEmpty {
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("Integrations")
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    if integrations.isEmpty {
-                        Text("No integrations available")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    } else {
-                        ForEach(integrations, id: \.id) { integration in
-                            integrationRow(integration)
-                        }
+                    ForEach(integrations, id: \.id) { integration in
+                        integrationRow(integration)
                     }
                 }
                 .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Hide the "Integrations" section on the settings page when no integrations are available, instead of showing "No integrations available"
- The section still appears when integrations exist

## Original prompt
Remove this section on our settings page that shows empty integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
