### PR TITLE
fix: enable cross-paragraph text selection in chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -759,104 +759,24 @@ struct ChatBubble: View {
                         case .text: return false
                         }
                     })
-                    VStack(alignment: .leading, spacing: hasRichContent ? VSpacing.lg : VSpacing.xs) {
-
-                        if hasRichContent {
-                            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                                switch segment {
-                                case .text(let text):
-                                    let options = AttributedString.MarkdownParsingOptions(
-                                        interpretedSyntax: .inlineOnlyPreservingWhitespace
-                                    )
-                                    let attributed = (try? AttributedString(markdown: text, options: options))
-                                        ?? AttributedString(text)
-                                    Text(attributed)
-                                        .font(.system(size: 13))
-                                        .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                        .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                                        .textSelection(.enabled)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                case .table(let headers, let rows):
-                                    MarkdownTableView(headers: headers, rows: rows)
-                                case .image(let alt, let url):
-                                    AnimatedImageView(urlString: url)
-                                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                                        .accessibilityLabel(alt.isEmpty ? "Image" : alt)
-                                case .heading(let level, let headingText):
-                                    let font: Font = switch level {
-                                    case 1: .system(size: 20, weight: .bold)
-                                    case 2: .system(size: 17, weight: .semibold)
-                                    case 3: .system(size: 14, weight: .semibold)
-                                    default: .system(size: 13, weight: .semibold)
-                                    }
-                                    Text(headingText)
-                                        .font(font)
-                                        .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                        .textSelection(.enabled)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                        .padding(.top, level == 1 ? VSpacing.xs : 0)
-
-                                case .codeBlock(let language, let code):
-                                    VStack(alignment: .leading, spacing: 0) {
-                                        if let language, !language.isEmpty {
-                                            Text(language)
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textMuted)
-                                                .padding(.horizontal, VSpacing.sm)
-                                                .padding(.top, VSpacing.xs)
-                                        }
-                                        ScrollView(.horizontal, showsIndicators: false) {
-                                            Text(code)
-                                                .font(VFont.mono)
-                                                .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                                .textSelection(.enabled)
-                                                .fixedSize(horizontal: true, vertical: true)
-                                                .padding(VSpacing.sm)
-                                        }
-                                    }
-                                    .background(isUser ? VColor.userBubbleText.opacity(0.1) : VColor.backgroundSubtle)
-                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-
-                                case .horizontalRule:
-                                    Rectangle()
-                                        .fill(isUser ? VColor.userBubbleText.opacity(0.3) : VColor.surfaceBorder)
-                                        .frame(height: 1)
-                                        .padding(.vertical, VSpacing.xs)
-
-                                case .list(let items):
-                                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                                            let prefix = item.ordered ? "\(item.number). " : "\u{2022} "
-                                            let indentLevel = item.indent / 2
-                                            HStack(alignment: .top, spacing: 0) {
-                                                Text(prefix)
-                                                    .font(.system(size: 13))
-                                                    .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary)
-                                                let options = AttributedString.MarkdownParsingOptions(
-                                                    interpretedSyntax: .inlineOnlyPreservingWhitespace
-                                                )
-                                                let attributed = (try? AttributedString(markdown: item.text, options: options))
-                                                    ?? AttributedString(item.text)
-                                                Text(attributed)
-                                                    .font(.system(size: 13))
-                                                    .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                                    .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                                                    .textSelection(.enabled)
-                                                    .fixedSize(horizontal: false, vertical: true)
-                                            }
-                                            .padding(.leading, CGFloat(indentLevel) * 16)
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            Text(markdownText)
-                                .font(.system(size: 13))
-                                .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
-                                .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+                    if hasRichContent {
+                        MarkdownSegmentView(
+                            segments: segments,
+                            maxContentWidth: nil,
+                            textColor: isUser ? VColor.userBubbleText : VColor.textPrimary,
+                            secondaryTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary,
+                            mutedTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textMuted,
+                            tintColor: isUser ? VColor.userBubbleText : VColor.accent,
+                            codeBackgroundColor: isUser ? VColor.userBubbleText.opacity(0.1) : VColor.backgroundSubtle,
+                            hrColor: isUser ? VColor.userBubbleText.opacity(0.3) : VColor.surfaceBorder
+                        )
+                    } else {
+                        Text(markdownText)
+                            .font(.system(size: 13))
+                            .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
+                            .tint(isUser ? VColor.userBubbleText : VColor.accent)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if !message.attachments.isEmpty {
                     Text(attachmentSummary)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -2,64 +2,53 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
-/// Used by both ChatBubble and SubagentDetailPanel.
+/// Groups consecutive text-selectable segments (text, headings, lists) into
+/// unified Text views so that text selection can span across paragraphs.
 struct MarkdownSegmentView: View {
     let segments: [MarkdownSegment]
     var maxContentWidth: CGFloat? = 520
+    var textColor: Color = VColor.textPrimary
+    var secondaryTextColor: Color = VColor.textSecondary
+    var mutedTextColor: Color = VColor.textMuted
+    var tintColor: Color = VColor.accent
+    var codeBackgroundColor: Color = VColor.backgroundSubtle
+    var hrColor: Color = VColor.surfaceBorder
 
     var body: some View {
+        let groups = groupedSegments
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                switch segment {
-                case .text(let text):
-                    let options = AttributedString.MarkdownParsingOptions(
-                        interpretedSyntax: .inlineOnlyPreservingWhitespace
-                    )
-                    let attributed = (try? AttributedString(markdown: text, options: options))
-                        ?? AttributedString(text)
+            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                switch group {
+                case .selectableRun(let runSegments):
+                    let attributed = buildCombinedAttributedString(from: runSegments)
                     Text(attributed)
                         .font(.system(size: 13))
-                        .foregroundColor(VColor.textPrimary)
-                        .tint(VColor.accent)
+                        .foregroundColor(textColor)
+                        .tint(tintColor)
                         .textSelection(.enabled)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
-
-                case .heading(let level, let headingText):
-                    let font: Font = switch level {
-                    case 1: .system(size: 20, weight: .bold)
-                    case 2: .system(size: 17, weight: .semibold)
-                    case 3: .system(size: 14, weight: .semibold)
-                    default: .system(size: 13, weight: .semibold)
-                    }
-                    Text(headingText)
-                        .font(font)
-                        .foregroundColor(VColor.textPrimary)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
-                        .padding(.top, level == 1 ? VSpacing.xs : 0)
 
                 case .codeBlock(let language, let code):
                     VStack(alignment: .leading, spacing: 0) {
                         if let language, !language.isEmpty {
                             Text(language)
                                 .font(.system(size: 11, weight: .medium))
-                                .foregroundColor(VColor.textMuted)
+                                .foregroundColor(mutedTextColor)
                                 .padding(.horizontal, VSpacing.sm)
                                 .padding(.top, VSpacing.xs)
                         }
                         ScrollView(.horizontal, showsIndicators: false) {
                             Text(code)
                                 .font(VFont.mono)
-                                .foregroundColor(VColor.textPrimary)
+                                .foregroundColor(textColor)
                                 .textSelection(.enabled)
                                 .fixedSize(horizontal: true, vertical: true)
                                 .padding(VSpacing.sm)
                         }
                     }
                     .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
-                    .background(VColor.backgroundSubtle)
+                    .background(codeBackgroundColor)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 case .table(let headers, let rows):
@@ -70,40 +59,118 @@ struct MarkdownSegmentView: View {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .accessibilityLabel(alt.isEmpty ? "Image" : alt)
 
-                case .list(let items):
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                            let prefix = item.ordered ? "\(item.number). " : "\u{2022} "
-                            let indentLevel = item.indent / 2
-                            HStack(alignment: .top, spacing: 0) {
-                                Text(prefix)
-                                    .font(.system(size: 13))
-                                    .foregroundColor(VColor.textSecondary)
-                                let options = AttributedString.MarkdownParsingOptions(
-                                    interpretedSyntax: .inlineOnlyPreservingWhitespace
-                                )
-                                let attributed = (try? AttributedString(markdown: item.text, options: options))
-                                    ?? AttributedString(item.text)
-                                Text(attributed)
-                                    .font(.system(size: 13))
-                                    .foregroundColor(VColor.textPrimary)
-                                    .tint(VColor.accent)
-                                    .textSelection(.enabled)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                            .padding(.leading, CGFloat(indentLevel) * 16)
-                        }
-                    }
-                    .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
-
                 case .horizontalRule:
                     Rectangle()
-                        .fill(VColor.surfaceBorder)
+                        .fill(hrColor)
                         .frame(height: 1)
                         .frame(maxWidth: maxContentWidth ?? .infinity)
                         .padding(.vertical, VSpacing.xs)
                 }
             }
         }
+    }
+
+    // MARK: - Segment Grouping
+
+    /// Groups of segments for unified text selection rendering.
+    private enum SegmentGroup {
+        /// Consecutive text-selectable segments combined for cross-paragraph selection.
+        case selectableRun([MarkdownSegment])
+        case codeBlock(language: String?, code: String)
+        case table(headers: [String], rows: [[String]])
+        case image(alt: String, url: String)
+        case horizontalRule
+    }
+
+    /// Groups consecutive text-selectable segments together so they render
+    /// as a single Text view, enabling cross-paragraph text selection.
+    private var groupedSegments: [SegmentGroup] {
+        var groups: [SegmentGroup] = []
+        var currentRun: [MarkdownSegment] = []
+
+        func flushRun() {
+            if !currentRun.isEmpty {
+                groups.append(.selectableRun(currentRun))
+                currentRun = []
+            }
+        }
+
+        for segment in segments {
+            switch segment {
+            case .text, .heading, .list:
+                currentRun.append(segment)
+            case .codeBlock(let language, let code):
+                flushRun()
+                groups.append(.codeBlock(language: language, code: code))
+            case .table(let headers, let rows):
+                flushRun()
+                groups.append(.table(headers: headers, rows: rows))
+            case .image(let alt, let url):
+                flushRun()
+                groups.append(.image(alt: alt, url: url))
+            case .horizontalRule:
+                flushRun()
+                groups.append(.horizontalRule)
+            }
+        }
+
+        flushRun()
+        return groups
+    }
+
+    // MARK: - Combined AttributedString
+
+    /// Builds a single AttributedString from consecutive text-selectable segments,
+    /// allowing text selection to span across paragraphs, headings, and list items.
+    private func buildCombinedAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
+        let mdOptions = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        var result = AttributedString()
+
+        for (index, segment) in segments.enumerated() {
+            if index > 0 {
+                result += AttributedString("\n\n")
+            }
+
+            switch segment {
+            case .text(let text):
+                let attributed = (try? AttributedString(markdown: text, options: mdOptions))
+                    ?? AttributedString(text)
+                result += attributed
+
+            case .heading(let level, let headingText):
+                var heading = AttributedString(headingText)
+                heading.font = switch level {
+                case 1: .system(size: 20, weight: .bold)
+                case 2: .system(size: 17, weight: .semibold)
+                case 3: .system(size: 14, weight: .semibold)
+                default: .system(size: 13, weight: .semibold)
+                }
+                result += heading
+
+            case .list(let items):
+                for (itemIndex, item) in items.enumerated() {
+                    if itemIndex > 0 {
+                        result += AttributedString("\n")
+                    }
+                    let indent = String(repeating: "    ", count: item.indent / 2)
+                    let prefix = item.ordered ? "\(item.number). " : "\u{2022} "
+                    var prefixAttr = AttributedString(indent + prefix)
+                    prefixAttr.foregroundColor = secondaryTextColor
+                    prefixAttr.font = .system(size: 13)
+                    result += prefixAttr
+
+                    let itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
+                        ?? AttributedString(item.text)
+                    result += itemAttr
+                }
+
+            default:
+                break
+            }
+        }
+
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- Groups consecutive text-selectable markdown segments (paragraphs, headings, lists) into a single `AttributedString` rendered as one SwiftUI `Text` view, enabling text selection across paragraph boundaries
- Adds color parameters to `MarkdownSegmentView` so it can handle both user and assistant bubble color variants, eliminating ~90 lines of duplicated rendering logic from `ChatBubble`
- Non-text segments (code blocks, tables, images, horizontal rules) remain as separate views that naturally break selection runs

## Original prompt
Right now on the mac desktop app, I cannot seem to highlight text within a chat message across paragraphs. The highlighted portion stops at the beginning/end of a new line. Help me fix this so that its easy to highlight text within a chat message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
