### PR TITLE
feat: wire conflict UX from actual send-conflict events (#6588)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -727,10 +727,25 @@ private struct ScrollWheelDetector: NSViewRepresentable {
 // MARK: - Sync Conflict
 
 /// Info about a sync conflict when the current thread is not the canonical owner.
+/// May originate from passive duplicate-binding detection or from an actual
+/// send-conflict error emitted by a messaging tool.
 struct SyncConflictInfo {
     let ownerThreadTitle: String
+    /// Thread ID of the owner thread (when resolved from a send-conflict payload).
+    let ownerThreadId: UUID?
     let sourceChannel: String
     let externalChatId: String
+    /// Daemon conversation ID from the send-conflict payload, if this conflict
+    /// was detected from an actual tool error rather than passive binding check.
+    let ownerConversationId: String?
+
+    init(ownerThreadTitle: String, ownerThreadId: UUID? = nil, sourceChannel: String, externalChatId: String, ownerConversationId: String? = nil) {
+        self.ownerThreadTitle = ownerThreadTitle
+        self.ownerThreadId = ownerThreadId
+        self.sourceChannel = sourceChannel
+        self.externalChatId = externalChatId
+        self.ownerConversationId = ownerConversationId
+    }
 }
 
 /// Banner shown when the user tries to send from a non-canonical synced thread.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -312,7 +312,17 @@ extension MainWindowView {
     var chatView: some View {
         if let viewModel = threadManager.activeViewModel {
             let activeThread = threadManager.activeThread
+
+            // Merge two conflict sources: active send-conflict from a tool error
+            // takes priority over passive duplicate-binding detection.
             let syncConflict: SyncConflictInfo? = {
+                // 1. Active send-conflict from a tool error payload
+                if let thread = activeThread,
+                   let conflict = viewModel.sendConflict,
+                   let resolved = threadManager.resolveSendConflict(conflict, excludingThread: thread.id) {
+                    return resolved
+                }
+                // 2. Passive duplicate-binding detection (existing behavior)
                 guard let thread = activeThread,
                       let sourceChannel = thread.sourceChannel,
                       let externalChatId = thread.externalChatId,
@@ -339,7 +349,16 @@ extension MainWindowView {
                 syncedChannelLabel: activeThread?.isSynced == true ? activeThread?.sourceChannel?.capitalized : nil,
                 syncConflict: syncConflict,
                 onContinueInSyncedThread: syncConflict != nil ? {
+                    // When conflict was resolved from a send-conflict payload, use
+                    // the ownerThreadId directly instead of re-scanning bindings.
                     if let thread = threadManager.activeThread,
+                       let ownerThreadId = syncConflict?.ownerThreadId {
+                        viewModel.dismissSendConflict()
+                        threadManager.continueInSyncedThread(
+                            targetThreadId: ownerThreadId,
+                            sourceThreadId: thread.id
+                        )
+                    } else if let thread = threadManager.activeThread,
                        let sourceChannel = thread.sourceChannel,
                        let externalChatId = thread.externalChatId,
                        let canonical = threadManager.findCanonicalThread(
@@ -347,6 +366,7 @@ extension MainWindowView {
                            externalChatId: externalChatId,
                            excludingThread: thread.id
                        ) {
+                        viewModel.dismissSendConflict()
                         threadManager.continueInSyncedThread(
                             targetThreadId: canonical.id,
                             sourceThreadId: thread.id
@@ -354,7 +374,16 @@ extension MainWindowView {
                     }
                 } : nil,
                 onMoveSyncHere: syncConflict != nil ? {
+                    viewModel.dismissSendConflict()
                     if let thread = threadManager.activeThread,
+                       let sourceChannel = syncConflict?.sourceChannel, !sourceChannel.isEmpty,
+                       let externalChatId = syncConflict?.externalChatId, !externalChatId.isEmpty {
+                        threadManager.moveSyncHereAndResend(
+                            threadId: thread.id,
+                            sourceChannel: sourceChannel,
+                            externalChatId: externalChatId
+                        )
+                    } else if let thread = threadManager.activeThread,
                        let sourceChannel = thread.sourceChannel,
                        let externalChatId = thread.externalChatId {
                         threadManager.moveSyncHereAndResend(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -430,6 +430,28 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         })
     }
 
+    /// Find a thread by its daemon session/conversation ID.
+    /// Used to resolve `ownerConversationId` from send-conflict payloads to a concrete thread.
+    func findThreadBySessionId(_ sessionId: String) -> ThreadModel? {
+        return threads.first(where: { $0.sessionId == sessionId && !$0.isArchived })
+    }
+
+    /// Resolve a send-conflict's `ownerConversationId` into a `SyncConflictInfo` for the UI.
+    /// Returns nil if the owner thread cannot be found (e.g. archived or unknown session).
+    func resolveSendConflict(_ conflict: SendConflictInfo, excludingThread: UUID) -> SyncConflictInfo? {
+        guard let ownerThread = findThreadBySessionId(conflict.ownerConversationId),
+              ownerThread.id != excludingThread else {
+            return nil
+        }
+        return SyncConflictInfo(
+            ownerThreadTitle: ownerThread.title,
+            ownerThreadId: ownerThread.id,
+            sourceChannel: ownerThread.sourceChannel ?? "",
+            externalChatId: ownerThread.externalChatId ?? "",
+            ownerConversationId: conflict.ownerConversationId
+        )
+    }
+
     /// Switch to the canonical synced thread, carrying over any draft text and
     /// attachments from the source thread's composer so the user doesn't lose work.
     func continueInSyncedThread(targetThreadId: UUID, sourceThreadId: UUID) {
@@ -1031,10 +1053,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Subscribe to the new active view model if one exists
         guard let viewModel = activeViewModel else { return }
 
-        // Only observe message count changes, not all ChatViewModel property changes
-        activeViewModelCancellable = viewModel.$messages
+        // Observe message count changes and send-conflict state changes.
+        // Message count drives the sidebar unread indicator; sendConflict
+        // triggers re-evaluation of the conflict banner in chatView.
+        let messagesPublisher = viewModel.$messages
             .map { $0.count }
             .removeDuplicates()
+            .map { _ in () }
+        let conflictPublisher = viewModel.$sendConflict
+            .removeDuplicates(by: { $0?.ownerConversationId == $1?.ownerConversationId })
+            .map { _ in () }
+        activeViewModelCancellable = messagesPublisher
+            .merge(with: conflictPublisher)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2376,4 +2376,147 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertNil(viewModel.pendingSendDirectText)
     }
+
+    // MARK: - Send Conflict Detection from Tool Errors
+
+    func testToolResultConflictErrorSetsSendConflict() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Start a tool call so toolResult has something to complete
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "messaging_send",
+            input: ["text": AnyCodable("hello")],
+            sessionId: "sess-1"
+        )))
+
+        // Simulate a conflict error from messaging-send
+        let conflictPayload = """
+        {"error":"conflict","ownerConversationId":"owner-session-42","message":"Another thread owns this chat."}
+        """
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(
+            type: "tool_result",
+            toolName: "messaging_send",
+            result: conflictPayload,
+            isError: true,
+            diff: nil,
+            status: nil,
+            sessionId: "sess-1",
+            imageData: nil
+        )))
+
+        XCTAssertNotNil(viewModel.sendConflict, "Send conflict should be set from tool error")
+        XCTAssertEqual(viewModel.sendConflict?.ownerConversationId, "owner-session-42")
+        XCTAssertEqual(viewModel.sendConflict?.message, "Another thread owns this chat.")
+    }
+
+    func testToolResultNonConflictErrorDoesNotSetSendConflict() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls")],
+            sessionId: "sess-1"
+        )))
+
+        // A regular tool error should not trigger sendConflict
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(
+            type: "tool_result",
+            toolName: "bash",
+            result: "command not found",
+            isError: true,
+            diff: nil,
+            status: nil,
+            sessionId: "sess-1",
+            imageData: nil
+        )))
+
+        XCTAssertNil(viewModel.sendConflict, "Regular errors should not set sendConflict")
+    }
+
+    func testToolResultSuccessDoesNotSetSendConflict() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "messaging_send",
+            input: ["text": AnyCodable("hello")],
+            sessionId: "sess-1"
+        )))
+
+        // Successful tool result should not trigger sendConflict
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(
+            type: "tool_result",
+            toolName: "messaging_send",
+            result: "Message sent (ID: 123).",
+            isError: false,
+            diff: nil,
+            status: nil,
+            sessionId: "sess-1",
+            imageData: nil
+        )))
+
+        XCTAssertNil(viewModel.sendConflict, "Successful tool results should not set sendConflict")
+    }
+
+    func testDismissSendConflictClearsConflict() {
+        viewModel.sendConflict = SendConflictInfo(
+            ownerConversationId: "owner-1",
+            message: "Conflict"
+        )
+
+        viewModel.dismissSendConflict()
+
+        XCTAssertNil(viewModel.sendConflict)
+    }
+
+    // MARK: - SendConflictInfo Parsing
+
+    func testSendConflictInfoParseValidPayload() {
+        let json = """
+        {"error":"conflict","ownerConversationId":"sess-owner","message":"Another thread owns this chat."}
+        """
+        let result = SendConflictInfo.parse(from: json)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.ownerConversationId, "sess-owner")
+        XCTAssertEqual(result?.message, "Another thread owns this chat.")
+    }
+
+    func testSendConflictInfoParseNonConflictError() {
+        let json = """
+        {"error":"not_found","message":"Chat not found"}
+        """
+        let result = SendConflictInfo.parse(from: json)
+        XCTAssertNil(result, "Non-conflict errors should return nil")
+    }
+
+    func testSendConflictInfoParsePlainText() {
+        let result = SendConflictInfo.parse(from: "command not found")
+        XCTAssertNil(result, "Plain text errors should return nil")
+    }
+
+    func testSendConflictInfoParseMissingOwnerConversationId() {
+        let json = """
+        {"error":"conflict","message":"Conflict without owner"}
+        """
+        let result = SendConflictInfo.parse(from: json)
+        XCTAssertNil(result, "Conflict without ownerConversationId should return nil")
+    }
+
+    func testSendConflictInfoParseDefaultMessage() {
+        let json = """
+        {"error":"conflict","ownerConversationId":"sess-123"}
+        """
+        let result = SendConflictInfo.parse(from: json)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.ownerConversationId, "sess-123")
+        XCTAssertEqual(result?.message, "Another thread owns this chat.", "Should use default message when not provided")
+    }
 }

--- a/clients/macos/vellum-assistantTests/ThreadManagerSyncConflictTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerSyncConflictTests.swift
@@ -480,4 +480,105 @@ final class ThreadManagerSyncConflictTests: XCTestCase {
 
         XCTAssertNil(canonical, "Archived threads should not be returned as canonical")
     }
+
+    // MARK: - findThreadBySessionId
+
+    func testFindThreadBySessionIdReturnsCorrectThread() {
+        let (ownerThread, _) = createSyncedThread(title: "Owner Thread")
+
+        let found = threadManager.findThreadBySessionId(ownerThread.sessionId!)
+
+        XCTAssertEqual(found?.id, ownerThread.id)
+    }
+
+    func testFindThreadBySessionIdExcludesArchived() {
+        let (ownerThread, _) = createSyncedThread(title: "Archived Owner")
+
+        // Archive the thread
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == ownerThread.id }) {
+            threadManager.threads[idx].isArchived = true
+        }
+
+        let found = threadManager.findThreadBySessionId(ownerThread.sessionId!)
+
+        XCTAssertNil(found, "Archived threads should not be returned by findThreadBySessionId")
+    }
+
+    func testFindThreadBySessionIdReturnsNilForUnknownSession() {
+        let _ = createSyncedThread(title: "Some Thread")
+
+        let found = threadManager.findThreadBySessionId("nonexistent-session-id")
+
+        XCTAssertNil(found)
+    }
+
+    // MARK: - resolveSendConflict
+
+    func testResolveSendConflictReturnsInfoForKnownOwner() {
+        let (ownerThread, _) = createSyncedThread(title: "Owner Thread")
+        let (nonOwnerThread, _) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        let conflict = SendConflictInfo(
+            ownerConversationId: ownerThread.sessionId!,
+            message: "Another thread owns this chat."
+        )
+
+        let resolved = threadManager.resolveSendConflict(conflict, excludingThread: nonOwnerThread.id)
+
+        XCTAssertNotNil(resolved)
+        XCTAssertEqual(resolved?.ownerThreadTitle, "Owner Thread")
+        XCTAssertEqual(resolved?.ownerThreadId, ownerThread.id)
+        XCTAssertEqual(resolved?.ownerConversationId, ownerThread.sessionId)
+        XCTAssertEqual(resolved?.sourceChannel, "telegram")
+        XCTAssertEqual(resolved?.externalChatId, "chat-123")
+    }
+
+    func testResolveSendConflictReturnsNilForUnknownOwner() {
+        let (nonOwnerThread, _) = createSyncedThread(
+            externalChatId: "chat-456",
+            title: "Non-Owner"
+        )
+
+        let conflict = SendConflictInfo(
+            ownerConversationId: "unknown-session-id",
+            message: "Conflict"
+        )
+
+        let resolved = threadManager.resolveSendConflict(conflict, excludingThread: nonOwnerThread.id)
+
+        XCTAssertNil(resolved, "Should return nil when owner session cannot be found")
+    }
+
+    func testResolveSendConflictExcludesSelf() {
+        let (ownerThread, _) = createSyncedThread(title: "Self Thread")
+
+        let conflict = SendConflictInfo(
+            ownerConversationId: ownerThread.sessionId!,
+            message: "Conflict"
+        )
+
+        // Exclude the same thread as the owner — should return nil
+        let resolved = threadManager.resolveSendConflict(conflict, excludingThread: ownerThread.id)
+
+        XCTAssertNil(resolved, "Should not resolve conflict when owner is the excluded thread itself")
+    }
+
+    func testResolveSendConflictUsesOwnerThreadId() {
+        // Verify the resolved conflict includes the ownerThreadId for direct navigation
+        let (ownerThread, _) = createSyncedThread(title: "Target Owner")
+
+        let conflict = SendConflictInfo(
+            ownerConversationId: ownerThread.sessionId!,
+            message: "Use the synced thread."
+        )
+
+        let resolved = threadManager.resolveSendConflict(conflict, excludingThread: UUID())
+
+        XCTAssertNotNil(resolved)
+        XCTAssertEqual(resolved?.ownerThreadId, ownerThread.id,
+                       "Resolved conflict must include ownerThreadId for direct thread navigation")
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1016,6 +1016,14 @@ extension ChatViewModel {
                     }
                 }
             }
+            // Detect structured conflict payloads from messaging tool errors.
+            // The messaging-send and messaging-reply tools return a JSON string
+            // with {"error":"conflict","ownerConversationId":"..."} when the
+            // current thread is not the sync owner.
+            if msg.isError == true, let conflictInfo = SendConflictInfo.parse(from: msg.result) {
+                sendConflict = conflictInfo
+            }
+
             // Tool completed — agent is now processing the result. Show
             // thinking indicator until the next text delta or tool starts.
             if isSending && !isCancelling {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -47,6 +47,11 @@ public final class ChatViewModel: ObservableObject {
     /// Widget IDs dismissed by the user, persisted across view recreation.
     @Published public var dismissedDocumentSurfaceIds: Set<String> = []
 
+    /// Active send-conflict detected from a tool error with `{"error":"conflict","ownerConversationId":"..."}`.
+    /// Set when a messaging tool (e.g. messaging-send, messaging-reply) returns a conflict error,
+    /// indicating the current thread is not the sync owner. Cleared on dismiss or when the conflict is resolved.
+    @Published public var sendConflict: SendConflictInfo?
+
     /// The currently active model ID, updated via `model_info` IPC messages.
     @Published public var selectedModel: String = "claude-opus-4-6"
     /// Set of provider keys with configured API keys, updated via `model_info` IPC messages.
@@ -336,6 +341,7 @@ public final class ChatViewModel: ObservableObject {
         pendingSuggestionRequestId = nil
         errorText = nil
         sessionError = nil
+        sendConflict = nil
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
@@ -1431,10 +1437,45 @@ public final class ChatViewModel: ObservableObject {
         // Surfaces are now included directly in the history response and populated above
     }
 
+    /// Dismiss the active send-conflict banner.
+    public func dismissSendConflict() {
+        sendConflict = nil
+    }
+
     deinit {
         messageLoopTask?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+    }
+}
+
+// MARK: - Send Conflict Info
+
+/// Parsed conflict payload from a messaging tool error indicating the current
+/// thread tried to send to a chat owned by a different conversation.
+public struct SendConflictInfo: Equatable {
+    /// Daemon conversation/session ID of the thread that owns the external chat binding.
+    public let ownerConversationId: String
+    /// Human-readable message from the conflict error.
+    public let message: String
+
+    public init(ownerConversationId: String, message: String) {
+        self.ownerConversationId = ownerConversationId
+        self.message = message
+    }
+
+    /// Try to parse a tool error result string as a JSON conflict payload.
+    /// Returns nil if the string is not a valid conflict payload.
+    public static func parse(from toolResult: String) -> SendConflictInfo? {
+        guard let data = toolResult.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = json["error"] as? String,
+              error == "conflict",
+              let ownerConversationId = json["ownerConversationId"] as? String else {
+            return nil
+        }
+        let message = json["message"] as? String ?? "Another thread owns this chat."
+        return SendConflictInfo(ownerConversationId: ownerConversationId, message: message)
     }
 }


### PR DESCRIPTION
## Summary\n- Parse structured conflict payload from tool errors in macOS message pipeline\n- Convert ownerConversationId into thread target when available\n- Show CTA banner/actions based on real conflict event state\n- Resolve owner thread by ownerConversationId from conflict payload\n\nCloses #6588
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
