### PR TITLE
fix: don't show Thinking indicator while tools are running

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -524,7 +524,12 @@ struct ChatView: View {
 
                     let lastVisible = displayMessages.last
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
-                    let hasActiveToolCall = lastVisible?.toolCalls.contains(where: { !$0.isComplete }) == true
+                    // Check all messages for active tool calls — not just lastVisible —
+                    // because confirmation messages are inserted after the assistant
+                    // message that owns the tool call, so lastVisible may miss it.
+                    let hasActiveToolCall = displayMessages.contains(where: {
+                        $0.toolCalls.contains(where: { !$0.isComplete })
+                    })
                     if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {
                         HStack(alignment: .top, spacing: VSpacing.sm) {
                             Image(nsImage: appearance.chatAvatarImage)

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2090,9 +2090,9 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking, "Tool chip is visible, thinking should be false")
 
-        // Tool completes — agent is now processing the result
+        // Tool completes — agent is processing the result but isn't "thinking" yet
         viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
-        XCTAssertTrue(viewModel.isThinking, "Thinking should restore after tool result while still sending")
+        XCTAssertFalse(viewModel.isThinking, "Thinking should not restore after tool result — tool chip indicates activity")
     }
 
     func testToolResultDoesNotRestoreThinkingWhenNotSending() {
@@ -2127,7 +2127,8 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testThinkingCycleThroughMultipleTools() {
-        // Full cycle: thinking → text → tool1 → result → thinking → tool2 → result → thinking → complete
+        // Full cycle: thinking → text → tool1 → result → tool2 → result → complete
+        // Thinking should NOT re-appear between tools — only the tool chip shows activity
         viewModel.isSending = true
         viewModel.isThinking = true
 
@@ -2139,17 +2140,17 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking)
 
-        // First tool completes
+        // First tool completes — no "Thinking" flash between tools
         viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "files", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
-        XCTAssertTrue(viewModel.isThinking, "Thinking should show between tools")
+        XCTAssertFalse(viewModel.isThinking, "Thinking should not show between tools")
 
         // Second tool starts
         viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "file_read", input: ["path": AnyCodable("foo.txt")], sessionId: nil)))
-        XCTAssertFalse(viewModel.isThinking, "Thinking should clear when new tool starts")
+        XCTAssertFalse(viewModel.isThinking, "Thinking should stay false when new tool starts")
 
         // Second tool completes
         viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "file_read", result: "contents", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
-        XCTAssertTrue(viewModel.isThinking, "Thinking should show again after second tool")
+        XCTAssertFalse(viewModel.isThinking, "Thinking should not show after second tool")
 
         // Message completes
         viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1023,12 +1023,10 @@ extension ChatViewModel {
             if msg.isError == true, let conflictInfo = SendConflictInfo.parse(from: msg.result) {
                 sendConflict = conflictInfo
             }
-
-            // Tool completed — agent is now processing the result. Show
-            // thinking indicator until the next text delta or tool starts.
-            if isSending && !isCancelling {
-                isThinking = true
-            }
+            // Tool completed — don't re-show "Thinking..." here. The tool
+            // call chip already indicates activity, and the LLM isn't actually
+            // thinking yet. isThinking will be set when the user sends a new
+            // message or the daemon echoes it back.
 
         case .uiSurfaceShow(let msg):
             log.info("Received ui_surface_show: surfaceId=\(msg.surfaceId), messageId=\(msg.messageId ?? "nil"), display=\(msg.display ?? "nil")")


### PR DESCRIPTION
## Summary
- Fixed the Thinking indicator showing simultaneously with Running a command by checking all messages for active tool calls, not just the last visible message
- Removed the isThinking=true assignment after tool results, which caused Thinking to flash between consecutive tool executions
- Updated tests to match the new behavior

## Original prompt
the assistant will often show "Thinking..." while it'a actually just waiting for commands to be run (i.e. it says "Running a command...."). We should only showing thinking if the assistant is actually thinking (i.e. the LLM api call is happening). Help me clean up this UX. I've attahced a screenshot that shows what I mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
