### PR TITLE
fix: guard empty text in call-bridge answer path (PR #6581 feedback)

### DIFF
--- a/assistant/src/calls/call-bridge.ts
+++ b/assistant/src/calls/call-bridge.ts
@@ -74,6 +74,12 @@ async function handleAnswer(
   pendingQuestion: { id: string; questionText: string },
   userText: string,
 ): Promise<CallBridgeResult> {
+  // Empty text (e.g. attachment-only messages) should not be consumed as
+  // an answer — fall through to normal processing so attachments are handled.
+  if (!userText.trim()) {
+    return { handled: false, reason: 'empty_answer_text' };
+  }
+
   const orchestrator = getCallOrchestrator(callSessionId);
   if (!orchestrator) {
     // The call may have ended between the question being asked and the


### PR DESCRIPTION
## Summary
- Add empty-text guard in handleAnswer to prevent attachment-only messages from being consumed as empty answers
- Mirrors the guard already added in handleInstruction

Addresses feedback on #6581
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
