### PR TITLE
test: assert empty payload in clear-URL reconcile test (PR #6598 feedback)

### DIFF
--- a/assistant/src/__tests__/ingress-reconcile.test.ts
+++ b/assistant/src/__tests__/ingress-reconcile.test.ts
@@ -460,6 +460,8 @@ describe('Ingress reconcile trigger in handleIngressConfig', () => {
     // When no URL and no env fallback, effectiveUrl is undefined so
     // the reconcile body should send empty string (clears the gateway's URL)
     expect(reconcileCalls).toHaveLength(1);
+    const body = JSON.parse(reconcileCalls[0]!.body);
+    expect(body.ingressPublicBaseUrl).toBe('');
   });
 
   // ── Disable flow ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add assertion to verify reconcile payload contains empty ingressPublicBaseUrl for clear case
- Prevents silent regression if handler sends stale URL

Addresses feedback on #6598
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
