### PR TITLE
fix: preserve hidden session timestamp when session stays hidden (PR #6585 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -608,7 +608,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         var hidden = hiddenSessionTimestamps
         hidden.removeValue(forKey: sessionId)
         hiddenSessionTimestamps = hidden
-        // Also clear the in-memory tracker so the monitor task stops watching
+        clearHiddenSessionMonitor(sessionId)
+    }
+
+    /// Clear only the in-memory hidden-session tracker (monitor task) without
+    /// touching the persisted timestamp. Used when a session should stay hidden
+    /// across restarts but the monitor is no longer needed (e.g. the session
+    /// restorer already re-created the thread as archived).
+    func clearHiddenSessionMonitor(_ sessionId: String) {
         hiddenSessions.removeValue(forKey: sessionId)
         if hiddenSessions.isEmpty {
             hiddenSessionMonitorTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -25,6 +25,10 @@ protocol ThreadRestorerDelegate: AnyObject {
     /// Remove a session from the hidden-sessions tracker (called when the
     /// session restorer re-creates the thread on daemon reconnect).
     func clearHiddenSession(_ sessionId: String)
+    /// Clear only the in-memory hidden-session monitor without removing the
+    /// persisted timestamp. Used when a session should stay hidden across
+    /// restarts but the monitor is no longer needed.
+    func clearHiddenSessionMonitor(_ sessionId: String)
 }
 
 /// Handles daemon session restoration: fetching the session list on connect,
@@ -114,12 +118,19 @@ final class ThreadSessionRestorer {
             // re-appears as visible.
             let isHidden = delegate.isSessionHidden(session.id, updatedAt: session.updatedAt)
 
-            // Now that the hidden check is done, clear the in-memory monitor
-            // so the hidden-session monitor task stops watching for this session.
-            // The persisted timestamp was already handled by isSessionHidden above
-            // (it auto-clears when new activity is detected).
+            // Clean up hidden-session tracking now that the thread is being
+            // re-created by the session restorer.
             if delegate.isSessionHidden(session.id) {
-                delegate.clearHiddenSession(session.id)
+                if isHidden {
+                    // Session should stay hidden (no new activity) — only stop the
+                    // in-memory monitor. Preserve the persisted timestamp so the
+                    // thread remains hidden across future app restarts.
+                    delegate.clearHiddenSessionMonitor(session.id)
+                } else {
+                    // New activity detected — fully clear hidden state (both
+                    // in-memory and persisted) so the thread re-appears as visible.
+                    delegate.clearHiddenSession(session.id)
+                }
             }
 
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -73,6 +73,10 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         hiddenSessionTimestamps.removeValue(forKey: sessionId)
     }
 
+    func clearHiddenSessionMonitor(_ sessionId: String) {
+        hiddenSessionIds.remove(sessionId)
+    }
+
     func restoreLastActiveThread() {
         // no-op for tests
     }


### PR DESCRIPTION
## Summary
- Fix clearHiddenSession to preserve persisted timestamp when session should stay hidden
- Only clear persisted timestamp when new activity is detected (isHidden == false)

Addresses feedback on #6585
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
