### PR TITLE
fix: restore hanging indents for wrapped list items (PR #6595 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -150,19 +151,39 @@ struct MarkdownSegmentView: View {
                 result += heading
 
             case .list(let items):
+                let indentStep: CGFloat = 16
+                let font = NSFont.systemFont(ofSize: 13)
+
                 for (itemIndex, item) in items.enumerated() {
                     if itemIndex > 0 {
                         result += AttributedString("\n")
                     }
-                    let indent = String(repeating: "    ", count: item.indent / 2)
-                    let prefix = item.ordered ? "\(item.number). " : "\u{2022} "
-                    var prefixAttr = AttributedString(indent + prefix)
+
+                    let indentLevel = CGFloat(item.indent / 2)
+                    let leftMargin = indentLevel * indentStep
+                    let prefix = item.ordered ? "\(item.number).\t" : "\u{2022}\t"
+
+                    // Measure the prefix width to set the tab stop / hanging indent
+                    let prefixForMeasure = item.ordered ? "\(item.number). " : "\u{2022} "
+                    let prefixSize = (prefixForMeasure as NSString).size(withAttributes: [.font: font])
+                    let textColumn = leftMargin + prefixSize.width
+
+                    // Build paragraph style with hanging indent so wrapped lines
+                    // align with the text column rather than the bullet/number.
+                    let paraStyle = NSMutableParagraphStyle()
+                    paraStyle.firstLineHeadIndent = leftMargin
+                    paraStyle.headIndent = textColumn
+                    paraStyle.tabStops = [NSTextTab(textAlignment: .left, location: textColumn)]
+
+                    var prefixAttr = AttributedString(prefix)
                     prefixAttr.foregroundColor = secondaryTextColor
                     prefixAttr.font = .system(size: 13)
+                    prefixAttr.paragraphStyle = paraStyle
                     result += prefixAttr
 
-                    let itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
+                    var itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
                         ?? AttributedString(item.text)
+                    itemAttr.paragraphStyle = paraStyle
                     result += itemAttr
                 }
 


### PR DESCRIPTION
## Summary
- Fix list indentation regression from cross-paragraph selection changes
- Use paragraph style headIndent for proper hanging indents within unified AttributedString
- Maintains cross-paragraph text selection capability

Addresses feedback on #6595
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
