### PR TITLE
Fix Enter key approval regression in tool confirmation bubble

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -409,13 +409,6 @@ public struct ToolConfirmationBubble: View {
         removeKeyMonitor()
         keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            // Pass through when the first responder is a text view (e.g. the
-            // composer) so typing, Enter-to-send, Tab-to-accept-suggestion,
-            // and Escape-to-dismiss-slash-menu continue to work normally.
-            if let firstResponder = NSApp.keyWindow?.firstResponder,
-               firstResponder is NSTextView {
-                return event
-            }
             let mods = event.modifierFlags.intersection(Self.intentionalModifiers)
             // Nested popover is open — handle up/down/enter/escape within it
             if showAlwaysAllowMenu || showScopePickerMenu {


### PR DESCRIPTION
## Summary
- remove the text-view early return in the macOS confirmation key monitor
- allow Enter key events to reach ToolConfirmationBubble approval handlers again

## Validation
- swift build --target VellumAssistantShared (from clients/)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
