### PR TITLE
fix: move dismissSendConflict inside branches in onMoveSyncHere (PR #6600 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -374,10 +374,10 @@ extension MainWindowView {
                     }
                 } : nil,
                 onMoveSyncHere: syncConflict != nil ? {
-                    viewModel.dismissSendConflict()
                     if let thread = threadManager.activeThread,
                        let sourceChannel = syncConflict?.sourceChannel, !sourceChannel.isEmpty,
                        let externalChatId = syncConflict?.externalChatId, !externalChatId.isEmpty {
+                        viewModel.dismissSendConflict()
                         threadManager.moveSyncHereAndResend(
                             threadId: thread.id,
                             sourceChannel: sourceChannel,
@@ -386,6 +386,7 @@ extension MainWindowView {
                     } else if let thread = threadManager.activeThread,
                        let sourceChannel = thread.sourceChannel,
                        let externalChatId = thread.externalChatId {
+                        viewModel.dismissSendConflict()
                         threadManager.moveSyncHereAndResend(
                             threadId: thread.id,
                             sourceChannel: sourceChannel,


### PR DESCRIPTION
Move dismissSendConflict() from unconditional position before the if/else to inside each branch, matching the pattern in onContinueInSyncedThread. Prevents silent loss of conflict UI when both branches fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
