### PR TITLE
fix: restore targeted NSTextView guard in tool confirmation key monitor (PR #6608 feedback)

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -409,6 +409,14 @@ public struct ToolConfirmationBubble: View {
         removeKeyMonitor()
         keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // If an editable text view (e.g. the composer) is the first responder,
+            // let the event pass through so it can handle Enter/Tab/Escape normally.
+            // Non-editable text views (e.g. selectable command previews inside the
+            // confirmation bubble) don't need these keys, so we still intercept them.
+            if let firstResponder = NSApp.keyWindow?.firstResponder as? NSTextView,
+               firstResponder.isEditable {
+                return event
+            }
             let mods = event.modifierFlags.intersection(Self.intentionalModifiers)
             // Nested popover is open — handle up/down/enter/escape within it
             if showAlwaysAllowMenu || showScopePickerMenu {


### PR DESCRIPTION
Re-add a scoped first-responder check in ToolConfirmationBubble's key monitor so Enter/Tab/Escape pass through to the composer when it has focus, while still allowing confirmation approval when the composer doesn't have focus.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
