### PR TITLE
fix: scope active tool call detection to current turn (PR #6602 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -524,10 +524,20 @@ struct ChatView: View {
 
                     let lastVisible = displayMessages.last
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
-                    // Check all messages for active tool calls — not just lastVisible —
-                    // because confirmation messages are inserted after the assistant
-                    // message that owns the tool call, so lastVisible may miss it.
-                    let hasActiveToolCall = displayMessages.contains(where: {
+                    // Check the current assistant turn for active tool calls.
+                    // We scope to messages after the last user message so that
+                    // stale incomplete tool calls from earlier turns (e.g. after
+                    // daemon errors) don't permanently suppress the thinking
+                    // indicator. We still scan beyond lastVisible because
+                    // confirmation messages are inserted after the assistant
+                    // message that owns the tool call.
+                    let currentTurnMessages: ArraySlice<ChatMessage> = {
+                        if let lastUserIndex = displayMessages.lastIndex(where: { $0.role == .user }) {
+                            return displayMessages[displayMessages.index(after: lastUserIndex)...]
+                        }
+                        return displayMessages[displayMessages.startIndex...]
+                    }()
+                    let hasActiveToolCall = currentTurnMessages.contains(where: {
                         $0.toolCalls.contains(where: { !$0.isComplete })
                     })
                     if isSending && !(lastVisible?.isStreaming == true) && !hasPendingConfirmation && !hasActiveToolCall {


### PR DESCRIPTION
Restrict hasActiveToolCall check to messages from the current assistant turn instead of scanning all displayMessages. Prevents stale incomplete tool calls from earlier turns permanently suppressing the thinking indicator.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
