### PR TITLE
Harden /update gateway startup routing defaults

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -36,7 +36,7 @@ Pull the latest changes from main, restart the backend daemon, rebuild/launch th
    cd assistant && bun run daemon:restart:http && cd ..
    ```
 
-5. Resolve gateway ingress and Twilio auth env from local config/credential store:
+5. Resolve gateway ingress, Twilio auth, and routing env from local config/credential store:
    ```bash
    INGRESS_PUBLIC_BASE_URL="$(
      python3 - <<'PY'
@@ -56,11 +56,65 @@ PY
      bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:auth_token") ?? "")'
      cd ..
    )"
+
+   # Mirror CLI startGateway() behavior: only auto-enable default routing
+   # when exactly one assistant is present in ~/.vellum.lock.json.
+   ASSISTANT_ROUTING_INFO="$(
+     python3 - <<'PY'
+import json, os
+lock_path = os.path.expanduser("~/.vellum.lock.json")
+count = 0
+assistant_id = ""
+try:
+    with open(lock_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assistants = data.get("assistants")
+    if isinstance(assistants, list):
+        valid = []
+        for item in assistants:
+            if isinstance(item, dict):
+                raw_id = item.get("assistantId")
+                if isinstance(raw_id, str):
+                    aid = raw_id.strip()
+                    if aid:
+                        valid.append(aid)
+        count = len(valid)
+        if count == 1:
+            assistant_id = valid[0]
+except Exception:
+    pass
+print(count)
+print(assistant_id)
+PY
+   )"
+   ASSISTANT_COUNT="$(printf '%s\n' "$ASSISTANT_ROUTING_INFO" | sed -n '1p')"
+   SINGLE_ASSISTANT_ID="$(printf '%s\n' "$ASSISTANT_ROUTING_INFO" | sed -n '2p')"
+
+   if [ -z "${GATEWAY_UNMAPPED_POLICY:-}" ] && [ "$ASSISTANT_COUNT" = "1" ]; then
+     GATEWAY_UNMAPPED_POLICY="default"
+   fi
+   if [ -z "${GATEWAY_DEFAULT_ASSISTANT_ID:-}" ] && [ "$ASSISTANT_COUNT" = "1" ]; then
+     GATEWAY_DEFAULT_ASSISTANT_ID="$SINGLE_ASSISTANT_ID"
+   fi
+   if [ "${GATEWAY_UNMAPPED_POLICY:-}" = "default" ] && [ -z "${GATEWAY_DEFAULT_ASSISTANT_ID:-}" ]; then
+     echo "WARNING: GATEWAY_UNMAPPED_POLICY=default but no GATEWAY_DEFAULT_ASSISTANT_ID is set. Falling back to reject."
+     GATEWAY_UNMAPPED_POLICY="reject"
+   fi
+
    if [ -z "$INGRESS_PUBLIC_BASE_URL" ]; then
      echo "WARNING: INGRESS_PUBLIC_BASE_URL is empty (Twilio signature validation may fail)."
    fi
    if [ -z "$TWILIO_AUTH_TOKEN" ]; then
      echo "WARNING: TWILIO_AUTH_TOKEN is empty (Twilio webhooks will be rejected)."
+   fi
+   if [ "${GATEWAY_UNMAPPED_POLICY:-}" = "default" ]; then
+     if [ -n "${GATEWAY_DEFAULT_ASSISTANT_ID:-}" ]; then
+       echo "Gateway routing: default -> ${GATEWAY_DEFAULT_ASSISTANT_ID}"
+     else
+       echo "WARNING: Gateway routing policy is default but default assistant is empty."
+     fi
+   else
+     echo "Gateway routing: ${GATEWAY_UNMAPPED_POLICY:-reject}"
    fi
    ```
 
@@ -73,6 +127,8 @@ PY
      GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false \
      INGRESS_PUBLIC_BASE_URL="$INGRESS_PUBLIC_BASE_URL" \
      TWILIO_AUTH_TOKEN="$TWILIO_AUTH_TOKEN" \
+     GATEWAY_UNMAPPED_POLICY="${GATEWAY_UNMAPPED_POLICY:-}" \
+     GATEWAY_DEFAULT_ASSISTANT_ID="${GATEWAY_DEFAULT_ASSISTANT_ID:-}" \
      bun run dev:proxy \
      > "${HOME}/.vellum/gateway-dev.log" 2>&1 &
    cd ..
@@ -95,4 +151,5 @@ Report:
 1. What was pulled (new commits).
 2. Daemon health and gateway health results.
 3. Whether ingress and Twilio auth env were non-empty at startup.
-4. The gateway log path: `~/.vellum/gateway-dev.log`.
+4. Gateway routing env values used (`GATEWAY_UNMAPPED_POLICY`, `GATEWAY_DEFAULT_ASSISTANT_ID`).
+5. The gateway log path: `~/.vellum/gateway-dev.log`.

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env injected from local config/credentials, then launch app pinned to local `gateway/`. |
+| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, then launch app pinned to local `gateway/`. |
 
 
 ### Review


### PR DESCRIPTION
## Summary
- update `.claude/commands/update.md` to resolve and inject resilient gateway routing env vars during `/update`
- mirror CLI `startGateway()` behavior: only auto-set `GATEWAY_UNMAPPED_POLICY=default` and `GATEWAY_DEFAULT_ASSISTANT_ID` when exactly one assistant exists in `~/.vellum.lock.json`
- add guardrail fallback to `reject` when `default` policy has no assistant id
- expand `/update` report output to include routing env values used
- update `/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/README.md` slash-command table entry for `/update`

## Why
`/update` started the gateway directly from source but did not inject routing defaults, so Telegram webhook traffic could be rejected with "could not be routed to an assistant" after restart.

## Validation
- reviewed command diff and verified injected env vars are present in gateway startup step
- verified docs are updated to match slash-command behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
