### PR TITLE
ci: run CLI checks on push to main to catch compile failures early

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -1,7 +1,12 @@
-name: PR CLI Checks
+name: CLI Checks
 
 on:
   pull_request:
+    paths:
+      - 'cli/**'
+      - '.github/workflows/ci-cli.yml'
+  push:
+    branches: [main]
     paths:
       - 'cli/**'
       - '.github/workflows/ci-cli.yml'


### PR DESCRIPTION
## Summary

- Extends the CLI CI checks workflow to also run on pushes to main when `cli/**` files change
- Previously the workflow only ran on pull requests; compile errors introduced directly to main would not be caught until the next `clients/Package.swift` change triggered a release build
- Renames workflow from "PR CLI Checks" to "CLI Checks" to reflect the expanded trigger scope

## Root Cause

This PR addresses the root cause of the CI failure in run [#22202052052](https://github.com/vellum-ai/vellum-assistant/actions/runs/22202052052), triggered by merging PR [#5500](https://github.com/vellum-ai/vellum-assistant/pull/5500).

The failure occurred because PR #5452 introduced `import ... with { type: "text" }` syntax in `cli/src/lib/interfaces-seed.ts`. Bun 1.3.9 does not support this import attribute for `.ts` files in compiled binary mode — it treats the import as a regular module import and fails with "No matching export for import default" when running `bun build --compile`.

The compile error was not caught by the `ci-cli.yml` PR check (which only ran lint and typecheck at the time). It only surfaced when PR #5500 triggered the `build-and-release-macos.yml` workflow by modifying `clients/Package.swift`.

Previous fixes already applied:
- PR #5591: Fixed `interfaces-seed.ts` to use `Bun.file()` instead of text imports
- PR #5983: Added `Compile check` step to `ci-cli.yml` for PRs
- PR #6164: Removed `interfaces-seed.ts` entirely

This PR adds the final safeguard: running the compile check on every push to `main` when CLI files change, so future regressions are caught immediately at merge time rather than at the next release build.

## Test plan

- [ ] Verify the "CLI Checks" workflow runs on PRs that touch `cli/**` (existing behavior preserved)
- [ ] Verify the "CLI Checks" workflow runs on pushes to `main` that touch `cli/**` (new behavior)
- [ ] Confirm the compile check step catches `bun build --compile` failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
