### PR TITLE
M1: Runtime approval types, pending-run helpers, and text parser

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'channel-approval-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, resetDb } from '../memory/db.js';
+import {
+  createRun,
+  setRunConfirmation,
+  getPendingConfirmationsByConversation,
+} from '../memory/runs-store.js';
+import type { PendingConfirmation } from '../memory/runs-store.js';
+import { parseApprovalDecision } from '../runtime/channel-approval-parser.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helper: insert a conversation so FK constraints pass
+// ---------------------------------------------------------------------------
+
+function ensureConversation(conversationId: string): void {
+  const { getDb } = require('../memory/db.js');
+  const db = getDb();
+  const { conversations } = require('../memory/schema.js');
+  try {
+    db.insert(conversations).values({
+      id: conversationId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }).run();
+  } catch {
+    // already exists
+  }
+}
+
+function resetTables(): void {
+  const { getDb } = require('../memory/db.js');
+  const db = getDb();
+  db.run('DELETE FROM message_runs');
+  db.run('DELETE FROM conversations');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Plain-text approval decision parser
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('parseApprovalDecision', () => {
+  // ── Approve once ──────────────────────────────────────────────────
+
+  test.each([
+    'yes',
+    'Yes',
+    'YES',
+    'approve',
+    'Approve',
+    'APPROVE',
+    'allow',
+    'Allow',
+    'go ahead',
+    'Go Ahead',
+    'GO AHEAD',
+  ])('recognises "%s" as approve_once', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_once');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Approve always ────────────────────────────────────────────────
+
+  test.each([
+    'always',
+    'Always',
+    'ALWAYS',
+    'approve always',
+    'Approve Always',
+    'APPROVE ALWAYS',
+    'allow always',
+    'Allow Always',
+    'ALLOW ALWAYS',
+  ])('recognises "%s" as approve_always', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_always');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Reject ────────────────────────────────────────────────────────
+
+  test.each([
+    'no',
+    'No',
+    'NO',
+    'reject',
+    'Reject',
+    'REJECT',
+    'deny',
+    'Deny',
+    'DENY',
+    'cancel',
+    'Cancel',
+    'CANCEL',
+  ])('recognises "%s" as reject', (input) => {
+    const result = parseApprovalDecision(input);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('reject');
+    expect(result!.source).toBe('plain_text');
+  });
+
+  // ── Whitespace handling ───────────────────────────────────────────
+
+  test('trims leading and trailing whitespace', () => {
+    const result = parseApprovalDecision('  approve  ');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('approve_once');
+  });
+
+  test('trims tabs and newlines', () => {
+    const result = parseApprovalDecision('\t\nreject\n\t');
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('reject');
+  });
+
+  // ── Non-matching text ─────────────────────────────────────────────
+
+  test.each([
+    '',
+    '   ',
+    'hello',
+    'please approve this',
+    'I approve',
+    'yes please',
+    'nope',
+    'approved',
+    'allow me',
+    'go',
+    'ahead',
+    'maybe',
+    'approve once',
+  ])('returns null for non-matching text: "%s"', (input) => {
+    expect(parseApprovalDecision(input)).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Pending-run lookup helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('getPendingConfirmationsByConversation', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  const sampleConfirmation: PendingConfirmation = {
+    toolName: 'shell',
+    toolUseId: 'req-abc-123',
+    input: { command: 'rm -rf /tmp/test' },
+    riskLevel: 'high',
+  };
+
+  test('returns empty array when no runs exist', () => {
+    ensureConversation('conv-1');
+    const result = getPendingConfirmationsByConversation('conv-1');
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when no runs need confirmation', () => {
+    ensureConversation('conv-1');
+    createRun('conv-1', 'msg-1');
+    const result = getPendingConfirmationsByConversation('conv-1');
+    expect(result).toEqual([]);
+  });
+
+  test('returns pending confirmation for a run needing confirmation', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const result = getPendingConfirmationsByConversation('conv-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].runId).toBe(run.id);
+    expect(result[0].requestId).toBe('req-abc-123');
+    expect(result[0].toolName).toBe('shell');
+    expect(result[0].input).toEqual({ command: 'rm -rf /tmp/test' });
+    expect(result[0].riskLevel).toBe('high');
+  });
+
+  test('only returns runs for the specified conversation', () => {
+    ensureConversation('conv-1');
+    ensureConversation('conv-2');
+
+    const run1 = createRun('conv-1', 'msg-1');
+    const run2 = createRun('conv-2', 'msg-2');
+    setRunConfirmation(run1.id, sampleConfirmation);
+    setRunConfirmation(run2.id, { ...sampleConfirmation, toolUseId: 'req-def-456' });
+
+    const result1 = getPendingConfirmationsByConversation('conv-1');
+    expect(result1).toHaveLength(1);
+    expect(result1[0].runId).toBe(run1.id);
+
+    const result2 = getPendingConfirmationsByConversation('conv-2');
+    expect(result2).toHaveLength(1);
+    expect(result2[0].runId).toBe(run2.id);
+  });
+
+  test('returns multiple pending runs for the same conversation', () => {
+    ensureConversation('conv-1');
+
+    const run1 = createRun('conv-1', 'msg-1');
+    const run2 = createRun('conv-1', 'msg-2');
+    setRunConfirmation(run1.id, sampleConfirmation);
+    setRunConfirmation(run2.id, { ...sampleConfirmation, toolUseId: 'req-ghi-789', toolName: 'file_edit' });
+
+    const result = getPendingConfirmationsByConversation('conv-1');
+    expect(result).toHaveLength(2);
+
+    const runIds = result.map((r) => r.runId).sort();
+    expect(runIds).toContain(run1.id);
+    expect(runIds).toContain(run2.id);
+  });
+
+  test('excludes completed and failed runs', () => {
+    ensureConversation('conv-1');
+
+    const run1 = createRun('conv-1', 'msg-1');
+    const run2 = createRun('conv-1', 'msg-2');
+    const run3 = createRun('conv-1', 'msg-3');
+
+    setRunConfirmation(run1.id, sampleConfirmation);
+    // run2 stays in 'running' state
+    // run3 gets confirmation then completes — simulated by not setting confirmation
+
+    const result = getPendingConfirmationsByConversation('conv-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].runId).toBe(run1.id);
+  });
+});

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -6,7 +6,7 @@
  *   running → needs_secret       → running → completed | failed
  */
 
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { messageRuns } from './schema.js';
@@ -215,6 +215,59 @@ export function failRun(runId: string, error: string): void {
     .where(eq(messageRuns.id, runId))
     .run();
 }
+
+// ---------------------------------------------------------------------------
+// Pending-confirmation lookups
+// ---------------------------------------------------------------------------
+
+/** Summary of a run awaiting confirmation, used by channel approval flows. */
+export interface PendingRunInfo {
+  runId: string;
+  /** The prompter-level request ID stored inside PendingConfirmation.toolUseId. */
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  riskLevel: string;
+}
+
+/**
+ * Find all runs in `needs_confirmation` state for a given conversation.
+ *
+ * Returns structured info for each pending run so channel adapters can
+ * render approval prompts and route decisions without reaching into
+ * raw DB rows.
+ */
+export function getPendingConfirmationsByConversation(conversationId: string): PendingRunInfo[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(messageRuns)
+    .where(
+      and(
+        eq(messageRuns.conversationId, conversationId),
+        eq(messageRuns.status, 'needs_confirmation'),
+      ),
+    )
+    .all();
+
+  const results: PendingRunInfo[] = [];
+  for (const row of rows) {
+    const run = rowToRun(row);
+    if (!run.pendingConfirmation) continue;
+    results.push({
+      runId: run.id,
+      requestId: run.pendingConfirmation.toolUseId,
+      toolName: run.pendingConfirmation.toolName,
+      input: run.pendingConfirmation.input,
+      riskLevel: run.pendingConfirmation.riskLevel,
+    });
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan recovery
+// ---------------------------------------------------------------------------
 
 /**
  * Mark all non-terminal runs as failed.

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -1,0 +1,60 @@
+/**
+ * Channel-agnostic plain-text approval decision parser.
+ *
+ * Parses inbound user text to determine whether it matches an approval,
+ * rejection, or "approve always" intent. This module is transport-agnostic
+ * and can be used by any channel adapter (Telegram, SMS, etc.).
+ */
+
+import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-types.js';
+
+// ---------------------------------------------------------------------------
+// Phrase → action mapping
+// ---------------------------------------------------------------------------
+
+const APPROVE_ONCE_PHRASES = ['yes', 'approve', 'allow', 'go ahead'];
+const APPROVE_ALWAYS_PHRASES = ['always', 'approve always', 'allow always'];
+const REJECT_PHRASES = ['no', 'reject', 'deny', 'cancel'];
+
+/**
+ * Build a Map from lowercased phrase to action. "Approve always" phrases
+ * are checked first (longest-match-wins) because "approve" is a prefix
+ * of "approve always".
+ */
+function buildPhraseMap(): Map<string, ApprovalAction> {
+  const map = new Map<string, ApprovalAction>();
+
+  // Insert longer phrases first so iteration order does not matter —
+  // we match on exact equality after normalising, not prefix matching.
+  for (const phrase of APPROVE_ALWAYS_PHRASES) {
+    map.set(phrase, 'approve_always');
+  }
+  for (const phrase of APPROVE_ONCE_PHRASES) {
+    map.set(phrase, 'approve_once');
+  }
+  for (const phrase of REJECT_PHRASES) {
+    map.set(phrase, 'reject');
+  }
+  return map;
+}
+
+const PHRASE_MAP = buildPhraseMap();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a plain-text message into an approval decision.
+ *
+ * Returns a structured `ApprovalDecisionResult` if the text matches one
+ * of the known intent phrases, or `null` if it does not match.
+ *
+ * Matching is case-insensitive with leading/trailing whitespace trimmed.
+ */
+export function parseApprovalDecision(text: string): ApprovalDecisionResult | null {
+  const normalised = text.trim().toLowerCase();
+  const action = PHRASE_MAP.get(normalised);
+  if (!action) return null;
+  return { action, source: 'plain_text' };
+}

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -1,0 +1,71 @@
+/**
+ * Channel-agnostic approval flow types.
+ *
+ * These types model the approval prompt/decision lifecycle for tool-use
+ * confirmations surfaced through external channels (Telegram, SMS, etc.).
+ * They are intentionally decoupled from any specific channel so that the
+ * same approval flow can be reused across transports.
+ */
+
+// ---------------------------------------------------------------------------
+// Approval actions
+// ---------------------------------------------------------------------------
+
+/** The set of actions a user can take on an approval prompt. */
+export type ApprovalAction = 'approve_once' | 'approve_always' | 'reject';
+
+/** An action presented to the user as a tappable button or text option. */
+export interface ApprovalActionOption {
+  id: ApprovalAction;
+  label: string;
+}
+
+/** Default action options presented to users across all channels. */
+export const DEFAULT_APPROVAL_ACTIONS: readonly ApprovalActionOption[] = [
+  { id: 'approve_once', label: 'Approve once' },
+  { id: 'approve_always', label: 'Approve always' },
+  { id: 'reject', label: 'Reject' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Approval prompt
+// ---------------------------------------------------------------------------
+
+/** The approval prompt model sent to users via a channel. */
+export interface ChannelApprovalPrompt {
+  /** Human-readable description of what is being approved. */
+  promptText: string;
+  /** Available actions the user can take. */
+  actions: ApprovalActionOption[];
+  /** Instruction text for channels that only support plain text (no buttons). */
+  plainTextFallback: string;
+}
+
+// ---------------------------------------------------------------------------
+// Approval UI metadata (gateway callback payload)
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata attached to gateway callback payloads so the channel adapter
+ * can render approval UI and route the user's decision back to the
+ * correct pending run.
+ */
+export interface ApprovalUIMetadata {
+  runId: string;
+  requestId: string;
+  actions: ApprovalActionOption[];
+  plainTextFallback: string;
+}
+
+// ---------------------------------------------------------------------------
+// Decision result
+// ---------------------------------------------------------------------------
+
+/** How the user communicated their decision. */
+export type ApprovalDecisionSource = 'telegram_button' | 'plain_text';
+
+/** The structured result of a user's approval decision. */
+export interface ApprovalDecisionResult {
+  action: ApprovalAction;
+  source: ApprovalDecisionSource;
+}


### PR DESCRIPTION
Part of #6626. Adds foundational types, pending-run lookup helpers in runs-store, and a channel-agnostic plain-text approval decision parser for the Telegram approval flow feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
