### PR TITLE
M3: Telegram inline keyboard outbound support

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../../config.js";
 import { createTelegramDeliverHandler } from "./telegram-deliver.js";
 
 // ---- Mocks ----
 
+// Track calls to sendTelegramReply so we can assert on approval passthrough.
+let sendTelegramReplyCalls: Array<unknown[]> = [];
+
 mock.module("../../telegram/send.js", () => ({
-  sendTelegramReply: async () => {},
+  sendTelegramReply: async (...args: unknown[]) => {
+    sendTelegramReplyCalls.push(args);
+  },
   sendTelegramAttachments: async () => {},
 }));
 
@@ -155,5 +160,214 @@ describe("telegram-deliver attachment validation", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
+  });
+});
+
+describe("telegram-deliver approval validation", () => {
+  const config = makeConfig();
+  const handler = createTelegramDeliverHandler(config);
+
+  beforeEach(() => {
+    sendTelegramReplyCalls = [];
+  });
+
+  it("accepts a valid payload without approval (existing behavior unchanged)", async () => {
+    const res = await handler(makeRequest({ chatId: "123", text: "hello" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("accepts a valid payload with approval", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "Please approve",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [
+            { id: "approve_once", label: "Approve once" },
+            { id: "reject", label: "Reject" },
+          ],
+          plainTextFallback: "Reply: approve or reject",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when approval is not an object", async () => {
+    const res = await handler(
+      makeRequest({ chatId: "123", text: "hi", approval: "bad" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval must be an object");
+  });
+
+  it("returns 400 when approval is null", async () => {
+    const res = await handler(
+      makeRequest({ chatId: "123", text: "hi", approval: null }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval must be an object");
+  });
+
+  it("returns 400 when approval is an array", async () => {
+    const res = await handler(
+      makeRequest({ chatId: "123", text: "hi", approval: [] }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval must be an object");
+  });
+
+  it("returns 400 when approval.runId is missing", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          requestId: "req-1",
+          actions: [{ id: "ok", label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval.runId is required");
+  });
+
+  it("returns 400 when approval.requestId is missing", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          actions: [{ id: "ok", label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval.requestId is required");
+  });
+
+  it("returns 400 when approval.actions is empty", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval.actions must be a non-empty array");
+  });
+
+  it("returns 400 when approval.actions is not an array", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: "not-array",
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("approval.actions must be a non-empty array");
+  });
+
+  it("returns 400 when an action is missing id", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [{ label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each approval action must have an id");
+  });
+
+  it("returns 400 when an action is missing label", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [{ id: "ok" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each approval action must have a label");
+  });
+
+  it("returns 400 when an action is not an object", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "hi",
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [null],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("each approval action must be an object");
+  });
+
+  it("passes approval payload through to sendTelegramReply", async () => {
+    const approval = {
+      runId: "run-x",
+      requestId: "req-y",
+      actions: [{ id: "go", label: "Go" }],
+      plainTextFallback: "go",
+    };
+    await handler(makeRequest({ chatId: "c1", text: "msg", approval }));
+
+    expect(sendTelegramReplyCalls).toHaveLength(1);
+    // sendTelegramReply(config, chatId, text, approval)
+    const args = sendTelegramReplyCalls[0];
+    expect(args[3]).toEqual(approval);
+  });
+
+  it("does not pass approval to sendTelegramReply when not provided", async () => {
+    await handler(makeRequest({ chatId: "c1", text: "msg" }));
+
+    expect(sendTelegramReplyCalls).toHaveLength(1);
+    const args = sendTelegramReplyCalls[0];
+    expect(args[3]).toBeUndefined();
   });
 });

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -6,6 +6,18 @@ import { sendTelegramAttachments, sendTelegramReply } from "../../telegram/send.
 
 const log = getLogger("telegram-deliver");
 
+export type ApprovalAction = {
+  id: string;
+  label: string;
+};
+
+export type ApprovalPayload = {
+  runId: string;
+  requestId: string;
+  actions: ApprovalAction[];
+  plainTextFallback: string;
+};
+
 export function createTelegramDeliverHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
@@ -42,6 +54,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       text?: string;
       assistantId?: string;
       attachments?: RuntimeAttachmentMeta[];
+      approval?: ApprovalPayload;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -49,7 +62,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { chatId, text, assistantId, attachments } = body;
+    const { chatId, text, assistantId, attachments, approval } = body;
 
     if (!chatId || typeof chatId !== "string") {
       return Response.json({ error: "chatId is required" }, { status: 400 });
@@ -76,9 +89,36 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       }
     }
 
+    // Validate approval payload shape when present.
+    if (approval !== undefined) {
+      if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {
+        return Response.json({ error: "approval must be an object" }, { status: 400 });
+      }
+      if (!approval.runId || typeof approval.runId !== "string") {
+        return Response.json({ error: "approval.runId is required" }, { status: 400 });
+      }
+      if (!approval.requestId || typeof approval.requestId !== "string") {
+        return Response.json({ error: "approval.requestId is required" }, { status: 400 });
+      }
+      if (!Array.isArray(approval.actions) || approval.actions.length === 0) {
+        return Response.json({ error: "approval.actions must be a non-empty array" }, { status: 400 });
+      }
+      for (const action of approval.actions) {
+        if (action === null || typeof action !== "object" || Array.isArray(action)) {
+          return Response.json({ error: "each approval action must be an object" }, { status: 400 });
+        }
+        if (!action.id || typeof action.id !== "string") {
+          return Response.json({ error: "each approval action must have an id" }, { status: 400 });
+        }
+        if (!action.label || typeof action.label !== "string") {
+          return Response.json({ error: "each approval action must have a label" }, { status: 400 });
+        }
+      }
+    }
+
     try {
       if (text) {
-        await sendTelegramReply(config, chatId, text);
+        await sendTelegramReply(config, chatId, text, approval);
       }
 
       if (attachments && attachments.length > 0) {

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
+import { buildInlineKeyboard, sendTelegramReply } from "./send.js";
+import type { GatewayConfig } from "../config.js";
+
+// Capture calls to callTelegramApi so we can inspect payloads without
+// hitting the network.
+const callTelegramApiMock = mock(() => Promise.resolve({}));
+
+// Mock the api module before importing send.ts functions. The import
+// above resolved the real module, but Bun's mock.module patches the
+// resolved module so subsequent internal imports from send.ts pick up the
+// mock.
+mock.module("./api.js", () => ({
+  callTelegramApi: callTelegramApiMock,
+  callTelegramApiMultipart: mock(() => Promise.resolve({})),
+}));
+
+const baseConfig: GatewayConfig = {
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  defaultAssistantId: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+  logFile: { dir: undefined, retentionDays: 30 },
+  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentConcurrency: 3,
+  maxWebhookPayloadBytes: 1024 * 1024,
+  port: 7830,
+  routingEntries: [],
+  runtimeBearerToken: undefined,
+  runtimeInitialBackoffMs: 500,
+  runtimeMaxRetries: 2,
+  runtimeProxyBearerToken: undefined,
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeTimeoutMs: 30000,
+  shutdownDrainMs: 5000,
+  telegramApiBaseUrl: "https://api.telegram.org",
+  telegramBotToken: "test-token",
+  telegramDeliverAuthBypass: true,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
+  telegramTimeoutMs: 15000,
+  telegramWebhookSecret: undefined,
+  twilioAuthToken: undefined,
+  ingressPublicBaseUrl: undefined,
+  unmappedPolicy: "reject",
+};
+
+const sampleApproval: ApprovalPayload = {
+  runId: "run-123",
+  requestId: "req-456",
+  actions: [
+    { id: "approve_once", label: "Approve once" },
+    { id: "approve_always", label: "Approve always" },
+    { id: "reject", label: "Reject" },
+  ],
+  plainTextFallback: "Reply: approve, always, or reject",
+};
+
+describe("buildInlineKeyboard", () => {
+  it("maps each action to its own row with compact callback data", () => {
+    const result = buildInlineKeyboard(sampleApproval);
+
+    expect(result.inline_keyboard).toHaveLength(3);
+    expect(result.inline_keyboard[0]).toEqual([
+      { text: "Approve once", callback_data: "apr:run-123:approve_once" },
+    ]);
+    expect(result.inline_keyboard[1]).toEqual([
+      { text: "Approve always", callback_data: "apr:run-123:approve_always" },
+    ]);
+    expect(result.inline_keyboard[2]).toEqual([
+      { text: "Reject", callback_data: "apr:run-123:reject" },
+    ]);
+  });
+
+  it("handles a single action", () => {
+    const approval: ApprovalPayload = {
+      runId: "r1",
+      requestId: "rq1",
+      actions: [{ id: "ok", label: "OK" }],
+      plainTextFallback: "ok",
+    };
+    const result = buildInlineKeyboard(approval);
+    expect(result.inline_keyboard).toHaveLength(1);
+    expect(result.inline_keyboard[0][0].callback_data).toBe("apr:r1:ok");
+  });
+
+  it("uses compact callback data format apr:<runId>:<actionId>", () => {
+    const approval: ApprovalPayload = {
+      runId: "abc-def",
+      requestId: "req",
+      actions: [{ id: "my_action", label: "Do it" }],
+      plainTextFallback: "do it",
+    };
+    const result = buildInlineKeyboard(approval);
+    expect(result.inline_keyboard[0][0].callback_data).toBe("apr:abc-def:my_action");
+  });
+});
+
+describe("sendTelegramReply", () => {
+  beforeEach(() => {
+    callTelegramApiMock.mockClear();
+  });
+
+  it("sends a plain message without reply_markup when no approval", async () => {
+    await sendTelegramReply(baseConfig, "chat-1", "Hello");
+
+    expect(callTelegramApiMock).toHaveBeenCalledTimes(1);
+    const payload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    expect(payload.chat_id).toBe("chat-1");
+    expect(payload.text).toBe("Hello");
+    expect(payload.reply_markup).toBeUndefined();
+  });
+
+  it("attaches inline keyboard when approval is provided", async () => {
+    await sendTelegramReply(baseConfig, "chat-1", "Approve?", sampleApproval);
+
+    expect(callTelegramApiMock).toHaveBeenCalledTimes(1);
+    const payload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    expect(payload.reply_markup).toBeDefined();
+
+    const markup = payload.reply_markup as {
+      inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+    };
+    expect(markup.inline_keyboard).toHaveLength(3);
+    expect(markup.inline_keyboard[0][0].callback_data).toBe("apr:run-123:approve_once");
+  });
+
+  it("attaches inline keyboard only to the last chunk for long messages", async () => {
+    // Create a message that exceeds TELEGRAM_MAX_MESSAGE_LEN (4000 chars)
+    const longText = "A".repeat(4001);
+    await sendTelegramReply(baseConfig, "chat-1", longText, sampleApproval);
+
+    expect(callTelegramApiMock).toHaveBeenCalledTimes(2);
+
+    const firstPayload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    expect(firstPayload.reply_markup).toBeUndefined();
+
+    const lastPayload = callTelegramApiMock.mock.calls[1][2] as Record<string, unknown>;
+    expect(lastPayload.reply_markup).toBeDefined();
+  });
+});

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../config.js";
+import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
 import { getLogger } from "../logger.js";
 import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
@@ -28,18 +29,40 @@ function splitText(text: string): string[] {
   return chunks;
 }
 
+export function buildInlineKeyboard(
+  approval: ApprovalPayload,
+): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: approval.actions.map((action) => [
+      {
+        text: action.label,
+        callback_data: `apr:${approval.runId}:${action.id}`,
+      },
+    ]),
+  };
+}
+
 export async function sendTelegramReply(
   config: GatewayConfig,
   chatId: string,
   text: string,
+  approval?: ApprovalPayload,
 ): Promise<void> {
   const chunks = splitText(text);
 
-  for (const chunk of chunks) {
-    await callTelegramApi(config, "sendMessage", {
+  for (let i = 0; i < chunks.length; i++) {
+    const payload: Record<string, unknown> = {
       chat_id: chatId,
-      text: chunk,
-    });
+      text: chunks[i],
+    };
+
+    // Attach inline keyboard only to the last chunk so buttons appear after
+    // the full message text.
+    if (approval && i === chunks.length - 1) {
+      payload.reply_markup = buildInlineKeyboard(approval);
+    }
+
+    await callTelegramApi(config, "sendMessage", payload);
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");


### PR DESCRIPTION
Part of #6626. Adds optional approval UI payload to the Telegram deliver endpoint and renders inline keyboard buttons for approval prompts. Non-approval messages are unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
