### PR TITLE
M2: Telegram callback_query inbound support

### DIFF
--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -190,10 +190,10 @@ describe("normalizeTelegramUpdate", () => {
     expect(result!.sender.externalUserId).toBe("12345");
   });
 
-  test("returns null for non-message updates (e.g. callback_query)", () => {
+  test("returns null for callback_query without message context", () => {
     const payload = {
       update_id: 1,
-      callback_query: { id: "abc", data: "some_data" },
+      callback_query: { id: "abc", from: { id: 123 }, data: "some_data" },
     };
     expect(normalizeTelegramUpdate(payload)).toBeNull();
   });
@@ -277,6 +277,163 @@ describe("normalizeTelegramUpdate", () => {
       },
     };
     expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+});
+
+describe("normalizeTelegramUpdate: callback_query", () => {
+  test("normalizes a callback_query update with message context", () => {
+    const payload = {
+      update_id: 5001,
+      callback_query: {
+        id: "cbq-123",
+        from: {
+          id: 67890,
+          is_bot: false,
+          username: "testuser",
+          first_name: "Test",
+          last_name: "User",
+          language_code: "en",
+        },
+        message: {
+          message_id: 42,
+          text: "Original message",
+          chat: { id: 12345, type: "private" },
+        },
+        data: "apr:run-abc:approve",
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe("v1");
+    expect(result!.sourceChannel).toBe("telegram");
+    expect(result!.message.content).toBe("apr:run-abc:approve");
+    expect(result!.message.externalChatId).toBe("12345");
+    expect(result!.message.externalMessageId).toBe("5001");
+    expect(result!.message.callbackQueryId).toBe("cbq-123");
+    expect(result!.message.callbackData).toBe("apr:run-abc:approve");
+    expect(result!.message.attachments).toBeUndefined();
+    expect(result!.sender.externalUserId).toBe("67890");
+    expect(result!.sender.username).toBe("testuser");
+    expect(result!.sender.displayName).toBe("Test User");
+    expect(result!.sender.firstName).toBe("Test");
+    expect(result!.sender.lastName).toBe("User");
+    expect(result!.sender.languageCode).toBe("en");
+    expect(result!.sender.isBot).toBe(false);
+    expect(result!.source.updateId).toBe("5001");
+    expect(result!.source.messageId).toBe("42");
+    expect(result!.source.chatType).toBe("private");
+  });
+
+  test("returns null when callback_query has no message (inline mode edge case)", () => {
+    const payload = {
+      update_id: 5002,
+      callback_query: {
+        id: "cbq-456",
+        from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+        data: "some-data",
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when callback_query has no data", () => {
+    const payload = {
+      update_id: 5003,
+      callback_query: {
+        id: "cbq-789",
+        from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+        message: {
+          message_id: 42,
+          text: "Original message",
+          chat: { id: 12345, type: "private" },
+        },
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when callback_query message has no chat id", () => {
+    const payload = {
+      update_id: 5004,
+      callback_query: {
+        id: "cbq-no-chat",
+        from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+        message: {
+          message_id: 42,
+          text: "Original message",
+          chat: {},
+        },
+        data: "some-data",
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).toBeNull();
+  });
+
+  test("falls back to chat.id for externalUserId when from.id is missing", () => {
+    const payload = {
+      update_id: 5005,
+      callback_query: {
+        id: "cbq-no-from-id",
+        from: { is_bot: false, username: "testuser", first_name: "Test" },
+        message: {
+          message_id: 42,
+          text: "Original message",
+          chat: { id: 12345, type: "private" },
+        },
+        data: "some-data",
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.sender.externalUserId).toBe("12345");
+  });
+
+  test("callback_query does not set isEdit or attachments", () => {
+    const payload = {
+      update_id: 5006,
+      callback_query: {
+        id: "cbq-clean",
+        from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+        message: {
+          message_id: 42,
+          text: "Original message",
+          chat: { id: 12345, type: "private" },
+        },
+        data: "apr:run-xyz:reject",
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.isEdit).toBeUndefined();
+    expect(result!.message.attachments).toBeUndefined();
+  });
+
+  test("regular text messages are unaffected by callback_query support", () => {
+    const payload = {
+      update_id: 6001,
+      message: {
+        message_id: 100,
+        text: "Hello world",
+        chat: { id: 12345, type: "private" },
+        from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+      },
+    };
+
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("Hello world");
+    expect(result!.message.callbackQueryId).toBeUndefined();
+    expect(result!.message.callbackData).toBeUndefined();
   });
 });
 

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -364,3 +364,102 @@ describe("telegram webhook handler: in-flight dedup", () => {
     expect(fetchCalls.length).toBe(beforeCount);
   });
 });
+
+function makeCallbackQueryPayload(data: string, updateId = 7001) {
+  return {
+    update_id: updateId,
+    callback_query: {
+      id: "cbq-test-id",
+      from: { id: 67890, is_bot: false, username: "testuser", first_name: "Test" },
+      message: {
+        message_id: 42,
+        text: "Choose an action",
+        chat: { id: 12345, type: "private" },
+      },
+      data,
+    },
+  };
+}
+
+describe("telegram webhook handler: callback_query forwarding", () => {
+  test("forwards callback_query data to the runtime with callback metadata", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeCallbackQueryPayload("apr:run-abc:approve", 7001);
+    const req = makeWebhookRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify the runtime forward call includes callback metadata
+    const runtimeCall = fetchCalls.find((c) => c.url.includes("/inbound"));
+    expect(runtimeCall).toBeDefined();
+    const runtimeBody = runtimeCall!.body as any;
+    expect(runtimeBody.callbackQueryId).toBe("cbq-test-id");
+    expect(runtimeBody.callbackData).toBe("apr:run-abc:approve");
+    expect(runtimeBody.content).toBe("apr:run-abc:approve");
+  });
+
+  test("acknowledges the callback query via answerCallbackQuery after forwarding", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeCallbackQueryPayload("apr:run-xyz:reject", 7002);
+    const req = makeWebhookRequest(payload);
+    await handler(req);
+
+    // Allow the fire-and-forget answerCallbackQuery call to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify answerCallbackQuery was called
+    const ackCall = fetchCalls.find((c) => c.url.includes("/answerCallbackQuery"));
+    expect(ackCall).toBeDefined();
+    expect((ackCall!.body as any).callback_query_id).toBe("cbq-test-id");
+  });
+
+  test("does not call answerCallbackQuery for regular text messages", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("hello", 7003);
+    const req = makeWebhookRequest(payload);
+    await handler(req);
+
+    // Allow any fire-and-forget calls to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify no answerCallbackQuery call was made
+    const ackCall = fetchCalls.find((c) => c.url.includes("/answerCallbackQuery"));
+    expect(ackCall).toBeUndefined();
+  });
+
+  test("regular text messages do not include callback metadata in runtime payload", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("hello", 7004);
+    const req = makeWebhookRequest(payload);
+    await handler(req);
+
+    const runtimeCall = fetchCalls.find((c) => c.url.includes("/inbound"));
+    expect(runtimeCall).toBeDefined();
+    const runtimeBody = runtimeCall!.body as any;
+    expect(runtimeBody.callbackQueryId).toBeUndefined();
+    expect(runtimeBody.callbackData).toBeUndefined();
+  });
+});

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -72,6 +72,8 @@ export async function handleInbound(
         externalMessageId: event.message.externalMessageId,
         content: event.message.content,
         ...(event.message.isEdit ? { isEdit: true } : {}),
+        ...(event.message.callbackQueryId ? { callbackQueryId: event.message.callbackQueryId } : {}),
+        ...(event.message.callbackData ? { callbackData: event.message.callbackData } : {}),
         senderName: displayName,
         senderExternalUserId: event.sender.externalUserId,
         senderUsername: event.sender.username,

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -4,6 +4,7 @@ import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
 import { AttachmentValidationError, resetConversation, uploadAttachment } from "../../runtime/client.js";
+import { callTelegramApi } from "../../telegram/api.js";
 import { downloadTelegramFile } from "../../telegram/download.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
 import { sendTelegramReply } from "../../telegram/send.js";
@@ -213,6 +214,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     }
 
     const isEdit = !!normalized.message.isEdit;
+    const isCallback = !!normalized.message.callbackQueryId;
 
     // Check routing early so we can gate attachments
     const chatId = normalized.message.externalChatId;
@@ -223,11 +225,11 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     );
     const routable = !isRejection(routing);
 
-    // Download and upload attachments if present (skip for edits — the runtime
-    // edit path only updates text content and doesn't link new attachments)
+    // Download and upload attachments if present (skip for edits and callback
+    // queries — edits only update text, callbacks have no media to process)
     let attachmentIds: string[] | undefined;
     const eventAttachments = normalized.message.attachments;
-    if (eventAttachments && eventAttachments.length > 0 && routable && !isEdit) {
+    if (eventAttachments && eventAttachments.length > 0 && routable && !isEdit && !isCallback) {
       try {
         attachmentIds = [];
 
@@ -315,6 +317,16 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       }
 
       tlog.info({ status: "forwarded" }, "Forwarded to runtime");
+
+      // Acknowledge the callback query to clear the button spinner in the
+      // Telegram client. Best-effort — log errors but don't fail the flow.
+      if (isCallback && normalized.message.callbackQueryId) {
+        callTelegramApi(config, "answerCallbackQuery", {
+          callback_query_id: normalized.message.callbackQueryId,
+        }).catch((err) => {
+          tlog.error({ err, callbackQueryId: normalized.message.callbackQueryId }, "Failed to acknowledge callback query");
+        });
+      }
     } catch (err) {
       tlog.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       if (updateId !== undefined) dedupCache.unreserve(updateId);

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -30,6 +30,8 @@ export type RuntimeInboundPayload = {
   externalMessageId: string;
   content: string;
   isEdit?: boolean;
+  callbackQueryId?: string;
+  callbackData?: string;
   senderName?: string;
   senderExternalUserId?: string;
   senderUsername?: string;

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -33,10 +33,25 @@ interface TelegramMessage {
   document?: TelegramDocument;
 }
 
+interface TelegramCallbackQuery {
+  id: string;
+  from: {
+    id?: number;
+    is_bot?: boolean;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+    language_code?: string;
+  };
+  message?: TelegramMessage;
+  data?: string;
+}
+
 interface TelegramUpdate {
   update_id?: number;
   message?: TelegramMessage;
   edited_message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
 }
 
 /**
@@ -47,9 +62,61 @@ export function normalizeTelegramUpdate(
   payload: Record<string, unknown>,
 ): Omit<GatewayInboundEventV1, "routing"> | null {
   const update = payload as TelegramUpdate;
+  const updateId = update.update_id;
+
+  // Handle callback_query updates (inline button clicks)
+  if (update.callback_query) {
+    const cbq = update.callback_query;
+
+    // Skip if callback_query has no message (edge case, e.g. inline mode)
+    if (!cbq.message?.chat?.id || updateId == null) {
+      return null;
+    }
+
+    // Skip if there is no callback data to forward
+    if (!cbq.data) {
+      return null;
+    }
+
+    const chatId = String(cbq.message.chat.id);
+    const externalUserId = cbq.from?.id ? String(cbq.from.id) : chatId;
+
+    const displayName = [cbq.from?.first_name, cbq.from?.last_name]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+
+    return {
+      version: "v1",
+      sourceChannel: "telegram",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: cbq.data,
+        externalChatId: chatId,
+        externalMessageId: String(updateId),
+        callbackQueryId: cbq.id,
+        callbackData: cbq.data,
+      },
+      sender: {
+        externalUserId,
+        username: cbq.from?.username,
+        displayName: displayName || undefined,
+        firstName: cbq.from?.first_name,
+        lastName: cbq.from?.last_name,
+        languageCode: cbq.from?.language_code,
+        isBot: cbq.from?.is_bot,
+      },
+      source: {
+        updateId: String(updateId),
+        messageId: cbq.message.message_id != null ? String(cbq.message.message_id) : undefined,
+        chatType: cbq.message.chat.type,
+      },
+      raw: payload,
+    };
+  }
+
   const isEdit = !update.message && !!update.edited_message;
   const message = update.message ?? update.edited_message;
-  const updateId = update.update_id;
 
   const hasContent = !!(message?.text || message?.photo || message?.document);
   if (!hasContent || !message?.chat?.id || updateId == null) {

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -11,6 +11,8 @@ export type GatewayInboundEventV1 = {
     externalChatId: string;
     externalMessageId: string;
     isEdit?: boolean;
+    callbackQueryId?: string;
+    callbackData?: string;
     attachments?: {
       type: "photo" | "document";
       fileId: string;


### PR DESCRIPTION
Part of #6626. Adds callback_query normalization in gateway, forwards callback metadata to runtime, and acknowledges callback queries to clear Telegram button spinners.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
