### PR TITLE
M4: Channel approval orchestration module

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -1,0 +1,393 @@
+import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'channel-approvals-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import {
+  createRun,
+  setRunConfirmation,
+} from '../memory/runs-store.js';
+import type { PendingConfirmation, PendingRunInfo } from '../memory/runs-store.js';
+import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import {
+  getChannelApprovalPrompt,
+  buildApprovalUIMetadata,
+  handleChannelDecision,
+  buildReminderPrompt,
+} from '../runtime/channel-approvals.js';
+import type { ApprovalDecisionResult, ChannelApprovalPrompt } from '../runtime/channel-approval-types.js';
+import * as trustStore from '../permissions/trust-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureConversation(conversationId: string): void {
+  const db = getDb();
+  try {
+    db.run(
+      `INSERT INTO conversations (id, createdAt, updatedAt) VALUES (?, ?, ?)`,
+      [conversationId, Date.now(), Date.now()],
+    );
+  } catch {
+    // already exists
+  }
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM message_runs');
+  db.run('DELETE FROM conversations');
+}
+
+const sampleConfirmation: PendingConfirmation = {
+  toolName: 'shell',
+  toolUseId: 'req-abc-123',
+  input: { command: 'rm -rf /tmp/test' },
+  riskLevel: 'high',
+  allowlistOptions: [{ label: 'rm -rf /tmp/test', pattern: 'rm -rf /tmp/test' }],
+  scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+};
+
+function makeMockOrchestrator(
+  submitResult: 'applied' | 'run_not_found' | 'no_pending_decision' = 'applied',
+): RunOrchestrator {
+  return {
+    submitDecision: mock(() => submitResult),
+  } as unknown as RunOrchestrator;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. getChannelApprovalPrompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('getChannelApprovalPrompt', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('returns null when no pending runs exist', () => {
+    ensureConversation('conv-1');
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when runs exist but none need confirmation', () => {
+    ensureConversation('conv-1');
+    createRun('conv-1', 'msg-1');
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).toBeNull();
+  });
+
+  test('returns a prompt when a run needs confirmation', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).not.toBeNull();
+    expect(result!.promptText).toContain('shell');
+    expect(result!.actions).toHaveLength(3);
+    expect(result!.actions.map((a) => a.id)).toEqual([
+      'approve_once',
+      'approve_always',
+      'reject',
+    ]);
+    expect(result!.plainTextFallback).toContain('yes');
+    expect(result!.plainTextFallback).toContain('always');
+    expect(result!.plainTextFallback).toContain('no');
+  });
+
+  test('uses the first pending run when multiple exist', () => {
+    ensureConversation('conv-1');
+    const run1 = createRun('conv-1', 'msg-1');
+    const run2 = createRun('conv-1', 'msg-2');
+    setRunConfirmation(run1.id, sampleConfirmation);
+    setRunConfirmation(run2.id, {
+      ...sampleConfirmation,
+      toolName: 'file_edit',
+      toolUseId: 'req-def-456',
+    });
+
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).not.toBeNull();
+    // Should contain one of the tool names (the first pending run)
+    expect(result!.promptText).toMatch(/shell|file_edit/);
+  });
+
+  test('does not return prompts for other conversations', () => {
+    ensureConversation('conv-1');
+    ensureConversation('conv-2');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const result = getChannelApprovalPrompt('conv-2');
+    expect(result).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. buildApprovalUIMetadata
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildApprovalUIMetadata', () => {
+  test('maps prompt and run info to UI metadata', () => {
+    const prompt: ChannelApprovalPrompt = {
+      promptText: 'Allow shell?',
+      actions: [
+        { id: 'approve_once', label: 'Approve once' },
+        { id: 'reject', label: 'Reject' },
+      ],
+      plainTextFallback: 'Reply yes or no.',
+    };
+
+    const runInfo: PendingRunInfo = {
+      runId: 'run-123',
+      requestId: 'req-abc',
+      toolName: 'shell',
+      input: { command: 'ls' },
+      riskLevel: 'low',
+    };
+
+    const metadata = buildApprovalUIMetadata(prompt, runInfo);
+    expect(metadata.runId).toBe('run-123');
+    expect(metadata.requestId).toBe('req-abc');
+    expect(metadata.actions).toEqual(prompt.actions);
+    expect(metadata.plainTextFallback).toBe('Reply yes or no.');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. handleChannelDecision
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('handleChannelDecision', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('returns applied: false when no pending runs exist', () => {
+    ensureConversation('conv-1');
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_once',
+      source: 'plain_text',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(false);
+    expect(result.runId).toBeUndefined();
+  });
+
+  test('approves once via orchestrator.submitDecision with "allow"', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_once',
+      source: 'plain_text',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(true);
+    expect(result.runId).toBe(run.id);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+  });
+
+  test('rejects via orchestrator.submitDecision with "deny"', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'reject',
+      source: 'telegram_button',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(true);
+    expect(result.runId).toBe(run.id);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+  });
+
+  test('approve_always adds a trust rule and submits "allow"', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      ...sampleConfirmation,
+      executionTarget: 'sandbox',
+      allowlistOptions: [{ label: 'rm pattern', pattern: 'rm -rf *' }],
+      scopeOptions: [{ label: 'project dir', scope: '/tmp/project' }],
+    });
+
+    const addRuleSpy = spyOn(trustStore, 'addRule');
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_always',
+      source: 'plain_text',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(true);
+    expect(result.runId).toBe(run.id);
+
+    // Trust rule added with first allowlist and scope option
+    expect(addRuleSpy).toHaveBeenCalledWith(
+      'shell',
+      'rm -rf *',
+      '/tmp/project',
+      'allow',
+      100,
+      { executionTarget: 'sandbox' },
+    );
+
+    // The run is still approved with a simple "allow"
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    addRuleSpy.mockRestore();
+  });
+
+  test('approve_always falls back to "**" / "everywhere" when no options available', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      toolName: 'bash',
+      toolUseId: 'req-no-opts',
+      input: { command: 'echo hi' },
+      riskLevel: 'low',
+      // No allowlistOptions or scopeOptions
+    });
+
+    const addRuleSpy = spyOn(trustStore, 'addRule');
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_always',
+      source: 'telegram_button',
+    };
+
+    handleChannelDecision('conv-1', decision, orchestrator);
+
+    expect(addRuleSpy).toHaveBeenCalledWith(
+      'bash',
+      '**',
+      'everywhere',
+      'allow',
+      100,
+      { executionTarget: undefined },
+    );
+
+    addRuleSpy.mockRestore();
+  });
+
+  test('returns applied: false when orchestrator cannot apply decision', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const orchestrator = makeMockOrchestrator('no_pending_decision');
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_once',
+      source: 'plain_text',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(false);
+    expect(result.runId).toBe(run.id);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. buildReminderPrompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildReminderPrompt', () => {
+  test('prefixes promptText with a reminder', () => {
+    const original: ChannelApprovalPrompt = {
+      promptText: 'Allow shell?',
+      actions: [
+        { id: 'approve_once', label: 'Approve once' },
+        { id: 'reject', label: 'Reject' },
+      ],
+      plainTextFallback: 'Reply yes or no.',
+    };
+
+    const reminder = buildReminderPrompt(original);
+    expect(reminder.promptText).toContain("I'm still waiting");
+    expect(reminder.promptText).toContain('Allow shell?');
+  });
+
+  test('preserves the original actions', () => {
+    const original: ChannelApprovalPrompt = {
+      promptText: 'Approve file_edit?',
+      actions: [
+        { id: 'approve_once', label: 'Approve once' },
+        { id: 'approve_always', label: 'Approve always' },
+        { id: 'reject', label: 'Reject' },
+      ],
+      plainTextFallback: 'Reply yes, always, or no.',
+    };
+
+    const reminder = buildReminderPrompt(original);
+    expect(reminder.actions).toEqual(original.actions);
+  });
+
+  test('prefixes plainTextFallback with a reminder', () => {
+    const original: ChannelApprovalPrompt = {
+      promptText: 'Allow bash?',
+      actions: [],
+      plainTextFallback: 'Reply yes or no.',
+    };
+
+    const reminder = buildReminderPrompt(original);
+    expect(reminder.plainTextFallback).toContain("I'm still waiting");
+    expect(reminder.plainTextFallback).toContain('Reply yes or no.');
+  });
+
+  test('does not mutate the original prompt', () => {
+    const original: ChannelApprovalPrompt = {
+      promptText: 'Allow grep?',
+      actions: [{ id: 'approve_once', label: 'Approve once' }],
+      plainTextFallback: 'Reply yes.',
+    };
+
+    const originalText = original.promptText;
+    buildReminderPrompt(original);
+    expect(original.promptText).toBe(originalText);
+  });
+});

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -1,0 +1,145 @@
+/**
+ * Channel-agnostic approval orchestration module.
+ *
+ * Bridges the gap between external channel adapters (Telegram, SMS, etc.)
+ * and the internal run orchestrator / permission system:
+ *
+ *   1. Detect pending confirmations for a conversation
+ *   2. Build human-readable approval prompts with action buttons
+ *   3. Consume user decisions and apply them to the underlying run
+ *   4. Build reminder prompts when non-decision messages arrive
+ */
+
+import { getPendingConfirmationsByConversation, getRun } from '../memory/runs-store.js';
+import type { PendingRunInfo } from '../memory/runs-store.js';
+import { addRule } from '../permissions/trust-store.js';
+import type { RunOrchestrator } from './run-orchestrator.js';
+import { DEFAULT_APPROVAL_ACTIONS } from './channel-approval-types.js';
+import type {
+  ChannelApprovalPrompt,
+  ApprovalUIMetadata,
+  ApprovalDecisionResult,
+} from './channel-approval-types.js';
+
+// ---------------------------------------------------------------------------
+// 1. Detect pending confirmations and build prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a conversation has a pending tool-use confirmation and,
+ * if so, build a human-readable approval prompt.
+ *
+ * Returns `null` when there is nothing waiting for approval.
+ */
+export function getChannelApprovalPrompt(
+  conversationId: string,
+): ChannelApprovalPrompt | null {
+  const pending = getPendingConfirmationsByConversation(conversationId);
+  if (pending.length === 0) return null;
+
+  // Use the first pending run — channel UIs show one prompt at a time.
+  const info = pending[0];
+  return buildPromptFromRunInfo(info);
+}
+
+/**
+ * Internal helper: turn a PendingRunInfo into a ChannelApprovalPrompt.
+ */
+function buildPromptFromRunInfo(info: PendingRunInfo): ChannelApprovalPrompt {
+  const promptText = `The assistant wants to use the tool "${info.toolName}". Do you want to allow this?`;
+  const actions = [...DEFAULT_APPROVAL_ACTIONS];
+  const plainTextFallback =
+    `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
+
+  return { promptText, actions, plainTextFallback };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Build gateway-facing UI metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a prompt + run info into the `ApprovalUIMetadata` payload that
+ * gateway adapters use to render buttons and route decisions back.
+ */
+export function buildApprovalUIMetadata(
+  prompt: ChannelApprovalPrompt,
+  runInfo: PendingRunInfo,
+): ApprovalUIMetadata {
+  return {
+    runId: runInfo.runId,
+    requestId: runInfo.requestId,
+    actions: prompt.actions,
+    plainTextFallback: prompt.plainTextFallback,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Consume a user decision and apply it to the run
+// ---------------------------------------------------------------------------
+
+export interface HandleDecisionResult {
+  applied: boolean;
+  runId?: string;
+}
+
+/**
+ * Find the pending run for a conversation, map the user's decision to the
+ * permission system's vocabulary, and apply it.
+ *
+ * For `approve_always`, a trust rule is persisted using the first allowlist
+ * option and first scope option from the pending confirmation (narrow
+ * default). The current invocation is also approved.
+ */
+export function handleChannelDecision(
+  conversationId: string,
+  decision: ApprovalDecisionResult,
+  orchestrator: RunOrchestrator,
+): HandleDecisionResult {
+  const pending = getPendingConfirmationsByConversation(conversationId);
+  if (pending.length === 0) return { applied: false };
+
+  const info = pending[0];
+
+  if (decision.action === 'approve_always') {
+    // Persist a trust rule so future invocations of this tool are auto-approved.
+    const run = getRun(info.runId);
+    const confirmation = run?.pendingConfirmation;
+    if (confirmation) {
+      const pattern = confirmation.allowlistOptions?.[0]?.pattern ?? '**';
+      const scope = confirmation.scopeOptions?.[0]?.scope ?? 'everywhere';
+      addRule(confirmation.toolName, pattern, scope, 'allow', 100, {
+        executionTarget: confirmation.executionTarget,
+      });
+    }
+  }
+
+  // Map channel-level action to the permission system's UserDecision type.
+  const userDecision = decision.action === 'reject' ? 'deny' as const : 'allow' as const;
+  const result = orchestrator.submitDecision(info.runId, userDecision);
+
+  return {
+    applied: result === 'applied',
+    runId: info.runId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Reminder prompt for non-decision messages
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a reminder prompt when the user sends a non-decision message while
+ * an approval is pending. Reuses the original actions and fallback text
+ * but prefixes the prompt text with a reminder.
+ */
+export function buildReminderPrompt(
+  pendingPrompt: ChannelApprovalPrompt,
+): ChannelApprovalPrompt {
+  const reminderPrefix = "I'm still waiting for your decision on the previous request.";
+  return {
+    promptText: `${reminderPrefix}\n\n${pendingPrompt.promptText}`,
+    actions: pendingPrompt.actions,
+    plainTextFallback: `${reminderPrefix}\n\n${pendingPrompt.plainTextFallback}`,
+  };
+}


### PR DESCRIPTION
Part of #6626. Adds the core channel-approvals.ts orchestration module that detects pending confirmations, renders approval prompts, consumes decisions (button clicks or text), maps them to run decisions, and builds reminder prompts for non-decision messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
