### PR TITLE
M5: Channel routes + gateway client integration

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1,0 +1,438 @@
+import { describe, test, expect, beforeEach, afterAll, afterEach, mock, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'channel-approval-routes-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Mock security check to always pass
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+// Mock render to return the raw content as text
+mock.module('../daemon/handlers.js', () => ({
+  renderHistoryContent: (content: unknown) => ({
+    text: typeof content === 'string' ? content : JSON.stringify(content),
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import {
+  createRun,
+  setRunConfirmation,
+} from '../memory/runs-store.js';
+import type { PendingConfirmation } from '../memory/runs-store.js';
+import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
+import * as gatewayClient from '../runtime/gateway-client.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureConversation(conversationId: string): void {
+  const db = getDb();
+  try {
+    db.run(
+      `INSERT INTO conversations (id, createdAt, updatedAt) VALUES (?, ?, ?)`,
+      [conversationId, Date.now(), Date.now()],
+    );
+  } catch {
+    // already exists
+  }
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM message_runs');
+  db.run('DELETE FROM channel_inbound_events');
+  db.run('DELETE FROM conversations');
+}
+
+const sampleConfirmation: PendingConfirmation = {
+  toolName: 'shell',
+  toolUseId: 'req-abc-123',
+  input: { command: 'rm -rf /tmp/test' },
+  riskLevel: 'high',
+  allowlistOptions: [{ label: 'rm -rf /tmp/test', pattern: 'rm -rf /tmp/test' }],
+  scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+};
+
+function makeMockOrchestrator(
+  submitResult: 'applied' | 'run_not_found' | 'no_pending_decision' = 'applied',
+): RunOrchestrator {
+  return {
+    submitDecision: mock(() => submitResult),
+    getRun: mock(() => null),
+    startRun: mock(async () => ({
+      id: 'run-1',
+      conversationId: 'conv-1',
+      messageId: null,
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })),
+  } as unknown as RunOrchestrator;
+}
+
+function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
+  const body = {
+    sourceChannel: 'telegram',
+    externalChatId: 'chat-123',
+    externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+    content: 'hello',
+    replyCallbackUrl: 'https://gateway.test/deliver',
+    ...overrides,
+  };
+  return new Request('http://localhost/channels/inbound', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const noopProcessMessage = mock(async () => ({ messageId: 'msg-1' }));
+
+// ---------------------------------------------------------------------------
+// Set up / tear down feature flag for each test
+// ---------------------------------------------------------------------------
+
+let originalEnv: string | undefined;
+
+beforeEach(() => {
+  resetTables();
+  originalEnv = process.env.CHANNEL_APPROVALS_ENABLED;
+  noopProcessMessage.mockClear();
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.CHANNEL_APPROVALS_ENABLED;
+  } else {
+    process.env.CHANNEL_APPROVALS_ENABLED = originalEnv;
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Feature flag gating
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('isChannelApprovalsEnabled', () => {
+  test('returns false when env var is not set', () => {
+    delete process.env.CHANNEL_APPROVALS_ENABLED;
+    expect(isChannelApprovalsEnabled()).toBe(false);
+  });
+
+  test('returns false when env var is "false"', () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'false';
+    expect(isChannelApprovalsEnabled()).toBe(false);
+  });
+
+  test('returns true when env var is "true"', () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    expect(isChannelApprovalsEnabled()).toBe(true);
+  });
+});
+
+describe('feature flag disabled → normal flow', () => {
+  beforeEach(() => {
+    delete process.env.CHANNEL_APPROVALS_ENABLED;
+  });
+
+  test('proceeds normally even when pending approvals exist', async () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const orchestrator = makeMockOrchestrator();
+    const req = makeInboundRequest({
+      content: 'approve',
+      callbackData: 'apr:run-1:approve_once',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, undefined, orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    // Should proceed normally — no approval interception
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Callback data triggers decision handling
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('inbound callback metadata triggers decision handling', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('callback data "apr:<runId>:approve_once" is parsed and applied', async () => {
+    // We need the conversation to exist AND have a pending run.
+    // The channel-delivery-store will create a conversation for us via recordInbound,
+    // but we also need the run to be linked to the same conversationId.
+    // Let's set up the conversation first, then create a run.
+    ensureConversation('conv-1');
+
+    // Create and record an earlier inbound event for this chat to establish
+    // the conversation mapping (so recordInbound returns the same conversationId).
+    // Actually, recordInbound auto-creates a conversationId based on source+chat.
+    // We need to find out what conversationId will be generated for telegram:chat-123.
+
+    // Let's use a spy to check if handleChannelDecision-equivalent behavior fires.
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // First, send a normal message to establish the conversation.
+    const initReq = makeInboundRequest({ content: 'init' });
+    const initRes = await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+    const initBody = await initRes.json() as { conversationId?: string; eventId?: string; accepted?: boolean };
+
+    // Now we need to find the actual conversationId that was created.
+    // Check the channel_inbound_events table.
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    expect(conversationId).toBeTruthy();
+
+    // Ensure conversation row exists for FK constraints
+    ensureConversation(conversationId!);
+
+    // Create a pending run for this conversation
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Now send a callback data message
+    const req = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('callback data "apr:<runId>:reject" applies a rejection', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:reject`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Plain text triggers decision handling
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('inbound text matching approval phrases triggers decision handling', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('text "approve" triggers approve_once decision', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeInboundRequest({ content: 'approve' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('text "always" triggers approve_always decision', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeInboundRequest({ content: 'always' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Non-decision messages during pending approval trigger reminder
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('non-decision messages during pending approval trigger reminder', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('sends a reminder prompt when message is not a decision', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const replySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send a message that is NOT a decision
+    const req = makeInboundRequest({ content: 'what is the weather?' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('reminder_sent');
+
+    // The approval prompt delivery should have been called
+    expect(deliverSpy).toHaveBeenCalled();
+    const callArgs = deliverSpy.mock.calls[0];
+    // The text should contain the reminder prefix
+    expect(callArgs[2]).toContain("I'm still waiting");
+    // The approval UI metadata should be present
+    expect(callArgs[3]).toBeDefined();
+    expect(callArgs[3]!.runId).toBe(run.id);
+
+    deliverSpy.mockRestore();
+    replySpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Messages without pending approval proceed normally
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('messages without pending approval proceed normally', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('proceeds to normal processing when no pending approval exists', async () => {
+    const orchestrator = makeMockOrchestrator();
+
+    const req = makeInboundRequest({ content: 'hello world' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBeUndefined();
+    // Normal flow should have been triggered
+  });
+
+  test('text "approve" is processed normally when no pending approval exists', async () => {
+    const orchestrator = makeMockOrchestrator();
+
+    const req = makeInboundRequest({ content: 'approve' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should NOT be treated as an approval decision since there's no pending approval
+    expect(body.approval).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../util/logger.js';
 import type { RuntimeAttachmentMetadata } from './http-types.js';
+import type { ApprovalUIMetadata } from './channel-approval-types.js';
 
 const log = getLogger('gateway-client');
 
@@ -10,6 +11,7 @@ export interface ChannelReplyPayload {
   text?: string;
   assistantId?: string;
   attachments?: RuntimeAttachmentMetadata[];
+  approval?: ApprovalUIMetadata;
 }
 
 export async function deliverChannelReply(
@@ -39,4 +41,18 @@ export async function deliverChannelReply(
   }
 
   log.info({ chatId: payload.chatId, callbackUrl }, 'Channel reply delivered');
+}
+
+/**
+ * Deliver an approval prompt (text + inline keyboard metadata) to the
+ * gateway so it can render the approval UI in the channel.
+ */
+export async function deliverApprovalPrompt(
+  callbackUrl: string,
+  chatId: string,
+  text: string,
+  approval: ApprovalUIMetadata,
+  bearerToken?: string,
+): Promise<void> {
+  await deliverChannelReply(callbackUrl, { chatId, text, approval }, bearerToken);
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -717,7 +717,7 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -7,17 +7,53 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { getPendingConfirmationsByConversation } from '../../memory/runs-store.js';
 import { renderHistoryContent } from '../../daemon/handlers.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
-import { deliverChannelReply } from '../gateway-client.js';
+import { deliverChannelReply, deliverApprovalPrompt } from '../gateway-client.js';
+import { parseApprovalDecision } from '../channel-approval-parser.js';
+import {
+  getChannelApprovalPrompt,
+  buildApprovalUIMetadata,
+  handleChannelDecision,
+  buildReminderPrompt,
+} from '../channel-approvals.js';
+import type { ApprovalAction, ApprovalDecisionResult } from '../channel-approval-types.js';
+import type { RunOrchestrator } from '../run-orchestrator.js';
 import type {
   MessageProcessor,
   RuntimeAttachmentMetadata,
 } from '../http-types.js';
 
 const log = getLogger('runtime-http');
+
+// ---------------------------------------------------------------------------
+// Feature flag
+// ---------------------------------------------------------------------------
+
+export function isChannelApprovalsEnabled(): boolean {
+  return process.env.CHANNEL_APPROVALS_ENABLED === 'true';
+}
+
+// ---------------------------------------------------------------------------
+// Callback data parser — format: "apr:<runId>:<action>"
+// ---------------------------------------------------------------------------
+
+const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
+  'approve_once',
+  'approve_always',
+  'reject',
+]);
+
+function parseCallbackData(data: string): ApprovalDecisionResult | null {
+  const parts = data.split(':');
+  if (parts.length < 3 || parts[0] !== 'apr') return null;
+  const action = parts.slice(2).join(':');
+  if (!VALID_ACTIONS.has(action)) return null;
+  return { action: action as ApprovalAction, source: 'telegram_button' };
+}
 
 export async function handleDeleteConversation(req: Request): Promise<Response> {
   const body = await req.json() as {
@@ -45,6 +81,7 @@ export async function handleChannelInbound(
   req: Request,
   processMessage?: MessageProcessor,
   bearerToken?: string,
+  runOrchestrator?: RunOrchestrator,
 ): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
@@ -58,6 +95,8 @@ export async function handleChannelInbound(
     senderUsername?: string;
     sourceMetadata?: Record<string, unknown>;
     replyCallbackUrl?: string;
+    callbackQueryId?: string;
+    callbackData?: string;
   };
 
   const {
@@ -201,6 +240,33 @@ export async function handleChannelInbound(
 
   const replyCallbackUrl = body.replyCallbackUrl;
 
+  // ── Approval interception (gated behind feature flag) ──
+  if (
+    isChannelApprovalsEnabled() &&
+    runOrchestrator &&
+    replyCallbackUrl &&
+    !result.duplicate
+  ) {
+    const approvalResult = await handleApprovalInterception({
+      conversationId: result.conversationId,
+      callbackData: body.callbackData,
+      content: trimmedContent,
+      externalChatId,
+      replyCallbackUrl,
+      bearerToken,
+      orchestrator: runOrchestrator,
+    });
+
+    if (approvalResult.handled) {
+      return Response.json({
+        accepted: true,
+        duplicate: false,
+        eventId: result.eventId,
+        approval: approvalResult.type,
+      });
+    }
+  }
+
   // For new (non-duplicate) messages, run the secret ingress check
   // synchronously, then fire off the agent loop in the background.
   if (!result.duplicate && processMessage) {
@@ -229,21 +295,40 @@ export async function handleChannelInbound(
       throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
     }
 
-    // Fire-and-forget: process the message and deliver the reply in the background.
-    // The HTTP response returns immediately so the gateway webhook is not blocked.
-    processChannelMessageInBackground({
-      processMessage,
-      conversationId: result.conversationId,
-      eventId: result.eventId,
-      content: content ?? '',
-      attachmentIds: hasAttachments ? attachmentIds : undefined,
-      sourceChannel,
-      externalChatId,
-      metadataHints,
-      metadataUxBrief,
-      replyCallbackUrl,
-      bearerToken,
-    });
+    // When approval flow is enabled and we have an orchestrator, use the
+    // orchestrator-backed path which properly intercepts confirmation_request
+    // events and sends proactive approval prompts to the channel.
+    const useApprovalPath =
+      isChannelApprovalsEnabled() && runOrchestrator && replyCallbackUrl;
+
+    if (useApprovalPath) {
+      processChannelMessageWithApprovals({
+        orchestrator: runOrchestrator,
+        conversationId: result.conversationId,
+        eventId: result.eventId,
+        content: content ?? '',
+        attachmentIds: hasAttachments ? attachmentIds : undefined,
+        externalChatId,
+        replyCallbackUrl,
+        bearerToken,
+      });
+    } else {
+      // Fire-and-forget: process the message and deliver the reply in the background.
+      // The HTTP response returns immediately so the gateway webhook is not blocked.
+      processChannelMessageInBackground({
+        processMessage,
+        conversationId: result.conversationId,
+        eventId: result.eventId,
+        content: content ?? '',
+        attachmentIds: hasAttachments ? attachmentIds : undefined,
+        sourceChannel,
+        externalChatId,
+        metadataHints,
+        metadataUxBrief,
+        replyCallbackUrl,
+        bearerToken,
+      });
+    }
   }
 
   return Response.json({
@@ -308,6 +393,189 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
       channelDeliveryStore.recordProcessingFailure(eventId, err);
     }
   })();
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator-backed channel processing with approval prompt delivery
+// ---------------------------------------------------------------------------
+
+const RUN_POLL_INTERVAL_MS = 500;
+const RUN_POLL_MAX_WAIT_MS = 300_000; // 5 minutes
+
+interface ApprovalProcessingParams {
+  orchestrator: RunOrchestrator;
+  conversationId: string;
+  eventId: string;
+  content: string;
+  attachmentIds?: string[];
+  externalChatId: string;
+  replyCallbackUrl: string;
+  bearerToken?: string;
+}
+
+/**
+ * Process a channel message using the run orchestrator so that
+ * `confirmation_request` events are intercepted and written to the
+ * runs store. Polls the run until it reaches a terminal state,
+ * sending approval prompts when `needs_confirmation` is detected.
+ */
+function processChannelMessageWithApprovals(params: ApprovalProcessingParams): void {
+  const {
+    orchestrator,
+    conversationId,
+    eventId,
+    content,
+    attachmentIds,
+    externalChatId,
+    replyCallbackUrl,
+    bearerToken,
+  } = params;
+
+  (async () => {
+    try {
+      const run = await orchestrator.startRun(conversationId, content, attachmentIds);
+
+      // Poll the run until it reaches a terminal state, delivering approval
+      // prompts when it transitions to needs_confirmation.
+      const startTime = Date.now();
+      let lastStatus = run.status;
+
+      while (Date.now() - startTime < RUN_POLL_MAX_WAIT_MS) {
+        await new Promise((resolve) => setTimeout(resolve, RUN_POLL_INTERVAL_MS));
+
+        const current = orchestrator.getRun(run.id);
+        if (!current) break;
+
+        if (current.status === 'needs_confirmation' && lastStatus !== 'needs_confirmation') {
+          // Run just transitioned to needs_confirmation — send approval prompt
+          const prompt = getChannelApprovalPrompt(conversationId);
+          if (prompt) {
+            const pending = getPendingConfirmationsByConversation(conversationId);
+            if (pending.length > 0) {
+              const uiMetadata = buildApprovalUIMetadata(prompt, pending[0]);
+              try {
+                await deliverApprovalPrompt(
+                  replyCallbackUrl,
+                  externalChatId,
+                  prompt.promptText,
+                  uiMetadata,
+                  bearerToken,
+                );
+              } catch (err) {
+                log.error({ err, runId: run.id }, 'Failed to deliver approval prompt for channel run');
+              }
+            }
+          }
+        }
+
+        lastStatus = current.status;
+
+        if (current.status === 'completed' || current.status === 'failed') {
+          break;
+        }
+      }
+
+      channelDeliveryStore.markProcessed(eventId);
+
+      // Deliver the final assistant reply
+      await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+    } catch (err) {
+      log.error({ err, conversationId }, 'Approval-aware channel message processing failed');
+      channelDeliveryStore.recordProcessingFailure(eventId, err);
+    }
+  })();
+}
+
+// ---------------------------------------------------------------------------
+// Approval interception
+// ---------------------------------------------------------------------------
+
+interface ApprovalInterceptionParams {
+  conversationId: string;
+  callbackData?: string;
+  content: string;
+  externalChatId: string;
+  replyCallbackUrl: string;
+  bearerToken?: string;
+  orchestrator: RunOrchestrator;
+}
+
+interface ApprovalInterceptionResult {
+  handled: boolean;
+  type?: 'decision_applied' | 'reminder_sent';
+}
+
+/**
+ * Check for pending approvals and handle inbound messages accordingly.
+ *
+ * Returns `{ handled: true }` when the message was consumed by the approval
+ * flow (either as a decision or a reminder), so the caller should NOT proceed
+ * to normal message processing.
+ */
+async function handleApprovalInterception(
+  params: ApprovalInterceptionParams,
+): Promise<ApprovalInterceptionResult> {
+  const {
+    conversationId,
+    callbackData,
+    content,
+    externalChatId,
+    replyCallbackUrl,
+    bearerToken,
+    orchestrator,
+  } = params;
+
+  const pendingPrompt = getChannelApprovalPrompt(conversationId);
+  if (!pendingPrompt) return { handled: false };
+
+  // Try to extract a decision from callback data (button press) first,
+  // then fall back to plain-text parsing.
+  let decision: ApprovalDecisionResult | null = null;
+
+  if (callbackData) {
+    decision = parseCallbackData(callbackData);
+  }
+
+  if (!decision && content) {
+    decision = parseApprovalDecision(content);
+  }
+
+  if (decision) {
+    const result = handleChannelDecision(conversationId, decision, orchestrator);
+
+    if (result.applied) {
+      // Deliver the run's result back to the channel once the decision is applied.
+      // The run will resume in the background; deliver whatever assistant reply
+      // is available now (there may not be one yet if the run is still processing).
+      try {
+        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver post-decision reply');
+      }
+    }
+
+    return { handled: true, type: 'decision_applied' };
+  }
+
+  // The message is not a decision — send a reminder with the approval buttons.
+  const reminder = buildReminderPrompt(pendingPrompt);
+  const pending = getPendingConfirmationsByConversation(conversationId);
+  if (pending.length > 0) {
+    const uiMetadata = buildApprovalUIMetadata(reminder, pending[0]);
+    try {
+      await deliverApprovalPrompt(
+        replyCallbackUrl,
+        externalChatId,
+        reminder.promptText,
+        uiMetadata,
+        bearerToken,
+      );
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to deliver approval reminder');
+    }
+  }
+
+  return { handled: true, type: 'reminder_sent' };
 }
 
 async function deliverReplyViaCallback(


### PR DESCRIPTION
Part of #6626. Wires the channel approval orchestration into channel-routes.ts, extends gateway-client.ts for approval UI payloads, adds run lifecycle integration for needs_confirmation transitions, and gates everything behind CHANNEL_APPROVALS_ENABLED feature flag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
