### PR TITLE
M6: Documentation and architecture updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3543,6 +3543,45 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 
 **Bot-account limitations:** The Telegram Bot API only supports sending messages to chats that have previously interacted with the bot. Bots cannot enumerate chats, read message history, or search messages. A future MTProto user-account session track may lift some of these restrictions.
 
+### Channel Approval Flow
+
+When the assistant requires tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. Gated behind the `CHANNEL_APPROVALS_ENABLED` feature flag.
+
+**State machine:**
+
+```
+Running → NeedsConfirmation → Running → Completed | Failed
+```
+
+The run transitions to `NeedsConfirmation` when the agent loop emits a `confirmation_request` event. It returns to `Running` after the user submits a decision (approve/reject), and eventually reaches `Completed` or `Failed`.
+
+**Telegram button round-trip:**
+
+```
+Runtime detects needs_confirmation
+  → runtime builds approval prompt + UI metadata
+  → POST /deliver/telegram with `approval` payload
+  → gateway renders inline keyboard (buttons: Approve once, Approve always, Reject)
+  → user clicks button → Telegram callback_query
+  → gateway normalizes callback_query into inbound event (callbackData field)
+  → runtime parses callback data (format: apr:<runId>:<action>)
+  → runtime applies decision to pending run → run resumes
+```
+
+**Plain-text fallback:** When no button click is detected (e.g., non-Telegram channels or user typing a reply), the text parser matches approval phrases case-insensitively: `yes`, `approve`, `allow`, `go ahead` (approve once), `always`, `approve always`, `allow always` (approve always), `no`, `reject`, `deny`, `cancel` (reject). If the user sends a non-decision message while an approval is pending, a reminder prompt is re-sent with the approval buttons.
+
+**Key modules:**
+
+| Module | Purpose |
+|--------|---------|
+| `assistant/src/runtime/channel-approvals.ts` | Orchestration: detect pending confirmations, build prompts, apply decisions, build reminders |
+| `assistant/src/runtime/channel-approval-parser.ts` | Plain-text decision parser (phrase matching) |
+| `assistant/src/runtime/channel-approval-types.ts` | Shared types: actions, prompts, UI metadata, decisions |
+| `assistant/src/runtime/routes/channel-routes.ts` | Integration point: approval interception in the channel inbound handler |
+| `assistant/src/runtime/gateway-client.ts` | `deliverApprovalPrompt()` — sends approval payload to gateway |
+| `gateway/src/telegram/send.ts` | `buildInlineKeyboard()` — renders approval actions as Telegram inline buttons |
+| `gateway/src/telegram/normalize.ts` | `callback_query` normalization into `GatewayInboundEventV1` |
+
 ### Telegram Credential Flow
 
 In desktop deployments, Telegram bot tokens are stored in secure storage (macOS Keychain or the encrypted file fallback) and never in plaintext config files. When deploying the gateway standalone, operators may also supply credentials via environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`).

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -120,6 +120,38 @@ assistant/
 └── package.json
 ```
 
+## Channel Approval Flow
+
+When the assistant needs tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. This is gated behind the `CHANNEL_APPROVALS_ENABLED=true` environment variable.
+
+### How it works
+
+1. **Detection** — When a channel inbound message triggers an agent loop, the runtime polls the run status. If the run transitions to `needs_confirmation`, the runtime sends an approval prompt to the gateway with inline keyboard metadata.
+2. **Interception** — Subsequent inbound messages on the same conversation are intercepted before normal processing. The handler checks for a pending approval and attempts to extract a decision from either callback data (button clicks) or plain text.
+3. **Decision** — The user's decision is mapped to the permission system (`allow` or `deny`) and applied to the pending run. For `approve_always`, a trust rule is persisted so future invocations of the same tool are auto-approved.
+4. **Reminder** — If the user sends a non-decision message while an approval is pending, a reminder prompt is re-sent with the approval buttons.
+
+### Key modules
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/channel-approvals.ts` | Orchestration: `getChannelApprovalPrompt`, `buildApprovalUIMetadata`, `handleChannelDecision`, `buildReminderPrompt` |
+| `src/runtime/channel-approval-parser.ts` | Plain-text decision parser — matches phrases like `yes`, `approve`, `always`, `no`, `reject`, `deny`, `cancel` (case-insensitive) |
+| `src/runtime/channel-approval-types.ts` | Shared types: `ApprovalAction`, `ChannelApprovalPrompt`, `ApprovalUIMetadata`, `ApprovalDecisionResult` |
+| `src/runtime/routes/channel-routes.ts` | Integration point: `handleApprovalInterception` and `processChannelMessageWithApprovals` in the channel inbound handler |
+| `src/runtime/gateway-client.ts` | `deliverApprovalPrompt()` — sends the approval payload (text + UI metadata) to the gateway for rendering |
+| `src/memory/runs-store.ts` | `getPendingConfirmationsByConversation` — queries runs in `needs_confirmation` state |
+
+### Enabling
+
+Set the environment variable before starting the daemon:
+
+```bash
+CHANNEL_APPROVALS_ENABLED=true
+```
+
+When disabled (the default), channel messages follow the standard fire-and-forget processing path without approval interception.
+
 ## Database
 
 SQLite via Drizzle ORM, stored at `~/.vellum/workspace/data/db/assistant.db`. Key tables include conversations, messages, tool invocations, attachments, memory segments (with FTS5), memory items, entities, reminders, and recurrence schedules (cron + RRULE).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -74,7 +74,7 @@ Webhook registration is now handled automatically by the gateway. On startup, th
 For manual setup (or reference), register the webhook with Telegram using the `setWebhook` API method. Pass:
 - `url` — your gateway URL, e.g. `https://your-host/webhooks/telegram`
 - The verify value matching your `TELEGRAM_WEBHOOK_SECRET` env var
-- `allowed_updates` — `["message", "edited_message"]`
+- `allowed_updates` — `["message", "edited_message", "callback_query"]`
 
 See the [Telegram Bot API docs](https://core.telegram.org/bots/api#setwebhook) for the full API reference.
 
@@ -90,6 +90,43 @@ The `/deliver/telegram` endpoint requires bearer auth by default (fail-closed). 
 | No bearer token configured + bypass not set | 503 Service Not Configured |
 
 This ensures that misconfiguration cannot expose an unauthenticated public message-send surface. In production, always configure `RUNTIME_PROXY_BEARER_TOKEN`. The `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS` flag is intended for local development only.
+
+## Callback Query Handling
+
+The gateway normalizes Telegram `callback_query` updates (inline button clicks) into the same `GatewayInboundEventV1` format used for regular messages. When a `callback_query` is present in the webhook payload, the normalizer extracts:
+
+- `callbackQueryId` — the Telegram callback query ID
+- `callbackData` — the opaque data string attached to the button (e.g., `apr:<runId>:<action>`)
+- `content` — set to the callback data string (so the runtime always has content to process)
+
+These fields are forwarded to the runtime in the `/channels/inbound` payload alongside the standard `externalChatId`, `externalMessageId`, and sender metadata. The runtime uses `callbackData` to route the click to the appropriate approval handler.
+
+## Approval Buttons and Inline Keyboard
+
+The `/deliver/telegram` endpoint accepts an optional `approval` field in the request body. When present, the gateway renders Telegram inline keyboard buttons below the message text.
+
+**Approval payload shape:**
+
+```json
+{
+  "chatId": "123456",
+  "text": "The assistant wants to use the tool \"bash\". Do you want to allow this?",
+  "approval": {
+    "runId": "run-uuid",
+    "requestId": "request-uuid",
+    "actions": [
+      { "id": "approve_once", "label": "Approve once" },
+      { "id": "approve_always", "label": "Approve always" },
+      { "id": "reject", "label": "Reject" }
+    ],
+    "plainTextFallback": "Reply \"yes\" to approve once, \"always\" to approve always, or \"no\" to reject."
+  }
+}
+```
+
+**Inline keyboard format:** Each action is rendered as a single-button row. The callback data uses the compact format `apr:<runId>:<action>` (e.g., `apr:run-uuid:approve_once`) so the runtime can parse it back when the button is clicked.
+
+**Fallback behavior:** For non-Telegram channels that do not support inline keyboards, the `plainTextFallback` string is included in the prompt text, providing plain-text instructions for the user to type their decision.
 
 ## Public Ingress Routes
 


### PR DESCRIPTION
Part of #6626. Documents the channel approval flow in ARCHITECTURE.md (state machine, Telegram round-trip, feature flag), gateway/README.md (callback_query handling, inline keyboard, approval payload), and assistant/README.md (approval orchestration, text parser, feature flag).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
