### PR TITLE
feat: daemon TLS + stable session tokens + opt-in LAN binding

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,8 +1,11 @@
 import * as net from 'node:net';
+import * as tls from 'node:tls';
 import { randomBytes } from 'node:crypto';
-import { existsSync, chmodSync, readFileSync, writeFileSync, unlinkSync, readdirSync, watch, type FSWatcher } from 'node:fs';
+import { existsSync, chmodSync, readFileSync, writeFileSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
-import { getSocketPath, getSessionTokenPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile, getTCPPort, getTCPHost, isTCPEnabled } from '../util/platform.js';
+import { getSocketPath, getSessionTokenPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile, getTCPPort, getTCPHost, isTCPEnabled, isIOSPairingEnabled } from '../util/platform.js';
+import { ensureTlsCert } from './tls-certs.js';
+import { getLocalIPv4 } from '../util/network-info.js';
 import { hasNoAuthOverride } from './connection-policy.js';
 import { getLogger } from '../util/logger.js';
 import { getFailoverProvider, initializeProviders } from '../providers/registry.js';
@@ -58,7 +61,7 @@ const daemonVersion = readPackageVersion();
 
 export class DaemonServer {
   private server: net.Server | null = null;
-  private tcpServer: net.Server | null = null;
+  private tcpServer: tls.Server | null = null;
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
   private cuSessions = new Map<string, ComputerUseSession>();
@@ -204,15 +207,36 @@ export class DaemonServer {
 
     this.startFileWatchers();
 
-    // Generate a session token and write it to disk so clients can
-    // authenticate when connecting. Written before the socket starts
-    // listening to ensure the token is available by the time a client
-    // can connect.
-    this.sessionToken = randomBytes(32).toString('hex');
+    // Reuse existing session token from disk if present, so pairing
+    // (e.g. iOS QR code) survives daemon restarts. Only generate a
+    // new token when none exists on disk.
     const tokenPath = getSessionTokenPath();
-    writeFileSync(tokenPath, this.sessionToken, { mode: 0o600 });
-    chmodSync(tokenPath, 0o600);
-    log.info({ tokenPath }, 'Session token written');
+    let existingToken: string | null = null;
+    try {
+      const raw = readFileSync(tokenPath, 'utf-8').trim();
+      if (raw.length >= 32) existingToken = raw;
+    } catch { /* file doesn't exist yet */ }
+
+    if (existingToken) {
+      this.sessionToken = existingToken;
+      log.info({ tokenPath }, 'Reusing existing session token');
+    } else {
+      this.sessionToken = randomBytes(32).toString('hex');
+      writeFileSync(tokenPath, this.sessionToken, { mode: 0o600 });
+      chmodSync(tokenPath, 0o600);
+      log.info({ tokenPath }, 'New session token generated');
+    }
+
+    // Generate TLS certificate before starting listeners so it's
+    // available synchronously in the listen callback.
+    let tlsCreds: { cert: string; key: string; fingerprint: string } | null = null;
+    if (isTCPEnabled()) {
+      try {
+        tlsCreds = await ensureTlsCert();
+      } catch (err) {
+        log.error({ err }, 'Failed to generate TLS certificate — TCP listener will not start');
+      }
+    }
 
     return new Promise((resolve, reject) => {
       this.server = net.createServer((socket) => {
@@ -237,17 +261,31 @@ export class DaemonServer {
         chmodSync(this.socketPath, 0o600);
         log.info({ socketPath: this.socketPath }, 'Daemon server listening');
 
-        // Start TCP listener for iOS clients (alongside the Unix socket)
-        if (isTCPEnabled()) {
+        // Start TLS-encrypted TCP listener for iOS clients (alongside the Unix socket)
+        if (tlsCreds) {
           const tcpPort = getTCPPort();
-          this.tcpServer = net.createServer((socket) => {
-            this.handleConnection(socket);
-          });
+          const tcpHost = getTCPHost();
+          this.tcpServer = tls.createServer(
+            { cert: tlsCreds.cert, key: tlsCreds.key },
+            (socket) => { this.handleConnection(socket); },
+          );
           this.tcpServer.on('error', (err) => {
-            log.error({ err, tcpPort }, 'TCP server error');
+            log.error({ err, tcpPort }, 'TLS TCP server error');
           });
-          this.tcpServer.listen(tcpPort, getTCPHost(), () => {
-            log.info({ tcpPort, tcpHost: getTCPHost() }, 'TCP listener started');
+          const fingerprint = tlsCreds.fingerprint;
+          this.tcpServer.listen(tcpPort, tcpHost, () => {
+            const localIP = getLocalIPv4();
+            log.info(
+              { tcpPort, tcpHost, fingerprint, localIP, iosPairing: isIOSPairingEnabled() },
+              'TLS TCP listener started',
+            );
+            if (isIOSPairingEnabled() && localIP) {
+              log.warn(
+                { localIP, tcpPort },
+                'iOS pairing enabled — daemon is reachable on the local network at %s:%d',
+                localIP, tcpPort,
+              );
+            }
           });
         }
 
@@ -265,10 +303,9 @@ export class DaemonServer {
     }
     this.stopFileWatchers();
 
-    // Clean up session token
-    try {
-      unlinkSync(getSessionTokenPath());
-    } catch { /* ignore if already gone */ }
+    // Session token is intentionally kept on disk so pairing
+    // (e.g. iOS QR code) survives daemon restarts. To regenerate,
+    // delete ~/.vellum/session-token and restart the daemon.
 
     for (const timer of this.authTimeouts.values()) {
       clearTimeout(timer);

--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -1,6 +1,6 @@
 import { mkdir, stat, readFile, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
-import { X509Certificate } from 'node:crypto';
+import { X509Certificate, createPrivateKey } from 'node:crypto';
 import { getRootDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 
@@ -43,11 +43,11 @@ function computeFingerprint(cert: X509Certificate): string {
 
 /**
  * Check whether an existing cert+key pair is valid:
- * - Both files exist
+ * - All three files exist (cert, key, fingerprint)
  * - Cert is parseable as X509
  * - Cert is not expired
  * - Fingerprint file exists and matches the cert
- * - Key corresponds to the cert (modulus check via OpenSSL)
+ * - Private key is valid and matches the certificate
  */
 async function isExistingCertValid(): Promise<boolean> {
   const certPath = getTlsCertPath();
@@ -66,8 +66,9 @@ async function isExistingCertValid(): Promise<boolean> {
   }
 
   try {
-    const [certPem, storedFp] = await Promise.all([
+    const [certPem, keyPem, storedFp] = await Promise.all([
       readFile(certPath, 'utf-8'),
+      readFile(keyPath, 'utf-8'),
       readFile(fpPath, 'utf-8'),
     ]);
 
@@ -84,6 +85,15 @@ async function isExistingCertValid(): Promise<boolean> {
     const actualFp = computeFingerprint(x509);
     if (actualFp !== storedFp.trim()) {
       log.info('TLS fingerprint mismatch, will regenerate');
+      return false;
+    }
+
+    // Verify the private key is valid and matches the certificate's public key.
+    // This catches corrupted key files or cert/key mismatches that would cause
+    // tls.createServer() to fail at runtime.
+    const privateKey = createPrivateKey(keyPem);
+    if (!x509.checkPrivateKey(privateKey)) {
+      log.info('TLS private key does not match certificate, will regenerate');
       return false;
     }
 

--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -1,0 +1,179 @@
+import { mkdir, stat, readFile, writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { X509Certificate } from 'node:crypto';
+import { getRootDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('tls-certs');
+
+const TLS_DIR = 'tls';
+const CERT_FILENAME = 'cert.pem';
+const KEY_FILENAME = 'key.pem';
+const FINGERPRINT_FILENAME = 'fingerprint';
+
+/** Returns the TLS directory path (~/.vellum/tls/). */
+export function getTlsDir(): string {
+  return join(getRootDir(), TLS_DIR);
+}
+
+/** Returns the path to the TLS certificate. */
+export function getTlsCertPath(): string {
+  return join(getTlsDir(), CERT_FILENAME);
+}
+
+/** Returns the path to the TLS private key. */
+export function getTlsKeyPath(): string {
+  return join(getTlsDir(), KEY_FILENAME);
+}
+
+/** Returns the path to the certificate fingerprint file. */
+export function getTlsFingerprintPath(): string {
+  return join(getTlsDir(), FINGERPRINT_FILENAME);
+}
+
+/**
+ * Compute the SHA-256 fingerprint of a DER-encoded certificate.
+ * Returns hex lowercase, no colons.
+ */
+function computeFingerprint(cert: X509Certificate): string {
+  // X509Certificate.fingerprint256 returns colon-separated uppercase hex.
+  // Normalize to lowercase without colons for compact storage and comparison.
+  return cert.fingerprint256.replace(/:/g, '').toLowerCase();
+}
+
+/**
+ * Check whether an existing cert+key pair is valid:
+ * - Both files exist
+ * - Cert is parseable as X509
+ * - Cert is not expired
+ * - Fingerprint file exists and matches the cert
+ * - Key corresponds to the cert (modulus check via OpenSSL)
+ */
+async function isExistingCertValid(): Promise<boolean> {
+  const certPath = getTlsCertPath();
+  const keyPath = getTlsKeyPath();
+  const fpPath = getTlsFingerprintPath();
+
+  // Check all three files exist
+  const [certExists, keyExists, fpExists] = await Promise.all([
+    stat(certPath).then(() => true, () => false),
+    stat(keyPath).then(() => true, () => false),
+    stat(fpPath).then(() => true, () => false),
+  ]);
+
+  if (!certExists || !keyExists || !fpExists) {
+    return false;
+  }
+
+  try {
+    const [certPem, storedFp] = await Promise.all([
+      readFile(certPath, 'utf-8'),
+      readFile(fpPath, 'utf-8'),
+    ]);
+
+    const x509 = new X509Certificate(certPem);
+
+    // Check expiration
+    const notAfter = new Date(x509.validTo);
+    if (notAfter <= new Date()) {
+      log.info('Existing TLS certificate has expired, will regenerate');
+      return false;
+    }
+
+    // Check fingerprint matches
+    const actualFp = computeFingerprint(x509);
+    if (actualFp !== storedFp.trim()) {
+      log.info('TLS fingerprint mismatch, will regenerate');
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    log.warn({ err }, 'Failed to validate existing TLS certificate, will regenerate');
+    return false;
+  }
+}
+
+/**
+ * Ensure a self-signed TLS certificate exists for the daemon.
+ *
+ * Stores files in `~/.vellum/tls/`:
+ * - `cert.pem` (0o644) — self-signed certificate
+ * - `key.pem` (0o600) — private key
+ * - `fingerprint` (0o644) — SHA-256 hex fingerprint (lowercase, no colons)
+ *
+ * Idempotent: skips generation if a valid cert already exists.
+ * Auto-regenerates if the cert is expired, fingerprint is missing/mismatched,
+ * or key/cert files are corrupt.
+ *
+ * Returns the cert, key (PEM strings), and fingerprint.
+ */
+export async function ensureTlsCert(): Promise<{ cert: string; key: string; fingerprint: string }> {
+  const tlsDir = getTlsDir();
+  const certPath = getTlsCertPath();
+  const keyPath = getTlsKeyPath();
+  const fpPath = getTlsFingerprintPath();
+
+  // Check if existing cert is still valid
+  if (await isExistingCertValid()) {
+    const [cert, key, fingerprint] = await Promise.all([
+      readFile(certPath, 'utf-8'),
+      readFile(keyPath, 'utf-8'),
+      readFile(fpPath, 'utf-8'),
+    ]);
+    log.info('Using existing TLS certificate');
+    return { cert, key, fingerprint: fingerprint.trim() };
+  }
+
+  // Generate new cert
+  log.info('Generating new self-signed TLS certificate');
+  await mkdir(tlsDir, { recursive: true });
+
+  // Generate RSA 2048 key
+  const keyProc = Bun.spawn(
+    ['openssl', 'genrsa', '-out', keyPath, '2048'],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const keyExit = await keyProc.exited;
+  if (keyExit !== 0) {
+    const stderr = await new Response(keyProc.stderr).text();
+    throw new Error(`Failed to generate TLS key: ${stderr}`);
+  }
+
+  // Generate self-signed cert (10-year validity)
+  const certProc = Bun.spawn(
+    [
+      'openssl', 'req', '-new', '-x509',
+      '-key', keyPath,
+      '-out', certPath,
+      '-days', '3650',
+      '-subj', '/CN=Vellum Daemon',
+    ],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const certExit = await certProc.exited;
+  if (certExit !== 0) {
+    const stderr = await new Response(certProc.stderr).text();
+    throw new Error(`Failed to generate TLS certificate: ${stderr}`);
+  }
+
+  // Compute and write fingerprint
+  const certPem = await readFile(certPath, 'utf-8');
+  const x509 = new X509Certificate(certPem);
+  const fingerprint = computeFingerprint(x509);
+  await writeFile(fpPath, fingerprint);
+
+  // Set permissions: key is private, cert and fingerprint are readable
+  await Promise.all([
+    chmod(keyPath, 0o600),
+    chmod(certPath, 0o644),
+    chmod(fpPath, 0o644),
+  ]);
+
+  log.info({ fingerprint, certPath }, 'TLS certificate generated');
+  return {
+    cert: certPem,
+    key: await readFile(keyPath, 'utf-8'),
+    fingerprint,
+  };
+}

--- a/assistant/src/util/network-info.ts
+++ b/assistant/src/util/network-info.ts
@@ -1,0 +1,47 @@
+import { networkInterfaces } from 'node:os';
+
+/**
+ * Returns the local IPv4 address most likely to be reachable from other
+ * devices on the same LAN.
+ *
+ * Priority order:
+ *   1. en0 (Wi-Fi on macOS)
+ *   2. en1 (secondary network on macOS)
+ *   3. First non-loopback IPv4 on any interface
+ *
+ * Skips link-local addresses (169.254.x.x) and IPv6.
+ * Returns null if no suitable address is found (e.g. no network).
+ */
+export function getLocalIPv4(): string | null {
+  const ifaces = networkInterfaces();
+
+  // Priority interfaces in order
+  const priorityInterfaces = ['en0', 'en1'];
+
+  for (const ifName of priorityInterfaces) {
+    const addrs = ifaces[ifName];
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family === 'IPv4' && !addr.internal && !isLinkLocal(addr.address)) {
+        return addr.address;
+      }
+    }
+  }
+
+  // Fallback: first non-loopback, non-link-local IPv4 on any interface
+  for (const [, addrs] of Object.entries(ifaces)) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family === 'IPv4' && !addr.internal && !isLinkLocal(addr.address)) {
+        return addr.address;
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Returns true for IPv4 link-local addresses (169.254.x.x). */
+function isLinkLocal(address: string): boolean {
+  return address.startsWith('169.254.');
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -135,12 +135,37 @@ export function isTCPEnabled(): boolean {
 
 /**
  * Returns the hostname/address for the TCP listener.
- * Reads VELLUM_DAEMON_TCP_HOST env var; defaults to '127.0.0.1' (localhost only).
- * Set VELLUM_DAEMON_TCP_HOST=0.0.0.0 to accept connections from all interfaces
- * (required for real iOS device connections over a local network).
+ * Resolution order (first match wins):
+ *   1. VELLUM_DAEMON_TCP_HOST env var (explicit override)
+ *   2. If iOS pairing is enabled: '0.0.0.0' (LAN-accessible)
+ *   3. Default: '127.0.0.1' (localhost only)
  */
 export function getTCPHost(): string {
-  return process.env.VELLUM_DAEMON_TCP_HOST?.trim() || '127.0.0.1';
+  const override = process.env.VELLUM_DAEMON_TCP_HOST?.trim();
+  if (override) return override;
+  if (isIOSPairingEnabled()) return '0.0.0.0';
+  return '127.0.0.1';
+}
+
+/**
+ * Returns whether iOS pairing mode is enabled.
+ * When enabled, the TCP listener binds to 0.0.0.0 (all interfaces)
+ * instead of 127.0.0.1 (localhost only), making the daemon reachable
+ * from iOS devices on the same local network.
+ *
+ * Resolution order (first match wins):
+ *   1. VELLUM_DAEMON_IOS_PAIRING env var ('true'/'1' → on, 'false'/'0' → off)
+ *   2. Presence of the flag file ~/.vellum/ios-pairing-enabled (exists → on)
+ *   3. Default: false
+ *
+ * This is separate from isTCPEnabled() — TCP can be enabled for localhost-only
+ * access without exposing the daemon to the LAN.
+ */
+export function isIOSPairingEnabled(): boolean {
+  const override = process.env.VELLUM_DAEMON_IOS_PAIRING?.trim();
+  if (override === 'true' || override === '1') return true;
+  if (override === 'false' || override === '0') return false;
+  return existsSync(join(getRootDir(), 'ios-pairing-enabled'));
 }
 
 export function getHttpTokenPath(): string {


### PR DESCRIPTION
## Summary

- Add TLS encryption for all daemon TCP connections (mandatory, no plaintext fallback)
- Make session tokens stable across daemon restarts so QR pairing survives restarts
- Add opt-in `0.0.0.0` binding via `ios-pairing-enabled` flag for LAN accessibility
- Add local IP detection utility for daemon startup logging and future QR code generation

## Implementation

### Self-signed TLS certificate management (`tls-certs.ts`)
- Generates RSA 2048 self-signed cert with CN=Vellum Daemon, 10-year validity
- Stores in `~/.vellum/tls/`: `cert.pem` (0o644), `key.pem` (0o600), `fingerprint` (0o644)
- SHA-256 fingerprint in hex lowercase, no colons (compact format for QR codes)
- Idempotent: reuses existing valid cert; auto-regenerates on expiry, fingerprint mismatch, or corruption
- Uses OpenSSL CLI (same pattern as `script-proxy/certs.ts`)

### TLS TCP listener (`server.ts`)
- Replaces `net.createServer()` with `tls.createServer()` for the TCP listener
- `tls.TLSSocket` extends `net.Socket` so `handleConnection()` is unchanged
- Cert is generated before the listen promise to avoid async-in-callback issues
- Logs local IP, fingerprint, and iOS pairing status on startup

### Stable session tokens (`server.ts`)
- Token is now read from `~/.vellum/session-token` on startup if it exists and is valid (>= 32 chars)
- Only generates a new token when none exists on disk
- Token cleanup on shutdown is removed — pairing persists until explicit regeneration
- To regenerate: delete `~/.vellum/session-token` and restart the daemon

### Opt-in LAN binding (`platform.ts`)
- New `isIOSPairingEnabled()`: checks `VELLUM_DAEMON_IOS_PAIRING` env or `~/.vellum/ios-pairing-enabled` flag file
- `getTCPHost()` now returns `0.0.0.0` when iOS pairing is enabled, `127.0.0.1` otherwise
- Explicit env var (`VELLUM_DAEMON_TCP_HOST`) still takes highest priority
- Keeps existing TCP behavior unchanged — LAN exposure requires explicit opt-in

### Local IP detection (`network-info.ts`)
- Enumerates network interfaces, preferring en0 (Wi-Fi) > en1 > first non-loopback IPv4
- Ignores link-local (169.254.x.x) and IPv6
- Used for daemon startup logging; will be shared with macOS QR code generation in PR 2

## Security Properties

- TLS encrypts all TCP traffic including the auth token
- 256-bit random session token (stable across restarts)
- `tls.createServer()` inherently rejects plaintext connections
- LAN binding requires explicit opt-in (`ios-pairing-enabled` flag)
- Warning logged when LAN exposure is active

## Files Changed

| File | Change |
|------|--------|
| `assistant/src/daemon/tls-certs.ts` | **NEW** — Self-signed cert generation and validation |
| `assistant/src/util/network-info.ts` | **NEW** — Local IPv4 address detection |
| `assistant/src/daemon/server.ts` | TLS for TCP, stable tokens, log local IP |
| `assistant/src/util/platform.ts` | `isIOSPairingEnabled()`, update `getTCPHost()` |

## Test Plan

- [ ] `VELLUM_DAEMON_TCP_ENABLED=1 VELLUM_DAEMON_IOS_PAIRING=1` → binds to `0.0.0.0` with TLS
- [ ] `openssl s_client -connect <ip>:8765` shows self-signed cert
- [ ] `~/.vellum/tls/fingerprint` exists and matches cert
- [ ] Token persists across daemon restarts
- [ ] Second start reuses existing cert (idempotent)
- [ ] Without `ios-pairing-enabled`, binds to `127.0.0.1`
- [ ] Plaintext TCP connections are rejected

Part of plan: ios-connection-plan.md (PR 1 of 3 — PR 3 cloud sign-in deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
