### PR TITLE
Fix: Accept 'approve once' in plain-text parser (feedback on #6633)

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -88,6 +88,10 @@ describe('parseApprovalDecision', () => {
     'go ahead',
     'Go Ahead',
     'GO AHEAD',
+    'approve once',
+    'Approve once',
+    'Approve Once',
+    'APPROVE ONCE',
   ])('recognises "%s" as approve_once', (input) => {
     const result = parseApprovalDecision(input);
     expect(result).not.toBeNull();
@@ -165,7 +169,6 @@ describe('parseApprovalDecision', () => {
     'go',
     'ahead',
     'maybe',
-    'approve once',
   ])('returns null for non-matching text: "%s"', (input) => {
     expect(parseApprovalDecision(input)).toBeNull();
   });

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -12,7 +12,7 @@ import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-
 // Phrase → action mapping
 // ---------------------------------------------------------------------------
 
-const APPROVE_ONCE_PHRASES = ['yes', 'approve', 'allow', 'go ahead'];
+const APPROVE_ONCE_PHRASES = ['yes', 'approve', 'approve once', 'allow', 'go ahead'];
 const APPROVE_ALWAYS_PHRASES = ['always', 'approve always', 'allow always'];
 const REJECT_PHRASES = ['no', 'reject', 'deny', 'cancel'];
 


### PR DESCRIPTION
Addresses review feedback on #6633. Adds 'approve once' to the recognized phrases for approve_once action in the channel-approval-parser.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
