### PR TITLE
Fix: Approval payload validation (feedback on #6634)

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -370,4 +370,64 @@ describe("telegram-deliver approval validation", () => {
     const args = sendTelegramReplyCalls[0];
     expect(args[3]).toBeUndefined();
   });
+
+  it("returns 400 when approval is present but text is missing", async () => {
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        attachments: [{ id: "att-1" }],
+        approval: {
+          runId: "run-1",
+          requestId: "req-1",
+          actions: [{ id: "ok", label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("text is required when approval is present");
+  });
+
+  it("returns 400 when callback_data would exceed 64 bytes", async () => {
+    // "apr:" (4 bytes) + runId + ":" (1 byte) + actionId must stay <= 64
+    // A 60-char runId + short action id will exceed the limit.
+    const longRunId = "r".repeat(60);
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "Approve?",
+        approval: {
+          runId: longRunId,
+          requestId: "req-1",
+          actions: [{ id: "ok", label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("64-byte limit");
+  });
+
+  it("accepts callback_data exactly at 64 bytes", async () => {
+    // "apr:" = 4 bytes, ":" separator = 1 byte, so runId + actionId = 59 bytes
+    const runId = "r".repeat(50);
+    const actionId = "a".repeat(9);
+    const res = await handler(
+      makeRequest({
+        chatId: "123",
+        text: "Approve?",
+        approval: {
+          runId,
+          requestId: "req-1",
+          actions: [{ id: actionId, label: "OK" }],
+          plainTextFallback: "ok",
+        },
+      }),
+    );
+    // Verify the callback_data is exactly 64 bytes
+    expect(Buffer.byteLength(`apr:${runId}:${actionId}`)).toBe(64);
+    expect(res.status).toBe(200);
+  });
 });

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -91,6 +91,12 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
 
     // Validate approval payload shape when present.
     if (approval !== undefined) {
+      if (!text) {
+        return Response.json(
+          { error: "text is required when approval is present" },
+          { status: 400 },
+        );
+      }
       if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {
         return Response.json({ error: "approval must be an object" }, { status: 400 });
       }
@@ -112,6 +118,16 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
         }
         if (!action.label || typeof action.label !== "string") {
           return Response.json({ error: "each approval action must have a label" }, { status: 400 });
+        }
+        // Telegram enforces a 1-64 byte limit on callback_data. Validate
+        // the would-be value up front so callers get a clear 400 instead of
+        // a downstream Telegram API failure surfaced as a 502.
+        const callbackData = `apr:${approval.runId}:${action.id}`;
+        if (Buffer.byteLength(callbackData) > 64) {
+          return Response.json(
+            { error: `callback_data for action "${action.id}" exceeds Telegram's 64-byte limit` },
+            { status: 400 },
+          );
         }
       }
     }

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -95,6 +95,31 @@ describe("buildInlineKeyboard", () => {
     const result = buildInlineKeyboard(approval);
     expect(result.inline_keyboard[0][0].callback_data).toBe("apr:abc-def:my_action");
   });
+
+  it("throws when callback_data exceeds 64 bytes", () => {
+    const approval: ApprovalPayload = {
+      runId: "r".repeat(60),
+      requestId: "req",
+      actions: [{ id: "action", label: "Go" }],
+      plainTextFallback: "go",
+    };
+    expect(() => buildInlineKeyboard(approval)).toThrow("64-byte limit");
+  });
+
+  it("accepts callback_data exactly at 64 bytes", () => {
+    // "apr:" = 4 bytes, ":" = 1 byte, so runId + actionId = 59 bytes
+    const runId = "r".repeat(50);
+    const actionId = "a".repeat(9);
+    const approval: ApprovalPayload = {
+      runId,
+      requestId: "req",
+      actions: [{ id: actionId, label: "Go" }],
+      plainTextFallback: "go",
+    };
+    expect(Buffer.byteLength(`apr:${runId}:${actionId}`)).toBe(64);
+    const result = buildInlineKeyboard(approval);
+    expect(result.inline_keyboard[0][0].callback_data).toBe(`apr:${runId}:${actionId}`);
+  });
 });
 
 describe("sendTelegramReply", () => {

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -8,6 +8,9 @@ const log = getLogger("telegram-send");
 
 const TELEGRAM_MAX_MESSAGE_LEN = 4000;
 
+/** Telegram Bot API enforces a 1-64 byte limit on InlineKeyboardButton callback_data. */
+export const TELEGRAM_MAX_CALLBACK_DATA_BYTES = 64;
+
 const IMAGE_MIME_PREFIXES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 function splitText(text: string): string[] {
@@ -33,12 +36,20 @@ export function buildInlineKeyboard(
   approval: ApprovalPayload,
 ): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
   return {
-    inline_keyboard: approval.actions.map((action) => [
-      {
-        text: action.label,
-        callback_data: `apr:${approval.runId}:${action.id}`,
-      },
-    ]),
+    inline_keyboard: approval.actions.map((action) => {
+      const callbackData = `apr:${approval.runId}:${action.id}`;
+      if (Buffer.byteLength(callbackData) > TELEGRAM_MAX_CALLBACK_DATA_BYTES) {
+        throw new Error(
+          `callback_data for action "${action.id}" is ${Buffer.byteLength(callbackData)} bytes, exceeding Telegram's ${TELEGRAM_MAX_CALLBACK_DATA_BYTES}-byte limit`,
+        );
+      }
+      return [
+        {
+          text: action.label,
+          callback_data: callbackData,
+        },
+      ];
+    }),
   };
 }
 


### PR DESCRIPTION
Addresses review feedback on #6634. Returns 400 when approval payload is present but text is missing. Validates callback_data length against Telegram's 64-byte limit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
