### PR TITLE
Fix: Security guards for approve_always (feedback on #6637)

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -148,6 +148,55 @@ describe('getChannelApprovalPrompt', () => {
     expect(result!.promptText).toMatch(/shell|file_edit/);
   });
 
+  test('excludes approve_always action when persistentDecisionsAllowed is false', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      ...sampleConfirmation,
+      persistentDecisionsAllowed: false,
+    });
+
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).not.toBeNull();
+    expect(result!.actions.map((a) => a.id)).toEqual(['approve_once', 'reject']);
+    expect(result!.plainTextFallback).not.toContain('always');
+  });
+
+  test('includes approve_always when persistentDecisionsAllowed is undefined', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      ...sampleConfirmation,
+      // persistentDecisionsAllowed not set — defaults to allowed
+    });
+
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).not.toBeNull();
+    expect(result!.actions.map((a) => a.id)).toEqual([
+      'approve_once',
+      'approve_always',
+      'reject',
+    ]);
+    expect(result!.plainTextFallback).toContain('always');
+  });
+
+  test('includes approve_always when persistentDecisionsAllowed is true', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      ...sampleConfirmation,
+      persistentDecisionsAllowed: true,
+    });
+
+    const result = getChannelApprovalPrompt('conv-1');
+    expect(result).not.toBeNull();
+    expect(result!.actions.map((a) => a.id)).toEqual([
+      'approve_once',
+      'approve_always',
+      'reject',
+    ]);
+  });
+
   test('does not return prompts for other conversations', () => {
     ensureConversation('conv-1');
     ensureConversation('conv-2');
@@ -283,7 +332,7 @@ describe('handleChannelDecision', () => {
     addRuleSpy.mockRestore();
   });
 
-  test('approve_always falls back to "**" / "everywhere" when no options available', () => {
+  test('approve_always does not persist rule when no allowlist/scope options are available', () => {
     ensureConversation('conv-1');
     const run = createRun('conv-1', 'msg-1');
     setRunConfirmation(run.id, {
@@ -291,7 +340,38 @@ describe('handleChannelDecision', () => {
       toolUseId: 'req-no-opts',
       input: { command: 'echo hi' },
       riskLevel: 'low',
-      // No allowlistOptions or scopeOptions
+      // No allowlistOptions or scopeOptions — should not create blanket rule
+    });
+
+    const addRuleSpy = spyOn(trustStore, 'addRule');
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_always',
+      source: 'telegram_button',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+
+    // Rule should NOT be persisted — no blanket "**"/"everywhere" fallback
+    expect(addRuleSpy).not.toHaveBeenCalled();
+
+    // The decision should still be applied as a one-time approval
+    expect(result.applied).toBe(true);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    addRuleSpy.mockRestore();
+  });
+
+  test('approve_always does not persist rule when allowlist/scope are empty arrays', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      toolName: 'bash',
+      toolUseId: 'req-empty-opts',
+      input: { command: 'echo hi' },
+      riskLevel: 'low',
+      allowlistOptions: [],
+      scopeOptions: [],
     });
 
     const addRuleSpy = spyOn(trustStore, 'addRule');
@@ -303,14 +383,36 @@ describe('handleChannelDecision', () => {
 
     handleChannelDecision('conv-1', decision, orchestrator);
 
-    expect(addRuleSpy).toHaveBeenCalledWith(
-      'bash',
-      '**',
-      'everywhere',
-      'allow',
-      100,
-      { executionTarget: undefined },
-    );
+    // Empty arrays should not trigger rule persistence
+    expect(addRuleSpy).not.toHaveBeenCalled();
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    addRuleSpy.mockRestore();
+  });
+
+  test('approve_always does not persist rule when persistentDecisionsAllowed is false', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1', 'msg-1');
+    setRunConfirmation(run.id, {
+      ...sampleConfirmation,
+      persistentDecisionsAllowed: false,
+    });
+
+    const addRuleSpy = spyOn(trustStore, 'addRule');
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_always',
+      source: 'telegram_button',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+
+    // Persistence blocked — rule must not be created
+    expect(addRuleSpy).not.toHaveBeenCalled();
+
+    // The current invocation should still be approved (one-time allow)
+    expect(result.applied).toBe(true);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
 
     addRuleSpy.mockRestore();
   });

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -228,6 +228,8 @@ export interface PendingRunInfo {
   toolName: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  /** When false, persistent trust rules (approve_always) are not allowed. */
+  persistentDecisionsAllowed?: boolean;
 }
 
 /**
@@ -260,6 +262,7 @@ export function getPendingConfirmationsByConversation(conversationId: string): P
       toolName: run.pendingConfirmation.toolName,
       input: run.pendingConfirmation.input,
       riskLevel: run.pendingConfirmation.riskLevel,
+      persistentDecisionsAllowed: run.pendingConfirmation.persistentDecisionsAllowed,
     });
   }
   return results;

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -47,9 +47,15 @@ export function getChannelApprovalPrompt(
  */
 function buildPromptFromRunInfo(info: PendingRunInfo): ChannelApprovalPrompt {
   const promptText = `The assistant wants to use the tool "${info.toolName}". Do you want to allow this?`;
-  const actions = [...DEFAULT_APPROVAL_ACTIONS];
-  const plainTextFallback =
-    `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
+
+  // Hide "approve always" when persistent trust rules are disallowed for this invocation.
+  const actions = info.persistentDecisionsAllowed === false
+    ? DEFAULT_APPROVAL_ACTIONS.filter((a) => a.id !== 'approve_always')
+    : [...DEFAULT_APPROVAL_ACTIONS];
+
+  const plainTextFallback = info.persistentDecisionsAllowed === false
+    ? `${promptText}\n\nReply "yes" to approve or "no" to reject.`
+    : `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
 
   return { promptText, actions, plainTextFallback };
 }
@@ -102,16 +108,25 @@ export function handleChannelDecision(
   const info = pending[0];
 
   if (decision.action === 'approve_always') {
-    // Persist a trust rule so future invocations of this tool are auto-approved.
+    // Only persist a trust rule when the confirmation explicitly allows persistence
+    // AND provides explicit allowlist/scope options. Without explicit options we
+    // would create a blanket "**"/"everywhere" rule, which is a security risk.
     const run = getRun(info.runId);
     const confirmation = run?.pendingConfirmation;
-    if (confirmation) {
-      const pattern = confirmation.allowlistOptions?.[0]?.pattern ?? '**';
-      const scope = confirmation.scopeOptions?.[0]?.scope ?? 'everywhere';
+    if (
+      confirmation &&
+      confirmation.persistentDecisionsAllowed !== false &&
+      confirmation.allowlistOptions?.length &&
+      confirmation.scopeOptions?.length
+    ) {
+      const pattern = confirmation.allowlistOptions[0].pattern;
+      const scope = confirmation.scopeOptions[0].scope;
       addRule(confirmation.toolName, pattern, scope, 'allow', 100, {
         executionTarget: confirmation.executionTarget,
       });
     }
+    // When persistence is not allowed or options are missing, the decision
+    // still proceeds as a one-time approval (falls through to submitDecision).
   }
 
   // Map channel-level action to the permission system's UserDecision type.


### PR DESCRIPTION
Addresses review feedback on #6637. Checks persistentDecisionsAllowed before persisting trust rules, requires explicit allowlist/scope options (no blanket ** fallback), and hides approve_always action when persistence is not allowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
