### PR TITLE
Fix: Add callback_query to webhook ALLOWED_UPDATES (feedback on #6639)

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -78,7 +78,7 @@ describe("reconcileTelegramWebhook", () => {
     expect(calls[1].method).toBe("setWebhook");
     expect((calls[1].body as any).url).toBe("https://example.ngrok.io/webhooks/telegram");
     expect((calls[1].body as any).secret_token).toBe("test-webhook-secret");
-    expect((calls[1].body as any).allowed_updates).toEqual(["message", "edited_message"]);
+    expect((calls[1].body as any).allowed_updates).toEqual(["message", "edited_message", "callback_query"]);
   });
 
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -11,7 +11,7 @@ interface WebhookInfo {
   /** Telegram does not return the secret itself, but we can detect a mismatch by re-setting. */
 }
 
-const ALLOWED_UPDATES = ["message", "edited_message"];
+const ALLOWED_UPDATES = ["message", "edited_message", "callback_query"];
 
 /**
  * Reconciles the Telegram webhook registration against the expected state


### PR DESCRIPTION
Addresses review feedback on #6639. Adds 'callback_query' to the ALLOWED_UPDATES array in webhook-manager.ts so Telegram delivers inline button clicks to the webhook.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
