### PR TITLE
Fix: Channel routes approval integration (feedback on #6638)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -46,6 +46,7 @@ import {
   setRunConfirmation,
 } from '../memory/runs-store.js';
 import type { PendingConfirmation } from '../memory/runs-store.js';
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
@@ -434,5 +435,398 @@ describe('messages without pending approval proceed normally', () => {
     expect(body.accepted).toBe(true);
     // Should NOT be treated as an approval decision since there's no pending approval
     expect(body.approval).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Empty content with callbackData bypasses validation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('empty content with callbackData bypasses validation', () => {
+  test('rejects empty content without callbackData', async () => {
+    const req = makeInboundRequest({ content: '' });
+    const res = await handleChannelInbound(req, noopProcessMessage);
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe('content or attachmentIds is required');
+  });
+
+  test('allows empty content when callbackData is present', async () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    const orchestrator = makeMockOrchestrator();
+
+    // Establish the conversation first
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    // Should NOT return 400 — callbackData allows empty content through
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('allows undefined content when callbackData is present', async () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    const orchestrator = makeMockOrchestrator();
+
+    // Establish the conversation first
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Send with no content field at all, just callbackData
+    const body = {
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-123',
+      externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+      callbackData: `apr:${run.id}:approve_once`,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+    };
+    const req = new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    expect(res.status).toBe(200);
+    const resBody = await res.json() as Record<string, unknown>;
+    expect(resBody.accepted).toBe(true);
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Callback run ID validation — stale button press
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('callback run ID validation', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('ignores stale callback when run ID does not match pending run', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    // Create a pending run
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send callback with a DIFFERENT run ID (stale button)
+    const req = makeInboundRequest({
+      content: '',
+      callbackData: `apr:stale-run-id:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    // submitDecision should NOT have been called because the run ID didn't match
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('applies callback when run ID matches pending run', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    // Create a pending run
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send callback with the CORRECT run ID
+    const req = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    // submitDecision SHOULD have been called with the correct run ID
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('plain-text decisions bypass run ID validation (no runId in result)', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
+    const conversationId = events[0]?.conversationId;
+    ensureConversation(conversationId!);
+
+    // Create a pending run
+    const run = createRun(conversationId!, 'msg-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send plain text "yes" — no runId in the parsed result, so validation is skipped
+    const req = makeInboundRequest({ content: 'yes' });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. linkMessage in approval-aware processing path
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('linkMessage in approval-aware processing path', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('linkMessage is called when run has a messageId and reaches terminal state', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage');
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-link-test',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-42',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // getRun returns completed status immediately so the poll loop exits
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello world' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify linkMessage was called with the run's messageId
+    const linkCalls = linkSpy.mock.calls.filter(
+      (call) => call[1] === 'user-msg-42',
+    );
+    expect(linkCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Verify markProcessed was also called
+    expect(markSpy).toHaveBeenCalled();
+
+    linkSpy.mockRestore();
+    markSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. Terminal state check before markProcessed
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('terminal state check before markProcessed', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('does NOT markProcessed when run is not in terminal state after poll timeout', async () => {
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-nonterminal',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-99',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // getRun always returns 'running' — the run never completes within the poll
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'running' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    // To avoid the 5-minute timeout, we patch the poll constants by testing
+    // through a short scenario: since the poll loop checks Date.now() vs
+    // RUN_POLL_MAX_WAIT_MS (300_000), we can't easily test the full timeout.
+    // Instead, test the terminal check by having getRun return null (run
+    // disappeared), which causes the poll to break without a terminal status.
+    const orchNull = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => null),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello world' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchNull);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // markProcessed should NOT have been called because the run is not terminal
+    // (getRun returned null, so isTerminal = false)
+    const markCalls = markSpy.mock.calls;
+    // Filter for calls that would correspond to the approval path event
+    // (the init message from processChannelMessageInBackground could also call markProcessed,
+    // but that's the non-approval path)
+    expect(markCalls.length).toBe(0);
+
+    markSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test('markProcessed is called when run reaches completed state', async () => {
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-completes',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-100',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello world' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // markProcessed should have been called because the run reached completed
+    expect(markSpy).toHaveBeenCalled();
+
+    markSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test('markProcessed is called when run reaches failed state', async () => {
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-fails',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-101',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'failed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello world' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // markProcessed should have been called because the run reached failed
+    expect(markSpy).toHaveBeenCalled();
+
+    markSpy.mockRestore();
+    deliverSpy.mockRestore();
   });
 });

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -68,4 +68,6 @@ export type ApprovalDecisionSource = 'telegram_button' | 'plain_text';
 export interface ApprovalDecisionResult {
   action: ApprovalAction;
   source: ApprovalDecisionSource;
+  /** Run ID extracted from callback data (button presses only). */
+  runId?: string;
 }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -50,9 +50,10 @@ const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
 function parseCallbackData(data: string): ApprovalDecisionResult | null {
   const parts = data.split(':');
   if (parts.length < 3 || parts[0] !== 'apr') return null;
+  const runId = parts[1];
   const action = parts.slice(2).join(':');
-  if (!VALID_ACTIONS.has(action)) return null;
-  return { action: action as ApprovalAction, source: 'telegram_button' };
+  if (!runId || !VALID_ACTIONS.has(action)) return null;
+  return { action: action as ApprovalAction, source: 'telegram_button', runId };
 }
 
 export async function handleDeleteConversation(req: Request): Promise<Response> {
@@ -127,7 +128,9 @@ export async function handleChannelInbound(
   const trimmedContent = typeof content === 'string' ? content.trim() : '';
   const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
-  if (trimmedContent.length === 0 && !hasAttachments && !isEdit) {
+  const hasCallbackData = typeof body.callbackData === 'string' && body.callbackData.length > 0;
+
+  if (trimmedContent.length === 0 && !hasAttachments && !isEdit && !hasCallbackData) {
     return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
   }
 
@@ -475,10 +478,30 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         }
       }
 
-      channelDeliveryStore.markProcessed(eventId);
+      // Only mark processed and deliver the final reply when the run has
+      // actually reached a terminal state. If the poll loop timed out while
+      // the run is still in progress, leave the event unprocessed so it can
+      // be retried or dead-lettered.
+      const finalRun = orchestrator.getRun(run.id);
+      const isTerminal = finalRun?.status === 'completed' || finalRun?.status === 'failed';
 
-      // Deliver the final assistant reply
-      await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+      if (isTerminal) {
+        // Link the inbound event to the user message created by the run so
+        // that edit lookups and dead letter replay work correctly.
+        if (run.messageId) {
+          channelDeliveryStore.linkMessage(eventId, run.messageId);
+        }
+
+        channelDeliveryStore.markProcessed(eventId);
+
+        // Deliver the final assistant reply
+        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+      } else {
+        log.warn(
+          { runId: run.id, status: finalRun?.status, conversationId },
+          'Approval-path poll loop timed out before run reached terminal state',
+        );
+      }
     } catch (err) {
       log.error({ err, conversationId }, 'Approval-aware channel message processing failed');
       channelDeliveryStore.recordProcessingFailure(eventId, err);
@@ -541,6 +564,20 @@ async function handleApprovalInterception(
   }
 
   if (decision) {
+    // When the decision came from a callback button, validate that the embedded
+    // run ID matches the currently pending run. A stale button (from a previous
+    // approval prompt) must not apply to a different pending run.
+    if (decision.runId) {
+      const pending = getPendingConfirmationsByConversation(conversationId);
+      if (pending.length === 0 || pending[0].runId !== decision.runId) {
+        log.warn(
+          { conversationId, callbackRunId: decision.runId, pendingRunId: pending[0]?.runId },
+          'Callback run ID does not match pending run, ignoring stale button press',
+        );
+        return { handled: true, type: 'decision_applied' };
+      }
+    }
+
     const result = handleChannelDecision(conversationId, decision, orchestrator);
 
     if (result.applied) {


### PR DESCRIPTION
## Summary
Addresses review feedback on #6638:

- **Empty content with callbackData**: Button press callbacks arrive with empty content. The validation now allows empty content through when `callbackData` is present, so approval buttons actually reach the interception code.
- **Missing linkMessage**: The approval-aware processing path now calls `channelDeliveryStore.linkMessage(eventId, run.messageId)` after the run completes, matching the non-approval path behavior. This fixes edit lookups and dead letter replay.
- **Run ID validation**: `parseCallbackData` now extracts and returns the `runId` from `apr:<runId>:<action>` format. Before applying a callback decision, the run ID is validated against the currently pending run to prevent stale buttons from applying to the wrong run.
- **Terminal state check**: `processChannelMessageWithApprovals` now only calls `markProcessed` and delivers the final reply when the run has actually reached a terminal state (`completed` or `failed`). If the poll loop times out, the event is left unprocessed.

## Test plan
- [x] Added tests for empty content bypass when callbackData is present
- [x] Added tests for stale callback run ID rejection
- [x] Added tests for linkMessage being called in approval path
- [x] Added tests for markProcessed gated on terminal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
