### PR TITLE
Fix: Stale callback handling (feedback on #6654)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -561,7 +561,7 @@ describe('callback run ID validation', () => {
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.approval).toBe('decision_applied');
+    expect(body.approval).toBe('stale_ignored');
     // submitDecision should NOT have been called because the run ID didn't match
     expect(orchestrator.submitDecision).not.toHaveBeenCalled();
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -371,6 +371,19 @@ export async function handleChannelInbound(
         approval: approvalResult.type,
       });
     }
+
+    // When a callback-only payload (no text content, no attachments) was not
+    // handled by approval interception, it's a stale button press with no
+    // pending approval. Return early instead of falling through to normal
+    // message processing, which would start a run with empty user content.
+    if (hasCallbackData && trimmedContent.length === 0 && !hasAttachments) {
+      return Response.json({
+        accepted: true,
+        duplicate: false,
+        eventId: result.eventId,
+        approval: 'stale_ignored',
+      });
+    }
   }
 
   // For new (non-duplicate) messages, run the secret ingress check
@@ -707,7 +720,7 @@ interface ApprovalInterceptionParams {
 
 interface ApprovalInterceptionResult {
   handled: boolean;
-  type?: 'decision_applied' | 'reminder_sent' | 'guardian_decision_applied';
+  type?: 'decision_applied' | 'reminder_sent' | 'guardian_decision_applied' | 'stale_ignored';
 }
 
 /**
@@ -783,7 +796,7 @@ async function handleApprovalInterception(
             { externalChatId, callbackRunId: decision.runId, approvalRunId: guardianApproval.runId },
             'Callback run ID does not match guardian approval run, ignoring stale button press',
           );
-          return { handled: true, type: 'guardian_decision_applied' };
+          return { handled: true, type: 'stale_ignored' };
         }
 
         // Apply the decision to the underlying run using the requester's
@@ -894,7 +907,7 @@ async function handleApprovalInterception(
           { conversationId, callbackRunId: decision.runId, pendingRunId: pending[0]?.runId },
           'Callback run ID does not match pending run, ignoring stale button press',
         );
-        return { handled: true, type: 'decision_applied' };
+        return { handled: true, type: 'stale_ignored' };
       }
     }
 


### PR DESCRIPTION
Addresses review feedback on #6654. Prevents stale callback-only payloads from falling through to normal message processing, and uses a distinct 'stale_ignored' type instead of misleading 'decision_applied' for stale button presses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
