### PR TITLE
fix: revoke prior challenges and add expiry check to approval lookup

### DIFF
--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -221,6 +221,19 @@ export function createChallenge(params: {
   const db = getDb();
   const now = Date.now();
 
+  // Revoke any prior pending challenges for the same (assistantId, channel)
+  // to close the replay window — only the latest challenge should be valid.
+  db.update(channelGuardianVerificationChallenges)
+    .set({ status: 'revoked', updatedAt: now })
+    .where(
+      and(
+        eq(channelGuardianVerificationChallenges.assistantId, params.assistantId),
+        eq(channelGuardianVerificationChallenges.channel, params.channel),
+        eq(channelGuardianVerificationChallenges.status, 'pending'),
+      ),
+    )
+    .run();
+
   const row = {
     id: params.id,
     assistantId: params.assistantId,
@@ -331,6 +344,7 @@ export function createApprovalRequest(params: {
 
 export function getPendingApprovalForRun(runId: string): GuardianApprovalRequest | null {
   const db = getDb();
+  const now = Date.now();
 
   const row = db
     .select()
@@ -339,6 +353,7 @@ export function getPendingApprovalForRun(runId: string): GuardianApprovalRequest
       and(
         eq(channelGuardianApprovalRequests.runId, runId),
         eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
       ),
     )
     .get();


### PR DESCRIPTION
Addresses review feedback from #6653:

1. Revokes prior pending verification challenges before creating a new one for the same (assistantId, channel) pair, closing a replay window.
2. Adds expiresAt check to getPendingApprovalForRun so expired approval requests are not returned as actionable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
