### PR TITLE
fix: harden guardian approval flow (expiry, strict-side-effects, approve_always)

### DIFF
--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -8,7 +8,7 @@
  * requests track per-run guardian approval decisions.
  */
 
-import { and, eq, gt } from 'drizzle-orm';
+import { and, desc, eq, gt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import {
@@ -370,6 +370,7 @@ export function getPendingApprovalByGuardianChat(
   guardianChatId: string,
 ): GuardianApprovalRequest | null {
   const db = getDb();
+  const now = Date.now();
 
   const row = db
     .select()
@@ -379,8 +380,10 @@ export function getPendingApprovalByGuardianChat(
         eq(channelGuardianApprovalRequests.channel, channel),
         eq(channelGuardianApprovalRequests.guardianChatId, guardianChatId),
         eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
       ),
     )
+    .orderBy(desc(channelGuardianApprovalRequests.createdAt))
     .get();
 
   return row ? rowToApprovalRequest(row) : null;

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -790,6 +790,13 @@ async function handleApprovalInterception(
       }
 
       if (decision) {
+        // approve_always is not available for guardian approvals — guardians
+        // should not be able to permanently allowlist tools on behalf of the
+        // requester. Downgrade to approve_once.
+        if (decision.action === 'approve_always') {
+          decision = { ...decision, action: 'approve_once' };
+        }
+
         // Validate run ID from callback matches the guardian approval's run
         if (decision.runId && decision.runId !== guardianApproval.runId) {
           log.warn(

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -97,14 +97,14 @@ export class RunOrchestrator {
       throw new Error('Session is already processing a message');
     }
 
-    // Apply run-level overrides to the session's memory policy before the
-    // agent loop starts. The policy is read lazily at tool execution time.
-    if (options?.forceStrictSideEffects) {
-      session.memoryPolicy = {
-        ...session.memoryPolicy,
-        strictSideEffects: true,
-      };
-    }
+    // Always set strictSideEffects explicitly so that cached sessions from
+    // a previous guardian run are reset. Without this, a non-guardian run
+    // that set strictSideEffects=true would leave the flag on for a
+    // subsequent guardian run on the same conversation.
+    session.memoryPolicy = {
+      ...session.memoryPolicy,
+      strictSideEffects: options?.forceStrictSideEffects ?? false,
+    };
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)


### PR DESCRIPTION
Addresses review feedback from #6657:

1. Adds expiresAt check to getPendingApprovalByGuardianChat so expired approval requests are not acted upon.
2. Converts approve_always to approve_once in guardian approval context (approve_always should not be available for guardian approvals).
3. Always sets strictSideEffects explicitly at run start so it resets properly for guardian runs after non-guardian runs.
4. Orders multiple pending approvals by createdAt DESC so the most recent is always selected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
