### PR TITLE
fix: gate requester approval notification on guardian prompt delivery success

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -610,6 +610,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               expiresAt: Date.now() + GUARDIAN_APPROVAL_TTL_MS,
             });
 
+            let guardianNotified = false;
             try {
               await deliverApprovalPrompt(
                 replyCallbackUrl,
@@ -618,18 +619,21 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                 uiMetadata,
                 bearerToken,
               );
+              guardianNotified = true;
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver guardian approval prompt');
             }
 
-            // Notify the requester that their request is pending guardian approval
-            try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: guardianCtx.requesterChatId ?? externalChatId,
-                text: `Your request to run "${pending[0].toolName}" has been sent to the guardian for approval.`,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, runId: run.id }, 'Failed to notify requester of pending guardian approval');
+            // Only notify the requester if the guardian prompt was actually delivered
+            if (guardianNotified) {
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: guardianCtx.requesterChatId ?? externalChatId,
+                  text: `Your request to run "${pending[0].toolName}" has been sent to the guardian for approval.`,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, runId: run.id }, 'Failed to notify requester of pending guardian approval');
+              }
             }
           } else {
             // Guardian actor or no guardian binding: standard approval prompt


### PR DESCRIPTION
Addresses review feedback from #6659:

Only sends the requester the 'sent to guardian for approval' notification if the guardian approval prompt was actually delivered successfully. Previously, this message was sent regardless, which could mislead the requester when delivery failed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
