### PR TITLE
feat: remove dead Telegram sync UI and add channel-lane filter tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -700,25 +700,12 @@ struct MainWindowView: View {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(VColor.accent.opacity(0.7))
-                } else if thread.isSynced {
-                    Image(systemName: "paperplane.fill")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
                 }
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(thread.title)
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    if let senderLabel = thread.senderLabel {
-                        Text(senderLabel)
-                            .font(VFont.small)
-                            .foregroundColor(VColor.textMuted)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
+                Text(thread.title)
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -18,32 +18,7 @@ struct ThreadModel: Identifiable, Hashable {
     var lastInteractedAt: Date
     var kind: ThreadKind
 
-    // MARK: - Channel Binding
-
-    /// The source channel for channel-bound threads (e.g. "telegram").
-    var sourceChannel: String?
-    /// Display name of the external user who initiated the conversation.
-    var displayName: String?
-    /// Username of the external user (e.g. Telegram @handle).
-    var username: String?
-    /// External chat identifier for the synced conversation.
-    var externalChatId: String?
-
-    /// Whether this thread is bound to an external channel (e.g. Telegram).
-    var isSynced: Bool { sourceChannel != nil }
-
-    /// Best available label for the external sender: displayName, @username, or truncated chat ID.
-    var senderLabel: String? {
-        if let displayName, !displayName.isEmpty { return displayName }
-        if let username, !username.isEmpty { return "@\(username)" }
-        if let externalChatId, !externalChatId.isEmpty {
-            let suffix = String(externalChatId.suffix(6))
-            return "Telegram \(suffix)"
-        }
-        return nil
-    }
-
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, sourceChannel: String? = nil, displayName: String? = nil, username: String? = nil, externalChatId: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -53,9 +28,5 @@ struct ThreadModel: Identifiable, Hashable {
         self.pinnedOrder = pinnedOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
-        self.sourceChannel = sourceChannel
-        self.displayName = displayName
-        self.username = username
-        self.externalChatId = externalChatId
     }
 }

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -60,17 +60,25 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 // MARK: - Helpers
 
 /// Build an IPCSessionListResponse via JSON round-trip.
-private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
     let sessionDicts = sessions.map { session -> [String: Any] in
         var dict: [String: Any] = ["id": session.id, "title": session.title, "updatedAt": session.updatedAt]
         if let threadType = session.threadType {
             dict["threadType"] = threadType
+        }
+        if let channelBinding = session.channelBinding {
+            dict["channelBinding"] = channelBinding
         }
         return dict
     }
     let dict: [String: Any] = ["type": "session_list_response", "sessions": sessionDicts]
     let data = try! JSONSerialization.data(withJSONObject: dict)
     return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
+}
+
+/// Convenience overload with threadType but no channelBinding.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.threadType, nil) })
 }
 
 /// Convenience overload without threadType for existing tests.
@@ -425,5 +433,59 @@ struct ThreadSessionRestorerTests {
 
         #expect(delegate.threads.count == 1)
         #expect(delegate.threads[0].kind == .standard)
+    }
+
+    // MARK: - Channel Binding Filtering
+
+    @Test @MainActor
+    func telegramBoundSessionIsExcludedFromRestore() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Telegram Chat", updatedAt: 2000, threadType: nil,
+             channelBinding: ["sourceChannel": "telegram", "externalChatId": "123456"]),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Telegram-bound session filtered out; empty default removed; new thread created
+        #expect(delegate.threads.count == 1)
+        #expect(delegate.threads[0].kind == .standard)
+        #expect(delegate.threads[0].sessionId == nil)
+        #expect(delegate.createThreadCallCount == 1)
+    }
+
+    @Test @MainActor
+    func mixedDesktopAndTelegramRestoresOnlyDesktop() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Desktop Chat", updatedAt: 3000, threadType: nil, channelBinding: nil),
+            (id: "s2", title: "Telegram Chat", updatedAt: 2000, threadType: nil,
+             channelBinding: ["sourceChannel": "telegram", "externalChatId": "789"]),
+            (id: "s3", title: "Another Desktop Chat", updatedAt: 1000, threadType: nil, channelBinding: nil),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Only the two desktop sessions should be restored
+        #expect(delegate.threads.count == 2)
+        #expect(delegate.threads[0].sessionId == "s1")
+        #expect(delegate.threads[0].title == "Desktop Chat")
+        #expect(delegate.threads[1].sessionId == "s3")
+        #expect(delegate.threads[1].title == "Another Desktop Chat")
+        #expect(delegate.createThreadCallCount == 0)
     }
 }


### PR DESCRIPTION
## Summary
- Remove dead ThreadModel fields (`sourceChannel`, `displayName`, `username`, `externalChatId`, `isSynced`, `senderLabel`) that were only used for the removed cross-channel sync UI
- Remove sidebar rendering branches for synced paperplane icon and sender label subtitle in MainWindowView
- Add two regression tests for channel-lane filtering: telegram-only exclusion and mixed desktop+telegram sessions

## Original prompt
Implement the remaining Telegram lane-separation cleanup in **one PR**.

## Goal
Finish the last cleanup after removing cross-channel Telegram sync, while preserving current behavior:
1. Desktop only shows desktop-lane threads.
2. Telegram core inbound/outbound behavior remains unchanged.
3. Remove residual dead sync UI/model code.
4. Add explicit regression test coverage for the channel-lane filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
