### PR TITLE
Fix: Reorder approval validation checks (feedback on #6643)

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -91,14 +91,14 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
 
     // Validate approval payload shape when present.
     if (approval !== undefined) {
+      if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {
+        return Response.json({ error: "approval must be an object" }, { status: 400 });
+      }
       if (!text) {
         return Response.json(
           { error: "text is required when approval is present" },
           { status: 400 },
         );
-      }
-      if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {
-        return Response.json({ error: "approval must be an object" }, { status: 400 });
       }
       if (!approval.runId || typeof approval.runId !== "string") {
         return Response.json({ error: "approval.runId is required" }, { status: 400 });


### PR DESCRIPTION
Moves the approval shape check (null/non-object/array) before the text-requirement check so that malformed approval payloads get the correct error message instead of being told text is required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
