### PR TITLE
Fix: Guardian command spelling in tests and docs (feedback on #6664)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3604,9 +3604,9 @@ sequenceDiagram
     Desktop->>Daemon: guardian_verify IPC (action: create_challenge)
     Daemon->>Daemon: Generate random secret, hash (SHA-256), store challenge (10min TTL)
     Daemon-->>Desktop: Return secret + instruction
-    Desktop-->>User: Display: "Send /guardian-verify <secret> to the bot"
-    User->>TG: /guardian-verify <secret>
-    TG->>Daemon: POST /v1/channels/inbound (content: /guardian-verify <secret>)
+    Desktop-->>User: Display: "Send /guardian_verify <secret> to the bot"
+    User->>TG: /guardian_verify <secret>
+    TG->>Daemon: POST /v1/channels/inbound (content: /guardian_verify <secret>)
     Daemon->>Daemon: Hash secret, find pending challenge, validate expiry
     Daemon->>Daemon: Consume challenge (replay prevention)
     Daemon->>Daemon: Revoke existing binding (if any)
@@ -3653,7 +3653,7 @@ The `channelGuardianApprovalRequests` table tracks per-run approval state. Each 
 |--------|---------|
 | `assistant/src/memory/channel-guardian-store.ts` | CRUD for guardian bindings, verification challenges, and approval requests |
 | `assistant/src/runtime/channel-guardian-service.ts` | Challenge creation/validation, guardian identity checks (`isGuardian()`, `getGuardianBinding()`) |
-| `assistant/src/runtime/routes/channel-routes.ts` | Guardian verification intercept (`/guardian-verify` command), actor role resolution, approval routing to guardian |
+| `assistant/src/runtime/routes/channel-routes.ts` | Guardian verification intercept (`/guardian_verify` command), actor role resolution, approval routing to guardian |
 
 ### Telegram Credential Flow
 

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -309,7 +309,7 @@ describe('guardian service challenge validation', () => {
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
     expect(result.secret.length).toBe(64); // 32 bytes hex-encoded
-    expect(result.instruction).toContain('/guardian-verify');
+    expect(result.instruction).toContain('/guardian_verify');
     expect(result.instruction).toContain(result.secret);
   });
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -46,7 +46,7 @@ If the webhook secret changes (e.g., secret rotation), the gateway's credential 
 
 ### Step 4: Register Bot Commands
 
-Send the `telegram_config` IPC message with `action: "set_commands"` to register the `/new` and `/guardian-verify` commands:
+Send the `telegram_config` IPC message with `action: "set_commands"` to register the `/new` and `/guardian_verify` commands:
 
 ```json
 {
@@ -74,9 +74,9 @@ Now link the user's Telegram account as the trusted guardian for this bot. Tell 
 }
 ```
 
-2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the instruction to the user. It will look like: "Send `/guardian-verify <secret>` to your bot from your Telegram account within 10 minutes."
+2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the instruction to the user. It will look like: "Send `/guardian_verify <secret>` to your bot from your Telegram account within 10 minutes."
 
-3. Wait for the user to confirm they have sent the command. The verification happens automatically when the bot receives the `/guardian-verify` message — the channel inbound handler validates the token and creates the guardian binding.
+3. Wait for the user to confirm they have sent the command. The verification happens automatically when the bot receives the `/guardian_verify` message — the channel inbound handler validates the token and creates the guardian binding.
 
 4. If the user confirms success: "Guardian verified! Your Telegram account is now the trusted guardian for this bot."
 
@@ -131,5 +131,5 @@ The following steps still require **manual** action:
 |------|---------|
 | Bot token from @BotFather | User must create a bot and provide the token via secure prompt |
 | Bot command registration | Registered via the setup skill (Step 4 above) |
-| Guardian verification | User sends `/guardian-verify <secret>` to the bot (Step 5 above) |
+| Guardian verification | User sends `/guardian_verify <secret>` to the bot (Step 5 above) |
 | Multi-assistant routing | Requires manual `GATEWAY_ASSISTANT_ROUTING_JSON` configuration |


### PR DESCRIPTION
Updates all remaining occurrences of /guardian-verify (hyphen) to /guardian_verify (underscore) in test assertions, SKILL.md, and ARCHITECTURE.md to match the code change from #6664.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
