### PR TITLE
Fix: Callback query test helper and non-DM acknowledgment (feedback on #6648)

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -156,6 +156,21 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
     // Normalize the update
     const normalized = normalizeTelegramUpdate(payload);
     if (!normalized) {
+      // If the dropped update was a callback query, acknowledge it so the
+      // Telegram button spinner clears (e.g. non-DM callback queries).
+      const cbqId =
+        payload.callback_query &&
+        typeof payload.callback_query === "object" &&
+        "id" in (payload.callback_query as Record<string, unknown>)
+          ? String((payload.callback_query as Record<string, unknown>).id)
+          : undefined;
+      if (cbqId) {
+        callTelegramApi(config, "answerCallbackQuery", {
+          callback_query_id: cbqId,
+        }).catch((err) => {
+          tlog.error({ err, callbackQueryId: cbqId }, "Failed to acknowledge dropped callback query");
+        });
+      }
       return respond({ ok: true });
     }
 

--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -7,6 +7,7 @@ function makeCallbackQueryPayload(overrides?: {
   data?: string;
   fromId?: number;
 }) {
+  const hasChatType = overrides !== undefined && "chatType" in overrides;
   return {
     update_id: 100,
     callback_query: {
@@ -16,7 +17,7 @@ function makeCallbackQueryPayload(overrides?: {
         message_id: 10,
         chat: {
           id: overrides?.chatId ?? 42,
-          type: overrides?.chatType ?? "private",
+          type: hasChatType ? overrides!.chatType : "private",
         },
       },
       data: overrides?.data ?? "apr:run1:approve",


### PR DESCRIPTION
Two fixes from review feedback on #6648: (1) Fix test helper to not default chatType to 'private' when explicitly undefined, (2) Acknowledge callback queries from non-DM chats before dropping them to prevent stuck button spinners.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
