### PR TITLE
Fix: Address review feedback (feedback on #6613)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -494,15 +494,27 @@ struct ChatView: View {
                     let lastVisible = displayMessages.last
                     let hasPendingConfirmation = lastVisible?.confirmation?.state == .pending
                     // Check the current assistant turn for active tool calls.
-                    // We scope to messages after the last user message so that
-                    // stale incomplete tool calls from earlier turns (e.g. after
-                    // daemon errors) don't permanently suppress the thinking
-                    // indicator. We still scan beyond lastVisible because
-                    // confirmation messages are inserted after the assistant
-                    // message that owns the tool call.
+                    // We scope to messages after the last user message that
+                    // started an assistant turn so that stale incomplete tool
+                    // calls from earlier turns (e.g. after daemon errors) don't
+                    // permanently suppress the thinking indicator. We skip
+                    // trailing user messages (queued follow-ups sent while
+                    // isSending) so they don't shrink the slice to empty and
+                    // incorrectly hide active tool calls. We still scan beyond
+                    // lastVisible because confirmation messages are inserted
+                    // after the assistant message that owns the tool call.
                     let currentTurnMessages: ArraySlice<ChatMessage> = {
-                        if let lastUserIndex = displayMessages.lastIndex(where: { $0.role == .user }) {
-                            return displayMessages[displayMessages.index(after: lastUserIndex)...]
+                        // Find the boundary of the current assistant turn by
+                        // locating the last user message that is followed by at
+                        // least one non-user message. This ignores queued user
+                        // messages appended at the tail during isSending.
+                        let lastTurnStart = displayMessages.indices.reversed().first(where: { idx in
+                            displayMessages[idx].role == .user
+                                && displayMessages.index(after: idx) < displayMessages.endIndex
+                                && displayMessages[displayMessages.index(after: idx)].role != .user
+                        })
+                        if let idx = lastTurnStart {
+                            return displayMessages[displayMessages.index(after: idx)...]
                         }
                         return displayMessages[displayMessages.startIndex...]
                     }()


### PR DESCRIPTION
Addresses review comments from #6613.

The Codex review on PR #6613 identified a race condition: when a user queues a follow-up message while the assistant is still processing (during isSending), the queued user message gets appended to displayMessages. The previous logic used lastIndex(where: role == .user) which would then point to this queued message, making the currentTurnMessages slice empty. This caused hasActiveToolCall to become false, incorrectly showing the thinking indicator alongside an actively running tool call.

Fix: Instead of finding the absolute last user message, find the last user message that is followed by at least one non-user message. This correctly identifies the start of the current assistant turn while ignoring trailing queued user messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
