### PR TITLE
Fix: Guardian approval expiry checks (feedback on #6663)

### DIFF
--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -362,6 +362,29 @@ export function getPendingApprovalForRun(runId: string): GuardianApprovalRequest
 }
 
 /**
+ * Find a pending (status = 'pending') guardian approval request for a run
+ * regardless of whether it has expired. Used by the non-guardian gate to
+ * detect expired-but-unresolved approvals that should still block the
+ * requester from self-approving.
+ */
+export function getUnresolvedApprovalForRun(runId: string): GuardianApprovalRequest | null {
+  const db = getDb();
+
+  const row = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.runId, runId),
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+      ),
+    )
+    .get();
+
+  return row ? rowToApprovalRequest(row) : null;
+}
+
+/**
  * Find a pending guardian approval request by the guardian's chat ID.
  * Used when the guardian sends a decision from their chat.
  */

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -21,6 +21,7 @@ import {
   createApprovalRequest,
   getPendingApprovalByGuardianChat,
   getPendingApprovalForRun,
+  getUnresolvedApprovalForRun,
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
 import { deliverChannelReply, deliverApprovalPrompt } from '../gateway-client.js';
@@ -891,6 +892,32 @@ async function handleApprovalInterception(
           log.error({ err, conversationId }, 'Failed to deliver guardian-pending notice to requester');
         }
         return { handled: true, type: 'reminder_sent' };
+      }
+
+      // Check for an expired-but-unresolved guardian approval. If the approval
+      // expired without a guardian decision, auto-deny the run and transition
+      // the approval to 'expired'. Without this, the requester could bypass
+      // guardian-only controls by simply waiting for the TTL to elapse.
+      const unresolvedApproval = getUnresolvedApprovalForRun(pending[0].runId);
+      if (unresolvedApproval) {
+        updateApprovalDecision(unresolvedApproval.id, { status: 'expired' });
+
+        // Auto-deny the underlying run so it does not remain actionable
+        const expiredDecision: ApprovalDecisionResult = {
+          action: 'reject',
+          source: 'plain_text',
+        };
+        handleChannelDecision(conversationId, expiredDecision, orchestrator);
+
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: 'Your guardian approval request has expired and the action has been denied. Please try again.',
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, conversationId }, 'Failed to deliver guardian-expiry notice to requester');
+        }
+        return { handled: true, type: 'decision_applied' };
       }
     }
   }


### PR DESCRIPTION
Two fixes: (1) Add expiresAt check to getPendingApprovalByGuardianChat to prevent guardians from acting on expired approvals, (2) Ensure expired guardian requests still block requester decisions to prevent bypass-by-waiting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
