### PR TITLE
Fix: Preserve session strictSideEffects when no override (feedback on #6665)

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -97,14 +97,17 @@ export class RunOrchestrator {
       throw new Error('Session is already processing a message');
     }
 
-    // Always set strictSideEffects explicitly so that cached sessions from
-    // a previous guardian run are reset. Without this, a non-guardian run
-    // that set strictSideEffects=true would leave the flag on for a
-    // subsequent guardian run on the same conversation.
-    session.memoryPolicy = {
-      ...session.memoryPolicy,
-      strictSideEffects: options?.forceStrictSideEffects ?? false,
-    };
+    // Only override strictSideEffects when the caller explicitly requests it
+    // (e.g. guardian-gated channels forcing strict mode on for non-guardian
+    // actors). When not provided, preserve the session's existing memory
+    // policy — this avoids clobbering conversation-level defaults such as
+    // private-thread policies derived in server.ts.
+    if (options?.forceStrictSideEffects !== undefined) {
+      session.memoryPolicy = {
+        ...session.memoryPolicy,
+        strictSideEffects: options.forceStrictSideEffects,
+      };
+    }
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)


### PR DESCRIPTION
Only set strictSideEffects on the session memory policy when forceStrictSideEffects is explicitly provided, preserving conversation-level defaults for HTTP runs without guardian overrides.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
