### PR TITLE
Fix: Cancel approval on delivery failure (feedback on #6667)

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -598,7 +598,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
 
             // Persist the guardian approval request so we can look it up when
             // the guardian responds from their chat.
-            createApprovalRequest({
+            const approvalReqRecord = createApprovalRequest({
               runId: run.id,
               conversationId,
               channel: sourceChannel,
@@ -623,6 +623,9 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               guardianNotified = true;
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver guardian approval prompt');
+              // Cancel the stale approval record so the requester is not
+              // permanently blocked by an approval the guardian never saw.
+              updateApprovalDecision(approvalReqRecord.id, { status: 'cancelled' });
             }
 
             // Only notify the requester if the guardian prompt was actually delivered


### PR DESCRIPTION
When deliverApprovalPrompt throws, the already-persisted approval request is now cancelled to prevent the run from being stuck in a deadlock where the guardian was never notified but the requester is blocked.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
