### PR TITLE
Always start gateway during local hatch

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -520,16 +520,7 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
 
   await startLocalDaemon();
 
-  // The desktop app communicates with the daemon directly via Unix socket,
-  // so the HTTP gateway is only needed for non-desktop (CLI) usage.
-  let runtimeUrl: string;
-
-  if (process.env.VELLUM_DESKTOP_APP) {
-    // No gateway needed — the macOS app uses DaemonClient over the Unix socket.
-    runtimeUrl = "local";
-  } else {
-    runtimeUrl = await startGateway();
-  }
+  const runtimeUrl = await startGateway();
 
   const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
   const localEntry: AssistantEntry = {


### PR DESCRIPTION
## Summary
- Removes the conditional that skipped `startGateway()` when `VELLUM_DESKTOP_APP` was set
- The gateway is now always started during `hatchLocal()`, ensuring HTTP-dependent integrations (e.g. Twilio webhook validation via `INGRESS_PUBLIC_BASE_URL`) work regardless of how the assistant was launched

## Test plan
- [ ] Run `vel hatch` from CLI — gateway starts as before
- [ ] Run `vel hatch` from desktop app — gateway now starts (previously skipped)
- [ ] Verify `runtimeUrl` in `.vellum.lock.json` points to the gateway URL in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
