### PR TITLE
fix: resolve assistant typecheck and test failures

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -886,6 +886,21 @@ exports[`IPC message snapshots ClientMessage types tool_permission_simulate seri
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types tool_names_list serializes to expected JSON 1`] = `
+{
+  "type": "tool_names_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types guardian_verification serializes to expected JSON 1`] = `
+{
+  "action": "create_challenge",
+  "channel": "telegram",
+  "sessionId": "sess-001",
+  "type": "guardian_verification",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -2449,78 +2464,22 @@ exports[`IPC message snapshots ServerMessage types tool_permission_simulate_resp
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types app_history_request serializes to expected JSON 1`] = `
+exports[`IPC message snapshots ServerMessage types tool_names_list_response serializes to expected JSON 1`] = `
 {
-  "appId": "app-001",
-  "type": "app_history_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_diff_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "fromCommit": "abc123",
-  "type": "app_diff_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_file_at_version_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123",
-  "path": "index.html",
-  "type": "app_file_at_version_request",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types app_restore_request serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "commitHash": "abc123",
-  "type": "app_restore_request",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_history_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "type": "app_history_response",
-  "versions": [
-    {
-      "commitHash": "abc123",
-      "message": "Initial commit",
-      "timestamp": 1700000000,
-    },
+  "names": [
+    "bash",
+    "file_read",
+    "file_write",
   ],
+  "type": "tool_names_list_response",
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types app_diff_response serializes to expected JSON 1`] = `
+exports[`IPC message snapshots ServerMessage types guardian_verification_response serializes to expected JSON 1`] = `
 {
-  "appId": "app-001",
-  "diff": 
-"--- a/index.html
-+++ b/index.html
-@@ -1 +1 @@
--old
-+new"
-,
-  "type": "app_diff_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_file_at_version_response serializes to expected JSON 1`] = `
-{
-  "appId": "app-001",
-  "content": "<html></html>",
-  "path": "index.html",
-  "type": "app_file_at_version_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types app_restore_response serializes to expected JSON 1`] = `
-{
+  "instruction": "Send this code to the bot",
+  "secret": "VERIFY-ABC123",
   "success": true,
-  "type": "app_restore_response",
+  "type": "guardian_verification_response",
 }
 `;

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -41,6 +41,7 @@ mock.module('../daemon/handlers.js', () => ({
 }));
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
 import {
   createRun,
   setRunConfirmation,
@@ -65,10 +66,11 @@ afterAll(() => {
 function ensureConversation(conversationId: string): void {
   const db = getDb();
   try {
-    db.run(
-      `INSERT INTO conversations (id, createdAt, updatedAt) VALUES (?, ?, ?)`,
-      [conversationId, Date.now(), Date.now()],
-    );
+    db.insert(conversations).values({
+      id: conversationId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }).run();
   } catch {
     // already exists
   }
@@ -179,7 +181,7 @@ describe('feature flag disabled → normal flow', () => {
 
   test('proceeds normally even when pending approvals exist', async () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const orchestrator = makeMockOrchestrator();
@@ -230,15 +232,15 @@ describe('inbound callback metadata triggers decision handling', () => {
     // Now we need to find the actual conversationId that was created.
     // Check the channel_inbound_events table.
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     expect(conversationId).toBeTruthy();
 
     // Ensure conversation row exists for FK constraints
     ensureConversation(conversationId!);
 
     // Create a pending run for this conversation
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Now send a callback data message
@@ -266,11 +268,11 @@ describe('inbound callback metadata triggers decision handling', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeInboundRequest({
@@ -307,11 +309,11 @@ describe('inbound text matching approval phrases triggers decision handling', ()
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeInboundRequest({ content: 'approve' });
@@ -334,11 +336,11 @@ describe('inbound text matching approval phrases triggers decision handling', ()
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeInboundRequest({ content: 'always' });
@@ -372,11 +374,11 @@ describe('non-decision messages during pending approval trigger reminder', () =>
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Send a message that is NOT a decision
@@ -460,11 +462,11 @@ describe('empty content with callbackData bypasses validation', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
@@ -493,11 +495,11 @@ describe('empty content with callbackData bypasses validation', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
@@ -543,12 +545,12 @@ describe('callback run ID validation', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
     // Create a pending run
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Send callback with a DIFFERENT run ID (stale button)
@@ -577,12 +579,12 @@ describe('callback run ID validation', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
     // Create a pending run
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Send callback with the CORRECT run ID
@@ -611,12 +613,12 @@ describe('callback run ID validation', () => {
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
-    const events = db.prepare('SELECT conversationId FROM channel_inbound_events').all() as Array<{ conversationId: string }>;
-    const conversationId = events[0]?.conversationId;
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
     // Create a pending run
-    const run = createRun(conversationId!, 'msg-1');
+    const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Send plain text "yes" — no runId in the parsed result, so validation is skipped
@@ -643,7 +645,7 @@ describe('linkMessage in approval-aware processing path', () => {
   });
 
   test('linkMessage is called when run has a messageId and reaches terminal state', async () => {
-    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage');
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
@@ -672,8 +674,8 @@ describe('linkMessage in approval-aware processing path', () => {
     const req = makeInboundRequest({ content: 'hello world' });
     await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
 
-    // Wait for the background async to complete
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Wait for the background async to complete (must exceed RUN_POLL_INTERVAL_MS of 500ms)
+    await new Promise((resolve) => setTimeout(resolve, 800));
 
     // Verify linkMessage was called with the run's messageId
     const linkCalls = linkSpy.mock.calls.filter(
@@ -700,6 +702,7 @@ describe('terminal state check before markProcessed', () => {
   });
 
   test('does NOT markProcessed when run is not in terminal state after poll timeout', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
@@ -750,11 +753,13 @@ describe('terminal state check before markProcessed', () => {
     // but that's the non-approval path)
     expect(markCalls.length).toBe(0);
 
+    linkSpy.mockRestore();
     markSpy.mockRestore();
     deliverSpy.mockRestore();
   });
 
   test('markProcessed is called when run reaches completed state', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
@@ -788,11 +793,13 @@ describe('terminal state check before markProcessed', () => {
     // markProcessed should have been called because the run reached completed
     expect(markSpy).toHaveBeenCalled();
 
+    linkSpy.mockRestore();
     markSpy.mockRestore();
     deliverSpy.mockRestore();
   });
 
   test('markProcessed is called when run reaches failed state', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
@@ -826,6 +833,7 @@ describe('terminal state check before markProcessed', () => {
     // markProcessed should have been called because the run reached failed
     expect(markSpy).toHaveBeenCalled();
 
+    linkSpy.mockRestore();
     markSpy.mockRestore();
     deliverSpy.mockRestore();
   });

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -29,6 +29,7 @@ mock.module('../util/logger.js', () => ({
 }));
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
 import {
   createRun,
   setRunConfirmation,
@@ -58,10 +59,11 @@ afterAll(() => {
 function ensureConversation(conversationId: string): void {
   const db = getDb();
   try {
-    db.run(
-      `INSERT INTO conversations (id, createdAt, updatedAt) VALUES (?, ?, ?)`,
-      [conversationId, Date.now(), Date.now()],
-    );
+    db.insert(conversations).values({
+      id: conversationId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }).run();
   } catch {
     // already exists
   }
@@ -107,14 +109,14 @@ describe('getChannelApprovalPrompt', () => {
 
   test('returns null when runs exist but none need confirmation', () => {
     ensureConversation('conv-1');
-    createRun('conv-1', 'msg-1');
+    createRun('conv-1');
     const result = getChannelApprovalPrompt('conv-1');
     expect(result).toBeNull();
   });
 
   test('returns a prompt when a run needs confirmation', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const result = getChannelApprovalPrompt('conv-1');
@@ -133,8 +135,8 @@ describe('getChannelApprovalPrompt', () => {
 
   test('uses the first pending run when multiple exist', () => {
     ensureConversation('conv-1');
-    const run1 = createRun('conv-1', 'msg-1');
-    const run2 = createRun('conv-1', 'msg-2');
+    const run1 = createRun('conv-1');
+    const run2 = createRun('conv-1');
     setRunConfirmation(run1.id, sampleConfirmation);
     setRunConfirmation(run2.id, {
       ...sampleConfirmation,
@@ -150,7 +152,7 @@ describe('getChannelApprovalPrompt', () => {
 
   test('excludes approve_always action when persistentDecisionsAllowed is false', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       ...sampleConfirmation,
       persistentDecisionsAllowed: false,
@@ -164,7 +166,7 @@ describe('getChannelApprovalPrompt', () => {
 
   test('includes approve_always when persistentDecisionsAllowed is undefined', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       ...sampleConfirmation,
       // persistentDecisionsAllowed not set — defaults to allowed
@@ -182,7 +184,7 @@ describe('getChannelApprovalPrompt', () => {
 
   test('includes approve_always when persistentDecisionsAllowed is true', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       ...sampleConfirmation,
       persistentDecisionsAllowed: true,
@@ -200,7 +202,7 @@ describe('getChannelApprovalPrompt', () => {
   test('does not return prompts for other conversations', () => {
     ensureConversation('conv-1');
     ensureConversation('conv-2');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const result = getChannelApprovalPrompt('conv-2');
@@ -263,7 +265,7 @@ describe('handleChannelDecision', () => {
 
   test('approves once via orchestrator.submitDecision with "allow"', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const orchestrator = makeMockOrchestrator();
@@ -280,7 +282,7 @@ describe('handleChannelDecision', () => {
 
   test('rejects via orchestrator.submitDecision with "deny"', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const orchestrator = makeMockOrchestrator();
@@ -297,7 +299,7 @@ describe('handleChannelDecision', () => {
 
   test('approve_always adds a trust rule and submits "allow"', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       ...sampleConfirmation,
       executionTarget: 'sandbox',
@@ -334,7 +336,7 @@ describe('handleChannelDecision', () => {
 
   test('approve_always does not persist rule when no allowlist/scope options are available', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       toolName: 'bash',
       toolUseId: 'req-no-opts',
@@ -364,7 +366,7 @@ describe('handleChannelDecision', () => {
 
   test('approve_always does not persist rule when allowlist/scope are empty arrays', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       toolName: 'bash',
       toolUseId: 'req-empty-opts',
@@ -392,7 +394,7 @@ describe('handleChannelDecision', () => {
 
   test('approve_always does not persist rule when persistentDecisionsAllowed is false', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, {
       ...sampleConfirmation,
       persistentDecisionsAllowed: false,
@@ -419,7 +421,7 @@ describe('handleChannelDecision', () => {
 
   test('returns applied: false when orchestrator cannot apply decision', () => {
     ensureConversation('conv-1');
-    const run = createRun('conv-1', 'msg-1');
+    const run = createRun('conv-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
     const orchestrator = makeMockOrchestrator('no_pending_decision');

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -554,6 +554,12 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   tool_names_list: {
     type: 'tool_names_list',
   },
+  guardian_verification: {
+    type: 'guardian_verification',
+    action: 'create_challenge',
+    channel: 'telegram',
+    sessionId: 'sess-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1585,6 +1591,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   tool_names_list_response: {
     type: 'tool_names_list_response',
     names: ['bash', 'file_read', 'file_write'],
+  },
+  guardian_verification_response: {
+    type: 'guardian_verification_response',
+    success: true,
+    secret: 'VERIFY-ABC123',
+    instruction: 'Send this code to the bot',
   },
 };
 


### PR DESCRIPTION
## Summary
- Fix TypeScript compile errors in channel-approval test files by using `db.$client.prepare()` for raw SQL and `db.insert(table).values({}).run()` for parameterized inserts
- Add missing `guardian_verification` and `guardian_verification_response` IPC snapshot fixtures
- Fix runtime test failures: snake_case column names, remove invalid FK messageId args, mock `linkMessage` in background processing, increase async wait to 800ms

## Original prompt
Fix baseline breakage: assistant TypeScript typecheck errors and test failures.

## Test plan
- [x] `gateway` tests pass (282 pass, 0 fail)
- [x] `assistant` TypeScript typecheck clean (`bunx tsc --noEmit`)
- [x] `channel-approval-routes.test.ts` passes (21 pass, 0 fail)
- [x] `channel-approvals.test.ts` passes
- [x] `ipc-snapshot.test.ts` passes (243 snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
