### PR TITLE
M1: Twilio setup primitive + config model

### DIFF
--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -1,0 +1,659 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as net from 'node:net';
+
+const testDir = mkdtempSync(join(tmpdir(), 'handlers-twilio-cfg-test-'));
+
+// Track loadRawConfig / saveRawConfig calls
+let rawConfigStore: Record<string, unknown> = {};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({}),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({ ...rawConfigStore }),
+  saveRawConfig: (cfg: Record<string, unknown>) => {
+    rawConfigStore = { ...cfg };
+  },
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => join(testDir, 'ipc-blobs'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  readHttpToken: () => undefined,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    isDebug: () => false,
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      isDebug: () => false,
+    }),
+  }),
+}));
+
+// Mock secure key storage
+let secureKeyStore: Record<string, string> = {};
+let setSecureKeyOverride: ((account: string, value: string) => boolean) | null = null;
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    if (setSecureKeyOverride) return setSecureKeyOverride(account, value);
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return true;
+    }
+    return false;
+  },
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+// Mock credential metadata store
+let credentialMetadataStore: Array<{ service: string; field: string; accountInfo?: string }> = [];
+const deletedMetadata: Array<{ service: string; field: string }> = [];
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: (service: string, field: string) =>
+    credentialMetadataStore.find((m) => m.service === service && m.field === field) ?? undefined,
+  upsertCredentialMetadata: (service: string, field: string, policy?: Record<string, unknown>) => {
+    const existing = credentialMetadataStore.find((m) => m.service === service && m.field === field);
+    if (existing) {
+      if (policy?.accountInfo !== undefined) existing.accountInfo = policy.accountInfo as string;
+      return existing;
+    }
+    const record = { service, field, accountInfo: policy?.accountInfo as string | undefined };
+    credentialMetadataStore.push(record);
+    return record;
+  },
+  deleteCredentialMetadata: (service: string, field: string) => {
+    deletedMetadata.push({ service, field });
+    const idx = credentialMetadataStore.findIndex((m) => m.service === service && m.field === field);
+    if (idx !== -1) {
+      credentialMetadataStore.splice(idx, 1);
+      return true;
+    }
+    return false;
+  },
+  listCredentialMetadata: () => credentialMetadataStore,
+  assertMetadataWritable: () => {},
+  _setMetadataPath: () => {},
+}));
+
+// Mock fetch for Twilio API validation
+const originalFetch = globalThis.fetch;
+
+import { handleTwilioConfig } from '../daemon/handlers/config.js';
+import type { HandlerContext } from '../daemon/handlers.js';
+import type {
+  TwilioConfigRequest,
+  ServerMessage,
+} from '../daemon/ipc-contract.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+describe('Twilio config handler', () => {
+  beforeEach(() => {
+    rawConfigStore = {};
+    secureKeyStore = {};
+    setSecureKeyOverride = null;
+    credentialMetadataStore = [];
+    deletedMetadata.length = 0;
+    globalThis.fetch = originalFetch;
+  });
+
+  // ── get ──────────────────────────────────────────────────────────────
+
+  test('get action returns correct state when not configured', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean; phoneNumber?: string };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(false);
+    expect(res.phoneNumber).toBeUndefined();
+  });
+
+  test('get action returns correct state when fully configured', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'auth_token_value';
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean; phoneNumber?: string };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(true);
+    expect(res.phoneNumber).toBe('+15551234567');
+  });
+
+  // ── set_credentials ─────────────────────────────────────────────────
+
+  test('set_credentials validates and stores credentials', async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.twilio.com') && urlStr.includes('/Accounts/')) {
+        return new Response(JSON.stringify({
+          sid: 'AC1234567890abcdef1234567890abcdef',
+          friendly_name: 'Test Account',
+          status: 'active',
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC1234567890abcdef1234567890abcdef',
+      authToken: 'test_auth_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(true);
+
+    // Verify credentials were stored
+    expect(secureKeyStore['credential:twilio:account_sid']).toBe('AC1234567890abcdef1234567890abcdef');
+    expect(secureKeyStore['credential:twilio:auth_token']).toBe('test_auth_token');
+    // Verify metadata was stored
+    expect(credentialMetadataStore.find((m) => m.service === 'twilio' && m.field === 'account_sid')).toBeDefined();
+    expect(credentialMetadataStore.find((m) => m.service === 'twilio' && m.field === 'auth_token')).toBeDefined();
+  });
+
+  test('set_credentials returns error when accountSid is missing', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      authToken: 'test_auth_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('accountSid and authToken are required');
+  });
+
+  test('set_credentials returns error when authToken is missing', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC1234567890abcdef1234567890abcdef',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('accountSid and authToken are required');
+  });
+
+  test('set_credentials returns error when Twilio API rejects credentials', async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.twilio.com') && urlStr.includes('/Accounts/')) {
+        return new Response(JSON.stringify({
+          code: 20003,
+          message: 'Authenticate',
+        }), { status: 401 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC_invalid',
+      authToken: 'bad_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Twilio API validation failed');
+
+    // Verify credentials were NOT stored
+    expect(secureKeyStore['credential:twilio:account_sid']).toBeUndefined();
+    expect(secureKeyStore['credential:twilio:auth_token']).toBeUndefined();
+  });
+
+  test('set_credentials handles network error', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('Network error: ECONNREFUSED');
+    }) as unknown as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC1234567890abcdef1234567890abcdef',
+      authToken: 'test_auth_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Failed to validate Twilio credentials');
+    expect(res.error).toContain('ECONNREFUSED');
+  });
+
+  test('set_credentials rolls back account_sid when auth_token storage fails', async () => {
+    setSecureKeyOverride = (account: string, value: string) => {
+      if (account === 'credential:twilio:auth_token') return false;
+      secureKeyStore[account] = value;
+      return true;
+    };
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.twilio.com') && urlStr.includes('/Accounts/')) {
+        return new Response(JSON.stringify({ sid: 'AC123', status: 'active' }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC1234567890abcdef1234567890abcdef',
+      authToken: 'test_auth_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Failed to store Auth Token');
+
+    // Account SID should have been rolled back
+    expect(secureKeyStore['credential:twilio:account_sid']).toBeUndefined();
+  });
+
+  test('set_credentials fails when account_sid storage fails', async () => {
+    setSecureKeyOverride = () => false;
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('api.twilio.com') && urlStr.includes('/Accounts/')) {
+        return new Response(JSON.stringify({ sid: 'AC123', status: 'active' }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'set_credentials',
+      accountSid: 'AC1234567890abcdef1234567890abcdef',
+      authToken: 'test_auth_token',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Failed to store Account SID');
+  });
+
+  // ── clear_credentials ───────────────────────────────────────────────
+
+  test('clear_credentials removes stored credentials', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    credentialMetadataStore.push({ service: 'twilio', field: 'account_sid' });
+    credentialMetadataStore.push({ service: 'twilio', field: 'auth_token' });
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'clear_credentials',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(false);
+
+    // Verify everything was cleaned up
+    expect(secureKeyStore['credential:twilio:account_sid']).toBeUndefined();
+    expect(secureKeyStore['credential:twilio:auth_token']).toBeUndefined();
+    expect(deletedMetadata).toContainEqual({ service: 'twilio', field: 'account_sid' });
+    expect(deletedMetadata).toContainEqual({ service: 'twilio', field: 'auth_token' });
+  });
+
+  test('clear_credentials is idempotent when no credentials exist', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'clear_credentials',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean };
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(false);
+  });
+
+  // ── assign_number ───────────────────────────────────────────────────
+
+  test('assign_number persists phone number to config', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'assign_number',
+      phoneNumber: '+15551234567',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; phoneNumber?: string };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.phoneNumber).toBe('+15551234567');
+
+    // Verify config was persisted
+    expect((rawConfigStore.sms as Record<string, unknown>)?.phoneNumber).toBe('+15551234567');
+  });
+
+  test('assign_number returns error when phoneNumber is missing', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'assign_number',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('phoneNumber is required');
+  });
+
+  // ── list_numbers ────────────────────────────────────────────────────
+
+  test('list_numbers returns available numbers', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('IncomingPhoneNumbers.json')) {
+        return new Response(JSON.stringify({
+          incoming_phone_numbers: [
+            {
+              phone_number: '+15551234567',
+              friendly_name: 'My Number',
+              capabilities: { voice: true, sms: true },
+            },
+            {
+              phone_number: '+15559876543',
+              friendly_name: 'Other Number',
+              capabilities: { voice: true, sms: false },
+            },
+          ],
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'list_numbers',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean; numbers?: Array<{ phoneNumber: string; friendlyName: string; capabilities: { voice: boolean; sms: boolean } }> };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(true);
+    expect(res.numbers).toHaveLength(2);
+    expect(res.numbers![0].phoneNumber).toBe('+15551234567');
+    expect(res.numbers![0].friendlyName).toBe('My Number');
+    expect(res.numbers![0].capabilities.sms).toBe(true);
+    expect(res.numbers![1].phoneNumber).toBe('+15559876543');
+    expect(res.numbers![1].capabilities.sms).toBe(false);
+  });
+
+  test('list_numbers returns error when no credentials configured', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'list_numbers',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Twilio credentials not configured');
+  });
+
+  // ── provision_number ────────────────────────────────────────────────
+
+  test('provision_number searches and provisions a number', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      // Search available numbers
+      if (urlStr.includes('AvailablePhoneNumbers') && urlStr.includes('Local.json')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [
+            {
+              phone_number: '+15559999999',
+              friendly_name: '(555) 999-9999',
+              capabilities: { voice: true, sms: true },
+            },
+          ],
+        }), { status: 200 });
+      }
+      // Purchase number
+      if (urlStr.includes('IncomingPhoneNumbers.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          phone_number: '+15559999999',
+          friendly_name: '(555) 999-9999',
+          capabilities: { voice: true, sms: true },
+        }), { status: 201 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+      country: 'US',
+      areaCode: '555',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean; phoneNumber?: string };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(true);
+    expect(res.hasCredentials).toBe(true);
+    expect(res.phoneNumber).toBe('+15559999999');
+  });
+
+  test('provision_number returns error when no numbers available', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('AvailablePhoneNumbers')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [],
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('No available phone numbers found');
+  });
+
+  test('provision_number returns error when no credentials configured', async () => {
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Twilio credentials not configured');
+  });
+
+  // ── Unknown action ──────────────────────────────────────────────────
+
+  test('unrecognized action returns error response', async () => {
+    const msg = {
+      type: 'twilio_config',
+      action: 'nonexistent_action',
+    } as unknown as TwilioConfigRequest;
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.type).toBe('twilio_config_response');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Unknown action');
+    expect(res.error).toContain('nonexistent_action');
+  });
+
+  // ── Security ────────────────────────────────────────────────────────
+
+  test('response messages never contain raw credential values', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC_secret_account_sid_12345';
+    secureKeyStore['credential:twilio:auth_token'] = 'secret_auth_token_67890';
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'get',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const responseStr = JSON.stringify(sent[0]);
+    // No raw credential values should leak into the response
+    expect(responseStr).not.toContain('AC_secret_account_sid_12345');
+    expect(responseStr).not.toContain('secret_auth_token_67890');
+  });
+});

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { getLogger } from '../util/logger.js';
 import { getSecureKey } from '../security/secure-keys.js';
+import { getTwilioCredentials, twilioAuthHeader, twilioBaseUrl } from './twilio-rest.js';
 import type { VoiceProvider, InitiateCallOptions } from './voice-provider.js';
 
 const log = getLogger('twilio-provider');
@@ -17,22 +18,15 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── Credential helpers ──────────────────────────────────────────────
 
   private getCredentials(): { accountSid: string; authToken: string } {
-    const accountSid = getSecureKey('credential:twilio:account_sid');
-    const authToken = getSecureKey('credential:twilio:auth_token');
-    if (!accountSid || !authToken) {
-      throw new Error(
-        'Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.',
-      );
-    }
-    return { accountSid, authToken };
+    return getTwilioCredentials();
   }
 
   private authHeader(accountSid: string, authToken: string): string {
-    return 'Basic ' + Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+    return twilioAuthHeader(accountSid, authToken);
   }
 
   private baseUrl(accountSid: string): string {
-    return `https://api.twilio.com/2010-04-01/Accounts/${accountSid}`;
+    return twilioBaseUrl(accountSid);
   }
 
   // ── VoiceProvider interface ─────────────────────────────────────────

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -1,0 +1,156 @@
+/**
+ * Reusable Twilio REST API helpers.
+ *
+ * Provides low-level building blocks (auth header, base URL, credential
+ * resolution) shared across the voice provider, SMS channel, and IPC
+ * config handler. Uses fetch() directly — no twilio npm package.
+ */
+
+import { getSecureKey } from '../security/secure-keys.js';
+
+export interface TwilioCredentials {
+  accountSid: string;
+  authToken: string;
+}
+
+/** Resolve Twilio credentials from the secure key store. Throws if not configured. */
+export function getTwilioCredentials(): TwilioCredentials {
+  const accountSid = getSecureKey('credential:twilio:account_sid');
+  const authToken = getSecureKey('credential:twilio:auth_token');
+  if (!accountSid || !authToken) {
+    throw new Error(
+      'Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.',
+    );
+  }
+  return { accountSid, authToken };
+}
+
+/** Check whether Twilio credentials are present (non-throwing). */
+export function hasTwilioCredentials(): boolean {
+  return !!getSecureKey('credential:twilio:account_sid') && !!getSecureKey('credential:twilio:auth_token');
+}
+
+/** Build the HTTP Basic auth header for Twilio API requests. */
+export function twilioAuthHeader(accountSid: string, authToken: string): string {
+  return 'Basic ' + Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+}
+
+/** Build the Twilio REST API base URL for a given account. */
+export function twilioBaseUrl(accountSid: string): string {
+  return `https://api.twilio.com/2010-04-01/Accounts/${accountSid}`;
+}
+
+export interface TwilioPhoneNumber {
+  phoneNumber: string;
+  friendlyName: string;
+  capabilities: { voice: boolean; sms: boolean };
+}
+
+/** List incoming phone numbers owned by the account. */
+export async function listIncomingPhoneNumbers(
+  accountSid: string,
+  authToken: string,
+): Promise<TwilioPhoneNumber[]> {
+  const res = await fetch(`${twilioBaseUrl(accountSid)}/IncomingPhoneNumbers.json`, {
+    method: 'GET',
+    headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Twilio API error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    incoming_phone_numbers: Array<{
+      phone_number: string;
+      friendly_name: string;
+      capabilities: { voice: boolean; sms: boolean };
+    }>;
+  };
+
+  return data.incoming_phone_numbers.map((n) => ({
+    phoneNumber: n.phone_number,
+    friendlyName: n.friendly_name,
+    capabilities: { voice: n.capabilities.voice, sms: n.capabilities.sms },
+  }));
+}
+
+export interface AvailablePhoneNumber {
+  phoneNumber: string;
+  friendlyName: string;
+  capabilities: { voice: boolean; sms: boolean };
+}
+
+/** Search for available phone numbers to purchase. */
+export async function searchAvailableNumbers(
+  accountSid: string,
+  authToken: string,
+  country: string,
+  areaCode?: string,
+): Promise<AvailablePhoneNumber[]> {
+  const params = new URLSearchParams({ SmsEnabled: 'true', VoiceEnabled: 'true' });
+  if (areaCode) params.set('AreaCode', areaCode);
+
+  const res = await fetch(
+    `${twilioBaseUrl(accountSid)}/AvailablePhoneNumbers/${encodeURIComponent(country)}/Local.json?${params.toString()}`,
+    {
+      method: 'GET',
+      headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Twilio API error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    available_phone_numbers: Array<{
+      phone_number: string;
+      friendly_name: string;
+      capabilities: { voice: boolean; sms: boolean };
+    }>;
+  };
+
+  return data.available_phone_numbers.map((n) => ({
+    phoneNumber: n.phone_number,
+    friendlyName: n.friendly_name,
+    capabilities: { voice: n.capabilities.voice, sms: n.capabilities.sms },
+  }));
+}
+
+/** Provision (buy) a phone number. Returns the purchased number details. */
+export async function provisionPhoneNumber(
+  accountSid: string,
+  authToken: string,
+  phoneNumber: string,
+): Promise<TwilioPhoneNumber> {
+  const body = new URLSearchParams({ PhoneNumber: phoneNumber });
+
+  const res = await fetch(`${twilioBaseUrl(accountSid)}/IncomingPhoneNumbers.json`, {
+    method: 'POST',
+    headers: {
+      Authorization: twilioAuthHeader(accountSid, authToken),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Twilio API error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    phone_number: string;
+    friendly_name: string;
+    capabilities: { voice: boolean; sms: boolean };
+  };
+
+  return {
+    phoneNumber: data.phone_number,
+    friendlyName: data.friendly_name,
+    capabilities: { voice: data.capabilities.voice, sms: data.capabilities.sms },
+  };
+}

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -251,6 +251,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       allowPerCallOverride: true,
     },
   },
+  sms: {
+    enabled: false,
+    provider: 'twilio' as const,
+    phoneNumber: '',
+  },
   ingress: {
     enabled: undefined,
     publicBaseUrl: '',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -8,6 +8,7 @@ const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', '
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict', 'workspace'] as const;
+const VALID_SMS_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
 export const VALID_CALLER_IDENTITY_MODES = ['assistant_number', 'user_number'] as const;
@@ -1053,6 +1054,20 @@ export const SkillsConfigSchema = z.object({
   allowBundled: z.array(z.string()).nullable().default(null),
 });
 
+export const SmsConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'sms.enabled must be a boolean' })
+    .default(false),
+  provider: z
+    .enum(VALID_SMS_PROVIDERS, {
+      error: `sms.provider must be one of: ${VALID_SMS_PROVIDERS.join(', ')}`,
+    })
+    .default('twilio'),
+  phoneNumber: z
+    .string({ error: 'sms.phoneNumber must be a string' })
+    .default(''),
+});
+
 const IngressBaseSchema = z.object({
   enabled: z
     .boolean({ error: 'ingress.enabled must be a boolean' })
@@ -1348,6 +1363,11 @@ export const AssistantConfigSchema = z.object({
       allowPerCallOverride: true,
     },
   }),
+  sms: SmsConfigSchema.default({
+    enabled: false,
+    provider: 'twilio',
+    phoneNumber: '',
+  }),
   ingress: IngressConfigSchema,
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
@@ -1412,4 +1432,5 @@ export type CallsSafetyConfig = z.infer<typeof CallsSafetyConfigSchema>;
 export type CallsVoiceConfig = z.infer<typeof CallsVoiceConfigSchema>;
 export type CallsElevenLabsConfig = z.infer<typeof CallsElevenLabsConfigSchema>;
 export type CallerIdentityConfig = z.infer<typeof CallerIdentityConfigSchema>;
+export type SmsConfig = z.infer<typeof SmsConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -37,5 +37,6 @@ export type {
   CallsVoiceConfig,
   CallsElevenLabsConfig,
   CallerIdentityConfig,
+  SmsConfig,
   IngressConfig,
 } from './schema.js';

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -28,9 +28,16 @@ import type {
   VercelApiConfigRequest,
   TwitterIntegrationConfigRequest,
   TelegramConfigRequest,
+  TwilioConfigRequest,
   GuardianVerificationRequest,
   ToolPermissionSimulateRequest,
 } from '../ipc-protocol.js';
+import {
+  hasTwilioCredentials,
+  listIncomingPhoneNumbers,
+  searchAvailableNumbers,
+  provisionPhoneNumber,
+} from '../../calls/twilio-rest.js';
 import { createVerificationChallenge } from '../../runtime/channel-guardian-service.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
@@ -1091,6 +1098,218 @@ export async function handleTelegramConfig(
   }
 }
 
+export async function handleTwilioConfig(
+  msg: TwilioConfigRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    if (msg.action === 'get') {
+      const hasCredentials = hasTwilioCredentials();
+      const raw = loadRawConfig();
+      const sms = (raw?.sms ?? {}) as Record<string, unknown>;
+      const phoneNumber = (sms.phoneNumber as string) ?? '';
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials,
+        phoneNumber: phoneNumber || undefined,
+      });
+    } else if (msg.action === 'set_credentials') {
+      if (!msg.accountSid || !msg.authToken) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: hasTwilioCredentials(),
+          error: 'accountSid and authToken are required for set_credentials action',
+        });
+        return;
+      }
+
+      // Validate credentials by calling the Twilio API
+      const authHeader = 'Basic ' + Buffer.from(`${msg.accountSid}:${msg.authToken}`).toString('base64');
+      try {
+        const res = await fetch(
+          `https://api.twilio.com/2010-04-01/Accounts/${msg.accountSid}.json`,
+          {
+            method: 'GET',
+            headers: { Authorization: authHeader },
+          },
+        );
+        if (!res.ok) {
+          const body = await res.text();
+          ctx.send(socket, {
+            type: 'twilio_config_response',
+            success: false,
+            hasCredentials: false,
+            error: `Twilio API validation failed (${res.status}): ${body}`,
+          });
+          return;
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: `Failed to validate Twilio credentials: ${message}`,
+        });
+        return;
+      }
+
+      // Store credentials securely
+      const sidStored = setSecureKey('credential:twilio:account_sid', msg.accountSid);
+      if (!sidStored) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: 'Failed to store Account SID in secure storage',
+        });
+        return;
+      }
+
+      const tokenStored = setSecureKey('credential:twilio:auth_token', msg.authToken);
+      if (!tokenStored) {
+        // Roll back the Account SID
+        deleteSecureKey('credential:twilio:account_sid');
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: 'Failed to store Auth Token in secure storage',
+        });
+        return;
+      }
+
+      upsertCredentialMetadata('twilio', 'account_sid', {});
+      upsertCredentialMetadata('twilio', 'auth_token', {});
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: true,
+      });
+    } else if (msg.action === 'clear_credentials') {
+      deleteSecureKey('credential:twilio:account_sid');
+      deleteSecureKey('credential:twilio:auth_token');
+      deleteCredentialMetadata('twilio', 'account_sid');
+      deleteCredentialMetadata('twilio', 'auth_token');
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: false,
+      });
+    } else if (msg.action === 'provision_number') {
+      if (!hasTwilioCredentials()) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: 'Twilio credentials not configured. Set credentials first.',
+        });
+        return;
+      }
+
+      const accountSid = getSecureKey('credential:twilio:account_sid')!;
+      const authToken = getSecureKey('credential:twilio:auth_token')!;
+      const country = msg.country ?? 'US';
+
+      // Search for an available number
+      const available = await searchAvailableNumbers(accountSid, authToken, country, msg.areaCode);
+      if (available.length === 0) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: true,
+          error: `No available phone numbers found for country=${country}${msg.areaCode ? ` areaCode=${msg.areaCode}` : ''}`,
+        });
+        return;
+      }
+
+      // Purchase the first available number
+      const purchased = await provisionPhoneNumber(accountSid, authToken, available[0].phoneNumber);
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: true,
+        phoneNumber: purchased.phoneNumber,
+      });
+    } else if (msg.action === 'assign_number') {
+      if (!msg.phoneNumber) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: hasTwilioCredentials(),
+          error: 'phoneNumber is required for assign_number action',
+        });
+        return;
+      }
+
+      // Persist the phone number in assistant config (non-secret)
+      const raw = loadRawConfig();
+      const sms = (raw?.sms ?? {}) as Record<string, unknown>;
+      sms.phoneNumber = msg.phoneNumber;
+
+      const wasSuppressed = ctx.suppressConfigReload;
+      ctx.setSuppressConfigReload(true);
+      try {
+        saveRawConfig({ ...raw, sms });
+      } catch (err) {
+        ctx.setSuppressConfigReload(wasSuppressed);
+        throw err;
+      }
+      ctx.debounceTimers.schedule('__suppress_reset__', () => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: hasTwilioCredentials(),
+        phoneNumber: msg.phoneNumber,
+      });
+    } else if (msg.action === 'list_numbers') {
+      if (!hasTwilioCredentials()) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: 'Twilio credentials not configured. Set credentials first.',
+        });
+        return;
+      }
+
+      const accountSid = getSecureKey('credential:twilio:account_sid')!;
+      const authToken = getSecureKey('credential:twilio:auth_token')!;
+      const numbers = await listIncomingPhoneNumbers(accountSid, authToken);
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: true,
+        numbers,
+      });
+    } else {
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: false,
+        hasCredentials: hasTwilioCredentials(),
+        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to handle Twilio config');
+    ctx.send(socket, {
+      type: 'twilio_config_response',
+      success: false,
+      hasCredentials: hasTwilioCredentials(),
+      error: message,
+    });
+  }
+}
+
 export function handleGuardianVerification(
   msg: GuardianVerificationRequest,
   socket: net.Socket,
@@ -1260,6 +1479,7 @@ export const configHandlers = defineHandlers({
   vercel_api_config: handleVercelApiConfig,
   twitter_integration_config: handleTwitterIntegrationConfig,
   telegram_config: handleTelegramConfig,
+  twilio_config: handleTwilioConfig,
   guardian_verification: handleGuardianVerification,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
   tool_permission_simulate: handleToolPermissionSimulate,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -549,6 +549,25 @@ export interface TelegramConfigResponse {
   error?: string;
 }
 
+export interface TwilioConfigRequest {
+  type: 'twilio_config';
+  action: 'get' | 'set_credentials' | 'clear_credentials' | 'provision_number' | 'assign_number' | 'list_numbers';
+  accountSid?: string;        // Only for action: 'set_credentials'
+  authToken?: string;         // Only for action: 'set_credentials'
+  phoneNumber?: string;       // Only for action: 'assign_number'
+  areaCode?: string;          // Only for action: 'provision_number'
+  country?: string;           // Only for action: 'provision_number' (ISO 3166-1 alpha-2, default 'US')
+}
+
+export interface TwilioConfigResponse {
+  type: 'twilio_config_response';
+  success: boolean;
+  hasCredentials: boolean;
+  phoneNumber?: string;
+  numbers?: Array<{ phoneNumber: string; friendlyName: string; capabilities: { voice: boolean; sms: boolean } }>;
+  error?: string;
+}
+
 export interface GuardianVerificationRequest {
   type: 'guardian_verification';
   action: 'create_challenge';
@@ -1047,6 +1066,7 @@ export type ClientMessage =
   | VercelApiConfigRequest
   | TwitterIntegrationConfigRequest
   | TelegramConfigRequest
+  | TwilioConfigRequest
   | GuardianVerificationRequest
   | TwitterAuthStartRequest
   | TwitterAuthStatusRequest
@@ -2412,6 +2432,7 @@ export type ServerMessage =
   | VercelApiConfigResponse
   | TwitterIntegrationConfigResponse
   | TelegramConfigResponse
+  | TwilioConfigResponse
   | GuardianVerificationResponse
   | TwitterAuthResult
   | TwitterAuthStatusResponse


### PR DESCRIPTION
Part of #6692. Adds twilio_config IPC contract with get/set_credentials/clear_credentials/provision_number/assign_number/list_numbers operations. Implements daemon handler for Twilio config management with secure credential storage. Adds assistant-level phone number config schema and defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
