### PR TITLE
fix: timeout lifecycle + channel capability parity

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -980,3 +980,165 @@ describe('stale callback handling', () => {
     expect(body.approval).toBeUndefined();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 12. Timeout-to-retry lifecycle (WS-C)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('poll timeout calls recordProcessingFailure', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('records processing failure when run disappears (getRun returns null) before terminal state', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const failureSpy = spyOn(channelDeliveryStore, 'recordProcessingFailure').mockImplementation(() => {});
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-timeout-1',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-200',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // getRun returns null — run disappeared, poll loop breaks, isTerminal = false
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => null),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello timeout' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // recordProcessingFailure should have been called because the run is not terminal
+    expect(failureSpy).toHaveBeenCalled();
+    const failureArgs = failureSpy.mock.calls[0];
+    // First arg is the eventId (string), second is the error
+    expect(typeof failureArgs[0]).toBe('string');
+    expect(failureArgs[1]).toBeInstanceOf(Error);
+    expect((failureArgs[1] as Error).message).toContain('Approval poll timeout');
+    expect((failureArgs[1] as Error).message).toContain('300000');
+
+    // markProcessed should NOT have been called
+    expect(markSpy).not.toHaveBeenCalled();
+
+    linkSpy.mockRestore();
+    markSpy.mockRestore();
+    failureSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test('does NOT call recordProcessingFailure when run reaches terminal state', async () => {
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const failureSpy = spyOn(channelDeliveryStore, 'recordProcessingFailure').mockImplementation(() => {});
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-terminal-ok',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-201',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // getRun returns completed — run is terminal
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello terminal' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // recordProcessingFailure should NOT have been called
+    expect(failureSpy).not.toHaveBeenCalled();
+
+    // markProcessed SHOULD have been called
+    expect(markSpy).toHaveBeenCalled();
+
+    linkSpy.mockRestore();
+    markSpy.mockRestore();
+    failureSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 13. sourceChannel is passed to orchestrator.startRun (WS-D)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('sourceChannel passed to orchestrator.startRun', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('startRun is called with sourceChannel from inbound event', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-channel-test',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-300',
+      status: 'completed' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({
+      content: 'test channel pass-through',
+      sourceChannel: 'telegram',
+    });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to fire
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // Verify startRun was called with the sourceChannel option
+    expect(orchestrator.startRun).toHaveBeenCalled();
+    const startRunArgs = (orchestrator.startRun as ReturnType<typeof mock>).mock.calls[0];
+    // 4th argument is the options object
+    const options = startRunArgs[3] as { sourceChannel?: string } | undefined;
+    expect(options).toBeDefined();
+    expect(options!.sourceChannel).toBe('telegram');
+
+    deliverSpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -30,6 +30,7 @@ import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { createRun, getRun, setRunConfirmation } from '../memory/runs-store.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import type { ChannelCapabilities } from '../daemon/session-runtime-assembly.js';
 
 initializeDb();
 
@@ -124,17 +125,17 @@ describe('run failure detection', () => {
   });
 });
 
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
 describe('run approval state executionTarget', () => {
   beforeEach(() => {
     const db = getDb();
     db.run('DELETE FROM message_runs');
     db.run('DELETE FROM messages');
     db.run('DELETE FROM conversations');
-  });
-
-  afterAll(() => {
-    resetDb();
-    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
   test('stores pending confirmation executionTarget when provided', () => {
@@ -196,5 +197,111 @@ describe('run approval state executionTarget', () => {
     const stored = orchestrator.getRun(run.id);
     expect(stored?.status).toBe('needs_confirmation');
     expect(stored?.pendingConfirmation?.executionTarget).toBe('host');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Channel capability resolution via sourceChannel (WS-D)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('startRun channel capability resolution', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('resolves channel capabilities from provided sourceChannel', async () => {
+    const conversation = createConversation('telegram channel test');
+    let capturedCapabilities: ChannelCapabilities | null = null;
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: {},
+      setChannelCapabilities: (caps: ChannelCapabilities | null) => {
+        if (caps) capturedCapabilities = caps;
+      },
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun(conversation.id, 'Hello from Telegram', undefined, {
+      sourceChannel: 'telegram',
+    });
+
+    // Wait for the async agent loop to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedCapabilities).not.toBeNull();
+    expect(capturedCapabilities!.channel).toBe('telegram');
+    expect(capturedCapabilities!.dashboardCapable).toBe(false);
+  });
+
+  test('defaults to http-api when no sourceChannel is provided', async () => {
+    const conversation = createConversation('http-api default test');
+    let capturedCapabilities: ChannelCapabilities | null = null;
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: {},
+      setChannelCapabilities: (caps: ChannelCapabilities | null) => {
+        if (caps) capturedCapabilities = caps;
+      },
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun(conversation.id, 'Hello from HTTP');
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedCapabilities).not.toBeNull();
+    expect(capturedCapabilities!.channel).toBe('http-api');
+  });
+
+  test('defaults to http-api when options are provided without sourceChannel', async () => {
+    const conversation = createConversation('options no channel test');
+    let capturedCapabilities: ChannelCapabilities | null = null;
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: {},
+      setChannelCapabilities: (caps: ChannelCapabilities | null) => {
+        if (caps) capturedCapabilities = caps;
+      },
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    await orchestrator.startRun(conversation.id, 'Hello with options', undefined, {
+      forceStrictSideEffects: true,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedCapabilities).not.toBeNull();
+    expect(capturedCapabilities!.channel).toBe('http-api');
   });
 });

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -572,7 +572,10 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         conversationId,
         content,
         attachmentIds,
-        isNonGuardian ? { forceStrictSideEffects: true } : undefined,
+        {
+          ...(isNonGuardian ? { forceStrictSideEffects: true } : {}),
+          sourceChannel,
+        },
       );
 
       // Poll the run until it reaches a terminal state, delivering approval
@@ -698,10 +701,14 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
           }
         }
       } else {
+        const timeoutErr = new Error(
+          `Approval poll timeout: run did not reach terminal state within ${RUN_POLL_MAX_WAIT_MS}ms`,
+        );
         log.warn(
           { runId: run.id, status: finalRun?.status, conversationId },
           'Approval-path poll loop timed out before run reached terminal state',
         );
+        channelDeliveryStore.recordProcessingFailure(eventId, timeoutErr);
       }
     } catch (err) {
       log.error({ err, conversationId }, 'Approval-aware channel message processing failed');

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -54,6 +54,12 @@ export interface RunStartOptions {
    * Used for non-guardian actors in guardian-gated channels.
    */
   forceStrictSideEffects?: boolean;
+  /**
+   * The originating channel (e.g. 'telegram', 'slack'). When provided,
+   * channel capabilities are resolved for this channel instead of the
+   * default 'http-api'.
+   */
+  sourceChannel?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,9 +123,10 @@ export class RunOrchestrator {
     const messageId = session.persistUserMessage(content, attachments, requestId);
     const run = runsStore.createRun(conversationId, messageId);
 
-    // Runs are always HTTP-originated; set channel capabilities so the attachment
-    // scope heuristic resolves to 'self' rather than 'local-assistant'.
-    session.setChannelCapabilities(resolveChannelCapabilities('http-api'));
+    // Set channel capabilities based on the originating channel so capabilities
+    // (e.g. attachment scope) match the actual transport rather than always
+    // defaulting to 'http-api'.
+    session.setChannelCapabilities(resolveChannelCapabilities(options?.sourceChannel ?? 'http-api'));
 
     // Serialized publish chain so hub subscribers observe events in order.
     let hubChain: Promise<void> = Promise.resolve();


### PR DESCRIPTION
## Context
Part of #6682: Telegram Approval Follow-Up Gap Closure

## Changes
- On approval poll timeout with non-terminal run, call recordProcessingFailure so the retry sweep can pick it up
- Extend RunOrchestrator.startRun() to accept optional sourceChannel parameter for resolving channel capabilities
- Pass sourceChannel from channel-routes approval path so Telegram runs get Telegram capabilities
- Add tests for timeout failure recording and channel capability resolution

Closes #6684
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
