### PR TITLE
M4: Skills + Settings UI

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -39,6 +39,14 @@ Telegram uses a bot token (not OAuth). Install and load the **telegram-setup** s
 
 The telegram-setup skill handles: verifying the bot token from @BotFather, generating a webhook secret, registering bot commands, and storing credentials securely via the secure credential prompt flow. **Never accept a Telegram bot token pasted in plaintext chat — always use the secure prompt.** Webhook registration with Telegram is handled automatically by the gateway on startup and whenever credentials change.
 
+### SMS (Twilio)
+SMS messaging uses Twilio as the telephony provider. Twilio credentials and phone number configuration are shared with the **phone-calls** skill. Load the **twilio-setup** skill to configure Twilio:
+   - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "twilio-setup"`.
+   - Then call `skill_load` with `skill: "twilio-setup"`.
+   - Tell the user: *"I've loaded a setup guide for Twilio. It will walk you through configuring your Twilio account for SMS and voice calls."*
+
+The twilio-setup skill handles: credential storage (Account SID + Auth Token), phone number provisioning or assignment, and public ingress setup. Once Twilio is configured, SMS is available automatically — no additional feature flag is needed. The assistant's Twilio phone number is used for both outbound SMS and voice calls.
+
 ## Platform Selection
 
 - If the user specifies a platform (e.g., "check my Slack"), pass it as the `platform` parameter.

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -8,6 +8,18 @@ includes: ["public-ingress"]
 
 You are helping the user set up and make outgoing phone calls via Twilio. This skill covers the full lifecycle: Twilio account setup, credential storage, public ingress configuration, enabling the calls feature, placing calls, and monitoring live transcripts.
 
+## Prerequisites — Shared Twilio Setup
+
+Twilio credentials and phone number configuration are shared between voice calls and SMS messaging. If Twilio is not yet configured, load the **twilio-setup** skill first:
+
+```
+skill_load skill=twilio-setup
+```
+
+The twilio-setup skill handles credential storage, phone number provisioning/assignment, and public ingress setup. Once complete, return here to enable the calls feature and start making calls.
+
+If Twilio is already configured (check `twilio_config` with `action: "get"`), skip directly to **Step 5: Enable Calls** below.
+
 ## Overview
 
 The calling system uses Twilio's ConversationRelay to place outbound phone calls. Twilio works out of the box as the default voice provider. Optionally, you can enable ElevenLabs integration for higher-quality, more natural-sounding voices — but this is entirely optional.

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: "Twilio Setup"
+description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
+user-invocable: true
+includes: ["public-ingress"]
+metadata: {"vellum": {"emoji": "\ud83d\udcf1"}}
+---
+
+You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the `twilio_config` IPC contract and existing tools.
+
+## Overview
+
+This skill manages the full Twilio lifecycle:
+- **Credential storage** — Account SID and Auth Token
+- **Phone number provisioning** — Buy a new number directly from Twilio
+- **Phone number assignment** — Assign an existing Twilio number to the assistant
+- **Status checking** — Verify credentials and assigned number
+
+All operations go through the `twilio_config` IPC handler on the daemon, which validates inputs, stores credentials securely, and manages phone number state.
+
+## Step 1: Check Current Configuration
+
+First, check whether Twilio is already configured by sending the `twilio_config` IPC message with `action: "get"`:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "get"
+}
+```
+
+The daemon returns a `twilio_config_response` with:
+- `hasCredentials` — whether Account SID and Auth Token are stored
+- `phoneNumber` — the currently assigned phone number (if any)
+
+If both are present, tell the user Twilio is already configured and offer to show the current status or reconfigure.
+
+## Step 2: Collect and Store Credentials
+
+If credentials are not yet stored, guide the user through Twilio account setup:
+
+1. Tell the user: **"You'll need a Twilio account. Sign up at https://www.twilio.com/try-twilio — it's free to start and includes trial credit."**
+2. Once they have an account, they need two pieces of information:
+   - **Account SID** — found on the Twilio Console dashboard at https://console.twilio.com
+   - **Auth Token** — found on the same dashboard (click "Show" to reveal it)
+
+**IMPORTANT — Secure credential collection only:** Never use credentials pasted in plaintext chat. Always collect credentials through the secure credential prompt flow:
+
+- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "account_sid"`, `label: "Twilio Account SID"`, `description: "Enter your Account SID from the Twilio Console dashboard"`, and `placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
+- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard"`, and `placeholder: "your_auth_token"`.
+
+After both credentials are collected, store them via the daemon:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "set_credentials"
+}
+```
+
+The daemon retrieves the credentials from secure storage internally — you do not need to pass them in the message. If credentials are invalid, the daemon returns an error. Tell the user and ask them to re-enter via the secure prompt.
+
+## Step 3: Get a Phone Number
+
+The assistant needs a phone number to make calls and send SMS. There are two paths:
+
+### Option A: Provision a New Number
+
+If the user wants to buy a new number through Twilio, send:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "provision_number",
+  "areaCode": "415",
+  "country": "US"
+}
+```
+
+- `areaCode` is optional — ask the user if they have a preferred area code
+- `country` defaults to `"US"` — ask if they want a different country (ISO 3166-1 alpha-2)
+
+The daemon provisions the number via the Twilio API and automatically assigns it to the assistant. The response includes the new `phoneNumber`.
+
+**Trial account note:** Twilio trial accounts come with one free phone number. Check "Active Numbers" in the Twilio Console first before provisioning.
+
+### Option B: Assign an Existing Number
+
+If the user already has a Twilio phone number, first list available numbers:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "list_numbers"
+}
+```
+
+The response includes a `numbers` array with each number's `phoneNumber`, `friendlyName`, and `capabilities` (voice, SMS). Present these to the user and let them choose.
+
+Then assign the chosen number:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "assign_number",
+  "phoneNumber": "+14155551234"
+}
+```
+
+The phone number must be in E.164 format.
+
+### Option C: Manual Entry
+
+If the user wants to enter a number directly (e.g., they know it already), store it via credential store:
+
+```
+credential_store action=store service=twilio field=phone_number value=+14155551234
+```
+
+Then assign it through the IPC:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "assign_number",
+  "phoneNumber": "+14155551234"
+}
+```
+
+## Step 4: Set Up Public Ingress
+
+Twilio needs a publicly reachable URL for voice webhooks, ConversationRelay WebSocket, and SMS delivery reports. The **public-ingress** skill handles this via ngrok.
+
+Check if ingress is already configured:
+
+```bash
+vellum config get ingress.publicBaseUrl
+vellum config get ingress.enabled
+```
+
+If not configured, load and run the public-ingress skill:
+
+```
+skill_load skill=public-ingress
+```
+
+**Twilio webhook endpoints (handled automatically by the gateway):**
+- Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
+- Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
+- ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
+- SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
+
+No manual Twilio webhook configuration is needed — webhook URLs are registered dynamically.
+
+## Step 5: Verify Setup
+
+After configuration, verify by sending `twilio_config` with `action: "get"` again.
+
+Confirm:
+- `hasCredentials` is `true`
+- `phoneNumber` is set to the expected number
+
+Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
+
+## Step 6: Enable Features
+
+Now that Twilio is configured, the user can enable the features that depend on it:
+
+**For voice calls:**
+```bash
+vellum config set calls.enabled true
+```
+
+**For SMS messaging:**
+SMS is available automatically once Twilio is configured — no additional feature flag is needed.
+
+## Clearing Credentials
+
+If the user wants to disconnect Twilio, send:
+
+```json
+{
+  "type": "twilio_config",
+  "action": "clear_credentials"
+}
+```
+
+This removes the stored Account SID, Auth Token, and phone number assignment. Both voice calls and SMS will stop working until credentials are reconfigured.
+
+## Troubleshooting
+
+### "Twilio credentials not configured"
+Run Steps 2 and 3 to store credentials and assign a phone number.
+
+### "No phone number assigned"
+Run Step 3 to provision or assign a phone number.
+
+### Phone number provisioning fails
+- Verify Twilio credentials are correct
+- On trial accounts, you may already have a free number — check "Active Numbers" in the Console
+- Ensure the Twilio account has sufficient balance for paid accounts
+
+### Calls/SMS fail after setup
+- Verify public ingress is running (`ingress.publicBaseUrl` must be set)
+- For calls, ensure `calls.enabled` is `true`
+- On trial accounts, outbound calls and SMS can only reach verified numbers
+
+### "Number not found" when assigning
+- The number must be owned by the same Twilio account
+- Use `list_numbers` to see available numbers
+- Ensure the number is in E.164 format (`+` followed by country code and number)

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -1,0 +1,144 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+struct TwilioSettingsSection: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    @State private var hasCredentials = false
+    @State private var phoneNumber: String?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var isClearing = false
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        Section("Twilio (Calls & SMS)") {
+            if isLoading {
+                HStack {
+                    Text("Loading...")
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            } else {
+                // Connection status
+                HStack {
+                    Text("Credentials")
+                    Spacer()
+                    if hasCredentials {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                        Text("Connected")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Image(systemName: "xmark.circle")
+                            .foregroundColor(VColor.error)
+                        Text("Not configured")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // Phone number
+                HStack {
+                    Text("Phone Number")
+                    Spacer()
+                    if let number = phoneNumber {
+                        Text(number)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("None assigned")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // Actions
+                if hasCredentials {
+                    Button(role: .destructive) {
+                        showClearConfirmation = true
+                    } label: {
+                        HStack {
+                            if isClearing {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text("Clearing...")
+                            } else {
+                                Text("Clear Credentials")
+                            }
+                        }
+                    }
+                    .disabled(isClearing)
+                } else {
+                    Text("Use the Twilio Setup skill in chat to configure credentials and phone number.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(VColor.error)
+                }
+            }
+        }
+        .confirmationDialog("Clear Twilio Credentials", isPresented: $showClearConfirmation, titleVisibility: .visible) {
+            Button("Clear", role: .destructive) {
+                clearCredentials()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will remove your Twilio Account SID, Auth Token, and phone number assignment. Voice calls and SMS will stop working until reconfigured.")
+        }
+        .onAppear { loadStatus() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { loadStatus() }
+        }
+        .onDisappear {
+            if let daemon = clientProvider.client as? DaemonClient {
+                daemon.onTwilioConfigResponse = nil
+            }
+        }
+    }
+
+    private func loadStatus() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        isLoading = true
+        errorMessage = nil
+
+        daemon.onTwilioConfigResponse = { response in
+            isLoading = false
+            isClearing = false
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                errorMessage = nil
+            } else {
+                errorMessage = response.error ?? "Failed to load Twilio status"
+            }
+        }
+
+        do {
+            try daemon.sendTwilioConfig(action: "get")
+        } catch {
+            isLoading = false
+            errorMessage = "Failed to connect to daemon"
+        }
+    }
+
+    private func clearCredentials() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        isClearing = true
+        errorMessage = nil
+
+        do {
+            try daemon.sendTwilioConfig(action: "clear_credentials")
+        } catch {
+            isClearing = false
+            errorMessage = "Failed to send clear request"
+        }
+    }
+}
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
                 }
                 DaemonConnectionSection()
                 IntegrationsSection()
+                TwilioSettingsSection()
                 TrustRulesSection()
                 SchedulesSection()
                 RemindersSection()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -282,6 +282,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `telegram_config_response` message.
     public var onTelegramConfigResponse: ((TelegramConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `twilio_config_response` message.
+    public var onTwilioConfigResponse: ((TwilioConfigResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `twitter_integration_config_response` message.
     public var onTwitterIntegrationConfigResponse: ((TwitterIntegrationConfigResponseMessage) -> Void)?
 
@@ -934,6 +937,25 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Get, set, or clear Telegram bot token configuration.
     public func sendTelegramConfig(action: String, botToken: String? = nil, commands: [IPCTelegramConfigRequestCommand]? = nil) throws {
         try send(TelegramConfigRequestMessage(action: action, botToken: botToken, commands: commands))
+    }
+
+    /// Get, set, or clear Twilio credentials and manage phone numbers.
+    public func sendTwilioConfig(
+        action: String,
+        accountSid: String? = nil,
+        authToken: String? = nil,
+        phoneNumber: String? = nil,
+        areaCode: String? = nil,
+        country: String? = nil
+    ) throws {
+        try send(TwilioConfigRequestMessage(
+            action: action,
+            accountSid: accountSid,
+            authToken: authToken,
+            phoneNumber: phoneNumber,
+            areaCode: areaCode,
+            country: country
+        ))
     }
 
     /// Publish a static page to Vercel.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -129,6 +129,8 @@ extension DaemonClient {
             onVercelApiConfigResponse?(msg)
         case .telegramConfigResponse(let msg):
             onTelegramConfigResponse?(msg)
+        case .twilioConfigResponse(let msg):
+            onTwilioConfigResponse?(msg)
         case .twitterIntegrationConfigResponse(let msg):
             onTwitterIntegrationConfigResponse?(msg)
         case .twitterAuthResult(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -46,6 +46,13 @@ import Foundation
 // │                                 │ generated contract                      │
 // │ SubagentEventMessage            │ Contains recursive ServerMessage ref;   │
 // │                                 │ codegen skips ServerMessage              │
+// │ TwilioConfigRequestMessage      │ Code generator has not yet produced     │
+// │                                 │ this type from the TS contract          │
+// │ TwilioConfigResponseMessage     │ Code generator has not yet produced     │
+// │                                 │ this type from the TS contract          │
+// │ TwilioNumberInfo                │ Nested type within                      │
+// │                                 │ TwilioConfigResponseMessage             │
+// │ TwilioNumberCapabilities        │ Nested type within TwilioNumberInfo     │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1815,6 +1822,59 @@ extension IPCTelegramConfigRequest {
 /// Backed by generated `IPCTelegramConfigResponse`.
 public typealias TelegramConfigResponseMessage = IPCTelegramConfigResponse
 
+// MARK: - Twilio Config Messages
+
+/// Sent to get/set/clear Twilio credentials and manage phone numbers.
+/// Manually defined because the code generator has not yet produced this type.
+public struct TwilioConfigRequestMessage: Encodable, Sendable {
+    public let type: String = "twilio_config"
+    public let action: String
+    public let accountSid: String?
+    public let authToken: String?
+    public let phoneNumber: String?
+    public let areaCode: String?
+    public let country: String?
+
+    public init(
+        action: String,
+        accountSid: String? = nil,
+        authToken: String? = nil,
+        phoneNumber: String? = nil,
+        areaCode: String? = nil,
+        country: String? = nil
+    ) {
+        self.action = action
+        self.accountSid = accountSid
+        self.authToken = authToken
+        self.phoneNumber = phoneNumber
+        self.areaCode = areaCode
+        self.country = country
+    }
+}
+
+/// Number entry returned in `twilio_config_response` `numbers` array.
+public struct TwilioNumberInfo: Decodable, Sendable {
+    public let phoneNumber: String
+    public let friendlyName: String
+    public let capabilities: TwilioNumberCapabilities
+}
+
+/// Capabilities of a Twilio phone number.
+public struct TwilioNumberCapabilities: Decodable, Sendable {
+    public let voice: Bool
+    public let sms: Bool
+}
+
+/// Response from Twilio config operations.
+/// Manually defined because the code generator has not yet produced this type.
+public struct TwilioConfigResponseMessage: Decodable, Sendable {
+    public let success: Bool
+    public let hasCredentials: Bool
+    public let phoneNumber: String?
+    public let numbers: [TwilioNumberInfo]?
+    public let error: String?
+}
+
 // MARK: - Twitter Integration Config Messages
 
 /// Sent to get/set Twitter integration config.
@@ -2023,6 +2083,7 @@ public enum ServerMessage: Decodable, Sendable {
     case ingressConfigResponse(IngressConfigResponseMessage)
     case vercelApiConfigResponse(VercelApiConfigResponseMessage)
     case telegramConfigResponse(TelegramConfigResponseMessage)
+    case twilioConfigResponse(TwilioConfigResponseMessage)
     case twitterIntegrationConfigResponse(TwitterIntegrationConfigResponseMessage)
     case twitterAuthResult(TwitterAuthResultMessage)
     case twitterAuthStatusResponse(TwitterAuthStatusResponseMessage)
@@ -2300,6 +2361,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "telegram_config_response":
             let message = try TelegramConfigResponseMessage(from: decoder)
             self = .telegramConfigResponse(message)
+        case "twilio_config_response":
+            let message = try TwilioConfigResponseMessage(from: decoder)
+            self = .twilioConfigResponse(message)
         case "twitter_integration_config_response":
             let message = try TwitterIntegrationConfigResponseMessage(from: decoder)
             self = .twitterIntegrationConfigResponse(message)


### PR DESCRIPTION
Part of #6692. Creates twilio-setup skill as reusable Twilio configuration primitive. Updates phone-calls skill to reference shared Twilio setup. Adds Twilio settings IPC client methods and iOS Settings section displaying connection status, assigned number, and management actions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
