### PR TITLE
fix: plain-text fallback surfacing + test repair

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1142,3 +1142,90 @@ describe('sourceChannel passed to orchestrator.startRun', () => {
     deliverSpy.mockRestore();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 14. Plain-text fallback surfacing for non-rich channels (WS-E)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('plain-text fallback surfacing for non-rich channels', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('reminder prompt includes plainTextFallback for non-rich channel (http-api)', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const replySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation using http-api (non-rich channel)
+    const initReq = makeInboundRequest({ content: 'init', sourceChannel: 'http-api' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send a non-decision message to trigger a reminder
+    const req = makeInboundRequest({ content: 'what is happening?', sourceChannel: 'http-api' });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('reminder_sent');
+
+    // The delivered text should include the plainTextFallback instructions
+    expect(deliverSpy).toHaveBeenCalled();
+    const callArgs = deliverSpy.mock.calls[0];
+    const deliveredText = callArgs[2] as string;
+    // For non-rich channels, the text should contain both the reminder prefix
+    // AND the plainTextFallback instructions (e.g. "Reply yes to approve")
+    expect(deliveredText).toContain("I'm still waiting");
+    expect(deliveredText).toContain('Reply "yes"');
+
+    deliverSpy.mockRestore();
+    replySpy.mockRestore();
+  });
+
+  test('reminder prompt does NOT include plainTextFallback for telegram (rich channel)', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const replySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation using telegram (rich channel)
+    const initReq = makeInboundRequest({ content: 'init', sourceChannel: 'telegram' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Send a non-decision message to trigger a reminder
+    const req = makeInboundRequest({ content: 'what is happening?', sourceChannel: 'telegram' });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('reminder_sent');
+
+    // For rich channels (telegram), the delivered text should be just the
+    // promptText (with reminder prefix) — NOT the plainTextFallback.
+    expect(deliverSpy).toHaveBeenCalled();
+    const callArgs = deliverSpy.mock.calls[0];
+    const deliveredText = callArgs[2] as string;
+    expect(deliveredText).toContain("I'm still waiting");
+    // The raw promptText does not contain "Reply" instructions — those are
+    // only in the plainTextFallback.
+    expect(deliveredText).not.toContain('Reply "yes"');
+
+    deliverSpy.mockRestore();
+    replySpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -62,10 +62,28 @@ function ensureConversation(conversationId: string): void {
   }
 }
 
+function ensureMessage(messageId: string, conversationId: string): void {
+  const { getDb } = require('../memory/db.js');
+  const db = getDb();
+  const { messages } = require('../memory/schema.js');
+  try {
+    db.insert(messages).values({
+      id: messageId,
+      conversationId,
+      role: 'user',
+      content: 'test',
+      createdAt: Date.now(),
+    }).run();
+  } catch {
+    // already exists
+  }
+}
+
 function resetTables(): void {
   const { getDb } = require('../memory/db.js');
   const db = getDb();
   db.run('DELETE FROM message_runs');
+  db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
 }
 
@@ -198,6 +216,7 @@ describe('getPendingConfirmationsByConversation', () => {
 
   test('returns empty array when no runs need confirmation', () => {
     ensureConversation('conv-1');
+    ensureMessage('msg-1', 'conv-1');
     createRun('conv-1', 'msg-1');
     const result = getPendingConfirmationsByConversation('conv-1');
     expect(result).toEqual([]);
@@ -205,6 +224,7 @@ describe('getPendingConfirmationsByConversation', () => {
 
   test('returns pending confirmation for a run needing confirmation', () => {
     ensureConversation('conv-1');
+    ensureMessage('msg-1', 'conv-1');
     const run = createRun('conv-1', 'msg-1');
     setRunConfirmation(run.id, sampleConfirmation);
 
@@ -220,6 +240,8 @@ describe('getPendingConfirmationsByConversation', () => {
   test('only returns runs for the specified conversation', () => {
     ensureConversation('conv-1');
     ensureConversation('conv-2');
+    ensureMessage('msg-1', 'conv-1');
+    ensureMessage('msg-2', 'conv-2');
 
     const run1 = createRun('conv-1', 'msg-1');
     const run2 = createRun('conv-2', 'msg-2');
@@ -237,6 +259,8 @@ describe('getPendingConfirmationsByConversation', () => {
 
   test('returns multiple pending runs for the same conversation', () => {
     ensureConversation('conv-1');
+    ensureMessage('msg-1', 'conv-1');
+    ensureMessage('msg-2', 'conv-1');
 
     const run1 = createRun('conv-1', 'msg-1');
     const run2 = createRun('conv-1', 'msg-2');
@@ -253,6 +277,9 @@ describe('getPendingConfirmationsByConversation', () => {
 
   test('excludes completed and failed runs', () => {
     ensureConversation('conv-1');
+    ensureMessage('msg-1', 'conv-1');
+    ensureMessage('msg-2', 'conv-1');
+    ensureMessage('msg-3', 'conv-1');
 
     const run1 = createRun('conv-1', 'msg-1');
     const run2 = createRun('conv-1', 'msg-2');

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -41,6 +41,7 @@ import {
   buildApprovalUIMetadata,
   handleChannelDecision,
   buildReminderPrompt,
+  channelSupportsRichApprovalUI,
 } from '../runtime/channel-approvals.js';
 import type { ApprovalDecisionResult, ChannelApprovalPrompt } from '../runtime/channel-approval-types.js';
 import * as trustStore from '../permissions/trust-store.js';
@@ -493,5 +494,28 @@ describe('buildReminderPrompt', () => {
     const originalText = original.promptText;
     buildReminderPrompt(original);
     expect(original.promptText).toBe(originalText);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. channelSupportsRichApprovalUI
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('channelSupportsRichApprovalUI', () => {
+  test('returns true for telegram', () => {
+    expect(channelSupportsRichApprovalUI('telegram')).toBe(true);
+  });
+
+  test('returns false for http-api', () => {
+    expect(channelSupportsRichApprovalUI('http-api')).toBe(false);
+  });
+
+  test('returns false for sms', () => {
+    expect(channelSupportsRichApprovalUI('sms')).toBe(false);
+  });
+
+  test('returns false for unknown channels', () => {
+    expect(channelSupportsRichApprovalUI('slack')).toBe(false);
+    expect(channelSupportsRichApprovalUI('')).toBe(false);
   });
 });

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -165,7 +165,28 @@ export function buildGuardianApprovalPrompt(
 }
 
 // ---------------------------------------------------------------------------
-// 5. Reminder prompt for non-decision messages
+// 5. Channel UI capability check
+// ---------------------------------------------------------------------------
+
+/**
+ * Channels known to support rich inline approval UI (e.g. inline keyboards).
+ * All other channels fall back to plain-text instructions embedded in the
+ * message body.
+ */
+const RICH_APPROVAL_CHANNELS: ReadonlySet<string> = new Set(['telegram']);
+
+/**
+ * Returns true when the given channel supports rich approval UI such as
+ * inline buttons / keyboards. For channels that return false, the
+ * plainTextFallback instructions should be appended to the message body
+ * so the user sees how to approve or reject via text.
+ */
+export function channelSupportsRichApprovalUI(channel: string): boolean {
+  return RICH_APPROVAL_CHANNELS.has(channel);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Reminder prompt for non-decision messages
 // ---------------------------------------------------------------------------
 
 /**

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -32,6 +32,7 @@ import {
   buildGuardianApprovalPrompt,
   handleChannelDecision,
   buildReminderPrompt,
+  channelSupportsRichApprovalUI,
 } from '../channel-approvals.js';
 import type { ApprovalAction, ApprovalDecisionResult } from '../channel-approval-types.js';
 import type { RunOrchestrator } from '../run-orchestrator.js';
@@ -64,6 +65,20 @@ export interface GuardianContext {
 
 /** Guardian approval request expiry (30 minutes). */
 const GUARDIAN_APPROVAL_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Return the effective prompt text for an approval prompt, appending the
+ * plainTextFallback instructions when the channel does not support rich
+ * inline approval UI (e.g. Telegram inline keyboards).
+ */
+function effectivePromptText(
+  promptText: string,
+  plainTextFallback: string,
+  channel: string,
+): string {
+  if (channelSupportsRichApprovalUI(channel)) return promptText;
+  return `${promptText}\n\n${plainTextFallback}`;
+}
 
 // ---------------------------------------------------------------------------
 // Feature flag
@@ -617,10 +632,15 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
 
             let guardianNotified = false;
             try {
+              const guardianText = effectivePromptText(
+                guardianPrompt.promptText,
+                guardianPrompt.plainTextFallback,
+                sourceChannel,
+              );
               await deliverApprovalPrompt(
                 replyCallbackUrl,
                 guardianCtx.guardianChatId,
-                guardianPrompt.promptText,
+                guardianText,
                 uiMetadata,
                 bearerToken,
               );
@@ -650,10 +670,15 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
             if (prompt && pending.length > 0) {
               const uiMetadata = buildApprovalUIMetadata(prompt, pending[0]);
               try {
+                const promptTextForChannel = effectivePromptText(
+                  prompt.promptText,
+                  prompt.plainTextFallback,
+                  sourceChannel,
+                );
                 await deliverApprovalPrompt(
                   replyCallbackUrl,
                   externalChatId,
-                  prompt.promptText,
+                  promptTextForChannel,
                   uiMetadata,
                   bearerToken,
                 );
@@ -866,10 +891,15 @@ async function handleApprovalInterception(
         const reminder = buildReminderPrompt(guardianPrompt);
         const uiMetadata = buildApprovalUIMetadata(reminder, pendingInfo[0]);
         try {
+          const reminderText = effectivePromptText(
+            reminder.promptText,
+            reminder.plainTextFallback,
+            sourceChannel,
+          );
           await deliverApprovalPrompt(
             replyCallbackUrl,
             externalChatId,
-            reminder.promptText,
+            reminderText,
             uiMetadata,
             bearerToken,
           );
@@ -975,10 +1005,15 @@ async function handleApprovalInterception(
   if (pending.length > 0) {
     const uiMetadata = buildApprovalUIMetadata(reminder, pending[0]);
     try {
+      const reminderText = effectivePromptText(
+        reminder.promptText,
+        reminder.plainTextFallback,
+        sourceChannel,
+      );
       await deliverApprovalPrompt(
         replyCallbackUrl,
         externalChatId,
-        reminder.promptText,
+        reminderText,
         uiMetadata,
         bearerToken,
       );


### PR DESCRIPTION
## Context
Part of #6682: Telegram Approval Follow-Up Gap Closure

## Changes
- Add channelSupportsRichApprovalUI helper for channel UI capability routing
- For non-rich channels, append plainTextFallback instructions to approval prompt message body
- Fix FK constraint failures in channel-approval.test.ts by creating prerequisite conversation/message records
- Add regression test for plain-text fallback rendering
- Verify all approval-focused test suites pass in both assistant and gateway

Closes #6685
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
