### PR TITLE
feat: recursive sweep loop for blitz commands

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -46,9 +46,11 @@ gh issue close <issue-number>
 
 - Everything else follows the standard swarm workflow (worktrees, conflict avoidance, TODO/DONE/UNREVIEWED tracking).
 
-## Phase 5: Sweep
+## Phase 5: Recursive Sweep
 
 Read and follow `.claude/phases/sweep.md`. When it says "back to the Swarm phase", return to Phase 4 above. When it says "final phase", proceed to Phase 6.
+
+This phase runs a recursive loop: check reviews → swarm to address feedback → check reviews on the new feedback PRs → repeat. PRs created to address feedback are themselves tracked in UNREVIEWED_PRS.md and must be reviewed before the blitz is considered done. The blitz only exits the sweep when there are no namespaced TODO items AND no namespaced PRs pending review.
 
 ## Phase 6: Report
 

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -140,9 +140,11 @@ gh issue close <issue-number>
 10. **If the user has NOT signaled stop AND the max-tasks limit has NOT been reached**: pick the next task and spawn a new agent.
 11. **If the user HAS signaled stop OR the max-tasks limit has been reached**: don't spawn. Once all in-flight agents finish, proceed to shutdown.
 
-## Phase 5: Sweep
+## Phase 5: Recursive Sweep
 
 Read and follow `.claude/phases/sweep.md`. When it says "back to the Swarm phase", return to Phase 4 above. When it says "final phase", proceed to Phase 6.
+
+This phase runs a recursive loop: check reviews → swarm to address feedback → check reviews on the new feedback PRs → repeat. PRs created to address feedback are themselves tracked in UNREVIEWED_PRS.md and must be reviewed before the blitz is considered done. The blitz only exits the sweep when there are no namespaced TODO items AND no namespaced PRs pending review.
 
 ## Phase 6: Create Final PR (Feature Branch -> Main)
 

--- a/.claude/phases/sweep.md
+++ b/.claude/phases/sweep.md
@@ -1,12 +1,32 @@
 ## Sweep
 
+This phase runs a **recursive sweep loop** that keeps checking for review feedback and CI failures until all PRs related to the blitz are fully reviewed and all resulting action items are resolved — including transitive feedback (i.e., feedback on PRs that were themselves opened to address earlier feedback).
+
+The blitz is NOT done until there is zero remaining feedback or transitive feedback relating to the blitz.
+
+### Entry
+
 1. Unless `--auto` was passed, pause and ask the user: **"Initial swarm complete. Run sweep for review feedback?"**
    - If the user declines, skip to the final phase.
+2. If `--auto` was passed, skip the pause and begin the sweep loop automatically.
 
-2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace.
+### Sweep loop
 
-3. After check-reviews completes, read `.private/TODO.md`:
-   - If new `[<namespace>]`-prefixed "Address the feedback" or "Fix CI failures" items were added, run another swarm pass (back to the Swarm phase).
-   - If no new namespaced feedback items, proceed to the final phase.
+Repeat the following until the exit condition is met:
 
-4. If `--auto` was passed, skip the pause and run the sweep automatically. Still loop back to the Swarm phase if feedback items were added.
+1. **Run check-reviews**: Read and follow `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace.
+
+2. **Check for new action items**: After check-reviews completes, read `.private/TODO.md`:
+   - If new `[<namespace>]`-prefixed "Address the feedback" or "Fix CI failures" items were added, go back to the Swarm phase to address them. When swarm finishes, return here and restart the sweep loop from step 1 (the new feedback PRs will be in UNREVIEWED_PRS.md and need their own reviews).
+
+3. **Check for pending PRs**: If no new TODO items were added, read `.private/UNREVIEWED_PRS.md` and check if any PRs with branches starting with `swarm/<namespace>/` are still listed (meaning they haven't been fully reviewed yet):
+   - If namespaced PRs remain, **wait 60 seconds**, then restart the sweep loop from step 1. Reviewers may not have processed them yet. Log: `"Waiting for reviewers — <N> blitz PRs still pending review in UNREVIEWED_PRS.md..."`.
+   - If no namespaced PRs remain, the exit condition is met.
+
+### Exit condition
+
+The sweep is complete when ALL of the following are true after a check-reviews pass:
+- No new `[<namespace>]`-prefixed items were added to `.private/TODO.md`
+- No PRs with `swarm/<namespace>/` branches remain in `.private/UNREVIEWED_PRS.md`
+
+When the exit condition is met, proceed to the final phase.


### PR DESCRIPTION
## Summary
- Updated the blitz sweep phase to recursively loop until ALL blitz-related PRs are fully reviewed and all resulting action items are resolved
- The sweep now checks UNREVIEWED_PRS.md for pending namespaced PRs (not just TODO.md for new items), preventing premature exit when reviewers haven't processed feedback PRs yet
- Updated blitz.md and safe-blitz.md Phase 5 descriptions to clearly document the recursive behavior for future users

## Original prompt
update our claude blitz command such that once all milestone prs are complete, it automatically does sweeps to look for PR feedback and CI failures until it exhausts all action items relating to the blitz. For example, if it has 4 mlestones, then once all 4 are merged, it keeps checking to see if devin/codex have left reviews on each of the 4. Once feedback is left, it should auto-swarm that feedback. As PRs are added to UNREVIEWED_PRS.md, it should include the blitz namespace and keep recursing until all PRs relating to the blitz of no change requests (inlcuding PRs that were opened to address prior feedback). The blitz should only be considered done once there is no feedback or transitive feedback relating to the blitz remaining. Please update the claude coode command to make this clear for future blirz users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
