### PR TITLE
M3: Runtime guardian parity adjustments

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1147,6 +1147,305 @@ describe('sourceChannel passed to orchestrator.startRun', () => {
 // 14. Plain-text fallback surfacing for non-rich channels (WS-E)
 // ═══════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════
+// 15. SMS channel approval decisions
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('SMS channel approval decisions', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  function makeSmsInboundRequest(overrides: Record<string, unknown> = {}): Request {
+    const body = {
+      sourceChannel: 'sms',
+      externalChatId: 'sms-chat-123',
+      externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+      content: 'hello',
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      ...overrides,
+    };
+    return new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('plain-text "yes" via SMS triggers approve_once decision', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation via SMS
+    const initReq = makeSmsInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[events.length - 1]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeSmsInboundRequest({ content: 'yes' });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('plain-text "no" via SMS triggers reject decision', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeSmsInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[events.length - 1]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeSmsInboundRequest({ content: 'no' });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('non-decision SMS message during pending approval triggers reminder with plain-text fallback', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const replySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeSmsInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[events.length - 1]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const req = makeSmsInboundRequest({ content: 'what is happening?' });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('reminder_sent');
+
+    // SMS is a non-rich channel so the delivered text should include plain-text fallback
+    expect(deliverSpy).toHaveBeenCalled();
+    const callArgs = deliverSpy.mock.calls[0];
+    const deliveredText = callArgs[2] as string;
+    expect(deliveredText).toContain("I'm still waiting");
+    expect(deliveredText).toContain('Reply "yes"');
+
+    deliverSpy.mockRestore();
+    replySpy.mockRestore();
+  });
+
+  test('sourceChannel "sms" is passed to orchestrator.startRun', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-sms-channel-test',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-sms',
+      status: 'completed' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeSmsInboundRequest({ content: 'test sms channel pass-through' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to fire
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    expect(orchestrator.startRun).toHaveBeenCalled();
+    const startRunArgs = (orchestrator.startRun as ReturnType<typeof mock>).mock.calls[0];
+    const options = startRunArgs[3] as { sourceChannel?: string } | undefined;
+    expect(options).toBeDefined();
+    expect(options!.sourceChannel).toBe('sms');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 16. SMS guardian verify intercept
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('SMS guardian verify intercept', () => {
+  test('/guardian_verify command works with sourceChannel sms', async () => {
+    // Set up a guardian verification challenge for SMS
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    const { secret } = createVerificationChallenge('self', 'sms');
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'sms',
+        externalChatId: 'sms-chat-verify',
+        externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+        content: `/guardian_verify ${secret}`,
+        senderExternalUserId: 'sms-user-42',
+        replyCallbackUrl: 'https://gateway.test/deliver',
+      }),
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBe('verified');
+
+    // Verify the reply was delivered
+    expect(deliverSpy).toHaveBeenCalled();
+    const replyArgs = deliverSpy.mock.calls[0];
+    const replyPayload = replyArgs[1] as { chatId: string; text: string };
+    expect(replyPayload.chatId).toBe('sms-chat-verify');
+    expect(replyPayload.text).toContain('Guardian verified successfully');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('/guardian_verify with invalid token returns failed via SMS', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'sms',
+        externalChatId: 'sms-chat-verify-fail',
+        externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+        content: '/guardian_verify invalid-token-here',
+        senderExternalUserId: 'sms-user-43',
+        replyCallbackUrl: 'https://gateway.test/deliver',
+      }),
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBe('failed');
+
+    expect(deliverSpy).toHaveBeenCalled();
+    const replyArgs = deliverSpy.mock.calls[0];
+    const replyPayload = replyArgs[1] as { chatId: string; text: string };
+    expect(replyPayload.text).toContain('Verification failed');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 17. SMS non-guardian actor gating
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('SMS non-guardian actor gating', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('non-guardian SMS actor gets stricter controls when guardian binding exists', async () => {
+    // Create a guardian binding for the sms channel
+    const { createBinding } = await import('../memory/channel-guardian-store.js');
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: 'sms-guardian-user',
+      guardianDeliveryChatId: 'sms-guardian-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-sms-nongrd',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-sms-nongrd',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    // Send message from a NON-guardian sms user
+    const req = new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'sms',
+        externalChatId: 'sms-other-chat',
+        externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+        content: 'do something',
+        senderExternalUserId: 'sms-other-user',
+        replyCallbackUrl: 'https://gateway.test/deliver',
+      }),
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to fire
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // startRun should have been called with forceStrictSideEffects for non-guardian
+    expect(orchestrator.startRun).toHaveBeenCalled();
+    const startRunArgs = (orchestrator.startRun as ReturnType<typeof mock>).mock.calls[0];
+    const options = startRunArgs[3] as { forceStrictSideEffects?: boolean; sourceChannel?: string } | undefined;
+    expect(options).toBeDefined();
+    expect(options!.forceStrictSideEffects).toBe(true);
+    expect(options!.sourceChannel).toBe('sms');
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+});
+
 describe('plain-text fallback surfacing for non-rich channels', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -313,6 +313,20 @@ describe('guardian service challenge validation', () => {
     expect(result.instruction).toContain(result.secret);
   });
 
+  test('createVerificationChallenge instruction mentions Telegram for telegram channel', () => {
+    const result = createVerificationChallenge('asst-1', 'telegram');
+    expect(result.instruction).toContain('via Telegram');
+    expect(result.instruction).not.toContain('via SMS');
+  });
+
+  test('createVerificationChallenge instruction mentions SMS for sms channel', () => {
+    const result = createVerificationChallenge('asst-1', 'sms');
+    expect(result.instruction).toContain('via SMS');
+    expect(result.instruction).not.toContain('via Telegram');
+    expect(result.instruction).toContain('/guardian_verify');
+    expect(result.instruction).toContain(result.secret);
+  });
+
   test('validateAndConsumeChallenge succeeds with correct secret', () => {
     const { secret } = createVerificationChallenge('asst-1', 'telegram');
 
@@ -409,6 +423,65 @@ describe('guardian service challenge validation', () => {
     expect(result2.success).toBe(false);
   });
 
+  test('validateAndConsumeChallenge succeeds with sms channel', () => {
+    const { secret } = createVerificationChallenge('asst-1', 'sms');
+
+    const result = validateAndConsumeChallenge(
+      'asst-1',
+      'sms',
+      secret,
+      'phone-user-1',
+      'sms-chat-1',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.bindingId).toBeDefined();
+    }
+
+    // Verify the binding was created for the sms channel
+    const binding = getActiveBinding('asst-1', 'sms');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('phone-user-1');
+    expect(binding!.guardianDeliveryChatId).toBe('sms-chat-1');
+    expect(binding!.channel).toBe('sms');
+  });
+
+  test('sms and telegram guardian challenges are independent', () => {
+    const telegramChallenge = createVerificationChallenge('asst-1', 'telegram');
+    const smsChallenge = createVerificationChallenge('asst-1', 'sms');
+
+    // Validate SMS challenge against telegram channel should fail
+    const crossResult = validateAndConsumeChallenge(
+      'asst-1',
+      'telegram',
+      smsChallenge.secret,
+      'user-1',
+      'chat-1',
+    );
+    expect(crossResult.success).toBe(false);
+
+    // Validate SMS challenge against correct channel should succeed
+    const smsResult = validateAndConsumeChallenge(
+      'asst-1',
+      'sms',
+      smsChallenge.secret,
+      'user-1',
+      'chat-1',
+    );
+    expect(smsResult.success).toBe(true);
+
+    // Telegram challenge should still be valid
+    const telegramResult = validateAndConsumeChallenge(
+      'asst-1',
+      'telegram',
+      telegramChallenge.secret,
+      'user-2',
+      'chat-2',
+    );
+    expect(telegramResult.success).toBe(true);
+  });
+
   test('validateAndConsumeChallenge revokes existing binding before creating new one', () => {
     // Create initial guardian binding
     createBinding({
@@ -498,6 +571,20 @@ describe('guardian identity check', () => {
   test('getGuardianBinding returns null when no binding exists', () => {
     const binding = getGuardianBinding('asst-1', 'telegram');
     expect(binding).toBeNull();
+  });
+
+  test('isGuardian works for sms channel', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'sms',
+      guardianExternalUserId: 'phone-user-1',
+      guardianDeliveryChatId: 'sms-chat-1',
+    });
+
+    expect(isGuardian('asst-1', 'sms', 'phone-user-1')).toBe(true);
+    expect(isGuardian('asst-1', 'sms', 'phone-user-2')).toBe(false);
+    // Telegram guardian should not match sms channel
+    expect(isGuardian('asst-1', 'telegram', 'phone-user-1')).toBe(false);
   });
 
   test('serviceRevokeBinding revokes the active binding', () => {
@@ -682,6 +769,51 @@ describe('guardian approval request CRUD', () => {
     expect(found2).not.toBeNull();
     expect(found1!.toolName).toBe('shell');
     expect(found2!.toolName).toBe('browser');
+  });
+
+  test('createApprovalRequest works for sms channel', () => {
+    const request = createApprovalRequest({
+      runId: 'run-sms-1',
+      conversationId: 'conv-sms-1',
+      channel: 'sms',
+      requesterExternalUserId: 'phone-user-99',
+      requesterChatId: 'sms-chat-99',
+      guardianExternalUserId: 'phone-user-42',
+      guardianChatId: 'sms-chat-42',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    expect(request.id).toBeDefined();
+    expect(request.runId).toBe('run-sms-1');
+    expect(request.channel).toBe('sms');
+    expect(request.status).toBe('pending');
+
+    const found = getPendingApprovalForRun('run-sms-1');
+    expect(found).not.toBeNull();
+    expect(found!.channel).toBe('sms');
+  });
+
+  test('getPendingApprovalByGuardianChat works for sms channel', () => {
+    createApprovalRequest({
+      runId: 'run-sms-2',
+      conversationId: 'conv-sms-2',
+      channel: 'sms',
+      requesterExternalUserId: 'phone-user-99',
+      requesterChatId: 'sms-chat-99',
+      guardianExternalUserId: 'phone-user-42',
+      guardianChatId: 'sms-chat-42',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const found = getPendingApprovalByGuardianChat('sms', 'sms-chat-42');
+    expect(found).not.toBeNull();
+    expect(found!.channel).toBe('sms');
+
+    // Should not find it under a different channel
+    const notFound = getPendingApprovalByGuardianChat('telegram', 'sms-chat-42');
+    expect(notFound).toBeNull();
   });
 
   test('createApprovalRequest with optional fields omitted defaults to null', () => {

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -52,6 +52,19 @@ function hashSecret(secret: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a human-readable channel label for use in guardian challenge
+ * instructions. Avoids hardcoding "Telegram" so SMS and future
+ * channels get appropriate wording.
+ */
+function channelLabel(channel: string): string {
+  switch (channel) {
+    case 'telegram': return 'Telegram';
+    case 'sms': return 'SMS';
+    default: return channel;
+  }
+}
+
+/**
  * Create a new verification challenge for a guardian candidate.
  *
  * Generates a random secret, hashes it (SHA-256), and stores the
@@ -77,10 +90,12 @@ export function createVerificationChallenge(
     createdBySessionId: sessionId,
   });
 
+  const label = channelLabel(channel);
+
   return {
     challengeId,
     secret,
-    instruction: `Send \`/guardian_verify ${secret}\` to your bot from your Telegram account within 10 minutes.`,
+    instruction: `Send \`/guardian_verify ${secret}\` to your bot via ${label} within 10 minutes.`,
   };
 }
 


### PR DESCRIPTION
Part of #6692. Makes guardian challenge instruction text channel-specific (not Telegram-hardcoded). Verifies /guardian_verify intercept works for sourceChannel sms. Ensures approval-decision parser is channel-agnostic. Adds tests for SMS guardian and approval flows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
