### PR TITLE
M5: Docs + architecture updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,6 +185,8 @@ graph TB
         GW_TWILIO_STATUS["Twilio Status Webhook<br/>/webhooks/twilio/status"]
         GW_TWILIO_CONNECT["Twilio Connect-Action<br/>/webhooks/twilio/connect-action"]
         GW_TWILIO_RELAY["Twilio Relay WS<br/>/webhooks/twilio/relay<br/>(bidirectional proxy)"]
+        GW_SMS_WEBHOOK["Twilio SMS Webhook<br/>/webhooks/twilio/sms<br/>(HMAC-SHA1 validated)"]
+        GW_SMS_DELIVER["SMS Deliver<br/>/deliver/sms<br/>(internal, from runtime)"]
         GW_OAUTH["OAuth Callback<br/>/webhooks/oauth/callback"]
         GW_PROXY["Runtime Proxy<br/>(optional, bearer auth)"]
         GW_PROBES["/healthz + /readyz<br/>k8s liveness/readiness"]
@@ -316,11 +318,16 @@ graph TB
     GW_TG_DELIVER --> GW_REPLY
     GW_TG_DELIVER --> GW_ATTACH
 
-    %% Gateway flow — Twilio webhooks
+    %% Gateway flow — Twilio voice webhooks
     GW_TWILIO_VOICE -->|"HTTP"| HTTP_SERVER
     GW_TWILIO_STATUS -->|"HTTP"| HTTP_SERVER
     GW_TWILIO_CONNECT -->|"HTTP"| HTTP_SERVER
     GW_TWILIO_RELAY -->|"WebSocket proxy"| HTTP_SERVER
+
+    %% Gateway flow — SMS channel (Twilio SMS webhook → gateway → runtime → gateway → Twilio Messages API)
+    GW_SMS_WEBHOOK -->|"normalize + MessageSid dedup<br/>+ route resolver"| GW_FORWARD
+    HTTP_SERVER -->|"POST /deliver/sms<br/>(via gatewayInternalBaseUrl)"| GW_SMS_DELIVER
+    GW_SMS_DELIVER -->|"Twilio Messages API<br/>(text-only, no MMS in v1)"| GW_SMS_WEBHOOK
 
     %% Gateway flow — OAuth callback
     GW_OAUTH -->|"forward code + state"| HTTP_SERVER
@@ -409,6 +416,26 @@ graph TB
 - Session runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
 - Daemon startup runs `ensurePrebuiltHomeBaseSeeded()` to provision one idempotent prebuilt Home Base app in `~/.vellum/workspace/data/apps`.
 - Home Base onboarding buttons relay prefilled natural-language prompts to the main assistant; permission setup remains user-initiated and hatch + first-conversation flows avoid proactive permission asks.
+
+### SMS Channel (Twilio)
+
+The SMS channel provides text-only messaging via Twilio, sharing the same telephony provider as voice calls. It follows the same ingress/egress pattern as Telegram but uses Twilio's HMAC-SHA1 signature validation instead of a secret header.
+
+**Ingress** (`POST /webhooks/twilio/sms`):
+1. Twilio delivers an inbound SMS as a form-encoded POST to the gateway.
+2. The gateway validates the `X-Twilio-Signature` header using HMAC-SHA1 with the Twilio Auth Token against the canonical request URL (reconstructed from `INGRESS_PUBLIC_BASE_URL` when behind a tunnel).
+3. The payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"` and `externalChatId` set to the sender's phone number (E.164).
+4. `MessageSid` deduplication prevents reprocessing retried webhooks.
+5. The event is forwarded to the runtime via `POST /channels/inbound`, including SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
+
+**Egress** (`POST /deliver/sms`):
+1. The runtime calls the gateway's `/deliver/sms` endpoint with `{ to, text }`.
+2. The gateway authenticates the request via bearer token (same fail-closed model as `/deliver/telegram`).
+3. The gateway sends the SMS via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number.
+
+**Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant.
+
+**Limitations (v1)**: Text-only — MMS (media attachments) is deferred to a future release.
 
 ---
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -152,6 +152,33 @@ CHANNEL_APPROVALS_ENABLED=true
 
 When disabled (the default), channel messages follow the standard fire-and-forget processing path without approval interception.
 
+## Twilio Setup Primitive
+
+Twilio is the shared telephony provider for both voice calls and SMS messaging. Configuration is managed through the `twilio_config` IPC contract and the `twilio-setup` skill.
+
+### `twilio_config` IPC Contract
+
+The daemon handles `twilio_config` messages with the following actions:
+
+| Action | Description |
+|--------|-------------|
+| `get` | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned) |
+| `set_credentials` | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file). Credentials are retrieved from the credential store internally. |
+| `clear_credentials` | Removes stored Account SID, Auth Token, and phone number assignment |
+| `provision_number` | Provisions a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Auto-assigns the provisioned number. |
+| `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant |
+| `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
+
+Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, and optional `error`.
+
+### Single-Number-Per-Assistant Model
+
+Each assistant is assigned a single Twilio phone number that is shared between voice calls and SMS. The number is stored in the assistant's config at `sms.phoneNumber` and used as the `From` for outbound SMS via the gateway's `/deliver/sms` endpoint. The same credentials (Account SID, Auth Token) are used for both voice and SMS operations.
+
+### Channel-Aware Guardian Challenges
+
+The channel guardian service generates verification challenge instructions with channel-appropriate wording. The `channelLabel()` function maps `sourceChannel` values to human-readable labels (e.g., `"telegram"` -> `"Telegram"`, `"sms"` -> `"SMS"`), so challenge prompts reference the correct channel name.
+
 ## Database
 
 SQLite via Drizzle ORM, stored at `~/.vellum/workspace/data/db/assistant.db`. Key tables include conversations, messages, tool invocations, attachments, memory segments (with FTS5), memory items, entities, reminders, and recurrence schedules (cron + RRULE).

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -60,5 +60,20 @@ ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
 
 # Optional: Canonical public base URL where the gateway is reachable externally.
 # Used by the assistant runtime to construct webhook and OAuth callback URLs.
+# Required for Twilio SMS webhook signature validation when behind a tunnel.
 # Set this to your tunnel's public URL during local development.
 # INGRESS_PUBLIC_BASE_URL=https://your-public-domain.com
+
+# --- SMS (Twilio) ---
+
+# Optional: Twilio Account SID for outbound SMS via the Messages API
+# TWILIO_ACCOUNT_SID=
+
+# Optional: Twilio Auth Token for webhook signature validation and outbound SMS
+# TWILIO_AUTH_TOKEN=
+
+# Optional: Twilio phone number (E.164) used as the From number for outbound SMS
+# TWILIO_PHONE_NUMBER=
+
+# Optional: Dev-only bypass for bearer auth on /deliver/sms (default: false)
+# GATEWAY_SMS_DELIVER_AUTH_BYPASS=false

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,6 +1,6 @@
 # Vellum Gateway
 
-Standalone service that serves as the public ingress boundary for all external webhooks and callbacks. It owns Telegram integration end-to-end, routes Twilio voice webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime.
+Standalone service that serves as the public ingress boundary for all external webhooks and callbacks. It owns Telegram integration end-to-end, routes Twilio voice and SMS webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime.
 
 ## Architecture
 
@@ -49,6 +49,10 @@ bun run dev
 | `GATEWAY_MAX_ATTACHMENT_BYTES` | No | `20971520` | Max single attachment size (oversized are skipped) |
 | `GATEWAY_MAX_ATTACHMENT_CONCURRENCY` | No | `3` | Max concurrent attachment download/upload operations |
 | `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS` | No | `false` | Dev-only: skip bearer auth on `/deliver/telegram` when no token is configured |
+| `TWILIO_ACCOUNT_SID` | No | — | Twilio Account SID for sending outbound SMS via the Messages API |
+| `TWILIO_AUTH_TOKEN` | No | — | Twilio Auth Token for HMAC-SHA1 webhook signature validation and outbound SMS |
+| `TWILIO_PHONE_NUMBER` | No | — | Twilio phone number (E.164) used as the `From` for outbound SMS |
+| `GATEWAY_SMS_DELIVER_AUTH_BYPASS` | No | `false` | Dev-only: skip bearer auth on `/deliver/sms` when no token is configured |
 
 ## Routing
 
@@ -90,6 +94,33 @@ The `/deliver/telegram` endpoint requires bearer auth by default (fail-closed). 
 | No bearer token configured + bypass not set | 503 Service Not Configured |
 
 This ensures that misconfiguration cannot expose an unauthenticated public message-send surface. In production, always configure `RUNTIME_PROXY_BEARER_TOKEN`. The `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS` flag is intended for local development only.
+
+## SMS Ingress (Twilio)
+
+The `/webhooks/twilio/sms` endpoint receives inbound SMS messages from Twilio. On each request:
+
+1. **Signature validation** — The `X-Twilio-Signature` header is validated using HMAC-SHA1 with the `TWILIO_AUTH_TOKEN`. When behind a tunnel or reverse proxy, the gateway reconstructs the canonical request URL from `INGRESS_PUBLIC_BASE_URL` for validation.
+2. **MessageSid dedup** — Each `MessageSid` is tracked in an in-memory dedup cache. Duplicate webhook deliveries (Twilio retries) are silently accepted without re-forwarding.
+3. **Normalization** — The form-encoded Twilio payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"`. The sender's phone number (`From`) is used as both `externalChatId` and `externalUserId`.
+4. **Routing** — The same routing resolver used for Telegram (chat_id -> user_id -> default/reject) determines the target assistant.
+5. **Forwarding** — The event is forwarded to the runtime via `POST /channels/inbound` with SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
+
+SMS is text-only in v1 — MMS (media attachments) is deferred.
+
+## SMS Deliver Endpoint Security
+
+The `/deliver/sms` endpoint requires the same fail-closed bearer auth as `/deliver/telegram`:
+
+| Condition | Result |
+|-----------|--------|
+| Bearer token configured + valid `Authorization` header | Request allowed |
+| Bearer token configured + missing/invalid `Authorization` header | 401 Unauthorized |
+| No bearer token configured + `GATEWAY_SMS_DELIVER_AUTH_BYPASS=true` | Request allowed (dev-only) |
+| No bearer token configured + bypass not set | 503 Service Not Configured |
+
+The endpoint also requires `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` to be configured. If any are missing, requests return `503 SMS integration not configured`.
+
+Outbound SMS is sent via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number. The request body is `{ to: string, text: string }`.
 
 ## Callback Query Handling
 
@@ -140,6 +171,8 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/webhooks/twilio/status` | POST | Twilio status callback (validated via HMAC-SHA1 signature) |
 | `/webhooks/twilio/connect-action` | POST | Twilio connect-action callback (validated via HMAC-SHA1 signature) |
 | `/webhooks/twilio/relay` | WS | Twilio ConversationRelay WebSocket (bidirectional proxy to runtime, requires `callSessionId` query param) |
+| `/webhooks/twilio/sms` | POST | Twilio SMS webhook — validates X-Twilio-Signature (HMAC-SHA1), normalizes into `GatewayInboundEventV1` with `sourceChannel: "sms"`, deduplicates by `MessageSid`, and forwards to runtime |
+| `/deliver/sms` | POST | Internal endpoint for the assistant runtime to deliver outbound SMS messages via the Twilio Messages API |
 | `/webhooks/oauth/callback` | GET | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe |


### PR DESCRIPTION
Part of #6692. Documents new SMS ingress/egress routes in gateway README. Documents Twilio setup primitive and config model in assistant README. Updates ARCHITECTURE.md with SMS channel flow. Updates gateway .env.example with SMS-related config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
