### PR TITLE
fix: deduplicate plain-text fallback prompt text

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -77,7 +77,7 @@ function effectivePromptText(
   channel: string,
 ): string {
   if (channelSupportsRichApprovalUI(channel)) return promptText;
-  return `${promptText}\n\n${plainTextFallback}`;
+  return plainTextFallback;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context
Addresses review feedback on #6702

## Changes
- In effectivePromptText(), return plainTextFallback directly for non-rich channels instead of concatenating with promptText (which is already included in plainTextFallback)
- Update test to expect non-duplicated output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
