### PR TITLE
Fix Twilio config feedback from PR #6698

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1141,7 +1141,7 @@ export async function handleTwilioConfig(
           ctx.send(socket, {
             type: 'twilio_config_response',
             success: false,
-            hasCredentials: false,
+            hasCredentials: hasTwilioCredentials(),
             error: `Twilio API validation failed (${res.status}): ${body}`,
           });
           return;
@@ -1151,7 +1151,7 @@ export async function handleTwilioConfig(
         ctx.send(socket, {
           type: 'twilio_config_response',
           success: false,
-          hasCredentials: false,
+          hasCredentials: hasTwilioCredentials(),
           error: `Failed to validate Twilio credentials: ${message}`,
         });
         return;
@@ -1248,7 +1248,11 @@ export async function handleTwilioConfig(
         return;
       }
 
-      // Persist the phone number in assistant config (non-secret)
+      // Persist the phone number in the secure credential store so the
+      // active Twilio runtime can read it via credential:twilio:phone_number
+      setSecureKey('credential:twilio:phone_number', msg.phoneNumber);
+
+      // Also persist in assistant config (non-secret) for the UI
       const raw = loadRawConfig();
       const sms = (raw?.sms ?? {}) as Record<string, unknown>;
       sms.phoneNumber = msg.phoneNumber;


### PR DESCRIPTION
Addresses review feedback from #6698. Fixes hasCredentials to use hasTwilioCredentials() on error paths instead of hardcoding false. Persists assigned phone number to runtime credential store alongside config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
