### PR TITLE
Fix Gateway SMS dedup feedback from PR #6701

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { DedupCache } from "../dedup-cache.js";
+import { DedupCache, StringDedupCache } from "../dedup-cache.js";
 
 describe("DedupCache", () => {
   let cache: DedupCache;
@@ -124,5 +124,69 @@ describe("DedupCache", () => {
     }
 
     expect(shortCache.reserve(90)).toBe(true);
+  });
+});
+
+describe("StringDedupCache", () => {
+  let cache: StringDedupCache;
+
+  beforeEach(() => {
+    cache = new StringDedupCache(5_000, 100);
+  });
+
+  test("has() returns false for unseen key", () => {
+    expect(cache.has("SM-123")).toBe(false);
+  });
+
+  test("has() returns true after mark()", () => {
+    cache.mark("SM-123");
+    expect(cache.has("SM-123")).toBe(true);
+  });
+
+  test("has() does not mark the key as seen", () => {
+    cache.has("SM-123");
+    // Key should still not be in the cache
+    expect(cache.size).toBe(0);
+    expect(cache.has("SM-123")).toBe(false);
+  });
+
+  test("seen() checks and marks atomically", () => {
+    // First call: not seen, marks it
+    expect(cache.seen("SM-456")).toBe(false);
+    // Second call: already seen
+    expect(cache.seen("SM-456")).toBe(true);
+  });
+
+  test("mark() then has() works across multiple keys", () => {
+    cache.mark("SM-a");
+    cache.mark("SM-b");
+    expect(cache.has("SM-a")).toBe(true);
+    expect(cache.has("SM-b")).toBe(true);
+    expect(cache.has("SM-c")).toBe(false);
+  });
+
+  test("expired entries are not returned by has()", () => {
+    const shortCache = new StringDedupCache(1, 100);
+    shortCache.mark("SM-expire");
+
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait for expiry
+    }
+
+    expect(shortCache.has("SM-expire")).toBe(false);
+  });
+
+  test("mark() evicts oldest when at capacity", () => {
+    const tinyCache = new StringDedupCache(60_000, 3);
+    tinyCache.mark("a");
+    tinyCache.mark("b");
+    tinyCache.mark("c");
+    expect(tinyCache.size).toBe(3);
+
+    tinyCache.mark("d");
+    expect(tinyCache.size).toBe(3);
+    expect(tinyCache.has("a")).toBe(false);
+    expect(tinyCache.has("d")).toBe(true);
   });
 });

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -148,12 +148,32 @@ export class StringDedupCache {
    * If not seen, marks it as seen and returns false.
    */
   seen(key: string): boolean {
+    if (this.has(key)) return true;
+    this.mark(key);
+    return false;
+  }
+
+  /**
+   * Returns true if the key is already in the cache (within the TTL window),
+   * without marking it as seen. Use this for a read-only check when you want
+   * to defer marking until after successful processing.
+   */
+  has(key: string): boolean {
     const now = Date.now();
     const expiresAt = this.cache.get(key);
     if (expiresAt !== undefined) {
       if (now <= expiresAt) return true;
       this.cache.delete(key);
     }
+    return false;
+  }
+
+  /**
+   * Marks a key as seen. Call this after successful processing to prevent
+   * future duplicates while still allowing retries on failure.
+   */
+  mark(key: string): void {
+    const now = Date.now();
 
     // Evict expired entries if at capacity
     if (this.cache.size >= this.maxSize) {
@@ -167,7 +187,6 @@ export class StringDedupCache {
     }
 
     this.cache.set(key, now + this.ttlMs);
-    return false;
   }
 
   get size(): number {

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -221,6 +221,70 @@ describe("twilio-sms-webhook", () => {
     expect(res.status).toBe(500);
   });
 
+  it("allows retry after failed forwarding (does not dedup failures)", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "retry test",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-retry-test",
+    };
+
+    // First attempt fails
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: false, rejected: false }),
+    );
+    const req1 = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res1 = await handler(req1);
+    expect(res1.status).toBe(500);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    // Retry with same MessageSid should NOT be deduped since first attempt failed
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: true, rejected: false }),
+    );
+    const req2 = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res2 = await handler(req2);
+    expect(res2.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(2);
+
+    // Now a third attempt should be deduped since the second succeeded
+    const req3 = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res3 = await handler(req3);
+    expect(res3.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows retry after handleInbound throws (does not dedup exceptions)", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "throw test",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-throw-test",
+    };
+
+    // First attempt throws
+    handleInboundMock.mockImplementation(() =>
+      Promise.reject(new Error("connection refused")),
+    );
+    const req1 = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res1 = await handler(req1);
+    expect(res1.status).toBe(500);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    // Retry should succeed and not be treated as duplicate
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: true, rejected: false }),
+    );
+    const req2 = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res2 = await handler(req2);
+    expect(res2.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(2);
+  });
+
   it("returns 200 when routing rejects the SMS", async () => {
     handleInboundMock.mockImplementation(() =>
       Promise.resolve({ forwarded: false, rejected: true, rejectionReason: "No route" }),

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -72,8 +72,9 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Missing MessageSid" }, { status: 400 });
     }
 
-    // Dedup by MessageSid
-    if (dedupCache.seen(messageSid)) {
+    // Dedup by MessageSid — check only, defer marking until after successful forwarding
+    // so Twilio retries are not suppressed when downstream handling fails.
+    if (dedupCache.has(messageSid)) {
       tlog.info({ messageSid }, "Duplicate MessageSid, ignoring");
       return Response.json({ ok: true });
     }
@@ -125,6 +126,8 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
 
+      // Mark as seen only after successful forwarding
+      dedupCache.mark(messageSid);
       tlog.info({ status: "forwarded", messageSid }, "SMS forwarded to runtime");
     } catch (err) {
       tlog.error({ err, messageSid }, "Failed to process inbound SMS");


### PR DESCRIPTION
Addresses review feedback from #6701. Moves dedupCache.seen() call to after successful runtime forwarding instead of before, preventing message loss when downstream handling fails and Twilio retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
