### PR TITLE
Decouple connection status from SSE, drive from health check

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -524,4 +524,7 @@ private final class FailOnceDaemonClient: DaemonClientProtocol {
     func disconnect() {
         isConnected = false
     }
+
+    func startSSE() {}
+    func stopSSE() {}
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -558,6 +558,10 @@ struct MainWindowView: View {
                 windowState.persistentThreadId = activeId
             }
             requestHomeBaseDashboardIfNeeded()
+            daemonClient.startSSE()
+        }
+        .onDisappear {
+            daemonClient.stopSSE()
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -45,6 +45,9 @@ final class MockDaemonClient: DaemonClientProtocol {
     func disconnect() {
         isConnected = false
     }
+
+    func startSSE() {}
+    func stopSSE() {}
 }
 
 // MARK: - Mocks

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -103,6 +103,8 @@ public protocol DaemonClientProtocol {
     func send<T: Encodable>(_ message: T) throws
     func connect() async throws
     func disconnect()
+    func startSSE()
+    func stopSSE()
 }
 
 extension Notification.Name {

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -293,8 +293,9 @@ extension DaemonClient {
 
     // MARK: - HTTP Transport
 
-    /// Connect to a remote assistant via HTTP REST + SSE.
+    /// Connect to a remote assistant via HTTP REST + health check polling.
     /// Used when `config.transport` is `.http`.
+    /// SSE is managed separately via `startSSE()` / `stopSSE()`.
     func connectHTTP(baseURL: String, bearerToken: String?, conversationKey: String) async throws {
         let transport = HTTPTransport(
             baseURL: baseURL,
@@ -307,7 +308,7 @@ extension DaemonClient {
             self?.handleServerMessage(message)
         }
 
-        // Bridge HTTP transport connection state to DaemonClient's @Published isConnected.
+        // Bridge HTTP transport connection state (health-check driven) to DaemonClient.
         transport.onConnectionStateChanged = { [weak self] connected in
             guard let self else { return }
             self.isConnected = connected
@@ -321,8 +322,6 @@ extension DaemonClient {
 
         do {
             try await transport.connect()
-            // isConnected is set by the onConnectionStateChanged callback
-            // when the SSE stream establishes.
             isAuthenticated = true  // HTTP transport uses bearer token, no IPC auth needed
             isConnecting = false
         } catch {
@@ -330,6 +329,18 @@ extension DaemonClient {
             httpTransport = nil
             throw error
         }
+    }
+
+    // MARK: - SSE Lifecycle
+
+    /// Start the SSE event stream. Call when a chat window opens.
+    public func startSSE() {
+        httpTransport?.startSSE()
+    }
+
+    /// Stop the SSE event stream. Call when a chat window closes.
+    public func stopSSE() {
+        httpTransport?.stopSSE()
     }
 
     // MARK: - Disconnect

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -434,19 +434,47 @@ final class HTTPTransport {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                log.error("Fetch history failed")
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                log.error("Fetch history failed (HTTP \(statusCode))")
                 return
             }
 
-            // The /v1/messages endpoint returns { messages: [...] } which doesn't
-            // directly map to a HistoryResponseMessage. We need to construct one.
+            // The runtime's /v1/messages endpoint returns messages with `content`
+            // (string) and `timestamp` (ISO 8601 string), but IPCHistoryResponseMessage
+            // expects `text` and `timestamp` as a Double (ms since epoch). Transform
+            // the response to match the expected IPC format.
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let messages = json["messages"] as? [[String: Any]] {
+
+                    let isoFormatter = ISO8601DateFormatter()
+                    isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+                    let transformed: [[String: Any]] = messages.map { msg in
+                        var m = msg
+                        // Rename `content` → `text`
+                        if let content = m.removeValue(forKey: "content") {
+                            m["text"] = content
+                        }
+                        // Convert ISO 8601 timestamp string → Double (ms since epoch)
+                        if let tsString = m["timestamp"] as? String {
+                            if let date = isoFormatter.date(from: tsString) {
+                                m["timestamp"] = date.timeIntervalSince1970 * 1000.0
+                            } else {
+                                // Fallback: try without fractional seconds
+                                let fallback = ISO8601DateFormatter()
+                                if let date = fallback.date(from: tsString) {
+                                    m["timestamp"] = date.timeIntervalSince1970 * 1000.0
+                                }
+                            }
+                        }
+                        return m
+                    }
+
                     let historyPayload: [String: Any] = [
                         "type": "history_response",
                         "sessionId": sessionId,
-                        "messages": messages
+                        "messages": transformed
                     ]
 
                     let historyData = try JSONSerialization.data(withJSONObject: historyPayload)

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -35,9 +35,9 @@ struct ConversationsListResponse: Decodable {
 /// `.http` transport via `DaemonConfig`.
 ///
 /// Responsibilities:
-/// - SSE stream connection to `GET /v1/events?conversationKey=...`
+/// - Periodic health check via `GET /healthz` to drive connection status
+/// - SSE stream connection to `GET /v1/events?conversationKey=...` (on demand)
 /// - Translating IPC message types to HTTP API calls
-/// - Health check via `GET /healthz`
 /// - Auto-reconnect with exponential backoff
 @MainActor
 final class HTTPTransport {
@@ -49,28 +49,37 @@ final class HTTPTransport {
     /// Currently active SSE task.
     private var sseTask: Task<Void, Never>?
 
+    /// Periodic health check task.
+    private var healthCheckTask: Task<Void, Never>?
+
+    /// Health check interval in seconds.
+    private let healthCheckInterval: TimeInterval = 15.0
+
     /// Currently active run ID, tracked for decision/secret endpoints.
     private(set) var activeRunId: String?
 
-    /// Whether the SSE stream is connected.
+    /// Whether the assistant is reachable (health check passes).
     private(set) var isConnected: Bool = false
+
+    /// Whether the SSE stream is active and receiving events.
+    private(set) var isSSEConnected: Bool = false
 
     /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
 
-    /// Current reconnect backoff delay in seconds.
-    private var reconnectDelay: TimeInterval = 1.0
+    /// Current reconnect backoff delay in seconds (for SSE).
+    private var sseReconnectDelay: TimeInterval = 1.0
 
     /// Maximum reconnect backoff delay.
     private let maxReconnectDelay: TimeInterval = 30.0
 
-    /// Reconnect task handle.
-    private var reconnectTask: Task<Void, Never>?
+    /// SSE reconnect task handle.
+    private var sseReconnectTask: Task<Void, Never>?
 
     /// Callback for incoming server messages (called on main actor).
     var onMessage: ((ServerMessage) -> Void)?
 
-    /// Callback for connection state changes.
+    /// Callback for connection state changes (health check driven).
     var onConnectionStateChanged: ((Bool) -> Void)?
 
     private let decoder = JSONDecoder()
@@ -85,13 +94,22 @@ final class HTTPTransport {
         self.conversationKey = conversationKey
     }
 
-    // MARK: - Connect
+    // MARK: - Connect (health check driven)
 
-    /// Verify reachability via health check, then open SSE stream.
+    /// Verify reachability via health check and start periodic health monitoring.
+    /// Connection status is driven by health checks, not SSE.
     func connect() async throws {
         shouldReconnect = true
 
-        // 1. Health check
+        // Run initial health check
+        try await performHealthCheck()
+
+        // Start periodic health checks
+        startHealthCheckLoop()
+    }
+
+    /// Run a single health check against the gateway.
+    private func performHealthCheck() async throws {
         let healthURL = URL(string: "\(baseURL)/healthz")!
         var healthReq = URLRequest(url: healthURL)
         healthReq.timeoutInterval = 10
@@ -103,18 +121,57 @@ final class HTTPTransport {
                 throw HTTPTransportError.healthCheckFailed
             }
             log.info("Health check passed for \(self.baseURL, privacy: .public)")
+            setConnected(true)
         } catch let error as HTTPTransportError {
+            setConnected(false)
             throw error
         } catch {
             log.error("Health check failed: \(error.localizedDescription)")
+            setConnected(false)
             throw HTTPTransportError.healthCheckFailed
         }
+    }
 
-        // 2. Open SSE stream
+    /// Periodically poll `/healthz` to maintain connection status.
+    private func startHealthCheckLoop() {
+        healthCheckTask?.cancel()
+
+        healthCheckTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: UInt64((self?.healthCheckInterval ?? 15.0) * 1_000_000_000))
+                } catch {
+                    return
+                }
+
+                guard let self, self.shouldReconnect else { return }
+
+                do {
+                    try await self.performHealthCheck()
+                } catch {
+                    // Health check failed — isConnected already set to false
+                    log.warning("Periodic health check failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // MARK: - SSE Stream (on demand)
+
+    /// Start the SSE event stream. Call when a chat window opens.
+    func startSSE() {
+        guard sseTask == nil else { return }
         startSSEStream()
     }
 
-    // MARK: - SSE Stream
+    /// Stop the SSE event stream. Call when a chat window closes.
+    func stopSSE() {
+        sseReconnectTask?.cancel()
+        sseReconnectTask = nil
+        sseTask?.cancel()
+        sseTask = nil
+        setSSEConnected(false)
+    }
 
     private func startSSEStream() {
         sseTask?.cancel()
@@ -139,11 +196,11 @@ final class HTTPTransport {
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                     let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                     log.error("SSE connection failed with status \(statusCode)")
-                    self.handleDisconnect()
+                    self.handleSSEDisconnect()
                     return
                 }
 
-                self.setConnected(true)
+                self.setSSEConnected(true)
                 log.info("SSE stream connected to \(urlString, privacy: .public)")
 
                 var dataBuffer = ""
@@ -167,7 +224,7 @@ final class HTTPTransport {
             }
 
             if !Task.isCancelled {
-                self.handleDisconnect()
+                self.handleSSEDisconnect()
             }
         }
     }
@@ -433,29 +490,32 @@ final class HTTPTransport {
 
     func disconnect() {
         shouldReconnect = false
-        reconnectTask?.cancel()
-        reconnectTask = nil
+        healthCheckTask?.cancel()
+        healthCheckTask = nil
+        sseReconnectTask?.cancel()
+        sseReconnectTask = nil
         sseTask?.cancel()
         sseTask = nil
         setConnected(false)
+        setSSEConnected(false)
         activeRunId = nil
     }
 
-    // MARK: - Reconnect
+    // MARK: - SSE Reconnect
 
-    private func handleDisconnect() {
-        setConnected(false)
-        guard shouldReconnect else { return }
-        scheduleReconnect()
+    private func handleSSEDisconnect() {
+        setSSEConnected(false)
+        guard shouldReconnect, sseTask != nil else { return }
+        scheduleSSEReconnect()
     }
 
-    private func scheduleReconnect() {
-        reconnectTask?.cancel()
+    private func scheduleSSEReconnect() {
+        sseReconnectTask?.cancel()
 
-        let delay = reconnectDelay
-        log.info("HTTP transport: scheduling reconnect in \(delay)s")
+        let delay = sseReconnectDelay
+        log.info("HTTP transport: scheduling SSE reconnect in \(delay)s")
 
-        reconnectTask = Task { @MainActor [weak self] in
+        sseReconnectTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             } catch {
@@ -463,16 +523,9 @@ final class HTTPTransport {
             }
 
             guard let self, self.shouldReconnect else { return }
-            self.reconnectDelay = min(self.reconnectDelay * 2, self.maxReconnectDelay)
+            self.sseReconnectDelay = min(self.sseReconnectDelay * 2, self.maxReconnectDelay)
 
-            do {
-                try await self.connect()
-            } catch {
-                log.error("HTTP reconnect failed: \(error.localizedDescription)")
-                if self.shouldReconnect {
-                    self.scheduleReconnect()
-                }
-            }
+            self.startSSEStream()
         }
     }
 
@@ -487,8 +540,13 @@ final class HTTPTransport {
     private func setConnected(_ connected: Bool) {
         guard isConnected != connected else { return }
         isConnected = connected
-        reconnectDelay = connected ? 1.0 : reconnectDelay
         onConnectionStateChanged?(connected)
+    }
+
+    private func setSSEConnected(_ connected: Bool) {
+        guard isSSEConnected != connected else { return }
+        isSSEConnected = connected
+        sseReconnectDelay = connected ? 1.0 : sseReconnectDelay
     }
 
     // MARK: - Errors

--- a/clients/shared/IPC/MockDaemonClient.swift
+++ b/clients/shared/IPC/MockDaemonClient.swift
@@ -33,6 +33,9 @@ public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
         isConnected = false
     }
 
+    public func startSSE() {}
+    public func stopSSE() {}
+
     /// Inject a server message into all active subscribers.
     public func emit(_ message: ServerMessage) {
         for continuation in continuations {


### PR DESCRIPTION
## Summary
- Desktop app showed "Disconnected" for GCP assistants even when reachable, because `isConnected` was driven by SSE stream status (which failed through the gateway proxy)
- `isConnected` is now driven by periodic health checks (`GET /healthz` every 15s) — matches what the CLI does
- SSE is now on-demand: `startSSE()` when the chat window appears, `stopSSE()` when it disappears
- HTTP API calls (runs, messages, conversations) work independently of SSE status

## Test plan
- [ ] Open desktop app with a GCP-hatched assistant — should show "Connected" (green) in settings
- [ ] Open a chat window — SSE stream starts, real-time events flow
- [ ] Close the chat window — SSE stream stops
- [ ] Kill the remote gateway — status transitions to "Disconnected" within ~15s
- [ ] Restart the gateway — status recovers to "Connected" on next health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
