### PR TITLE
M1: Enforce fail-closed guardian gate and eliminate delivery-failure bypass

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -48,6 +48,12 @@ import {
 } from '../memory/runs-store.js';
 import type { PendingConfirmation } from '../memory/runs-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+import {
+  createBinding,
+  createApprovalRequest,
+  getPendingApprovalForRun,
+  getUnresolvedApprovalForRun,
+} from '../memory/channel-guardian-store.js';
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
@@ -78,6 +84,9 @@ function ensureConversation(conversationId: string): void {
 
 function resetTables(): void {
   const db = getDb();
+  db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM channel_guardian_verification_challenges');
+  db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM message_runs');
   db.run('DELETE FROM channel_inbound_events');
   db.run('DELETE FROM conversations');
@@ -836,5 +845,427 @@ describe('terminal state check before markProcessed', () => {
     linkSpy.mockRestore();
     markSpy.mockRestore();
     deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 10. Fail-closed guardian gate: unverified channel + sensitive request
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Helper to build a mock orchestrator that creates a real run in the DB
+ * with a pending confirmation, so `getPendingConfirmationsByConversation`
+ * returns the expected data during the background poll loop.
+ *
+ * The `startRun` callback discovers the auto-generated conversationId from
+ * the channel_inbound_events table and creates a real run+confirmation.
+ */
+function makeSensitiveOrchestrator(opts: {
+  runId: string;
+  /** After needs_confirmation is detected and handled, return this terminal status. */
+  terminalStatus: 'completed' | 'failed';
+}): RunOrchestrator & { realRunId: () => string | undefined } {
+  let realRunId: string | undefined;
+  let pollCount = 0;
+
+  return {
+    submitDecision: mock(() => 'applied' as const),
+    getRun: mock(() => {
+      pollCount++;
+      if (pollCount === 1 && realRunId) {
+        return {
+          id: realRunId,
+          conversationId: 'conv-1',
+          messageId: null,
+          status: 'needs_confirmation' as const,
+          pendingConfirmation: sampleConfirmation,
+          pendingSecret: null,
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+      }
+      return {
+        id: realRunId ?? opts.runId,
+        conversationId: 'conv-1',
+        messageId: null,
+        status: opts.terminalStatus,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+    }),
+    startRun: mock(async (conversationId: string) => {
+      // Create a real run in the DB so getPendingConfirmationsByConversation works
+      ensureConversation(conversationId);
+      const run = createRun(conversationId);
+      setRunConfirmation(run.id, sampleConfirmation);
+      realRunId = run.id;
+      return {
+        id: run.id,
+        conversationId,
+        messageId: null,
+        status: 'running' as const,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+    }),
+    realRunId: () => realRunId,
+  } as unknown as RunOrchestrator & { realRunId: () => string | undefined };
+}
+
+describe('fail-closed guardian gate (unverified channel)', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('no-binding + sensitive request auto-denies and never self-approves', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-unverified-deny',
+      terminalStatus: 'failed',
+    });
+
+    // Send from a non-guardian user with no guardian binding on the channel.
+    // senderExternalUserId triggers the actor role resolution path.
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'user-no-guardian',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The orchestrator should have auto-denied (submitDecision called with 'deny')
+    const realId = (orchestrator as unknown as { realRunId: () => string }).realRunId();
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(realId, 'deny');
+
+    // The requester should have been notified about missing guardian
+    const replyCalls = deliverReplySpy.mock.calls;
+    const denialNotice = replyCalls.find(
+      (call) => typeof call[1]?.text === 'string' &&
+        call[1].text.includes('no guardian has been set up'),
+    );
+    expect(denialNotice).toBeDefined();
+
+    deliverReplySpy.mockRestore();
+  });
+
+  test('no-binding + non-sensitive request still completes normally', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-unverified-ok',
+      conversationId: 'conv-1',
+      messageId: null,
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // Run completes without ever needing confirmation (non-sensitive action)
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({
+      content: 'hello world',
+      senderExternalUserId: 'user-no-guardian',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // submitDecision should NOT have been called because no confirmation was needed
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // No denial notice should have been sent
+    const denialNotice = deliverReplySpy.mock.calls.find(
+      (call) => typeof call[1]?.text === 'string' &&
+        call[1].text.includes('no guardian has been set up'),
+    );
+    expect(denialNotice).toBeUndefined();
+
+    deliverReplySpy.mockRestore();
+  });
+
+  test('unverified channel user cannot self-approve via approval interception', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Establish the conversation from the unverified user
+    const initReq = makeInboundRequest({
+      content: 'init',
+      senderExternalUserId: 'user-no-guardian',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Create a pending run for this conversation
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Try to self-approve as the unverified user
+    const req = makeInboundRequest({
+      content: 'approve',
+      senderExternalUserId: 'user-no-guardian',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should be denied, not approved
+    expect(body.approval).toBe('decision_applied');
+    // submitDecision should have been called with 'deny' (auto-deny)
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    deliverReplySpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 11. Guardian-with-binding path regression
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian-with-binding path regression', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('non-guardian with binding routes approval to guardian', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const deliverApprovalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    // Set up a guardian binding for telegram channel
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-1',
+      guardianDeliveryChatId: 'guardian-chat-1',
+      verifiedVia: 'challenge',
+    });
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-with-binding',
+      terminalStatus: 'completed',
+    });
+
+    // Non-guardian user sends a message
+    const req = makeInboundRequest({
+      content: 'do something',
+      senderExternalUserId: 'requester-user-1',
+      senderUsername: 'requester_username',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for background async
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The approval prompt should be delivered to the guardian's chat
+    expect(deliverApprovalSpy).toHaveBeenCalled();
+    const approvalCall = deliverApprovalSpy.mock.calls[0];
+    expect(approvalCall[1]).toBe('guardian-chat-1'); // guardian chat ID
+
+    // The requester should have been notified
+    const requesterNotice = deliverReplySpy.mock.calls.find(
+      (call) => typeof call[1]?.text === 'string' &&
+        call[1].text.includes('sent to the guardian for approval'),
+    );
+    expect(requesterNotice).toBeDefined();
+
+    // submitDecision should NOT have been called with 'deny' (no auto-deny)
+    const denyCalls = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls.filter(
+      (call: unknown[]) => call[1] === 'deny',
+    );
+    expect(denyCalls.length).toBe(0);
+
+    deliverReplySpy.mockRestore();
+    deliverApprovalSpy.mockRestore();
+  });
+
+  test('guardian actor gets standard self-approval prompt', async () => {
+    const deliverApprovalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Set up a guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-2',
+      guardianDeliveryChatId: 'guardian-chat-2',
+      verifiedVia: 'challenge',
+    });
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-guardian-self',
+      terminalStatus: 'completed',
+    });
+
+    // Guardian user sends a message (their external user ID matches the binding)
+    const req = makeInboundRequest({
+      content: 'do something',
+      senderExternalUserId: 'guardian-user-2',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for background async
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The approval prompt should be delivered to the guardian's own chat (self-approval)
+    expect(deliverApprovalSpy).toHaveBeenCalled();
+    const approvalCall = deliverApprovalSpy.mock.calls[0];
+    // Should be sent to the requester's chat (externalChatId), not the guardian binding chat
+    expect(approvalCall[1]).toBe('chat-123');
+
+    deliverApprovalSpy.mockRestore();
+    deliverReplySpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 12. Guardian delivery failure denial
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian delivery failure denial', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('delivery failure immediately denies run and notifies requester', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    // Make deliverApprovalPrompt throw to simulate delivery failure
+    const deliverApprovalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockRejectedValue(
+      new Error('Network error: guardian unreachable'),
+    );
+
+    // Set up a guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-fail',
+      guardianDeliveryChatId: 'guardian-chat-fail',
+      verifiedVia: 'challenge',
+    });
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-delivery-fail',
+      terminalStatus: 'failed',
+    });
+
+    // Non-guardian user sends a message
+    const req = makeInboundRequest({
+      content: 'do something sensitive',
+      senderExternalUserId: 'requester-user-fail',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for background async
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The run should have been auto-denied
+    const realId = (orchestrator as unknown as { realRunId: () => string }).realRunId();
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(realId, 'deny');
+
+    // The requester should be notified that approval could not be obtained
+    const denialNotice = deliverReplySpy.mock.calls.find(
+      (call) => typeof call[1]?.text === 'string' &&
+        call[1].text.includes('could not be sent to the guardian'),
+    );
+    expect(denialNotice).toBeDefined();
+
+    // No success notice ("has been sent to the guardian") should have been sent
+    // (the delivery failed, so the success notification should be skipped)
+    const successNotice = deliverReplySpy.mock.calls.find(
+      (call) => typeof call[1]?.text === 'string' &&
+        call[1].text.includes('has been sent to the guardian for approval'),
+    );
+    expect(successNotice).toBeUndefined();
+
+    deliverReplySpy.mockRestore();
+    deliverApprovalSpy.mockRestore();
+  });
+
+  test('delivery failure sets approval status to denied, preventing requester fallback', async () => {
+    const deliverReplySpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    // Make deliverApprovalPrompt throw
+    const deliverApprovalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    // Set up a guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-fail-2',
+      guardianDeliveryChatId: 'guardian-chat-fail-2',
+      verifiedVia: 'challenge',
+    });
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-delivery-fail-2',
+      terminalStatus: 'failed',
+    });
+
+    const req = makeInboundRequest({
+      content: 'do something sensitive',
+      senderExternalUserId: 'requester-user-fail-2',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for background async
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // After delivery failure, there should be no pending approval that the
+    // requester could exploit as a fallback path.
+    const realId = (orchestrator as unknown as { realRunId: () => string }).realRunId()!;
+    const pendingApproval = getPendingApprovalForRun(realId);
+    expect(pendingApproval).toBeNull();
+
+    // The unresolved approval (if any) should also not be in 'pending' status
+    const unresolvedApproval = getUnresolvedApprovalForRun(realId);
+    expect(unresolvedApproval).toBeNull();
+
+    deliverReplySpy.mockRestore();
+    deliverApprovalSpy.mockRestore();
   });
 });

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -46,7 +46,7 @@ const log = getLogger('runtime-http');
 // Actor role
 // ---------------------------------------------------------------------------
 
-export type ActorRole = 'guardian' | 'non-guardian';
+export type ActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
 
 export interface GuardianContext {
   actorRole: ActorRole;
@@ -323,6 +323,9 @@ export async function handleChannelInbound(
   // Determine whether the sender is the guardian for this channel.
   // When a guardian binding exists, non-guardian actors get stricter
   // side-effect controls and their approvals route to the guardian's chat.
+  // When NO binding exists and the sender is not the guardian, they are
+  // treated as 'unverified_channel' — sensitive actions are auto-denied
+  // (fail-closed) until a guardian is set up.
   let guardianCtx: GuardianContext = { actorRole: 'guardian' };
   if (isChannelApprovalsEnabled() && body.senderExternalUserId) {
     const senderIsGuardian = isGuardian('self', sourceChannel, body.senderExternalUserId);
@@ -337,6 +340,14 @@ export async function handleChannelInbound(
           guardianChatId: binding.guardianDeliveryChatId,
           guardianExternalUserId: binding.guardianExternalUserId,
           requesterIdentifier: requesterLabel,
+          requesterExternalUserId: body.senderExternalUserId,
+          requesterChatId: externalChatId,
+        };
+      } else {
+        // No guardian binding exists — treat as unverified so sensitive
+        // actions are denied rather than allowing self-approval.
+        guardianCtx = {
+          actorRole: 'unverified_channel',
           requesterExternalUserId: body.senderExternalUserId,
           requesterChatId: externalChatId,
         };
@@ -564,14 +575,17 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
+  const isUnverifiedChannel = guardianCtx.actorRole === 'unverified_channel';
 
   (async () => {
     try {
+      // Both non-guardian and unverified_channel actors get strict side-effect
+      // enforcement so all sensitive tools trigger the confirmation flow.
       const run = await orchestrator.startRun(
         conversationId,
         content,
         attachmentIds,
-        isNonGuardian ? { forceStrictSideEffects: true } : undefined,
+        (isNonGuardian || isUnverifiedChannel) ? { forceStrictSideEffects: true } : undefined,
       );
 
       // Poll the run until it reaches a terminal state, delivering approval
@@ -588,7 +602,26 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         if (current.status === 'needs_confirmation' && lastStatus !== 'needs_confirmation') {
           const pending = getPendingConfirmationsByConversation(conversationId);
 
-          if (isNonGuardian && guardianCtx.guardianChatId && pending.length > 0) {
+          if (isUnverifiedChannel && pending.length > 0) {
+            // Unverified channel (no guardian binding): auto-deny the sensitive
+            // action and tell the requester to set up a guardian first. This
+            // enforces fail-closed behavior — no self-approval for sensitive
+            // actions when no guardian has been configured.
+            const denyDecision: ApprovalDecisionResult = {
+              action: 'reject',
+              source: 'plain_text',
+            };
+            handleChannelDecision(conversationId, denyDecision, orchestrator);
+
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied. Please ask an admin to configure a guardian first.`,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, runId: run.id }, 'Failed to deliver unverified-channel denial notice');
+            }
+          } else if (isNonGuardian && guardianCtx.guardianChatId && pending.length > 0) {
             // Non-guardian actor: route the approval prompt to the guardian's chat
             const guardianPrompt = buildGuardianApprovalPrompt(
               pending[0],
@@ -623,9 +656,25 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               guardianNotified = true;
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver guardian approval prompt');
-              // Cancel the stale approval record so the requester is not
-              // permanently blocked by an approval the guardian never saw.
-              updateApprovalDecision(approvalReqRecord.id, { status: 'cancelled' });
+              // Guardian delivery failed — immediately deny the run so the
+              // requester cannot bypass guardian control. Mark the approval as
+              // 'denied' (not 'cancelled') to prevent any fallback path.
+              updateApprovalDecision(approvalReqRecord.id, { status: 'denied' });
+
+              const failDenyDecision: ApprovalDecisionResult = {
+                action: 'reject',
+                source: 'plain_text',
+              };
+              handleChannelDecision(conversationId, failDenyDecision, orchestrator);
+
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: guardianCtx.requesterChatId ?? externalChatId,
+                  text: `Your request to run "${pending[0].toolName}" could not be sent to the guardian for approval. The action has been denied.`,
+                }, bearerToken);
+              } catch (notifyErr) {
+                log.error({ err: notifyErr, runId: run.id }, 'Failed to notify requester of guardian delivery failure denial');
+              }
             }
 
             // Only notify the requester if the guardian prompt was actually delivered
@@ -877,6 +926,32 @@ async function handleApprovalInterception(
   // ── Standard approval interception (existing flow) ──
   const pendingPrompt = getChannelApprovalPrompt(conversationId);
   if (!pendingPrompt) return { handled: false };
+
+  // When the sender is on an unverified channel (no guardian binding),
+  // block self-approval entirely. The approval was already auto-denied in
+  // processChannelMessageWithApprovals, but this is a defense-in-depth
+  // check in case a pending confirmation somehow remains.
+  if (guardianCtx.actorRole === 'unverified_channel') {
+    const pending = getPendingConfirmationsByConversation(conversationId);
+    if (pending.length > 0) {
+      // Auto-deny and notify
+      const denyDecision: ApprovalDecisionResult = {
+        action: 'reject',
+        source: 'plain_text',
+      };
+      handleChannelDecision(conversationId, denyDecision, orchestrator);
+
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied. Please ask an admin to configure a guardian first.`,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver unverified-channel denial notice');
+      }
+      return { handled: true, type: 'decision_applied' };
+    }
+  }
 
   // When the sender is a non-guardian and there's a pending guardian approval
   // for this conversation's run, block self-approval. The non-guardian must


### PR DESCRIPTION
Part of #6686. Closes #6687.

## Summary
- Replace default guardian context with explicit `unverified_channel` when no binding exists
- Auto-deny sensitive actions for unverified channels instead of allowing self-approval
- When guardian prompt delivery fails, immediately deny the run instead of falling back to requester
- Add comprehensive tests for fail-closed behavior and delivery-failure denial

## Changes

### WS-1: Fail-closed guardian gate
- Added `unverified_channel` actor role to `ActorRole` type
- When channel approvals are enabled and no guardian binding exists, non-guardian users are assigned `unverified_channel` role instead of defaulting to `guardian`
- Unverified channel actors get `forceStrictSideEffects: true` so sensitive tools trigger confirmation
- When `needs_confirmation` is detected for an unverified channel, the action is auto-denied with a message to set up a guardian
- Defense-in-depth: `handleApprovalInterception` also blocks self-approval for unverified channel actors

### WS-2: Delivery-failure bypass elimination
- When `deliverApprovalPrompt` fails, the approval status is set to `denied` (not `cancelled`)
- The underlying run is immediately denied via `handleChannelDecision` with a reject action
- Requester is notified that approval could not be obtained and the action was denied
- No pending/unresolved approval records remain that could enable requester fallback

### Tests
- No-binding + sensitive request: auto-denies and calls `submitDecision` with `deny`
- No-binding + non-sensitive request: completes normally without denial
- Unverified channel self-approval blocked via approval interception
- Non-guardian with binding: routes to guardian (regression)
- Guardian actor: gets self-approval prompt (regression)
- Delivery failure: immediately denies run and notifies requester
- Delivery failure: no pending/unresolved approvals remain after failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
