### PR TITLE
M1: Enforce fail-closed guardian gate and eliminate delivery-failure bypass

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -49,6 +49,12 @@ import {
 import type { PendingConfirmation } from '../memory/runs-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import {
+  createBinding,
+  createApprovalRequest,
+  getPendingApprovalForRun,
+  getUnresolvedApprovalForRun,
+} from '../memory/channel-guardian-store.js';
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
@@ -79,6 +85,9 @@ function ensureConversation(conversationId: string): void {
 
 function resetTables(): void {
   const db = getDb();
+  db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM channel_guardian_verification_challenges');
+  db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM message_runs');
   db.run('DELETE FROM channel_inbound_events');
   db.run('DELETE FROM messages');
@@ -1633,5 +1642,382 @@ describe('plain-text fallback surfacing for non-rich channels', () => {
 
     deliverSpy.mockRestore();
     replySpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: orchestrator that creates real DB runs with pending confirmations
+// ---------------------------------------------------------------------------
+
+function makeSensitiveOrchestrator(opts: {
+  runId: string;
+  terminalStatus: 'completed' | 'failed';
+}): RunOrchestrator & { realRunId: () => string | undefined } {
+  let realRunId: string | undefined;
+  let pollCount = 0;
+  return {
+    submitDecision: mock(() => 'applied' as const),
+    getRun: mock(() => {
+      pollCount++;
+      if (pollCount === 1 && realRunId) {
+        return {
+          id: realRunId,
+          conversationId: 'conv-1',
+          messageId: null,
+          status: 'needs_confirmation' as const,
+          pendingConfirmation: sampleConfirmation,
+          pendingSecret: null,
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+      }
+      return {
+        id: realRunId ?? opts.runId,
+        conversationId: 'conv-1',
+        messageId: null,
+        status: opts.terminalStatus,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+    }),
+    startRun: mock(async (conversationId: string) => {
+      ensureConversation(conversationId);
+      const run = createRun(conversationId);
+      setRunConfirmation(run.id, sampleConfirmation);
+      realRunId = run.id;
+      return {
+        id: run.id,
+        conversationId,
+        messageId: null,
+        status: 'running' as const,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+    }),
+    realRunId: () => realRunId,
+  } as unknown as RunOrchestrator & { realRunId: () => string | undefined };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 18. Fail-closed guardian gate (WS-1)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('fail-closed guardian gate — unverified channel', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('no binding + sensitive action → auto-deny and setup notice', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-unv-1', terminalStatus: 'failed' });
+
+    // Non-guardian sender, no binding exists → unverified_channel
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'user-no-binding',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The run should have been denied (submitDecision called with deny)
+    expect(orchestrator.submitDecision).toHaveBeenCalled();
+    const decisionArgs = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls[0];
+    expect(decisionArgs[1]).toBe('deny');
+
+    // The requester should have been notified about missing guardian setup
+    const replyCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
+    );
+    expect(replyCalls.length).toBeGreaterThanOrEqual(1);
+
+    // No approval prompt should have been sent to a guardian (none exists)
+    expect(approvalSpy).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+
+  test('no binding + non-sensitive action → completes normally', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Orchestrator that completes without hitting needs_confirmation
+    const mockRun = {
+      id: 'run-unv-safe',
+      conversationId: 'conv-1',
+      messageId: null,
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => ({ ...mockRun, status: 'completed' as const })),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({
+      content: 'what time is it',
+      senderExternalUserId: 'user-no-binding',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // submitDecision should NOT have been called — no confirmation needed
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('unverified channel cannot self-approve via interception', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-unv-self', terminalStatus: 'failed' });
+
+    // First, send a message to establish the conversation and trigger
+    // the sensitive action (which will be auto-denied in the poll loop).
+    const initReq = makeInboundRequest({
+      content: 'do something',
+      senderExternalUserId: 'user-no-binding',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Now find the conversation
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Create another pending run in this conversation
+    const run2 = createRun(conversationId!);
+    setRunConfirmation(run2.id, sampleConfirmation);
+
+    deliverSpy.mockClear();
+
+    // Try to self-approve
+    const approveReq = makeInboundRequest({
+      content: 'approve',
+      senderExternalUserId: 'user-no-binding',
+    });
+
+    const res = await handleChannelInbound(approveReq, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+
+    // The denial notice should have been sent
+    const denialCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
+    );
+    expect(denialCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 19. Guardian-with-binding path regression
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian-with-binding path regression', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('non-guardian with binding routes approval to guardian chat', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-1',
+      guardianDeliveryChatId: 'guardian-chat-1',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-binding-1', terminalStatus: 'completed' });
+
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'non-guardian-user',
+      senderUsername: 'nongrd',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Approval prompt should have been sent to the guardian's chat
+    expect(approvalSpy).toHaveBeenCalled();
+    const approvalArgs = approvalSpy.mock.calls[0];
+    expect(approvalArgs[1]).toBe('guardian-chat-1');
+
+    // Requester should have been notified the request was sent to the guardian
+    const notifyCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('has been sent to the guardian for approval'),
+    );
+    expect(notifyCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+
+  test('guardian sender gets standard self-approval flow', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-2',
+      guardianDeliveryChatId: 'guardian-chat-2',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-binding-2', terminalStatus: 'completed' });
+
+    // Message from the guardian user — should get standard approval prompt
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'guardian-user-2',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Approval prompt should have been sent to the requester's own chat
+    // (standard self-approval flow, not routed to guardian)
+    expect(approvalSpy).toHaveBeenCalled();
+    const approvalArgs = approvalSpy.mock.calls[0];
+    // The chat ID should be the sender's own chat, not guardian-chat-2
+    expect(approvalArgs[1]).toBe('chat-123');
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 20. Guardian delivery failure denial (WS-2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian delivery failure → denial', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('delivery failure denies run and notifies requester', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-df',
+      guardianDeliveryChatId: 'guardian-chat-df',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    // Make the guardian approval prompt delivery fail
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockRejectedValue(
+      new Error('Network error: guardian unreachable'),
+    );
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-df-1', terminalStatus: 'failed' });
+
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'non-guardian-df-user',
+      senderUsername: 'nongrd_df',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The run should have been denied
+    expect(orchestrator.submitDecision).toHaveBeenCalled();
+    const decisionArgs = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls[0];
+    expect(decisionArgs[1]).toBe('deny');
+
+    // Requester should have been notified that delivery failed
+    const failureCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('could not be sent to the guardian for approval'),
+    );
+    expect(failureCalls.length).toBeGreaterThanOrEqual(1);
+
+    // The "has been sent to the guardian for approval" success notice should
+    // NOT have been delivered (since delivery failed).
+    const successCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('has been sent to the guardian for approval'),
+    );
+    expect(successCalls.length).toBe(0);
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+
+  test('no pending/unresolved approvals remain after delivery failure', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-df2',
+      guardianDeliveryChatId: 'guardian-chat-df2',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockRejectedValue(
+      new Error('Network error: guardian unreachable'),
+    );
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-df-2', terminalStatus: 'failed' });
+
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'non-guardian-df2-user',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Verify the run ID was created
+    const runId = orchestrator.realRunId();
+    expect(runId).toBeTruthy();
+
+    // After delivery failure, there should be NO pending approval for the run
+    const pendingApproval = getPendingApprovalForRun(runId!);
+    expect(pendingApproval).toBeNull();
+
+    // There should also be NO unresolved approval (it was set to 'denied')
+    const unresolvedApproval = getUnresolvedApprovalForRun(runId!);
+    expect(unresolvedApproval).toBeNull();
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
   });
 });

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -47,7 +47,7 @@ const log = getLogger('runtime-http');
 // Actor role
 // ---------------------------------------------------------------------------
 
-export type ActorRole = 'guardian' | 'non-guardian';
+export type ActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
 
 export interface GuardianContext {
   actorRole: ActorRole;
@@ -355,6 +355,14 @@ export async function handleChannelInbound(
           requesterExternalUserId: body.senderExternalUserId,
           requesterChatId: externalChatId,
         };
+      } else {
+        // No guardian binding configured for this channel — the sender is
+        // unverified. Sensitive actions will be auto-denied (fail-closed).
+        guardianCtx = {
+          actorRole: 'unverified_channel',
+          requesterExternalUserId: body.senderExternalUserId,
+          requesterChatId: externalChatId,
+        };
       }
     }
   }
@@ -584,6 +592,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
+  const isUnverifiedChannel = guardianCtx.actorRole === 'unverified_channel';
 
   (async () => {
     try {
@@ -592,7 +601,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         content,
         attachmentIds,
         {
-          ...(isNonGuardian ? { forceStrictSideEffects: true } : {}),
+          ...((isNonGuardian || isUnverifiedChannel) ? { forceStrictSideEffects: true } : {}),
           sourceChannel,
         },
       );
@@ -611,7 +620,18 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         if (current.status === 'needs_confirmation' && lastStatus !== 'needs_confirmation') {
           const pending = getPendingConfirmationsByConversation(conversationId);
 
-          if (isNonGuardian && guardianCtx.guardianChatId && pending.length > 0) {
+          if (isUnverifiedChannel && pending.length > 0) {
+            // No guardian binding — auto-deny the sensitive action (fail-closed).
+            handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied. Please ask an administrator to configure a guardian.`,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, runId: run.id }, 'Failed to deliver unverified-channel denial notice');
+            }
+          } else if (isNonGuardian && guardianCtx.guardianChatId && pending.length > 0) {
             // Non-guardian actor: route the approval prompt to the guardian's chat
             const guardianPrompt = buildGuardianApprovalPrompt(
               pending[0],
@@ -651,9 +671,20 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               guardianNotified = true;
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver guardian approval prompt');
-              // Cancel the stale approval record so the requester is not
-              // permanently blocked by an approval the guardian never saw.
-              updateApprovalDecision(approvalReqRecord.id, { status: 'cancelled' });
+              // Deny the approval and the underlying run — fail-closed. If
+              // the prompt could not be delivered, the guardian will never see
+              // it, so the safest action is to deny rather than cancel (which
+              // would allow requester fallback).
+              updateApprovalDecision(approvalReqRecord.id, { status: 'denied' });
+              handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: guardianCtx.requesterChatId ?? externalChatId,
+                  text: `Your request to run "${pending[0].toolName}" could not be sent to the guardian for approval. The action has been denied.`,
+                }, bearerToken);
+              } catch (notifyErr) {
+                log.error({ err: notifyErr, runId: run.id }, 'Failed to notify requester of guardian delivery failure');
+              }
             }
 
             // Only notify the requester if the guardian prompt was actually delivered
@@ -936,6 +967,24 @@ async function handleApprovalInterception(
   // ── Standard approval interception (existing flow) ──
   const pendingPrompt = getChannelApprovalPrompt(conversationId);
   if (!pendingPrompt) return { handled: false };
+
+  // When the sender is from an unverified channel (no guardian binding),
+  // auto-deny any pending confirmation and block self-approval.
+  if (guardianCtx.actorRole === 'unverified_channel') {
+    const pending = getPendingConfirmationsByConversation(conversationId);
+    if (pending.length > 0) {
+      handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied.`,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver unverified-channel denial notice during interception');
+      }
+      return { handled: true, type: 'decision_applied' };
+    }
+  }
 
   // When the sender is a non-guardian and there's a pending guardian approval
   // for this conversation's run, block self-approval. The non-guardian must


### PR DESCRIPTION
## Summary

Closes two security gaps in the Telegram guardian approval flow:

### WS-1: Fail-closed guardian gate
- When no guardian binding exists for a channel, the actor role is now set to `unverified_channel` instead of defaulting to `guardian` (which was fail-open).
- Sensitive actions (tool confirmations) from unverified channels are automatically denied with a message directing the admin to configure a guardian.
- Unverified channel users cannot self-approve pending confirmations.

### WS-2: Eliminate delivery-failure bypass
- When `deliverApprovalPrompt` fails (guardian unreachable), the approval status is now set to `denied` instead of `cancelled`.
- The underlying run is immediately denied via `handleChannelDecision`, preventing requester fallback.
- The requester is notified that their request could not be sent to the guardian.

## Test plan
- [x] 7 new tests covering both work streams (suites 18-20)
- [x] All 46 existing + new tests pass
- [x] Type-check passes (no new errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
