### PR TITLE
fix: preserve tool-call detection when user queues follow-up during active tool call

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -510,8 +510,20 @@ struct ChatView: View {
                         // still sending, the assistant hasn't started responding
                         // yet. Return an empty slice so stale tool calls from
                         // the prior turn don't suppress the thinking indicator.
+                        // However, if the user queued a follow-up while the
+                        // assistant is still processing (assistant messages
+                        // exist after the most recent turn-starting user
+                        // message), fall through to the lastTurnStart logic
+                        // so active tool calls remain visible.
                         if isSending, let last = displayMessages.last, last.role == .user {
-                            return displayMessages[displayMessages.endIndex...]
+                            let hasAssistantAfterLastUser = displayMessages.indices.reversed().contains(where: { idx in
+                                displayMessages[idx].role == .user
+                                    && displayMessages.index(after: idx) < displayMessages.endIndex
+                                    && displayMessages[displayMessages.index(after: idx)].role != .user
+                            })
+                            if !hasAssistantAfterLastUser {
+                                return displayMessages[displayMessages.endIndex...]
+                            }
                         }
                         // Find the boundary of the current assistant turn by
                         // locating the last user message that is followed by at


### PR DESCRIPTION
Refines the early return in currentTurnMessages to only return empty when the assistant truly hasn't started responding. When the user queues a follow-up while the assistant has active tool calls, the code now falls through to the existing lastTurnStart logic to preserve tool-call detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
