### PR TITLE
fix: correct twilio_config action descriptions to match actual behavior

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -164,8 +164,8 @@ The daemon handles `twilio_config` messages with the following actions:
 |--------|-------------|
 | `get` | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned) |
 | `set_credentials` | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file). Credentials are retrieved from the credential store internally. |
-| `clear_credentials` | Removes stored Account SID, Auth Token, and phone number assignment |
-| `provision_number` | Provisions a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Auto-assigns the provisioned number. |
+| `clear_credentials` | Removes stored Account SID and Auth Token from secure storage. Does not affect the phone number assignment. |
+| `provision_number` | Purchases a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Returns the purchased number but does not assign it — call `assign_number` separately to persist it. |
 | `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant |
 | `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
 


### PR DESCRIPTION
Updates the twilio_config documentation table in README.md to accurately reflect what each action does in the code, fixing misleading descriptions for clear_credentials and provision_number.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
