### PR TITLE
fix: make twilio-setup prerequisite install idempotent in phone-calls skill

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -12,7 +12,7 @@ You are helping the user set up and make outgoing phone calls via Twilio. This s
 
 Twilio credentials and phone number configuration are shared between voice calls and SMS messaging. If Twilio is not yet configured, install and load the **twilio-setup** skill first:
 
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "twilio-setup"`.
+- Call `vellum_skills_catalog` with `action: "install"`, `skill_id: "twilio-setup"`, and `overwrite: true` (so it succeeds even if already installed).
 - Then call `skill_load` with `skill: "twilio-setup"`.
 
 The twilio-setup skill handles credential storage, phone number provisioning/assignment, and public ingress setup. Once complete, return here to enable the calls feature and start making calls.


### PR DESCRIPTION
Makes the twilio-setup prerequisite install idempotent so it doesn't error when the skill is already installed. Users re-running phone-call setup will no longer hit a failure on the prerequisite step.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
