### PR TITLE
fix: clean up phone number on clear_credentials and validate setSecureKey in assign_number

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1193,6 +1193,7 @@ export async function handleTwilioConfig(
     } else if (msg.action === 'clear_credentials') {
       deleteSecureKey('credential:twilio:account_sid');
       deleteSecureKey('credential:twilio:auth_token');
+      deleteSecureKey('credential:twilio:phone_number');
       deleteCredentialMetadata('twilio', 'account_sid');
       deleteCredentialMetadata('twilio', 'auth_token');
 
@@ -1250,7 +1251,16 @@ export async function handleTwilioConfig(
 
       // Persist the phone number in the secure credential store so the
       // active Twilio runtime can read it via credential:twilio:phone_number
-      setSecureKey('credential:twilio:phone_number', msg.phoneNumber);
+      const phoneStored = setSecureKey('credential:twilio:phone_number', msg.phoneNumber);
+      if (!phoneStored) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: hasTwilioCredentials(),
+          error: 'Failed to store phone number in secure storage',
+        });
+        return;
+      }
 
       // Also persist in assistant config (non-secret) for the UI
       const raw = loadRawConfig();


### PR DESCRIPTION
1. Adds deleteSecureKey for phone_number in clear_credentials to prevent orphaned credentials. 2. Checks setSecureKey return value for phone_number in assign_number, matching the existing pattern for account_sid and auth_token.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
