### PR TITLE
fix: add reserve/unreserve dedup pattern to SMS webhook to prevent race condition

### DIFF
--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -132,9 +132,15 @@ export class DedupCache {
  * Simple string-keyed TTL set for deduplication.
  * Used for SMS MessageSid dedup where we only need to track whether
  * a message ID has been seen, not cache a full response.
+ *
+ * Supports a reserve/unreserve pattern to prevent concurrent duplicates
+ * during async processing windows (matching the DedupCache pattern used
+ * by the Telegram webhook).
  */
 export class StringDedupCache {
   private cache = new Map<string, number>();
+  /** Keys that have been reserved but not yet finalized via mark(). */
+  private processing = new Set<string>();
   private readonly ttlMs: number;
   private readonly maxSize: number;
 
@@ -154,11 +160,11 @@ export class StringDedupCache {
   }
 
   /**
-   * Returns true if the key is already in the cache (within the TTL window),
-   * without marking it as seen. Use this for a read-only check when you want
-   * to defer marking until after successful processing.
+   * Returns true if the key is already in the cache (within the TTL window)
+   * or is currently reserved for processing. Use this for a read-only check.
    */
   has(key: string): boolean {
+    if (this.processing.has(key)) return true;
     const now = Date.now();
     const expiresAt = this.cache.get(key);
     if (expiresAt !== undefined) {
@@ -169,10 +175,35 @@ export class StringDedupCache {
   }
 
   /**
+   * Atomically checks whether a key is already reserved or cached, and if
+   * not, claims it so concurrent requests for the same key are blocked.
+   * Returns true if a new reservation was created (caller should proceed),
+   * false if the key was already present (caller should short-circuit).
+   *
+   * Call {@link mark} after successful processing to finalize, or
+   * {@link unreserve} on failure so retries are not blocked.
+   */
+  reserve(key: string): boolean {
+    if (this.has(key)) return false;
+    this.processing.add(key);
+    return true;
+  }
+
+  /**
+   * Remove a reserved-but-not-finalized key so that retries are not blocked
+   * after a processing failure.
+   */
+  unreserve(key: string): void {
+    this.processing.delete(key);
+  }
+
+  /**
    * Marks a key as seen. Call this after successful processing to prevent
    * future duplicates while still allowing retries on failure.
+   * Also clears any in-flight reservation for the key.
    */
   mark(key: string): void {
+    this.processing.delete(key);
     const now = Date.now();
 
     // Evict expired entries if at capacity

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -72,9 +72,10 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Missing MessageSid" }, { status: 400 });
     }
 
-    // Dedup by MessageSid — check only, defer marking until after successful forwarding
-    // so Twilio retries are not suppressed when downstream handling fails.
-    if (dedupCache.has(messageSid)) {
+    // Dedup by MessageSid — atomically reserve the key so concurrent retries
+    // are blocked even while the first request is still processing.
+    // On failure, unreserve() allows Twilio retries; on success, mark() finalizes.
+    if (!dedupCache.reserve(messageSid)) {
       tlog.info({ messageSid }, "Duplicate MessageSid, ignoring");
       return Response.json({ ok: true });
     }
@@ -123,6 +124,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
 
       if (!result.forwarded) {
         tlog.error({ messageSid }, "Failed to forward SMS to runtime");
+        dedupCache.unreserve(messageSid);
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
 
@@ -131,6 +133,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       tlog.info({ status: "forwarded", messageSid }, "SMS forwarded to runtime");
     } catch (err) {
       tlog.error({ err, messageSid }, "Failed to process inbound SMS");
+      dedupCache.unreserve(messageSid);
       return Response.json({ error: "Internal error" }, { status: 500 });
     }
 


### PR DESCRIPTION
Replaces the has()/mark() dedup pattern with an atomic reserve/unreserve pattern (matching the Telegram webhook) to prevent concurrent Twilio retries from both passing the dedup check during the async handleInbound gap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
