### PR TITLE
fix: re-derive strictSideEffects default when no override to prevent stale flag across runs

### DIFF
--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -66,6 +66,7 @@ function makeSessionEmittingViaClient(...messages: ServerMessage[]): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
@@ -87,6 +88,7 @@ function makeSessionEmittingViaAgentLoop(...messages: ServerMessage[]): Session 
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
@@ -130,6 +132,7 @@ describe('HTTP run → confirmation_request mirrors to assistant-events hub', ()
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'Do something');
@@ -176,6 +179,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'Hello');
@@ -209,6 +213,7 @@ describe('HTTP run → message flow mirrors to assistant-events hub', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'ping');

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -41,6 +41,7 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     // Return undefined so createRun stores messageId as null and avoids
     // a foreign-key dependency on the conversation-store message table.
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
@@ -61,6 +62,7 @@ function makeSessionWithEvent(message: ServerMessage): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
@@ -91,6 +93,7 @@ describe('run failure detection', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Hello');
@@ -113,6 +116,7 @@ describe('run failure detection', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Hello');
@@ -191,6 +195,7 @@ describe('run approval state executionTarget', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Run host command');
@@ -231,6 +236,7 @@ describe('startRun channel capability resolution', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'Hello from Telegram', undefined, {
@@ -264,6 +270,7 @@ describe('startRun channel capability resolution', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'Hello from HTTP');
@@ -293,6 +300,7 @@ describe('startRun channel capability resolution', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => session,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     await orchestrator.startRun(conversation.id, 'Hello with options', undefined, {
@@ -303,5 +311,115 @@ describe('startRun channel capability resolution', () => {
 
     expect(capturedCapabilities).not.toBeNull();
     expect(capturedCapabilities!.channel).toBe('http-api');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// strictSideEffects re-derivation prevents stale flag across runs
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('strictSideEffects re-derivation across runs', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('forceStrictSideEffects=true does not persist to subsequent run without override', async () => {
+    const conversation = createConversation('stale strict test');
+
+    // Shared session simulating a cached session reused across runs
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+
+    // First run: force strict mode on
+    await orchestrator.startRun(conversation.id, 'non-guardian message', undefined, {
+      forceStrictSideEffects: true,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect((session as unknown as { memoryPolicy: { strictSideEffects: boolean } }).memoryPolicy.strictSideEffects).toBe(true);
+
+    // Second run: no override — should reset to derived default (false)
+    await orchestrator.startRun(conversation.id, 'guardian message');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect((session as unknown as { memoryPolicy: { strictSideEffects: boolean } }).memoryPolicy.strictSideEffects).toBe(false);
+  });
+
+  test('private thread re-derives strictSideEffects=true when no override', async () => {
+    const conversation = createConversation('private thread strict test');
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'private-scope', includeDefaultFallback: true, strictSideEffects: true },
+      setChannelCapabilities: () => {},
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      // Simulate private thread → default is true
+      deriveDefaultStrictSideEffects: () => true,
+    });
+
+    // Run with explicit false override
+    await orchestrator.startRun(conversation.id, 'override to false', undefined, {
+      forceStrictSideEffects: false,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect((session as unknown as { memoryPolicy: { strictSideEffects: boolean } }).memoryPolicy.strictSideEffects).toBe(false);
+
+    // Run without override — should re-derive to true (private thread)
+    await orchestrator.startRun(conversation.id, 'no override');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect((session as unknown as { memoryPolicy: { strictSideEffects: boolean } }).memoryPolicy.strictSideEffects).toBe(true);
+  });
+
+  test('explicit forceStrictSideEffects=false sets strict to false', async () => {
+    const conversation = createConversation('explicit false test');
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: true },
+      setChannelCapabilities: () => {},
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => true,
+    });
+
+    await orchestrator.startRun(conversation.id, 'force off', undefined, {
+      forceStrictSideEffects: false,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect((session as unknown as { memoryPolicy: { strictSideEffects: boolean } }).memoryPolicy.strictSideEffects).toBe(false);
   });
 });

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -58,6 +58,7 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
@@ -73,6 +74,7 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
@@ -87,6 +89,7 @@ function makeConfirmationSession(toolName: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
@@ -113,6 +116,7 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
@@ -152,6 +156,7 @@ describe('runtime runs — HTTP layer', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => sessionFactory(),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
     server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN, runOrchestrator: orchestrator });
     await server.start();

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -48,6 +48,7 @@ function makeCompletingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
@@ -66,6 +67,7 @@ function makeHangingSession(): Session {
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
@@ -82,6 +84,7 @@ function makeFailingSession(errorMsg: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
@@ -97,6 +100,7 @@ function makeConfirmationSession(toolName: string): Session {
   return {
     isProcessing: () => false,
     persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
@@ -140,6 +144,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeCompletingSession(),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Build a feature');
@@ -157,6 +162,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeFailingSession('Swarm backend unavailable'),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Run swarm');
@@ -173,6 +179,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeConfirmationSession('swarm_delegate'),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Delegate a swarm task');
@@ -190,6 +197,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeConfirmationSession('swarm_delegate'),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     const run = await orchestrator.startRun(conversation.id, 'Run with approval');
@@ -214,6 +222,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => hangingSession,
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
 
     // First run starts and hangs
@@ -234,6 +243,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeCompletingSession(),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
     expect(orchestrator.getRun('nonexistent-id')).toBeNull();
   });
@@ -242,6 +252,7 @@ describe('runtime runs — swarm lifecycle', () => {
     const orchestrator = new RunOrchestrator({
       getOrCreateSession: async () => makeCompletingSession(),
       resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
     });
     const result = orchestrator.submitDecision('nonexistent-id', 'allow');
     expect(result).toBe('run_not_found');

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1192,6 +1192,8 @@ export class DaemonServer {
           mimeType: a.mimeType,
           data: a.dataBase64,
         })),
+      deriveDefaultStrictSideEffects: (conversationId) =>
+        this.deriveMemoryPolicy(conversationId).strictSideEffects,
     });
   }
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -44,6 +44,13 @@ export interface RunOrchestratorDeps {
     mimeType: string;
     data: string;
   }>;
+  /**
+   * Re-derive the default `strictSideEffects` value for a conversation
+   * from its thread type (e.g. private → true, standard → false).
+   * Called when `forceStrictSideEffects` is not explicitly provided so
+   * the session never retains a stale override from a prior run.
+   */
+  deriveDefaultStrictSideEffects: (conversationId: string) => boolean;
 }
 
 export interface RunStartOptions {
@@ -103,17 +110,17 @@ export class RunOrchestrator {
       throw new Error('Session is already processing a message');
     }
 
-    // Only override strictSideEffects when the caller explicitly requests it
-    // (e.g. guardian-gated channels forcing strict mode on for non-guardian
-    // actors). When not provided, preserve the session's existing memory
-    // policy — this avoids clobbering conversation-level defaults such as
-    // private-thread policies derived in server.ts.
-    if (options?.forceStrictSideEffects !== undefined) {
-      session.memoryPolicy = {
-        ...session.memoryPolicy,
-        strictSideEffects: options.forceStrictSideEffects,
-      };
-    }
+    // Determine the correct strictSideEffects value for this run:
+    // - explicit true/false from the caller → use that value
+    // - undefined → re-derive from the conversation's thread type so a
+    //   prior run's forceStrictSideEffects=true doesn't stick on the
+    //   cached session (private threads → true, standard → false)
+    const strictSideEffects = options?.forceStrictSideEffects
+      ?? this.deps.deriveDefaultStrictSideEffects(conversationId);
+    session.memoryPolicy = {
+      ...session.memoryPolicy,
+      strictSideEffects,
+    };
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)


### PR DESCRIPTION
Fixes the stale strictSideEffects flag issue where a prior run with forceStrictSideEffects: true leaves the session in strict mode for later runs. When forceStrictSideEffects is undefined, we now re-derive the default from the session's original memory policy instead of preserving the potentially-stale value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
