### PR TITLE
fix: finalize dedup reservation on SMS rejection paths

### DIFF
--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -104,6 +104,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         { from: params.From, reason: routing.reason },
         "Routing rejected inbound SMS",
       );
+      dedupCache.mark(messageSid);
       return Response.json({ ok: true });
     }
 
@@ -119,6 +120,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           { from: params.From, reason: result.rejectionReason },
           "Routing rejected inbound SMS",
         );
+        dedupCache.mark(messageSid);
         return Response.json({ ok: true });
       }
 


### PR DESCRIPTION
Addresses review feedback on #6721. Adds dedupCache.mark(messageSid) on the routing rejection and result.rejected paths to prevent permanent reservation leaks in the processing Set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
