### PR TITLE
fix: address review feedback on safe-blitz sequential milestones (#6706)

### DIFF
--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -5,6 +5,7 @@ Arguments (optional): $ARGUMENTS
 Parse optional flags from `$ARGUMENTS`:
 
 - **`--namespace NAME`** (optional): when provided, only process PRs whose head branch starts with `swarm/<NAME>/`. Any TODO items added will be prefixed with `[<NAME>]` (e.g., `- [<NAME>] Address the feedback on <link>`). When omitted, process all PRs. TODO items will still be namespaced if the PR's branch name matches `swarm/<NAME>/...` (the namespace is inferred from the branch).
+- **`--branch NAME`** (optional): the branch to check for CI failures in Phase 2 (default: `main`). Use this when PRs merge into a branch other than main (e.g., a feature branch in safe-blitz).
 
 To check a PR's head branch name, include `headRefName` in the `--json` fields when fetching PR data.
 
@@ -112,15 +113,17 @@ Do NOT continue processing remaining PRs until the user responds.
 
 ## Phase 2: Check for merged PRs with CI failures
 
-After processing all items in UNREVIEWED_PRS.md, check for recently merged PRs where CI failed on the main branch.
+After processing all items in UNREVIEWED_PRS.md, check for recently merged PRs where CI failed on the target branch.
 
 **If `--namespace` was provided**: only consider CI failures from PRs whose head branch started with `swarm/<namespace>/`. Skip failures from unrelated PRs.
 
 ### How to detect CI failures
 
-Run: `gh run list --branch main --status failure --limit 10 --json databaseId,headSha,displayTitle,url,conclusion,createdAt,event`
+Use the branch specified by `--branch` (default: `main`):
 
-This returns failed workflow runs on main. For each failed run:
+Run: `gh run list --branch <branch-name> --status failure --limit 10 --json databaseId,headSha,displayTitle,url,conclusion,createdAt,event`
+
+This returns failed workflow runs on the target branch. For each failed run:
 
 1. **Find the associated PR**: Use `gh pr list --state merged --search "<headSha>" --json number,url,title,mergedAt,headRefName --limit 1` or cross-reference the run's `displayTitle` / `headSha` with merged PRs. If you can't find a matching PR, use the run URL directly.
 2. **Namespace filter**: If `--namespace` was provided, check the PR's `headRefName`. Skip this failure if the branch does NOT start with `swarm/<namespace>/`.
@@ -134,7 +137,7 @@ This returns failed workflow runs on main. For each failed run:
 
 Append a second table to the output:
 
-**CI Failures on main:**
+**CI Failures on `<branch-name>`:**
 
 | Run | PR | Title | Age | Added to TODO |
 | --- | --- | ----- | --- | ------------- |
@@ -145,6 +148,6 @@ Append a second table to the output:
 - **Age**: How long ago the run was created
 - **Added to TODO**: ✅ if added, `dup` if already in TODO, — if skipped for other reasons
 
-If there are no CI failures on main, print: "No CI failures on main. ✅"
+If there are no CI failures on the target branch, print: "No CI failures on `<branch-name>`. ✅"
 
 IMPORTANT: .private/TODO.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md and .private/UNREVIEWED_PRS.md are gitignored.

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -59,7 +59,10 @@ When presenting the plan for approval, also show:
 
 ## Phase 3: Prepare Milestone List
 
-Do NOT use `.claude/phases/populate-todo.md` here. Instead, maintain an internal ordered list of milestones from the plan (M1, M2, ..., MN) with their titles and GitHub issue numbers. These milestones will be executed **one at a time** in Phase 4 — do NOT write them all to TODO.md at once.
+Do NOT use `.claude/phases/populate-todo.md` here. Instead, maintain an internal ordered list of milestones (M1, M2, ..., MN) with their titles and GitHub issue numbers. These milestones will be executed **one at a time** in Phase 4 — do NOT write them all to TODO.md at once.
+
+- **If planning was performed** (no `--skip-plan`): use the milestones from the plan created in Phase 2.
+- **If `--skip-plan` was passed**: use the milestones fetched from existing "Ready" issues in Phase 2 (see `.claude/phases/plan-and-spec.md` skip-plan path). Order them by issue number (ascending) unless a dependency order is apparent from the issue descriptions.
 
 ## Phase 4: Execute Milestones with Review Gates
 
@@ -150,11 +153,11 @@ For "Fix CI failures from merged PR <PR URL> (run: <run URL>)" tasks:
 
 #### 4c. Per-milestone recursive sweep
 
-Run the recursive sweep (`.claude/phases/sweep.md`) with `--namespace <namespace>`. **Skip the entry pause** — treat as `--auto` for per-milestone sweeps. The user-facing pause only applies to the final sweep in Phase 5.
+Run the recursive sweep (`.claude/phases/sweep.md`) with `--namespace <namespace>` and `--branch <feature-branch-name>`. **Skip the entry pause** — treat as `--auto` for per-milestone sweeps. The user-facing pause only applies to the final sweep in Phase 5.
 
 When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/commands/swarm.md`) with these modifications:
 - Pass `--namespace <namespace>` so only namespaced feedback items are processed.
-- Pass the `--workers` count (or default: 12).
+- Pass the worker count as the first positional argument (or default: 12), e.g., `.claude/commands/swarm.md 12 --namespace <namespace>`.
 - All agents must use `--base <feature-branch-name>` (not main).
 - Create worktrees from the feature branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<feature-branch-name>`.
 
@@ -175,7 +178,7 @@ When the sweep says "final phase," proceed to step 4d.
 
 After all milestones are merged and their individual reviews are clean, run one final recursive sweep on the entire feature branch.
 
-Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>`. Unless `--auto` was passed, this is where the user-facing pause happens: **"All milestones complete. Run final sweep for review feedback?"**
+Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>` and `--branch <feature-branch-name>`. Unless `--auto` was passed, this is where the user-facing pause happens: **"All milestones complete. Run final sweep for review feedback?"**
 
 This final sweep catches:
 - Any cross-milestone issues that individual per-milestone sweeps missed

--- a/.claude/phases/sweep.md
+++ b/.claude/phases/sweep.md
@@ -14,7 +14,7 @@ The blitz is NOT done until there is zero remaining feedback or transitive feedb
 
 Repeat the following until the exit condition is met:
 
-1. **Run check-reviews**: Read and follow `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace.
+1. **Run check-reviews**: Read and follow `.claude/commands/check-reviews.md`, passing `--namespace <namespace>` so that only PRs from this blitz are checked and any TODO items added are prefixed with the namespace. If a `--branch` was provided to the sweep (e.g., from safe-blitz), also pass `--branch <branch-name>` to check-reviews so CI failures are checked on the correct branch instead of main.
 
 2. **Check for new action items**: After check-reviews completes, read `.private/TODO.md`:
    - If new `[<namespace>]`-prefixed "Address the feedback" or "Fix CI failures" items were added, go back to the Swarm phase to address them. When swarm finishes, return here and restart the sweep loop from step 1 (the new feedback PRs will be in UNREVIEWED_PRS.md and need their own reviews).


### PR DESCRIPTION
Addresses review feedback on #6706.

## Changes
- Add `--branch NAME` flag to check-reviews.md so CI failure detection uses the correct branch instead of hardcoding `main` (fixes Devin's bug report about feature-branch CI failures being invisible)
- Pass `--branch <feature-branch-name>` from safe-blitz sweep invocations (Phase 4c and Phase 5) through sweep.md to check-reviews
- Add explicit `--skip-plan` fallback in Phase 3 to use milestones fetched from Ready issues in Phase 2 (fixes Codex P1)
- Fix swarm worker count instruction to use positional argument instead of `--workers` flag, matching swarm.md's actual interface (fixes Codex P2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
