### PR TITLE
M2: Harden guardian decision scoping and timeout closure (#6688)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -54,9 +54,15 @@ import {
   createApprovalRequest,
   getPendingApprovalForRun,
   getUnresolvedApprovalForRun,
+  getExpiredPendingApprovals,
+  updateApprovalDecision,
 } from '../memory/channel-guardian-store.js';
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
-import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
+import {
+  handleChannelInbound,
+  isChannelApprovalsEnabled,
+  sweepExpiredGuardianApprovals,
+} from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
 
 initializeDb();
@@ -2019,5 +2025,286 @@ describe('guardian delivery failure → denial', () => {
 
     deliverSpy.mockRestore();
     approvalSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 21. Guardian decision scoping — callback for older run resolves correctly
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian decision scoping — multiple pending approvals', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('callback for older run resolves to the correct approval request', async () => {
+    // Set up a guardian binding so the guardian actor role is recognized
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-scope-user',
+      guardianDeliveryChatId: 'guardian-scope-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create two approval requests for different runs, both targeting the
+    // same guardian chat. The older run (run-older) was created first.
+    const olderConvId = 'conv-scope-older';
+    const newerConvId = 'conv-scope-newer';
+    ensureConversation(olderConvId);
+    ensureConversation(newerConvId);
+
+    const olderRun = createRun(olderConvId);
+    setRunConfirmation(olderRun.id, sampleConfirmation);
+    createApprovalRequest({
+      runId: olderRun.id,
+      conversationId: olderConvId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-a',
+      requesterChatId: 'chat-requester-a',
+      guardianExternalUserId: 'guardian-scope-user',
+      guardianChatId: 'guardian-scope-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const newerRun = createRun(newerConvId);
+    setRunConfirmation(newerRun.id, sampleConfirmation);
+    createApprovalRequest({
+      runId: newerRun.id,
+      conversationId: newerConvId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-b',
+      requesterChatId: 'chat-requester-b',
+      guardianExternalUserId: 'guardian-scope-user',
+      guardianChatId: 'guardian-scope-chat',
+      toolName: 'browser',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // The guardian clicks the approval button for the OLDER run
+    const req = makeInboundRequest({
+      content: '',
+      externalChatId: 'guardian-scope-chat',
+      callbackData: `apr:${olderRun.id}:approve_once`,
+      senderExternalUserId: 'guardian-scope-user',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // The older run's approval should have been resolved
+    const olderApproval = getPendingApprovalForRun(olderRun.id);
+    expect(olderApproval).toBeNull();
+
+    // The newer run's approval should still be pending (untouched)
+    const newerApproval = getPendingApprovalForRun(newerRun.id);
+    expect(newerApproval).not.toBeNull();
+    expect(newerApproval!.status).toBe('pending');
+
+    // Verify the decision was applied to the correct (older) run's conversation
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(olderRun.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 22. Ambiguous plain-text decision with multiple pending requests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ambiguous plain-text decision with multiple pending requests', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('does not apply plain-text decision to wrong run when multiple pending', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-ambig-user',
+      guardianDeliveryChatId: 'guardian-ambig-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create two pending approval requests targeting the same guardian chat
+    const convA = 'conv-ambig-a';
+    const convB = 'conv-ambig-b';
+    ensureConversation(convA);
+    ensureConversation(convB);
+
+    const runA = createRun(convA);
+    setRunConfirmation(runA.id, sampleConfirmation);
+    createApprovalRequest({
+      runId: runA.id,
+      conversationId: convA,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-x',
+      requesterChatId: 'chat-requester-x',
+      guardianExternalUserId: 'guardian-ambig-user',
+      guardianChatId: 'guardian-ambig-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const runB = createRun(convB);
+    setRunConfirmation(runB.id, sampleConfirmation);
+    createApprovalRequest({
+      runId: runB.id,
+      conversationId: convB,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-y',
+      requesterChatId: 'chat-requester-y',
+      guardianExternalUserId: 'guardian-ambig-user',
+      guardianChatId: 'guardian-ambig-chat',
+      toolName: 'browser',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian sends plain-text "yes" — ambiguous because two approvals are pending
+    const req = makeInboundRequest({
+      content: 'yes',
+      externalChatId: 'guardian-ambig-chat',
+      senderExternalUserId: 'guardian-ambig-user',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // Neither approval should have been resolved — disambiguation was required
+    const approvalA = getPendingApprovalForRun(runA.id);
+    const approvalB = getPendingApprovalForRun(runB.id);
+    expect(approvalA).not.toBeNull();
+    expect(approvalB).not.toBeNull();
+
+    // submitDecision should NOT have been called — no decision was applied
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // A disambiguation message should have been sent to the guardian
+    const disambigCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('pending approval requests'),
+    );
+    expect(disambigCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 23. Expired guardian approval auto-denies and transitions to terminal status
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('expired guardian approval auto-denies via sweep', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('sweepExpiredGuardianApprovals auto-denies and notifies both parties', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create a guardian approval that is already expired
+    const convId = 'conv-expiry-sweep';
+    ensureConversation(convId);
+
+    const run = createRun(convId);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: convId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-exp',
+      requesterChatId: 'chat-requester-exp',
+      guardianExternalUserId: 'guardian-exp-user',
+      guardianChatId: 'guardian-exp-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() - 1000, // already expired
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Run the sweep
+    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test/deliver', 'token');
+
+    // Wait for async notifications
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // The run should have been denied
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    // The approval should no longer be pending
+    const pendingApproval = getPendingApprovalForRun(run.id);
+    expect(pendingApproval).toBeNull();
+
+    // There should be no unresolved approval — it was set to 'expired'
+    const unresolvedApproval = getUnresolvedApprovalForRun(run.id);
+    expect(unresolvedApproval).toBeNull();
+
+    // Both requester and guardian should have been notified
+    const requesterNotify = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { chatId?: string }).chatId === 'chat-requester-exp' &&
+        (call[1] as { text?: string }).text?.includes('expired'),
+    );
+    expect(requesterNotify.length).toBeGreaterThanOrEqual(1);
+
+    const guardianNotify = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { chatId?: string }).chatId === 'guardian-exp-chat' &&
+        (call[1] as { text?: string }).text?.includes('expired'),
+    );
+    expect(guardianNotify.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+
+  test('non-expired approvals are not affected by the sweep', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const convId = 'conv-not-expired';
+    ensureConversation(convId);
+
+    const run = createRun(convId);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: convId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-ne',
+      requesterChatId: 'chat-requester-ne',
+      guardianExternalUserId: 'guardian-ne-user',
+      guardianChatId: 'guardian-ne-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000, // still valid
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test/deliver', 'token');
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // The approval should still be pending
+    const pendingApproval = getPendingApprovalForRun(run.id);
+    expect(pendingApproval).not.toBeNull();
+    expect(pendingApproval!.status).toBe('pending');
+
+    // submitDecision should NOT have been called
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
   });
 });

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -8,7 +8,7 @@
  * requests track per-run guardian approval decisions.
  */
 
-import { and, desc, eq, gt } from 'drizzle-orm';
+import { and, desc, eq, gt, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import {
@@ -410,6 +410,89 @@ export function getPendingApprovalByGuardianChat(
     .get();
 
   return row ? rowToApprovalRequest(row) : null;
+}
+
+/**
+ * Find a pending guardian approval request scoped to a specific run,
+ * guardian chat, and channel. Used when a callback button provides a run ID,
+ * so the decision is applied to exactly the right approval even when
+ * multiple approvals target the same guardian chat.
+ */
+export function getPendingApprovalByRunAndGuardianChat(
+  runId: string,
+  channel: string,
+  guardianChatId: string,
+): GuardianApprovalRequest | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.runId, runId),
+        eq(channelGuardianApprovalRequests.channel, channel),
+        eq(channelGuardianApprovalRequests.guardianChatId, guardianChatId),
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToApprovalRequest(row) : null;
+}
+
+/**
+ * Return all pending (non-expired) guardian approval requests for a given
+ * guardian chat and channel. Used to detect ambiguity when a guardian sends
+ * a plain-text decision while multiple approvals are pending.
+ */
+export function getAllPendingApprovalsByGuardianChat(
+  channel: string,
+  guardianChatId: string,
+): GuardianApprovalRequest[] {
+  const db = getDb();
+  const now = Date.now();
+
+  const rows = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.channel, channel),
+        eq(channelGuardianApprovalRequests.guardianChatId, guardianChatId),
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .orderBy(desc(channelGuardianApprovalRequests.createdAt))
+    .all();
+
+  return rows.map(rowToApprovalRequest);
+}
+
+/**
+ * Return all pending approval requests whose expiresAt has passed.
+ * Used by the proactive expiry sweep to auto-deny expired approvals
+ * without waiting for requester follow-up traffic.
+ */
+export function getExpiredPendingApprovals(): GuardianApprovalRequest[] {
+  const db = getDb();
+  const now = Date.now();
+
+  const rows = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        lte(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .all();
+
+  return rows.map(rowToApprovalRequest);
 }
 
 export function updateApprovalDecision(

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -20,8 +20,11 @@ import {
 import {
   createApprovalRequest,
   getPendingApprovalByGuardianChat,
+  getPendingApprovalByRunAndGuardianChat,
+  getAllPendingApprovalsByGuardianChat,
   getPendingApprovalForRun,
   getUnresolvedApprovalForRun,
+  getExpiredPendingApprovals,
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
 import { deliverChannelReply, deliverApprovalPrompt } from '../gateway-client.js';
@@ -837,7 +840,51 @@ async function handleApprovalInterception(
     guardianCtx.actorRole === 'guardian' &&
     senderExternalUserId
   ) {
-    const guardianApproval = getPendingApprovalByGuardianChat(sourceChannel, externalChatId);
+    // First, try to parse the inbound payload to determine if it carries
+    // a run ID (callback button) or is plain text. This governs how we
+    // look up the target approval request.
+    let decision: ApprovalDecisionResult | null = null;
+    if (callbackData) {
+      decision = parseCallbackData(callbackData);
+    }
+    if (!decision && content) {
+      decision = parseApprovalDecision(content);
+    }
+
+    // When a callback button provides a run ID, use the scoped lookup so
+    // the decision resolves to exactly the right approval even when
+    // multiple approvals target the same guardian chat.
+    let guardianApproval = decision?.runId
+      ? getPendingApprovalByRunAndGuardianChat(decision.runId, sourceChannel, externalChatId)
+      : null;
+
+    // For plain-text decisions (no run ID), check how many pending
+    // approvals exist for this guardian chat. If there are multiple,
+    // the guardian must use buttons to disambiguate.
+    if (!guardianApproval && decision && !decision.runId) {
+      const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId);
+      if (allPending.length > 1) {
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: `You have ${allPending.length} pending approval requests. Please use the approval buttons to respond to a specific request.`,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, externalChatId }, 'Failed to deliver disambiguation notice');
+        }
+        return { handled: true, type: 'guardian_decision_applied' };
+      }
+      if (allPending.length === 1) {
+        guardianApproval = allPending[0];
+      }
+    }
+
+    // Fall back to the single-result lookup for non-decision messages
+    // (reminder path) or when the scoped lookup found nothing.
+    if (!guardianApproval && !decision) {
+      guardianApproval = getPendingApprovalByGuardianChat(sourceChannel, externalChatId);
+    }
+
     if (guardianApproval) {
       // Validate that the sender is the specific guardian who was assigned
       // this approval request. This is a defense-in-depth check — the
@@ -860,30 +907,12 @@ async function handleApprovalInterception(
         return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      let decision: ApprovalDecisionResult | null = null;
-
-      if (callbackData) {
-        decision = parseCallbackData(callbackData);
-      }
-      if (!decision && content) {
-        decision = parseApprovalDecision(content);
-      }
-
       if (decision) {
         // approve_always is not available for guardian approvals — guardians
         // should not be able to permanently allowlist tools on behalf of the
         // requester. Downgrade to approve_once.
         if (decision.action === 'approve_always') {
           decision = { ...decision, action: 'approve_once' };
-        }
-
-        // Validate run ID from callback matches the guardian approval's run
-        if (decision.runId && decision.runId !== guardianApproval.runId) {
-          log.warn(
-            { externalChatId, callbackRunId: decision.runId, approvalRunId: guardianApproval.runId },
-            'Callback run ID does not match guardian approval run, ignoring stale button press',
-          );
-          return { handled: true, type: 'stale_ignored' };
         }
 
         // Apply the decision to the underlying run using the requester's
@@ -961,6 +990,11 @@ async function handleApprovalInterception(
       }
 
       return { handled: true, type: 'reminder_sent' };
+    }
+
+    // Callback with a run ID that no longer has a pending approval — stale button
+    if (decision?.runId) {
+      return { handled: true, type: 'stale_ignored' };
     }
   }
 
@@ -1228,4 +1262,89 @@ export async function handleChannelDeliveryAck(req: Request): Promise<Response> 
   }
 
   return new Response(null, { status: 204 });
+}
+
+// ---------------------------------------------------------------------------
+// Proactive guardian approval expiry sweep
+// ---------------------------------------------------------------------------
+
+/** Interval at which the expiry sweep runs (60 seconds). */
+const GUARDIAN_EXPIRY_SWEEP_INTERVAL_MS = 60_000;
+
+/** Timer handle for the expiry sweep so it can be stopped in tests. */
+let expirySweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Sweep expired guardian approval requests, auto-deny the underlying runs,
+ * and notify both the requester and guardian. This runs proactively on a
+ * timer so expired approvals are closed without waiting for follow-up
+ * traffic from either party.
+ */
+export function sweepExpiredGuardianApprovals(
+  orchestrator: RunOrchestrator,
+  replyCallbackUrl: string,
+  bearerToken?: string,
+): void {
+  const expired = getExpiredPendingApprovals();
+  for (const approval of expired) {
+    // Mark the approval as expired
+    updateApprovalDecision(approval.id, { status: 'expired' });
+
+    // Auto-deny the underlying run
+    const expiredDecision: ApprovalDecisionResult = {
+      action: 'reject',
+      source: 'plain_text',
+    };
+    handleChannelDecision(approval.conversationId, expiredDecision, orchestrator);
+
+    // Notify the requester that the approval expired
+    deliverChannelReply(replyCallbackUrl, {
+      chatId: approval.requesterChatId,
+      text: `Your guardian approval request for "${approval.toolName}" has expired and the action has been denied. Please try again.`,
+    }, bearerToken).catch((err) => {
+      log.error({ err, runId: approval.runId }, 'Failed to notify requester of guardian approval expiry');
+    });
+
+    // Notify the guardian that the approval expired
+    deliverChannelReply(replyCallbackUrl, {
+      chatId: approval.guardianChatId,
+      text: `The approval request for "${approval.toolName}" from user ${approval.requesterExternalUserId} has expired and was automatically denied.`,
+    }, bearerToken).catch((err) => {
+      log.error({ err, runId: approval.runId }, 'Failed to notify guardian of approval expiry');
+    });
+
+    log.info(
+      { runId: approval.runId, approvalId: approval.id },
+      'Auto-denied expired guardian approval request',
+    );
+  }
+}
+
+/**
+ * Start the periodic expiry sweep. Idempotent — calling it multiple times
+ * re-uses the same timer.
+ */
+export function startGuardianExpirySweep(
+  orchestrator: RunOrchestrator,
+  replyCallbackUrl: string,
+  bearerToken?: string,
+): void {
+  if (expirySweepTimer) return;
+  expirySweepTimer = setInterval(() => {
+    try {
+      sweepExpiredGuardianApprovals(orchestrator, replyCallbackUrl, bearerToken);
+    } catch (err) {
+      log.error({ err }, 'Guardian expiry sweep failed');
+    }
+  }, GUARDIAN_EXPIRY_SWEEP_INTERVAL_MS);
+}
+
+/**
+ * Stop the periodic expiry sweep. Used in tests and shutdown.
+ */
+export function stopGuardianExpirySweep(): void {
+  if (expirySweepTimer) {
+    clearInterval(expirySweepTimer);
+    expirySweepTimer = null;
+  }
 }


### PR DESCRIPTION
Implements #6688 from the tg-guardian-gaps milestone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
