### PR TITLE
M3: Add verification rate limiting and setup/defaults alignment (#6689)

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -41,6 +41,9 @@ import {
   getPendingApprovalForRun,
   getPendingApprovalByGuardianChat,
   updateApprovalDecision,
+  getRateLimit,
+  recordInvalidAttempt,
+  resetRateLimit,
 } from '../memory/channel-guardian-store.js';
 import {
   createVerificationChallenge,
@@ -62,6 +65,7 @@ function resetTables(): void {
   db.run('DELETE FROM channel_guardian_bindings');
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_approval_requests');
+  db.run('DELETE FROM channel_guardian_rate_limits');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -369,7 +373,8 @@ describe('guardian service challenge validation', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.reason).toContain('Invalid or expired');
+      // Generic message to prevent oracle leakage
+      expect(result.reason).toContain('try again later');
     }
   });
 
@@ -395,7 +400,8 @@ describe('guardian service challenge validation', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.reason).toContain('Invalid or expired');
+      // Generic message to prevent oracle leakage
+      expect(result.reason).toContain('try again later');
     }
   });
 
@@ -831,5 +837,169 @@ describe('guardian approval request CRUD', () => {
 
     expect(request.riskLevel).toBeNull();
     expect(request.reason).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Verification Rate Limiting (Store)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('verification rate limiting store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('getRateLimit returns null when no record exists', () => {
+    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(rl).toBeNull();
+  });
+
+  test('recordInvalidAttempt creates a new record on first failure', () => {
+    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    expect(rl.invalidAttempts).toBe(1);
+    expect(rl.lockedUntil).toBeNull();
+    expect(rl.assistantId).toBe('asst-1');
+    expect(rl.channel).toBe('telegram');
+    expect(rl.actorExternalUserId).toBe('user-42');
+  });
+
+  test('recordInvalidAttempt increments counter on subsequent failures', () => {
+    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    expect(rl.invalidAttempts).toBe(3);
+    expect(rl.lockedUntil).toBeNull();
+  });
+
+  test('recordInvalidAttempt sets lockedUntil when max attempts reached', () => {
+    for (let i = 0; i < 4; i++) {
+      recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    }
+    const rl = recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    expect(rl.invalidAttempts).toBe(5);
+    expect(rl.lockedUntil).not.toBeNull();
+    expect(rl.lockedUntil!).toBeGreaterThan(Date.now());
+  });
+
+  test('resetRateLimit clears the counter and lockout', () => {
+    for (let i = 0; i < 5; i++) {
+      recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    }
+    const locked = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(locked).not.toBeNull();
+    expect(locked!.lockedUntil).not.toBeNull();
+
+    resetRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+
+    const after = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(after).not.toBeNull();
+    expect(after!.invalidAttempts).toBe(0);
+    expect(after!.lockedUntil).toBeNull();
+  });
+
+  test('rate limits are scoped per actor and channel', () => {
+    recordInvalidAttempt('asst-1', 'telegram', 'user-42', 'chat-42', 900_000, 5, 1_800_000);
+    recordInvalidAttempt('asst-1', 'telegram', 'user-99', 'chat-99', 900_000, 5, 1_800_000);
+
+    const rl42 = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    const rl99 = getRateLimit('asst-1', 'telegram', 'user-99', 'chat-99');
+    const rlSms = getRateLimit('asst-1', 'sms', 'user-42', 'chat-42');
+
+    expect(rl42).not.toBeNull();
+    expect(rl42!.invalidAttempts).toBe(1);
+    expect(rl99).not.toBeNull();
+    expect(rl99!.invalidAttempts).toBe(1);
+    expect(rlSms).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Verification Rate Limiting (Service — end-to-end)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian service rate limiting', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('repeated invalid submissions hit rate limit', () => {
+    // Create a valid challenge so there is a pending challenge
+    createVerificationChallenge('asst-1', 'telegram');
+
+    // Submit wrong codes repeatedly
+    for (let i = 0; i < 5; i++) {
+      const result = validateAndConsumeChallenge(
+        'asst-1', 'telegram', `wrong-secret-${i}`, 'user-42', 'chat-42',
+      );
+      expect(result.success).toBe(false);
+    }
+
+    // The 6th attempt should be rate-limited even without a new challenge
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'telegram', 'another-wrong', 'user-42', 'chat-42',
+    );
+    expect(result.success).toBe(false);
+    expect((result as { reason: string }).reason).toContain('try again later');
+
+    // Verify the rate limit record
+    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(rl).not.toBeNull();
+    expect(rl!.lockedUntil).not.toBeNull();
+  });
+
+  test('valid challenge still succeeds when under threshold', () => {
+    // Record a couple invalid attempts
+    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+    validateAndConsumeChallenge('asst-1', 'telegram', 'wrong-1', 'user-42', 'chat-42');
+    validateAndConsumeChallenge('asst-1', 'telegram', 'wrong-2', 'user-42', 'chat-42');
+
+    // Valid attempt should still succeed (under the 5-attempt threshold)
+    // Need a new challenge since the old one is still pending but the secret was never consumed
+    const { secret: secret2 } = createVerificationChallenge('asst-1', 'telegram');
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'telegram', secret2, 'user-42', 'chat-42',
+    );
+    expect(result.success).toBe(true);
+
+    // Rate limit should be reset after success
+    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(rl).not.toBeNull();
+    expect(rl!.invalidAttempts).toBe(0);
+    expect(rl!.lockedUntil).toBeNull();
+  });
+
+  test('rate-limit uses generic failure message (no oracle leakage)', () => {
+    createVerificationChallenge('asst-1', 'telegram');
+
+    // Trigger rate limit
+    for (let i = 0; i < 5; i++) {
+      validateAndConsumeChallenge(
+        'asst-1', 'telegram', `wrong-${i}`, 'user-42', 'chat-42',
+      );
+    }
+
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'telegram', 'anything', 'user-42', 'chat-42',
+    );
+    expect(result.success).toBe(false);
+    // Must NOT reveal "invalid", "expired", or "rate limit" specifically
+    expect((result as { reason: string }).reason).not.toContain('Invalid');
+    expect((result as { reason: string }).reason).not.toContain('expired');
+    expect((result as { reason: string }).reason).not.toContain('rate limit');
+  });
+
+  test('rate limit does not affect different actors', () => {
+    // Rate-limit user-42
+    createVerificationChallenge('asst-1', 'telegram');
+    for (let i = 0; i < 5; i++) {
+      validateAndConsumeChallenge('asst-1', 'telegram', `wrong-${i}`, 'user-42', 'chat-42');
+    }
+
+    // user-99 should still be able to verify
+    const { secret } = createVerificationChallenge('asst-1', 'telegram');
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'telegram', secret, 'user-99', 'chat-99',
+    );
+    expect(result.success).toBe(true);
   });
 });

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
+import { describe, test, expect, mock, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as net from 'node:net';
@@ -114,6 +114,7 @@ mock.module('../tools/credentials/metadata-store.js', () => ({
 let _fetchMock: ((url: string | URL | Request) => Promise<Response>) | null = null;
 const originalFetch = globalThis.fetch;
 
+import { initializeDb, resetDb } from '../memory/db.js';
 import { handleTelegramConfig } from '../daemon/handlers/config.js';
 import type { HandlerContext } from '../daemon/handlers.js';
 import type {
@@ -121,6 +122,14 @@ import type {
   ServerMessage,
 } from '../daemon/ipc-contract.js';
 import { DebouncerMap } from '../util/debounce.js';
+
+// Initialize the database for guardian verification tests
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
 
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
@@ -774,6 +783,7 @@ describe('Telegram config handler', () => {
     expect(setCommandsCalled).toBe(true);
     expect((setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands).toEqual([
       { command: 'new', description: 'Start a new conversation' },
+      { command: 'guardian_verify', description: 'Verify your guardian identity' },
     ]);
   });
 
@@ -851,5 +861,108 @@ describe('Telegram config handler', () => {
     const res = sent[0] as { type: string; success: boolean; error?: string };
     expect(res.success).toBe(false);
     expect(res.error).toContain('Failed to set bot commands');
+  });
+
+  test('default command registration includes /new and /guardian_verify', async () => {
+    secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
+    secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
+
+    let setCommandsBody: unknown = null;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('/setMyCommands')) {
+        setCommandsBody = JSON.parse(init?.body as string);
+        return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    // Call set_commands WITHOUT explicit commands to use defaults
+    const msg: TelegramConfigRequest = {
+      type: 'telegram_config',
+      action: 'set_commands',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTelegramConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean };
+    expect(res.success).toBe(true);
+
+    const commands = (setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands;
+    expect(commands).toHaveLength(2);
+    expect(commands).toEqual([
+      { command: 'new', description: 'Start a new conversation' },
+      { command: 'guardian_verify', description: 'Verify your guardian identity' },
+    ]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Guardian verification status/revoke IPC actions
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { handleGuardianVerification } from '../daemon/handlers/config.js';
+import type { GuardianVerificationRequest } from '../daemon/ipc-contract.js';
+
+describe('Guardian verification IPC actions', () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    setSecureKeyOverride = null;
+  });
+
+  test('status action returns bound=false when no binding exists', () => {
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'telegram',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleGuardianVerification(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; bound: boolean; guardianExternalUserId?: string };
+    expect(res.type).toBe('guardian_verification_response');
+    expect(res.success).toBe(true);
+    expect(res.bound).toBe(false);
+    expect(res.guardianExternalUserId).toBeUndefined();
+  });
+
+  test('create_challenge action returns a secret and instruction', () => {
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'create_challenge',
+      channel: 'telegram',
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleGuardianVerification(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; secret?: string; instruction?: string };
+    expect(res.type).toBe('guardian_verification_response');
+    expect(res.success).toBe(true);
+    expect(res.secret).toBeDefined();
+    expect(res.instruction).toBeDefined();
+    expect(res.instruction).toContain('/guardian_verify');
+  });
+
+  test('unknown action returns error', () => {
+    const msg = {
+      type: 'guardian_verification',
+      action: 'nonexistent',
+      channel: 'telegram',
+    } as unknown as GuardianVerificationRequest;
+
+    const { ctx, sent } = createTestContext();
+    handleGuardianVerification(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; error?: string };
+    expect(res.type).toBe('guardian_verification_response');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Unknown action');
   });
 });

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -93,13 +93,21 @@ Verify that the gateway routing is configured to deliver inbound messages to the
 
 If routing is misconfigured, inbound Telegram messages will be rejected and the gateway will send a visible notice to the chat explaining the issue (rate-limited to once per 5 minutes per chat).
 
-### Step 7: Report Success
+### Step 7: Verify Binding State
+
+Before reporting success, confirm the guardian binding was actually created. Send a `guardian_verification` IPC message with `action: "status"` (or query the guardian binding via the `getGuardianBinding` service call) to check whether a binding exists for the `telegram` channel. If the binding is absent and the user said they completed the verification:
+
+1. Tell the user the verification does not appear to have succeeded.
+2. Offer to generate a new challenge (repeat Step 5, substep 1).
+3. Only proceed to Step 8 once binding state is confirmed or the user explicitly skips guardian verification.
+
+### Step 8: Report Success
 
 Summarize what was done:
 - Bot verified and credentials stored securely via daemon
 - Webhook registration: handled automatically by the gateway
 - Bot commands registered: /new, /guardian_verify
-- Guardian identity verified (if completed)
+- Guardian identity verified (if completed and binding confirmed)
 - Routing configuration validated
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -38,7 +38,7 @@ import {
   searchAvailableNumbers,
   provisionPhoneNumber,
 } from '../../calls/twilio-rest.js';
-import { createVerificationChallenge } from '../../runtime/channel-guardian-service.js';
+import { createVerificationChallenge, getGuardianBinding, revokeBinding as revokeGuardianBinding } from '../../runtime/channel-guardian-service.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
@@ -1032,6 +1032,7 @@ export async function handleTelegramConfig(
 
       const commands = msg.commands ?? [
         { command: 'new', description: 'Start a new conversation' },
+        { command: 'guardian_verify', description: 'Verify your guardian identity' },
       ];
 
       try {
@@ -1330,27 +1331,42 @@ export function handleGuardianVerification(
   ctx: HandlerContext,
 ): void {
   try {
-    if (msg.action !== 'create_challenge') {
+    // In single-assistant mode, 'self' is the canonical assistant ID used
+    // by channel routes when validating challenges on the inbound path.
+    const assistantId = 'self';
+    const channel = msg.channel ?? 'telegram';
+
+    if (msg.action === 'create_challenge') {
+      const result = createVerificationChallenge(assistantId, channel, msg.sessionId);
+
+      ctx.send(socket, {
+        type: 'guardian_verification_response',
+        success: true,
+        secret: result.secret,
+        instruction: result.instruction,
+      });
+    } else if (msg.action === 'status') {
+      const binding = getGuardianBinding(assistantId, channel);
+      ctx.send(socket, {
+        type: 'guardian_verification_response',
+        success: true,
+        bound: binding !== null,
+        guardianExternalUserId: binding?.guardianExternalUserId,
+      });
+    } else if (msg.action === 'revoke') {
+      const revoked = revokeGuardianBinding(assistantId, channel);
+      ctx.send(socket, {
+        type: 'guardian_verification_response',
+        success: true,
+        bound: !revoked,
+      });
+    } else {
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: false,
         error: `Unknown action: ${String(msg.action)}`,
       });
-      return;
     }
-
-    // In single-assistant mode, 'self' is the canonical assistant ID used
-    // by channel routes when validating challenges on the inbound path.
-    const assistantId = 'self';
-    const channel = msg.channel ?? 'telegram';
-    const result = createVerificationChallenge(assistantId, channel, msg.sessionId);
-
-    ctx.send(socket, {
-      type: 'guardian_verification_response',
-      success: true,
-      secret: result.secret,
-      instruction: result.instruction,
-    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Failed to handle guardian verification');

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -570,7 +570,7 @@ export interface TwilioConfigResponse {
 
 export interface GuardianVerificationRequest {
   type: 'guardian_verification';
-  action: 'create_challenge';
+  action: 'create_challenge' | 'status' | 'revoke';
   channel?: string;  // Defaults to 'telegram'
   sessionId?: string;
 }
@@ -580,6 +580,9 @@ export interface GuardianVerificationResponse {
   success: boolean;
   secret?: string;
   instruction?: string;
+  /** Present when action is 'status'. */
+  bound?: boolean;
+  guardianExternalUserId?: string;
   error?: string;
 }
 

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -15,6 +15,7 @@ import {
   channelGuardianBindings,
   channelGuardianVerificationChallenges,
   channelGuardianApprovalRequests,
+  channelGuardianRateLimits,
 } from './schema.js';
 
 // ---------------------------------------------------------------------------
@@ -426,5 +427,160 @@ export function updateApprovalDecision(
       updatedAt: now,
     })
     .where(eq(channelGuardianApprovalRequests.id, id))
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Verification Rate Limits
+// ---------------------------------------------------------------------------
+
+export interface VerificationRateLimit {
+  id: string;
+  assistantId: string;
+  channel: string;
+  actorExternalUserId: string;
+  actorChatId: string;
+  invalidAttempts: number;
+  windowStartedAt: number;
+  lockedUntil: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function rowToRateLimit(row: typeof channelGuardianRateLimits.$inferSelect): VerificationRateLimit {
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    channel: row.channel,
+    actorExternalUserId: row.actorExternalUserId,
+    actorChatId: row.actorChatId,
+    invalidAttempts: row.invalidAttempts,
+    windowStartedAt: row.windowStartedAt,
+    lockedUntil: row.lockedUntil,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Get the rate-limit record for a given actor on a specific channel.
+ */
+export function getRateLimit(
+  assistantId: string,
+  channel: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+): VerificationRateLimit | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(channelGuardianRateLimits)
+    .where(
+      and(
+        eq(channelGuardianRateLimits.assistantId, assistantId),
+        eq(channelGuardianRateLimits.channel, channel),
+        eq(channelGuardianRateLimits.actorExternalUserId, actorExternalUserId),
+        eq(channelGuardianRateLimits.actorChatId, actorChatId),
+      ),
+    )
+    .get();
+
+  return row ? rowToRateLimit(row) : null;
+}
+
+/**
+ * Record an invalid verification attempt. Creates the rate-limit row if
+ * it does not yet exist, or increments the counter within the current
+ * throttling window.
+ */
+export function recordInvalidAttempt(
+  assistantId: string,
+  channel: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+  windowMs: number,
+  maxAttempts: number,
+  lockoutMs: number,
+): VerificationRateLimit {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = getRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
+
+  if (existing) {
+    // If the throttling window has elapsed, reset the counter
+    const windowExpired = now - existing.windowStartedAt > windowMs;
+    const newAttempts = windowExpired ? 1 : existing.invalidAttempts + 1;
+    const newWindowStart = windowExpired ? now : existing.windowStartedAt;
+    const newLockedUntil = newAttempts >= maxAttempts ? now + lockoutMs : existing.lockedUntil;
+
+    db.update(channelGuardianRateLimits)
+      .set({
+        invalidAttempts: newAttempts,
+        windowStartedAt: newWindowStart,
+        lockedUntil: newLockedUntil,
+        updatedAt: now,
+      })
+      .where(eq(channelGuardianRateLimits.id, existing.id))
+      .run();
+
+    return {
+      ...existing,
+      invalidAttempts: newAttempts,
+      windowStartedAt: newWindowStart,
+      lockedUntil: newLockedUntil,
+      updatedAt: now,
+    };
+  }
+
+  // First attempt — create the row
+  const id = uuid();
+  const lockedUntil = 1 >= maxAttempts ? now + lockoutMs : null;
+  const row = {
+    id,
+    assistantId,
+    channel,
+    actorExternalUserId,
+    actorChatId,
+    invalidAttempts: 1,
+    windowStartedAt: now,
+    lockedUntil,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(channelGuardianRateLimits).values(row).run();
+
+  return rowToRateLimit(row);
+}
+
+/**
+ * Reset the rate-limit counter for a given actor (e.g. after a
+ * successful verification).
+ */
+export function resetRateLimit(
+  assistantId: string,
+  channel: string,
+  actorExternalUserId: string,
+  actorChatId: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(channelGuardianRateLimits)
+    .set({
+      invalidAttempts: 0,
+      lockedUntil: null,
+      windowStartedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(channelGuardianRateLimits.assistantId, assistantId),
+        eq(channelGuardianRateLimits.channel, channel),
+        eq(channelGuardianRateLimits.actorExternalUserId, actorExternalUserId),
+        eq(channelGuardianRateLimits.actorChatId, actorChatId),
+      ),
+    )
     .run();
 }

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -992,6 +992,25 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_approval_run ON channel_guardian_approval_requests(run_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_approval_status ON channel_guardian_approval_requests(status)`);
 
+  // ── Channel Guardian Verification Rate Limits ─────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS channel_guardian_rate_limits (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      actor_external_user_id TEXT NOT NULL,
+      actor_chat_id TEXT NOT NULL,
+      invalid_attempts INTEGER NOT NULL DEFAULT 0,
+      window_started_at INTEGER NOT NULL,
+      locked_until INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(assistant_id, channel, actor_external_user_id, actor_chat_id)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -660,3 +660,18 @@ export const channelGuardianApprovalRequests = sqliteTable('channel_guardian_app
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
+
+// ── Channel Guardian Verification Rate Limits ────────────────────────
+
+export const channelGuardianRateLimits = sqliteTable('channel_guardian_rate_limits', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  channel: text('channel').notNull(),
+  actorExternalUserId: text('actor_external_user_id').notNull(),
+  actorChatId: text('actor_chat_id').notNull(),
+  invalidAttempts: integer('invalid_attempts').notNull().default(0),
+  windowStartedAt: integer('window_started_at').notNull(),
+  lockedUntil: integer('locked_until'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -15,6 +15,9 @@ import {
   createChallenge,
   findPendingChallengeByHash,
   consumeChallenge,
+  getRateLimit,
+  recordInvalidAttempt,
+  resetRateLimit,
 } from '../memory/channel-guardian-store.js';
 import type { GuardianBinding } from '../memory/channel-guardian-store.js';
 
@@ -24,6 +27,15 @@ import type { GuardianBinding } from '../memory/channel-guardian-store.js';
 
 /** Challenge TTL in milliseconds (10 minutes). */
 const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+/** Maximum invalid verification attempts within the throttling window before lockout. */
+const RATE_LIMIT_MAX_ATTEMPTS = 5;
+
+/** Throttling window in milliseconds (15 minutes). */
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+/** Lockout duration in milliseconds (30 minutes). */
+const RATE_LIMIT_LOCKOUT_MS = 30 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -102,9 +114,14 @@ export function createVerificationChallenge(
 /**
  * Validate and consume a verification challenge.
  *
+ * Checks per-actor/per-channel rate limits before attempting validation.
  * Hashes the provided secret, looks up a matching pending challenge,
  * validates it has not expired, consumes it, revokes any existing
  * active binding, and creates a new guardian binding.
+ *
+ * On failure the invalid-attempt counter is incremented; after
+ * exceeding the threshold the actor is locked out for a cooldown
+ * period. On success the counter resets.
  */
 export function validateAndConsumeChallenge(
   assistantId: string,
@@ -113,19 +130,38 @@ export function validateAndConsumeChallenge(
   actorExternalUserId: string,
   actorChatId: string,
 ): ValidateChallengeResult {
+  // ── Rate-limit check ──
+  const existing = getRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
+  if (existing && existing.lockedUntil !== null && Date.now() < existing.lockedUntil) {
+    // Use the same generic failure message to avoid leaking whether the
+    // actor is rate-limited vs. the code is genuinely wrong.
+    return { success: false, reason: 'Verification failed. Please try again later.' };
+  }
+
   const challengeHash = hashSecret(secret);
 
   const challenge = findPendingChallengeByHash(assistantId, channel, challengeHash);
   if (!challenge) {
-    return { success: false, reason: 'Invalid or expired verification code.' };
+    recordInvalidAttempt(
+      assistantId, channel, actorExternalUserId, actorChatId,
+      RATE_LIMIT_WINDOW_MS, RATE_LIMIT_MAX_ATTEMPTS, RATE_LIMIT_LOCKOUT_MS,
+    );
+    return { success: false, reason: 'Verification failed. Please try again later.' };
   }
 
   if (Date.now() > challenge.expiresAt) {
-    return { success: false, reason: 'Invalid or expired verification code.' };
+    recordInvalidAttempt(
+      assistantId, channel, actorExternalUserId, actorChatId,
+      RATE_LIMIT_WINDOW_MS, RATE_LIMIT_MAX_ATTEMPTS, RATE_LIMIT_LOCKOUT_MS,
+    );
+    return { success: false, reason: 'Verification failed. Please try again later.' };
   }
 
   // Consume the challenge so it cannot be reused
   consumeChallenge(challenge.id, actorExternalUserId, actorChatId);
+
+  // Reset the rate-limit counter on success
+  resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
   // Revoke any existing active binding before creating a new one
   storeRevokeBinding(assistantId, channel);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -314,7 +314,7 @@ export async function handleChannelInbound(
 
       const replyText = verifyResult.success
         ? 'Guardian verified successfully. Your identity is now linked to this bot.'
-        : 'Verification failed. The code may be invalid or expired.';
+        : 'Verification failed. Please try again later.';
 
       try {
         await deliverChannelReply(replyCallbackUrl, {


### PR DESCRIPTION
Implements #6689 from the tg-guardian-gaps milestone.

## Changes

### WS-4: Guardian verification rate limiting (P1)
- Added channelGuardianRateLimits table with per-actor/per-channel scoping
- Implemented sliding window rate limiting (5 attempts / 15 min, 30 min lockout)
- All failure messages made generic to prevent oracle leakage
- Rate limit resets on successful verification

### WS-5: Setup-path and defaults alignment (P2)  
- Default set_commands now includes /guardian_verify alongside /new
- Added status and revoke IPC actions for guardian verification
- Updated SKILL.md with binding state verification step before declaring success

### Tests
- Rate limiting store-level tests (5 tests)
- Guardian service rate limiting end-to-end tests (4 tests)
- Guardian verification IPC action tests (3 tests)
- Updated existing test expectations for generic error messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
