### PR TITLE
M2: Harden guardian decision scoping and timeout closure

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -52,8 +52,11 @@ import * as conversationStore from '../memory/conversation-store.js';
 import {
   createBinding,
   createApprovalRequest,
+  getAllPendingApprovalsByGuardianChat,
+  getPendingApprovalByRunAndGuardianChat,
   getPendingApprovalForRun,
   getUnresolvedApprovalForRun,
+  updateApprovalDecision,
 } from '../memory/channel-guardian-store.js';
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import { handleChannelInbound, isChannelApprovalsEnabled } from '../runtime/routes/channel-routes.js';
@@ -2019,5 +2022,578 @@ describe('guardian delivery failure → denial', () => {
 
     deliverSpy.mockRestore();
     approvalSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 21. Scoped guardian decision lookup — multiple pending approvals (WS-3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('scoped guardian decision lookup — multiple pending approvals', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('callback for older run resolves correctly when multiple approvals are pending', async () => {
+    // Set up a guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-multi',
+      guardianDeliveryChatId: 'guardian-chat-multi',
+    });
+
+    // Create two conversations and runs with pending approvals
+    ensureConversation('conv-older');
+    const olderRun = createRun('conv-older');
+    setRunConfirmation(olderRun.id, sampleConfirmation);
+
+    ensureConversation('conv-newer');
+    const newerRun = createRun('conv-newer');
+    setRunConfirmation(newerRun.id, sampleConfirmation);
+
+    // Create guardian approval requests for both runs — same guardian chat
+    createApprovalRequest({
+      runId: olderRun.id,
+      conversationId: 'conv-older',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-a',
+      requesterChatId: 'chat-requester-a',
+      guardianExternalUserId: 'guardian-multi',
+      guardianChatId: 'guardian-chat-multi',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    createApprovalRequest({
+      runId: newerRun.id,
+      conversationId: 'conv-newer',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-b',
+      requesterChatId: 'chat-requester-b',
+      guardianExternalUserId: 'guardian-multi',
+      guardianChatId: 'guardian-chat-multi',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian sends a callback button targeting the OLDER run specifically
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: 'guardian-chat-multi',
+      senderExternalUserId: 'guardian-multi',
+      content: '',
+      callbackData: `apr:${olderRun.id}:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // The older approval should now be resolved ('approved')
+    const olderResolved = getPendingApprovalForRun(olderRun.id);
+    expect(olderResolved).toBeNull(); // no longer pending
+
+    // The newer approval should still be pending
+    const newerPending = getPendingApprovalForRun(newerRun.id);
+    expect(newerPending).not.toBeNull();
+    expect(newerPending!.status).toBe('pending');
+
+    // The orchestrator should have been called with the OLDER run's conversation
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(olderRun.id, 'allow');
+
+    // Requester A should have been notified
+    const notifyCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { chatId?: string }).chatId === 'chat-requester-a' &&
+        (call[1] as { text?: string }).text?.includes('approved by the guardian'),
+    );
+    expect(notifyCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+
+  test('scoped lookup by (runId, channel, guardianChatId) returns correct approval', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-scope',
+      guardianDeliveryChatId: 'guardian-chat-scope',
+    });
+
+    ensureConversation('conv-scope-1');
+    const run1 = createRun('conv-scope-1');
+    setRunConfirmation(run1.id, sampleConfirmation);
+
+    ensureConversation('conv-scope-2');
+    const run2 = createRun('conv-scope-2');
+    setRunConfirmation(run2.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run1.id,
+      conversationId: 'conv-scope-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-1',
+      requesterChatId: 'chat-req-1',
+      guardianExternalUserId: 'guardian-scope',
+      guardianChatId: 'guardian-chat-scope',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    createApprovalRequest({
+      runId: run2.id,
+      conversationId: 'conv-scope-2',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-2',
+      requesterChatId: 'chat-req-2',
+      guardianExternalUserId: 'guardian-scope',
+      guardianChatId: 'guardian-chat-scope',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    // Scoped lookup for run1 returns the correct approval
+    const result1 = getPendingApprovalByRunAndGuardianChat(
+      run1.id, 'telegram', 'guardian-chat-scope',
+    );
+    expect(result1).not.toBeNull();
+    expect(result1!.runId).toBe(run1.id);
+    expect(result1!.conversationId).toBe('conv-scope-1');
+
+    // Scoped lookup for run2 returns the correct approval
+    const result2 = getPendingApprovalByRunAndGuardianChat(
+      run2.id, 'telegram', 'guardian-chat-scope',
+    );
+    expect(result2).not.toBeNull();
+    expect(result2!.runId).toBe(run2.id);
+    expect(result2!.conversationId).toBe('conv-scope-2');
+
+    // Scoped lookup for a non-existent run returns null
+    const result3 = getPendingApprovalByRunAndGuardianChat(
+      'nonexistent-run', 'telegram', 'guardian-chat-scope',
+    );
+    expect(result3).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 22. Ambiguous plain-text decision with multiple pending requests (WS-3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ambiguous plain-text guardian decision with multiple pending approvals', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('plain-text "approve" with multiple pending approvals requires disambiguation', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-disambig',
+      guardianDeliveryChatId: 'guardian-chat-disambig',
+    });
+
+    // Create two pending approvals in the same guardian chat
+    ensureConversation('conv-disambig-1');
+    const run1 = createRun('conv-disambig-1');
+    setRunConfirmation(run1.id, sampleConfirmation);
+
+    ensureConversation('conv-disambig-2');
+    const run2 = createRun('conv-disambig-2');
+    setRunConfirmation(run2.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run1.id,
+      conversationId: 'conv-disambig-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-d1',
+      requesterChatId: 'chat-req-d1',
+      guardianExternalUserId: 'guardian-disambig',
+      guardianChatId: 'guardian-chat-disambig',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    createApprovalRequest({
+      runId: run2.id,
+      conversationId: 'conv-disambig-2',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-d2',
+      requesterChatId: 'chat-req-d2',
+      guardianExternalUserId: 'guardian-disambig',
+      guardianChatId: 'guardian-chat-disambig',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian sends plain-text "approve" — ambiguous since 2 requests are pending
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: 'guardian-chat-disambig',
+      senderExternalUserId: 'guardian-disambig',
+      content: 'approve',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // submitDecision should NOT have been called — the plain-text decision was
+    // rejected due to ambiguity
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // Both approvals should still be pending
+    const pending1 = getPendingApprovalForRun(run1.id);
+    const pending2 = getPendingApprovalForRun(run2.id);
+    expect(pending1).not.toBeNull();
+    expect(pending2).not.toBeNull();
+
+    // The disambiguation message should have been sent
+    const disambigCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { text?: string }).text?.includes('pending approval requests'),
+    );
+    expect(disambigCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+
+  test('plain-text "approve" with single pending approval works normally', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-single',
+      guardianDeliveryChatId: 'guardian-chat-single',
+    });
+
+    ensureConversation('conv-single-1');
+    const run1 = createRun('conv-single-1');
+    setRunConfirmation(run1.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run1.id,
+      conversationId: 'conv-single-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-s1',
+      requesterChatId: 'chat-req-s1',
+      guardianExternalUserId: 'guardian-single',
+      guardianChatId: 'guardian-chat-single',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian sends plain-text "approve" — only one request, so no ambiguity
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: 'guardian-chat-single',
+      senderExternalUserId: 'guardian-single',
+      content: 'approve',
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // submitDecision SHOULD have been called — single pending approval
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run1.id, 'allow');
+
+    // The approval should now be resolved
+    const resolved = getPendingApprovalForRun(run1.id);
+    expect(resolved).toBeNull();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('callback button works even with multiple pending approvals (uses scoped lookup)', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-btn-multi',
+      guardianDeliveryChatId: 'guardian-chat-btn-multi',
+    });
+
+    ensureConversation('conv-btn-1');
+    const run1 = createRun('conv-btn-1');
+    setRunConfirmation(run1.id, sampleConfirmation);
+
+    ensureConversation('conv-btn-2');
+    const run2 = createRun('conv-btn-2');
+    setRunConfirmation(run2.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run1.id,
+      conversationId: 'conv-btn-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-btn-1',
+      requesterChatId: 'chat-req-btn-1',
+      guardianExternalUserId: 'guardian-btn-multi',
+      guardianChatId: 'guardian-chat-btn-multi',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    createApprovalRequest({
+      runId: run2.id,
+      conversationId: 'conv-btn-2',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-btn-2',
+      requesterChatId: 'chat-req-btn-2',
+      guardianExternalUserId: 'guardian-btn-multi',
+      guardianChatId: 'guardian-chat-btn-multi',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian uses callback button for run2 specifically
+    const req = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: 'guardian-chat-btn-multi',
+      senderExternalUserId: 'guardian-btn-multi',
+      content: '',
+      callbackData: `apr:${run2.id}:reject`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // submitDecision should have been called for run2 (reject)
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run2.id, 'deny');
+
+    // run1 should still be pending
+    const pending1 = getPendingApprovalForRun(run1.id);
+    expect(pending1).not.toBeNull();
+
+    // run2 should be resolved
+    const pending2 = getPendingApprovalForRun(run2.id);
+    expect(pending2).toBeNull();
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 23. Expired guardian approval auto-denies proactively (WS-3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('expired guardian approval auto-denies proactively', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('expired approval is auto-denied when requester sends follow-up', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-expiry',
+      guardianDeliveryChatId: 'guardian-chat-expiry',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    ensureConversation('conv-expiry-manual');
+    const run = createRun('conv-expiry-manual');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Create an approval request that has ALREADY expired
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: 'conv-expiry-manual',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-expiry',
+      requesterChatId: 'chat-requester-expiry',
+      guardianExternalUserId: 'guardian-expiry',
+      guardianChatId: 'guardian-chat-expiry',
+      toolName: 'shell',
+      expiresAt: Date.now() - 1000, // already expired
+    });
+
+    // The approval should be detectable as unresolved but NOT as pending
+    // (since it's expired)
+    const pendingCheck = getPendingApprovalForRun(run.id);
+    expect(pendingCheck).toBeNull(); // expired, so not returned by time-filtered query
+
+    const unresolvedCheck = getUnresolvedApprovalForRun(run.id);
+    expect(unresolvedCheck).not.toBeNull(); // still status='pending' in DB
+    expect(unresolvedCheck!.status).toBe('pending');
+
+    const orchestrator = makeMockOrchestrator();
+
+    // We need to establish the conversation mapping for the requester's chat
+    // so that recordInbound returns the correct conversationId.
+    const db = getDb();
+    const now = Date.now();
+    try {
+      db.run(`INSERT INTO conversation_keys (id, conversation_key, conversation_id, created_at)
+        VALUES ('ck-setup-expiry', 'telegram:chat-requester-expiry', 'conv-expiry-manual', ${now})`);
+    } catch { /* already exists */ }
+
+    deliverSpy.mockClear();
+
+    // When the requester sends a follow-up, the expired-but-unresolved
+    // approval should be auto-denied via the interception path
+    const reqFromRequester = makeInboundRequest({
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-requester-expiry',
+      senderExternalUserId: 'requester-expiry',
+      content: 'what happened?',
+    });
+
+    const res = await handleChannelInbound(reqFromRequester, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+
+    // The orchestrator should have denied the run
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    // The approval should now be marked as 'expired' (not 'pending')
+    const afterExpiry = getUnresolvedApprovalForRun(run.id);
+    expect(afterExpiry).toBeNull(); // status changed from 'pending'
+
+    // The requester should have received the expiry notice
+    const expiryCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { text?: string }).text?.includes('expired'),
+    );
+    expect(expiryCalls.length).toBeGreaterThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+
+  test('getExpiredPendingApprovals returns expired but still-pending approvals', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-timer',
+      guardianDeliveryChatId: 'guardian-chat-timer',
+    });
+
+    ensureConversation('conv-timer');
+    const run = createRun('conv-timer');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Create an approval request with a very short TTL (already expired)
+    const approval = createApprovalRequest({
+      runId: run.id,
+      conversationId: 'conv-timer',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-timer',
+      requesterChatId: 'chat-requester-timer',
+      guardianExternalUserId: 'guardian-timer',
+      guardianChatId: 'guardian-chat-timer',
+      toolName: 'shell',
+      expiresAt: Date.now() - 100, // already expired
+    });
+
+    // The approval should be unresolved (status='pending') but not returned
+    // by getPendingApprovalForRun (time-filtered)
+    const unresolved = getUnresolvedApprovalForRun(run.id);
+    expect(unresolved).not.toBeNull();
+    expect(unresolved!.status).toBe('pending');
+
+    const pending = getPendingApprovalForRun(run.id);
+    expect(pending).toBeNull();
+
+    // getExpiredPendingApprovals should find it
+    const { getExpiredPendingApprovals } = await import('../memory/channel-guardian-store.js');
+    const expired = getExpiredPendingApprovals();
+    const matchingExpired = expired.filter((a) => a.runId === run.id);
+    expect(matchingExpired.length).toBe(1);
+    expect(matchingExpired[0].id).toBe(approval.id);
+
+    // After marking it expired, it should no longer appear
+    updateApprovalDecision(approval.id, { status: 'expired' });
+    const afterUpdate = getUnresolvedApprovalForRun(run.id);
+    expect(afterUpdate).toBeNull();
+  });
+
+  test('getAllPendingApprovalsByGuardianChat returns all pending approvals', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-all',
+      guardianDeliveryChatId: 'guardian-chat-all',
+    });
+
+    ensureConversation('conv-all-1');
+    const run1 = createRun('conv-all-1');
+    setRunConfirmation(run1.id, sampleConfirmation);
+
+    ensureConversation('conv-all-2');
+    const run2 = createRun('conv-all-2');
+    setRunConfirmation(run2.id, sampleConfirmation);
+
+    ensureConversation('conv-all-3');
+    const run3 = createRun('conv-all-3');
+    setRunConfirmation(run3.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run1.id,
+      conversationId: 'conv-all-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-all-1',
+      requesterChatId: 'chat-req-all-1',
+      guardianExternalUserId: 'guardian-all',
+      guardianChatId: 'guardian-chat-all',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    createApprovalRequest({
+      runId: run2.id,
+      conversationId: 'conv-all-2',
+      channel: 'telegram',
+      requesterExternalUserId: 'req-all-2',
+      requesterChatId: 'chat-req-all-2',
+      guardianExternalUserId: 'guardian-all',
+      guardianChatId: 'guardian-chat-all',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    // Third approval for a different channel — should NOT be returned
+    createApprovalRequest({
+      runId: run3.id,
+      conversationId: 'conv-all-3',
+      channel: 'sms',
+      requesterExternalUserId: 'req-all-3',
+      requesterChatId: 'chat-req-all-3',
+      guardianExternalUserId: 'guardian-all',
+      guardianChatId: 'guardian-chat-all',
+      toolName: 'shell',
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    const allPending = getAllPendingApprovalsByGuardianChat('telegram', 'guardian-chat-all');
+    expect(allPending.length).toBe(2);
+    const runIds = allPending.map((a) => a.runId);
+    expect(runIds).toContain(run1.id);
+    expect(runIds).toContain(run2.id);
   });
 });

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -8,7 +8,7 @@
  * requests track per-run guardian approval decisions.
  */
 
-import { and, desc, eq, gt } from 'drizzle-orm';
+import { and, desc, eq, gt, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import {
@@ -387,6 +387,10 @@ export function getUnresolvedApprovalForRun(runId: string): GuardianApprovalRequ
 /**
  * Find a pending guardian approval request by the guardian's chat ID.
  * Used when the guardian sends a decision from their chat.
+ *
+ * When multiple pending approvals exist for the same guardian chat, this
+ * returns the most recently created one. Callers should use
+ * `getAllPendingApprovalsByGuardianChat` to detect ambiguity.
  */
 export function getPendingApprovalByGuardianChat(
   channel: string,
@@ -410,6 +414,91 @@ export function getPendingApprovalByGuardianChat(
     .get();
 
   return row ? rowToApprovalRequest(row) : null;
+}
+
+/**
+ * Return ALL non-expired pending guardian approval requests for a given
+ * guardian chat. Used to detect ambiguity when the guardian sends a
+ * plain-text decision — if more than one approval is pending, the guardian
+ * must use the inline buttons (which carry the runId) to avoid applying
+ * a decision to the wrong run.
+ */
+export function getAllPendingApprovalsByGuardianChat(
+  channel: string,
+  guardianChatId: string,
+): GuardianApprovalRequest[] {
+  const db = getDb();
+  const now = Date.now();
+
+  const rows = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.channel, channel),
+        eq(channelGuardianApprovalRequests.guardianChatId, guardianChatId),
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .orderBy(desc(channelGuardianApprovalRequests.createdAt))
+    .all();
+
+  return rows.map(rowToApprovalRequest);
+}
+
+/**
+ * Scoped lookup: find a pending guardian approval by (runId, guardianChatId,
+ * channel). Used for callback-button decisions where the runId is embedded
+ * in the callback data, allowing deterministic resolution even when
+ * multiple approvals are pending in the same guardian chat.
+ */
+export function getPendingApprovalByRunAndGuardianChat(
+  runId: string,
+  channel: string,
+  guardianChatId: string,
+): GuardianApprovalRequest | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.runId, runId),
+        eq(channelGuardianApprovalRequests.channel, channel),
+        eq(channelGuardianApprovalRequests.guardianChatId, guardianChatId),
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        gt(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToApprovalRequest(row) : null;
+}
+
+/**
+ * Find all pending guardian approval requests that have expired (past
+ * their expiresAt timestamp). Used by the proactive expiry sweep to
+ * auto-deny expired approvals without waiting for requester follow-up.
+ */
+export function getExpiredPendingApprovals(): GuardianApprovalRequest[] {
+  const db = getDb();
+  const now = Date.now();
+
+  const rows = db
+    .select()
+    .from(channelGuardianApprovalRequests)
+    .where(
+      and(
+        eq(channelGuardianApprovalRequests.status, 'pending'),
+        lte(channelGuardianApprovalRequests.expiresAt, now),
+      ),
+    )
+    .all();
+
+  return rows.map(rowToApprovalRequest);
 }
 
 export function updateApprovalDecision(

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -19,7 +19,9 @@ import {
 } from '../channel-guardian-service.js';
 import {
   createApprovalRequest,
+  getAllPendingApprovalsByGuardianChat,
   getPendingApprovalByGuardianChat,
+  getPendingApprovalByRunAndGuardianChat,
   getPendingApprovalForRun,
   getUnresolvedApprovalForRun,
   updateApprovalDecision,
@@ -697,6 +699,22 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               } catch (err) {
                 log.error({ err, runId: run.id }, 'Failed to notify requester of pending guardian approval');
               }
+
+              // Schedule proactive auto-deny when the approval TTL expires.
+              // This ensures the requester and guardian are both notified of
+              // the timeout without waiting for follow-up traffic.
+              scheduleApprovalExpiry({
+                approvalRequestId: approvalReqRecord.id,
+                runId: run.id,
+                conversationId,
+                requesterChatId: guardianCtx.requesterChatId ?? externalChatId,
+                guardianChatId: guardianCtx.guardianChatId,
+                toolName: pending[0].toolName,
+                expiresAt: approvalReqRecord.expiresAt,
+                replyCallbackUrl,
+                bearerToken,
+                orchestrator,
+              });
             }
           } else {
             // Guardian actor or no guardian binding: standard approval prompt
@@ -837,7 +855,23 @@ async function handleApprovalInterception(
     guardianCtx.actorRole === 'guardian' &&
     senderExternalUserId
   ) {
-    const guardianApproval = getPendingApprovalByGuardianChat(sourceChannel, externalChatId);
+    // Parse the decision first so we know whether a runId is available
+    // from callback data. This determines the lookup strategy.
+    let decision: ApprovalDecisionResult | null = null;
+    if (callbackData) {
+      decision = parseCallbackData(callbackData);
+    }
+    if (!decision && content) {
+      decision = parseApprovalDecision(content);
+    }
+
+    // Choose lookup strategy based on whether we have a scoped runId.
+    // Callback buttons embed the runId, enabling deterministic resolution
+    // even when multiple approvals are pending in the same guardian chat.
+    let guardianApproval = decision?.runId
+      ? getPendingApprovalByRunAndGuardianChat(decision.runId, sourceChannel, externalChatId)
+      : getPendingApprovalByGuardianChat(sourceChannel, externalChatId);
+
     if (guardianApproval) {
       // Validate that the sender is the specific guardian who was assigned
       // this approval request. This is a defense-in-depth check — the
@@ -860,15 +894,6 @@ async function handleApprovalInterception(
         return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      let decision: ApprovalDecisionResult | null = null;
-
-      if (callbackData) {
-        decision = parseCallbackData(callbackData);
-      }
-      if (!decision && content) {
-        decision = parseApprovalDecision(content);
-      }
-
       if (decision) {
         // approve_always is not available for guardian approvals — guardians
         // should not be able to permanently allowlist tools on behalf of the
@@ -877,13 +902,26 @@ async function handleApprovalInterception(
           decision = { ...decision, action: 'approve_once' };
         }
 
-        // Validate run ID from callback matches the guardian approval's run
-        if (decision.runId && decision.runId !== guardianApproval.runId) {
-          log.warn(
-            { externalChatId, callbackRunId: decision.runId, approvalRunId: guardianApproval.runId },
-            'Callback run ID does not match guardian approval run, ignoring stale button press',
-          );
-          return { handled: true, type: 'stale_ignored' };
+        // For plain-text decisions (no runId), check if multiple pending
+        // approvals exist in this guardian chat. If so, the decision is
+        // ambiguous and we cannot safely apply it to any specific run.
+        if (!decision.runId) {
+          const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId);
+          if (allPending.length > 1) {
+            log.warn(
+              { externalChatId, pendingCount: allPending.length },
+              'Ambiguous plain-text guardian decision with multiple pending approvals',
+            );
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: `There are ${allPending.length} pending approval requests. Please use the inline buttons to approve or deny a specific request.`,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver disambiguation notice');
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
         }
 
         // Apply the decision to the underlying run using the requester's
@@ -1145,6 +1183,90 @@ function schedulePostDecisionDelivery(
       log.error({ err, runId, conversationId }, 'Post-decision delivery failed');
     }
   })();
+}
+
+// ---------------------------------------------------------------------------
+// Proactive approval expiry
+// ---------------------------------------------------------------------------
+
+interface ApprovalExpiryParams {
+  approvalRequestId: string;
+  runId: string;
+  conversationId: string;
+  requesterChatId: string;
+  guardianChatId: string;
+  toolName: string;
+  expiresAt: number;
+  replyCallbackUrl: string;
+  bearerToken?: string;
+  orchestrator: RunOrchestrator;
+}
+
+/**
+ * Schedule a timer that fires when the guardian approval TTL expires.
+ * If the approval is still pending at that point, auto-deny the run
+ * and notify both the requester and the guardian.
+ *
+ * This is proactive — the denial happens without waiting for the
+ * requester to send a follow-up message.
+ */
+function scheduleApprovalExpiry(params: ApprovalExpiryParams): void {
+  const {
+    approvalRequestId,
+    runId,
+    conversationId,
+    requesterChatId,
+    guardianChatId,
+    toolName,
+    expiresAt,
+    replyCallbackUrl,
+    bearerToken,
+    orchestrator,
+  } = params;
+
+  const delay = Math.max(0, expiresAt - Date.now());
+
+  setTimeout(async () => {
+    try {
+      // Re-fetch the approval to check if it's still pending — it may have
+      // been resolved by the guardian in the meantime.
+      const approval = getUnresolvedApprovalForRun(runId);
+      if (!approval || approval.id !== approvalRequestId || approval.status !== 'pending') {
+        return; // Already resolved, nothing to do
+      }
+
+      // Mark expired and deny the underlying run
+      updateApprovalDecision(approvalRequestId, { status: 'expired' });
+      handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
+
+      log.info(
+        { runId, approvalRequestId, conversationId },
+        'Guardian approval expired, auto-denied run',
+      );
+
+      // Notify the requester
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: requesterChatId,
+          text: `Your request to run "${toolName}" expired without guardian approval and has been denied. Please try again.`,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, runId, conversationId }, 'Failed to notify requester of approval expiry');
+      }
+
+      // Notify the guardian
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: guardianChatId,
+          text: `The approval request for "${toolName}" has expired and was automatically denied.`,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, runId, conversationId }, 'Failed to notify guardian of approval expiry');
+      }
+    } catch (err) {
+      log.error({ err, runId, approvalRequestId }, 'Approval expiry handler failed');
+    }
+  }, delay);
 }
 
 async function deliverReplyViaCallback(


### PR DESCRIPTION
Part of #6686. Closes #6688.

## Summary
- Add lookup by (runId, guardianChatId, channel) for callback decisions to prevent ambiguity when multiple approvals are pending
- Require disambiguation for plain-text guardian decisions with multiple pending approvals
- Proactively auto-deny on guardian approval expiry via scheduled timer
- Consistent requester/guardian notifications on timeout denial
- Comprehensive tests for multi-pending and timeout scenarios (8 new tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
