### PR TITLE
feat: make gateway responsive to runtime config changes

### DIFF
--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -54,6 +54,7 @@ function readConfigFile(path: string): { ingressPublicBaseUrl?: string; smsPhone
 
 export class ConfigFileWatcher {
   private watcher: FSWatcher | null = null;
+  private watchingDirectory = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastIngressPublicBaseUrl: string | undefined;
   private lastSmsPhoneNumber: string | undefined;
@@ -68,14 +69,15 @@ export class ConfigFileWatcher {
   start(): void {
     this.pollOnce();
 
-    const watchTarget = existsSync(this.configPath)
-      ? this.configPath
-      : dirname(this.configPath);
+    this.watchingDirectory = !existsSync(this.configPath);
+    const watchTarget = this.watchingDirectory
+      ? dirname(this.configPath)
+      : this.configPath;
 
     try {
       this.watcher = watch(watchTarget, { persistent: false }, (_event, filename) => {
         if (
-          watchTarget !== this.configPath &&
+          this.watchingDirectory &&
           filename !== CONFIG_FILENAME
         ) {
           return;
@@ -108,11 +110,7 @@ export class ConfigFileWatcher {
       this.debounceTimer = null;
       this.pollOnce();
 
-      if (
-        !this.watcher ||
-        (existsSync(this.configPath) &&
-          this.watcher.ref === undefined)
-      ) {
+      if (this.watchingDirectory && existsSync(this.configPath)) {
         this.upgradeWatcher();
       }
     }, DEBOUNCE_MS);
@@ -134,6 +132,7 @@ export class ConfigFileWatcher {
           this.scheduleCheck();
         },
       );
+      this.watchingDirectory = false;
       log.debug("Upgraded watcher to config file");
     } catch (err) {
       log.warn({ err }, "Failed to upgrade config file watcher");

--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -1,0 +1,176 @@
+/**
+ * Watches ~/.vellum/workspace/config.json for changes to ingress URL
+ * and SMS phone number. Uses the same fs.watch() + debounce pattern
+ * as CredentialWatcher.
+ */
+
+import { existsSync, readFileSync, watch, type FSWatcher } from "node:fs";
+import { dirname, join } from "node:path";
+import { getLogger } from "./logger.js";
+import { getRootDir } from "./credential-reader.js";
+
+const log = getLogger("config-file-watcher");
+
+const DEBOUNCE_MS = 500;
+const CONFIG_FILENAME = "config.json";
+
+export type ConfigChangeEvent = {
+  ingressPublicBaseUrl: string | undefined;
+  ingressChanged: boolean;
+  smsPhoneNumber: string | undefined;
+  smsPhoneNumberChanged: boolean;
+};
+
+export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
+
+function getConfigPath(): string {
+  return join(getRootDir(), "workspace", CONFIG_FILENAME);
+}
+
+function readConfigFile(path: string): { ingressPublicBaseUrl?: string; smsPhoneNumber?: string } {
+  try {
+    if (!existsSync(path)) return {};
+
+    const raw = readFileSync(path, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object") return {};
+
+    const ingressPublicBaseUrl =
+      data.ingress && typeof data.ingress.publicBaseUrl === "string"
+        ? data.ingress.publicBaseUrl || undefined
+        : undefined;
+
+    const smsPhoneNumber =
+      data.sms && typeof data.sms.phoneNumber === "string"
+        ? data.sms.phoneNumber || undefined
+        : undefined;
+
+    return { ingressPublicBaseUrl, smsPhoneNumber };
+  } catch (err) {
+    log.debug({ err }, "Failed to read config file");
+    return {};
+  }
+}
+
+export class ConfigFileWatcher {
+  private watcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastIngressPublicBaseUrl: string | undefined;
+  private lastSmsPhoneNumber: string | undefined;
+  private callback: ConfigChangeCallback;
+  private configPath: string;
+
+  constructor(callback: ConfigChangeCallback) {
+    this.callback = callback;
+    this.configPath = getConfigPath();
+  }
+
+  start(): void {
+    this.pollOnce();
+
+    const watchTarget = existsSync(this.configPath)
+      ? this.configPath
+      : dirname(this.configPath);
+
+    try {
+      this.watcher = watch(watchTarget, { persistent: false }, (_event, filename) => {
+        if (
+          watchTarget !== this.configPath &&
+          filename !== CONFIG_FILENAME
+        ) {
+          return;
+        }
+        this.scheduleCheck();
+      });
+
+      log.info({ path: watchTarget }, "Watching for config file changes");
+    } catch (err) {
+      log.warn({ err, path: watchTarget }, "Failed to start config file watcher");
+    }
+  }
+
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  private scheduleCheck(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.pollOnce();
+
+      if (
+        !this.watcher ||
+        (existsSync(this.configPath) &&
+          this.watcher.ref === undefined)
+      ) {
+        this.upgradeWatcher();
+      }
+    }, DEBOUNCE_MS);
+  }
+
+  private upgradeWatcher(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+
+    if (!existsSync(this.configPath)) return;
+
+    try {
+      this.watcher = watch(
+        this.configPath,
+        { persistent: false },
+        () => {
+          this.scheduleCheck();
+        },
+      );
+      log.debug("Upgraded watcher to config file");
+    } catch (err) {
+      log.warn({ err }, "Failed to upgrade config file watcher");
+    }
+  }
+
+  private pollOnce(): void {
+    const { ingressPublicBaseUrl, smsPhoneNumber } = readConfigFile(this.configPath);
+
+    const ingressChanged = ingressPublicBaseUrl !== this.lastIngressPublicBaseUrl;
+    const smsPhoneNumberChanged = smsPhoneNumber !== this.lastSmsPhoneNumber;
+
+    if (!ingressChanged && !smsPhoneNumberChanged) {
+      return;
+    }
+
+    this.lastIngressPublicBaseUrl = ingressPublicBaseUrl;
+    this.lastSmsPhoneNumber = smsPhoneNumber;
+
+    if (ingressChanged) {
+      log.info(
+        { ingressPublicBaseUrl },
+        "Ingress URL updated from config file",
+      );
+    }
+    if (smsPhoneNumberChanged) {
+      log.info(
+        { smsPhoneNumber },
+        "SMS phone number updated",
+      );
+    }
+
+    this.callback({
+      ingressPublicBaseUrl,
+      ingressChanged,
+      smsPhoneNumber,
+      smsPhoneNumberChanged,
+    });
+  }
+}

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -188,6 +188,11 @@ export type TelegramCredentials = {
   webhookSecret: string;
 };
 
+export type TwilioCredentials = {
+  accountSid: string;
+  authToken: string;
+};
+
 /**
  * Read a credential by trying keychain first (on macOS), then encrypted store.
  */
@@ -244,6 +249,52 @@ export function readTelegramCredentials(): TelegramCredentials | null {
     return { botToken, webhookSecret };
   } catch (err) {
     log.debug({ err }, "Failed to read Telegram credentials");
+    return null;
+  }
+}
+
+/**
+ * Check the credential metadata file for Twilio credentials and read
+ * them from secure storage (keychain on macOS, then encrypted store).
+ *
+ * Returns `null` if:
+ * - The metadata file doesn't exist or can't be parsed
+ * - Twilio account_sid or auth_token entries are missing from metadata
+ * - The actual secret values can't be read from any backend
+ */
+export function readTwilioCredentials(): TwilioCredentials | null {
+  try {
+    const metadataPath = getMetadataPath();
+    if (!existsSync(metadataPath)) return null;
+
+    const raw = readFileSync(metadataPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || !Array.isArray(data.credentials)) return null;
+
+    const hasAccountSid = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "twilio" && c.field === "account_sid",
+    );
+    const hasAuthToken = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "twilio" && c.field === "auth_token",
+    );
+
+    if (!hasAccountSid || !hasAuthToken) return null;
+
+    const accountSid = readCredentialWithFallback("credential:twilio:account_sid");
+    const authToken = readCredentialWithFallback("credential:twilio:auth_token");
+
+    if (!accountSid || !authToken) {
+      log.warn(
+        "Twilio credential metadata exists but secrets could not be read from any backend",
+      );
+      return null;
+    }
+
+    return { accountSid, authToken };
+  } catch (err) {
+    log.debug({ err }, "Failed to read Twilio credentials");
     return null;
   }
 }

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -1,7 +1,7 @@
 /**
  * Watches the assistant's credential metadata file for changes and
- * triggers a callback when Telegram credentials are added, updated,
- * or removed.
+ * triggers a callback when Telegram or Twilio credentials are added,
+ * updated, or removed.
  *
  * Uses fs.watch() on the metadata file with debouncing to avoid
  * rapid re-reads from atomic rename writes.
@@ -13,22 +13,31 @@ import { getLogger } from "./logger.js";
 import {
   getMetadataPath,
   readTelegramCredentials,
+  readTwilioCredentials,
   type TelegramCredentials,
+  type TwilioCredentials,
 } from "./credential-reader.js";
 
 const log = getLogger("credential-watcher");
 
 const DEBOUNCE_MS = 500;
 
-export type CredentialChangeCallback = (
-  credentials: TelegramCredentials | null,
-) => void;
+export type CredentialChangeEvent = {
+  telegramCredentials: TelegramCredentials | null;
+  telegramChanged: boolean;
+  twilioCredentials: TwilioCredentials | null;
+  twilioChanged: boolean;
+};
+
+export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
 
 export class CredentialWatcher {
   private watcher: FSWatcher | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastBotToken: string | undefined;
   private lastWebhookSecret: string | undefined;
+  private lastTwilioAccountSid: string | undefined;
+  private lastTwilioAuthToken: string | undefined;
   private callback: CredentialChangeCallback;
   private metadataPath: string;
 
@@ -113,26 +122,49 @@ export class CredentialWatcher {
   }
 
   private pollOnce(): void {
-    const credentials = readTelegramCredentials();
+    const telegramCredentials = readTelegramCredentials();
+    const twilioCredentials = readTwilioCredentials();
 
-    const newBotToken = credentials?.botToken;
-    const newWebhookSecret = credentials?.webhookSecret;
+    const newBotToken = telegramCredentials?.botToken;
+    const newWebhookSecret = telegramCredentials?.webhookSecret;
+    const newTwilioAccountSid = twilioCredentials?.accountSid;
+    const newTwilioAuthToken = twilioCredentials?.authToken;
 
-    if (
-      newBotToken === this.lastBotToken &&
-      newWebhookSecret === this.lastWebhookSecret
-    ) {
+    const telegramChanged =
+      newBotToken !== this.lastBotToken ||
+      newWebhookSecret !== this.lastWebhookSecret;
+
+    const twilioChanged =
+      newTwilioAccountSid !== this.lastTwilioAccountSid ||
+      newTwilioAuthToken !== this.lastTwilioAuthToken;
+
+    if (!telegramChanged && !twilioChanged) {
       return;
     }
 
     this.lastBotToken = newBotToken;
     this.lastWebhookSecret = newWebhookSecret;
+    this.lastTwilioAccountSid = newTwilioAccountSid;
+    this.lastTwilioAuthToken = newTwilioAuthToken;
 
-    log.info(
-      { hasCredentials: !!credentials },
-      "Telegram credentials changed",
-    );
+    if (telegramChanged) {
+      log.info(
+        { hasCredentials: !!telegramCredentials },
+        "Telegram credentials changed",
+      );
+    }
+    if (twilioChanged) {
+      log.info(
+        { hasCredentials: !!twilioCredentials },
+        "Twilio credentials changed",
+      );
+    }
 
-    this.callback(credentials);
+    this.callback({
+      telegramCredentials,
+      telegramChanged,
+      twilioCredentials,
+      twilioChanged,
+    });
   }
 }

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -33,6 +33,7 @@ export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
 
 export class CredentialWatcher {
   private watcher: FSWatcher | null = null;
+  private watchingDirectory = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastBotToken: string | undefined;
   private lastWebhookSecret: string | undefined;
@@ -49,14 +50,15 @@ export class CredentialWatcher {
   start(): void {
     this.pollOnce();
 
-    const watchTarget = existsSync(this.metadataPath)
-      ? this.metadataPath
-      : dirname(this.metadataPath);
+    this.watchingDirectory = !existsSync(this.metadataPath);
+    const watchTarget = this.watchingDirectory
+      ? dirname(this.metadataPath)
+      : this.metadataPath;
 
     try {
       this.watcher = watch(watchTarget, { persistent: false }, (_event, filename) => {
         if (
-          watchTarget !== this.metadataPath &&
+          this.watchingDirectory &&
           filename !== "metadata.json"
         ) {
           return;
@@ -89,11 +91,7 @@ export class CredentialWatcher {
       this.debounceTimer = null;
       this.pollOnce();
 
-      if (
-        !this.watcher ||
-        (existsSync(this.metadataPath) &&
-          this.watcher.ref === undefined)
-      ) {
+      if (this.watchingDirectory && existsSync(this.metadataPath)) {
         this.upgradeWatcher();
       }
     }, DEBOUNCE_MS);
@@ -115,6 +113,7 @@ export class CredentialWatcher {
           this.scheduleCheck();
         },
       );
+      this.watchingDirectory = false;
       log.debug("Upgraded watcher to metadata file");
     } catch (err) {
       log.warn({ err }, "Failed to upgrade credential file watcher");

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
@@ -167,25 +168,54 @@ function main() {
     });
   }
 
-  const credentialWatcher = new CredentialWatcher((credentials) => {
-    if (credentials) {
-      config.telegramBotToken = credentials.botToken;
-      config.telegramWebhookSecret = credentials.webhookSecret;
-      log.info("Telegram credentials loaded from credential vault");
-      registerTelegramCommands();
-      reconcileTelegramWebhook(config).catch((err) => {
-        log.error({ err }, "Failed to reconcile Telegram webhook after credential change");
-      });
-    } else {
-      config.telegramBotToken = undefined;
-      config.telegramWebhookSecret = undefined;
-      log.info("Telegram credentials cleared");
+  const credentialWatcher = new CredentialWatcher((event) => {
+    if (event.telegramChanged) {
+      if (event.telegramCredentials) {
+        config.telegramBotToken = event.telegramCredentials.botToken;
+        config.telegramWebhookSecret = event.telegramCredentials.webhookSecret;
+        log.info("Telegram credentials loaded from credential vault");
+        registerTelegramCommands();
+        reconcileTelegramWebhook(config).catch((err) => {
+          log.error({ err }, "Failed to reconcile Telegram webhook after credential change");
+        });
+      } else {
+        config.telegramBotToken = undefined;
+        config.telegramWebhookSecret = undefined;
+        log.info("Telegram credentials cleared");
+      }
+    }
+
+    if (event.twilioChanged) {
+      if (event.twilioCredentials) {
+        config.twilioAccountSid = event.twilioCredentials.accountSid;
+        config.twilioAuthToken = event.twilioCredentials.authToken;
+        log.info("Twilio credentials loaded from credential vault");
+      } else {
+        config.twilioAccountSid = undefined;
+        config.twilioAuthToken = undefined;
+        log.info("Twilio credentials cleared");
+      }
     }
   });
 
-  if (!isTelegramConfigured()) {
-    credentialWatcher.start();
-  }
+  credentialWatcher.start();
+
+  const configFileWatcher = new ConfigFileWatcher((event) => {
+    if (event.smsPhoneNumberChanged) {
+      config.twilioPhoneNumber = event.smsPhoneNumber;
+    }
+
+    if (event.ingressChanged) {
+      config.ingressPublicBaseUrl = event.ingressPublicBaseUrl;
+      if (isTelegramConfigured()) {
+        reconcileTelegramWebhook(config).catch((err) => {
+          log.error({ err }, "Failed to reconcile Telegram webhook after ingress URL change");
+        });
+      }
+    }
+  });
+
+  configFileWatcher.start();
 
   const drainMs = config.shutdownDrainMs;
 
@@ -193,6 +223,7 @@ function main() {
     log.info("SIGTERM received, starting graceful shutdown");
     draining = true;
     credentialWatcher.stop();
+    configFileWatcher.stop();
     setTimeout(() => {
       log.info("Drain window elapsed, stopping server");
       server.stop(true);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -168,8 +168,10 @@ function main() {
     });
   }
 
+  const telegramFromEnv = isTelegramConfigured();
+
   const credentialWatcher = new CredentialWatcher((event) => {
-    if (event.telegramChanged) {
+    if (event.telegramChanged && !telegramFromEnv) {
       if (event.telegramCredentials) {
         config.telegramBotToken = event.telegramCredentials.botToken;
         config.telegramWebhookSecret = event.telegramCredentials.webhookSecret;


### PR DESCRIPTION
## Summary

- Add `readTwilioCredentials()` to `credential-reader.ts`, mirroring the existing Telegram pattern (metadata check + keychain/encrypted store fallback)
- Broaden `CredentialWatcher` to track and emit both Telegram and Twilio credential changes via a `CredentialChangeEvent`
- Add new `ConfigFileWatcher` that watches `~/.vellum/workspace/config.json` for `ingress.publicBaseUrl` and `sms.phoneNumber` changes (same `fs.watch()` + 500ms debounce pattern)
- Always start credential watcher regardless of Telegram config state, so Twilio credentials are picked up dynamically
- Wire config file watcher to update `ingressPublicBaseUrl` and `twilioPhoneNumber` at runtime, triggering Telegram webhook reconciliation on ingress changes
- Stop both watchers on SIGTERM

## Test plan

- [ ] Start gateway, then store Twilio credentials via `credential_store` — verify `config.twilioAccountSid` / `config.twilioAuthToken` update without restart (check logs for "Twilio credentials loaded from credential vault")
- [ ] Update `ingress.publicBaseUrl` in `config.json` — verify logs show "Ingress URL updated from config file" and Telegram webhook reconciliation fires
- [ ] Update `sms.phoneNumber` in `config.json` — verify logs show "SMS phone number updated"
- [ ] Confirm existing Telegram credential watcher still works
- [ ] Run existing gateway tests (`bun test` — 309 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
