### PR TITLE
fix: add gateway-origin header to runtime proxy forwarded requests

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -390,4 +390,48 @@ describe("runtime proxy handler", () => {
       expect(fetchCalls.length).toBe(1);
     });
   });
+
+  // ── Gateway-origin header on proxied requests ────────────────────────
+
+  describe("gateway-origin header", () => {
+    test("sets X-Gateway-Origin header when runtimeBearerToken is configured", async () => {
+      let capturedHeaders: Headers | undefined;
+      globalThis.fetch = mock(async (_input: any, init?: any) => {
+        capturedHeaders = init?.headers;
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(
+        makeConfig({ runtimeBearerToken: "runtime-secret" }),
+      );
+      const req = new Request("http://localhost:7830/v1/channels/inbound", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "hello" }),
+      });
+      await handler(req);
+
+      expect(capturedHeaders!.get("x-gateway-origin")).toBe("runtime-secret");
+    });
+
+    test("does not set X-Gateway-Origin header when no runtimeBearerToken", async () => {
+      let capturedHeaders: Headers | undefined;
+      globalThis.fetch = mock(async (_input: any, init?: any) => {
+        capturedHeaders = init?.headers;
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const handler = createRuntimeProxyHandler(
+        makeConfig({ runtimeBearerToken: undefined }),
+      );
+      const req = new Request("http://localhost:7830/v1/channels/inbound", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "hello" }),
+      });
+      await handler(req);
+
+      expect(capturedHeaders!.has("x-gateway-origin")).toBe(false);
+    });
+  });
 });

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -85,7 +85,7 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
     headers.forEach((v, k) => { result[k] = v; });
   } else if (headers && typeof headers === "object" && !Array.isArray(headers)) {
     for (const [k, v] of Object.entries(headers)) {
-      result[k] = v;
+      result[k.toLowerCase()] = v;
     }
   }
   return result;

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -1,6 +1,7 @@
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
 import { validateBearerToken } from "../auth/bearer.js";
+import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
 
 const log = getLogger("runtime-proxy");
 
@@ -98,6 +99,9 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     // Add the runtime's bearer token so the upstream accepts the request
     if (config.runtimeBearerToken) {
       reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
+      // Attach gateway-origin proof so the runtime can distinguish
+      // gateway-forwarded requests from direct external calls.
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeBearerToken);
     }
 
     if (config.runtimeProxyBearerToken) {


### PR DESCRIPTION
Addresses review feedback on #6728.

## Summary
- Add X-Gateway-Origin header to proxied /v1/channels/inbound requests in runtime-proxy.ts
- Fix extractHeaders in telegram-webhook-handler test to normalize header keys to lowercase
- Preserves runtime-proxy contract when GATEWAY_RUNTIME_PROXY_ENABLED=true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
