### PR TITLE
fix: use rolling rate-limit window and correct revoke bound state

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1358,7 +1358,7 @@ export function handleGuardianVerification(
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
-        bound: !revoked,
+        bound: false,
       });
     } else {
       ctx.send(socket, {

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -591,8 +591,10 @@ export function recordInvalidAttempt(
   const existing = getRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
   if (existing) {
-    // If the throttling window has elapsed, reset the counter
-    const windowExpired = now - existing.windowStartedAt > windowMs;
+    // Rolling window: reset the counter only when enough time has elapsed
+    // since the last attempt (updatedAt), not since a fixed window start.
+    // This prevents timing attacks that split attempts around a fixed boundary.
+    const windowExpired = now - existing.updatedAt > windowMs;
     const newAttempts = windowExpired ? 1 : existing.invalidAttempts + 1;
     const newWindowStart = windowExpired ? now : existing.windowStartedAt;
     const newLockedUntil = newAttempts >= maxAttempts ? now + lockoutMs : existing.lockedUntil;


### PR DESCRIPTION
Addresses review feedback on #6729.\n\n## Summary\n- Change rate limiter from fixed window to rolling/sliding window for brute-force protection\n- Fix bound: !revoked to always return bound: false after revoke action
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
