### PR TITLE
fix: resolve gateway-not-found and orphaned daemon on local hatch failure

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from "crypto";
-import { existsSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createRequire } from "module";
-import { tmpdir, userInfo } from "os";
-import { join } from "path";
+import { homedir, tmpdir, userInfo } from "os";
+import { dirname, join } from "path";
 
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
-import { saveAssistantEntry } from "../lib/assistant-config";
+import { loadAllAssistants, saveAssistantEntry } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import { hatchAws } from "../lib/aws";
 import {
@@ -17,7 +17,8 @@ import {
 import type { RemoteHost, Species } from "../lib/constants";
 import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
-import { startLocalDaemon, startGateway } from "../lib/local";
+import { startLocalDaemon, startGateway, stopLocalProcesses } from "../lib/local";
+import { isProcessAlive } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
 import { exec } from "../lib/step-runner";
 
@@ -514,13 +515,36 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
   const instanceName =
     name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
 
+  // Clean up stale local state: if daemon/gateway processes are running but
+  // the lock file has no entries, stop them before starting fresh.
+  const vellumDir = join(homedir(), ".vellum");
+  const existingAssistants = loadAllAssistants();
+  const localAssistants = existingAssistants.filter((a) => a.cloud === "local");
+  if (localAssistants.length === 0) {
+    const daemonPid = isProcessAlive(join(vellumDir, "vellum.pid"));
+    const gatewayPid = isProcessAlive(join(vellumDir, "gateway.pid"));
+    if (daemonPid.alive || gatewayPid.alive) {
+      console.log("🧹 Cleaning up stale local processes (no lock file entry)...\n");
+      await stopLocalProcesses();
+    }
+  }
+
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
 
   await startLocalDaemon();
 
-  const runtimeUrl = await startGateway();
+  let runtimeUrl: string;
+  try {
+    runtimeUrl = await startGateway();
+  } catch (error) {
+    // Gateway failed — stop the daemon we just started so we don't leave
+    // orphaned processes with no lock file entry.
+    console.error(`\n❌ Gateway startup failed — stopping daemon to avoid orphaned processes.`);
+    await stopLocalProcesses();
+    throw error;
+  }
 
   const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
   const localEntry: AssistantEntry = {
@@ -545,14 +569,27 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
 }
 
 function getCliVersion(): string {
+  // Strategy 1: createRequire — works in Bun dev (source tree).
   try {
-    // Use createRequire for JSON import — works in both Bun dev and compiled binary.
     const require = createRequire(import.meta.url);
     const pkg = require("../../package.json") as { version?: string };
-    return pkg.version ?? "unknown";
+    if (pkg.version) return pkg.version;
   } catch {
-    return "unknown";
+    // Fall through to next strategy.
   }
+
+  // Strategy 2: Read package.json adjacent to the compiled binary.
+  try {
+    const binPkg = join(dirname(process.execPath), "package.json");
+    if (existsSync(binPkg)) {
+      const pkg = JSON.parse(readFileSync(binPkg, "utf-8")) as { version?: string };
+      if (pkg.version) return pkg.version;
+    }
+  } catch {
+    // Fall through.
+  }
+
+  return "unknown";
 }
 
 export async function hatch(): Promise<void> {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "path";
 
 import { loadAllAssistants, loadLatestAssistant } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
+import { stopProcessByPidFile } from "./process.js";
 
 const _require = createRequire(import.meta.url);
 
@@ -49,9 +50,16 @@ function resolveGatewayDir(): string {
     return override;
   }
 
+  // Source tree: cli/src/lib/ → ../../.. → repo root → gateway/
   const sourceDir = join(import.meta.dir, "..", "..", "..", "gateway");
   if (isGatewaySourceDir(sourceDir)) {
     return sourceDir;
+  }
+
+  // Compiled binary: gateway/ bundled adjacent to the CLI executable.
+  const binGateway = join(dirname(process.execPath), "gateway");
+  if (isGatewaySourceDir(binGateway)) {
+    return binGateway;
   }
 
   const cwdSourceDir = findGatewaySourceFromCwd();
@@ -338,4 +346,19 @@ export async function startGateway(): Promise<string> {
 
   console.log("✅ Gateway started\n");
   return publicUrl || `http://localhost:${GATEWAY_PORT}`;
+}
+
+/**
+ * Stop any locally-running daemon and gateway processes and clean up
+ * PID/socket files. Called when hatch fails partway through so we don't
+ * leave orphaned processes with no lock file entry.
+ */
+export async function stopLocalProcesses(): Promise<void> {
+  const vellumDir = join(homedir(), ".vellum");
+  const daemonPidFile = join(vellumDir, "vellum.pid");
+  const socketFile = join(vellumDir, "vellum.sock");
+  await stopProcessByPidFile(daemonPidFile, "daemon", [socketFile]);
+
+  const gatewayPidFile = join(vellumDir, "gateway.pid");
+  await stopProcessByPidFile(gatewayPidFile, "gateway");
 }


### PR DESCRIPTION
## Summary

- **Gateway resolution**: Added compiled-binary discovery strategy (`dirname(process.execPath)/gateway`) so the gateway is found when bundled alongside the CLI binary — mirrors how `vellum-daemon` is already discovered
- **Orphaned process cleanup**: If `startGateway()` fails after the daemon is already running, `hatchLocal()` now catches the error and calls `stopLocalProcesses()` before re-throwing, preventing orphaned daemons with no lock file entry
- **Stale state recovery**: On hatch, if daemon/gateway PIDs are alive but the lock file has no local entries, the stale processes are cleaned up before starting fresh — fixes the "stuck" state where `retire` can't help
- **Version display**: `getCliVersion()` now falls back to reading `package.json` adjacent to the compiled binary, fixing the `vunknown` display

## Test plan

- [ ] Run `vel hatch` from source tree — gateway should resolve via `import.meta.dir` as before
- [ ] Run compiled CLI binary with gateway bundled adjacent — gateway should resolve via `dirname(process.execPath)/gateway`
- [ ] Kill gateway mid-hatch or set `VELLUM_GATEWAY_DIR` to invalid path — daemon should be stopped, no orphaned processes
- [ ] Manually create stale state (running daemon, empty lock file), then run `vel hatch` — stale processes should be cleaned up automatically
- [ ] Check version display shows `v0.3.0` instead of `vunknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
