### PR TITLE
fix: use per-channel delivery URL in guardian expiry sweep

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2281,8 +2281,8 @@ describe('expired guardian approval auto-denies via sweep', () => {
 
     const orchestrator = makeMockOrchestrator();
 
-    // Run the sweep
-    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test/deliver', 'token');
+    // Run the sweep — pass the gateway base URL (not a full /deliver/<channel> URL)
+    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test', 'token');
 
     // Wait for async notifications
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -2313,6 +2313,12 @@ describe('expired guardian approval auto-denies via sweep', () => {
     );
     expect(guardianNotify.length).toBeGreaterThanOrEqual(1);
 
+    // Verify the delivery URL is constructed per-channel (telegram in this case)
+    const allDeliverCalls = deliverSpy.mock.calls;
+    for (const call of allDeliverCalls) {
+      expect(call[0]).toBe('https://gateway.test/deliver/telegram');
+    }
+
     deliverSpy.mockRestore();
   });
 
@@ -2339,7 +2345,7 @@ describe('expired guardian approval auto-denies via sweep', () => {
 
     const orchestrator = makeMockOrchestrator();
 
-    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test/deliver', 'token');
+    sweepExpiredGuardianApprovals(orchestrator, 'https://gateway.test', 'token');
 
     await new Promise((resolve) => setTimeout(resolve, 200));
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -413,8 +413,7 @@ export class RuntimeHttpServer {
 
     // Start proactive guardian approval expiry sweep when approvals are enabled
     if (isChannelApprovalsEnabled() && this.runOrchestrator) {
-      const gatewayDeliverUrl = `${getGatewayBaseUrl()}/deliver/telegram`;
-      startGuardianExpirySweep(this.runOrchestrator, gatewayDeliverUrl, this.bearerToken);
+      startGuardianExpirySweep(this.runOrchestrator, getGatewayBaseUrl(), this.bearerToken);
       log.info('Guardian approval expiry sweep started');
     }
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1336,7 +1336,7 @@ let expirySweepTimer: ReturnType<typeof setInterval> | null = null;
  */
 export function sweepExpiredGuardianApprovals(
   orchestrator: RunOrchestrator,
-  replyCallbackUrl: string,
+  gatewayBaseUrl: string,
   bearerToken?: string,
 ): void {
   const expired = getExpiredPendingApprovals();
@@ -1351,8 +1351,11 @@ export function sweepExpiredGuardianApprovals(
     };
     handleChannelDecision(approval.conversationId, expiredDecision, orchestrator);
 
+    // Construct the per-channel delivery URL from the approval's channel
+    const deliverUrl = `${gatewayBaseUrl}/deliver/${approval.channel}`;
+
     // Notify the requester that the approval expired
-    deliverChannelReply(replyCallbackUrl, {
+    deliverChannelReply(deliverUrl, {
       chatId: approval.requesterChatId,
       text: `Your guardian approval request for "${approval.toolName}" has expired and the action has been denied. Please try again.`,
     }, bearerToken).catch((err) => {
@@ -1360,7 +1363,7 @@ export function sweepExpiredGuardianApprovals(
     });
 
     // Notify the guardian that the approval expired
-    deliverChannelReply(replyCallbackUrl, {
+    deliverChannelReply(deliverUrl, {
       chatId: approval.guardianChatId,
       text: `The approval request for "${approval.toolName}" from user ${approval.requesterExternalUserId} has expired and was automatically denied.`,
     }, bearerToken).catch((err) => {
@@ -1380,13 +1383,13 @@ export function sweepExpiredGuardianApprovals(
  */
 export function startGuardianExpirySweep(
   orchestrator: RunOrchestrator,
-  replyCallbackUrl: string,
+  gatewayBaseUrl: string,
   bearerToken?: string,
 ): void {
   if (expirySweepTimer) return;
   expirySweepTimer = setInterval(() => {
     try {
-      sweepExpiredGuardianApprovals(orchestrator, replyCallbackUrl, bearerToken);
+      sweepExpiredGuardianApprovals(orchestrator, gatewayBaseUrl, bearerToken);
     } catch (err) {
       log.error({ err }, 'Guardian expiry sweep failed');
     }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/deliver/telegram` URL in guardian expiry sweep with per-channel URL construction
- `startGuardianExpirySweep` and `sweepExpiredGuardianApprovals` now accept `gatewayBaseUrl` and construct `${gatewayBaseUrl}/deliver/${approval.channel}` dynamically
- Ensures SMS and future channel approvals route to the correct delivery endpoint on expiry

Addresses feedback from PR #6739.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit` — only pre-existing `ipc-snapshot.test.ts` errors)
- [x] Sweep-related channel approval tests pass
- [x] Verify per-channel URL construction in sweep logic (new assertion added to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
