### PR TITLE
fix: preserve legacy rate-limit columns for backward compatibility

### DIFF
--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -525,7 +525,7 @@ export interface VerificationRateLimit {
   actorChatId: string;
   /** Individual attempt timestamps (epoch-ms) within the sliding window. */
   attemptTimestamps: number[];
-  /** Derived count of attempts currently inside the window (convenience). */
+  /** Total stored attempt count (may include expired timestamps; use lockedUntil for enforcement decisions). */
   invalidAttempts: number;
   lockedUntil: number | null;
   createdAt: number;

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1001,6 +1001,8 @@ export function initializeDb(): void {
       channel TEXT NOT NULL,
       actor_external_user_id TEXT NOT NULL,
       actor_chat_id TEXT NOT NULL,
+      invalid_attempts INTEGER NOT NULL DEFAULT 0,
+      window_started_at INTEGER NOT NULL DEFAULT 0,
       attempt_timestamps_json TEXT NOT NULL DEFAULT '[]',
       locked_until INTEGER,
       created_at INTEGER NOT NULL,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -669,6 +669,10 @@ export const channelGuardianRateLimits = sqliteTable('channel_guardian_rate_limi
   channel: text('channel').notNull(),
   actorExternalUserId: text('actor_external_user_id').notNull(),
   actorChatId: text('actor_chat_id').notNull(),
+  // Legacy columns kept with defaults for backward compatibility with upgraded databases
+  // that still have the old NOT NULL columns without DEFAULT. Not read by app logic.
+  invalidAttempts: integer('invalid_attempts').notNull().default(0),
+  windowStartedAt: integer('window_started_at').notNull().default(0),
   attemptTimestampsJson: text('attempt_timestamps_json').notNull().default('[]'),
   lockedUntil: integer('locked_until'),
   createdAt: integer('created_at').notNull(),


### PR DESCRIPTION
Codex flagged that removing window_started_at from the drizzle schema breaks inserts on upgraded databases (NOT NULL without DEFAULT). Re-adds legacy columns with defaults. Also fixes JSDoc on invalidAttempts per Devin's feedback. Addresses feedback from PR #6748.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
