### PR TITLE
fix: spawn compiled gateway binary in desktop app instead of source

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from "crypto";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
-import { createRequire } from "module";
+import { existsSync, unlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir, userInfo } from "os";
-import { dirname, join } from "path";
+import { join } from "path";
+
+// Direct import — bun embeds this at compile time so it works in compiled binaries.
+import cliPkg from "../../package.json";
 
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
 import { loadAllAssistants, saveAssistantEntry } from "../lib/assistant-config";
@@ -569,27 +571,7 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
 }
 
 function getCliVersion(): string {
-  // Strategy 1: createRequire — works in Bun dev (source tree).
-  try {
-    const require = createRequire(import.meta.url);
-    const pkg = require("../../package.json") as { version?: string };
-    if (pkg.version) return pkg.version;
-  } catch {
-    // Fall through to next strategy.
-  }
-
-  // Strategy 2: Read package.json adjacent to the compiled binary.
-  try {
-    const binPkg = join(dirname(process.execPath), "package.json");
-    if (existsSync(binPkg)) {
-      const pkg = JSON.parse(readFileSync(binPkg, "utf-8")) as { version?: string };
-      if (pkg.version) return pkg.version;
-    }
-  } catch {
-    // Fall through.
-  }
-
-  return "unknown";
+  return cliPkg.version ?? "unknown";
 }
 
 export async function hatch(): Promise<void> {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -294,7 +294,7 @@ export async function startGateway(): Promise<string> {
   }
 
   console.log("🌐 Starting gateway...");
-  const gatewayDir = resolveGatewayDir();
+
   // Only auto-configure default routing when the workspace has exactly one
   // assistant.  In multi-assistant deployments, falling back to "default"
   // would silently deliver unmapped Telegram chats to whichever assistant was
@@ -331,12 +331,34 @@ export async function startGateway(): Promise<string> {
     console.log(`   Ingress URL: ${ingressPublicBaseUrl}`);
   }
 
-  const gateway = spawn("bun", ["run", "src/index.ts"], {
-    cwd: gatewayDir,
-    detached: true,
-    stdio: "ignore",
-    env: gatewayEnv,
-  });
+  let gateway;
+
+  if (process.env.VELLUM_DESKTOP_APP) {
+    // Desktop app: spawn the compiled gateway binary directly (mirrors daemon pattern).
+    const gatewayBinary = join(dirname(process.execPath), "vellum-gateway");
+    if (!existsSync(gatewayBinary)) {
+      throw new Error(
+        `vellum-gateway binary not found at ${gatewayBinary}.\n` +
+          "  Ensure the gateway binary is bundled alongside the CLI in the app bundle.",
+      );
+    }
+
+    gateway = spawn(gatewayBinary, [], {
+      detached: true,
+      stdio: "ignore",
+      env: gatewayEnv,
+    });
+  } else {
+    // Source tree / bunx: resolve the gateway source directory and run via bun.
+    const gatewayDir = resolveGatewayDir();
+    gateway = spawn("bun", ["run", "src/index.ts"], {
+      cwd: gatewayDir,
+      detached: true,
+      stdio: "ignore",
+      env: gatewayEnv,
+    });
+  }
+
   gateway.unref();
 
   if (gateway.pid) {


### PR DESCRIPTION
## Summary

- **Gateway startup**: `startGateway()` now checks `VELLUM_DESKTOP_APP` and spawns the compiled `vellum-gateway` binary directly from `dirname(process.execPath)`, mirroring how `startLocalDaemon()` already handles the daemon binary
- **Version display**: Replaced `createRequire` approach with direct `import cliPkg from "../../package.json"` which bun embeds at compile time, fixing `vunknown` in compiled binaries
- Source tree / bunx code path unchanged — `resolveGatewayDir()` + `bun run src/index.ts` still used when `VELLUM_DESKTOP_APP` is not set

## Root cause

The build script (`build.sh`) compiles all three binaries (`vellum-cli`, `vellum-daemon`, `vellum-gateway`) and bundles them into `Vellum.app/Contents/MacOS/`. The daemon startup was already updated to spawn its compiled binary when `VELLUM_DESKTOP_APP=1`, but the gateway startup was never updated — it still tried to find a gateway source directory and run `bun run src/index.ts`, both of which don't exist in the compiled app context.

## Test plan

- [ ] Build macOS app via `./build.sh` and verify all three binaries are in `MacOS/`
- [ ] Launch app and verify hatch succeeds (gateway starts from compiled binary)
- [ ] Verify version shows `v0.3.0` instead of `vunknown`
- [ ] Run `bun run cli/src/index.ts hatch` from source tree — verify gateway still starts via `bun run src/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
