### PR TITLE
fix: add ALTER TABLE migration for legacy rate-limit columns

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1015,6 +1015,12 @@ export function initializeDb(): void {
   // doesn't support DROP COLUMN in older versions) but are no longer read by the app.
   try { database.run(/*sql*/ `ALTER TABLE channel_guardian_rate_limits ADD COLUMN attempt_timestamps_json TEXT NOT NULL DEFAULT '[]'`); } catch { /* already exists */ }
 
+  // Migration: re-add legacy columns for databases created during the brief window when
+  // PR #6748 was live (columns were absent from CREATE TABLE). These columns are not read
+  // by app logic but must exist so drizzle inserts don't fail.
+  try { database.run(/*sql*/ `ALTER TABLE channel_guardian_rate_limits ADD COLUMN invalid_attempts INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE channel_guardian_rate_limits ADD COLUMN window_started_at INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(assistant_id, channel, actor_external_user_id, actor_chat_id)`);
 
   migrateMemoryFtsBackfill(database);


### PR DESCRIPTION
Both Codex and Devin flagged that PR #6751 re-added legacy columns to CREATE TABLE but missed ALTER TABLE migrations for databases created during the brief window when PR #6748 was live. Adds try/catch ALTER TABLE ADD COLUMN statements for `invalid_attempts` and `window_started_at`, following the existing migration pattern.

Addresses feedback from PR #6751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
