### PR TITLE
fix: stabilize gateway telegram test typings for clean typecheck

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -3,7 +3,10 @@ import type { GatewayConfig } from "../../config.js";
 
 // --- Mocks ----------------------------------------------------------------
 
-const callTelegramApiMock = mock(() => Promise.resolve({}));
+const callTelegramApiMock = mock(
+  (_config: GatewayConfig, _method: string, _body: Record<string, unknown>) =>
+    Promise.resolve({}),
+);
 const sendTelegramReplyMock = mock(() => Promise.resolve());
 const handleInboundMock = mock(() =>
   Promise.resolve({ forwarded: true, rejected: false }),

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -5,7 +5,10 @@ import type { GatewayConfig } from "../config.js";
 
 // Capture calls to callTelegramApi so we can inspect payloads without
 // hitting the network.
-const callTelegramApiMock = mock(() => Promise.resolve({}));
+const callTelegramApiMock = mock(
+  (_config: GatewayConfig, _method: string, _body: Record<string, unknown>) =>
+    Promise.resolve({}),
+);
 
 // Mock the api module before importing send.ts functions. The import
 // above resolved the real module, but Bun's mock.module patches the
@@ -134,7 +137,7 @@ describe("sendTelegramReply", () => {
     await sendTelegramReply(baseConfig, "chat-1", "Hello");
 
     expect(callTelegramApiMock).toHaveBeenCalledTimes(1);
-    const payload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    const payload = callTelegramApiMock.mock.calls[0][2];
     expect(payload.chat_id).toBe("chat-1");
     expect(payload.text).toBe("Hello");
     expect(payload.reply_markup).toBeUndefined();
@@ -144,7 +147,7 @@ describe("sendTelegramReply", () => {
     await sendTelegramReply(baseConfig, "chat-1", "Approve?", sampleApproval);
 
     expect(callTelegramApiMock).toHaveBeenCalledTimes(1);
-    const payload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    const payload = callTelegramApiMock.mock.calls[0][2];
     expect(payload.reply_markup).toBeDefined();
 
     const markup = payload.reply_markup as {
@@ -161,10 +164,10 @@ describe("sendTelegramReply", () => {
 
     expect(callTelegramApiMock).toHaveBeenCalledTimes(2);
 
-    const firstPayload = callTelegramApiMock.mock.calls[0][2] as Record<string, unknown>;
+    const firstPayload = callTelegramApiMock.mock.calls[0][2];
     expect(firstPayload.reply_markup).toBeUndefined();
 
-    const lastPayload = callTelegramApiMock.mock.calls[1][2] as Record<string, unknown>;
+    const lastPayload = callTelegramApiMock.mock.calls[1][2];
     expect(lastPayload.reply_markup).toBeDefined();
   });
 });


### PR DESCRIPTION
Fix brittle tuple/index assumptions and unsafe casts in gateway Telegram test files. Replaces unsafe type assertions with typed guards while preserving identical test behavior and assertions. Part of #6754, closes #6757.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
