### PR TITLE
fix: add deliver-once guard for terminal reply idempotency in approval flows

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -98,6 +98,7 @@ function resetTables(): void {
   db.run('DELETE FROM channel_inbound_events');
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
+  channelDeliveryStore.resetAllRunDeliveryClaims();
 }
 
 const sampleConfirmation: PendingConfirmation = {
@@ -2356,6 +2357,258 @@ describe('expired guardian approval auto-denies via sweep', () => {
 
     // submitDecision should NOT have been called
     expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 24. Deliver-once idempotency guard
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('deliver-once idempotency guard', () => {
+  test('claimRunDelivery returns true on first call, false on subsequent calls', () => {
+    const runId = 'run-idem-unit';
+    expect(channelDeliveryStore.claimRunDelivery(runId)).toBe(true);
+    expect(channelDeliveryStore.claimRunDelivery(runId)).toBe(false);
+    expect(channelDeliveryStore.claimRunDelivery(runId)).toBe(false);
+    channelDeliveryStore.resetRunDeliveryClaim(runId);
+  });
+
+  test('different run IDs are independent', () => {
+    expect(channelDeliveryStore.claimRunDelivery('run-a')).toBe(true);
+    expect(channelDeliveryStore.claimRunDelivery('run-b')).toBe(true);
+    expect(channelDeliveryStore.claimRunDelivery('run-a')).toBe(false);
+    expect(channelDeliveryStore.claimRunDelivery('run-b')).toBe(false);
+    channelDeliveryStore.resetRunDeliveryClaim('run-a');
+    channelDeliveryStore.resetRunDeliveryClaim('run-b');
+  });
+
+  test('resetRunDeliveryClaim allows re-claim', () => {
+    const runId = 'run-idem-reset';
+    expect(channelDeliveryStore.claimRunDelivery(runId)).toBe(true);
+    channelDeliveryStore.resetRunDeliveryClaim(runId);
+    expect(channelDeliveryStore.claimRunDelivery(runId)).toBe(true);
+    channelDeliveryStore.resetRunDeliveryClaim(runId);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 25. Final reply idempotency — main poll wins vs post-decision poll wins
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('final reply idempotency — no duplicate delivery', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('main poll wins: deliverChannelReply called exactly once when main poll delivers first', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init' });
+    const orchestrator = makeMockOrchestrator();
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Create a pending run and add an assistant message for delivery
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+    conversationStore.addMessage(conversationId!, 'assistant', 'Main poll result.');
+
+    // Orchestrator: first getRun returns needs_confirmation (to trigger
+    // approval prompt delivery in the poll), subsequent calls return
+    // completed so the main poll can deliver the reply.
+    let getRunCount = 0;
+    const racingOrchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => {
+        getRunCount++;
+        if (getRunCount <= 1) {
+          return {
+            id: run.id,
+            conversationId: conversationId!,
+            messageId: null,
+            status: 'needs_confirmation' as const,
+            pendingConfirmation: sampleConfirmation,
+            pendingSecret: null,
+            inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+            error: null,
+            createdAt: Date.now(), updatedAt: Date.now(),
+          };
+        }
+        return {
+          id: run.id,
+          conversationId: conversationId!,
+          messageId: null,
+          status: 'completed' as const,
+          pendingConfirmation: null,
+          pendingSecret: null,
+          inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(), updatedAt: Date.now(),
+        };
+      }),
+      startRun: mock(async () => ({
+        id: run.id,
+        conversationId: conversationId!,
+        messageId: null,
+        status: 'running' as const,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(), updatedAt: Date.now(),
+      })),
+    } as unknown as RunOrchestrator;
+
+    deliverSpy.mockClear();
+
+    // Send a message that triggers the approval path, then send a decision
+    // to trigger the post-decision poll. Both pollers should compete for delivery.
+    const msgReq = makeInboundRequest({ content: 'do something' });
+    await handleChannelInbound(msgReq, noopProcessMessage, 'token', racingOrchestrator);
+
+    // Send the decision to start the post-decision delivery poll
+    const decisionReq = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+    await handleChannelInbound(decisionReq, noopProcessMessage, 'token', racingOrchestrator);
+
+    // Wait for both pollers to finish
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Count deliverChannelReply calls that carry the assistant reply text.
+    // Approval-related notifications (e.g. "has been sent to the guardian")
+    // are separate from the final reply. The final reply call is the one
+    // that delivers the actual conversation content.
+    const replyDeliveryCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { text?: string }).text === 'Main poll result.',
+    );
+
+    // The guard should ensure at most one delivery of the final reply
+    expect(replyDeliveryCalls.length).toBeLessThanOrEqual(1);
+
+    deliverSpy.mockRestore();
+  });
+
+  test('post-decision poll wins: delivers exactly once when main poll already exited', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation
+    const initReq = makeInboundRequest({ content: 'init-late' });
+    const orchestrator = makeMockOrchestrator();
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[events.length - 1]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    // Create a pending run
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+    conversationStore.addMessage(conversationId!, 'assistant', 'Post-decision result.');
+
+    // Orchestrator: getRun always returns needs_confirmation for the main poll
+    // (so the main poll times out without delivering), then returns completed
+    // for the post-decision poll. We use a separate call counter per context.
+    let mainPollExited = false;
+    let postDecisionGetRunCount = 0;
+    const lateOrchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => {
+        if (!mainPollExited) {
+          // Main poll context — always return needs_confirmation so it exits
+          // without delivering (the 5min timeout is simulated by having the
+          // main poll see needs_confirmation until it gives up).
+          return {
+            id: run.id,
+            conversationId: conversationId!,
+            messageId: null,
+            status: 'needs_confirmation' as const,
+            pendingConfirmation: sampleConfirmation,
+            pendingSecret: null,
+            inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+            error: null,
+            createdAt: Date.now(), updatedAt: Date.now(),
+          };
+        }
+        // Post-decision poll — return completed after a short delay
+        postDecisionGetRunCount++;
+        if (postDecisionGetRunCount <= 1) {
+          return {
+            id: run.id,
+            conversationId: conversationId!,
+            messageId: null,
+            status: 'needs_confirmation' as const,
+            pendingConfirmation: null,
+            pendingSecret: null,
+            inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+            error: null,
+            createdAt: Date.now(), updatedAt: Date.now(),
+          };
+        }
+        return {
+          id: run.id,
+          conversationId: conversationId!,
+          messageId: null,
+          status: 'completed' as const,
+          pendingConfirmation: null,
+          pendingSecret: null,
+          inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(), updatedAt: Date.now(),
+        };
+      }),
+      startRun: mock(async () => ({
+        id: run.id,
+        conversationId: conversationId!,
+        messageId: null,
+        status: 'running' as const,
+        pendingConfirmation: null,
+        pendingSecret: null,
+        inputTokens: 0, outputTokens: 0, estimatedCost: 0,
+        error: null,
+        createdAt: Date.now(), updatedAt: Date.now(),
+      })),
+    } as unknown as RunOrchestrator;
+
+    deliverSpy.mockClear();
+
+    // Start the main poll — it will see needs_confirmation and exit after
+    // the first poll interval (marking the event as processed, not delivering).
+    const msgReq = makeInboundRequest({ content: 'do something late' });
+    await handleChannelInbound(msgReq, noopProcessMessage, 'token', lateOrchestrator);
+
+    // Wait for the main poll to see needs_confirmation and mark processed
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    mainPollExited = true;
+
+    // Now send the decision to trigger the post-decision delivery
+    const decisionReq = makeInboundRequest({
+      content: '',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+    await handleChannelInbound(decisionReq, noopProcessMessage, 'token', lateOrchestrator);
+
+    // Wait for the post-decision poll to deliver
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Count deliveries of the final assistant reply
+    const replyDeliveryCalls = deliverSpy.mock.calls.filter(
+      (call) => typeof call[1] === 'object' &&
+        (call[1] as { text?: string }).text === 'Post-decision result.',
+    );
+
+    // Exactly one delivery should have occurred (from the post-decision poll)
+    expect(replyDeliveryCalls.length).toBe(1);
 
     deliverSpy.mockRestore();
   });

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -316,6 +316,46 @@ export function getDeadLetterEvents(): Array<{
     .all();
 }
 
+// ── Deliver-once guard for terminal reply idempotency ────────────────
+//
+// When both the main poll (processChannelMessageWithApprovals) and the
+// post-decision poll (schedulePostDecisionDelivery) race to deliver the
+// final assistant reply for the same run, this guard ensures only one
+// of them actually sends the message. The guard is run-scoped so old
+// assistant messages from previous runs are not affected.
+
+const deliveredRuns = new Set<string>();
+
+/**
+ * Atomically claim the right to deliver the final reply for a run.
+ * Returns `true` if this caller won the claim (and should proceed with
+ * delivery). Returns `false` if another caller already claimed it.
+ *
+ * This is an in-memory guard — sufficient because both racing pollers
+ * execute within the same process. The Set is never persisted; on restart
+ * there are no in-flight pollers to race.
+ */
+export function claimRunDelivery(runId: string): boolean {
+  if (deliveredRuns.has(runId)) return false;
+  deliveredRuns.add(runId);
+  return true;
+}
+
+/**
+ * Reset the deliver-once guard for a run. Used in tests to ensure
+ * isolation between test cases.
+ */
+export function resetRunDeliveryClaim(runId: string): void {
+  deliveredRuns.delete(runId);
+}
+
+/**
+ * Clear all delivery claims. Used in tests for full isolation.
+ */
+export function resetAllRunDeliveryClaims(): void {
+  deliveredRuns.clear();
+}
+
 /**
  * Reset dead-lettered events back to 'failed' so the sweep can retry
  * them. Resets attempt counter and sets an immediate retry_after.

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -792,8 +792,12 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
 
         channelDeliveryStore.markProcessed(eventId);
 
-        // Deliver the final assistant reply to the requester's chat
-        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+        // Deliver the final assistant reply exactly once. The post-decision
+        // poll in schedulePostDecisionDelivery races with this path; the
+        // claimRunDelivery guard ensures only the winner sends the reply.
+        if (channelDeliveryStore.claimRunDelivery(run.id)) {
+          await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+        }
 
         // If this was a non-guardian run that went through guardian approval,
         // also notify the guardian's chat about the outcome.
@@ -1153,8 +1157,8 @@ async function handleApprovalInterception(
     // Schedule a background poll for run terminal state and deliver the reply.
     // This handles the case where the original poll in
     // processChannelMessageWithApprovals has already exited due to timeout.
-    // If the original poll is still running and delivers first, the duplicate
-    // delivery is acceptable (gateway deduplicates or user sees a repeat).
+    // The claimRunDelivery guard ensures at-most-once delivery when both
+    // pollers race to terminal state.
     if (result.applied && result.runId) {
       schedulePostDecisionDelivery(
         orchestrator,
@@ -1201,9 +1205,9 @@ async function handleApprovalInterception(
  * handles the case where the original poll in `processChannelMessageWithApprovals`
  * has already exited due to the 5-minute timeout.
  *
- * If the original poll already delivered the reply, delivering it again is
- * acceptable — the gateway will deduplicate or the user sees a duplicate
- * (better than seeing nothing).
+ * Uses the same `claimRunDelivery` guard as the main poll to guarantee
+ * at-most-once delivery: whichever poller reaches terminal state first
+ * claims the delivery, and the other silently skips it.
  */
 function schedulePostDecisionDelivery(
   orchestrator: RunOrchestrator,
@@ -1221,7 +1225,9 @@ function schedulePostDecisionDelivery(
         const current = orchestrator.getRun(runId);
         if (!current) break;
         if (current.status === 'completed' || current.status === 'failed') {
-          await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+          if (channelDeliveryStore.claimRunDelivery(runId)) {
+            await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+          }
           return;
         }
       }


### PR DESCRIPTION
Introduces a deliver-once guard to prevent duplicate final assistant replies after approval decisions. Both the main poll and post-decision poll paths now check this guard before delivering. Removes 'duplicate acceptable' semantics. Tests cover both race scenarios (main poll wins vs post-decision poll wins). Part of #6754, closes #6755.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
