### PR TITLE
feat: assistant-scoped guardian context plumbing (#6760)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2613,3 +2613,174 @@ describe('final reply idempotency — no duplicate delivery', () => {
     deliverSpy.mockRestore();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 26. Assistant-scoped guardian verification via handleChannelInbound
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('assistant-scoped guardian verification via handleChannelInbound', () => {
+  test('/guardian_verify uses the threaded assistantId (default: self)', async () => {
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    const { secret } = createVerificationChallenge('self', 'telegram');
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = makeInboundRequest({
+      content: `/guardian_verify ${secret}`,
+      senderExternalUserId: 'user-default-asst',
+    });
+
+    // No assistantId passed => defaults to 'self'
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBe('verified');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('/guardian_verify with explicit assistantId resolves against that assistant', async () => {
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    const { getGuardianBinding } = await import('../runtime/channel-guardian-service.js');
+
+    // Create a challenge for asst-route-X
+    const { secret } = createVerificationChallenge('asst-route-X', 'telegram');
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = makeInboundRequest({
+      content: `/guardian_verify ${secret}`,
+      senderExternalUserId: 'user-for-asst-x',
+    });
+
+    // Pass assistantId = 'asst-route-X'
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', undefined, 'asst-route-X');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBe('verified');
+
+    // Binding should exist for asst-route-X, not for 'self'
+    const bindingX = getGuardianBinding('asst-route-X', 'telegram');
+    expect(bindingX).not.toBeNull();
+    expect(bindingX!.guardianExternalUserId).toBe('user-for-asst-x');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('cross-assistant challenge verification fails', async () => {
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+
+    // Create challenge for asst-A
+    const { secret } = createVerificationChallenge('asst-A-cross', 'telegram');
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const req = makeInboundRequest({
+      content: `/guardian_verify ${secret}`,
+      senderExternalUserId: 'user-cross-test',
+    });
+
+    // Try to verify using asst-B — should fail because the challenge is for asst-A
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', undefined, 'asst-B-cross');
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBe('failed');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('actor role resolution uses threaded assistantId', async () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+
+    // Create guardian binding for asst-role-X
+    createBinding({
+      assistantId: 'asst-role-X',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-role-user',
+      guardianDeliveryChatId: 'guardian-role-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-role-scoped', terminalStatus: 'completed' });
+
+    // Non-guardian user sending to asst-role-X should be recognized as non-guardian
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'non-guardian-role-user',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator, 'asst-role-X');
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The approval prompt should have been sent to the guardian's chat
+    expect(approvalSpy).toHaveBeenCalled();
+    const approvalArgs = approvalSpy.mock.calls[0];
+    expect(approvalArgs[1]).toBe('guardian-role-chat');
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+
+  test('same user is guardian for one assistant but not another', async () => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+
+    // user-multi is guardian for asst-M1 but not asst-M2
+    createBinding({
+      assistantId: 'asst-M1',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-multi',
+      guardianDeliveryChatId: 'chat-multi',
+    });
+    createBinding({
+      assistantId: 'asst-M2',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-other-guardian',
+      guardianDeliveryChatId: 'chat-other-guardian',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+
+    // For asst-M1: user-multi is the guardian, so should get standard self-approval
+    const orch1 = makeSensitiveOrchestrator({ runId: 'run-m1', terminalStatus: 'completed' });
+    const req1 = makeInboundRequest({
+      content: 'dangerous action',
+      senderExternalUserId: 'user-multi',
+    });
+
+    await handleChannelInbound(req1, noopProcessMessage, 'token', orch1, 'asst-M1');
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // For asst-M1, user-multi is guardian — approval prompt to own chat (standard flow)
+    expect(approvalSpy).toHaveBeenCalled();
+    const m1ApprovalArgs = approvalSpy.mock.calls[0];
+    // Should be sent to user-multi's own chat (chat-123 from makeInboundRequest default)
+    expect(m1ApprovalArgs[1]).toBe('chat-123');
+
+    approvalSpy.mockClear();
+    deliverSpy.mockClear();
+
+    // For asst-M2: user-multi is NOT the guardian, so approval should route to asst-M2's guardian
+    const orch2 = makeSensitiveOrchestrator({ runId: 'run-m2', terminalStatus: 'completed' });
+    const req2 = makeInboundRequest({
+      content: 'another dangerous action',
+      senderExternalUserId: 'user-multi',
+    });
+
+    await handleChannelInbound(req2, noopProcessMessage, 'token', orch2, 'asst-M2');
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // For asst-M2, user-multi is non-guardian — approval should go to user-other-guardian's chat
+    expect(approvalSpy).toHaveBeenCalled();
+    const m2ApprovalArgs = approvalSpy.mock.calls[0];
+    expect(m2ApprovalArgs[1]).toBe('chat-other-guardian');
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1003,3 +1003,186 @@ describe('guardian service rate limiting', () => {
     expect(result.success).toBe(true);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Assistant-scoped guardian resolution
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('assistant-scoped guardian resolution', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('isGuardian resolves independently per assistantId', () => {
+    // Create guardian binding for asst-A on telegram
+    createBinding({
+      assistantId: 'asst-A',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-alpha',
+      guardianDeliveryChatId: 'chat-alpha',
+    });
+    // Create guardian binding for asst-B on telegram with a different user
+    createBinding({
+      assistantId: 'asst-B',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-beta',
+      guardianDeliveryChatId: 'chat-beta',
+    });
+
+    // user-alpha is guardian for asst-A but not asst-B
+    expect(isGuardian('asst-A', 'telegram', 'user-alpha')).toBe(true);
+    expect(isGuardian('asst-B', 'telegram', 'user-alpha')).toBe(false);
+
+    // user-beta is guardian for asst-B but not asst-A
+    expect(isGuardian('asst-B', 'telegram', 'user-beta')).toBe(true);
+    expect(isGuardian('asst-A', 'telegram', 'user-beta')).toBe(false);
+  });
+
+  test('getGuardianBinding returns different bindings for different assistants', () => {
+    createBinding({
+      assistantId: 'asst-A',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-alpha',
+      guardianDeliveryChatId: 'chat-alpha',
+    });
+    createBinding({
+      assistantId: 'asst-B',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-beta',
+      guardianDeliveryChatId: 'chat-beta',
+    });
+
+    const bindingA = getGuardianBinding('asst-A', 'telegram');
+    const bindingB = getGuardianBinding('asst-B', 'telegram');
+
+    expect(bindingA).not.toBeNull();
+    expect(bindingB).not.toBeNull();
+    expect(bindingA!.guardianExternalUserId).toBe('user-alpha');
+    expect(bindingB!.guardianExternalUserId).toBe('user-beta');
+  });
+
+  test('revoking binding for one assistant does not affect another', () => {
+    createBinding({
+      assistantId: 'asst-A',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-alpha',
+      guardianDeliveryChatId: 'chat-alpha',
+    });
+    createBinding({
+      assistantId: 'asst-B',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-beta',
+      guardianDeliveryChatId: 'chat-beta',
+    });
+
+    serviceRevokeBinding('asst-A', 'telegram');
+
+    expect(getGuardianBinding('asst-A', 'telegram')).toBeNull();
+    expect(getGuardianBinding('asst-B', 'telegram')).not.toBeNull();
+  });
+
+  test('validateAndConsumeChallenge scoped to assistantId', () => {
+    // Create challenge for asst-A
+    const { secret: secretA } = createVerificationChallenge('asst-A', 'telegram');
+    // Create challenge for asst-B
+    const { secret: secretB } = createVerificationChallenge('asst-B', 'telegram');
+
+    // Attempting to consume asst-A challenge with asst-B should fail
+    const crossResult = validateAndConsumeChallenge(
+      'asst-B', 'telegram', secretA, 'user-1', 'chat-1',
+    );
+    expect(crossResult.success).toBe(false);
+
+    // Consuming with correct assistantId should succeed
+    const resultA = validateAndConsumeChallenge(
+      'asst-A', 'telegram', secretA, 'user-1', 'chat-1',
+    );
+    expect(resultA.success).toBe(true);
+
+    const resultB = validateAndConsumeChallenge(
+      'asst-B', 'telegram', secretB, 'user-2', 'chat-2',
+    );
+    expect(resultB.success).toBe(true);
+
+    // Verify bindings are scoped correctly
+    const bindingA = getGuardianBinding('asst-A', 'telegram');
+    const bindingB = getGuardianBinding('asst-B', 'telegram');
+    expect(bindingA!.guardianExternalUserId).toBe('user-1');
+    expect(bindingB!.guardianExternalUserId).toBe('user-2');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. Assistant-scoped approval request lookups
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('assistant-scoped approval request lookups', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('createApprovalRequest stores assistantId and defaults to self', () => {
+    const reqWithoutId = createApprovalRequest({
+      runId: 'run-1',
+      conversationId: 'conv-1',
+      channel: 'telegram',
+      requesterExternalUserId: 'user-99',
+      requesterChatId: 'chat-99',
+      guardianExternalUserId: 'user-42',
+      guardianChatId: 'chat-42',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+    expect(reqWithoutId.assistantId).toBe('self');
+
+    const reqWithId = createApprovalRequest({
+      runId: 'run-2',
+      conversationId: 'conv-2',
+      assistantId: 'asst-A',
+      channel: 'telegram',
+      requesterExternalUserId: 'user-99',
+      requesterChatId: 'chat-99',
+      guardianExternalUserId: 'user-42',
+      guardianChatId: 'chat-42',
+      toolName: 'browser',
+      expiresAt: Date.now() + 300_000,
+    });
+    expect(reqWithId.assistantId).toBe('asst-A');
+  });
+
+  test('approval requests from different assistants are independent', () => {
+    createApprovalRequest({
+      runId: 'run-A',
+      conversationId: 'conv-A',
+      assistantId: 'asst-A',
+      channel: 'telegram',
+      requesterExternalUserId: 'user-99',
+      requesterChatId: 'chat-99',
+      guardianExternalUserId: 'user-42',
+      guardianChatId: 'chat-42',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+    createApprovalRequest({
+      runId: 'run-B',
+      conversationId: 'conv-B',
+      assistantId: 'asst-B',
+      channel: 'telegram',
+      requesterExternalUserId: 'user-88',
+      requesterChatId: 'chat-88',
+      guardianExternalUserId: 'user-42',
+      guardianChatId: 'chat-42',
+      toolName: 'browser',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const foundA = getPendingApprovalForRun('run-A');
+    const foundB = getPendingApprovalForRun('run-B');
+    expect(foundA).not.toBeNull();
+    expect(foundB).not.toBeNull();
+    expect(foundA!.assistantId).toBe('asst-A');
+    expect(foundB!.assistantId).toBe('asst-B');
+    expect(foundA!.toolName).toBe('shell');
+    expect(foundB!.toolName).toBe('browser');
+  });
+});

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1331,9 +1331,9 @@ export function handleGuardianVerification(
   ctx: HandlerContext,
 ): void {
   try {
-    // In single-assistant mode, 'self' is the canonical assistant ID used
-    // by channel routes when validating challenges on the inbound path.
-    const assistantId = 'self';
+    // Use the assistant ID from the request when available; fall back to
+    // 'self' for backward compatibility with single-assistant mode.
+    const assistantId = msg.assistantId ?? 'self';
     const channel = msg.channel ?? 'telegram';
 
     if (msg.action === 'create_challenge') {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -573,6 +573,7 @@ export interface GuardianVerificationRequest {
   action: 'create_challenge' | 'status' | 'revoke';
   channel?: string;  // Defaults to 'telegram'
   sessionId?: string;
+  assistantId?: string;  // Defaults to 'self'
 }
 
 export interface GuardianVerificationResponse {

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -58,6 +58,7 @@ export interface GuardianApprovalRequest {
   id: string;
   runId: string;
   conversationId: string;
+  assistantId: string;
   channel: string;
   requesterExternalUserId: string;
   requesterChatId: string;
@@ -114,6 +115,7 @@ function rowToApprovalRequest(row: typeof channelGuardianApprovalRequests.$infer
     id: row.id,
     runId: row.runId,
     conversationId: row.conversationId,
+    assistantId: row.assistantId,
     channel: row.channel,
     requesterExternalUserId: row.requesterExternalUserId,
     requesterChatId: row.requesterChatId,
@@ -305,6 +307,7 @@ export function consumeChallenge(
 export function createApprovalRequest(params: {
   runId: string;
   conversationId: string;
+  assistantId?: string;
   channel: string;
   requesterExternalUserId: string;
   requesterChatId: string;
@@ -323,6 +326,7 @@ export function createApprovalRequest(params: {
     id,
     runId: params.runId,
     conversationId: params.conversationId,
+    assistantId: params.assistantId ?? 'self',
     channel: params.channel,
     requesterExternalUserId: params.requesterExternalUserId,
     requesterChatId: params.requesterChatId,

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -992,6 +992,10 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_approval_run ON channel_guardian_approval_requests(run_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_approval_status ON channel_guardian_approval_requests(status)`);
 
+  // Migration: add assistant_id column to scope approval requests by assistant.
+  // Existing rows default to 'self' for backward compatibility.
+  try { database.run(/*sql*/ `ALTER TABLE channel_guardian_approval_requests ADD COLUMN assistant_id TEXT NOT NULL DEFAULT 'self'`); } catch { /* already exists */ }
+
   // ── Channel Guardian Verification Rate Limits ─────────────────────
 
   database.run(/*sql*/ `

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -646,6 +646,7 @@ export const channelGuardianApprovalRequests = sqliteTable('channel_guardian_app
   id: text('id').primaryKey(),
   runId: text('run_id').notNull(),
   conversationId: text('conversation_id').notNull(),
+  assistantId: text('assistant_id').notNull().default('self'),
   channel: text('channel').notNull(),
   requesterExternalUserId: text('requester_external_user_id').notNull(),
   requesterChatId: text('requester_chat_id').notNull(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -616,7 +616,7 @@ export class RuntimeHttpServer {
     const assistantId = match[1];
     const endpoint = match[2];
     log.warn({ endpoint, assistantId }, '[deprecated] /v1/assistants/:assistantId/... route used; migrate to /v1/...');
-    return this.dispatchEndpoint(endpoint, req, url);
+    return this.dispatchEndpoint(endpoint, req, url, assistantId);
   }
 
   /**
@@ -628,6 +628,7 @@ export class RuntimeHttpServer {
     endpoint: string,
     req: Request,
     url: URL,
+    assistantId: string = 'self',
   ): Promise<Response> {
     try {
       if (endpoint === 'health' && req.method === 'GET') {
@@ -736,7 +737,7 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -169,6 +169,7 @@ export async function handleChannelInbound(
   processMessage?: MessageProcessor,
   bearerToken?: string,
   runOrchestrator?: RunOrchestrator,
+  assistantId: string = 'self',
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which
@@ -285,7 +286,7 @@ export async function handleChannelInbound(
       if (original) break;
       if (attempt < EDIT_LOOKUP_RETRIES) {
         log.info(
-          { assistantId: "self", sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
+          { assistantId, sourceMessageId, attempt: attempt + 1, maxAttempts: EDIT_LOOKUP_RETRIES },
           'Original message not linked yet, retrying edit lookup',
         );
         await new Promise((resolve) => setTimeout(resolve, EDIT_LOOKUP_DELAY_MS));
@@ -295,12 +296,12 @@ export async function handleChannelInbound(
     if (original) {
       conversationStore.updateMessageContent(original.messageId, content ?? '');
       log.info(
-        { assistantId: "self", sourceMessageId, messageId: original.messageId },
+        { assistantId, sourceMessageId, messageId: original.messageId },
         'Updated message content from edited_message',
       );
     } else {
       log.warn(
-        { assistantId: "self", sourceChannel, externalChatId, sourceMessageId },
+        { assistantId, sourceChannel, externalChatId, sourceMessageId },
         'Could not find original message for edit after retries, ignoring',
       );
     }
@@ -351,7 +352,7 @@ export async function handleChannelInbound(
     const token = trimmedContent.slice('/guardian_verify '.length).trim();
     if (token.length > 0) {
       const verifyResult = validateAndConsumeChallenge(
-        'self',
+        assistantId,
         sourceChannel,
         token,
         body.senderExternalUserId,
@@ -386,9 +387,9 @@ export async function handleChannelInbound(
   // side-effect controls and their approvals route to the guardian's chat.
   let guardianCtx: GuardianContext = { actorRole: 'guardian' };
   if (isChannelApprovalsEnabled() && body.senderExternalUserId) {
-    const senderIsGuardian = isGuardian('self', sourceChannel, body.senderExternalUserId);
+    const senderIsGuardian = isGuardian(assistantId, sourceChannel, body.senderExternalUserId);
     if (!senderIsGuardian) {
-      const binding = getGuardianBinding('self', sourceChannel);
+      const binding = getGuardianBinding(assistantId, sourceChannel);
       if (binding) {
         const requesterLabel = body.senderUsername
           ? `@${body.senderUsername}`
@@ -431,6 +432,7 @@ export async function handleChannelInbound(
       bearerToken,
       orchestrator: runOrchestrator,
       guardianCtx,
+      assistantId,
     });
 
     if (approvalResult.handled) {
@@ -503,6 +505,7 @@ export async function handleChannelInbound(
         replyCallbackUrl,
         bearerToken,
         guardianCtx,
+        assistantId,
       });
     } else {
       // Fire-and-forget: process the message and deliver the reply in the background.
@@ -610,6 +613,7 @@ interface ApprovalProcessingParams {
   replyCallbackUrl: string;
   bearerToken?: string;
   guardianCtx: GuardianContext;
+  assistantId: string;
 }
 
 /**
@@ -636,6 +640,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
     replyCallbackUrl,
     bearerToken,
     guardianCtx,
+    assistantId,
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
@@ -691,6 +696,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
             const approvalReqRecord = createApprovalRequest({
               runId: run.id,
               conversationId,
+              assistantId,
               channel: sourceChannel,
               requesterExternalUserId: guardianCtx.requesterExternalUserId ?? '',
               requesterChatId: guardianCtx.requesterChatId ?? externalChatId,
@@ -857,6 +863,7 @@ interface ApprovalInterceptionParams {
   bearerToken?: string;
   orchestrator: RunOrchestrator;
   guardianCtx: GuardianContext;
+  assistantId: string;
 }
 
 interface ApprovalInterceptionResult {


### PR DESCRIPTION
## Summary

Closes the fidelity gap where guardian binding lookups and verification intercepts hardcode assistant ID `self`, preventing proper multi-assistant guardian scoping.

- Thread `assistantId` parameter through `handleChannelInbound`, `dispatchEndpoint`, approval processing/interception interfaces, and `createApprovalRequest`
- In legacy route shape (`/v1/assistants/:assistantId/...`), pass parsed path assistant ID through guardian logic; assistant-less routes default to `self`
- Replace all hardcoded `'self'` in `validateAndConsumeChallenge`, `isGuardian`, `getGuardianBinding` call sites with the threaded `assistantId`
- Extend `GuardianVerificationRequest` IPC type with optional `assistantId` field; daemon handler defaults to `self`
- Add `assistantId` column to `channel_guardian_approval_requests` schema with migration for existing databases (defaults to `self`)
- Add assistant-scoped guardian resolution tests proving `isGuardian` and `getGuardianBinding` resolve independently per assistantId
- Add assistant-scoped approval request tests proving `createApprovalRequest` stores and retrieves `assistantId` correctly
- Add route-level tests proving cross-assistant challenge verification fails and actor role resolution uses the threaded assistantId

Closes #6760

## Test plan
- [ ] Existing guardian tests pass (backward-compatible `self` default)
- [ ] New tests: guardian resolution differs by assistantId
- [ ] New tests: approval request lookups are assistant-scoped
- [ ] New tests: route-level guardian verify uses threaded assistantId
- [ ] New tests: cross-assistant challenge verification fails
- [ ] New tests: same user is guardian for one assistant but not another
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
