### PR TITLE
fix: add approval prompt failure handling and stabilize assistant typecheck/tests

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -594,6 +594,13 @@ exports[`IPC message snapshots ClientMessage types telegram_config serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types twilio_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "twilio_config",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types guardian_verification serializes to expected JSON 1`] = `
 {
   "action": "create_challenge",
@@ -1917,6 +1924,15 @@ exports[`IPC message snapshots ServerMessage types telegram_config_response seri
   "hasWebhookSecret": true,
   "success": true,
   "type": "telegram_config_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types twilio_config_response serializes to expected JSON 1`] = `
+{
+  "hasCredentials": true,
+  "phoneNumber": "+15551234567",
+  "success": true,
+  "type": "twilio_config_response",
 }
 `;
 

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -62,6 +62,7 @@ import {
   handleChannelInbound,
   isChannelApprovalsEnabled,
   sweepExpiredGuardianApprovals,
+  _setTestPollMaxWait,
 } from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
 
@@ -133,6 +134,10 @@ function makeMockOrchestrator(
   } as unknown as RunOrchestrator;
 }
 
+/** Default bearer token used by tests. Include the X-Gateway-Origin header
+ *  so that verifyGatewayOrigin does not reject the request. */
+const TEST_BEARER_TOKEN = 'token';
+
 function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
   const body = {
     sourceChannel: 'telegram',
@@ -144,7 +149,10 @@ function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
   };
   return new Request('http://localhost/channels/inbound', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Gateway-Origin': TEST_BEARER_TOKEN,
+    },
     body: JSON.stringify(body),
   });
 }
@@ -532,11 +540,14 @@ describe('empty content with callbackData bypasses validation', () => {
     };
     const req = new Request('http://localhost/channels/inbound', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
       body: JSON.stringify(body),
     });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(req, noopProcessMessage, TEST_BEARER_TOKEN, orchestrator);
     expect(res.status).toBe(200);
     const resBody = await res.json() as Record<string, unknown>;
     expect(resBody.accepted).toBe(true);
@@ -1049,6 +1060,10 @@ describe('poll timeout handling by run state', () => {
   });
 
   test('marks event as processed when run is in needs_confirmation state after poll timeout', async () => {
+    // Use a short poll timeout so the test can exercise the timeout path
+    // without waiting 5 minutes.
+    _setTestPollMaxWait(600);
+
     const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const failureSpy = spyOn(channelDeliveryStore, 'recordProcessingFailure').mockImplementation(() => {});
@@ -1081,8 +1096,8 @@ describe('poll timeout handling by run state', () => {
     const req = makeInboundRequest({ content: 'hello needs_confirm' });
     await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
 
-    // Wait for the background async to complete
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    // Wait for the background async to complete (poll timeout is 600ms + one poll interval of 500ms)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
     // markProcessed SHOULD have been called — the run is waiting for approval,
     // and the post-decision delivery path will handle the final reply.
@@ -1095,6 +1110,7 @@ describe('poll timeout handling by run state', () => {
     markSpy.mockRestore();
     failureSpy.mockRestore();
     deliverSpy.mockRestore();
+    _setTestPollMaxWait(null);
   });
 
   test('does NOT call recordProcessingFailure when run reaches terminal state', async () => {
@@ -1336,7 +1352,10 @@ describe('SMS channel approval decisions', () => {
     };
     return new Request('http://localhost/channels/inbound', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
       body: JSON.stringify(body),
     });
   }
@@ -1482,7 +1501,10 @@ describe('SMS guardian verify intercept', () => {
 
     const req = new Request('http://localhost/channels/inbound', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
       body: JSON.stringify({
         sourceChannel: 'sms',
         externalChatId: 'sms-chat-verify',
@@ -1493,7 +1515,7 @@ describe('SMS guardian verify intercept', () => {
       }),
     });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const res = await handleChannelInbound(req, noopProcessMessage, TEST_BEARER_TOKEN);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -1514,7 +1536,10 @@ describe('SMS guardian verify intercept', () => {
 
     const req = new Request('http://localhost/channels/inbound', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
       body: JSON.stringify({
         sourceChannel: 'sms',
         externalChatId: 'sms-chat-verify-fail',
@@ -1525,7 +1550,7 @@ describe('SMS guardian verify intercept', () => {
       }),
     });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token');
+    const res = await handleChannelInbound(req, noopProcessMessage, TEST_BEARER_TOKEN);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -1586,7 +1611,10 @@ describe('SMS non-guardian actor gating', () => {
     // Send message from a NON-guardian sms user
     const req = new Request('http://localhost/channels/inbound', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
       body: JSON.stringify({
         sourceChannel: 'sms',
         externalChatId: 'sms-other-chat',
@@ -1597,7 +1625,7 @@ describe('SMS non-guardian actor gating', () => {
       }),
     });
 
-    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await handleChannelInbound(req, noopProcessMessage, TEST_BEARER_TOKEN, orchestrator);
 
     // Wait for the background async to fire
     await new Promise((resolve) => setTimeout(resolve, 800));
@@ -2069,6 +2097,52 @@ describe('guardian delivery failure → denial', () => {
     // There should also be NO unresolved approval (it was set to 'denied')
     const unresolvedApproval = getUnresolvedApprovalForRun(runId!);
     expect(unresolvedApproval).toBeNull();
+
+    deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 20b. Standard approval prompt delivery failure → auto-deny (WS-B)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('standard approval prompt delivery failure → auto-deny', () => {
+  beforeEach(() => {
+    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+  });
+
+  test('standard prompt delivery failure auto-denies the run (fail-closed)', async () => {
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    // Make the approval prompt delivery fail for the standard (self-approval) path
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockRejectedValue(
+      new Error('Network error: approval prompt unreachable'),
+    );
+
+    // No guardian binding — sender is a guardian (default role), so the
+    // standard self-approval path is used.
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-std-fail', terminalStatus: 'failed' });
+
+    const req = makeInboundRequest({
+      content: 'do something dangerous',
+      senderExternalUserId: 'guardian-std-user',
+    });
+
+    // Set up a guardian binding so the sender is recognized as guardian
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-std-user',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // The run should have been auto-denied because the prompt could not be delivered
+    expect(orchestrator.submitDecision).toHaveBeenCalled();
+    const decisionArgs = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls[0];
+    expect(decisionArgs[1]).toBe('deny');
 
     deliverSpy.mockRestore();
     approvalSpy.mockRestore();

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -378,6 +378,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'telegram_config',
     action: 'get',
   },
+  twilio_config: {
+    type: 'twilio_config',
+    action: 'get',
+  },
   guardian_verification: {
     type: 'guardian_verification',
     action: 'create_challenge',
@@ -1217,6 +1221,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     botUsername: 'my_test_bot',
     connected: true,
     hasWebhookSecret: true,
+  },
+  twilio_config_response: {
+    type: 'twilio_config_response',
+    success: true,
+    hasCredentials: true,
+    phoneNumber: '+15551234567',
   },
   guardian_verification_response: {
     type: 'guardian_verification_response',

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -645,6 +645,9 @@ export function recordInvalidAttempt(
     channel,
     actorExternalUserId,
     actorChatId,
+    // Legacy columns kept for backward compatibility with upgraded databases
+    invalidAttempts: 0,
+    windowStartedAt: 0,
     attemptTimestampsJson: JSON.stringify(timestamps),
     lockedUntil,
     createdAt: now,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -599,6 +599,22 @@ const RUN_POLL_MAX_WAIT_MS = 300_000; // 5 minutes
 const POST_DECISION_POLL_INTERVAL_MS = 500;
 const POST_DECISION_POLL_MAX_WAIT_MS = RUN_POLL_MAX_WAIT_MS;
 
+/**
+ * Override the poll max-wait for tests. When set, used in place of
+ * RUN_POLL_MAX_WAIT_MS so tests can exercise timeout paths without
+ * waiting 5 minutes.
+ */
+let testPollMaxWaitOverride: number | null = null;
+
+/** @internal — test-only: set an override for the poll max-wait. */
+export function _setTestPollMaxWait(ms: number | null): void {
+  testPollMaxWaitOverride = ms;
+}
+
+function getEffectivePollMaxWait(): number {
+  return testPollMaxWaitOverride ?? RUN_POLL_MAX_WAIT_MS;
+}
+
 interface ApprovalProcessingParams {
   orchestrator: RunOrchestrator;
   conversationId: string;
@@ -656,9 +672,10 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
       // Poll the run until it reaches a terminal state, delivering approval
       // prompts when it transitions to needs_confirmation.
       const startTime = Date.now();
+      const pollMaxWait = getEffectivePollMaxWait();
       let lastStatus = run.status;
 
-      while (Date.now() - startTime < RUN_POLL_MAX_WAIT_MS) {
+      while (Date.now() - startTime < pollMaxWait) {
         await new Promise((resolve) => setTimeout(resolve, RUN_POLL_INTERVAL_MS));
 
         const current = orchestrator.getRun(run.id);
@@ -765,7 +782,14 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                   bearerToken,
                 );
               } catch (err) {
-                log.error({ err, runId: run.id }, 'Failed to deliver approval prompt for channel run');
+                // Fail-closed: if we cannot deliver the approval prompt, the
+                // user will never see it and the run would hang indefinitely
+                // in needs_confirmation. Auto-deny to avoid silent wait states.
+                log.error(
+                  { err, runId: run.id, conversationId },
+                  'Failed to deliver standard approval prompt; auto-denying (fail-closed)',
+                );
+                handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
               }
             }
           }
@@ -827,7 +851,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         // needs_secret, or disappeared). Record a processing failure so the
         // retry/dead-letter machinery can handle it.
         const timeoutErr = new Error(
-          `Approval poll timeout: run did not reach terminal state within ${RUN_POLL_MAX_WAIT_MS}ms (status: ${finalRun?.status ?? 'null'})`,
+          `Approval poll timeout: run did not reach terminal state within ${pollMaxWait}ms (status: ${finalRun?.status ?? 'null'})`,
         );
         log.warn(
           { runId: run.id, status: finalRun?.status, conversationId },


### PR DESCRIPTION
Adds deterministic failure policy for approval prompt delivery (fail-closed with logging). Fixes guardian rate-limit insert typing, updates IPC snapshot fixtures for Twilio message types, and reconciles approval-route tests with gateway-origin header requirements. Part of #6754, closes #6756.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
