### PR TITLE
feat: gateway-origin proof hardening — dedicated secret independent of bearer auth (#6762)

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -167,10 +167,11 @@ Guardian enforcement (actor-role resolution, fail-closed denial for unknown acto
 
 ### Gateway-Origin Ingress Contract
 
-The `/channels/inbound` endpoint requires a valid `X-Gateway-Origin` header that matches the configured bearer token. This ensures channel messages can only be submitted via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.
+The `/channels/inbound` endpoint requires a valid `X-Gateway-Origin` header to prove the request originated from the gateway. This ensures channel messages can only arrive via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.
 
-- **With bearer token configured:** Requests must include `X-Gateway-Origin` with the shared secret. Missing or invalid values return `403 GATEWAY_ORIGIN_REQUIRED`.
-- **Without bearer token:** Gateway-origin validation is skipped (local dev without auth).
+- **Dedicated secret (`RUNTIME_GATEWAY_ORIGIN_SECRET`):** When set, this is the expected value for the `X-Gateway-Origin` header. Both the gateway and the runtime must share this secret.
+- **Bearer token fallback:** When `RUNTIME_GATEWAY_ORIGIN_SECRET` is not set, the runtime falls back to validating against the bearer token for backward compatibility.
+- **Without any secret:** When neither a dedicated secret nor a bearer token is configured (local dev), gateway-origin validation is skipped entirely.
 - **Auth layer order:** Bearer token authentication (`Authorization` header) is checked first. Gateway-origin validation runs inside the handler.
 
 ## Twilio Setup Primitive

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -62,6 +62,7 @@ import {
   handleChannelInbound,
   isChannelApprovalsEnabled,
   sweepExpiredGuardianApprovals,
+  verifyGatewayOrigin,
   _setTestPollMaxWait,
 } from '../runtime/routes/channel-routes.js';
 import * as gatewayClient from '../runtime/gateway-client.js';
@@ -2970,5 +2971,52 @@ describe('guardian enforcement independence from approval flag', () => {
     expect(body.accepted).toBe(true);
 
     deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 28. Gateway-origin proof hardening — dedicated secret support
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('verifyGatewayOrigin with dedicated gateway-origin secret', () => {
+  function makeReqWithHeader(value?: string): Request {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (value !== undefined) {
+      headers['X-Gateway-Origin'] = value;
+    }
+    return new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers,
+      body: '{}',
+    });
+  }
+
+  test('returns true when no secrets configured (local dev)', () => {
+    expect(verifyGatewayOrigin(makeReqWithHeader(), undefined, undefined)).toBe(true);
+  });
+
+  test('falls back to bearerToken when no dedicated secret is set', () => {
+    expect(verifyGatewayOrigin(makeReqWithHeader('my-bearer'), 'my-bearer', undefined)).toBe(true);
+    expect(verifyGatewayOrigin(makeReqWithHeader('wrong'), 'my-bearer', undefined)).toBe(false);
+    expect(verifyGatewayOrigin(makeReqWithHeader(), 'my-bearer', undefined)).toBe(false);
+  });
+
+  test('uses dedicated secret when set, ignoring bearer token', () => {
+    // Dedicated secret matches — should pass even if bearer token differs
+    expect(verifyGatewayOrigin(makeReqWithHeader('dedicated-secret'), 'bearer-token', 'dedicated-secret')).toBe(true);
+    // Bearer token matches but dedicated secret doesn't — should fail
+    expect(verifyGatewayOrigin(makeReqWithHeader('bearer-token'), 'bearer-token', 'dedicated-secret')).toBe(false);
+  });
+
+  test('validates dedicated secret even when bearer token is not configured', () => {
+    // No bearer token but dedicated secret is set — should validate against it
+    expect(verifyGatewayOrigin(makeReqWithHeader('my-secret'), undefined, 'my-secret')).toBe(true);
+    expect(verifyGatewayOrigin(makeReqWithHeader('wrong'), undefined, 'my-secret')).toBe(false);
+  });
+
+  test('rejects missing header when any secret is configured', () => {
+    expect(verifyGatewayOrigin(makeReqWithHeader(), 'bearer', undefined)).toBe(false);
+    expect(verifyGatewayOrigin(makeReqWithHeader(), undefined, 'secret')).toBe(false);
+    expect(verifyGatewayOrigin(makeReqWithHeader(), 'bearer', 'secret')).toBe(false);
   });
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -737,7 +737,8 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId);
+        const gatewayOriginSecret = process.env.RUNTIME_GATEWAY_ORIGIN_SECRET || undefined;
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId, gatewayOriginSecret);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -53,27 +53,34 @@ const log = getLogger('runtime-http');
 
 /**
  * Header name used by the gateway to prove a request originated from it.
- * The gateway sets this to the shared bearer token; the runtime validates
- * it using constant-time comparison. Requests to `/channels/inbound`
- * that lack a valid gateway-origin proof are rejected with 403.
+ * The gateway sends a dedicated gateway-origin secret (or the bearer token
+ * as fallback). The runtime validates it using constant-time comparison.
+ * Requests to `/channels/inbound` that lack a valid proof are rejected with 403.
  */
 export const GATEWAY_ORIGIN_HEADER = 'X-Gateway-Origin';
 
 /**
  * Validate that the request carries a valid gateway-origin proof.
- * Returns true when the header value matches the expected bearer token
- * using constant-time comparison to prevent timing attacks.
+ * Uses constant-time comparison to prevent timing attacks.
  *
- * When no bearer token is configured (e.g., local dev without auth),
- * gateway-origin validation is skipped — the server is already
- * unauthenticated, so there is no shared secret to verify against.
+ * The `gatewayOriginSecret` parameter is the dedicated secret configured
+ * via `RUNTIME_GATEWAY_ORIGIN_SECRET`. When set, only this value is
+ * accepted. When not set, the function falls back to `bearerToken` for
+ * backward compatibility. When neither is configured (local dev), validation
+ * is skipped entirely.
  */
-export function verifyGatewayOrigin(req: Request, bearerToken?: string): boolean {
-  if (!bearerToken) return true; // No shared secret configured — skip validation
+export function verifyGatewayOrigin(
+  req: Request,
+  bearerToken?: string,
+  gatewayOriginSecret?: string,
+): boolean {
+  // Determine the expected secret: prefer dedicated secret, fall back to bearer token
+  const expectedSecret = gatewayOriginSecret ?? bearerToken;
+  if (!expectedSecret) return true; // No shared secret configured — skip validation
   const provided = req.headers.get(GATEWAY_ORIGIN_HEADER);
   if (!provided) return false;
   const a = Buffer.from(provided);
-  const b = Buffer.from(bearerToken);
+  const b = Buffer.from(expectedSecret);
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
 }
@@ -170,11 +177,12 @@ export async function handleChannelInbound(
   bearerToken?: string,
   runOrchestrator?: RunOrchestrator,
   assistantId: string = 'self',
+  gatewayOriginSecret?: string,
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which
   // performs webhook-level verification) and not via direct HTTP calls.
-  if (!verifyGatewayOrigin(req, bearerToken)) {
+  if (!verifyGatewayOrigin(req, bearerToken, gatewayOriginSecret)) {
     log.warn('Rejected channel inbound request: missing or invalid gateway-origin proof');
     return Response.json(
       { error: 'Forbidden: missing gateway-origin proof', code: 'GATEWAY_ORIGIN_REQUIRED' },

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -339,7 +339,7 @@ See [`benchmarking/gateway/README.md`](../benchmarking/gateway/README.md) for lo
 | "No route configured" replies | Add a routing entry or set `GATEWAY_UNMAPPED_POLICY=default` with a default assistant |
 | Runtime errors | Is `ASSISTANT_RUNTIME_BASE_URL` reachable? Check runtime logs. |
 | No reply from assistant | Is the assistant runtime processing messages? Check for `RUNTIME_HTTP_PORT` env var. |
-| 403 `GATEWAY_ORIGIN_REQUIRED` on channel inbound | The runtime rejected the request because it lacks a valid `X-Gateway-Origin` header. Ensure `RUNTIME_BEARER_TOKEN` (or the `~/.vellum/http-token` file) is set so the gateway and runtime share the same secret. |
+| 403 `GATEWAY_ORIGIN_REQUIRED` on channel inbound | The runtime rejected the request because it lacks a valid `X-Gateway-Origin` header. Ensure `RUNTIME_GATEWAY_ORIGIN_SECRET` (or `RUNTIME_BEARER_TOKEN` / `~/.vellum/http-token` as fallback) is set on both the gateway and runtime so they share the same secret. |
 
 ### Guardian-Specific Troubleshooting
 

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -23,6 +23,8 @@ export type GatewayConfig = {
   routingEntries: RoutingEntry[];
   /** Bearer token sent to the assistant runtime on gateway-to-runtime calls. */
   runtimeBearerToken: string | undefined;
+  /** Dedicated secret for the X-Gateway-Origin proof header. Falls back to runtimeBearerToken when not set. */
+  runtimeGatewayOriginSecret: string | undefined;
   runtimeInitialBackoffMs: number;
   runtimeMaxRetries: number;
   runtimeProxyBearerToken: string | undefined;
@@ -162,6 +164,11 @@ export function loadConfig(): GatewayConfig {
   const runtimeProxyBearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || runtimeTokenFromFile;
 
+  // Dedicated gateway-origin secret. Falls back to runtimeBearerToken for
+  // backward compatibility so existing deployments continue working.
+  const runtimeGatewayOriginSecret =
+    process.env.RUNTIME_GATEWAY_ORIGIN_SECRET || runtimeBearerToken;
+
   const MAX_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1, max safe setTimeout delay
 
   const shutdownDrainMsRaw = process.env.GATEWAY_SHUTDOWN_DRAIN_MS || "5000";
@@ -300,6 +307,7 @@ export function loadConfig(): GatewayConfig {
     port,
     routingEntries,
     runtimeBearerToken,
+    runtimeGatewayOriginSecret,
     runtimeInitialBackoffMs,
     runtimeMaxRetries,
     runtimeProxyBearerToken,

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -99,9 +99,11 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     // Add the runtime's bearer token so the upstream accepts the request
     if (config.runtimeBearerToken) {
       reqHeaders.set("authorization", `Bearer ${config.runtimeBearerToken}`);
-      // Attach gateway-origin proof so the runtime can distinguish
-      // gateway-forwarded requests from direct external calls.
-      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeBearerToken);
+    }
+    // Attach gateway-origin proof using the dedicated secret (falls back
+    // to runtimeBearerToken via config when not explicitly configured).
+    if (config.runtimeGatewayOriginSecret) {
+      reqHeaders.set(GATEWAY_ORIGIN_HEADER, config.runtimeGatewayOriginSecret);
     }
 
     if (config.runtimeProxyBearerToken) {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -5,8 +5,9 @@ const log = getLogger("runtime-client");
 
 /**
  * Header name used to prove a request originated from the gateway.
- * The value is the shared bearer token — the runtime validates it to reject
- * direct calls that bypass the gateway's webhook-level verification.
+ * The value is the dedicated gateway-origin secret (or the bearer token as
+ * fallback). The runtime validates it to reject direct calls that bypass
+ * the gateway's webhook-level verification.
  */
 export const GATEWAY_ORIGIN_HEADER = "X-Gateway-Origin";
 
@@ -15,9 +16,12 @@ function runtimeHeaders(config: GatewayConfig, extra?: Record<string, string>): 
   const headers: Record<string, string> = { ...extra };
   if (config.runtimeBearerToken) {
     headers["Authorization"] = `Bearer ${config.runtimeBearerToken}`;
-    // Attach gateway-origin proof so the runtime can distinguish
-    // gateway-forwarded requests from direct external calls.
-    headers[GATEWAY_ORIGIN_HEADER] = config.runtimeBearerToken;
+  }
+  // Attach gateway-origin proof using the dedicated secret. When
+  // RUNTIME_GATEWAY_ORIGIN_SECRET is not set, this falls back to
+  // runtimeBearerToken via the config layer.
+  if (config.runtimeGatewayOriginSecret) {
+    headers[GATEWAY_ORIGIN_HEADER] = config.runtimeGatewayOriginSecret;
   }
   return headers;
 }


### PR DESCRIPTION
Adds RUNTIME_GATEWAY_ORIGIN_SECRET config for explicit gateway-origin proof, decoupled from bearer auth. Falls back to bearer token when not set. Updates gateway client, runtime-proxy, and runtime verifier to use the dedicated secret. Adds unit tests for all combinations (no secret, bearer-only, dedicated-only, both).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
