### PR TITLE
M1: Fix SMS reply delivery contract

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -120,7 +120,7 @@ The `/deliver/sms` endpoint requires the same fail-closed bearer auth as `/deliv
 
 The endpoint also requires `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` to be configured. If any are missing, requests return `503 SMS integration not configured`.
 
-Outbound SMS is sent via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number. The request body is `{ to: string, text: string }`.
+Outbound SMS is sent via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number. The request body accepts either `{ to, text }` or `{ chatId, text }` — `chatId` is an alias for `to`, allowing the runtime channel callback (which sends `{ chatId, text }`) to work without translation. When both `to` and `chatId` are provided, `to` takes precedence.
 
 ## Callback Query Handling
 

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -200,6 +200,45 @@ describe("/deliver/sms", () => {
     expect(body.error).toBe("SMS delivery failed");
   });
 
+  it("accepts { chatId, text } and sends Twilio request to chatId", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, init: init ?? {} });
+      return new Response(JSON.stringify({ sid: "SM-sent" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const handler = createSmsDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
+    );
+    const req = makeRequest({ chatId: "+15559876543", text: "hello via chatId" }, {});
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify the Twilio Messages API was called with chatId as the To number
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("AC-test-sid/Messages.json");
+    const sentBody = fetchCalls[0].init.body as string;
+    const sentParams = new URLSearchParams(sentBody);
+    expect(sentParams.get("To")).toBe("+15559876543");
+    expect(sentParams.get("Body")).toBe("hello via chatId");
+  });
+
+  it("prefers 'to' over 'chatId' when both are provided", async () => {
+    mockTwilioApi();
+    const handler = createSmsDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
+    );
+    const req = makeRequest({ to: "+15551111111", chatId: "+15552222222", text: "both fields" }, {});
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+  });
+
   it("sends correct Twilio API request", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
     globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -76,6 +76,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
 
     let body: {
       to?: string;
+      chatId?: string;
       text?: string;
     };
     try {
@@ -84,7 +85,10 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { to, text } = body;
+    const { text } = body;
+    // Accept `chatId` as an alias for `to` so runtime channel callbacks
+    // (which send `{ chatId, text }`) work without translation.
+    const to = body.to ?? body.chatId;
 
     if (!to || typeof to !== "string") {
       return Response.json({ error: "to is required" }, { status: 400 });

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -759,12 +759,17 @@ export function buildSchema(): Record<string, unknown> {
         },
         SmsDeliverRequest: {
           type: "object",
-          required: ["to", "text"],
-          description: "Request to deliver an SMS message via Twilio.",
+          required: ["text"],
+          description: "Request to deliver an SMS message via Twilio. Provide either `to` or `chatId` (alias) as the recipient phone number.",
           properties: {
             to: { type: "string", description: "Recipient phone number in E.164 format" },
+            chatId: { type: "string", description: "Alias for `to` — recipient phone number in E.164 format. Used by the runtime channel callback payload." },
             text: { type: "string", description: "Text content to send", minLength: 1 },
           },
+          anyOf: [
+            { required: ["to"] },
+            { required: ["chatId"] },
+          ],
         },
         TelegramUpdate: {
           type: "object",


### PR DESCRIPTION
Part of #6765: SMS/Twilio Faithfulness Remediation

The runtime callback sends `{ chatId, text }` but `/deliver/sms` only accepted `{ to, text }`, breaking SMS reply delivery.

## Changes
- Accept `chatId` as alias for `to` in the SMS deliver endpoint
- Keep backward compatibility with existing `{ to, text }` callers
- Update schema and docs
- Add test coverage for the new payload shape

Closes #6766
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
