### PR TITLE
fix: release delivery claim on failure and add TTL eviction for run delivery guard

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -326,6 +326,9 @@ export function getDeadLetterEvents(): Array<{
 
 const deliveredRuns = new Set<string>();
 
+/** TTL for delivery claims — 10 minutes, well beyond the poll max-wait. */
+const CLAIM_TTL_MS = 10 * 60 * 1000;
+
 /**
  * Atomically claim the right to deliver the final reply for a run.
  * Returns `true` if this caller won the claim (and should proceed with
@@ -334,16 +337,21 @@ const deliveredRuns = new Set<string>();
  * This is an in-memory guard — sufficient because both racing pollers
  * execute within the same process. The Set is never persisted; on restart
  * there are no in-flight pollers to race.
+ *
+ * Claims are automatically evicted after CLAIM_TTL_MS to prevent
+ * unbounded Set growth over the lifetime of the process.
  */
 export function claimRunDelivery(runId: string): boolean {
   if (deliveredRuns.has(runId)) return false;
   deliveredRuns.add(runId);
+  setTimeout(() => deliveredRuns.delete(runId), CLAIM_TTL_MS);
   return true;
 }
 
 /**
- * Reset the deliver-once guard for a run. Used in tests to ensure
- * isolation between test cases.
+ * Reset the deliver-once guard for a run. Used to release a claim when
+ * delivery fails (so the other racing poller can retry) and in tests
+ * for isolation between test cases.
  */
 export function resetRunDeliveryClaim(runId: string): void {
   deliveredRuns.delete(runId);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -849,8 +849,15 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         // Deliver the final assistant reply exactly once. The post-decision
         // poll in schedulePostDecisionDelivery races with this path; the
         // claimRunDelivery guard ensures only the winner sends the reply.
+        // If delivery fails, release the claim so the other poller can retry
+        // rather than permanently losing the reply.
         if (channelDeliveryStore.claimRunDelivery(run.id)) {
-          await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+          try {
+            await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+          } catch (deliveryErr) {
+            channelDeliveryStore.resetRunDeliveryClaim(run.id);
+            throw deliveryErr;
+          }
         }
 
         // If this was a non-guardian run that went through guardian approval,
@@ -1281,7 +1288,12 @@ function schedulePostDecisionDelivery(
         if (!current) break;
         if (current.status === 'completed' || current.status === 'failed') {
           if (channelDeliveryStore.claimRunDelivery(runId)) {
-            await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+            try {
+              await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+            } catch (deliveryErr) {
+              channelDeliveryStore.resetRunDeliveryClaim(runId);
+              throw deliveryErr;
+            }
           }
           return;
         }


### PR DESCRIPTION
Addresses review feedback from #6773: (1) wraps both delivery sites in try/catch to release the delivery claim if deliverReplyViaCallback throws, preventing lost replies on transient failures; (2) adds 10-minute TTL-based cleanup to the deliveredRuns Set to prevent unbounded growth. Part of #6754.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
