### PR TITLE
M3: Make Twilio setup semantics consistent + auto-configure webhooks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -433,7 +433,7 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 2. The gateway authenticates the request via bearer token (same fail-closed model as `/deliver/telegram`).
 3. The gateway sends the SMS via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number.
 
-**Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant.
+**Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant. Both `provision_number` and `assign_number` auto-persist the number to config and secure storage, and auto-configure Twilio webhooks (voice URL, status callback, SMS URL) via the Twilio IncomingPhoneNumber API when a public ingress URL is available. Webhook configuration is best-effort — if ingress is not yet set up, the number is still assigned and webhooks can be configured later.
 
 **Limitations (v1)**: Text-only — MMS (media attachments) is deferred to a future release.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -204,8 +204,8 @@ The daemon handles `twilio_config` messages with the following actions:
 | `get` | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned) |
 | `set_credentials` | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file). Credentials are retrieved from the credential store internally. |
 | `clear_credentials` | Removes stored Account SID, Auth Token, and phone number from secure storage. |
-| `provision_number` | Purchases a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Returns the purchased number but does not assign it — call `assign_number` separately to persist it. |
-| `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant |
+| `provision_number` | Purchases a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Auto-assigns the number to the assistant (persists to config and secure storage) and configures Twilio webhooks (voice, status callback, SMS) when a public ingress URL is available. |
+| `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant and auto-configures webhooks when ingress is available |
 | `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
 
 Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, and optional `error`.

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -573,6 +573,169 @@ describe('Twilio config handler', () => {
     expect(res.phoneNumber).toBe('+15559999999');
   });
 
+  test('provision_number auto-assigns the purchased number to config and secure storage', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('AvailablePhoneNumbers') && urlStr.includes('Local.json')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [{
+            phone_number: '+15559999999',
+            friendly_name: '(555) 999-9999',
+            capabilities: { voice: true, sms: true },
+          }],
+        }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          phone_number: '+15559999999',
+          friendly_name: '(555) 999-9999',
+          capabilities: { voice: true, sms: true },
+        }), { status: 201 });
+      }
+      // Webhook lookup (no ingress configured, will fail gracefully)
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+      country: 'US',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; phoneNumber?: string };
+    expect(res.success).toBe(true);
+    expect(res.phoneNumber).toBe('+15559999999');
+
+    // Verify the number was persisted in secure storage (same as assign_number)
+    expect(secureKeyStore['credential:twilio:phone_number']).toBe('+15559999999');
+
+    // Verify the number was persisted in the config file (same as assign_number)
+    expect((rawConfigStore.sms as Record<string, unknown>)?.phoneNumber).toBe('+15559999999');
+  });
+
+  test('provision_number configures Twilio webhooks when ingress URL is available', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = { ingress: { enabled: true, publicBaseUrl: 'https://example.ngrok.io' } };
+
+    const fetchCalls: Array<{ url: string; method: string; body?: string }> = [];
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, method: init?.method ?? 'GET', body: init?.body?.toString() });
+
+      if (urlStr.includes('AvailablePhoneNumbers') && urlStr.includes('Local.json')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [{
+            phone_number: '+15559999999',
+            friendly_name: '(555) 999-9999',
+            capabilities: { voice: true, sms: true },
+          }],
+        }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers.json') && init?.method === 'POST'
+          && init?.body?.toString().includes('PhoneNumber')) {
+        return new Response(JSON.stringify({
+          phone_number: '+15559999999',
+          friendly_name: '(555) 999-9999',
+          capabilities: { voice: true, sms: true },
+        }), { status: 201 });
+      }
+      // Webhook number lookup
+      if (urlStr.includes('IncomingPhoneNumbers.json') && urlStr.includes('PhoneNumber=')) {
+        return new Response(JSON.stringify({
+          incoming_phone_numbers: [{ sid: 'PN123abc', phone_number: '+15559999999' }],
+        }), { status: 200 });
+      }
+      // Webhook update
+      if (urlStr.includes('IncomingPhoneNumbers/PN123abc.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ sid: 'PN123abc' }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+      country: 'US',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean };
+    expect(res.success).toBe(true);
+
+    // Find the webhook update call
+    const webhookUpdate = fetchCalls.find((c) =>
+      c.url.includes('IncomingPhoneNumbers/PN123abc.json') && c.method === 'POST',
+    );
+    expect(webhookUpdate).toBeDefined();
+
+    // Verify the webhook URLs contain the expected ingress base URL paths
+    const body = webhookUpdate!.body!;
+    expect(body).toContain('VoiceUrl=');
+    expect(body).toContain('webhooks%2Ftwilio%2Fvoice');
+    expect(body).toContain('StatusCallback=');
+    expect(body).toContain('webhooks%2Ftwilio%2Fstatus');
+    expect(body).toContain('SmsUrl=');
+    expect(body).toContain('webhooks%2Ftwilio%2Fsms');
+  });
+
+  test('provision_number succeeds with clear warning when ingress URL is missing', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    // No ingress config — webhook configuration will be skipped gracefully
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('AvailablePhoneNumbers') && urlStr.includes('Local.json')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [{
+            phone_number: '+15559999999',
+            friendly_name: '(555) 999-9999',
+            capabilities: { voice: true, sms: true },
+          }],
+        }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          phone_number: '+15559999999',
+          friendly_name: '(555) 999-9999',
+          capabilities: { voice: true, sms: true },
+        }), { status: 201 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+      country: 'US',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    // The provision should still succeed — webhook config failure is non-fatal
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; phoneNumber?: string };
+    expect(res.success).toBe(true);
+    expect(res.phoneNumber).toBe('+15559999999');
+
+    // Number should still be persisted even without webhook setup
+    expect(secureKeyStore['credential:twilio:phone_number']).toBe('+15559999999');
+    expect((rawConfigStore.sms as Record<string, unknown>)?.phoneNumber).toBe('+15559999999');
+  });
+
   test('provision_number returns error when no numbers available', async () => {
     secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
     secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -154,3 +154,73 @@ export async function provisionPhoneNumber(
     capabilities: { voice: data.capabilities.voice, sms: data.capabilities.sms },
   };
 }
+
+export interface WebhookUrls {
+  voiceUrl: string;
+  statusCallbackUrl: string;
+  smsUrl: string;
+}
+
+/**
+ * Update the webhook URLs on a Twilio IncomingPhoneNumber.
+ *
+ * Configures voice webhook, voice status callback, and SMS webhook so
+ * that Twilio routes inbound calls and messages to the assistant's
+ * gateway endpoints.
+ */
+export async function updatePhoneNumberWebhooks(
+  accountSid: string,
+  authToken: string,
+  phoneNumber: string,
+  webhooks: WebhookUrls,
+): Promise<void> {
+  // First, find the SID for this phone number
+  const listRes = await fetch(
+    `${twilioBaseUrl(accountSid)}/IncomingPhoneNumbers.json?PhoneNumber=${encodeURIComponent(phoneNumber)}`,
+    {
+      method: 'GET',
+      headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+    },
+  );
+
+  if (!listRes.ok) {
+    const text = await listRes.text();
+    throw new Error(`Twilio API error ${listRes.status} looking up phone number: ${text}`);
+  }
+
+  const listData = (await listRes.json()) as {
+    incoming_phone_numbers: Array<{ sid: string; phone_number: string }>;
+  };
+
+  const match = listData.incoming_phone_numbers.find((n) => n.phone_number === phoneNumber);
+  if (!match) {
+    throw new Error(`Phone number ${phoneNumber} not found on Twilio account ${accountSid}`);
+  }
+
+  // Update the phone number's webhook configuration
+  const body = new URLSearchParams({
+    VoiceUrl: webhooks.voiceUrl,
+    VoiceMethod: 'POST',
+    StatusCallback: webhooks.statusCallbackUrl,
+    StatusCallbackMethod: 'POST',
+    SmsUrl: webhooks.smsUrl,
+    SmsMethod: 'POST',
+  });
+
+  const updateRes = await fetch(
+    `${twilioBaseUrl(accountSid)}/IncomingPhoneNumbers/${match.sid}.json`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: twilioAuthHeader(accountSid, authToken),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    },
+  );
+
+  if (!updateRes.ok) {
+    const text = await updateRes.text();
+    throw new Error(`Twilio API error ${updateRes.status} updating webhooks: ${text}`);
+  }
+}

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -82,7 +82,14 @@ If the user wants to buy a new number through Twilio, send:
 - `areaCode` is optional — ask the user if they have a preferred area code
 - `country` defaults to `"US"` — ask if they want a different country (ISO 3166-1 alpha-2)
 
-The daemon provisions the number via the Twilio API and automatically assigns it to the assistant. The response includes the new `phoneNumber`.
+The daemon provisions the number via the Twilio API, automatically assigns it to the assistant (persisting to both secure storage and config), and configures Twilio webhooks (voice, status callback, SMS) if a public ingress URL is available. The response includes the new `phoneNumber`. No separate `assign_number` call is needed.
+
+**Webhook auto-configuration:** When `ingress.publicBaseUrl` is configured, the daemon automatically sets the following webhooks on the Twilio phone number:
+- Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
+- Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
+- SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
+
+If ingress is not yet configured, webhook setup is skipped gracefully — the number is still assigned and usable once ingress is set up later.
 
 **Trial account note:** Twilio trial accounts come with one free phone number. Check "Active Numbers" in the Twilio Console first before provisioning.
 
@@ -109,7 +116,7 @@ Then assign the chosen number:
 }
 ```
 
-The phone number must be in E.164 format.
+The phone number must be in E.164 format. Like `provision_number`, `assign_number` also auto-configures Twilio webhooks when a public ingress URL is available.
 
 ### Option C: Manual Entry
 
@@ -146,13 +153,13 @@ If not configured, load and run the public-ingress skill:
 skill_load skill=public-ingress
 ```
 
-**Twilio webhook endpoints (handled automatically by the gateway):**
+**Twilio webhook endpoints (auto-configured on provision/assign):**
 - Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
 - Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
 - ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
 - SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
 
-No manual Twilio webhook configuration is needed — webhook URLs are registered dynamically.
+Webhook URLs are automatically configured on the Twilio phone number when `provision_number` or `assign_number` is called with a valid ingress URL. No manual Twilio Console webhook configuration is needed.
 
 ## Step 5: Verify Setup
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -37,7 +37,15 @@ import {
   listIncomingPhoneNumbers,
   searchAvailableNumbers,
   provisionPhoneNumber,
+  updatePhoneNumberWebhooks,
 } from '../../calls/twilio-rest.js';
+import {
+  getPublicBaseUrl,
+  getTwilioVoiceWebhookUrl,
+  getTwilioStatusCallbackUrl,
+  getTwilioSmsWebhookUrl,
+  type IngressConfig,
+} from '../../inbound/public-ingress-urls.js';
 import { createVerificationChallenge, getGuardianBinding, revokeBinding as revokeGuardianBinding } from '../../runtime/channel-guardian-service.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
@@ -1233,6 +1241,45 @@ export async function handleTwilioConfig(
       // Purchase the first available number
       const purchased = await provisionPhoneNumber(accountSid, authToken, available[0].phoneNumber);
 
+      // Auto-assign: persist the purchased number in secure storage and config
+      // (same persistence as assign_number for consistency)
+      const phoneStored = setSecureKey('credential:twilio:phone_number', purchased.phoneNumber);
+      if (!phoneStored) {
+        log.warn('Failed to store provisioned phone number in secure storage');
+      }
+
+      const raw = loadRawConfig();
+      const sms = (raw?.sms ?? {}) as Record<string, unknown>;
+      sms.phoneNumber = purchased.phoneNumber;
+
+      const wasSuppressed = ctx.suppressConfigReload;
+      ctx.setSuppressConfigReload(true);
+      try {
+        saveRawConfig({ ...raw, sms });
+      } catch (err) {
+        ctx.setSuppressConfigReload(wasSuppressed);
+        throw err;
+      }
+      ctx.debounceTimers.schedule('__suppress_reset__', () => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
+
+      // Best-effort webhook configuration — non-fatal so the number is
+      // still usable even if ingress isn't configured yet.
+      try {
+        const ingressConfig: IngressConfig = loadRawConfig();
+        const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig, '{{CallSid}}');
+        const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
+        const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
+        await updatePhoneNumberWebhooks(accountSid, authToken, purchased.phoneNumber, {
+          voiceUrl,
+          statusCallbackUrl,
+          smsUrl,
+        });
+        log.info({ phoneNumber: purchased.phoneNumber }, 'Twilio webhooks configured for provisioned number');
+      } catch (webhookErr) {
+        const webhookMsg = webhookErr instanceof Error ? webhookErr.message : String(webhookErr);
+        log.warn({ err: webhookErr, phoneNumber: purchased.phoneNumber }, `Webhook configuration skipped: ${webhookMsg}`);
+      }
+
       ctx.send(socket, {
         type: 'twilio_config_response',
         success: true,
@@ -1277,6 +1324,27 @@ export async function handleTwilioConfig(
         throw err;
       }
       ctx.debounceTimers.schedule('__suppress_reset__', () => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
+
+      // Best-effort webhook configuration when credentials are available
+      if (hasTwilioCredentials()) {
+        try {
+          const acctSid = getSecureKey('credential:twilio:account_sid')!;
+          const acctToken = getSecureKey('credential:twilio:auth_token')!;
+          const ingressConfig: IngressConfig = loadRawConfig();
+          const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig, '{{CallSid}}');
+          const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
+          const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
+          await updatePhoneNumberWebhooks(acctSid, acctToken, msg.phoneNumber, {
+            voiceUrl,
+            statusCallbackUrl,
+            smsUrl,
+          });
+          log.info({ phoneNumber: msg.phoneNumber }, 'Twilio webhooks configured for assigned number');
+        } catch (webhookErr) {
+          const webhookMsg = webhookErr instanceof Error ? webhookErr.message : String(webhookErr);
+          log.warn({ err: webhookErr, phoneNumber: msg.phoneNumber }, `Webhook configuration skipped: ${webhookMsg}`);
+        }
+      }
 
       ctx.send(socket, {
         type: 'twilio_config_response',

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -115,6 +115,14 @@ export function getOAuthCallbackUrl(config: IngressConfig): string {
 }
 
 /**
+ * Build the Twilio SMS webhook URL.
+ */
+export function getTwilioSmsWebhookUrl(config: IngressConfig): string {
+  const base = getPublicBaseUrl(config);
+  return `${base}/webhooks/twilio/sms`;
+}
+
+/**
  * Build the Telegram webhook URL.
  */
 export function getTelegramWebhookUrl(config: IngressConfig): string {


### PR DESCRIPTION
Part of #6765: SMS/Twilio Faithfulness Remediation\n\nTwilio setup behavior was inconsistent: provision_number didn't persist assignment, and webhook URLs weren't auto-configured for SMS.\n\n## Changes\n- Make provision_number auto-assign the number (persist to config like assign_number)\n- Add webhook configuration on number setup (voice, status callback, SMS)\n- Use publicBaseUrl URL builders as source of truth\n- Add actionable errors when ingress URL missing\n- Update skill docs and README\n\nCloses #6768
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
