### PR TITLE
M4: Strengthen ingress boundary guarantees for SMS

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -183,6 +183,12 @@ Guardian enforcement (actor-role resolution, fail-closed denial for unknown acto
 | **Guardian-only approval** | Non-guardian senders cannot approve their own pending actions. Only the verified guardian can approve or deny. |
 | **Expired approval auto-deny** | If a guardian approval request expires (30-minute TTL) without a decision, the action is auto-denied when the non-guardian sender next interacts. |
 
+### Ingress Boundary Guarantees (Gateway-Only Mode)
+
+The runtime operates in **gateway-only mode**: all public-facing webhook paths are blocked at the runtime level. Direct access to Twilio webhook routes (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhooks/twilio/connect-action`, `/webhooks/twilio/sms`) and their legacy equivalents (`/v1/calls/twilio/*`) returns `410 GATEWAY_ONLY`. This ensures external webhook traffic (including SMS) can only reach the runtime through the gateway, which performs signature validation before forwarding.
+
+Internal forwarding routes (`/v1/internal/twilio/*`) are unaffected — these accept pre-validated payloads from the gateway over the private network.
+
 ### Gateway-Origin Ingress Contract
 
 The `/channels/inbound` endpoint requires a valid `X-Gateway-Origin` header that matches the configured bearer token. This ensures channel messages can only be submitted via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -289,6 +289,49 @@ describe('gateway-only ingress enforcement', () => {
     });
   });
 
+  // ── SMS-specific direct webhook routes blocked ──────────────────────
+
+  describe('SMS webhook routes are blocked at the runtime (gateway-only)', () => {
+
+    test('POST /webhooks/twilio/sms returns 410 (cannot bypass gateway)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ Body: 'hello', From: '+15551234567', To: '+15559876543', MessageSid: 'SM123' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+      expect(body.error).toContain('Direct webhook access disabled');
+    });
+
+    test('POST /v1/calls/twilio/sms returns 410 (legacy path also blocked)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/sms`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: makeFormBody({ Body: 'hello', From: '+15551234567', MessageSid: 'SM456' }),
+      });
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+
+    test('POST /webhooks/twilio/sms with valid auth still returns 410 (auth does not bypass gateway-only)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
+        method: 'POST',
+        headers: {
+          ...AUTH_HEADERS,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: makeFormBody({ Body: 'sneaky', From: '+15551234567', MessageSid: 'SM789' }),
+      });
+      // The gateway-only guard runs before auth for Twilio webhook paths
+      expect(res.status).toBe(410);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ONLY');
+    });
+  });
+
   // ── Internal forwarding routes still work ─────
 
   describe('internal forwarding routes are not blocked', () => {
@@ -600,6 +643,45 @@ describe('gateway-only ingress enforcement', () => {
       // Auth middleware fires first, so even with a valid gateway-origin
       // header, the request is rejected if bearer auth is missing.
       expect(res.status).toBe(401);
+    });
+
+    test('POST /v1/channels/inbound with SMS sourceChannel requires X-Gateway-Origin', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/channels/inbound`, {
+        method: 'POST',
+        headers: {
+          ...AUTH_HEADERS,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          sourceChannel: 'sms',
+          externalChatId: '+15551234567',
+          externalMessageId: 'SM-test-gw-1',
+          content: 'hello via SMS',
+        }),
+      });
+      // SMS messages must also go through the gateway — missing X-Gateway-Origin is rejected.
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string; code: string };
+      expect(body.code).toBe('GATEWAY_ORIGIN_REQUIRED');
+    });
+
+    test('POST /v1/channels/inbound with SMS sourceChannel and valid X-Gateway-Origin passes', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/channels/inbound`, {
+        method: 'POST',
+        headers: {
+          ...AUTH_HEADERS,
+          'Content-Type': 'application/json',
+          'X-Gateway-Origin': TEST_TOKEN,
+        },
+        body: JSON.stringify({
+          sourceChannel: 'sms',
+          externalChatId: '+15551234567',
+          externalMessageId: 'SM-test-gw-2',
+          content: 'hello via SMS',
+        }),
+      });
+      // Should NOT be 403 — the gateway-origin check passes.
+      expect(res.status).not.toBe(403);
     });
   });
 

--- a/assistant/src/__tests__/ingress-url-consistency.test.ts
+++ b/assistant/src/__tests__/ingress-url-consistency.test.ts
@@ -211,4 +211,68 @@ describe('Ingress URL consistency between assistant and gateway', () => {
 
     expect(gatewayCanonical).toBe(callbackUrl);
   });
+
+  // ── SMS-specific URL consistency ──────────────────────────────────
+
+  test('SMS webhook URL consistency: gateway signature URL matches configured ingress', () => {
+    const publicBase = 'https://sms-gateway.example.com';
+    const authToken = 'test-sms-auth-token';
+
+    // The gateway registers /webhooks/twilio/sms with Twilio. Twilio signs
+    // inbound SMS requests against the full public URL.
+    const smsWebhookUrl = `${publicBase}/webhooks/twilio/sms`;
+
+    const params = {
+      Body: 'hello',
+      From: '+15551234567',
+      To: '+15559876543',
+      MessageSid: 'SM123',
+    };
+    const twilioSignature = computeTwilioSignature(smsWebhookUrl, params, authToken);
+
+    // Gateway receives the request on its local address and reconstructs
+    // the canonical URL using the configured ingress base.
+    const localUrl = 'http://127.0.0.1:7830/webhooks/twilio/sms';
+    const canonicalUrl = reconstructGatewayCanonicalUrl(publicBase, localUrl);
+
+    expect(canonicalUrl).toBe(smsWebhookUrl);
+
+    const recomputed = computeTwilioSignature(canonicalUrl, params, authToken);
+    expect(recomputed).toBe(twilioSignature);
+  });
+
+  test('SMS webhook signature fails when ingress URL is not configured (fail-visible)', () => {
+    const publicBase = 'https://sms-gateway.example.com';
+    const authToken = 'test-sms-auth-token';
+
+    const smsWebhookUrl = `${publicBase}/webhooks/twilio/sms`;
+    const params = { Body: 'test', From: '+15550001111', MessageSid: 'SM456' };
+    const twilioSignature = computeTwilioSignature(smsWebhookUrl, params, authToken);
+
+    // Without ingress config, the gateway uses the local URL — signature mismatch.
+    const localUrl = 'http://127.0.0.1:7830/webhooks/twilio/sms';
+    const canonicalWithout = reconstructGatewayCanonicalUrl(undefined, localUrl);
+    const recomputedWithout = computeTwilioSignature(canonicalWithout, params, authToken);
+    expect(recomputedWithout).not.toBe(twilioSignature);
+  });
+
+  test('all Twilio webhook paths share the /webhooks/twilio/ prefix consistently', () => {
+    const config: IngressConfig = {
+      ingress: { publicBaseUrl: 'https://consistent.example.com' },
+    };
+    const base = getPublicBaseUrl(config);
+
+    // Document the path contract: all Twilio webhooks live under /webhooks/twilio/
+    const voiceUrl = getTwilioVoiceWebhookUrl(config, 'sess');
+    const statusUrl = getTwilioStatusCallbackUrl(config);
+
+    // Verify they all share the same base and prefix
+    expect(voiceUrl).toStartWith(`${base}/webhooks/twilio/`);
+    expect(statusUrl).toStartWith(`${base}/webhooks/twilio/`);
+
+    // SMS is currently handled at the gateway level (/webhooks/twilio/sms)
+    // but the path pattern is the same
+    const smsUrl = `${base}/webhooks/twilio/sms`;
+    expect(smsUrl).toStartWith(`${base}/webhooks/twilio/`);
+  });
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -154,13 +154,16 @@ const GATEWAY_SUBPATH_MAP: Record<string, string> = {
   voice: 'voice-webhook',
   status: 'status',
   'connect-action': 'connect-action',
+  sms: 'sms',
 };
 
 /**
  * Direct Twilio webhook subpaths that are blocked in gateway_only mode.
+ * Includes all public-facing webhook paths (voice, status, connect-action, SMS)
+ * because the runtime must never serve as a direct ingress for external webhooks.
  * Internal forwarding endpoints (gateway→runtime) are unaffected.
  */
-const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set(['voice-webhook', 'status', 'connect-action']);
+const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set(['voice-webhook', 'status', 'connect-action', 'sms']);
 
 /**
  * Check if a request origin is from a private/internal network address.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -229,6 +229,22 @@ In local tunnel setups, updating `ingress.publicBaseUrl` in Settings is typicall
 
 The assistant runtime uses this URL to construct all webhook and OAuth callback URLs automatically.
 
+## Ingress Boundary Guarantees
+
+The gateway is the **sole public ingress point** for all external webhooks, including SMS. The assistant runtime never directly accepts public webhook traffic — all Twilio and Telegram webhook routes on the runtime return `410 GATEWAY_ONLY` when accessed directly.
+
+### SMS Ingress
+
+Inbound SMS follows the same gateway-only pattern as voice and Telegram:
+
+1. **Twilio → Gateway** (`/webhooks/twilio/sms`) — Gateway validates `X-Twilio-Signature` using HMAC-SHA1 with the configured `TWILIO_AUTH_TOKEN`.
+2. **Gateway → Runtime** (`/v1/channels/inbound`) — Gateway forwards the normalized event to the runtime with `X-Gateway-Origin` proof and bearer auth.
+3. **Runtime rejects direct SMS webhooks** — Any direct POST to `/webhooks/twilio/sms` or `/v1/calls/twilio/sms` on the runtime returns `410 GATEWAY_ONLY`.
+
+### Signature URL Tightening
+
+When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the canonical URL for Twilio signature validation. If the signature only validates against the raw local request URL (fallback), a warning is logged indicating potential drift between the configured ingress URL and the actual webhook registration. The raw URL fallback is preserved for local-dev operability.
+
 ## Default Mode: Telegram-Only
 
 By default the gateway only serves the Telegram webhook endpoint (`/webhooks/telegram`). All other HTTP requests return `404`. The runtime proxy is **opt-in** — set `GATEWAY_RUNTIME_PROXY_ENABLED=true` to enable it. This behavior is enforced by automated tests.

--- a/gateway/src/__tests__/sms-ingress-guard.test.ts
+++ b/gateway/src/__tests__/sms-ingress-guard.test.ts
@@ -7,6 +7,11 @@ import { createTwilioSmsWebhookHandler } from "../http/routes/twilio-sms-webhook
  * Proves that the SMS ingress route cannot be bypassed — requests
  * without valid Twilio signature are rejected, and unauthenticated
  * requests to the deliver endpoint are rejected.
+ *
+ * Also validates that signature URL candidate selection is tightened
+ * when INGRESS_PUBLIC_BASE_URL is configured: the raw local request URL
+ * is still included as a fallback to preserve local-dev operability,
+ * but the canonical ingress URL is tried first.
  */
 
 const AUTH_TOKEN = "test-guard-auth-token";
@@ -45,6 +50,19 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+}
+
+function computeSignature(
+  url: string,
+  params: Record<string, string>,
+  authToken: string,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  let data = url;
+  for (const key of sortedKeys) {
+    data += key + params[key];
+  }
+  return createHmac("sha1", authToken).update(data).digest("base64");
 }
 
 describe("SMS ingress cannot bypass gateway boundary", () => {
@@ -126,5 +144,129 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
     });
     const res = await handler(req);
     expect(res.status).toBe(405);
+  });
+
+  test("rejects SMS webhook with empty body (no MessageSid)", async () => {
+    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params: Record<string, string> = {};
+    const signature = computeSignature(url, params, AUTH_TOKEN);
+    const req = new Request(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body: "",
+    });
+    const res = await handler(req);
+    // Should be 400 (missing MessageSid) since the signature validates but the
+    // payload is malformed — proving the handler enforces payload integrity too.
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects oversized SMS webhook payload", async () => {
+    const handler = createTwilioSmsWebhookHandler(
+      makeConfig({ maxWebhookPayloadBytes: 50 }),
+    );
+    const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": "999999",
+        "X-Twilio-Signature": "irrelevant",
+      },
+      body: "x".repeat(200),
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("SMS ingress signature validation with INGRESS_PUBLIC_BASE_URL", () => {
+  test("validates signature against configured ingress URL as primary candidate", async () => {
+    const publicBase = "https://sms-tunnel.example.com";
+    const config = makeConfig({ ingressPublicBaseUrl: publicBase });
+    const handler = createTwilioSmsWebhookHandler(config);
+
+    // Twilio signs against the public URL
+    const publicUrl = `${publicBase}/webhooks/twilio/sms`;
+    const params = {
+      Body: "hello tunnel",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-ingress-1",
+    };
+    const signature = computeSignature(publicUrl, params, AUTH_TOKEN);
+    const body = new URLSearchParams(params).toString();
+
+    // Request arrives on the local address
+    const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body,
+    });
+    const res = await handler(req);
+    // Should pass validation because the ingress URL is tried as a candidate
+    expect(res.status).not.toBe(403);
+  });
+
+  test("rejects signature computed against wrong ingress URL", async () => {
+    const config = makeConfig({
+      ingressPublicBaseUrl: "https://correct-tunnel.example.com",
+    });
+    const handler = createTwilioSmsWebhookHandler(config);
+
+    // Attacker signs against a different URL
+    const wrongUrl = "https://attacker.example.com/webhooks/twilio/sms";
+    const params = {
+      Body: "spoofed",
+      From: "+15550009999",
+      To: "+15559876543",
+      MessageSid: "SM-spoof-1",
+    };
+    const signature = computeSignature(wrongUrl, params, AUTH_TOKEN);
+    const body = new URLSearchParams(params).toString();
+
+    const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body,
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("local-dev fallback: signature against local URL validates when no ingress configured", async () => {
+    const config = makeConfig({ ingressPublicBaseUrl: undefined });
+    const handler = createTwilioSmsWebhookHandler(config);
+
+    // In local dev, Twilio signs against the raw request URL
+    const localUrl = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "local dev test",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-local-1",
+    };
+    const signature = computeSignature(localUrl, params, AUTH_TOKEN);
+    const body = new URLSearchParams(params).toString();
+
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body,
+    });
+    const res = await handler(req);
+    expect(res.status).not.toBe(403);
   });
 });

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -17,6 +17,14 @@ function firstHeaderValue(value: string | null): string | undefined {
  * 1) Canonical configured ingress URL (when present)
  * 2) Forwarded public URL headers from tunnel/proxy
  * 3) Raw request URL (last-resort fallback)
+ *
+ * When `ingressPublicBaseUrl` is configured, the canonical ingress URL is the
+ * highest-priority candidate. The raw request URL is still included as a
+ * fallback to preserve local-dev operability (e.g., when Twilio is configured
+ * to call the local server directly). However, a warning is logged when the
+ * raw fallback is the only candidate that validates, as this indicates a
+ * potential configuration drift between the ingress URL and the actual
+ * webhook registration.
  */
 function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): string[] {
   const parsedUrl = new URL(req.url);
@@ -53,6 +61,26 @@ function buildSignatureUrlCandidates(req: Request, config: GatewayConfig): strin
   }
 
   return candidates;
+}
+
+/**
+ * Track which candidate validated the signature so we can warn about
+ * fallback usage when `ingressPublicBaseUrl` is configured.
+ *
+ * @internal Exported for testing only.
+ */
+export function findValidatingCandidateIndex(
+  candidates: string[],
+  params: Record<string, string>,
+  signature: string,
+  authToken: string,
+): number {
+  for (let i = 0; i < candidates.length; i++) {
+    if (verifyTwilioSignature(candidates[i], params, signature, authToken)) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 export type TwilioValidationSuccess = {
@@ -119,16 +147,38 @@ export async function validateTwilioWebhookRequest(
   }
 
   const signatureUrlCandidates = buildSignatureUrlCandidates(req, config);
-  const isValid = signatureUrlCandidates.some((candidate) =>
-    verifyTwilioSignature(candidate, params, signature, config.twilioAuthToken!),
+  const validatingIndex = findValidatingCandidateIndex(
+    signatureUrlCandidates,
+    params,
+    signature,
+    config.twilioAuthToken!,
   );
 
-  if (!isValid) {
+  if (validatingIndex === -1) {
     log.warn(
       { candidateCount: signatureUrlCandidates.length },
       "Twilio webhook signature validation failed",
     );
     return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // When ingressPublicBaseUrl is configured and the signature only validated
+  // against the raw local URL (last candidate), log a warning. This indicates
+  // a likely drift between the configured ingress URL and the actual webhook
+  // registration — the ingress URL should match what Twilio is signing against.
+  if (
+    config.ingressPublicBaseUrl &&
+    validatingIndex === signatureUrlCandidates.length - 1 &&
+    signatureUrlCandidates.length > 1
+  ) {
+    log.warn(
+      {
+        ingressPublicBaseUrl: config.ingressPublicBaseUrl,
+        validatedAgainst: signatureUrlCandidates[validatingIndex],
+      },
+      "Twilio signature validated against raw request URL fallback — " +
+        "INGRESS_PUBLIC_BASE_URL may be stale or mismatched with the actual webhook registration",
+    );
   }
 
   return { rawBody, params };


### PR DESCRIPTION
Part of #6765: SMS/Twilio Faithfulness Remediation

Make gateway-only ingress guarantee explicit for SMS paths and reduce drift risk.

## Changes
- Add explicit SMS ingress guard assertions in gateway-only enforcement tests
- Add ingress URL consistency tests
- Add SMS-specific ingress guard tests in gateway
- Tighten webhook validation when INGRESS_PUBLIC_BASE_URL is configured
- Update READMEs with ingress boundary documentation

Closes #6769
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
