### PR TITLE
M2: Add SMS /new parity + explicit MMS unsupported behavior

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -424,9 +424,11 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 **Ingress** (`POST /webhooks/twilio/sms`):
 1. Twilio delivers an inbound SMS as a form-encoded POST to the gateway.
 2. The gateway validates the `X-Twilio-Signature` header using HMAC-SHA1 with the Twilio Auth Token against the canonical request URL (reconstructed from `INGRESS_PUBLIC_BASE_URL` when behind a tunnel).
-3. The payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"` and `externalChatId` set to the sender's phone number (E.164).
-4. `MessageSid` deduplication prevents reprocessing retried webhooks.
-5. The event is forwarded to the runtime via `POST /channels/inbound`, including SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
+3. `MessageSid` deduplication prevents reprocessing retried webhooks.
+4. **MMS detection**: If `NumMedia > 0`, the gateway replies with an unsupported notice and does not forward the payload. MMS payloads are explicitly rejected rather than silently dropped.
+5. **`/new` command**: When the message body is exactly `/new` (case-insensitive, trimmed), the gateway resolves routing, calls `resetConversation(...)` on the runtime, and sends a confirmation SMS. The message is not forwarded — matching Telegram `/new` semantics.
+6. The payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"` and `externalChatId` set to the sender's phone number (E.164).
+7. The event is forwarded to the runtime via `POST /channels/inbound`, including SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
 
 **Egress** (`POST /deliver/sms`):
 1. The runtime calls the gateway's `/deliver/sms` endpoint with `{ to, text }`.
@@ -435,7 +437,7 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 
 **Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant.
 
-**Limitations (v1)**: Text-only — MMS (media attachments) is deferred to a future release.
+**Limitations (v1)**: Text-only — MMS payloads are explicitly rejected with a user-facing notice rather than silently dropped.
 
 ---
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -101,11 +101,13 @@ The `/webhooks/twilio/sms` endpoint receives inbound SMS messages from Twilio. O
 
 1. **Signature validation** — The `X-Twilio-Signature` header is validated using HMAC-SHA1 with the `TWILIO_AUTH_TOKEN`. When behind a tunnel or reverse proxy, the gateway reconstructs the canonical request URL from `INGRESS_PUBLIC_BASE_URL` for validation.
 2. **MessageSid dedup** — Each `MessageSid` is tracked in an in-memory dedup cache. Duplicate webhook deliveries (Twilio retries) are silently accepted without re-forwarding.
-3. **Normalization** — The form-encoded Twilio payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"`. The sender's phone number (`From`) is used as both `externalChatId` and `externalUserId`.
-4. **Routing** — The same routing resolver used for Telegram (chat_id -> user_id -> default/reject) determines the target assistant.
-5. **Forwarding** — The event is forwarded to the runtime via `POST /channels/inbound` with SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
+3. **MMS detection** — If `NumMedia > 0`, the message contains media attachments. The gateway replies with an unsupported notice ("MMS is not supported yet") and does not forward the payload to the runtime.
+4. **`/new` command** — When the message body is exactly `/new` (case-insensitive, trimmed), the gateway resets the conversation via the runtime API and sends a confirmation SMS. The message is not forwarded to the runtime. This matches the Telegram `/new` command behavior.
+5. **Normalization** — The form-encoded Twilio payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "sms"`. The sender's phone number (`From`) is used as both `externalChatId` and `externalUserId`.
+6. **Routing** — The same routing resolver used for Telegram (chat_id -> user_id -> default/reject) determines the target assistant.
+7. **Forwarding** — The event is forwarded to the runtime via `POST /channels/inbound` with SMS-specific transport hints (`chat-first-medium`, `sms-character-limits`, etc.) and a `replyCallbackUrl` pointing to `/deliver/sms`.
 
-SMS is text-only in v1 — MMS (media attachments) is deferred.
+SMS is text-only in v1 — MMS payloads are explicitly rejected with a user-facing notice.
 
 ## SMS Deliver Endpoint Security
 

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -8,8 +8,20 @@ const handleInboundMock = mock(() =>
   Promise.resolve({ forwarded: true, rejected: false }),
 );
 
+const resetConversationMock = mock(() => Promise.resolve());
+
+const sendSmsReplyMock = mock(() => Promise.resolve());
+
 mock.module("../../handlers/handle-inbound.js", () => ({
   handleInbound: handleInboundMock,
+}));
+
+mock.module("../../runtime/client.js", () => ({
+  resetConversation: resetConversationMock,
+}));
+
+mock.module("../../twilio/send-sms.js", () => ({
+  sendSmsReply: sendSmsReplyMock,
 }));
 
 // Import after mocks are registered
@@ -90,6 +102,10 @@ describe("twilio-sms-webhook", () => {
     handleInboundMock.mockImplementation(() =>
       Promise.resolve({ forwarded: true, rejected: false }),
     );
+    resetConversationMock.mockClear();
+    resetConversationMock.mockImplementation(() => Promise.resolve());
+    sendSmsReplyMock.mockClear();
+    sendSmsReplyMock.mockImplementation(() => Promise.resolve());
   });
 
   it("rejects GET requests with 405", async () => {
@@ -321,5 +337,86 @@ describe("twilio-sms-webhook", () => {
     });
     const res = await handler(req);
     expect(res.status).toBe(413);
+  });
+
+  it("/new triggers resetConversation and does not forward as normal message", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "/new",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-new-cmd",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // resetConversation should have been called
+    expect(resetConversationMock).toHaveBeenCalledTimes(1);
+    const [, assistantId, sourceChannel, externalChatId] =
+      resetConversationMock.mock.calls[0] as unknown[];
+    expect(assistantId).toBe("ast-default");
+    expect(sourceChannel).toBe("sms");
+    expect(externalChatId).toBe("+15551234567");
+
+    // Confirmation SMS should have been sent
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(to).toBe("+15551234567");
+    expect(text).toBe("Starting a new conversation!");
+
+    // handleInbound should NOT have been called
+    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("/new is case-insensitive and trims whitespace", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "  /NEW  ",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-new-case",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(resetConversationMock).toHaveBeenCalledTimes(1);
+    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("MMS payload (NumMedia > 0) returns unsupported notice and does not forward", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "Check out this photo",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-mms-test",
+      NumMedia: "1",
+      MediaUrl0: "https://api.twilio.com/media/123",
+      MediaContentType0: "image/jpeg",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Unsupported notice should have been sent
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(to).toBe("+15551234567");
+    expect(typeof text).toBe("string");
+    expect((text as string).toLowerCase()).toContain("not supported");
+
+    // handleInbound should NOT have been called
+    expect(handleInboundMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -3,6 +3,8 @@ import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
+import { resetConversation } from "../../runtime/client.js";
+import { sendSmsReply } from "../../twilio/send-sms.js";
 import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
 import type { GatewayInboundEventV1 } from "../../types.js";
 
@@ -90,7 +92,56 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       "SMS webhook received",
     );
 
+    // --- MMS intercept: detect media attachments and reply with unsupported notice ---
+    const numMedia = parseInt(params.NumMedia || "0", 10);
+    if (numMedia > 0) {
+      tlog.info({ messageSid, numMedia }, "MMS payload detected, replying with unsupported notice");
+      sendSmsReply(config, params.From, "MMS (images, video, and other media) is not supported yet. Please send a text-only message.").catch(
+        (err) => {
+          tlog.error({ err, to: params.From }, "Failed to send MMS unsupported notice");
+        },
+      );
+      dedupCache.mark(messageSid);
+      return Response.json({ ok: true });
+    }
+
     const normalized = normalizeSmsPayload(params);
+
+    // --- /new intercept: reset conversation before it reaches the runtime ---
+    if (normalized.message.content.trim().toLowerCase() === "/new") {
+      const routing = resolveAssistant(
+        config,
+        normalized.message.externalChatId,
+        normalized.sender.externalUserId,
+      );
+
+      if (isRejection(routing)) {
+        tlog.warn(
+          { from: params.From, reason: routing.reason },
+          "Routing rejected /new command",
+        );
+      } else {
+        try {
+          await resetConversation(
+            config,
+            routing.assistantId,
+            normalized.sourceChannel,
+            normalized.message.externalChatId,
+          );
+          sendSmsReply(config, params.From, "Starting a new conversation!").catch((err) => {
+            tlog.error({ err }, "Failed to send /new confirmation");
+          });
+        } catch (err) {
+          tlog.error({ err }, "Failed to reset conversation");
+          sendSmsReply(config, params.From, "Failed to reset conversation. Please try again.").catch((replyErr) => {
+            tlog.error({ err: replyErr }, "Failed to send /new error reply");
+          });
+        }
+      }
+
+      dedupCache.mark(messageSid);
+      return Response.json({ ok: true });
+    }
 
     // Check routing
     const routing = resolveAssistant(

--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -1,0 +1,43 @@
+import type { GatewayConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("twilio-send-sms");
+
+/**
+ * Send an SMS message via the Twilio Messages API.
+ * Requires `twilioAccountSid`, `twilioAuthToken`, and `twilioPhoneNumber`
+ * to be configured. Silently returns if any are missing.
+ */
+export async function sendSmsReply(
+  config: GatewayConfig,
+  to: string,
+  body: string,
+): Promise<void> {
+  if (!config.twilioAccountSid || !config.twilioAuthToken || !config.twilioPhoneNumber) {
+    log.warn("Cannot send SMS reply: Twilio credentials not configured");
+    return;
+  }
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${config.twilioAccountSid}/Messages.json`;
+  const params = new URLSearchParams({
+    From: config.twilioPhoneNumber,
+    To: to,
+    Body: body,
+  });
+  const authHeader =
+    "Basic " + Buffer.from(`${config.twilioAccountSid}:${config.twilioAuthToken}`).toString("base64");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: authHeader,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Twilio Messages API error ${response.status}: ${text}`);
+  }
+}


### PR DESCRIPTION
Part of #6765: SMS/Twilio Faithfulness Remediation

SMS lacked Telegram-parity features: /new conversation reset and explicit MMS handling.

## Changes
- Add /new intercept in SMS webhook (resets conversation, sends confirmation)
- Add MMS detection (NumMedia > 0) with explicit unsupported notice
- Keep normal text-only flow unchanged
- Add test coverage for both new paths
- Update docs

Closes #6767
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
