### PR TITLE
M5: Complete Settings UX for Twilio number lifecycle

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -11,6 +11,16 @@ struct TwilioSettingsSection: View {
     @State private var isClearing = false
     @State private var showClearConfirmation = false
 
+    // Number lifecycle state
+    @State private var availableNumbers: [TwilioNumberInfo] = []
+    @State private var isLoadingNumbers = false
+    @State private var showProvisionSheet = false
+    @State private var provisionCountry = "US"
+    @State private var provisionAreaCode = ""
+    @State private var isProvisioning = false
+    @State private var isAssigning = false
+    @State private var assigningNumber: String?
+
     var body: some View {
         Section("Twilio (Calls & SMS)") {
             if isLoading {
@@ -55,8 +65,88 @@ struct TwilioSettingsSection: View {
                     }
                 }
 
-                // Actions
+                // Actions when credentials are configured
                 if hasCredentials {
+                    // List available numbers
+                    Button {
+                        listNumbers()
+                    } label: {
+                        HStack {
+                            Text("List Account Numbers")
+                            Spacer()
+                            if isLoadingNumbers {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "phone.badge.waveform")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .disabled(isLoadingNumbers)
+
+                    // Show available numbers for assignment
+                    if !availableNumbers.isEmpty {
+                        ForEach(availableNumbers, id: \.phoneNumber) { number in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(number.phoneNumber)
+                                        .font(.body)
+                                    HStack(spacing: 4) {
+                                        Text(number.friendlyName)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        if number.capabilities.voice {
+                                            Text("Voice")
+                                                .font(.caption2)
+                                                .padding(.horizontal, 4)
+                                                .padding(.vertical, 1)
+                                                .background(Color.blue.opacity(0.15))
+                                                .cornerRadius(4)
+                                        }
+                                        if number.capabilities.sms {
+                                            Text("SMS")
+                                                .font(.caption2)
+                                                .padding(.horizontal, 4)
+                                                .padding(.vertical, 1)
+                                                .background(Color.green.opacity(0.15))
+                                                .cornerRadius(4)
+                                        }
+                                    }
+                                }
+                                Spacer()
+                                if number.phoneNumber == phoneNumber {
+                                    Text("Active")
+                                        .font(.caption)
+                                        .foregroundColor(VColor.success)
+                                } else if assigningNumber == number.phoneNumber {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Button("Assign") {
+                                        assignNumber(number.phoneNumber)
+                                    }
+                                    .font(.caption)
+                                    .disabled(isAssigning)
+                                }
+                            }
+                        }
+                    }
+
+                    // Provision new number
+                    Button {
+                        showProvisionSheet = true
+                    } label: {
+                        HStack {
+                            Text("Provision New Number")
+                            Spacer()
+                            Image(systemName: "plus.circle")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .disabled(isProvisioning)
+
+                    // Clear credentials
                     Button(role: .destructive) {
                         showClearConfirmation = true
                     } label: {
@@ -92,6 +182,9 @@ struct TwilioSettingsSection: View {
         } message: {
             Text("This will remove your Twilio Account SID and Auth Token. Your phone number assignment will be preserved. Voice calls and SMS will stop working until credentials are reconfigured.")
         }
+        .sheet(isPresented: $showProvisionSheet) {
+            provisionSheet
+        }
         .onAppear { loadStatus() }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { loadStatus() }
@@ -102,6 +195,58 @@ struct TwilioSettingsSection: View {
             }
         }
     }
+
+    // MARK: - Provision Sheet
+
+    @ViewBuilder
+    private var provisionSheet: some View {
+        NavigationStack {
+            Form {
+                Section("Country") {
+                    TextField("Country code (e.g. US, GB)", text: $provisionCountry)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                }
+                Section("Area Code (Optional)") {
+                    TextField("e.g. 415", text: $provisionAreaCode)
+                        .keyboardType(.numberPad)
+                }
+                Section {
+                    Button {
+                        provisionNumber()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isProvisioning {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text("Provisioning...")
+                            } else {
+                                Text("Provision Number")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(isProvisioning || provisionCountry.isEmpty)
+                } footer: {
+                    Text("This will purchase a new phone number from Twilio in the selected country. Standard Twilio pricing applies.")
+                        .font(.caption)
+                }
+            }
+            .navigationTitle("Provision Number")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        showProvisionSheet = false
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    // MARK: - IPC Actions
 
     private func loadStatus() {
         guard let daemon = clientProvider.client as? DaemonClient else { return }
@@ -138,6 +283,95 @@ struct TwilioSettingsSection: View {
         } catch {
             isClearing = false
             errorMessage = "Failed to send clear request"
+        }
+    }
+
+    private func listNumbers() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        isLoadingNumbers = true
+        errorMessage = nil
+
+        daemon.onTwilioConfigResponse = { response in
+            isLoadingNumbers = false
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                availableNumbers = response.numbers ?? []
+                if availableNumbers.isEmpty {
+                    errorMessage = "No numbers found on this Twilio account."
+                } else {
+                    errorMessage = nil
+                }
+            } else {
+                errorMessage = response.error ?? "Failed to list numbers"
+            }
+        }
+
+        do {
+            try daemon.sendTwilioConfig(action: "list_numbers")
+        } catch {
+            isLoadingNumbers = false
+            errorMessage = "Failed to connect to daemon"
+        }
+    }
+
+    private func provisionNumber() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        isProvisioning = true
+        errorMessage = nil
+
+        daemon.onTwilioConfigResponse = { response in
+            isProvisioning = false
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                showProvisionSheet = false
+                provisionAreaCode = ""
+                errorMessage = nil
+                // Refresh the number list to include the newly provisioned number
+                listNumbers()
+            } else {
+                errorMessage = response.error ?? "Failed to provision number"
+            }
+        }
+
+        do {
+            let areaCode = provisionAreaCode.isEmpty ? nil : provisionAreaCode
+            try daemon.sendTwilioConfig(
+                action: "provision_number",
+                areaCode: areaCode,
+                country: provisionCountry
+            )
+        } catch {
+            isProvisioning = false
+            errorMessage = "Failed to connect to daemon"
+        }
+    }
+
+    private func assignNumber(_ number: String) {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        isAssigning = true
+        assigningNumber = number
+        errorMessage = nil
+
+        daemon.onTwilioConfigResponse = { response in
+            isAssigning = false
+            assigningNumber = nil
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                errorMessage = nil
+            } else {
+                errorMessage = response.error ?? "Failed to assign number"
+            }
+        }
+
+        do {
+            try daemon.sendTwilioConfig(action: "assign_number", phoneNumber: number)
+        } catch {
+            isAssigning = false
+            assigningNumber = nil
+            errorMessage = "Failed to connect to daemon"
         }
     }
 }


### PR DESCRIPTION
Part of #6765: SMS/Twilio Faithfulness Remediation

Settings UI only exposed status/clear but not provision/reassign workflow.

## Changes
- Add list numbers, provision number, and assign number actions to TwilioSettingsSection
- Wire up IPC messages with correct actions/payloads
- Keep existing clear-credentials flow intact
- Keep Twilio setup skill as guided fallback

Closes #6770
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
