### PR TITLE
fix: add timeout to sendSmsReply fetch calls

### DIFF
--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -34,6 +34,7 @@ export async function sendSmsReply(
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: params.toString(),
+    signal: AbortSignal.timeout(10_000),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Address review feedback on PR #6783 (M2: Add SMS /new parity + explicit MMS unsupported behavior):

Added AbortSignal.timeout to the fetch call in sendSmsReply to prevent open socket accumulation when Twilio API is slow or unreachable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
