### PR TITLE
fix: fail provisioning on secure-store error and fix voice webhook URL

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1245,7 +1245,13 @@ export async function handleTwilioConfig(
       // (same persistence as assign_number for consistency)
       const phoneStored = setSecureKey('credential:twilio:phone_number', purchased.phoneNumber);
       if (!phoneStored) {
-        log.warn('Failed to store provisioned phone number in secure storage');
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: hasTwilioCredentials(),
+          error: 'Failed to store provisioned phone number in secure storage',
+        });
+        return;
       }
 
       const raw = loadRawConfig();
@@ -1266,7 +1272,7 @@ export async function handleTwilioConfig(
       // still usable even if ingress isn't configured yet.
       try {
         const ingressConfig: IngressConfig = loadRawConfig();
-        const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig, '{{CallSid}}');
+        const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig);
         const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
         const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
         await updatePhoneNumberWebhooks(accountSid, authToken, purchased.phoneNumber, {
@@ -1331,7 +1337,7 @@ export async function handleTwilioConfig(
           const acctSid = getSecureKey('credential:twilio:account_sid')!;
           const acctToken = getSecureKey('credential:twilio:auth_token')!;
           const ingressConfig: IngressConfig = loadRawConfig();
-          const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig, '{{CallSid}}');
+          const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig);
           const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
           const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
           await updatePhoneNumberWebhooks(acctSid, acctToken, msg.phoneNumber, {

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -73,11 +73,20 @@ export function getPublicBaseUrl(config: IngressConfig): string {
 }
 
 /**
- * Build the Twilio voice webhook URL for a given call session.
+ * Build the Twilio voice webhook URL.
+ *
+ * When `callSessionId` is provided (outbound calls), it is included as a
+ * query parameter so the gateway can correlate the webhook to an existing
+ * session. When omitted (phone-number-level webhook configuration for
+ * inbound calls), the URL is returned without the query parameter — the
+ * gateway will create a new session for inbound calls.
  */
-export function getTwilioVoiceWebhookUrl(config: IngressConfig, callSessionId: string): string {
+export function getTwilioVoiceWebhookUrl(config: IngressConfig, callSessionId?: string): string {
   const base = getPublicBaseUrl(config);
-  return `${base}/webhooks/twilio/voice?callSessionId=${callSessionId}`;
+  if (callSessionId) {
+    return `${base}/webhooks/twilio/voice?callSessionId=${callSessionId}`;
+  }
+  return `${base}/webhooks/twilio/voice`;
 }
 
 /**


### PR DESCRIPTION
Address review feedback on PR #6781 (M3: Make Twilio setup semantics consistent):

1. **Fail provisioning when secure-store assignment cannot persist**: Changed provision_number to return an error when setSecureKey fails, matching assign_number behavior.

2. **Fix voice webhook URL template variable**: Removed non-functional {{CallSid}} template variable from phone number webhook configuration. Twilio doesn't support template substitution in webhook URLs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
