### PR TITLE
fix: resolve Twilio settings callback races and UX issues

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -273,10 +273,42 @@ struct TwilioSettingsSection: View {
         }
     }
 
+    /// Restores the default onTwilioConfigResponse handler (the one set by
+    /// loadStatus) so that subsequent responses — such as clear_credentials —
+    /// are handled correctly instead of being swallowed by a stale callback
+    /// from a previous action.
+    private func restoreDefaultHandler() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        daemon.onTwilioConfigResponse = { response in
+            isLoading = false
+            isClearing = false
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                errorMessage = nil
+            } else {
+                errorMessage = response.error ?? "Failed to load Twilio status"
+            }
+        }
+    }
+
     private func clearCredentials() {
         guard let daemon = clientProvider.client as? DaemonClient else { return }
         isClearing = true
         errorMessage = nil
+
+        daemon.onTwilioConfigResponse = { response in
+            isClearing = false
+            if response.success {
+                hasCredentials = response.hasCredentials
+                phoneNumber = response.phoneNumber
+                availableNumbers = []
+                errorMessage = nil
+            } else {
+                errorMessage = response.error ?? "Failed to clear credentials"
+            }
+            restoreDefaultHandler()
+        }
 
         do {
             try daemon.sendTwilioConfig(action: "clear_credentials")
@@ -295,7 +327,9 @@ struct TwilioSettingsSection: View {
             isLoadingNumbers = false
             if response.success {
                 hasCredentials = response.hasCredentials
-                phoneNumber = response.phoneNumber
+                // Don't update phoneNumber here — list_numbers responses don't
+                // include a phoneNumber field, so writing it would clear the
+                // currently assigned number in the UI.
                 availableNumbers = response.numbers ?? []
                 if availableNumbers.isEmpty {
                     errorMessage = "No numbers found on this Twilio account."
@@ -305,6 +339,7 @@ struct TwilioSettingsSection: View {
             } else {
                 errorMessage = response.error ?? "Failed to list numbers"
             }
+            restoreDefaultHandler()
         }
 
         do {
@@ -331,7 +366,11 @@ struct TwilioSettingsSection: View {
                 // Refresh the number list to include the newly provisioned number
                 listNumbers()
             } else {
+                // Dismiss the sheet so the error message is visible in the
+                // parent section rather than hidden behind the sheet.
+                showProvisionSheet = false
                 errorMessage = response.error ?? "Failed to provision number"
+                restoreDefaultHandler()
             }
         }
 
@@ -364,6 +403,7 @@ struct TwilioSettingsSection: View {
             } else {
                 errorMessage = response.error ?? "Failed to assign number"
             }
+            restoreDefaultHandler()
         }
 
         do {


### PR DESCRIPTION
Address review feedback on PR #6785 (M5: Complete Settings UX for Twilio number lifecycle):

1. **Preserve active number on list_numbers**: Don't overwrite phoneNumber from list_numbers response.
2. **Fix clearCredentials callback race**: Give clearCredentials its own response handler so it's not affected by list/provision/assign overwriting the callback.
3. **Dismiss provision sheet on error**: Close the provision sheet on failure so the error message is visible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
