### PR TITLE
feat: app version history panel for macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -651,8 +651,19 @@ struct DynamicWorkspaceWrapper: View {
     let onToggleChatDock: () -> Void
     let onMicrophoneToggle: () -> Void
 
+    @State private var showVersionHistory = false
+
     var body: some View {
         ZStack {
+            if showVersionHistory, let appId = data.appId {
+                AppVersionHistoryPanel(
+                    daemonClient: daemonClient,
+                    appId: appId,
+                    appName: data.preview?.title ?? "App",
+                    onClose: { showVersionHistory = false }
+                )
+            } else {
+
             DynamicPageSurfaceView(
                 data: data,
                 onAction: { actionId, actionData in
@@ -730,8 +741,16 @@ struct DynamicWorkspaceWrapper: View {
 
                     Spacer()
 
-                    // Right: Share + Close ghost buttons
+                    // Right: History + Share + Close ghost buttons
                     HStack(spacing: VSpacing.sm) {
+                        if data.appId != nil {
+                            VButton(label: "History", icon: "clock.arrow.circlepath", style: .ghost) {
+                                showVersionHistory = true
+                            }
+                            .controlSize(.small)
+                            .accessibilityLabel("Version history")
+                        }
+
                         if isPublishing {
                             ProgressView()
                                 .controlSize(.small)
@@ -779,6 +798,7 @@ struct DynamicWorkspaceWrapper: View {
 
                 Spacer()
             }
+            } // else (not showing version history)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Panel showing the version history of an app, with diff viewing and restore.
+struct AppVersionHistoryPanel: View {
+    let daemonClient: DaemonClient
+    let appId: String
+    let appName: String
+    let onClose: () -> Void
+
+    @State private var versions: [IPCAppHistoryResponseVersion] = []
+    @State private var isLoading = true
+    @State private var selectedVersion: IPCAppHistoryResponseVersion?
+    @State private var diffText: String?
+    @State private var isDiffLoading = false
+    @State private var restoreConfirmVersion: IPCAppHistoryResponseVersion?
+    @State private var isRestoring = false
+    @State private var restoreError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                VButton(label: "Back", icon: "chevron.left", style: .ghost) {
+                    onClose()
+                }
+                .controlSize(.small)
+
+                Spacer()
+
+                Text("Version History")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+
+                // Invisible spacer to balance the back button
+                Color.clear.frame(width: 60, height: 1)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+
+            Divider()
+                .foregroundColor(VColor.surfaceBorder)
+
+            if isLoading {
+                Spacer()
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading history...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                }
+                Spacer()
+            } else if versions.isEmpty {
+                Spacer()
+                HStack {
+                    Spacer()
+                    VStack(spacing: VSpacing.sm) {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .font(.system(size: 32))
+                            .foregroundColor(VColor.textTertiary)
+                        Text("No version history")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Changes will appear here after you edit the app.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textTertiary)
+                    }
+                    Spacer()
+                }
+                Spacer()
+            } else {
+                // Version list + optional diff detail
+                HSplitView {
+                    versionList
+                        .frame(minWidth: 280, idealWidth: 320)
+
+                    if let selected = selectedVersion {
+                        diffDetailView(for: selected)
+                            .frame(minWidth: 300)
+                    }
+                }
+            }
+        }
+        .background(VColor.background)
+        .onAppear { fetchHistory() }
+        .alert("Restore Version?", isPresented: .init(
+            get: { restoreConfirmVersion != nil },
+            set: { if !$0 { restoreConfirmVersion = nil } }
+        )) {
+            Button("Cancel", role: .cancel) {
+                restoreConfirmVersion = nil
+            }
+            Button("Restore", role: .destructive) {
+                if let version = restoreConfirmVersion {
+                    restoreVersion(version)
+                }
+            }
+        } message: {
+            if let version = restoreConfirmVersion {
+                Text("This will restore \"\(appName)\" to version \(String(version.commitHash.prefix(7))). A new version will be created with the restored content.")
+            }
+        }
+    }
+
+    // MARK: - Version List
+
+    private var versionList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(versions.enumerated()), id: \.element.commitHash) { index, version in
+                    versionRow(version, isFirst: index == 0)
+                }
+            }
+            .padding(.vertical, VSpacing.sm)
+        }
+    }
+
+    private func versionRow(_ version: IPCAppHistoryResponseVersion, isFirst: Bool) -> some View {
+        let isSelected = selectedVersion?.commitHash == version.commitHash
+        return Button(action: {
+            if selectedVersion?.commitHash == version.commitHash {
+                selectedVersion = nil
+                diffText = nil
+            } else {
+                selectVersion(version)
+            }
+        }) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                // Timeline dot
+                Circle()
+                    .fill(isFirst ? VColor.accent : VColor.textTertiary.opacity(0.5))
+                    .frame(width: 8, height: 8)
+                    .padding(.top, 5)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(version.message)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(2)
+
+                    HStack(spacing: VSpacing.sm) {
+                        Text(String(version.commitHash.prefix(7)))
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(VColor.textTertiary)
+
+                        Text(relativeTime(from: version.timestamp))
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textTertiary)
+                    }
+                }
+
+                Spacer()
+
+                if !isFirst {
+                    Button(action: {
+                        restoreConfirmVersion = version
+                    }) {
+                        Image(systemName: "arrow.counterclockwise")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Restore to this version")
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Diff Detail
+
+    @ViewBuilder
+    private func diffDetailView(for version: IPCAppHistoryResponseVersion) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Diff header
+            HStack {
+                Text("Changes in ")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                + Text(String(version.commitHash.prefix(7)))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+
+                if !isRestoring {
+                    VButton(label: "Restore", icon: "arrow.counterclockwise", style: .ghost) {
+                        restoreConfirmVersion = version
+                    }
+                    .controlSize(.small)
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+
+            Divider()
+
+            if isDiffLoading {
+                Spacer()
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                Spacer()
+            } else if let diff = diffText, !diff.isEmpty {
+                ScrollView(.vertical) {
+                    ScrollView(.horizontal) {
+                        Text(diff)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(VColor.textPrimary)
+                            .textSelection(.enabled)
+                            .padding(VSpacing.md)
+                    }
+                }
+            } else {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Text("No changes in this version")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                }
+                Spacer()
+            }
+
+            if let error = restoreError {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundColor(VColor.error)
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+            }
+        }
+        .background(VColor.surface)
+    }
+
+    // MARK: - Data Fetching
+
+    private func fetchHistory() {
+        isLoading = true
+        daemonClient.onAppHistoryResponse = { response in
+            if response.appId == appId {
+                versions = response.versions
+                isLoading = false
+            }
+        }
+        do {
+            try daemonClient.sendAppHistory(appId: appId)
+        } catch {
+            isLoading = false
+        }
+    }
+
+    private func selectVersion(_ version: IPCAppHistoryResponseVersion) {
+        selectedVersion = version
+        isDiffLoading = true
+        diffText = nil
+
+        // Find the previous version to diff against
+        guard let index = versions.firstIndex(where: { $0.commitHash == version.commitHash }),
+              index + 1 < versions.count else {
+            // First version — no previous to diff against
+            isDiffLoading = false
+            diffText = ""
+            return
+        }
+        let previousVersion = versions[index + 1]
+
+        daemonClient.onAppDiffResponse = { response in
+            if response.appId == appId {
+                diffText = response.diff
+                isDiffLoading = false
+            }
+        }
+        do {
+            try daemonClient.sendAppDiff(appId: appId, fromCommit: previousVersion.commitHash, toCommit: version.commitHash)
+        } catch {
+            isDiffLoading = false
+            diffText = ""
+        }
+    }
+
+    private func restoreVersion(_ version: IPCAppHistoryResponseVersion) {
+        isRestoring = true
+        restoreError = nil
+        restoreConfirmVersion = nil
+
+        daemonClient.onAppRestoreResponse = { response in
+            isRestoring = false
+            if response.success {
+                // Refresh history to show the new restore commit
+                fetchHistory()
+                selectedVersion = nil
+                diffText = nil
+            } else {
+                restoreError = response.error ?? "Restore failed"
+            }
+        }
+        do {
+            try daemonClient.sendAppRestore(appId: appId, commitHash: version.commitHash)
+        } catch {
+            isRestoring = false
+            restoreError = "Failed to send restore request"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func relativeTime(from timestamp: Double) -> String {
+        let date = Date(timeIntervalSince1970: timestamp / 1000)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -257,6 +257,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `fork_shared_app_response` message.
     public var onForkSharedAppResponse: ((ForkSharedAppResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `app_history_response` message.
+    public var onAppHistoryResponse: ((IPCAppHistoryResponse) -> Void)?
+
+    /// Called when the daemon sends an `app_diff_response` message.
+    public var onAppDiffResponse: ((IPCAppDiffResponse) -> Void)?
+
+    /// Called when the daemon sends an `app_restore_response` message.
+    public var onAppRestoreResponse: ((IPCAppRestoreResponse) -> Void)?
+
     /// Called when the daemon sends a `bundle_app_response` message.
     public var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
 
@@ -889,6 +898,21 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Request a single app's preview screenshot.
     public func sendAppPreview(appId: String) throws {
         try send(AppPreviewRequestMessage(type: "app_preview_request", appId: appId))
+    }
+
+    /// Request version history for an app.
+    public func sendAppHistory(appId: String, limit: Int? = nil) throws {
+        try send(IPCAppHistoryRequest(type: "app_history_request", appId: appId, limit: limit.map { Double($0) }))
+    }
+
+    /// Request a diff between two versions of an app.
+    public func sendAppDiff(appId: String, fromCommit: String, toCommit: String? = nil) throws {
+        try send(IPCAppDiffRequest(type: "app_diff_request", appId: appId, fromCommit: fromCommit, toCommit: toCommit))
+    }
+
+    /// Restore an app to a previous version.
+    public func sendAppRestore(appId: String, commitHash: String) throws {
+        try send(IPCAppRestoreRequest(type: "app_restore_request", appId: appId, commitHash: commitHash))
     }
 
     /// Request Home Base metadata from the daemon.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -103,8 +103,14 @@ extension DaemonClient {
             break // Fire-and-forget; no callback needed
         case .appPreviewResponse(let msg):
             onAppPreviewResponse?(msg)
-        case .appDiffResponse, .appFileAtVersionResponse, .appHistoryResponse, .appRestoreResponse:
-            break // Handled by subscribers; no dedicated callback yet
+        case .appHistoryResponse(let msg):
+            onAppHistoryResponse?(msg)
+        case .appDiffResponse(let msg):
+            onAppDiffResponse?(msg)
+        case .appFileAtVersionResponse:
+            break // Handled by subscribers
+        case .appRestoreResponse(let msg):
+            onAppRestoreResponse?(msg)
         case .sharedAppsListResponse(let msg):
             onSharedAppsListResponse?(msg)
         case .sharedAppDeleteResponse(let msg):


### PR DESCRIPTION
## Summary
- Add `AppVersionHistoryPanel.swift` — SwiftUI view showing app version history as a timeline, with diff viewer and restore-to-version with confirmation
- Wire up `DaemonClient` with `sendAppHistory`, `sendAppDiff`, `sendAppRestore` methods and response callbacks
- Route `app_history_response`, `app_diff_response`, `app_restore_response` in `DaemonMessageRouter`
- Add "History" button (clock icon) to the app toolbar in `DynamicWorkspaceWrapper`, next to Publish

## Original prompt
PR 4 of the app version control feature: macOS SwiftUI client panel for browsing version history, viewing diffs, and restoring previous versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
