### PR TITLE
fix: include purchased number in provision error for recovery

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1249,7 +1249,8 @@ export async function handleTwilioConfig(
           type: 'twilio_config_response',
           success: false,
           hasCredentials: hasTwilioCredentials(),
-          error: 'Failed to store provisioned phone number in secure storage',
+          phoneNumber: purchased.phoneNumber,
+          error: `Phone number ${purchased.phoneNumber} was purchased but could not be saved. Use assign_number to assign it manually.`,
         });
         return;
       }


### PR DESCRIPTION
Address review feedback on PR #6789:

When provision_number fails to persist to secure store, include the purchased phone number in the error response so the user can recover via assign_number instead of losing track of the purchased number.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
