### PR TITLE
fix: restore handler on clear failure and dismiss sheet on provision error

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -315,6 +315,7 @@ struct TwilioSettingsSection: View {
         } catch {
             isClearing = false
             errorMessage = "Failed to send clear request"
+            restoreDefaultHandler()
         }
     }
 
@@ -383,6 +384,7 @@ struct TwilioSettingsSection: View {
             )
         } catch {
             isProvisioning = false
+            showProvisionSheet = false
             errorMessage = "Failed to connect to daemon"
         }
     }


### PR DESCRIPTION
Address review feedback on PR #6790:

1. Add restoreDefaultHandler() to clearCredentials catch block to prevent stale handler after send failure.
2. Add showProvisionSheet = false to provisionNumber catch block so error is visible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
