### PR TITLE
Address feedback on #6786: strengthen assistant-scoped test

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -905,6 +905,7 @@ describe('Telegram config handler', () => {
 
 import { handleGuardianVerification } from '../daemon/handlers/config.js';
 import type { GuardianVerificationRequest } from '../daemon/ipc-contract.js';
+import { createBinding } from '../memory/channel-guardian-store.js';
 
 describe('Guardian verification IPC actions', () => {
   beforeEach(() => {
@@ -985,21 +986,48 @@ describe('Guardian verification IPC actions', () => {
   });
 
   test('status action with explicit assistantId checks binding for that assistant', () => {
-    // No binding exists for asst-ipc-Y, so status should return bound=false
-    const msg: GuardianVerificationRequest = {
+    // Create a control binding for a known assistant so we can verify
+    // that querying a *different* assistantId actually returns bound=false
+    // (not just because no bindings exist at all).
+    createBinding({
+      assistantId: 'asst-ipc-bound',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-1',
+      guardianDeliveryChatId: 'guardian-chat-1',
+    });
+
+    // Querying a different assistant should return bound=false
+    const unboundMsg: GuardianVerificationRequest = {
       type: 'guardian_verification',
       action: 'status',
       channel: 'telegram',
       assistantId: 'asst-ipc-Y',
     };
 
-    const { ctx, sent } = createTestContext();
-    handleGuardianVerification(msg, {} as net.Socket, ctx);
+    const { ctx: ctx1, sent: sent1 } = createTestContext();
+    handleGuardianVerification(unboundMsg, {} as net.Socket, ctx1);
 
-    expect(sent).toHaveLength(1);
-    const res = sent[0] as { type: string; success: boolean; bound: boolean };
-    expect(res.success).toBe(true);
-    expect(res.bound).toBe(false);
+    expect(sent1).toHaveLength(1);
+    const unboundRes = sent1[0] as { type: string; success: boolean; bound: boolean };
+    expect(unboundRes.success).toBe(true);
+    expect(unboundRes.bound).toBe(false);
+
+    // Querying the bound assistant should return bound=true
+    const boundMsg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'telegram',
+      assistantId: 'asst-ipc-bound',
+    };
+
+    const { ctx: ctx2, sent: sent2 } = createTestContext();
+    handleGuardianVerification(boundMsg, {} as net.Socket, ctx2);
+
+    expect(sent2).toHaveLength(1);
+    const boundRes = sent2[0] as { type: string; success: boolean; bound: boolean; guardianExternalUserId?: string };
+    expect(boundRes.success).toBe(true);
+    expect(boundRes.bound).toBe(true);
+    expect(boundRes.guardianExternalUserId).toBe('guardian-user-1');
   });
 
   test('assistantId defaults to "self" when not provided', () => {


### PR DESCRIPTION
Fixes review feedback from PR #6786. Adds a control binding to the assistant-scoped IPC test so it properly validates that assistant scoping works by asserting bound=true for the bound assistant and bound=false for a different assistantId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
