### PR TITLE
fix: add restoreDefaultHandler to all Twilio action catch blocks

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -348,6 +348,7 @@ struct TwilioSettingsSection: View {
         } catch {
             isLoadingNumbers = false
             errorMessage = "Failed to connect to daemon"
+            restoreDefaultHandler()
         }
     }
 
@@ -386,6 +387,7 @@ struct TwilioSettingsSection: View {
             isProvisioning = false
             showProvisionSheet = false
             errorMessage = "Failed to connect to daemon"
+            restoreDefaultHandler()
         }
     }
 
@@ -414,6 +416,7 @@ struct TwilioSettingsSection: View {
             isAssigning = false
             assigningNumber = nil
             errorMessage = "Failed to connect to daemon"
+            restoreDefaultHandler()
         }
     }
 }


### PR DESCRIPTION
Address review feedback on PR #6793:

Add restoreDefaultHandler() to the catch blocks of listNumbers(), provisionNumber(), and assignNumber() to prevent stale callback handlers after synchronous send failures. Matches the pattern already applied in clearCredentials().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
