### PR TITLE
fix: scope history loading timeout to specific fetch invocation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -17,6 +17,7 @@ struct AppVersionHistoryPanel: View {
     @State private var isRestoring = false
     @State private var restoreError: String?
     @State private var pendingDiffCommitHash: String?
+    @State private var fetchHistoryId: UUID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -254,6 +255,8 @@ struct AppVersionHistoryPanel: View {
     // MARK: - Data Fetching
 
     private func fetchHistory() {
+        let currentId = UUID()
+        fetchHistoryId = currentId
         isLoading = true
         daemonClient.onAppHistoryResponse = { response in
             if response.appId == appId {
@@ -269,6 +272,7 @@ struct AppVersionHistoryPanel: View {
         // Timeout: daemon sends a generic error on failure, not app_history_response,
         // so the spinner would get stuck without this fallback.
         DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            guard fetchHistoryId == currentId else { return }
             if isLoading {
                 isLoading = false
             }


### PR DESCRIPTION
## Summary
- Add `fetchHistoryId` UUID to scope the 10s loading timeout to each `fetchHistory()` invocation
- Prevents a stale timeout from a previous call (e.g., initial load) from prematurely clearing `isLoading` during a subsequent call (e.g., after restore)

## Original prompt
Addresses review feedback from #6798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
