### PR TITLE
fix: make all app viewer cards clickable after session restart

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -603,6 +603,13 @@ export async function surfaceProxyResolver(
       surfaceId,
       data: mergedData,
     });
+
+    // Keep the persisted snapshot in sync so updates survive session restart.
+    const idx = ctx.currentTurnSurfaces.findIndex(s => s.surfaceId === surfaceId);
+    if (idx !== -1) {
+      ctx.currentTurnSurfaces[idx].data = mergedData;
+    }
+
     return { content: 'Surface updated', isError: false };
   }
 
@@ -662,7 +669,10 @@ export async function surfaceProxyResolver(
     const seededHomeBase = findSeededHomeBaseApp();
     const defaultPreview = seededHomeBase && seededHomeBase.id === app.id
       ? getPrebuiltHomeBasePreview()
-      : undefined;
+      // Generate a minimal fallback preview from app metadata so that the
+      // surface is always rendered as a clickable preview card (not an
+      // un-clickable fallback chip) after session restart.
+      : { title: app.name, subtitle: app.description };
 
     const surfaceData: DynamicPageSurfaceData = {
       html: app.htmlDefinition,

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -129,7 +129,19 @@ public struct InlineSurfaceRouter: View {
                     }
                 }
             } else {
-                InlineFallbackChip(surfaceType: surface.surfaceType)
+                // Still allow opening the workspace even without a preview card.
+                Button {
+                    if let msg = surface.surfaceMessage {
+                        NotificationCenter.default.post(
+                            name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                            object: nil,
+                            userInfo: ["surfaceMessage": msg]
+                        )
+                    }
+                } label: {
+                    InlineFallbackChip(surfaceType: surface.surfaceType)
+                }
+                .buttonStyle(.plain)
             }
         case .table(let data):
             InlineTableWidget(data: data) { actionId, payload in


### PR DESCRIPTION
## Summary
- Generate a fallback preview from app name/description when `app_open` is called without an explicit preview, so every app surface gets a clickable preview card after restart
- Sync `currentTurnSurfaces` when `ui_update` modifies a surface, so preview data added via updates survives DB persistence
- Wrap `InlineFallbackChip` in a clickable `Button` as a safety net so dynamic_page surfaces are always openable

## Test plan
- [ ] Open an app viewer, restart the session, verify the card is still clickable
- [ ] Open multiple app viewers in the same session, restart, verify all are clickable
- [ ] Verify app viewers created with explicit previews still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
