### PR TITLE
feat: add send_result_to_user flag to subagent spawn

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -18,6 +18,10 @@ Subagents follow this status flow: `pending` -> `running` -> `completed` / `fail
 
 Only the parent session that spawned a subagent can interact with it (check status, send messages, abort, or read output).
 
+## Silent Mode
+
+Set `send_result_to_user: false` when spawning a subagent whose result is for internal processing only. The parent will still be notified on completion, but the notification will instruct it to read the result without presenting it to the user.
+
 ## Tips
 
 - Do NOT poll `subagent_status` in a loop. You will be notified automatically when a subagent completes.

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -20,6 +20,10 @@
           "context": {
             "type": "string",
             "description": "Optional additional context to pass to the subagent"
+          },
+          "send_result_to_user": {
+            "type": "boolean",
+            "description": "Whether to present the subagent's result to the user when it completes. Defaults to true. Set to false for internal/silent processing."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -482,10 +482,13 @@ export class SubagentManager {
     let message: string;
 
     if (outcome === 'completed') {
+      const silent = config.sendResultToUser === false;
       message =
         `[Subagent "${config.label}" completed]\n\n` +
         `Use subagent_read with subagent_id "${config.id}" to retrieve the full output.\n` +
-        `Do NOT re-spawn this subagent — just read and share the results.`;
+        (silent
+          ? `This subagent was spawned for internal processing. Read the result for your own use but do NOT share it with the user.`
+          : `Do NOT re-spawn this subagent — just read and share the results.`);
     } else {
       const error = managed.state.error ?? 'Unknown error';
       message =

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -42,6 +42,8 @@ export interface SubagentConfig {
   systemPromptOverride?: string;
   /** Optional skill IDs to pre-activate on the subagent session. */
   preactivatedSkillIds?: string[];
+  /** Whether the parent should present the result to the user. Defaults to true. */
+  sendResultToUser?: boolean;
 }
 
 // ── State (runtime) ─────────────────────────────────────────────────────

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -8,6 +8,7 @@ export async function executeSubagentSpawn(
   const label = input.label as string;
   const objective = input.objective as string;
   const extraContext = input.context as string | undefined;
+  const sendResultToUser = input.send_result_to_user !== false;
 
   if (!label || !objective) {
     return { content: 'Both "label" and "objective" are required.', isError: true };
@@ -26,6 +27,7 @@ export async function executeSubagentSpawn(
         label,
         objective,
         context: extraContext,
+        sendResultToUser,
       },
       sendToClient as (msg: unknown) => void,
     );


### PR DESCRIPTION
## Summary
- Add `send_result_to_user` boolean flag to `subagent_spawn` tool, defaulting to `true`
- When set to `false`, the parent notification instructs the LLM to read results internally without presenting them to the user
- Updated tool schema, config interface, spawn executor, manager notification, and skill docs

## Original prompt
Add `send_result_to_user` flag to subagent spawn for silent/internal processing mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
