### PR TITLE
fix: sync currentTurnSurfaces in refreshSurfacesForApp after app updates

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -429,6 +429,12 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string,
     };
     stored.data = updatedData;
 
+    // Keep the persisted snapshot in sync so updates survive session restart.
+    const idx = ctx.currentTurnSurfaces.findIndex(s => s.surfaceId === surfaceId);
+    if (idx !== -1) {
+      ctx.currentTurnSurfaces[idx].data = updatedData;
+    }
+
     // Push the update to the client
     ctx.sendToClient({
       type: 'ui_surface_update',


### PR DESCRIPTION
## Summary
- Add `currentTurnSurfaces` sync to `refreshSurfacesForApp` matching the pattern already applied to `ui_update`
- Without this, surfaces updated via `app_update`/`app_file_edit` during the same turn they were opened show stale content after session restart

## Original prompt
Addresses review feedback from #6801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
