### PR TITLE
fix: preserve anti-respawn guard in silent subagent completion

### DIFF
--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -487,7 +487,7 @@ export class SubagentManager {
         `[Subagent "${config.label}" completed]\n\n` +
         `Use subagent_read with subagent_id "${config.id}" to retrieve the full output.\n` +
         (silent
-          ? `This subagent was spawned for internal processing. Read the result for your own use but do NOT share it with the user.`
+          ? `This subagent was spawned for internal processing. Read the result for your own use but do NOT share it with the user.\nDo NOT re-spawn this subagent.`
           : `Do NOT re-spawn this subagent — just read and share the results.`);
     } else {
       const error = managed.state.error ?? 'Unknown error';


### PR DESCRIPTION
## Summary
- Add missing "Do NOT re-spawn" directive to the silent branch of subagent completion notification
- Addresses review feedback from #6802: the silent mode message previously dropped the anti-respawn guard, risking duplicate subagent spawns

## Original prompt
Fix: preserve anti-respawn guard in silent subagent completion message (addresses feedback from #6802)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
