### PR TITLE
feat: add reveal/hide toggle for session token

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -13,6 +13,7 @@ struct SettingsAdvancedTab: View {
 
     @State private var sessionToken: String = ""
     @State private var tokenCopied: Bool = false
+    @State private var tokenRevealed: Bool = false
     @State private var fingerprint: String = ""
     @State private var iosPairingEnabled: Bool = false
     @State private var showingPairingQR: Bool = false
@@ -333,9 +334,17 @@ struct SettingsAdvancedTab: View {
                             Text("Token:")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
-                            Text(String(sessionToken.prefix(16)) + "...")
+                            Text(tokenRevealed ? sessionToken : String(sessionToken.prefix(16)) + "...")
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.textSecondary)
+                                .textSelection(.enabled)
+                            Button(action: { tokenRevealed.toggle() }) {
+                                Image(systemName: tokenRevealed ? "eye.slash" : "eye")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(tokenRevealed ? "Hide token" : "Reveal token")
                         }
                     } else {
                         Text("Session token not found. Restart the daemon to generate one.")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -340,7 +340,7 @@ struct SettingsAdvancedTab: View {
                                 .textSelection(.enabled)
                             Button(action: { tokenRevealed.toggle() }) {
                                 Image(systemName: tokenRevealed ? "eye.slash" : "eye")
-                                    .font(.system(size: 11))
+                                    .font(VFont.caption)
                                     .foregroundColor(VColor.textMuted)
                             }
                             .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
Adds an eye icon toggle next to the session token in iOS pairing settings so users can reveal the full token to verify it matches what the iOS app received.

## Implementation
- Token displays first 16 characters by default (existing behavior)
- Clicking the eye icon reveals the full 64-character hex token
- Clicking again hides it back to truncated view
- Text selection is enabled when revealed for easy copy/paste

## Testing
- Toggle reveals full token, toggle again hides it
- Verify the revealed token matches what the iOS app shows after QR scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
