### PR TITLE
fix: improve Load More resilience against transient errors and disconnects

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -323,7 +323,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             threads.append(thread)
         }
 
-        hasMoreThreads = response.hasMore ?? false
+        if let hasMore = response.hasMore {
+            hasMoreThreads = hasMore
+        }
         isLoadingMoreThreads = false
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -11,7 +11,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 protocol ThreadRestorerDelegate: AnyObject {
     var threads: [ThreadModel] { get set }
     var restoreRecentThreads: Bool { get }
-    var isLoadingMoreThreads: Bool { get }
+    var isLoadingMoreThreads: Bool { get set }
     var hasMoreThreads: Bool { get set }
     var serverOffset: Int { get set }
     func chatViewModel(for threadId: UUID) -> ChatViewModel?
@@ -36,6 +36,7 @@ final class ThreadSessionRestorer {
 
     private let daemonClient: DaemonClient
     private var connectionCancellable: AnyCancellable?
+    private var disconnectCancellable: AnyCancellable?
 
     weak var delegate: ThreadRestorerDelegate?
 
@@ -58,6 +59,15 @@ final class ThreadSessionRestorer {
         // so the session restorer doesn't override the wake-up conversation thread.
         // The handlers above are still registered for later use (e.g. history loading).
         guard !skipInitialFetch else { return }
+
+        // Reset loading state when the daemon disconnects so the Load More
+        // button doesn't stay permanently disabled after a dropped connection.
+        disconnectCancellable = daemonClient.$isConnected
+            .removeDuplicates()
+            .filter { !$0 }
+            .sink { [weak self] _ in
+                self?.delegate?.isLoadingMoreThreads = false
+            }
 
         connectionCancellable = daemonClient.$isConnected
             .removeDuplicates()
@@ -158,7 +168,9 @@ final class ThreadSessionRestorer {
             delegate.createThread()
         }
 
-        delegate.hasMoreThreads = response.hasMore ?? false
+        if let hasMore = response.hasMore {
+            delegate.hasMoreThreads = hasMore
+        }
         delegate.serverOffset = response.sessions.count
         log.info("Restored \(restoredThreads.count) threads from daemon (hasMore: \(response.hasMore ?? false))")
         delegate.restoreLastActiveThread()

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -403,7 +403,7 @@ final class HTTPTransport {
 
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 log.error("Fetch session list failed")
-                onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: false)))
+                onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: nil)))
                 return
             }
 
@@ -415,11 +415,11 @@ final class HTTPTransport {
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {
                 log.error("Failed to decode session list response: \(error)")
-                onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: false)))
+                onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: nil)))
             }
         } catch {
             log.error("Fetch session list error: \(error.localizedDescription)")
-            onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: false)))
+            onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: nil)))
         }
     }
 


### PR DESCRIPTION
## Summary
- Don't set `hasMore` to `false` on HTTP error paths — use `nil` so transient failures don't permanently hide the Load More button
- Only update `hasMoreThreads` when the server explicitly provides a `hasMore` value (non-nil)
- Reset `isLoadingMoreThreads` on daemon disconnect so the button doesn't stay permanently disabled after a dropped connection
- Make `isLoadingMoreThreads` settable via the `ThreadRestorerDelegate` protocol so the restorer can reset it

## Original prompt
Addresses feedback from PR #6800

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
