### PR TITLE
fix: test isolation fix for gateway-only-enforcement and ingress-url-consistency

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -113,14 +113,11 @@ mock.module('../security/secure-keys.js', () => ({
   deleteSecureKey: () => {},
 }));
 
-mock.module('../inbound/public-ingress-urls.js', () => ({
-  getPublicBaseUrl: () => 'https://test.example.com',
-  getTwilioRelayUrl: () => 'wss://test.example.com/webhooks/twilio/relay',
-  getTwilioVoiceWebhookUrl: (_cfg: unknown, id: string) => `https://test.example.com/webhooks/twilio/voice?callSessionId=${id}`,
-  getTwilioStatusCallbackUrl: () => 'https://test.example.com/webhooks/twilio/status',
-  getTwilioConnectActionUrl: () => 'https://test.example.com/webhooks/twilio/connect-action',
-  getOAuthCallbackUrl: () => 'https://test.example.com/webhooks/oauth/callback',
-}));
+// NOTE: Do NOT mock '../inbound/public-ingress-urls.js' here.
+// Those are pure functions that derive URLs from the config object returned by
+// loadConfig() (which is already mocked above). Mocking them at the module level
+// leaks into other test files (e.g. ingress-url-consistency.test.ts) that need
+// the real implementations, causing cross-test contamination.
 
 // Mock the oauth callback registry
 mock.module('../security/oauth-callback-registry.js', () => ({


### PR DESCRIPTION
## Summary\n\n- Fix module-level mock leakage in gateway-only-enforcement.test.ts that broke ingress-url-consistency.test.ts in combined runs\n- Verified combined test runs pass reliably\n\nCloses #6812
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
