### PR TITLE
feat: Twilio webhook reconcile on ingress URL changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -435,7 +435,14 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 2. The gateway authenticates the request via bearer token (same fail-closed model as `/deliver/telegram`).
 3. The gateway sends the SMS via the Twilio Messages API using the configured `TWILIO_PHONE_NUMBER` as the `From` number.
 
-**Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant. Both `provision_number` and `assign_number` auto-persist the number to config and secure storage, and auto-configure Twilio webhooks (voice URL, status callback, SMS URL) via the Twilio IncomingPhoneNumber API when a public ingress URL is available. Webhook configuration is best-effort — if ingress is not yet set up, the number is still assigned and webhooks can be configured later.
+**Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant. Both `provision_number` and `assign_number` auto-persist the number to config and secure storage, and auto-configure Twilio webhooks (voice URL, status callback, SMS URL) via the Twilio IncomingPhoneNumber API when a public ingress URL is available. Webhook configuration is best-effort — if ingress is not yet set up, the number is still assigned and webhooks can be configured later. Non-fatal webhook failures are surfaced as a `warning` field in the `twilio_config_response`.
+
+**Webhook Lifecycle**: Twilio webhook URLs are managed through a shared `syncTwilioWebhooks` helper in `config.ts` that computes voice, status-callback, and SMS URLs from the ingress config and pushes them to Twilio. Webhooks are synchronized at three points:
+1. **Number provisioning** (`provision_number`) — immediately after purchasing a number.
+2. **Number assignment** (`assign_number`) — when an existing number is assigned to the assistant.
+3. **Ingress URL change** (`ingress_config` set) — when the public ingress URL is updated or enabled, the daemon automatically re-synchronizes Twilio webhooks (fire-and-forget) if credentials and an assigned number are present. This ensures tunnel URL changes (e.g., ngrok restart) propagate without manual re-assignment.
+
+All three paths are best-effort: webhook sync failures do not prevent the primary operation from succeeding.
 
 **Limitations (v1)**: Text-only — MMS payloads are explicitly rejected with a user-facing notice rather than silently dropped.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -217,7 +217,17 @@ The daemon handles `twilio_config` messages with the following actions:
 | `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant and auto-configures webhooks when ingress is available |
 | `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
 
-Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, and optional `error`.
+Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, optional `error`, and optional `warning` (for non-fatal webhook sync failures).
+
+### Ingress Webhook Reconciliation
+
+When the public ingress URL is changed via the Settings UI (`ingress_config` set action), the daemon automatically reconciles Twilio webhooks in addition to triggering a Telegram webhook reconcile on the gateway. If all of the following conditions are met, the daemon pushes updated webhook URLs (voice, status callback, SMS) to Twilio:
+
+1. Ingress is being **enabled** (not disabled)
+2. Twilio **credentials** are configured (Account SID + Auth Token in secure storage)
+3. A phone number is **assigned** (persisted in `sms.phoneNumber` config)
+
+This reconciliation is **best-effort and fire-and-forget** -- failures are logged but do not block the ingress config save or produce an error response. This ensures that changing a tunnel URL (e.g., restarting ngrok) automatically updates Twilio's webhook routing without requiring manual re-assignment of the phone number.
 
 ### Single-Number-Per-Assistant Model
 

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -113,10 +113,11 @@ mock.module('../tools/credentials/metadata-store.js', () => ({
 // Mock fetch for Twilio API validation
 const originalFetch = globalThis.fetch;
 
-import { handleTwilioConfig } from '../daemon/handlers/config.js';
+import { handleTwilioConfig, handleIngressConfig } from '../daemon/handlers/config.js';
 import type { HandlerContext } from '../daemon/handlers.js';
 import type {
   TwilioConfigRequest,
+  IngressConfigRequest,
   ServerMessage,
 } from '../daemon/ipc-contract.js';
 import { DebouncerMap } from '../util/debounce.js';
@@ -796,6 +797,245 @@ describe('Twilio config handler', () => {
     expect(res.success).toBe(false);
     expect(res.error).toContain('Unknown action');
     expect(res.error).toContain('nonexistent_action');
+  });
+
+  // ── Ingress webhook reconciliation ──────────────────────────────────
+
+  test('ingress config update triggers Twilio webhook sync when assigned number and credentials exist', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
+
+    const fetchCalls: Array<{ url: string; method: string; body?: string }> = [];
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, method: init?.method ?? 'GET', body: init?.body?.toString() });
+
+      // Webhook number lookup
+      if (urlStr.includes('IncomingPhoneNumbers.json') && urlStr.includes('PhoneNumber=')) {
+        return new Response(JSON.stringify({
+          incoming_phone_numbers: [{ sid: 'PN123abc', phone_number: '+15551234567' }],
+        }), { status: 200 });
+      }
+      // Webhook update
+      if (urlStr.includes('IncomingPhoneNumbers/PN123abc.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ sid: 'PN123abc' }), { status: 200 });
+      }
+      // Gateway reconcile (ignore)
+      if (urlStr.includes('/internal/telegram/reconcile')) {
+        return new Response('{}', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: IngressConfigRequest = {
+      type: 'ingress_config',
+      action: 'set',
+      publicBaseUrl: 'https://new-tunnel.ngrok.io',
+      enabled: true,
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleIngressConfig(msg, {} as net.Socket, ctx);
+
+    // Ingress save should succeed
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; enabled: boolean; publicBaseUrl: string };
+    expect(res.type).toBe('ingress_config_response');
+    expect(res.success).toBe(true);
+    expect(res.enabled).toBe(true);
+    expect(res.publicBaseUrl).toBe('https://new-tunnel.ngrok.io');
+
+    // Wait a tick for the fire-and-forget webhook sync to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify webhook update was attempted with the new ingress URL
+    const webhookUpdate = fetchCalls.find((c) =>
+      c.url.includes('IncomingPhoneNumbers/PN123abc.json') && c.method === 'POST',
+    );
+    expect(webhookUpdate).toBeDefined();
+    const body = webhookUpdate!.body!;
+    expect(body).toContain('VoiceUrl=');
+    expect(body).toContain('new-tunnel.ngrok.io');
+  });
+
+  test('webhook sync failure on ingress update does not fail the ingress update', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      // Gateway reconcile (ignore)
+      if (urlStr.includes('/internal/telegram/reconcile')) {
+        return new Response('{}', { status: 200 });
+      }
+      // Webhook number lookup — simulate failure
+      if (urlStr.includes('IncomingPhoneNumbers.json') && urlStr.includes('PhoneNumber=')) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: IngressConfigRequest = {
+      type: 'ingress_config',
+      action: 'set',
+      publicBaseUrl: 'https://example.ngrok.io',
+      enabled: true,
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleIngressConfig(msg, {} as net.Socket, ctx);
+
+    // The ingress update must still succeed despite the webhook sync failure
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; enabled: boolean };
+    expect(res.type).toBe('ingress_config_response');
+    expect(res.success).toBe(true);
+    expect(res.enabled).toBe(true);
+
+    // Wait a tick for the fire-and-forget promise
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('ingress config update skips webhook sync when no Twilio credentials', async () => {
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
+
+    const fetchCalls: Array<{ url: string }> = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr });
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: IngressConfigRequest = {
+      type: 'ingress_config',
+      action: 'set',
+      publicBaseUrl: 'https://example.ngrok.io',
+      enabled: true,
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleIngressConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean };
+    expect(res.success).toBe(true);
+
+    // No Twilio API calls should have been made (only gateway reconcile)
+    const twilioApiCalls = fetchCalls.filter((c) => c.url.includes('api.twilio.com'));
+    expect(twilioApiCalls).toHaveLength(0);
+  });
+
+  test('ingress config update skips webhook sync when no assigned number', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    // No sms.phoneNumber in config
+
+    const fetchCalls: Array<{ url: string }> = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr });
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: IngressConfigRequest = {
+      type: 'ingress_config',
+      action: 'set',
+      publicBaseUrl: 'https://example.ngrok.io',
+      enabled: true,
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleIngressConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean };
+    expect(res.success).toBe(true);
+
+    // No Twilio API calls should have been made
+    const twilioApiCalls = fetchCalls.filter((c) => c.url.includes('api.twilio.com'));
+    expect(twilioApiCalls).toHaveLength(0);
+  });
+
+  // ── Warning field ─────────────────────────────────────────────────
+
+  test('provision_number surfaces webhook warning when ingress is missing', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    // No ingress config — webhook configuration will produce a warning
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('AvailablePhoneNumbers') && urlStr.includes('Local.json')) {
+        return new Response(JSON.stringify({
+          available_phone_numbers: [{
+            phone_number: '+15559999999',
+            friendly_name: '(555) 999-9999',
+            capabilities: { voice: true, sms: true },
+          }],
+        }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          phone_number: '+15559999999',
+          friendly_name: '(555) 999-9999',
+          capabilities: { voice: true, sms: true },
+        }), { status: 201 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'provision_number',
+      country: 'US',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; phoneNumber?: string; warning?: string };
+    expect(res.success).toBe(true);
+    expect(res.phoneNumber).toBe('+15559999999');
+    // Warning should be present because no ingress URL is configured
+    expect(res.warning).toBeDefined();
+    expect(res.warning).toContain('Webhook configuration skipped');
+  });
+
+  test('assign_number surfaces webhook warning when Twilio API fails', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = { ingress: { enabled: true, publicBaseUrl: 'https://example.ngrok.io' } };
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      // Webhook number lookup — simulate Twilio API error
+      if (urlStr.includes('IncomingPhoneNumbers.json')) {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'assign_number',
+      phoneNumber: '+15551234567',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; phoneNumber?: string; warning?: string };
+    // Assignment itself succeeds
+    expect(res.success).toBe(true);
+    expect(res.phoneNumber).toBe('+15551234567');
+    // Warning should surface the webhook failure
+    expect(res.warning).toBeDefined();
+    expect(res.warning).toContain('Webhook configuration skipped');
   });
 
   // ── Security ────────────────────────────────────────────────────────

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -517,11 +517,46 @@ function triggerGatewayReconcile(ingressPublicBaseUrl: string | undefined): void
   });
 }
 
-export function handleIngressConfig(
+/**
+ * Best-effort Twilio webhook sync helper.
+ *
+ * Computes the voice, status-callback, and SMS webhook URLs from the current
+ * ingress config and pushes them to the Twilio IncomingPhoneNumber API.
+ *
+ * Returns `{ success, warning }`. When the update fails, `success` is false
+ * and `warning` contains a human-readable message. Callers should treat
+ * failure as non-fatal so that the primary operation (provision, assign,
+ * ingress save) still succeeds.
+ */
+async function syncTwilioWebhooks(
+  phoneNumber: string,
+  accountSid: string,
+  authToken: string,
+  ingressConfig: IngressConfig,
+): Promise<{ success: boolean; warning?: string }> {
+  try {
+    const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig);
+    const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
+    const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
+    await updatePhoneNumberWebhooks(accountSid, authToken, phoneNumber, {
+      voiceUrl,
+      statusCallbackUrl,
+      smsUrl,
+    });
+    log.info({ phoneNumber }, 'Twilio webhooks configured successfully');
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn({ err, phoneNumber }, `Webhook configuration skipped: ${message}`);
+    return { success: false, warning: `Webhook configuration skipped: ${message}` };
+  }
+}
+
+export async function handleIngressConfig(
   msg: IngressConfigRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   const localGatewayTarget = computeGatewayTarget();
   try {
     if (msg.action === 'get') {
@@ -592,6 +627,24 @@ export function handleIngressConfig(
       // fallback branch above) rather than the raw `value` from the UI.
       const effectiveUrl = isEnabled ? process.env.INGRESS_PUBLIC_BASE_URL : undefined;
       triggerGatewayReconcile(effectiveUrl);
+
+      // Best-effort Twilio webhook reconciliation: when ingress is being
+      // enabled/updated and a Twilio number is assigned with valid credentials,
+      // push the new webhook URLs to Twilio so calls and SMS route correctly.
+      if (isEnabled && hasTwilioCredentials()) {
+        const currentConfig = loadRawConfig();
+        const smsConfig = (currentConfig?.sms ?? {}) as Record<string, unknown>;
+        const assignedNumber = (smsConfig.phoneNumber as string) ?? '';
+        if (assignedNumber) {
+          const acctSid = getSecureKey('credential:twilio:account_sid')!;
+          const acctToken = getSecureKey('credential:twilio:auth_token')!;
+          // Fire-and-forget: webhook sync failure must not block the ingress save
+          syncTwilioWebhooks(assignedNumber, acctSid, acctToken, currentConfig as IngressConfig)
+            .catch(() => {
+              // Already logged inside syncTwilioWebhooks
+            });
+        }
+      }
     } else {
       ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
     }
@@ -1271,27 +1324,19 @@ export async function handleTwilioConfig(
 
       // Best-effort webhook configuration — non-fatal so the number is
       // still usable even if ingress isn't configured yet.
-      try {
-        const ingressConfig: IngressConfig = loadRawConfig();
-        const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig);
-        const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
-        const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
-        await updatePhoneNumberWebhooks(accountSid, authToken, purchased.phoneNumber, {
-          voiceUrl,
-          statusCallbackUrl,
-          smsUrl,
-        });
-        log.info({ phoneNumber: purchased.phoneNumber }, 'Twilio webhooks configured for provisioned number');
-      } catch (webhookErr) {
-        const webhookMsg = webhookErr instanceof Error ? webhookErr.message : String(webhookErr);
-        log.warn({ err: webhookErr, phoneNumber: purchased.phoneNumber }, `Webhook configuration skipped: ${webhookMsg}`);
-      }
+      const webhookResult = await syncTwilioWebhooks(
+        purchased.phoneNumber,
+        accountSid,
+        authToken,
+        loadRawConfig() as IngressConfig,
+      );
 
       ctx.send(socket, {
         type: 'twilio_config_response',
         success: true,
         hasCredentials: true,
         phoneNumber: purchased.phoneNumber,
+        warning: webhookResult.warning,
       });
     } else if (msg.action === 'assign_number') {
       if (!msg.phoneNumber) {
@@ -1333,24 +1378,17 @@ export async function handleTwilioConfig(
       ctx.debounceTimers.schedule('__suppress_reset__', () => { ctx.setSuppressConfigReload(false); }, CONFIG_RELOAD_DEBOUNCE_MS);
 
       // Best-effort webhook configuration when credentials are available
+      let webhookWarning: string | undefined;
       if (hasTwilioCredentials()) {
-        try {
-          const acctSid = getSecureKey('credential:twilio:account_sid')!;
-          const acctToken = getSecureKey('credential:twilio:auth_token')!;
-          const ingressConfig: IngressConfig = loadRawConfig();
-          const voiceUrl = getTwilioVoiceWebhookUrl(ingressConfig);
-          const statusCallbackUrl = getTwilioStatusCallbackUrl(ingressConfig);
-          const smsUrl = getTwilioSmsWebhookUrl(ingressConfig);
-          await updatePhoneNumberWebhooks(acctSid, acctToken, msg.phoneNumber, {
-            voiceUrl,
-            statusCallbackUrl,
-            smsUrl,
-          });
-          log.info({ phoneNumber: msg.phoneNumber }, 'Twilio webhooks configured for assigned number');
-        } catch (webhookErr) {
-          const webhookMsg = webhookErr instanceof Error ? webhookErr.message : String(webhookErr);
-          log.warn({ err: webhookErr, phoneNumber: msg.phoneNumber }, `Webhook configuration skipped: ${webhookMsg}`);
-        }
+        const acctSid = getSecureKey('credential:twilio:account_sid')!;
+        const acctToken = getSecureKey('credential:twilio:auth_token')!;
+        const webhookResult = await syncTwilioWebhooks(
+          msg.phoneNumber,
+          acctSid,
+          acctToken,
+          loadRawConfig() as IngressConfig,
+        );
+        webhookWarning = webhookResult.warning;
       }
 
       ctx.send(socket, {
@@ -1358,6 +1396,7 @@ export async function handleTwilioConfig(
         success: true,
         hasCredentials: hasTwilioCredentials(),
         phoneNumber: msg.phoneNumber,
+        warning: webhookWarning,
       });
     } else if (msg.action === 'list_numbers') {
       if (!hasTwilioCredentials()) {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -566,6 +566,8 @@ export interface TwilioConfigResponse {
   phoneNumber?: string;
   numbers?: Array<{ phoneNumber: string; friendlyName: string; capabilities: { voice: boolean; sms: boolean } }>;
   error?: string;
+  /** Non-fatal warning message (e.g. webhook sync failure that did not prevent the primary operation). */
+  warning?: string;
 }
 
 export interface GuardianVerificationRequest {


### PR DESCRIPTION
## Summary

- Extract shared webhook-update helper for Twilio number configuration
- Refactor provision_number and assign_number to use shared helper
- Add webhook reconciliation when ingress config is updated (best-effort, non-fatal)
- Add warning field to TwilioConfigResponse for non-fatal webhook failures
- Add tests for webhook sync on ingress update
- Update assistant README and ARCHITECTURE docs

Closes #6809
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
