### PR TITLE
fix: remove number source-of-truth drift (config-first + backward-compatible fallback)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -437,6 +437,10 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 
 **Setup**: Twilio credentials (Account SID, Auth Token) and phone number are managed via the `twilio_config` IPC contract and the `twilio-setup` skill. A single phone number is shared across voice and SMS for each assistant. Both `provision_number` and `assign_number` auto-persist the number to config and secure storage, and auto-configure Twilio webhooks (voice URL, status callback, SMS URL) via the Twilio IncomingPhoneNumber API when a public ingress URL is available. Webhook configuration is best-effort — if ingress is not yet set up, the number is still assigned and webhooks can be configured later. Non-fatal webhook failures are surfaced as a `warning` field in the `twilio_config_response`.
 
+**Phone Number Resolution**: At runtime, `getTwilioConfig()` resolves the phone number using this priority chain: (1) `TWILIO_PHONE_NUMBER` env var — highest priority, explicit override; (2) `sms.phoneNumber` in config — primary source of truth written by `provision_number`/`assign_number`; (3) `credential:twilio:phone_number` secure key — backward-compatible fallback. An error is thrown if no number is found after all sources are checked.
+
+**Credential Clearing Semantics**: `clear_credentials` removes only the authentication credentials (Account SID and Auth Token) from secure storage. The phone number is preserved in both the config file (`sms.phoneNumber`) and the secure key (`credential:twilio:phone_number`) so that re-entering credentials resumes working without needing to reassign the number.
+
 **Webhook Lifecycle**: Twilio webhook URLs are managed through a shared `syncTwilioWebhooks` helper in `config.ts` that computes voice, status-callback, and SMS URLs from the ingress config and pushes them to Twilio. Webhooks are synchronized at three points:
 1. **Number provisioning** (`provision_number`) — immediately after purchasing a number.
 2. **Number assignment** (`assign_number`) — when an existing number is assigned to the assistant.
@@ -4261,5 +4265,6 @@ This section tracks the SMS channel's feature parity with the Telegram channel a
 | **Ingress Boundary** | `MessageSid` deduplication prevents reprocessing retried webhooks | `gateway/src/http/routes/twilio-sms-webhook.test.ts` | `gateway/src/http/routes/twilio-sms-webhook.ts` |
 | **Settings UI** | `list_numbers` IPC action lists all incoming phone numbers with capabilities | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/daemon/handlers/config.ts` |
 | **Settings UI** | `set_credentials` validates and stores Account SID and Auth Token in secure storage | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/daemon/handlers/config.ts` |
-| **Settings UI** | `clear_credentials` removes all Twilio credentials from secure storage | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/daemon/handlers/config.ts` |
+| **Settings UI** | `clear_credentials` removes auth credentials but preserves phone number in config and secure key | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/daemon/handlers/config.ts` |
+| **Settings UI** | `getTwilioConfig()` resolves phone number with priority: env var > config > secure key | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/calls/twilio-config.ts` |
 | **Settings UI** | Single-number-per-assistant model: number stored at `sms.phoneNumber` in config | `assistant/src/__tests__/handlers-twilio-config.test.ts` | `assistant/src/daemon/handlers/config.ts` |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -212,7 +212,7 @@ The daemon handles `twilio_config` messages with the following actions:
 |--------|-------------|
 | `get` | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned) |
 | `set_credentials` | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file). Credentials are retrieved from the credential store internally. |
-| `clear_credentials` | Removes stored Account SID, Auth Token, and phone number from secure storage. |
+| `clear_credentials` | Removes stored Account SID and Auth Token from secure storage. Preserves the phone number in both config (`sms.phoneNumber`) and secure key (`credential:twilio:phone_number`) so that re-entering credentials resumes working without needing to reassign the number. |
 | `provision_number` | Purchases a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Auto-assigns the number to the assistant (persists to config and secure storage) and configures Twilio webhooks (voice, status callback, SMS) when a public ingress URL is available. |
 | `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant and auto-configures webhooks when ingress is available |
 | `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
@@ -232,6 +232,16 @@ This reconciliation is **best-effort and fire-and-forget** -- failures are logge
 ### Single-Number-Per-Assistant Model
 
 Each assistant is assigned a single Twilio phone number that is shared between voice calls and SMS. The number is stored in the assistant's config at `sms.phoneNumber` and used as the `From` for outbound SMS via the gateway's `/deliver/sms` endpoint. The same credentials (Account SID, Auth Token) are used for both voice and SMS operations.
+
+### Phone Number Resolution Order
+
+At runtime, `getTwilioConfig()` resolves the phone number using this priority chain:
+
+1. **`TWILIO_PHONE_NUMBER` env var** — highest priority, explicit override for dev/CI.
+2. **`sms.phoneNumber` in config** — the primary source of truth, written by `provision_number` and `assign_number`.
+3. **`credential:twilio:phone_number` secure key** — backward-compatible fallback for setups that predate the config-first model.
+
+If no number is found after all three sources, an error is thrown.
 
 ### Assistant-Scoped Guardian State
 

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -10,8 +10,8 @@ const testDir = mkdtempSync(join(tmpdir(), 'handlers-twilio-cfg-test-'));
 let rawConfigStore: Record<string, unknown> = {};
 
 mock.module('../config/loader.js', () => ({
-  getConfig: () => ({}),
-  loadConfig: () => ({}),
+  getConfig: () => ({ sms: rawConfigStore.sms ?? {} }),
+  loadConfig: () => ({ sms: rawConfigStore.sms ?? {} }),
   loadRawConfig: () => ({ ...rawConfigStore }),
   saveRawConfig: (cfg: Record<string, unknown>) => {
     rawConfigStore = { ...cfg };
@@ -19,6 +19,28 @@ mock.module('../config/loader.js', () => ({
   saveConfig: () => {},
   invalidateConfigCache: () => {},
 }));
+
+// Provide a thin mock of public-ingress-urls that computes real-looking
+// webhook URLs from the raw config store so that both getTwilioConfig()
+// and the syncTwilioWebhooks() helper used by ingress tests work correctly.
+mock.module('../inbound/public-ingress-urls.js', () => {
+  function getBase(config: Record<string, unknown>): string {
+    const ingress = (config?.ingress ?? {}) as Record<string, unknown>;
+    const url = (ingress.publicBaseUrl as string) ?? '';
+    if (!url) throw new Error('No public ingress URL configured');
+    return url;
+  }
+  return {
+    getPublicBaseUrl: (config: Record<string, unknown>) => getBase(config),
+    getTwilioRelayUrl: (config: Record<string, unknown>) => {
+      const base = getBase(config);
+      return base.replace(/^http(s?)/, 'ws$1') + '/webhooks/twilio/relay';
+    },
+    getTwilioVoiceWebhookUrl: (config: Record<string, unknown>) => getBase(config) + '/webhooks/twilio/voice',
+    getTwilioStatusCallbackUrl: (config: Record<string, unknown>) => getBase(config) + '/webhooks/twilio/status',
+    getTwilioSmsWebhookUrl: (config: Record<string, unknown>) => getBase(config) + '/webhooks/twilio/sms',
+  };
+});
 
 mock.module('../util/platform.js', () => ({
   getRootDir: () => testDir,
@@ -114,6 +136,7 @@ mock.module('../tools/credentials/metadata-store.js', () => ({
 const originalFetch = globalThis.fetch;
 
 import { handleTwilioConfig, handleIngressConfig } from '../daemon/handlers/config.js';
+import { getTwilioConfig } from '../calls/twilio-config.js';
 import type { HandlerContext } from '../daemon/handlers.js';
 import type {
   TwilioConfigRequest,
@@ -383,9 +406,11 @@ describe('Twilio config handler', () => {
 
   // ── clear_credentials ───────────────────────────────────────────────
 
-  test('clear_credentials removes stored credentials', async () => {
+  test('clear_credentials removes stored credentials but preserves phone number', async () => {
     secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
     secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    secureKeyStore['credential:twilio:phone_number'] = '+15551234567';
+    rawConfigStore = { sms: { phoneNumber: '+15551234567' } };
     credentialMetadataStore.push({ service: 'twilio', field: 'account_sid' });
     credentialMetadataStore.push({ service: 'twilio', field: 'auth_token' });
 
@@ -403,11 +428,15 @@ describe('Twilio config handler', () => {
     expect(res.success).toBe(true);
     expect(res.hasCredentials).toBe(false);
 
-    // Verify everything was cleaned up
+    // Verify auth credentials were cleaned up
     expect(secureKeyStore['credential:twilio:account_sid']).toBeUndefined();
     expect(secureKeyStore['credential:twilio:auth_token']).toBeUndefined();
     expect(deletedMetadata).toContainEqual({ service: 'twilio', field: 'account_sid' });
     expect(deletedMetadata).toContainEqual({ service: 'twilio', field: 'auth_token' });
+
+    // Verify phone number is preserved in both stores
+    expect(secureKeyStore['credential:twilio:phone_number']).toBe('+15551234567');
+    expect((rawConfigStore.sms as Record<string, unknown>)?.phoneNumber).toBe('+15551234567');
   });
 
   test('clear_credentials is idempotent when no credentials exist', async () => {
@@ -423,6 +452,75 @@ describe('Twilio config handler', () => {
     const res = sent[0] as { type: string; success: boolean; hasCredentials: boolean };
     expect(res.success).toBe(true);
     expect(res.hasCredentials).toBe(false);
+  });
+
+  // ── Phone number resolution order ──────────────────────────────────
+
+  test('getTwilioConfig resolves phone number from config when secure key also present', () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    secureKeyStore['credential:twilio:phone_number'] = '+15559999999';
+    rawConfigStore = {
+      sms: { phoneNumber: '+15551234567' },
+      ingress: { enabled: true, publicBaseUrl: 'https://test.ngrok.io' },
+    };
+
+    // Clean env var to test config-only resolution
+    const savedEnv = process.env.TWILIO_PHONE_NUMBER;
+    delete process.env.TWILIO_PHONE_NUMBER;
+
+    try {
+      const config = getTwilioConfig();
+      // Config value (+15551234567) should take priority over secure key (+15559999999)
+      expect(config.phoneNumber).toBe('+15551234567');
+    } finally {
+      if (savedEnv !== undefined) process.env.TWILIO_PHONE_NUMBER = savedEnv;
+    }
+  });
+
+  test('getTwilioConfig falls back to secure key when config has no phone number', () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    secureKeyStore['credential:twilio:phone_number'] = '+15559999999';
+    rawConfigStore = {
+      ingress: { enabled: true, publicBaseUrl: 'https://test.ngrok.io' },
+    };
+
+    const savedEnv = process.env.TWILIO_PHONE_NUMBER;
+    delete process.env.TWILIO_PHONE_NUMBER;
+
+    try {
+      const config = getTwilioConfig();
+      // Secure key should be used as fallback
+      expect(config.phoneNumber).toBe('+15559999999');
+    } finally {
+      if (savedEnv !== undefined) process.env.TWILIO_PHONE_NUMBER = savedEnv;
+    }
+  });
+
+  test('getTwilioConfig env var overrides both config and secure key', () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    secureKeyStore['credential:twilio:phone_number'] = '+15559999999';
+    rawConfigStore = {
+      sms: { phoneNumber: '+15551234567' },
+      ingress: { enabled: true, publicBaseUrl: 'https://test.ngrok.io' },
+    };
+
+    const savedEnv = process.env.TWILIO_PHONE_NUMBER;
+    process.env.TWILIO_PHONE_NUMBER = '+15550000000';
+
+    try {
+      const config = getTwilioConfig();
+      // Env var should take highest priority
+      expect(config.phoneNumber).toBe('+15550000000');
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env.TWILIO_PHONE_NUMBER = savedEnv;
+      } else {
+        delete process.env.TWILIO_PHONE_NUMBER;
+      }
+    }
   });
 
   // ── assign_number ───────────────────────────────────────────────────

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -16,8 +16,17 @@ export interface TwilioConfig {
 export function getTwilioConfig(): TwilioConfig {
   const accountSid = getSecureKey('credential:twilio:account_sid');
   const authToken = getSecureKey('credential:twilio:auth_token');
-  const phoneNumber = process.env.TWILIO_PHONE_NUMBER || getSecureKey('credential:twilio:phone_number') || '';
   const config = loadConfig();
+
+  // Phone number resolution priority:
+  // 1. TWILIO_PHONE_NUMBER env var (explicit override)
+  // 2. config file sms.phoneNumber (primary storage)
+  // 3. credential:twilio:phone_number secure key (backward-compat fallback)
+  const phoneNumber =
+    process.env.TWILIO_PHONE_NUMBER ||
+    config.sms?.phoneNumber ||
+    getSecureKey('credential:twilio:phone_number') ||
+    '';
   const webhookBaseUrl = getPublicBaseUrl(config);
 
   // Always use the centralized relay URL derived from the public ingress base URL.

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1253,9 +1253,12 @@ export async function handleTwilioConfig(
         hasCredentials: true,
       });
     } else if (msg.action === 'clear_credentials') {
+      // Only clear authentication credentials (Account SID and Auth Token).
+      // Preserve the phone number in both config (sms.phoneNumber) and secure
+      // key (credential:twilio:phone_number) so that re-entering credentials
+      // resumes working without needing to reassign the number.
       deleteSecureKey('credential:twilio:account_sid');
       deleteSecureKey('credential:twilio:auth_token');
-      deleteSecureKey('credential:twilio:phone_number');
       deleteCredentialMetadata('twilio', 'account_sid');
       deleteCredentialMetadata('twilio', 'auth_token');
 


### PR DESCRIPTION
## Summary\n\n- Update getTwilioConfig() to resolve phone number with priority: env var > config > secure key\n- Preserve phone number in both stores during clear_credentials\n- Add tests for number preservation and resolution order\n- Update assistant README and ARCHITECTURE docs\n\nCloses #6810
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
