### PR TITLE
fix: assistant-scoped channel conversation keying

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -135,6 +135,27 @@ describe('channel-delivery-store', () => {
     expect(r1.conversationId).not.toBe(r2.conversationId);
   });
 
+  test('same chat/channel but different assistantId uses different conversations', () => {
+    const r1 = recordInbound('telegram', 'chat-1', 'msg-1', { assistantId: 'asst-A' });
+    const r2 = recordInbound('telegram', 'chat-1', 'msg-2', { assistantId: 'asst-B' });
+
+    expect(r1.conversationId).not.toBe(r2.conversationId);
+  });
+
+  test('self assistant reuses legacy key and creates scoped alias', () => {
+    // Create a conversation via the legacy (no assistantId) path
+    const legacy = recordInbound('telegram', 'chat-1', 'msg-1');
+
+    // Now use assistantId='self' — should reuse the legacy conversation
+    const scoped = recordInbound('telegram', 'chat-1', 'msg-2', { assistantId: 'self' });
+    expect(scoped.conversationId).toBe(legacy.conversationId);
+
+    // The scoped alias key should exist, so subsequent calls with 'self'
+    // resolve directly without falling back to the legacy key
+    const again = recordInbound('telegram', 'chat-1', 'msg-3', { assistantId: 'self' });
+    expect(again.conversationId).toBe(legacy.conversationId);
+  });
+
   // ── Deduplication ─────────────────────────────────────────────────
 
   test('duplicate inbound returns duplicate: true with same eventId', () => {

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -15,7 +15,7 @@ import { eq, and, lte, isNotNull } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents, conversations } from './schema.js';
-import { getOrCreateConversation } from './conversation-key-store.js';
+import { getConversationByKey, getOrCreateConversation, setConversationKeyIfAbsent } from './conversation-key-store.js';
 import {
   classifyError,
   retryDelayForAttempt,
@@ -31,6 +31,7 @@ export interface InboundResult {
 
 export interface RecordInboundOptions {
   sourceMessageId?: string;
+  assistantId?: string;
 }
 
 /**
@@ -69,8 +70,30 @@ export function recordInbound(
     };
   }
 
-  const conversationKey = `${sourceChannel}:${externalChatId}`;
-  const mapping = getOrCreateConversation(conversationKey);
+  const assistantId = options?.assistantId;
+  const legacyKey = `${sourceChannel}:${externalChatId}`;
+  const scopedKey = assistantId ? `asst:${assistantId}:${sourceChannel}:${externalChatId}` : legacyKey;
+
+  // Resolve conversation mapping with assistant-scoped keying:
+  // 1. If scoped key exists, use it directly.
+  // 2. If assistantId is "self" and legacy key exists, reuse the legacy
+  //    conversation and create a scoped alias to prevent future bleed.
+  // 3. Otherwise, create/get conversation from the scoped key.
+  let mapping: { conversationId: string; created: boolean };
+  const scopedMapping = assistantId ? getConversationByKey(scopedKey) : null;
+  if (scopedMapping) {
+    mapping = { conversationId: scopedMapping.conversationId, created: false };
+  } else if (assistantId === 'self') {
+    const legacyMapping = getConversationByKey(legacyKey);
+    if (legacyMapping) {
+      mapping = { conversationId: legacyMapping.conversationId, created: false };
+      setConversationKeyIfAbsent(scopedKey, legacyMapping.conversationId);
+    } else {
+      mapping = getOrCreateConversation(scopedKey);
+    }
+  } else {
+    mapping = getOrCreateConversation(scopedKey);
+  }
   const now = Date.now();
   const eventId = uuid();
 

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -68,6 +68,26 @@ export function setConversationKey(conversationKey: string, conversationId: stri
 }
 
 /**
+ * Insert a conversation-key mapping only if the key does not already exist.
+ *
+ * Uses `onConflictDoNothing` on the unique `conversationKey` column to
+ * avoid unique-constraint races when concurrent first messages attempt
+ * to migrate a legacy key to a new scoped alias.
+ */
+export function setConversationKeyIfAbsent(conversationKey: string, conversationId: string): void {
+  const db = getDb();
+  db.insert(conversationKeys)
+    .values({
+      id: uuid(),
+      conversationKey,
+      conversationId,
+      createdAt: Date.now(),
+    })
+    .onConflictDoNothing()
+    .run();
+}
+
+/**
  * Get or create a conversation for the given conversationKey.
  *
  * If a mapping already exists, returns the existing conversation ID.

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -272,7 +272,7 @@ export async function handleChannelInbound(
       sourceChannel,
       externalChatId,
       externalMessageId,
-      { sourceMessageId },
+      { sourceMessageId, assistantId },
     );
 
     if (editResult.duplicate) {
@@ -331,7 +331,7 @@ export async function handleChannelInbound(
     sourceChannel,
     externalChatId,
     externalMessageId,
-    { sourceMessageId },
+    { sourceMessageId, assistantId },
   );
 
   // Upsert external conversation binding with sender metadata


### PR DESCRIPTION
Fixes cross-assistant approval bleed by scoping conversation keys to include assistantId. Part of #6815, closes #6817.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
