### PR TITLE
fix: add runtimeGatewayOriginSecret to gateway test configs

### DIFF
--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -3,7 +3,7 @@ import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js
 import type { GatewayConfig } from "../config.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "tok",
     telegramWebhookSecret: "wh-sec",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,
@@ -36,6 +37,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 describe("payload size guard", () => {

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -2,39 +2,46 @@ import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { createOAuthCallbackHandler } from "../http/routes/oauth-callback.js";
 
-const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
-  telegramBotToken: "tok",
-  telegramWebhookSecret: "wh-ver",
-  telegramApiBaseUrl: "https://api.telegram.org",
-  assistantRuntimeBaseUrl: "http://localhost:7821",
-  routingEntries: [],
-  defaultAssistantId: undefined,
-  unmappedPolicy: "reject",
-  port: 7830,
-  runtimeBearerToken: "rt-token",
-  runtimeProxyEnabled: false,
-  runtimeProxyRequireAuth: true,
-  runtimeProxyBearerToken: undefined,
-  shutdownDrainMs: 5000,
-  runtimeTimeoutMs: 30000,
-  runtimeMaxRetries: 2,
-  runtimeInitialBackoffMs: 500,
-  telegramDeliverAuthBypass: false,
-  telegramInitialBackoffMs: 1000,
-  telegramMaxRetries: 3,
-  telegramTimeoutMs: 15000,
-  maxWebhookPayloadBytes: 1048576,
-  logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20971520,
-  maxAttachmentConcurrency: 3,
-  twilioAuthToken: undefined,
-  twilioAccountSid: undefined,
-  twilioPhoneNumber: undefined,
-  smsDeliverAuthBypass: false,
-  ingressPublicBaseUrl: undefined,
-  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-  ...overrides,
-});
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "rt-token",
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
 
 function mockFetch(fn: () => Promise<Response>) {
   const m = mock(fn);

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -3,7 +3,7 @@ import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { GatewayConfig } from "../config.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "tok",
     telegramWebhookSecret: "wh-ver",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,
@@ -36,6 +37,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 describe("resolveAssistant", () => {

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -9,39 +9,46 @@ import {
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
-const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
-  telegramBotToken: "tok",
-  telegramWebhookSecret: "wh-ver",
-  telegramApiBaseUrl: "https://api.telegram.org",
-  assistantRuntimeBaseUrl: "http://localhost:7821",
-  routingEntries: [],
-  defaultAssistantId: undefined,
-  unmappedPolicy: "reject",
-  port: 7830,
-  runtimeBearerToken: undefined,
-  runtimeProxyEnabled: false,
-  runtimeProxyRequireAuth: true,
-  runtimeProxyBearerToken: undefined,
-  shutdownDrainMs: 5000,
-  runtimeTimeoutMs: 30000,
-  runtimeMaxRetries: 2,
-  runtimeInitialBackoffMs: 500,
-  telegramDeliverAuthBypass: false,
-  telegramInitialBackoffMs: 1000,
-  telegramMaxRetries: 3,
-  telegramTimeoutMs: 15000,
-  maxWebhookPayloadBytes: 1048576,
-  logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20971520,
-  maxAttachmentConcurrency: 3,
-  twilioAuthToken: undefined,
-  twilioAccountSid: undefined,
-  twilioPhoneNumber: undefined,
-  smsDeliverAuthBypass: false,
-  ingressPublicBaseUrl: undefined,
-  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-  ...overrides,
-});
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
 
 const payload = {
   sourceChannel: "telegram",

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -5,7 +5,7 @@ import type { GatewayConfig } from "../config.js";
 const TOKEN = "test-secret-token";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "tok",
     telegramWebhookSecret: "wh-ver",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: TOKEN,
@@ -38,6 +39,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 const originalFetch = globalThis.fetch;

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -3,7 +3,7 @@ import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
 import type { GatewayConfig } from "../config.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "tok",
     telegramWebhookSecret: "wh-ver",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
@@ -36,6 +37,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 const originalFetch = globalThis.fetch;

--- a/gateway/src/__tests__/sms-ingress-guard.test.ts
+++ b/gateway/src/__tests__/sms-ingress-guard.test.ts
@@ -17,7 +17,7 @@ import { createTwilioSmsWebhookHandler } from "../http/routes/twilio-sms-webhook
 const AUTH_TOKEN = "test-guard-auth-token";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: undefined,
     telegramWebhookSecret: undefined,
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -27,6 +27,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "default",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: "runtime-token",
@@ -50,6 +51,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 function computeSignature(

--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -5,7 +5,7 @@ import { callTelegramApi } from "../telegram/api.js";
 const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "test-bot-token",
     telegramWebhookSecret: "test-webhook-secret",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
@@ -38,6 +39,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 describe("callTelegramApi transport error redaction", () => {

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -5,7 +5,7 @@ import type { GatewayConfig } from "../config.js";
 const TOKEN = "test-deliver-token";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "tok",
     telegramWebhookSecret: "wh-sec",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: TOKEN,
@@ -38,6 +39,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 const originalFetch = globalThis.fetch;

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -16,7 +16,7 @@ function makeTelegramResponse(result: unknown) {
 }
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     assistantRuntimeBaseUrl: "http://localhost:7821",
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
@@ -27,6 +27,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     port: 7830,
     routingEntries: [],
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeInitialBackoffMs: 500,
     runtimeMaxRetries: 2,
     runtimeProxyBearerToken: "test-token",
@@ -49,6 +50,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 function makeRequest(

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -3,39 +3,46 @@ import { sendTelegramAttachments } from "../telegram/send.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
-const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
-  telegramBotToken: "tok",
-  telegramWebhookSecret: "wh-ver",
-  telegramApiBaseUrl: "https://api.telegram.org",
-  assistantRuntimeBaseUrl: "http://localhost:7821",
-  routingEntries: [],
-  defaultAssistantId: undefined,
-  unmappedPolicy: "reject",
-  port: 7830,
-  runtimeBearerToken: undefined,
-  runtimeProxyEnabled: false,
-  runtimeProxyRequireAuth: true,
-  runtimeProxyBearerToken: undefined,
-  shutdownDrainMs: 5000,
-  runtimeTimeoutMs: 30000,
-  runtimeMaxRetries: 2,
-  runtimeInitialBackoffMs: 500,
-  telegramDeliverAuthBypass: false,
-  telegramInitialBackoffMs: 1000,
-  telegramMaxRetries: 3,
-  telegramTimeoutMs: 15000,
-  maxWebhookPayloadBytes: 1048576,
-  logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20971520,
-  maxAttachmentConcurrency: 3,
-  twilioAuthToken: undefined,
-  twilioAccountSid: undefined,
-  twilioPhoneNumber: undefined,
-  smsDeliverAuthBypass: false,
-  ingressPublicBaseUrl: undefined,
-  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-  ...overrides,
-});
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -3,7 +3,7 @@ import type { GatewayConfig } from "../config.js";
 import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "test-bot-token",
     telegramWebhookSecret: "test-webhook-secret",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
@@ -36,6 +37,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 function makeTelegramPayload(text: string, updateId = 1001) {

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -3,7 +3,7 @@ import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     telegramBotToken: "test-bot-token",
     telegramWebhookSecret: "test-webhook-secret",
     telegramApiBaseUrl: "https://api.telegram.org",
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     port: 7830,
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
@@ -36,6 +37,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 const originalFetch = globalThis.fetch;

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -17,39 +17,46 @@ const WS_CLOSED = WebSocket.CLOSED;         // 3
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
-  telegramBotToken: "tok",
-  telegramWebhookSecret: "wh-ver",
-  telegramApiBaseUrl: "https://api.telegram.org",
-  assistantRuntimeBaseUrl: "http://localhost:7821",
-  routingEntries: [],
-  defaultAssistantId: undefined,
-  unmappedPolicy: "reject",
-  port: 7830,
-  runtimeBearerToken: undefined,
-  runtimeProxyEnabled: false,
-  runtimeProxyRequireAuth: true,
-  runtimeProxyBearerToken: undefined,
-  shutdownDrainMs: 5000,
-  runtimeTimeoutMs: 30000,
-  runtimeMaxRetries: 2,
-  runtimeInitialBackoffMs: 500,
-  telegramDeliverAuthBypass: false,
-  telegramInitialBackoffMs: 1000,
-  telegramMaxRetries: 3,
-  telegramTimeoutMs: 15000,
-  maxWebhookPayloadBytes: 1048576,
-  logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20971520,
-  maxAttachmentConcurrency: 3,
-  twilioAuthToken: undefined,
-  twilioAccountSid: undefined,
-  twilioPhoneNumber: undefined,
-  smsDeliverAuthBypass: false,
-  ingressPublicBaseUrl: undefined,
-  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-  ...overrides,
-});
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
 
 /**
  * Lightweight fake that mimics a Bun ServerWebSocket for the relay handler.

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -7,39 +7,46 @@ import { createTwilioConnectActionWebhookHandler } from "../http/routes/twilio-c
 
 const AUTH_TOKEN = "test-twilio-auth-token";
 
-const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
-  telegramBotToken: "tok",
-  telegramWebhookSecret: "wh-ver",
-  telegramApiBaseUrl: "https://api.telegram.org",
-  assistantRuntimeBaseUrl: "http://localhost:7821",
-  routingEntries: [],
-  defaultAssistantId: undefined,
-  unmappedPolicy: "reject",
-  port: 7830,
-  runtimeBearerToken: "rt-token",
-  runtimeProxyEnabled: false,
-  runtimeProxyRequireAuth: true,
-  runtimeProxyBearerToken: undefined,
-  shutdownDrainMs: 5000,
-  runtimeTimeoutMs: 30000,
-  runtimeMaxRetries: 2,
-  runtimeInitialBackoffMs: 500,
-  telegramDeliverAuthBypass: false,
-  telegramInitialBackoffMs: 1000,
-  telegramMaxRetries: 3,
-  telegramTimeoutMs: 15000,
-  maxWebhookPayloadBytes: 1048576,
-  logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20971520,
-  maxAttachmentConcurrency: 3,
-  twilioAuthToken: AUTH_TOKEN,
-  twilioAccountSid: undefined,
-  twilioPhoneNumber: undefined,
-  smsDeliverAuthBypass: false,
-  ingressPublicBaseUrl: undefined,
-  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-  ...overrides,
-});
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: "rt-token",
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: AUTH_TOKEN,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
 
 /**
  * Compute a valid Twilio signature for the given URL + params.

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -7,7 +7,7 @@ import { createSmsDeliverHandler } from "./sms-deliver.js";
 const TOKEN = "test-deliver-token";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     assistantRuntimeBaseUrl: "http://localhost:7821",
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
@@ -18,6 +18,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     port: 7830,
     routingEntries: [],
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeInitialBackoffMs: 500,
     runtimeMaxRetries: 2,
     runtimeProxyBearerToken: TOKEN,
@@ -40,6 +41,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 function makeRequest(body: unknown, headers?: Record<string, string>): Request {

--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -17,7 +17,7 @@ mock.module("../../telegram/send.js", () => ({
 // ---- Helpers ----
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
+  const merged: GatewayConfig = {
     assistantRuntimeBaseUrl: "http://localhost:7821",
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
@@ -28,6 +28,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     port: 7830,
     routingEntries: [],
     runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
     runtimeInitialBackoffMs: 500,
     runtimeMaxRetries: 2,
     runtimeProxyBearerToken: undefined,
@@ -50,6 +51,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     unmappedPolicy: "reject",
     ...overrides,
   };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
 }
 
 function makeRequest(body: unknown): Request {

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -58,6 +58,7 @@ const baseConfig: GatewayConfig = {
   port: 7830,
   routingEntries: [],
   runtimeBearerToken: undefined,
+  runtimeGatewayOriginSecret: undefined,
   runtimeInitialBackoffMs: 500,
   runtimeMaxRetries: 2,
   runtimeProxyBearerToken: undefined,

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -42,6 +42,7 @@ const baseConfig: GatewayConfig = {
   port: 7830,
   routingEntries: [],
   runtimeBearerToken: undefined,
+  runtimeGatewayOriginSecret: undefined,
   runtimeInitialBackoffMs: 500,
   runtimeMaxRetries: 2,
   runtimeProxyBearerToken: undefined,

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -30,6 +30,7 @@ const baseConfig: GatewayConfig = {
   port: 7830,
   routingEntries: [],
   runtimeBearerToken: undefined,
+  runtimeGatewayOriginSecret: undefined,
   runtimeInitialBackoffMs: 500,
   runtimeMaxRetries: 2,
   runtimeProxyBearerToken: undefined,


### PR DESCRIPTION
Adds missing runtimeGatewayOriginSecret field to all gateway test config objects to fix typecheck. Defaults to runtimeBearerToken when not explicitly set. Part of #6815, closes #6818.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
