### PR TITLE
fix: address review feedback on PR #6821 — test mock ingress propagation

### DIFF
--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -10,8 +10,8 @@ const testDir = mkdtempSync(join(tmpdir(), 'handlers-twilio-cfg-test-'));
 let rawConfigStore: Record<string, unknown> = {};
 
 mock.module('../config/loader.js', () => ({
-  getConfig: () => ({ sms: rawConfigStore.sms ?? {} }),
-  loadConfig: () => ({ sms: rawConfigStore.sms ?? {} }),
+  getConfig: () => ({ ...rawConfigStore }),
+  loadConfig: () => ({ ...rawConfigStore }),
   loadRawConfig: () => ({ ...rawConfigStore }),
   saveRawConfig: (cfg: Record<string, unknown>) => {
     rawConfigStore = { ...cfg };


### PR DESCRIPTION
## Summary

- Fix test mock to correctly propagate ingress config to getTwilioConfig resolution tests
- Ensures phone number precedence tests actually validate the intended behavior

Addresses feedback on #6821
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
