### PR TITLE
fix: delete scoped conversation keys in handleDeleteConversation

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -158,9 +158,13 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
   const body = await req.json() as {
     sourceChannel?: string;
     externalChatId?: string;
+    assistantId?: string;
   };
 
   const { sourceChannel, externalChatId } = body;
+  const assistantId = typeof body.assistantId === 'string' && body.assistantId.length > 0
+    ? body.assistantId
+    : 'self';
 
   if (!sourceChannel || typeof sourceChannel !== 'string') {
     return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
@@ -169,8 +173,12 @@ export async function handleDeleteConversation(req: Request): Promise<Response> 
     return Response.json({ error: 'externalChatId is required' }, { status: 400 });
   }
 
-  const conversationKey = `${sourceChannel}:${externalChatId}`;
-  deleteConversationKey(conversationKey);
+  // Delete both legacy and scoped conversation key aliases to handle
+  // migration scenarios where either or both keys may exist.
+  const legacyKey = `${sourceChannel}:${externalChatId}`;
+  const scopedKey = `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
+  deleteConversationKey(legacyKey);
+  deleteConversationKey(scopedKey);
   externalConversationStore.deleteBindingByChannelChat(sourceChannel, externalChatId);
 
   return Response.json({ ok: true });


### PR DESCRIPTION
Fixes handleDeleteConversation to also delete scoped conversation key aliases (asst:assistantId:channel:chatId) in addition to legacy keys. Without this, conversation resets are broken for scoped conversations. Addresses feedback from #6823.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
