### PR TITLE
feat: add /status slash command to UI menu

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -8,12 +8,13 @@
 
 import type { Message } from '../providers/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
+import type { UsageStats } from './ipc-contract.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
 import type { TraceEmitter } from './trace-emitter.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
-import { resolveSlash } from './session-slash.js';
+import { resolveSlash, type SlashContext } from './session-slash.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { tryRouteCallMessage } from '../calls/call-bridge.js';
@@ -56,6 +57,8 @@ export interface ProcessSessionContext {
   readonly traceEmitter: TraceEmitter;
   currentActiveSurfaceId?: string;
   currentPage?: string;
+  /** Cumulative token usage stats for the session. */
+  readonly usageStats: UsageStats;
   /** Request-scoped skill IDs preactivated via slash resolution. */
   preactivatedSkillIds?: string[];
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
@@ -65,6 +68,20 @@ export interface ProcessSessionContext {
     onEvent: (msg: ServerMessage) => void,
     options?: { skipPreMessageRollback?: boolean },
   ): Promise<void>;
+}
+
+/** Build a SlashContext from the current session state and config. */
+function buildSlashContext(session: ProcessSessionContext): SlashContext {
+  const config = getConfig();
+  return {
+    messageCount: session.messages.length,
+    inputTokens: session.usageStats.inputTokens,
+    outputTokens: session.usageStats.outputTokens,
+    maxInputTokens: config.contextWindow.maxInputTokens,
+    model: config.model,
+    provider: config.provider,
+    estimatedCost: session.usageStats.estimatedCost,
+  };
 }
 
 // ── drainQueue ───────────────────────────────────────────────────────
@@ -96,7 +113,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   });
 
   // Resolve slash commands for queued messages
-  const slashResult = resolveSlash(next.content);
+  const slashResult = resolveSlash(next.content, buildSlashContext(session));
 
   // Unknown slash — persist the exchange and continue draining.
   // Persist each message before pushing to session.messages so that a
@@ -242,7 +259,7 @@ export async function processMessage(
   session.currentPage = currentPage;
 
   // Resolve slash commands before persistence
-  const slashResult = resolveSlash(content);
+  const slashResult = resolveSlash(content, buildSlashContext(session));
 
   // Unknown slash command — persist the exchange (user + assistant) so the
   // messageId is real.  Persist each message before pushing to session.messages

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -15,6 +15,18 @@ export type SlashResolution =
   | { kind: 'rewritten'; content: string; skillId: string }
   | { kind: 'unknown'; message: string };
 
+// ── /status command ──────────────────────────────────────────────────
+
+export interface SlashContext {
+  messageCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  maxInputTokens: number;
+  model: string;
+  provider: string;
+  estimatedCost: number;
+}
+
 // ── /model command ───────────────────────────────────────────────────
 
 const AVAILABLE_MODELS = [
@@ -242,11 +254,31 @@ function resolveModelCommand(content: string): SlashResolution | null {
   };
 }
 
+function resolveStatusCommand(context: SlashContext): SlashResolution {
+  const { inputTokens, maxInputTokens, model, provider, messageCount, outputTokens, estimatedCost } = context;
+  const pct = maxInputTokens > 0 ? Math.round((inputTokens / maxInputTokens) * 100) : 0;
+  const filled = Math.round(pct / 5);
+  const bar = '█'.repeat(filled) + '░'.repeat(20 - filled);
+  const fmt = (n: number) => n.toLocaleString('en-US');
+  const displayName = MODEL_DISPLAY_NAMES[model] ?? model;
+
+  const lines = [
+    'Session Status\n',
+    `Context:  ${bar}  ${pct}%  (${fmt(inputTokens)} / ${fmt(maxInputTokens)} tokens)`,
+    `Model:    ${displayName} (${provider})`,
+    `Messages: ${fmt(messageCount)}`,
+    `Tokens:   ${fmt(inputTokens)} in / ${fmt(outputTokens)} out`,
+    `Cost:     $${estimatedCost.toFixed(2)} (estimated)`,
+  ];
+
+  return { kind: 'unknown', message: lines.join('\n') };
+}
+
 /**
  * Resolve slash commands against the current skill catalog.
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
  */
-export function resolveSlash(content: string): SlashResolution {
+export function resolveSlash(content: string, context?: SlashContext): SlashResolution {
   // Check provider shortcuts first (/gpt4, /opus, etc.)
   const providerResult = resolveProviderModelCommand(content);
   if (providerResult) return providerResult;
@@ -255,11 +287,19 @@ export function resolveSlash(content: string): SlashResolution {
   const modelResult = resolveModelCommand(content);
   if (modelResult) return modelResult;
 
+  // Handle /status command
+  if (content.trim() === '/status') {
+    if (!context) {
+      return { kind: 'unknown', message: 'Status information is not available in this context.' };
+    }
+    return resolveStatusCommand(context);
+  }
+
   // Handle /commands command
   if (content.trim() === '/commands') {
     return {
       kind: 'unknown',
-      message: '/commands — List all available commands\n/model — Show or switch the current model\n/models — List all available models',
+      message: '/commands — List all available commands\n/model — Show or switch the current model\n/models — List all available models\n/status — Show session status and context usage',
     };
   }
 

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -256,7 +256,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
 
 function resolveStatusCommand(context: SlashContext): SlashResolution {
   const { inputTokens, maxInputTokens, model, provider, messageCount, outputTokens, estimatedCost } = context;
-  const pct = maxInputTokens > 0 ? Math.round((inputTokens / maxInputTokens) * 100) : 0;
+  const pct = maxInputTokens > 0 ? Math.min(Math.round((inputTokens / maxInputTokens) * 100), 100) : 0;
   const filled = Math.round(pct / 5);
   const bar = '█'.repeat(filled) + '░'.repeat(20 - filled);
   const fmt = (n: number) => n.toLocaleString('en-US');

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -297,9 +297,17 @@ export function resolveSlash(content: string, context?: SlashContext): SlashReso
 
   // Handle /commands command
   if (content.trim() === '/commands') {
+    const lines = [
+      '/commands — List all available commands',
+      '/model — Show or switch the current model',
+      '/models — List all available models',
+    ];
+    if (context) {
+      lines.push('/status — Show session status and context usage');
+    }
     return {
       kind: 'unknown',
-      message: '/commands — List all available commands\n/model — Show or switch the current model\n/models — List all available models\n/status — Show session status and context usage',
+      message: lines.join('\n'),
     };
   }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -640,7 +640,6 @@ private struct ComposerTextView: NSViewRepresentable {
 
         if context.coordinator.isWritingFromView == false, textView.string != text {
             textView.string = text
-            textView.highlightSlashCommand()
             textView.needsDisplay = true
         }
 
@@ -775,7 +774,7 @@ private final class ComposerNativeTextView: NSTextView {
         highlightSlashCommand()
     }
 
-    func highlightSlashCommand() {
+    private func highlightSlashCommand() {
         guard let layoutManager = layoutManager, let textStorage = textStorage else { return }
         let fullRange = NSRange(location: 0, length: textStorage.length)
         guard fullRange.length > 0 else { return }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -67,6 +67,7 @@ struct ComposerView: View {
     @State private var showSlashMenu = false
     @State private var slashFilter = ""
     @State private var slashSelectedIndex = 0
+    @State private var suppressSlashReopen = false
     @State private var avatarSeed: String = "default"
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -490,6 +491,10 @@ struct ComposerView: View {
     }
 
     private func updateSlashState() {
+        if suppressSlashReopen {
+            suppressSlashReopen = false
+            return
+        }
         let text = inputText
 
         if text.hasPrefix("/") && !text.contains(" ") {
@@ -529,6 +534,7 @@ struct ComposerView: View {
                 selectSlashCommand(filtered[slashSelectedIndex])
             case .tab:
                 let command = filtered[slashSelectedIndex]
+                suppressSlashReopen = true
                 inputText = "/\(command.name)"
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
             case .dismiss:

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -13,6 +13,7 @@ struct SlashCommand {
         SlashCommand(name: "commands", description: "List all available commands", icon: "terminal"),
         SlashCommand(name: "model", description: "Switch the active model", icon: "cpu"),
         SlashCommand(name: "models", description: "List all available models", icon: "list.bullet"),
+        SlashCommand(name: "status", description: "Show session status and context usage", icon: "info.circle"),
     ]
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -18,7 +18,7 @@ struct SlashCommand {
 }
 
 enum SlashNavigation {
-    case up, down, select, dismiss
+    case up, down, select, tab, dismiss
 }
 
 struct ComposerView: View {
@@ -527,6 +527,10 @@ struct ComposerView: View {
                 slashSelectedIndex = (slashSelectedIndex + 1) % filtered.count
             case .select:
                 selectSlashCommand(filtered[slashSelectedIndex])
+            case .tab:
+                let command = filtered[slashSelectedIndex]
+                inputText = "/\(command.name)"
+                withAnimation(VAnimation.fast) { showSlashMenu = false }
             case .dismiss:
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
                 inputText = ""
@@ -794,6 +798,12 @@ private final class ComposerNativeTextView: NSTextView {
 
     override func keyDown(with event: NSEvent) {
         let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
+
+        // Tab autocompletes the selected slash command when the menu is open.
+        if event.keyCode == 48, !modifiers.contains(.shift), isSlashMenuOpen {
+            onSlashNavigate?(.tab)
+            return
+        }
 
         // Tab accepts ghost suggestions in-place when available.
         if event.keyCode == 48, !modifiers.contains(.shift), hasGhostSuffix {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -640,6 +640,7 @@ private struct ComposerTextView: NSViewRepresentable {
 
         if context.coordinator.isWritingFromView == false, textView.string != text {
             textView.string = text
+            textView.highlightSlashCommand()
             textView.needsDisplay = true
         }
 
@@ -774,7 +775,7 @@ private final class ComposerNativeTextView: NSTextView {
         highlightSlashCommand()
     }
 
-    private func highlightSlashCommand() {
+    func highlightSlashCommand() {
         guard let layoutManager = layoutManager, let textStorage = textStorage else { return }
         let fullRange = NSRange(location: 0, length: textStorage.length)
         guard fullRange.length > 0 else { return }


### PR DESCRIPTION
## Summary
- Add `/status` to the client-side slash command menu in `ComposerView.swift`
- Wire up `SlashContext` in the daemon to provide session stats (token usage, model, cost) to the `/status` handler
- Update `/commands` output to include `/status` in the listing

## Test plan
- [ ] Launch the app and type `/` in the composer — verify `/status` appears in the menu
- [ ] Select `/status` and verify it returns session context info (tokens, model, cost)
- [ ] Verify `/commands` lists `/status` in its output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
