### PR TITLE
feat: only auto-restart daemon if assistant is in lock file

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -455,6 +455,24 @@ final class AssistantCli {
 
     // MARK: - Private Helpers
 
+    /// Path to the lock file that tracks registered assistants.
+    private var lockFileURL: URL {
+        if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
+            return URL(fileURLWithPath: baseDir).appendingPathComponent(".vellum.lock.json")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".vellum.lock.json")
+    }
+
+    /// Returns `true` if the given assistant ID is present in `~/.vellum.lock.json`.
+    private func isAssistantInLockFile(assistantId: String) -> Bool {
+        guard let data = try? Data(contentsOf: lockFileURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let assistants = json["assistants"] as? [[String: Any]] else {
+            return false
+        }
+        return assistants.contains { ($0["assistantId"] as? String) == assistantId }
+    }
+
     /// Returns `true` if the daemon process is alive based on the PID file.
     private func isDaemonAlive() -> Bool {
         let pidData: Data
@@ -474,6 +492,14 @@ final class AssistantCli {
     private func restartDaemon() async {
         guard cliBinaryURL != nil else { return }
         guard !hasGivenUp else { return }
+
+        // Only restart if the assistant is still registered in the lock file
+        let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        guard let assistantId, isAssistantInLockFile(assistantId: assistantId) else {
+            log.info("Assistant not found in lock file — skipping restart and stopping monitor")
+            stopMonitoring()
+            return
+        }
 
         // Track consecutive rapid crashes for backoff
         if let lastLaunch = lastLaunchTime,
@@ -498,9 +524,7 @@ final class AssistantCli {
         }
 
         do {
-            // Pass the existing assistant name so the CLI reuses it
-            let existingName = UserDefaults.standard.string(forKey: "connectedAssistantId")
-            try await hatch(name: existingName, daemonOnly: true)
+            try await hatch(name: assistantId, daemonOnly: true)
             log.info("Daemon restarted successfully via CLI")
             onDaemonRestarted?()
         } catch {

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -289,9 +289,18 @@ final class AssistantCli {
     }
 
     /// Start a periodic health check that restarts the daemon if it dies.
-    /// No-op in dev mode (no bundled CLI binary).
+    /// No-op in dev mode (no bundled CLI binary) or when the assistant
+    /// is not registered in the lock file.
     func startMonitoring() {
         guard cliBinaryURL != nil else { return }
+
+        // Don't start monitoring if the assistant isn't in the lock file
+        let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        if let assistantId, !isAssistantInLockFile(assistantId: assistantId) {
+            log.info("Assistant '\(assistantId)' not in lock file — skipping monitor start")
+            return
+        }
+
         isStopping = false
         hasGivenUp = false
         consecutiveCrashes = 0
@@ -456,11 +465,9 @@ final class AssistantCli {
     // MARK: - Private Helpers
 
     /// Path to the lock file that tracks registered assistants.
+    /// Always at `~/.vellum.lock.json` (home directory), matching the CLI's `getLockfilePath()`.
     private var lockFileURL: URL {
-        if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-            return URL(fileURLWithPath: baseDir).appendingPathComponent(".vellum.lock.json")
-        }
-        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".vellum.lock.json")
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".vellum.lock.json")
     }
 
     /// Returns `true` if the given assistant ID is present in `~/.vellum.lock.json`.


### PR DESCRIPTION
## Summary
- Instead of unconditionally restarting the daemon when it dies, the health monitor now checks `~/.vellum.lock.json` first
- If the assistant ID is not found in the lock file (e.g. after retire or `rm -Rf ~/.vellum`), the restart is skipped and the monitor stops itself
- Retire already stops the monitor (`retire()` calls `stopMonitoring()`), so this adds a second safety net at the restart point

## Test plan
- [ ] Hatch an assistant, kill the daemon process — verify it auto-restarts (assistant is in lock file)
- [ ] Retire the assistant, kill the daemon process — verify it does NOT restart (monitor already stopped by retire)
- [ ] Delete `~/.vellum.lock.json`, kill the daemon — verify the monitor logs "Assistant not found in lock file" and stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)