### PR TITLE
fix: guard suppressSlashReopen flag against no-op tab autocomplete

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -534,8 +534,11 @@ struct ComposerView: View {
                 selectSlashCommand(filtered[slashSelectedIndex])
             case .tab:
                 let command = filtered[slashSelectedIndex]
-                suppressSlashReopen = true
-                inputText = "/\(command.name)"
+                let newText = "/\(command.name)"
+                if inputText != newText {
+                    suppressSlashReopen = true
+                }
+                inputText = newText
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
             case .dismiss:
                 withAnimation(VAnimation.fast) { showSlashMenu = false }


### PR DESCRIPTION
## Summary
- Only set `suppressSlashReopen = true` when the tab-autocompleted text differs from current input
- Prevents the flag from staying stale and skipping one keystroke of slash menu logic when user tabs on an already-complete command name

## Original prompt
Addresses feedback from PR #6837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
