### PR TITLE
fix: read assistantId from route params in handleDeleteConversation

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -24,7 +24,7 @@ mock.module('../util/logger.js', () => ({
 }));
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
-import { channelInboundEvents, messages } from '../memory/schema.js';
+import { channelInboundEvents, conversations, messages } from '../memory/schema.js';
 import {
   recordInbound,
   linkMessage,
@@ -40,6 +40,8 @@ import {
 } from '../memory/channel-delivery-store.js';
 import { RETRY_MAX_ATTEMPTS } from '../memory/job-utils.js';
 import { eq } from 'drizzle-orm';
+import { setConversationKey, getConversationByKey } from '../memory/conversation-key-store.js';
+import { handleDeleteConversation } from '../runtime/routes/channel-routes.js';
 
 initializeDb();
 
@@ -464,5 +466,85 @@ describe('channel-delivery-store', () => {
 
     const found = findMessageBySourceId('telegram', 'chat-1', 'src-1');
     expect(found!.messageId).toBe(msgId);
+  });
+
+  // ── handleDeleteConversation assistantId parameter ───────────────
+
+  test('handleDeleteConversation uses route assistantId param to delete scoped key', async () => {
+    // Set up a scoped conversation key like the one created by recordInbound
+    // with a specific assistantId.
+    const convId = 'conv-delete-test';
+    const scopedKey = 'asst:my-assistant:telegram:chat-del';
+    const legacyKey = 'telegram:chat-del';
+
+    // Insert a conversation row so FK constraints are satisfied
+    const now = Date.now();
+    const db = getDb();
+    db.insert(conversations).values({
+      id: convId,
+      title: 'test',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    setConversationKey(scopedKey, convId);
+    setConversationKey(legacyKey, convId);
+
+    // Verify both keys exist
+    expect(getConversationByKey(scopedKey)).not.toBeNull();
+    expect(getConversationByKey(legacyKey)).not.toBeNull();
+
+    // Call handleDeleteConversation with assistantId as a parameter (not in body)
+    const req = new Request('http://localhost/channels/conversation', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'telegram',
+        externalChatId: 'chat-del',
+        // Note: no assistantId in the body — it comes from the route param
+      }),
+    });
+
+    const res = await handleDeleteConversation(req, 'my-assistant');
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(true);
+
+    // Both the legacy key and the scoped key should be deleted
+    expect(getConversationByKey(scopedKey)).toBeNull();
+    expect(getConversationByKey(legacyKey)).toBeNull();
+  });
+
+  test('handleDeleteConversation defaults to "self" when no assistantId provided', async () => {
+    const convId = 'conv-delete-default';
+    const scopedKey = 'asst:self:telegram:chat-def';
+    const legacyKey = 'telegram:chat-def';
+
+    const now = Date.now();
+    const db = getDb();
+    db.insert(conversations).values({
+      id: convId,
+      title: 'test',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    setConversationKey(scopedKey, convId);
+    setConversationKey(legacyKey, convId);
+
+    const req = new Request('http://localhost/channels/conversation', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceChannel: 'telegram',
+        externalChatId: 'chat-def',
+      }),
+    });
+
+    // No assistantId parameter — should default to 'self'
+    const res = await handleDeleteConversation(req);
+    expect(res.status).toBe(200);
+
+    expect(getConversationByKey(scopedKey)).toBeNull();
+    expect(getConversationByKey(legacyKey)).toBeNull();
   });
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -739,7 +739,7 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/conversation' && req.method === 'DELETE') {
-        return await handleDeleteConversation(req);
+        return await handleDeleteConversation(req, assistantId);
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -154,17 +154,13 @@ function parseCallbackData(data: string): ApprovalDecisionResult | null {
   return { action: action as ApprovalAction, source: 'telegram_button', runId };
 }
 
-export async function handleDeleteConversation(req: Request): Promise<Response> {
+export async function handleDeleteConversation(req: Request, assistantId: string = 'self'): Promise<Response> {
   const body = await req.json() as {
     sourceChannel?: string;
     externalChatId?: string;
-    assistantId?: string;
   };
 
   const { sourceChannel, externalChatId } = body;
-  const assistantId = typeof body.assistantId === 'string' && body.assistantId.length > 0
-    ? body.assistantId
-    : 'self';
 
   if (!sourceChannel || typeof sourceChannel !== 'string') {
     return Response.json({ error: 'sourceChannel is required' }, { status: 400 });


### PR DESCRIPTION
## Summary
- `handleDeleteConversation` was reading `assistantId` from the request body, but the gateway's `resetConversation` sends it as a URL path parameter — so the handler always fell back to `"self"`
- Changed the handler to accept `assistantId` as a function parameter (default `'self'`), and pass it from `dispatchEndpoint` where it is already extracted from the route
- Added tests verifying the scoped key is correctly deleted when `assistantId` is provided as a parameter

Addresses review feedback on #6834.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/channel-delivery-store.test.ts` — 28 tests pass (2 new)
- [x] `bun test src/__tests__/channel-approval-routes.test.ts` — 77 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
