### PR TITLE
Move feature flag editor to Advanced settings tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -24,6 +24,7 @@ struct SettingsAdvancedTab: View {
     @State private var selectedAssistantId: String = ""
     @State private var identity: IdentityInfo?
     @State private var remoteIdentity: RemoteIdentityInfo?
+    @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
     #if DEBUG
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
@@ -40,6 +41,7 @@ struct SettingsAdvancedTab: View {
             switchAssistantSection
             retireAssistantSection
             hatchNewAssistantSection
+            featureFlagSection
 
             #if DEBUG
             developerSection
@@ -55,6 +57,9 @@ struct SettingsAdvancedTab: View {
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
             identity = IdentityInfo.load()
+            flagStates = FeatureFlag.allCases.map { flag in
+                (flag: flag, enabled: FeatureFlagManager.shared.isEnabled(flag))
+            }
 
             if identity == nil, let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }), assistant.isRemote {
                 Task {
@@ -509,6 +514,34 @@ struct SettingsAdvancedTab: View {
                         AppDelegate.shared?.replayOnboarding()
                         onClose()
                     }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+        }
+    }
+
+    // MARK: - Feature Flags
+
+    @ViewBuilder
+    private var featureFlagSection: some View {
+        if FeatureFlagManager.shared.isEnabled(.featureFlagEditorEnabled) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Feature Flags")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                ForEach(Array(flagStates.enumerated()), id: \.element.flag) { index, entry in
+                    Toggle(entry.flag.displayName, isOn: Binding(
+                        get: { flagStates[index].enabled },
+                        set: { newValue in
+                            flagStates[index].enabled = newValue
+                            FeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
                 }
             }
             .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -633,10 +633,6 @@ public struct SettingsView: View {
                 .font(.caption)
             }
 
-            if FeatureFlagManager.shared.isEnabled(.featureFlagEditorEnabled) {
-                FeatureFlagEditorSection()
-            }
-
             #if DEBUG
             if let daemonClient {
                 Section("Developer") {
@@ -720,35 +716,6 @@ public struct SettingsView: View {
         screenRecordingGranted = status == .granted
     }
 
-}
-
-// MARK: - Feature Flag Editor
-
-private struct FeatureFlagEditorSection: View {
-    @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
-
-    var body: some View {
-        Section("Feature Flags") {
-            ForEach(Array(flagStates.enumerated()), id: \.element.flag) { index, entry in
-                Toggle(entry.flag.displayName, isOn: Binding(
-                    get: { flagStates[index].enabled },
-                    set: { newValue in
-                        flagStates[index].enabled = newValue
-                        FeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
-                    }
-                ))
-            }
-        }
-        .onAppear {
-            loadFlags()
-        }
-    }
-
-    private func loadFlags() {
-        flagStates = FeatureFlag.allCases.map { flag in
-            (flag: flag, enabled: FeatureFlagManager.shared.isEnabled(flag))
-        }
-    }
 }
 
 // MARK: - Knowledge Section


### PR DESCRIPTION
## Summary
- Move the feature flag editor from the old `SettingsView` popup to `SettingsAdvancedTab`
- Styled as a `.vCard` section matching the existing Advanced tab pattern
- Guarded by the same `featureFlagEditorEnabled` feature flag

## Test plan
- [ ] Build: `cd clients/macos && ./build.sh`
- [ ] Open Control Center > Settings > Advanced tab — verify feature flag toggles appear (when `featureFlagEditorEnabled` is on)
- [ ] Open the old Settings popup — verify the feature flag section is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
