### PR TITLE
Remove premature setupDaemonClient() from showOnboarding()

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1100,8 +1100,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showOnboarding() {
-        setupDaemonClient()
-
         let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()


### PR DESCRIPTION
## Summary
- Remove the `setupDaemonClient()` call from `showOnboarding()` in `AppDelegate.swift`
- The call was premature — no daemon exists yet during onboarding, causing a failing hatch attempt, premature health monitor startup, and early callback wiring
- The actual setup already happens in `proceedToApp(isFirstLaunch: true)` after onboarding completes
- `daemonClient` is a computed property on `services`, so it can still be passed to `OnboardingWindow` without calling setup first

## Test plan
- [ ] Build: `cd clients/macos && ./build.sh`
- [ ] Delete `~/.vellum.lock.json` to force onboarding
- [ ] Launch the app — verify onboarding shows without errors
- [ ] Complete onboarding (hatch) — verify the daemon connects and the app works normally
- [ ] Verify no spurious "Daemon process not running" log messages during onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
