### PR TITLE
feat: include vellum-skills catalog in Available tab with source badges

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -5,8 +5,9 @@ import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../../config/skills.js';
 import { resolveSkillStates } from '../../config/skill-state.js';
 import { getWorkspaceSkillsDir } from '../../util/platform.js';
-import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../../skills/clawhub.js';
+import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect, type ClawhubSearchResultItem } from '../../skills/clawhub.js';
 import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } from '../../skills/managed-store.js';
+import { listCatalogEntries, installFromVellumCatalog } from '../../tools/skills/vellum-catalog.js';
 import type {
   SkillDetailRequest,
   SkillsEnableRequest,
@@ -186,26 +187,45 @@ export async function handleSkillsInstall(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    const result = await clawhubInstall(msg.slug, { version: msg.version });
-    if (!result.success) {
-      ctx.send(socket, {
-        type: 'skills_operation_response',
-        operation: 'install',
-        success: false,
-        error: result.error ?? 'Unknown error',
-      });
-      return;
+    // Check if the slug matches a vellum-skills catalog entry first
+    const catalogEntries = listCatalogEntries();
+    const isVellumSkill = catalogEntries.some((e) => e.id === msg.slug);
+
+    let skillId: string;
+
+    if (isVellumSkill) {
+      // Install from vellum-skills catalog (local copy)
+      const result = installFromVellumCatalog(msg.slug);
+      if (!result.success) {
+        ctx.send(socket, {
+          type: 'skills_operation_response',
+          operation: 'install',
+          success: false,
+          error: result.error ?? 'Unknown error',
+        });
+        return;
+      }
+      skillId = result.skillName ?? msg.slug;
+    } else {
+      // Install from clawhub (community)
+      const result = await clawhubInstall(msg.slug, { version: msg.version });
+      if (!result.success) {
+        ctx.send(socket, {
+          type: 'skills_operation_response',
+          operation: 'install',
+          success: false,
+          error: result.error ?? 'Unknown error',
+        });
+        return;
+      }
+      const rawId = result.skillName ?? msg.slug;
+      skillId = rawId.includes('/') ? rawId.split('/').pop()! : rawId;
     }
 
     // Reload skill catalog so the newly installed skill is picked up
     loadSkillCatalog();
 
     // Auto-enable the newly installed skill so it's immediately usable.
-    // Use basename of slug to match the catalog ID (directory basename), since
-    // install slugs can be namespaced (e.g. "org/name") but skill state keys use
-    // the bare directory name.
-    const rawId = result.skillName ?? msg.slug;
-    const skillId = rawId.includes('/') ? rawId.split('/').pop()! : rawId;
     try {
       const raw = loadRawConfig();
       ensureSkillEntry(raw, skillId).enabled = true;
@@ -404,12 +424,36 @@ export async function handleSkillsSearch(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    const result = await clawhubSearch(msg.query);
+    // Search vellum-skills catalog locally
+    const catalogEntries = listCatalogEntries();
+    const query = (msg.query ?? '').toLowerCase();
+    const matchingCatalog = catalogEntries.filter((e) => {
+      if (!query) return true;
+      return e.name.toLowerCase().includes(query) || e.description.toLowerCase().includes(query) || e.id.toLowerCase().includes(query);
+    });
+    const vellumSkills: ClawhubSearchResultItem[] = matchingCatalog.map((e) => ({
+      name: e.name,
+      slug: e.id,
+      description: e.description,
+      author: 'Vellum',
+      stars: 0,
+      installs: 0,
+      version: '',
+      createdAt: 0,
+      source: 'vellum' as const,
+    }));
+
+    // Search clawhub concurrently
+    const clawhubResult = await clawhubSearch(msg.query);
+
+    // Merge: vellum first, then clawhub
+    const merged = { skills: [...vellumSkills, ...clawhubResult.skills] };
+
     ctx.send(socket, {
       type: 'skills_operation_response',
       operation: 'search',
       success: true,
-      data: result,
+      data: merged,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -163,6 +163,8 @@ export interface ClawhubSearchResultItem {
   installs: number;
   version: string;
   createdAt: number;
+  /** Where this skill comes from: "vellum" (first-party) or "clawhub" (community). */
+  source: 'vellum' | 'clawhub';
 }
 
 export interface ClawhubSearchResult {
@@ -273,10 +275,10 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
     try {
       const parsed = JSON.parse(result.stdout);
       if (Array.isArray(parsed)) {
-        return { skills: parsed };
+        return { skills: parsed.map((s: ClawhubSearchResultItem) => ({ ...s, source: s.source ?? 'clawhub' as const })) };
       }
       if (parsed.skills && Array.isArray(parsed.skills)) {
-        return parsed as ClawhubSearchResult;
+        return { skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({ ...s, source: s.source ?? 'clawhub' as const })) };
       }
     } catch {
       // CLI outputs text: "slug vVersion  DisplayName  (score)"
@@ -296,6 +298,7 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
           stars: 0,
           installs: 0,
           createdAt: 0,
+          source: 'clawhub',
         });
       }
     }
@@ -330,6 +333,7 @@ export async function clawhubExplore(opts?: { limit?: number; sort?: string }): 
         installs: (item.stats as Record<string, number>)?.installsAllTime ?? 0,
         version: (item.tags as Record<string, string>)?.latest ?? '',
         createdAt: (item.createdAt as number) ?? 0,
+        source: 'clawhub',
       }));
       return { skills };
     } catch {

--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -15,7 +15,7 @@ function getVellumSkillsDir(): string {
   return join(import.meta.dir, '..', '..', 'config', 'vellum-skills');
 }
 
-interface CatalogEntry {
+export interface CatalogEntry {
   id: string;
   name: string;
   description: string;
@@ -88,7 +88,7 @@ function parseCatalogEntry(directory: string): CatalogEntry | null {
   }
 }
 
-function listCatalogEntries(): CatalogEntry[] {
+export function listCatalogEntries(): CatalogEntry[] {
   const catalogDir = getVellumSkillsDir();
   if (!existsSync(catalogDir)) return [];
 
@@ -105,6 +105,49 @@ function listCatalogEntries(): CatalogEntry[] {
   }
 
   return entries.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Install a skill from the vellum-skills catalog by ID.
+ * Returns { success, skillName, error }.
+ */
+export function installFromVellumCatalog(skillId: string): { success: boolean; skillName?: string; error?: string } {
+  const catalogDir = getVellumSkillsDir();
+  const skillDir = join(catalogDir, skillId.trim());
+  const skillFilePath = join(skillDir, 'SKILL.md');
+
+  if (!existsSync(skillFilePath)) {
+    return { success: false, error: `Skill "${skillId}" not found in the Vellum catalog` };
+  }
+
+  const content = readFileSync(skillFilePath, 'utf-8');
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return { success: false, error: `Skill "${skillId}" has invalid SKILL.md` };
+  }
+
+  const entry = parseCatalogEntry(skillDir);
+  if (!entry) {
+    return { success: false, error: `Skill "${skillId}" has invalid SKILL.md` };
+  }
+
+  const bodyMarkdown = content.slice(match[0].length);
+  const result = createManagedSkill({
+    id: entry.id,
+    name: entry.name,
+    description: entry.description,
+    bodyMarkdown,
+    emoji: entry.emoji,
+    includes: entry.includes,
+    overwrite: true,
+    addToIndex: true,
+  });
+
+  if (!result.created) {
+    return { success: false, error: result.error };
+  }
+
+  return { success: true, skillName: entry.id };
 }
 
 class VellumSkillsCatalogTool implements Tool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -324,7 +324,7 @@ struct AgentPanelContent: View {
 
     private func clawhubSkillCard(_ skill: ClawhubSkillItem) -> some View {
         let isInstalling = installingSlug == skill.slug
-        let isNew = skill.createdAt > 0 && Date().timeIntervalSince(
+        let isNew = !skill.isVellum && skill.createdAt > 0 && Date().timeIntervalSince(
             Date(timeIntervalSince1970: Double(skill.createdAt) / 1000)
         ) < 7 * 86400
 
@@ -332,9 +332,9 @@ struct AgentPanelContent: View {
             HStack(spacing: VSpacing.md) {
                 // Tappable area: icon + name + description
                 HStack(spacing: VSpacing.md) {
-                    Image(systemName: "shippingbox.fill")
+                    Image(systemName: skill.isVellum ? "v.square.fill" : "shippingbox.fill")
                         .font(.system(size: 16))
-                        .foregroundColor(VColor.textMuted)
+                        .foregroundColor(skill.isVellum ? VColor.accent : VColor.textMuted)
                         .frame(width: 24)
 
                     VStack(alignment: .leading, spacing: 2) {
@@ -343,7 +343,11 @@ struct AgentPanelContent: View {
                                 .font(VFont.bodyBold)
                                 .foregroundColor(VColor.textPrimary)
 
-                            if isNew {
+                            if skill.isVellum {
+                                Text("VELLUM")
+                                    .font(VFont.small)
+                                    .foregroundColor(VColor.accent)
+                            } else if isNew {
                                 Text("NEW")
                                     .font(VFont.small)
                                     .foregroundColor(Amber._500)
@@ -381,31 +385,39 @@ struct AgentPanelContent: View {
 
             // Trust signals row
             HStack(spacing: VSpacing.lg) {
-                if !skill.author.isEmpty {
+                if skill.isVellum {
                     HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "person.fill")
+                        Image(systemName: "checkmark.seal.fill")
                             .font(.system(size: 9))
-                        Text(skill.author)
+                        Text("First-party")
                     }
-                }
+                } else {
+                    if !skill.author.isEmpty {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "person.fill")
+                                .font(.system(size: 9))
+                            Text(skill.author)
+                        }
+                    }
 
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "star.fill")
-                        .font(.system(size: 9))
-                    Text("\(skill.stars)")
-                }
-
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "arrow.down.circle")
-                        .font(.system(size: 9))
-                    Text("\(skill.installs)")
-                }
-
-                if !skillAge(skill.createdAt).isEmpty {
                     HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "clock")
+                        Image(systemName: "star.fill")
                             .font(.system(size: 9))
-                        Text(skillAge(skill.createdAt))
+                        Text("\(skill.stars)")
+                    }
+
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "arrow.down.circle")
+                            .font(.system(size: 9))
+                        Text("\(skill.installs)")
+                    }
+
+                    if !skillAge(skill.createdAt).isEmpty {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "clock")
+                                .font(.system(size: 9))
+                            Text(skillAge(skill.createdAt))
+                        }
                     }
                 }
             }
@@ -418,7 +430,9 @@ struct AgentPanelContent: View {
         .onTapGesture {
             withAnimation(VAnimation.standard) {
                 selectedSkillSlug = skill.slug
-                skillsManager.inspectSkill(slug: skill.slug)
+                if !skill.isVellum {
+                    skillsManager.inspectSkill(slug: skill.slug)
+                }
             }
         }
         .vCard(background: VColor.surfaceSubtle)
@@ -428,7 +442,7 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private func skillDetailView(slug: String, searchItem: ClawhubSkillItem) -> some View {
-        let isNew = searchItem.createdAt > 0 && Date().timeIntervalSince(
+        let isNew = !searchItem.isVellum && searchItem.createdAt > 0 && Date().timeIntervalSince(
             Date(timeIntervalSince1970: Double(searchItem.createdAt) / 1000)
         ) < 7 * 86400
 
@@ -456,15 +470,28 @@ struct AgentPanelContent: View {
                     .font(VFont.cardTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                if isNew {
+                if searchItem.isVellum {
+                    Text("VELLUM")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.accent)
+                } else if isNew {
                     Text("NEW")
                         .font(VFont.small)
                         .foregroundColor(Amber._500)
                 }
             }
 
-            // Author row — use inspect owner if available, fall back to search author
-            if let owner = skillsManager.inspectedSkill?.owner {
+            // Author/source row
+            if searchItem.isVellum {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.accent)
+                    Text("First-party skill by Vellum")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else if let owner = skillsManager.inspectedSkill?.owner {
                 HStack(spacing: VSpacing.sm) {
                     if let imageURL = owner.image, let url = URL(string: imageURL) {
                         AsyncImage(url: url) { image in
@@ -505,8 +532,12 @@ struct AgentPanelContent: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Stats row — use inspect stats if available, fall back to search data
-            if let stats = skillsManager.inspectedSkill?.stats {
+            // Stats row — vellum skills show first-party badge; community shows stats
+            if searchItem.isVellum {
+                HStack(spacing: VSpacing.lg) {
+                    statItem(icon: "checkmark.seal.fill", value: "First-party")
+                }
+            } else if let stats = skillsManager.inspectedSkill?.stats {
                 HStack(spacing: VSpacing.lg) {
                     statItem(icon: "star.fill", value: "\(stats.stars)")
                     statItem(icon: "arrow.down.circle", value: "\(stats.installs)")
@@ -530,31 +561,33 @@ struct AgentPanelContent: View {
             }
 
             // Inspect-only content (loading, error, or enriched details)
-            if skillsManager.isInspecting {
-                HStack {
-                    Spacer()
-                    VStack(spacing: VSpacing.md) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Loading more details...")
+            if !searchItem.isVellum {
+                if skillsManager.isInspecting {
+                    HStack {
+                        Spacer()
+                        VStack(spacing: VSpacing.md) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading more details...")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                    }
+                    .frame(height: 80)
+                } else if let error = skillsManager.inspectError {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(Amber._500)
+                        Text(error)
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    Spacer()
+                } else if let data = skillsManager.inspectedSkill {
+                    // Enriched content from inspect (version, README, files)
+                    skillDetailEnrichedContent(data)
                 }
-                .frame(height: 80)
-            } else if let error = skillsManager.inspectError {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 11))
-                        .foregroundColor(Amber._500)
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-            } else if let data = skillsManager.inspectedSkill {
-                // Enriched content from inspect (version, README, files)
-                skillDetailEnrichedContent(data)
             }
 
             // Install button — always visible

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1037,7 +1037,7 @@ public typealias IdentityGetResponseMessage = IPCIdentityGetResponse
 /// Backed by generated `IPCSkillStateChanged`.
 public typealias SkillStateChangedMessage = IPCSkillStateChanged
 
-/// A ClaWHub skill returned from a search or explore query.
+/// A skill returned from a search or explore query.
 /// Kept hand-maintained — this type is decoded from the `data` field of
 /// `skills_operation_response` (which is `AnyCodable` in the contract).
 public struct ClawhubSkillItem: Decodable, Sendable, Identifiable, Equatable {
@@ -1051,6 +1051,10 @@ public struct ClawhubSkillItem: Decodable, Sendable, Identifiable, Equatable {
     public let version: String
     /// Epoch milliseconds when the skill was first published.
     public let createdAt: Int
+    /// Where this skill comes from: "vellum" (first-party) or "clawhub" (community).
+    public let source: String
+
+    public var isVellum: Bool { source == "vellum" }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -1062,10 +1066,11 @@ public struct ClawhubSkillItem: Decodable, Sendable, Identifiable, Equatable {
         installs = try container.decodeIfPresent(Int.self, forKey: .installs) ?? 0
         version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
         createdAt = try container.decodeIfPresent(Int.self, forKey: .createdAt) ?? 0
+        source = try container.decodeIfPresent(String.self, forKey: .source) ?? "clawhub"
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, slug, description, author, stars, installs, version, createdAt
+        case name, slug, description, author, stars, installs, version, createdAt, source
     }
 }
 


### PR DESCRIPTION
## Summary
- Search results in the Available Skills tab now include first-party skills from the `vellum-skills` catalog alongside community skills from ClawHub
- Each skill displays its source: **VELLUM** (violet badge + seal icon) for first-party or existing community trust signals (author, stars, installs) for ClawHub skills
- Install handler routes vellum-skills to the local catalog installer instead of ClawHub

## Changes

**Backend (TypeScript):**
- `handleSkillsSearch` merges vellum catalog entries with ClawHub results (Vellum first)
- `handleSkillsInstall` detects vellum-skills slugs and installs from the local catalog
- `ClawhubSearchResultItem` gains a `source` field (`"vellum"` | `"clawhub"`)
- Exported `listCatalogEntries` and `installFromVellumCatalog` from vellum-catalog module

**Frontend (macOS SwiftUI):**
- `ClawhubSkillItem` gains `source` field and `isVellum` computed property
- Skill cards: violet `v.square.fill` icon + "VELLUM" badge for first-party skills
- Detail view: "First-party skill by Vellum" with seal icon (skips ClawHub inspect)
- Community disclaimer remains for non-Vellum skills

## Test plan
- [ ] Open Agent panel → Available tab — verify Vellum skills appear at the top with violet badge
- [ ] Filter skills by name — verify both Vellum and ClawHub results appear
- [ ] Install a Vellum skill — verify it installs from local catalog (no network call)
- [ ] Install a ClawHub skill — verify existing flow still works
- [ ] Tap a Vellum skill card — verify detail view shows "First-party" without loading spinner
- [ ] Tap a ClawHub skill card — verify detail view still loads enriched inspect data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
