### PR TITLE
M12: Fix light mode colors and remove sidebar container

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -869,15 +869,11 @@ struct MainWindowView: View {
                     }
                 )
             }
-            .padding(VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.xxl)
-                    .fill(adaptiveColor(light: Moss._50, dark: Moss._800))
-            )
-            .padding(VSpacing.sm)
+            .padding(VSpacing.lg)
+            .background(adaptiveColor(light: Moss._50, dark: Moss._800))
         }
         .frame(width: threadDrawerWidth)
-        .background(adaptiveColor(light: Stone._200, dark: Moss._950))
+        .background(adaptiveColor(light: Moss._100, dark: Moss._950))
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -103,8 +103,8 @@
   --v-text-muted:     #AEAEB2;
   --v-accent:         var(--v-forest-600);
   --v-accent-hover:   var(--v-forest-700);
-  --v-user-bubble:    var(--v-forest-800);
-  --v-user-bubble-text: #ffffff;
+  --v-user-bubble:    var(--v-moss-300);
+  --v-user-bubble-text: var(--v-stone-900);
   --v-success:        var(--v-emerald-600);
   --v-danger:         var(--v-danger-600);
   --v-warning:        var(--v-amber-600);

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -117,7 +117,9 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered ? Forest._600 : Forest._800
+            return isHovered
+                ? adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._600)
+                : adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._800)
         case .danger:
             return isHovered ? Color(hex: 0xA53817) : Color(hex: 0x8A2F13)
         case .ghost:
@@ -128,9 +130,9 @@ private struct VButtonStyle: ButtonStyle {
     private func backgroundColor(isPressed: Bool) -> Color {
         switch style {
         case .primary:
-            if isPressed { return Forest._400 }
-            if isHovered { return Forest._500 }
-            return Forest._600
+            if isPressed { return adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._400) }
+            if isHovered { return adaptiveColor(light: Color(hex: 0x5A7B54), dark: Forest._500) }
+            return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._600)
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -157,9 +157,9 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Forest._800, dark: Forest._900)
-    public static let userBubbleText = adaptiveColor(light: Color.white, dark: Moss._50)
-    public static let userBubbleTextSecondary = adaptiveColor(light: Color.white.opacity(0.8), dark: Moss._50.opacity(0.8))
+    public static let userBubble = adaptiveColor(light: Moss._300, dark: Forest._900)
+    public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
+    public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)


### PR DESCRIPTION
Fix light mode: user bubble #BDB9A9, main bg #E8E6DA, primary buttons #4B6845, remove sidebar rounded container (16px flat padding instead). Part of #5927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
