### PR TITLE
Update color palette: Moss, Forest, and Danger scales

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -697,7 +697,7 @@ struct MainWindowView: View {
                 if isSelected {
                     adaptiveColor(light: Forest._100.opacity(0.6), dark: Moss._700)
                 } else if isHovered {
-                    adaptiveColor(light: Stone._200, dark: Moss._800)
+                    adaptiveColor(light: Stone._200, dark: Moss._700)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
@@ -870,7 +870,7 @@ struct MainWindowView: View {
                 )
             }
             .padding(VSpacing.lg)
-            .background(adaptiveColor(light: Moss._50, dark: Moss._800))
+            .background(adaptiveColor(light: Moss._50, dark: Moss._700))
         }
         .frame(width: threadDrawerWidth)
         .background(adaptiveColor(light: Moss._100, dark: Moss._950))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -120,7 +120,7 @@ struct GeneratedPanel: View {
                     }
                 }
                 .padding(VSpacing.md)
-                .background(Moss._800)
+                .background(Moss._700)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
@@ -344,7 +344,7 @@ struct GeneratedPanel: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(isHovered ? Moss._800 : Moss._900)
+        .background(isHovered ? Moss._700 : Moss._900)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -80,7 +80,7 @@ struct TraceTimelineView: View {
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .foregroundColor(Amber._500)
-                        .background(Moss._800)
+                        .background(Moss._700)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.sm)
@@ -204,7 +204,7 @@ struct TraceTimelineView: View {
                 .padding(.leading, 26)
                 .padding(.vertical, VSpacing.xs)
                 .padding(.trailing, VSpacing.sm)
-                .background(Moss._800.opacity(0.5))
+                .background(Moss._700.opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -144,7 +144,7 @@ struct WakeUpStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._800.opacity(0.4)))
+                .fill(adaptiveColor(light: Stone._300.opacity(0.3), dark: Moss._700.opacity(0.4)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -34,9 +34,8 @@
   --v-stone-50:  #FAFAF9;
 
   /* ── Palette: Moss (warm neutral, dark mode) ─────────────── */
-  --v-moss-950: #262624;
+  --v-moss-950: #20201E;
   --v-moss-900: #2A2A28;
-  --v-moss-800: #2F2F2D;
   --v-moss-700: #3A3A37;
   --v-moss-600: #4A4A46;
   --v-moss-500: #6B6B65;
@@ -46,17 +45,17 @@
   --v-moss-100: #E8E6DA;
   --v-moss-50:  #F5F3EB;
 
-  /* ── Palette: Forest (green accent, dark mode) ───────────── */
-  --v-forest-950: #0A2A14;
-  --v-forest-900: #123D1F;
-  --v-forest-800: #18522A;
-  --v-forest-700: #1C5F30;
-  --v-forest-600: #216C37;
-  --v-forest-500: #3A8A4F;
-  --v-forest-400: #5AAB6A;
-  --v-forest-300: #85C991;
-  --v-forest-200: #B5E1BC;
-  --v-forest-100: #E2F4E5;
+  /* ── Palette: Forest / Sage (green accent, dark mode) ────── */
+  --v-forest-950: #1A2316;
+  --v-forest-900: #2A3825;
+  --v-forest-800: #3D4F36;
+  --v-forest-700: #516748;
+  --v-forest-600: #657D5B;
+  --v-forest-500: #7A8B6F;
+  --v-forest-400: #98A88F;
+  --v-forest-300: #B5C3AE;
+  --v-forest-200: #D4DFD0;
+  --v-forest-100: #EDF2EB;
 
   /* ── Palette: Emerald ───────────────────────────────────────── */
   --v-emerald-950: #073D2E;
@@ -71,16 +70,16 @@
   --v-emerald-100: #ECFDF5;
 
   /* ── Palette: Danger ─────────────────────────────────────────── */
-  --v-danger-950: #620F21;
-  --v-danger-900: #85142F;
-  --v-danger-800: #A8183E;
-  --v-danger-700: #D02050;
-  --v-danger-600: #E84060;
-  --v-danger-500: #F06A86;
-  --v-danger-400: #F99AAE;
-  --v-danger-300: #FCBFC9;
-  --v-danger-200: #FFE1E6;
-  --v-danger-100: #FFF1F3;
+  --v-danger-950: #4E281D;
+  --v-danger-900: #803017;
+  --v-danger-800: #AB3F1C;
+  --v-danger-700: #DA491A;
+  --v-danger-600: #E86B40;
+  --v-danger-500: #F39B74;
+  --v-danger-400: #F9C0A2;
+  --v-danger-300: #F7DAC9;
+  --v-danger-200: #FFE4D5;
+  --v-danger-100: #FFF3EE;
 
   /* ── Palette: Amber ─────────────────────────────────────────── */
   --v-amber-950: #5E3207;
@@ -156,7 +155,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --v-bg:             var(--v-moss-950);
-    --v-surface:        var(--v-moss-800);
+    --v-surface:        var(--v-moss-700);
     --v-surface-border: var(--v-moss-700);
     --v-text:           var(--v-moss-50);
     --v-text-secondary: var(--v-moss-400);

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -62,7 +62,7 @@ struct TokensGallerySection: View {
                         Stone._500, Stone._400, Stone._300, Stone._200, Stone._100
                     ])
                     colorScaleRow(name: "Moss", colors: [
-                        Moss._950, Moss._900, Moss._800, Moss._700, Moss._600,
+                        Moss._950, Moss._900, Moss._700, Moss._600,
                         Moss._500, Moss._400, Moss._300, Moss._200, Moss._100
                     ])
                     colorScaleRow(name: "Forest", colors: [

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -52,16 +52,16 @@ public enum Emerald {
 }
 
 public enum Danger {
-    public static let _950 = Color(hex: 0x620F21)
-    public static let _900 = Color(hex: 0x85142F)
-    public static let _800 = Color(hex: 0xA8183E)
-    public static let _700 = Color(hex: 0xD02050)
-    public static let _600 = Color(hex: 0xE84060)
-    public static let _500 = Color(hex: 0xF06A86)
-    public static let _400 = Color(hex: 0xF99AAE)
-    public static let _300 = Color(hex: 0xFCBFC9)
-    public static let _200 = Color(hex: 0xFFE1E6)
-    public static let _100 = Color(hex: 0xFFF1F3)
+    public static let _950 = Color(hex: 0x4E281D)
+    public static let _900 = Color(hex: 0x803017)
+    public static let _800 = Color(hex: 0xAB3F1C)
+    public static let _700 = Color(hex: 0xDA491A)
+    public static let _600 = Color(hex: 0xE86B40)
+    public static let _500 = Color(hex: 0xF39B74)
+    public static let _400 = Color(hex: 0xF9C0A2)
+    public static let _300 = Color(hex: 0xF7DAC9)
+    public static let _200 = Color(hex: 0xFFE4D5)
+    public static let _100 = Color(hex: 0xFFF3EE)
 }
 
 public enum Amber {
@@ -96,9 +96,8 @@ public enum Stone {
 
 /// Warm neutral scale for dark mode backgrounds & text.
 public enum Moss {
-    public static let _950 = Color(hex: 0x262624)
+    public static let _950 = Color(hex: 0x20201E)
     public static let _900 = Color(hex: 0x2A2A28)
-    public static let _800 = Color(hex: 0x2F2F2D)
     public static let _700 = Color(hex: 0x3A3A37)
     public static let _600 = Color(hex: 0x4A4A46)
     public static let _500 = Color(hex: 0x6B6B65)
@@ -109,18 +108,18 @@ public enum Moss {
     public static let _50  = Color(hex: 0xF5F3EB)
 }
 
-/// Forest green accent scale for dark mode.
+/// Sage green accent scale for dark mode.
 public enum Forest {
-    public static let _950 = Color(hex: 0x0A2A14)
-    public static let _900 = Color(hex: 0x123D1F)
-    public static let _800 = Color(hex: 0x18522A)
-    public static let _700 = Color(hex: 0x1C5F30)
-    public static let _600 = Color(hex: 0x216C37)
-    public static let _500 = Color(hex: 0x3A8A4F)
-    public static let _400 = Color(hex: 0x5AAB6A)
-    public static let _300 = Color(hex: 0x85C991)
-    public static let _200 = Color(hex: 0xB5E1BC)
-    public static let _100 = Color(hex: 0xE2F4E5)
+    public static let _950 = Color(hex: 0x1A2316)
+    public static let _900 = Color(hex: 0x2A3825)
+    public static let _800 = Color(hex: 0x3D4F36)
+    public static let _700 = Color(hex: 0x516748)
+    public static let _600 = Color(hex: 0x657D5B)
+    public static let _500 = Color(hex: 0x7A8B6F)
+    public static let _400 = Color(hex: 0x98A88F)
+    public static let _300 = Color(hex: 0xB5C3AE)
+    public static let _200 = Color(hex: 0xD4DFD0)
+    public static let _100 = Color(hex: 0xEDF2EB)
 }
 
 // MARK: - Semantic Color Tokens
@@ -130,7 +129,7 @@ public enum VColor {
     public static let background = adaptiveColor(light: .white, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: .white, dark: Moss._950)
-    public static let surface = adaptiveColor(light: .white, dark: Moss._800)
+    public static let surface = adaptiveColor(light: .white, dark: Moss._700)
     public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._700)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)
 

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,7 +31,7 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Moss._800)
+        .background(Moss._700)
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()


### PR DESCRIPTION
## Summary
- **Moss**: Updated `_950` hex (#262624 → #20201E), removed `_800` step (not in new palette), remapped all `Moss._800` references to `Moss._700`
- **Forest**: Replaced pure green hex values with sage-toned palette (e.g. _600: #216C37 → #657D5B)
- **Danger**: Replaced pink-red hex values with warm orange-red palette (e.g. _600: #E84060 → #E86B40)
- **CSS**: Updated all `--v-moss-*`, `--v-forest-*`, `--v-danger-*` variables to match

## Files modified
- `clients/shared/DesignSystem/Tokens/ColorTokens.swift` — scale definitions
- `clients/macos/vellum-assistant/Resources/vellum-design-system.css` — CSS variables
- 6 files with `Moss._800` references remapped to `Moss._700`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
