### PR TITLE
Set light mode chat background to #E8E6DA

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -128,7 +128,7 @@ public enum VColor {
     // Backgrounds
     public static let background = adaptiveColor(light: .white, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
-    public static let chatBackground = adaptiveColor(light: .white, dark: Moss._950)
+    public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)
     public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._700)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)


### PR DESCRIPTION
## Summary
- Change `VColor.chatBackground` light mode from `.white` to `Moss._100` (#E8E6DA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
