### PR TITLE
Fix: seamless background color in light mode

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -126,7 +126,7 @@ public enum Forest {
 
 public enum VColor {
     // Backgrounds
-    public static let background = adaptiveColor(light: .white, dark: Moss._950)
+    public static let background = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let backgroundSubtle = adaptiveColor(light: Stone._100, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)


### PR DESCRIPTION
## Summary
- Change `VColor.background` light mode from `.white` to `Moss._100` (#E8E6DA)
- This makes the entire window background match the chat area, eliminating the white gap behind the floating sidebar panel and top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
