### PR TITLE
M3: Update VIconButton radius and icon colors

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -77,15 +77,15 @@ private struct VIconButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .foregroundColor(isActive ? VColor.textPrimary : VColor.textSecondary)
+            .foregroundColor(VColor.iconAccent)
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.buttonV)
             .background(backgroundColor(isPressed: configuration.isPressed))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
             .overlay(
-                RoundedRectangle(cornerRadius: VRadius.pill)
-                    .stroke(isActive ? VColor.textSecondary : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(isActive ? VColor.iconAccent : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
             )
             .animation(VAnimation.fast, value: configuration.isPressed)
             .animation(VAnimation.fast, value: isHovered)
@@ -95,7 +95,7 @@ private struct VIconButtonStyle: ButtonStyle {
         if isActive {
             if isPressed { return VColor.ghostPressed }
             if isHovered { return VColor.ghostHover }
-            return VColor.surfaceBorder
+            return VColor.buttonTertiaryBackground
         } else {
             if isPressed { return VColor.ghostPressed }
             if isHovered { return VColor.ghostHover }


### PR DESCRIPTION
Change VIconButton from VRadius.pill to VRadius.lg, update foreground color to VColor.iconAccent (#4B6845), update active state background to use buttonTertiaryBackground. Part of #6856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
