### PR TITLE
Rename VButton styles: ghost→tertiary, tertiary→secondary

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -718,7 +718,7 @@ struct DynamicWorkspaceWrapper: View {
                         }
                         .controlSize(.small)
                     } else {
-                        VButton(label: "Edit", icon: "pencil", style: .ghost) {
+                        VButton(label: "Edit", icon: "pencil", style: .tertiary) {
                             if !isChatDockOpen {
                                 windowState.workspaceComposerExpanded = false
                             }
@@ -741,10 +741,10 @@ struct DynamicWorkspaceWrapper: View {
 
                     Spacer()
 
-                    // Right: History + Share + Close ghost buttons
+                    // Right: History + Share + Close tertiary buttons
                     HStack(spacing: VSpacing.sm) {
                         if data.appId != nil {
-                            VButton(label: "History", icon: "clock.arrow.circlepath", style: .ghost) {
+                            VButton(label: "History", icon: "clock.arrow.circlepath", style: .tertiary) {
                                 showVersionHistory = true
                             }
                             .controlSize(.small)
@@ -756,19 +756,19 @@ struct DynamicWorkspaceWrapper: View {
                                 .controlSize(.small)
                                 .frame(height: 24)
                         } else if let url = publishedUrl {
-                            VButton(label: "Copied!", icon: "checkmark", style: .ghost) {
+                            VButton(label: "Copied!", icon: "checkmark", style: .tertiary) {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(url, forType: .string)
                             }
                             .controlSize(.small)
                         } else {
-                            VButton(label: "Publish", icon: "arrow.up.right", style: .ghost) {
+                            VButton(label: "Publish", icon: "arrow.up.right", style: .tertiary) {
                                 onPublishPage(data.html, data.preview?.title, data.appId)
                             }
                             .controlSize(.small)
                         }
 
-                        VButton(label: "X", style: .ghost) {
+                        VButton(label: "X", style: .tertiary) {
                             showSharePicker = false
                             windowState.activeDynamicSurface = nil
                             windowState.activeDynamicParsedSurface = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -23,7 +23,7 @@ struct AppVersionHistoryPanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack {
-                VButton(label: "Back", icon: "chevron.left", style: .ghost) {
+                VButton(label: "Back", icon: "chevron.left", style: .tertiary) {
                     onClose()
                 }
                 .controlSize(.small)
@@ -195,7 +195,7 @@ struct AppVersionHistoryPanel: View {
                 Spacer()
 
                 if !isRestoring && version.commitHash != versions.first?.commitHash {
-                    VButton(label: "Restore", icon: "arrow.counterclockwise", style: .ghost) {
+                    VButton(label: "Restore", icon: "arrow.counterclockwise", style: .tertiary) {
                         restoreConfirmVersion = version
                     }
                     .controlSize(.small)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1053,7 +1053,7 @@ struct SettingsPanel: View {
                                 .foregroundColor(VColor.textMuted)
                         }
                         Spacer()
-                        VButton(label: "Manage...", style: .ghost) {
+                        VButton(label: "Manage...", style: .tertiary) {
                             daemonClient?.isTrustRulesSheetOpen = true
                             showingTrustRules = true
                         }
@@ -1110,7 +1110,7 @@ struct SettingsPanel: View {
                                 .foregroundColor(VColor.textMuted)
                         }
                         Spacer()
-                        VButton(label: "Manage...", style: .ghost) {
+                        VButton(label: "Manage...", style: .tertiary) {
                             showingReminders = true
                         }
                     }
@@ -1491,7 +1491,7 @@ struct SettingsPanelEnvVarsSheet: View {
                     .font(VFont.headline)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
-                VButton(label: "Done", style: .ghost) { dismiss() }
+                VButton(label: "Done", style: .tertiary) { dismiss() }
             }
             .padding(VSpacing.lg)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesBriefingView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesBriefingView.swift
@@ -67,7 +67,7 @@ struct CapabilitiesBriefingView: View {
 
                             OnboardingButton(
                                 title: "See what I can do",
-                                style: .ghost,
+                                style: .tertiary,
                                 fadeIn: true,
                                 fadeDelay: 0.3
                             ) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
@@ -172,15 +172,15 @@ private struct JITPermissionManagerPreviewWrapper: View {
                 .foregroundColor(VColor.textSecondary)
 
             HStack(spacing: VSpacing.md) {
-                OnboardingButton(title: "Request Mic", style: .ghost) {
+                OnboardingButton(title: "Request Mic", style: .tertiary) {
                     manager.isActive = true
                     _ = manager.requestIfNeeded(.microphone)
                 }
-                OnboardingButton(title: "Request A11y", style: .ghost) {
+                OnboardingButton(title: "Request A11y", style: .tertiary) {
                     manager.isActive = true
                     _ = manager.requestIfNeeded(.accessibility)
                 }
-                OnboardingButton(title: "Request Screen", style: .ghost) {
+                OnboardingButton(title: "Request Screen", style: .tertiary) {
                     manager.isActive = true
                     _ = manager.requestIfNeeded(.screenCapture)
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
@@ -78,7 +78,7 @@ struct ObservationModeView: View {
 
                             OnboardingButton(
                                 title: "Skip for now",
-                                style: .ghost,
+                                style: .tertiary,
                                 fadeIn: true,
                                 fadeDelay: 0.3
                             ) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
@@ -133,7 +133,7 @@ struct ObservationSessionView: View {
                     // Stop early button
                     OnboardingButton(
                         title: "Stop early",
-                        style: .ghost
+                        style: .tertiary
                     ) {
                         stopObservation()
                         onStopEarly()

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
@@ -103,7 +103,7 @@ struct ObservationSummaryView: View {
 
                             OnboardingButton(
                                 title: "Maybe later",
-                                style: .ghost,
+                                style: .tertiary,
                                 fadeIn: true,
                                 fadeDelay: 0.3
                             ) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 enum OnboardingButtonStyle {
     case primary
-    case ghost
+    case tertiary
 }
 
 struct OnboardingButton: View {
@@ -29,7 +29,7 @@ struct OnboardingButton: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(borderColor, lineWidth: style == .ghost ? 1 : 0)
+                        .stroke(borderColor, lineWidth: style == .tertiary ? 1 : 0)
                 )
         }
         .buttonStyle(.plain)
@@ -58,7 +58,7 @@ struct OnboardingButton: View {
         switch style {
         case .primary:
             return disabled ? Color.white.opacity(0.4) : .white
-        case .ghost:
+        case .tertiary:
             return disabled ? VColor.textPrimary.opacity(0.3) : VColor.textPrimary.opacity(0.85)
         }
     }
@@ -67,13 +67,13 @@ struct OnboardingButton: View {
         switch style {
         case .primary:
             return AnyShapeStyle(disabled ? VColor.accent.opacity(0.3) : VColor.accent)
-        case .ghost:
+        case .tertiary:
             return AnyShapeStyle(Color.clear)
         }
     }
 
     private var borderColor: Color {
-        style == .ghost ? VColor.textPrimary.opacity(disabled ? 0.1 : 0.25) : .clear
+        style == .tertiary ? VColor.textPrimary.opacity(disabled ? 0.1 : 0.25) : .clear
     }
 
     private var opacity: Double {
@@ -86,7 +86,7 @@ struct OnboardingButton: View {
         VColor.background
         VStack(spacing: VSpacing.xl) {
             OnboardingButton(title: "Say hello", style: .primary) {}
-            OnboardingButton(title: "Skip", style: .ghost) {}
+            OnboardingButton(title: "Skip", style: .tertiary) {}
             OnboardingButton(title: "Disabled", style: .primary, disabled: true) {}
         }
         .frame(width: 300)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -614,7 +614,7 @@ struct SettingsAdvancedTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                     Spacer()
-                    VButton(label: "View...", style: .ghost) {
+                    VButton(label: "View...", style: .tertiary) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
                             .map { ($0.key, $0.value) }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -115,7 +115,7 @@ struct SettingsAppearanceTab: View {
 
                     HStack {
                         Spacer()
-                        VButton(label: "Reset to Defaults", style: .ghost) {
+                        VButton(label: "Reset to Defaults", style: .tertiary) {
                             store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
@@ -20,7 +20,7 @@ struct SkillDeleteConfirmView: View {
             }
 
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Cancel", style: .ghost) {
+                VButton(label: "Cancel", style: .tertiary) {
                     onCancel()
                 }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
@@ -40,7 +40,7 @@ struct FileUploadSurfaceView: View {
             HStack(spacing: VSpacing.lg) {
                 Spacer()
 
-                VButton(label: "Cancel", style: .ghost) {
+                VButton(label: "Cancel", style: .tertiary) {
                     onCancel()
                 }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -217,7 +217,7 @@ struct SecretPromptView: View {
                     // Buttons
                     HStack(spacing: VSpacing.lg) {
                         Spacer()
-                        VButton(label: "Cancel", style: .ghost) {
+                        VButton(label: "Cancel", style: .tertiary) {
                             onCancel()
                         }
                         VButton(label: "Save", style: .primary) {
@@ -235,7 +235,7 @@ struct SecretPromptView: View {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .font(.system(size: 10))
                                 .foregroundColor(VColor.warning)
-                            VButton(label: "Send Once (not saved)", style: .ghost) {
+                            VButton(label: "Send Once (not saved)", style: .tertiary) {
                                 let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
                                 guard !trimmed.isEmpty else { return }
                                 _ = onSendOnce(trimmed)

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -136,7 +136,7 @@ struct SurfaceContainerView: View {
     private func buttonStyle(for style: SurfaceActionStyle) -> VButton.Style {
         switch style {
         case .primary: return .primary
-        case .secondary: return .ghost
+        case .secondary: return .tertiary
         case .destructive: return .danger
         }
     }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -4,7 +4,7 @@ import AppKit
 #endif
 
 public struct VButton: View {
-    public enum Style: Hashable { case primary, ghost, tertiary, danger }
+    public enum Style: Hashable { case primary, secondary, tertiary, danger }
     public enum Size: Hashable { case small, medium, large }
 
     public let label: String
@@ -95,7 +95,7 @@ private struct VButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(borderColor(isPressed: configuration.isPressed), lineWidth: style == .ghost ? 1 : 0)
+                    .stroke(borderColor(isPressed: configuration.isPressed), lineWidth: style == .tertiary ? 1 : 0)
             )
             .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
             .shadow(color: configuration.isPressed ? .clear : shadowColor, radius: 0, x: 0, y: 2)
@@ -128,9 +128,9 @@ private struct VButtonStyle: ButtonStyle {
                 : adaptiveColor(light: Color(hex: 0x3D5739), dark: Forest._800)
         case .danger:
             return isHovered ? Color(hex: 0xA53817) : Color(hex: 0x8A2F13)
-        case .ghost:
-            return .clear
         case .tertiary:
+            return .clear
+        case .secondary:
             return .clear
         }
     }
@@ -141,7 +141,7 @@ private struct VButtonStyle: ButtonStyle {
             if isPressed { return VColor.buttonPrimaryPressed }
             if isHovered { return VColor.buttonPrimaryHover }
             return VColor.buttonPrimary
-        case .tertiary:
+        case .secondary:
             if isPressed { return VColor.ghostPressed }
             if isHovered { return adaptiveColor(light: Forest._200, dark: Forest._800) }
             return VColor.buttonTertiaryBackground
@@ -149,7 +149,7 @@ private struct VButtonStyle: ButtonStyle {
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }
             return Color(hex: 0xC1421B)
-        case .ghost:
+        case .tertiary:
             if isPressed { return VColor.ghostPressed }
             if isHovered { return VColor.ghostHover }
             return .clear
@@ -159,18 +159,18 @@ private struct VButtonStyle: ButtonStyle {
     private var foregroundColor: Color {
         switch style {
         case .primary: return .white
-        case .ghost: return VColor.buttonSecondaryText
-        case .tertiary: return VColor.iconAccent
+        case .tertiary: return VColor.buttonSecondaryText
+        case .secondary: return VColor.iconAccent
         case .danger: return .white
         }
     }
 
     private func borderColor(isPressed: Bool) -> Color {
         switch style {
-        case .ghost:
+        case .tertiary:
             if isPressed { return VColor.ghostPressed }
             return VColor.buttonSecondaryBorder
-        case .tertiary:
+        case .secondary:
             return .clear
         default:
             return .clear
@@ -185,13 +185,13 @@ private struct VButtonStyle: ButtonStyle {
             VButton(label: "Small", style: .primary, size: .small) {}
             VButton(label: "Medium", style: .primary, size: .medium) {}
             VButton(label: "Large", style: .primary, size: .large) {}
-            VButton(label: "Ghost Small", style: .ghost, size: .small) {}
-            VButton(label: "Ghost Large", style: .ghost, size: .large) {}
-            VButton(label: "Tertiary", style: .tertiary, size: .small) {}
-            VButton(label: "Tertiary Medium", style: .tertiary, size: .medium) {}
+            VButton(label: "Tertiary Small", style: .tertiary, size: .small) {}
+            VButton(label: "Tertiary Large", style: .tertiary, size: .large) {}
+            VButton(label: "Secondary", style: .secondary, size: .small) {}
+            VButton(label: "Secondary Medium", style: .secondary, size: .medium) {}
             VButton(label: "With Left Icon", leftIcon: "plus", style: .primary, size: .small) {}
-            VButton(label: "With Right Icon", rightIcon: "arrow.right", style: .ghost, size: .small) {}
-            VButton(label: "Both Icons", leftIcon: "star", rightIcon: "chevron.right", style: .tertiary, size: .medium) {}
+            VButton(label: "With Right Icon", rightIcon: "arrow.right", style: .tertiary, size: .small) {}
+            VButton(label: "Both Icons", leftIcon: "star", rightIcon: "chevron.right", style: .secondary, size: .medium) {}
             VButton(label: "Legacy Icon", icon: "gear", style: .primary, size: .small) {}
             VButton(label: "Full Width", style: .primary, isFullWidth: true) {}
         }

--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -52,7 +52,7 @@ public struct VToast: View {
             if primaryAction != nil || secondaryAction != nil || onDismiss != nil {
                 HStack(spacing: VSpacing.sm) {
                     if let secondary = secondaryAction {
-                        VButton(label: secondary.label, style: .ghost, action: secondary.action)
+                        VButton(label: secondary.label, style: .tertiary, action: secondary.action)
                     }
                     if let primary = primaryAction {
                         VButton(label: primary.label, style: actionButtonStyle, action: primary.action)

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -22,8 +22,8 @@ struct ButtonsGallerySection: View {
                     HStack(spacing: VSpacing.xl) {
                         Picker("Style", selection: $selectedStyle) {
                             Text("Primary").tag(VButton.Style.primary)
-                            Text("Ghost").tag(VButton.Style.ghost)
                             Text("Tertiary").tag(VButton.Style.tertiary)
+                            Text("Secondary").tag(VButton.Style.secondary)
                             Text("Danger").tag(VButton.Style.danger)
                         }
                         .pickerStyle(.segmented)
@@ -52,7 +52,7 @@ struct ButtonsGallerySection: View {
 
             VCard {
                 HStack(spacing: VSpacing.xl) {
-                    ForEach([VButton.Style.primary, .ghost, .tertiary, .danger], id: \.self) { style in
+                    ForEach([VButton.Style.primary, .tertiary, .secondary, .danger], id: \.self) { style in
                         VStack(spacing: VSpacing.md) {
                             VButton(label: styleName(style), style: style) {}
                             VButton(label: "Disabled", style: style, isDisabled: true) {}
@@ -148,8 +148,8 @@ struct ButtonsGallerySection: View {
     private func styleName(_ style: VButton.Style) -> String {
         switch style {
         case .primary: return "Primary"
-        case .ghost: return "Ghost"
         case .tertiary: return "Tertiary"
+        case .secondary: return "Secondary"
         case .danger: return "Danger"
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -112,11 +112,11 @@ public struct ToolConfirmationBubble: View {
                     #endif
                 }
 
-                VButton(label: "I\u{2019}ve granted it", style: .ghost) {
+                VButton(label: "I\u{2019}ve granted it", style: .tertiary) {
                     onAllow()
                 }
 
-                VButton(label: "Skip", style: .ghost) {
+                VButton(label: "Skip", style: .tertiary) {
                     onDeny()
                 }
             }

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -54,7 +54,7 @@ public struct ConfirmationSurfaceView: View {
 
                 VButton(
                     label: data.cancelLabel ?? "Cancel",
-                    style: .ghost
+                    style: .tertiary
                 ) {
                     onAction(cancelActionId)
                 }

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -107,7 +107,7 @@ public struct FormSurfaceView: View {
             if currentPage > 0 {
                 VButton(
                     label: data.pageLabels?.back ?? "Back",
-                    style: .ghost
+                    style: .tertiary
                 ) {
                     withAnimation(VAnimation.fast) {
                         currentPageIndex -= 1


### PR DESCRIPTION
Rename button style variants to match design spec naming: the outlined border style (formerly .ghost) is now .tertiary, and the subtle green background style (formerly .tertiary) is now .secondary. Updates all ~35 call sites across the codebase. Part of #6853.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
