### PR TITLE
refactor: use VButton .secondary for Control Center row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1158,38 +1158,19 @@ private struct SidebarThreadsHeader: View {
 
 private struct ControlCenterRow: View {
     let onToggle: () -> Void
-    @State private var isHovered = false
-
-    private let iconColor = adaptiveColor(light: Forest._700, dark: Forest._500)
-    private let textColor = adaptiveColor(light: Forest._800, dark: Forest._400)
-    private let chevronColor = adaptiveColor(light: Forest._700, dark: Forest._500)
-    private let bgColor = adaptiveColor(light: Forest._200, dark: Moss._700)
 
     var body: some View {
-        Button(action: onToggle) {
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(iconColor)
-                    .frame(width: 18)
-                Text("Control Center")
-                    .font(VFont.body)
-                    .foregroundColor(textColor)
-                Spacer()
-                Image(systemName: "chevron.up")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(chevronColor)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.md)
-            .background(bgColor.opacity(isHovered ? 1.0 : 0.85))
-            .clipShape(Capsule())
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
+        VButton(
+            label: "Control Center",
+            leftIcon: "gearshape",
+            rightIcon: "chevron.up",
+            style: .secondary,
+            size: .medium,
+            isFullWidth: true,
+            action: onToggle
+        )
         .padding(.horizontal, VSpacing.sm)
         .padding(.bottom, VSpacing.sm)
-        .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
Replaces the custom ControlCenterRow button implementation with a VButton using the .secondary style variant, leftIcon gearshape, and rightIcon chevron.up. Removes manual color definitions, hover state management, and capsule shape in favor of the design system component.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
