### PR TITLE
fix: blob avatar compile error — missing diameter variable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
@@ -212,6 +212,7 @@ enum PixelSpriteBuilder {
         context.strokePath()
 
         // Eyes: white sclera with dark pupils
+        let diameter = nominalRadius * 2.0
         let eyeOuterRadius = diameter * 0.10
         let pupilRadius = diameter * 0.055
         let eyeY = centerY + blobRadius * 0.08  // slightly above center


### PR DESCRIPTION
PR #6866 removed the diameter local variable when refactoring the canvas sizing but left three references to it in the eye positioning code (eyeOuterRadius, pupilRadius, eyeSpacing). Restores it as a computed value from nominalRadius.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
