### PR TITLE
Chat UI: remove assistant container, avatar on latest message, user bubble color

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -15,6 +15,7 @@ struct ChatBubble: View {
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var daemonHttpPort: Int?
+    var isLatestAssistantMessage: Bool = false
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
@@ -56,7 +57,7 @@ struct ChatBubble: View {
         } else if message.isError {
             AnyShapeStyle(VColor.error.opacity(0.1))
         } else {
-            AnyShapeStyle(VColor.surface)
+            AnyShapeStyle(Color.clear)
         }
     }
 
@@ -65,16 +66,14 @@ struct ChatBubble: View {
         if message.isError {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .strokeBorder(VColor.error.opacity(0.3), lineWidth: 1)
-        } else if !isUser {
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .strokeBorder(VColor.surfaceBorder.opacity(0.85), lineWidth: 0.5)
         }
     }
 
     private func bubbleChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.md)
+        let isPlainAssistant = !isUser && !message.isError
+        return content()
+            .padding(.horizontal, isPlainAssistant ? 0 : VSpacing.lg)
+            .padding(.vertical, isPlainAssistant ? 0 : VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .fill(bubbleFill)
@@ -139,7 +138,7 @@ struct ChatBubble: View {
             // Inner HStack: avatar/button and bubble are grouped so the button
             // is always immediately adjacent to the bubble, not the screen edge.
             HStack(alignment: .top, spacing: VSpacing.sm) {
-                if !isUser {
+                if !isUser && isLatestAssistantMessage {
                     Image(nsImage: appearance.chatAvatarImage)
                         .interpolation(.none)
                         .resizable()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -457,7 +457,8 @@ struct ChatView: View {
                                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                                 onReportMessage: onReportMessage,
                                 mediaEmbedSettings: mediaEmbedSettings,
-                                daemonHttpPort: daemonHttpPort
+                                daemonHttpPort: daemonHttpPort,
+                                isLatestAssistantMessage: message.role == .assistant && displayMessages.last(where: { $0.role == .assistant })?.id == message.id
                             )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -159,7 +159,7 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Moss._300, dark: Forest._900)
+    public static let userBubble = adaptiveColor(light: Moss._200, dark: Forest._900)
     public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))
 


### PR DESCRIPTION
- User bubble color changed to #D4D1C1 (Moss._200 light)
- Assistant messages no longer have a bubble container (no background fill, no border, no padding)
- Avatar only shows beside the latest assistant message (and thinking indicator)
- Error messages retain their error styling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
