### PR TITLE
Thread list: selected thread background #E8E6DA

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -692,7 +692,7 @@ struct MainWindowView: View {
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected {
-                    adaptiveColor(light: Forest._100.opacity(0.6), dark: Moss._700)
+                    adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700)
                 } else if isHovered {
                     adaptiveColor(light: Stone._200, dark: Moss._700)
                 } else if thread.kind == .private {


### PR DESCRIPTION
- Selected thread tab now uses #E8E6DA (Moss._100) in light mode
- Dark mode uses Moss._700 (unchanged)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
