### PR TITLE
VButton: icons at opposite ends in full-width mode

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -38,6 +38,9 @@ public struct VButton: View {
                 }
                 Text(label)
                     .font(labelFont)
+                if isFullWidth && (leftIcon != nil || rightIcon != nil) {
+                    Spacer(minLength: 0)
+                }
                 if let rightIcon {
                     Image(systemName: rightIcon)
                         .font(.system(size: iconSize, weight: .semibold))


### PR DESCRIPTION
- When isFullWidth is set and icons are present, a Spacer pushes the right icon to the trailing edge
- Text stays left-aligned next to the left icon
- Matches the Control Center button layout from Figma
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
