### PR TITLE
Secondary button: #D4D1C1 background, medium-weight text, color adjustments

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -75,7 +75,7 @@ public struct VButton: View {
     private var labelFont: Font {
         switch size {
         case .small: return VFont.monoSmall
-        case .medium: return VFont.monoSmall
+        case .medium: return VFont.monoBodyMedium
         case .large: return VFont.monoMedium
         }
     }
@@ -145,8 +145,8 @@ private struct VButtonStyle: ButtonStyle {
             if isHovered { return VColor.buttonPrimaryHover }
             return VColor.buttonPrimary
         case .secondary:
-            if isPressed { return VColor.ghostPressed }
-            if isHovered { return adaptiveColor(light: Forest._200, dark: Forest._800) }
+            if isPressed { return adaptiveColor(light: Moss._300, dark: Moss._600) }
+            if isHovered { return adaptiveColor(light: Moss._300, dark: Moss._600) }
             return VColor.buttonTertiaryBackground
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
@@ -163,7 +163,7 @@ private struct VButtonStyle: ButtonStyle {
         switch style {
         case .primary: return .white
         case .tertiary: return VColor.buttonSecondaryText
-        case .secondary: return VColor.iconAccent
+        case .secondary: return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
         case .danger: return .white
         }
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -180,5 +180,5 @@ public enum VColor {
     public static let buttonPrimaryPressed = adaptiveColor(light: Color(hex: 0x3D5739), dark: Color(hex: 0x3D5739))
     public static let buttonSecondaryBorder = adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._500)
     public static let buttonSecondaryText = adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
-    public static let buttonTertiaryBackground = adaptiveColor(light: Forest._100, dark: Forest._900)
+    public static let buttonTertiaryBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
 }

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -85,6 +85,7 @@ public enum VFont {
     public static let onboardingEmoji = Font.system(size: adaptiveSize(80))
     public static let mono       = dmMono("DMMono-Regular", size: 13)
     public static let monoSmall  = dmMono("DMMono-Regular", size: 11)
+    public static let monoBodyMedium = dmMono("DMMono-Medium", size: 13)
     public static let monoMedium = dmMono("DMMono-Medium", size: 16)
 
     /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")


### PR DESCRIPTION
## Summary
- Changed secondary button background to #D4D1C1 (Moss._200) in light mode, Moss._700 in dark mode
- Added `VFont.monoBodyMedium` (13pt DMMono-Medium) for medium-size button labels — matches icon size and adds medium weight
- Adjusted secondary button hover/pressed states to Moss tones instead of Forest
- Updated secondary button text color: dark green (#4B6845) in light, Forest._400 in dark

## Test plan
- [ ] Verify Control Center button matches Figma screenshots in both light and dark mode
- [ ] Check secondary button text is same size as icons
- [ ] Confirm hover/pressed states feel natural
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
