### PR TITLE
fix: handle truncated frontmatter in CC command summary extraction

### DIFF
--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -276,6 +276,33 @@ describe('summary extraction', () => {
     expect(entry!.summary).toBe('');
   });
 
+  test('returns empty summary when frontmatter is truncated by partial read', () => {
+    // Simulate frontmatter that exceeds SUMMARY_READ_BYTES (1024).
+    // The closing --- delimiter will be cut off, causing FRONTMATTER_REGEX to
+    // fail. extractSummary should return '' instead of '---'.
+    const largeFrontmatter = '---\n' + 'key: ' + 'x'.repeat(1100) + '\n---\n\nActual summary.';
+    createCommandsDir(tmpDir, {
+      'big-frontmatter.md': largeFrontmatter,
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const entry = registry.entries.get('big-frontmatter');
+    expect(entry).toBeDefined();
+    expect(entry!.summary).toBe('');
+  });
+
+  test('returns empty summary when frontmatter is truncated (CRLF)', () => {
+    const largeFrontmatter = '---\r\n' + 'key: ' + 'x'.repeat(1100) + '\r\n---\r\n\r\nActual summary.';
+    createCommandsDir(tmpDir, {
+      'big-frontmatter-crlf.md': largeFrontmatter,
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const entry = registry.entries.get('big-frontmatter-crlf');
+    expect(entry).toBeDefined();
+    expect(entry!.summary).toBe('');
+  });
+
   test('handles frontmatter with Windows-style line endings', () => {
     createCommandsDir(tmpDir, {
       'crlf.md': '---\r\ntitle: Test\r\n---\r\n\r\nSummary with CRLF.',

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -80,6 +80,11 @@ function extractSummary(content: string): string {
   const fmMatch = content.match(FRONTMATTER_REGEX);
   if (fmMatch) {
     body = content.slice(fmMatch[0].length);
+  } else if (/^---\r?\n/.test(content)) {
+    // Content starts with a frontmatter opening delimiter but the closing
+    // delimiter was not found — the frontmatter was truncated by the partial
+    // read (SUMMARY_READ_BYTES). Return empty rather than surfacing "---".
+    return '';
   }
 
   // Find first non-empty line


### PR DESCRIPTION
## Summary
- When YAML frontmatter exceeds the 1024-byte `SUMMARY_READ_BYTES` limit, `readFileHead` truncates the content before the closing `---` delimiter, causing `FRONTMATTER_REGEX` to fail and `extractSummary` to return `"---"` (the opening delimiter) as the summary.
- Added an early return of `''` when the content starts with `---` but the frontmatter regex does not match, indicating truncated frontmatter.
- Added two regression tests (LF and CRLF variants) that create files with frontmatter exceeding 1024 bytes and verify the summary is empty.

Addresses Codex P2 + Devin feedback on PR #5509.

## Test plan
- [x] Existing tests pass (24/24)
- [x] New test: truncated frontmatter (LF) returns empty summary
- [x] New test: truncated frontmatter (CRLF) returns empty summary
- [x] Normal frontmatter files still extract summaries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
