### PR TITLE
fix: prefer bundled WASM over cwd lookup in compiled binaries

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -89,23 +89,32 @@ const initGuard = new PromiseGuard<void>();
  */
 function findWasmPath(pkg: string, file: string): string {
   const dir = import.meta.dirname ?? __dirname;
-  const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
 
-  if (existsSync(sourcePath)) return sourcePath;
-
-  // Fallback: resolve from process.cwd() (the assistant/ directory).
-  // import.meta.dirname can resolve unexpectedly in compiled/daemon contexts.
-  const cwdPath = join(process.cwd(), 'node_modules', pkg, file);
-  if (existsSync(cwdPath)) return cwdPath;
-
+  // In compiled Bun binaries, import.meta.dirname points into the virtual
+  // /$bunfs/ filesystem.  Prefer bundled WASM assets shipped alongside the
+  // executable before falling back to process.cwd(), so we never accidentally
+  // pick up a mismatched version from the working directory.
   if (dir.startsWith('/$bunfs/')) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(execDir, '..', 'Resources', file);
     if (existsSync(resourcesPath)) return resourcesPath;
-    // Fallback: next to the binary itself (non-app-bundle deployments)
-    return join(execDir, file);
+    // Next to the binary itself (non-app-bundle deployments)
+    const execDirPath = join(execDir, file);
+    if (existsSync(execDirPath)) return execDirPath;
+    // Last resort: resolve from process.cwd() (the assistant/ directory)
+    const cwdPath = join(process.cwd(), 'node_modules', pkg, file);
+    if (existsSync(cwdPath)) return cwdPath;
+    return execDirPath;
   }
+
+  const sourcePath = join(dir, '..', '..', '..', 'node_modules', pkg, file);
+
+  if (existsSync(sourcePath)) return sourcePath;
+
+  // Fallback: resolve from process.cwd() (the assistant/ directory).
+  const cwdPath = join(process.cwd(), 'node_modules', pkg, file);
+  if (existsSync(cwdPath)) return cwdPath;
 
   return sourcePath;
 }


### PR DESCRIPTION
## Summary
- Reorders WASM path resolution in `findWasmPath` so bundled assets (Resources/execDir) are checked **before** `process.cwd()/node_modules` when running in compiled Bun binaries (`import.meta.dirname` under `/$bunfs/`)
- Prevents version mismatch and checksum verification failures when the daemon is launched from a directory containing different `web-tree-sitter` or `tree-sitter-bash` versions
- Addresses Codex P2 feedback on PR #6128

## Test plan
- [ ] Verify compiled binary finds bundled WASM from Resources/ or execDir before checking cwd
- [ ] Verify development mode (non-compiled) still resolves WASM from node_modules correctly
- [ ] Verify fallback to process.cwd() still works when bundled assets are missing

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
