### PR TITLE
fix: avatar evolution breathing animation and emoji color locking

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/DeterministicEvolutionEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/DeterministicEvolutionEngine.swift
@@ -149,6 +149,7 @@ enum DeterministicEvolutionEngine {
             if emojis.contains(where: { emoji.contains($0) }) {
                 if !state.lockedFields.contains(.bodyColor) {
                     state.userOverrides[.bodyColor] = color
+                    state.lockedFields.insert(.bodyColor)
                 }
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/EvolvingAvatarView.swift
@@ -49,9 +49,12 @@ struct EvolvingAvatarView: View {
                 withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
                     appeared = true
                 }
-                startBreathing()
             } else {
                 appeared = true
+            }
+            let breatheDelay: Double = animated ? 0.6 : 0.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + breatheDelay) {
+                startBreathing()
             }
         }
     }


### PR DESCRIPTION
## Summary
Addresses remaining unresolved feedback from PR #4682 (avatar evolution during onboarding):

- **EvolvingAvatarView**: Always starts idle breathing animation regardless of the `animated` flag. Previously, when `animated: false` (as used in `FirstMeetingIntroductionView`), `startBreathing()` was never called, leaving the avatar static. The `animated` flag now only controls the entrance spring — breathing runs unconditionally with a delay matching the spring duration when animated.
- **DeterministicEvolutionEngine**: Locks the `bodyColor` field after applying an emoji color hint via `applyEmojiColorHint`. Without locking, subsequent trait-driven resolution (e.g., from warmth score changes) could silently overwrite the emoji-derived body color.

### Items from the review that were NOT applicable:
- **Slang detection** (`ModelTraitInferenceService.swift`): File was deleted from the codebase before PR #4682 merged. No fix needed.
- **Milestone propagation**: Already fixed in the current code — `applyConversationMilestones` calls `AvatarEvolutionResolver.resolve()` + `AvatarAppearanceManager.shared.applyEvolutionResult()` at lines 192-193 of `FirstMeetingIntroductionView.swift`.

## Test plan
- [ ] Launch app with fresh onboarding state; verify the avatar blob has idle breathing animation on the FirstMeeting screen (where `animated: false`)
- [ ] Choose an emoji during onboarding; verify body color updates to the emoji-derived color
- [ ] After emoji color is applied, verify subsequent personality trait changes do not override the body color
- [ ] Verify the entrance spring animation still works on screens using `animated: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
