### PR TITLE
fix: route CC slash commands via command input for template execution

### DIFF
--- a/assistant/src/config/bundled-skills/claude-code/TOOLS.json
+++ b/assistant/src/config/bundled-skills/claude-code/TOOLS.json
@@ -11,7 +11,15 @@
         "properties": {
           "prompt": {
             "type": "string",
-            "description": "The coding task or question for Claude Code to work on"
+            "description": "The coding task or question for Claude Code to work on. Use this for free-form tasks. Mutually exclusive with command."
+          },
+          "command": {
+            "type": "string",
+            "description": "Name of a .claude/commands/*.md command template to execute. The template will be loaded and $ARGUMENTS substituted before execution. Use this instead of prompt when invoking a named CC command."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "Arguments to substitute into the command template ($ARGUMENTS placeholder). Only used with the command input."
           },
           "working_dir": {
             "type": "string",
@@ -30,8 +38,7 @@
             "enum": ["general", "researcher", "coder", "reviewer"],
             "description": "Worker profile that scopes tool access. Defaults to general (backward compatible)."
           }
-        },
-        "required": ["prompt"]
+        }
       },
       "executor": "tools/claude-code.ts",
       "execution_target": "host"

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -155,6 +155,10 @@ export function formatUnknownSlashSkillMessage(
 /**
  * Rewrite user input for a known slash command into a model-facing prompt
  * that explicitly instructs the model to invoke the skill.
+ *
+ * For the claude-code skill, trailing arguments are routed via the `command`
+ * input (not `prompt`) so that .claude/commands/*.md templates are loaded
+ * and $ARGUMENTS substitution is applied.
  */
 export function rewriteKnownSlashCommandPrompt(params: {
   rawInput: string;
@@ -162,6 +166,25 @@ export function rewriteKnownSlashCommandPrompt(params: {
   skillName: string;
   trailingArgs: string;
 }): string {
+  // For the claude-code skill, route trailing args through the `command` input
+  // so CC command templates (.claude/commands/*.md) are loaded and $ARGUMENTS
+  // substitution is applied, rather than sending them as a raw prompt.
+  if (params.skillId === 'claude-code' && params.trailingArgs) {
+    // Extract the command name (first word of trailing args) and remaining arguments
+    const parts = params.trailingArgs.split(/\s+/);
+    const commandName = parts[0];
+    const commandArgs = parts.slice(1).join(' ');
+
+    const lines = [
+      `The user invoked the slash command \`/${params.skillId}\`.`,
+      `Execute the Claude Code command "${commandName}" using the claude_code tool with command="${commandName}".`,
+    ];
+    if (commandArgs) {
+      lines.push(`Pass the following as the \`arguments\` input: ${commandArgs}`);
+    }
+    return lines.join('\n');
+  }
+
   const lines = [
     `The user invoked the slash command \`/${params.skillId}\`.`,
     `Please invoke the "${params.skillName}" skill (ID: ${params.skillId}).`,

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -6,6 +6,7 @@ import { getLogger } from '../../util/logger.js';
 import { truncate } from '../../util/truncate.js';
 import { getProfilePolicy } from '../../swarm/worker-backend.js';
 import type { WorkerProfile } from '../../swarm/worker-backend.js';
+import { getCCCommand, loadCCCommandTemplate } from '../../commands/cc-command-registry.js';
 
 const log = getLogger('claude-code-tool');
 
@@ -62,7 +63,15 @@ export const claudeCodeTool: Tool = {
         properties: {
           prompt: {
             type: 'string',
-            description: 'The coding task or question for Claude Code to work on',
+            description: 'The coding task or question for Claude Code to work on. Use this for free-form tasks. Mutually exclusive with command.',
+          },
+          command: {
+            type: 'string',
+            description: 'Name of a .claude/commands/*.md command template to execute. The template will be loaded and $ARGUMENTS substituted before execution. Use this instead of prompt when invoking a named CC command.',
+          },
+          arguments: {
+            type: 'string',
+            description: 'Arguments to substitute into the command template ($ARGUMENTS placeholder). Only used with the command input.',
           },
           working_dir: {
             type: 'string',
@@ -82,7 +91,6 @@ export const claudeCodeTool: Tool = {
             description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
           },
         },
-        required: ['prompt'],
       },
     };
   },
@@ -92,8 +100,46 @@ export const claudeCodeTool: Tool = {
       return { content: 'Cancelled', isError: true };
     }
 
-    const prompt = input.prompt as string;
     const workingDir = (input.working_dir as string) || context.workingDir;
+
+    // Resolve prompt: either from direct prompt input or by loading a CC command template
+    let prompt: string;
+    const commandName = input.command as string | undefined;
+    if (commandName) {
+      // Command-template execution path: load .claude/commands/<command>.md,
+      // apply $ARGUMENTS substitution, and use the result as the prompt.
+      const entry = getCCCommand(workingDir, commandName);
+      if (!entry) {
+        return {
+          content: `Error: CC command "${commandName}" not found. Looked for .claude/commands/${commandName}.md in ${workingDir} and parent directories.`,
+          isError: true,
+        };
+      }
+
+      let template: string;
+      try {
+        template = loadCCCommandTemplate(entry);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: `Error: Failed to load CC command template "${commandName}": ${message}`,
+          isError: true,
+        };
+      }
+
+      // Substitute $ARGUMENTS placeholder with the provided arguments
+      const args = (input.arguments as string) ?? '';
+      prompt = template.replace(/\$ARGUMENTS/g, args);
+
+      log.info({ command: commandName, templatePath: entry.filePath, hasArgs: !!args }, 'Loaded CC command template');
+    } else if (typeof input.prompt === 'string') {
+      prompt = input.prompt;
+    } else {
+      return {
+        content: 'Error: Either "prompt" or "command" must be provided.',
+        isError: true,
+      };
+    }
     const resumeSessionId = input.resume as string | undefined;
     const model = (input.model as string) || 'claude-sonnet-4-6';
     const profileName = (input.profile as WorkerProfile | undefined) ?? 'general';


### PR DESCRIPTION
## Summary
- Adds `command` and `arguments` inputs to the `claude_code` tool, enabling a command-template execution path that loads `.claude/commands/*.md` templates and applies `$ARGUMENTS` substitution
- Updates `rewriteKnownSlashCommandPrompt` to route `claude-code` skill trailing args through the `command` input (not `prompt`), so CC command templates are properly applied
- Addresses Codex P1 feedback on PR #5511: switching the rewrite to `prompt` caused CC commands to skip the command-template execution path

## Test plan
- [x] Existing `slash-commands-rewrite` tests pass (non-claude-code skills unaffected)
- [x] Existing `cc-command-registry` tests pass (template loading and discovery unchanged)
- [x] Existing `claude-code-skill-regression` tests pass
- [x] TypeScript type-check passes
- [ ] Invoke a CC slash command (e.g. `/claude-code test`) and verify the `claude_code` tool executes with `command="test"` loading the template from `.claude/commands/test.md`
- [ ] Verify `$ARGUMENTS` substitution works when trailing args are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
