### PR TITLE
feat: enable Home Base dashboard after first conversation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -369,6 +369,9 @@ struct MainWindowView: View {
                         lastAppliedBootstrapTurn = turnCount
                     }
                 }
+                // Enable Home Base dashboard as soon as bootstrap completes
+                // within the same session (BOOTSTRAP.md deleted by the AI).
+                requestHomeBaseDashboardIfNeeded()
             }
             .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
             .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in


### PR DESCRIPTION
## Summary
- Calls `requestHomeBaseDashboardIfNeeded()` in the `.onChange(of: messages)` handler so the `homeBaseDashboardDefaultEnabled` flag gets set as soon as `BOOTSTRAP.md` is deleted during the first conversation, rather than only on next app launch.

## Test plan
- [ ] Launch app fresh (delete `~/.vellum/workspace/` to simulate first run)
- [ ] Complete the bootstrap onboarding conversation (the AI should delete BOOTSTRAP.md at the end)
- [ ] Verify `homeBaseDashboardDefaultEnabled` is set to `true` in UserDefaults immediately after bootstrap completes (without restarting the app)
- [ ] Verify the Home Base dashboard loads on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
