### PR TITLE
feat: show assistant name in thinking indicator for first 5 conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -74,6 +74,7 @@ struct ChatView: View {
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
+    @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
 
     private var isEmptyState: Bool {
         messages.isEmpty && isHistoryLoaded
@@ -556,7 +557,11 @@ struct ChatView: View {
                                 .padding(.top, 2)
 
                             RunningIndicator(
-                                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user }) ? "Waking up..." : "Thinking",
+                                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                                    ? "Waking up..."
+                                    : completedConversationCount < 5 && identity?.name != nil
+                                        ? "\(identity!.name) is thinking"
+                                        : "Thinking",
                                 showIcon: false
                             )
                         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -16,6 +16,7 @@ private let titleGenerationModel = "claude-haiku-4-5-20251001"
 final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @AppStorage("restoreRecentThreads") private(set) var restoreRecentThreads = true
     @AppStorage("lastActiveThreadId") private var lastActiveThreadIdString: String?
+    @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @Published var threads: [ThreadModel] = []
     @Published var hasMoreThreads: Bool = false
     @Published var isLoadingMoreThreads: Bool = false
@@ -121,6 +122,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.isHistoryLoaded = true  // No session yet — nothing to load
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] text in
+            self?.completedConversationCount += 1
             self?.updateThreadTitle(id: threadId, title: "Untitled")
             self?.updateLastInteracted(threadId: threadId)
             Task { @MainActor in
@@ -139,6 +141,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.isHistoryLoaded = true  // No session yet — nothing to load
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] text in
+            self?.completedConversationCount += 1
             self?.updateThreadTitle(id: threadId, title: "Untitled")
             self?.updateLastInteracted(threadId: threadId)
             Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -7,11 +7,20 @@ import SwiftUI
 }
 
 struct ThinkingIndicatorView: View {
+    @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
+
+    private var thinkingText: String {
+        if completedConversationCount < 5, let name = IdentityInfo.load()?.name {
+            return "\(name) is thinking..."
+        }
+        return "Thinking..."
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             ProgressView()
                 .controlSize(.small)
-            Text("Thinking...")
+            Text(thinkingText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }


### PR DESCRIPTION
## Summary
- During the first 5 conversations, the typing/thinking indicator shows "[Name] is thinking" instead of generic "Thinking" dots, reinforcing the assistant identity created during onboarding
- After 5+ conversations, reverts to the standard "Thinking" indicator
- Applies to both the inline chat thinking indicator and the floating ThinkingIndicatorWindow

## Test plan
- [ ] Launch app with a fresh identity (or reset `completedConversationCount` in UserDefaults)
- [ ] Send a message and verify the thinking indicator shows "[YourAssistantName] is thinking..."
- [ ] Create 5+ conversations (threads with at least one user message each)
- [ ] Verify the indicator reverts to generic "Thinking" dots after 5 conversations
- [ ] Verify the count persists across app relaunches (backed by @AppStorage)
- [ ] Verify existing "Waking up..." behavior on first-ever message is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
