### PR TITLE
feat: time-aware and name-aware wake-up greeting

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -180,7 +180,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow(initialMessage: isFirstLaunch ? "Wake up, my friend" : nil, isFirstLaunch: isFirstLaunch)
+        showMainWindow(initialMessage: isFirstLaunch ? wakeUpGreeting() : nil, isFirstLaunch: isFirstLaunch)
         debugStateWriter.start(appDelegate: self)
 
         if isFirstLaunch {
@@ -1073,6 +1073,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
 
+            // Persist the assistant name in case it was changed during replay.
+            let trimmedName = state.assistantName.trimmingCharacters(in: .whitespaces)
+            if !trimmedName.isEmpty {
+                UserDefaults.standard.set(trimmedName, forKey: "assistantName")
+            }
+
             onboarding.close()
             self?.onboardingWindow = nil
 
@@ -1105,6 +1111,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
 
+            // Persist the assistant name chosen during onboarding so the
+            // wake-up greeting can use it (IDENTITY.md may not be written yet).
+            let trimmedName = state.assistantName.trimmingCharacters(in: .whitespaces)
+            if !trimmedName.isEmpty {
+                UserDefaults.standard.set(trimmedName, forKey: "assistantName")
+            }
+
             onboarding.close()
             self?.onboardingWindow = nil
 
@@ -1118,6 +1131,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         onboarding.show()
         onboardingWindow = onboarding
+    }
+
+    // MARK: - Wake-Up Greeting
+
+    /// Generates a time-aware, name-aware greeting for the assistant's first message.
+    private func wakeUpGreeting() -> String {
+        let name = IdentityInfo.load()?.name
+            ?? UserDefaults.standard.string(forKey: "assistantName")
+            ?? "friend"
+
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 5..<12:
+            return "Good morning, \(name). Time to wake up."
+        case 12..<18:
+            return "Hey \(name), I'm here."
+        case 18..<22:
+            return "Evening, \(name). Ready when you are."
+        default:
+            // 22–4 (late night)
+            return "Burning the midnight oil? Let's go, \(name)."
+        }
     }
 
     // MARK: - Main Window


### PR DESCRIPTION
## Summary
- Replaces the generic "Wake up, my friend" first-launch message with a time-of-day-aware greeting that uses the assistant's onboarded name
- Morning (5am-11:59am): "Good morning, [name]. Time to wake up."
- Afternoon (12pm-5:59pm): "Hey [name], I'm here."
- Evening (6pm-9:59pm): "Evening, [name]. Ready when you are."
- Late night (10pm-4:59am): "Burning the midnight oil? Let's go, [name]."
- Persists the assistant name from onboarding to `UserDefaults("assistantName")` so it is available for the greeting even before `IDENTITY.md` is written by the daemon

## Test plan
- [ ] Build succeeds (verified locally via `./build.sh`)
- [ ] Launch app after fresh onboarding at different times of day to verify correct greeting
- [ ] Verify assistant name appears in the greeting (from `IdentityInfo` or `UserDefaults` fallback)
- [ ] Verify fallback to "friend" if no name is available
- [ ] Verify replay onboarding also persists the assistant name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
