### PR TITLE
feat: animated coming-alive transition from onboarding to chat

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1178,11 +1178,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 withIdentifiers: ["tool-confirm-\(requestId)"]
             )
         }
-        // Send the initial message BEFORE showing the window so SwiftUI never
-        // renders the empty state.
-        if let message = initialMessage, let viewModel = main.activeViewModel {
-            viewModel.inputText = message
-            viewModel.sendMessage()
+        // On first launch, defer the wake-up message until after the
+        // "coming alive" transition so the animation plays uninterrupted.
+        // For non-first-launch cases, send the message immediately so
+        // SwiftUI never renders the empty state.
+        if let message = initialMessage {
+            if isFirstLaunch {
+                main.pendingWakeUpMessage = message
+            } else if let viewModel = main.activeViewModel {
+                viewModel.inputText = message
+                viewModel.sendMessage()
+            }
         }
         main.show()
         mainWindow = main

--- a/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Full-screen overlay shown briefly after onboarding completes.
+/// Displays the dino avatar with a bouncy scale-up animation and a
+/// radiating accent glow pulse, then calls `onComplete` so the caller
+/// can fade in the chat UI and send the wake-up message.
+struct ComingAliveOverlay: View {
+    let onComplete: () -> Void
+
+    @State private var appearance = AvatarAppearanceManager.shared
+
+    // Animation state
+    @State private var avatarScale: CGFloat = 0.0
+    @State private var avatarOpacity: Double = 0.0
+    @State private var glowScale: CGFloat = 0.6
+    @State private var glowOpacity: Double = 0.0
+    @State private var cachedBlobImage: NSImage?
+
+    /// Total transition budget: ~1.5 seconds.
+    /// - 0.0s: avatar springs in (bouncy, ~0.6s settle)
+    /// - 0.2s: glow pulse starts (0.8s expand + fade)
+    /// - 1.4s: onComplete fires
+    private let completionDelay: TimeInterval = 1.4
+
+    var body: some View {
+        ZStack {
+            VColor.background
+                .ignoresSafeArea()
+
+            // Radiating glow pulse
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            Meadow.avatarGradientStart.opacity(glowOpacity),
+                            Meadow.avatarGradientStart.opacity(glowOpacity * 0.3),
+                            Color.clear,
+                        ],
+                        center: .center,
+                        startRadius: 20,
+                        endRadius: 200
+                    )
+                )
+                .frame(width: 400, height: 400)
+                .scaleEffect(glowScale)
+                .allowsHitTesting(false)
+
+            // Dino avatar
+            Image(nsImage: blobImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 200, height: 180)
+                .shadow(color: Meadow.avatarGradientStart.opacity(0.3), radius: 12)
+                .scaleEffect(avatarScale)
+                .opacity(avatarOpacity)
+        }
+        .onAppear {
+            rebuildBlobImage()
+            startAnimation()
+        }
+        .onChange(of: appearance.palette) { _, _ in
+            rebuildBlobImage()
+        }
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Animation Sequence
+
+    private func startAnimation() {
+        // 1. Avatar bouncy entrance
+        withAnimation(VAnimation.bouncy) {
+            avatarScale = 1.0
+            avatarOpacity = 1.0
+        }
+
+        // 2. Glow pulse starts slightly after avatar begins
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            withAnimation(.easeOut(duration: 0.8)) {
+                glowScale = 1.6
+                glowOpacity = 0.5
+            }
+            // Fade glow out
+            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+                glowOpacity = 0.0
+            }
+        }
+
+        // 3. Notify completion
+        DispatchQueue.main.asyncAfter(deadline: .now() + completionDelay) {
+            onComplete()
+        }
+    }
+
+    // MARK: - Avatar Image
+
+    private var blobImage: NSImage {
+        cachedBlobImage ?? PixelSpriteBuilder.buildBlobNSImage(
+            pixelSize: Meadow.artPixelSize,
+            palette: appearance.palette
+        )
+    }
+
+    private func rebuildBlobImage() {
+        cachedBlobImage = PixelSpriteBuilder.buildBlobNSImage(
+            pixelSize: Meadow.artPixelSize,
+            palette: appearance.palette
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -141,6 +141,10 @@ final class MainWindow {
     var onMicrophoneToggle: (() -> Void)?
     let voiceModeManager = VoiceModeManager()
 
+    /// Wake-up greeting to auto-send after the "coming alive" transition completes.
+    /// Set by AppDelegate on first launch; consumed by MainWindowView.
+    var pendingWakeUpMessage: String?
+
     // Forwarding accessors — keeps existing references working while
     // ownership lives in the `services` container.
     private var daemonClient: DaemonClient { services.daemonClient }
@@ -264,7 +268,19 @@ final class MainWindow {
             return
         }
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager)
+        // Build a wake-up callback that sends the pending message once the
+        // "coming alive" transition finishes. Capture the message eagerly so
+        // the closure is self-contained.
+        let wakeUpMessage = pendingWakeUpMessage
+        let wakeUpCallback: (() -> Void)? = wakeUpMessage != nil ? { [weak self] in
+            guard let self, let message = wakeUpMessage,
+                  let viewModel = self.threadManager.activeViewModel else { return }
+            viewModel.inputText = message
+            viewModel.sendMessage()
+            self.pendingWakeUpMessage = nil
+        } : nil
+
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -51,7 +51,14 @@ struct MainWindowView: View {
     let onMicrophoneToggle: () -> Void
     @ObservedObject var voiceModeManager: VoiceModeManager
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager()) {
+    /// Callback to send the wake-up greeting after the "coming alive" transition.
+    /// Nil for returning users (no transition).
+    let onSendWakeUp: (() -> Void)?
+
+    /// Whether the "coming alive" overlay is currently showing.
+    @State private var showComingAlive: Bool = false
+
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -65,6 +72,7 @@ struct MainWindowView: View {
         self.avatarEvolutionState = avatarEvolutionState
         self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager
+        self.onSendWakeUp = onSendWakeUp
     }
 
     // MARK: - Layout Constants
@@ -287,6 +295,27 @@ struct MainWindowView: View {
 
     var body: some View {
         coreLayoutView
+            .opacity(showComingAlive ? 0 : 1)
+            .overlay {
+                if showComingAlive {
+                    ComingAliveOverlay(onComplete: {
+                        withAnimation(VAnimation.standard) {
+                            showComingAlive = false
+                        }
+                        // Send the wake-up message after the chat fades in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + VAnimation.durationStandard) {
+                            onSendWakeUp?()
+                        }
+                    })
+                    .transition(.opacity)
+                }
+            }
+            .onAppear {
+                // Trigger the "coming alive" transition on first launch
+                if onSendWakeUp != nil {
+                    showComingAlive = true
+                }
+            }
             .onChange(of: windowState.selection) { oldSelection, newSelection in
                 // Deactivate voice mode when navigating away from the voice panel
                 if case .panel(.voiceMode) = oldSelection, voiceModeManager.state != .off {


### PR DESCRIPTION
## Summary
- After onboarding completes, shows a brief (~1.5s) "coming alive" transition before the chat UI appears
- Dino avatar springs in with `VAnimation.bouncy` scale-up animation
- Radiating accent glow pulse (using `Meadow.avatarGradientStart` / Forest green) expands outward
- Chat UI fades in smoothly after the animation, then the wake-up greeting auto-sends
- Returning users (non-first-launch) skip the transition entirely — zero behavioral change

## Test plan
- [ ] Complete a fresh onboarding flow and verify the dino avatar appears centered with a bouncy entrance
- [ ] Verify the green glow pulse radiates outward during the transition
- [ ] Verify the chat UI fades in after ~1.5 seconds
- [ ] Verify the wake-up greeting message auto-sends after the transition completes
- [ ] Verify returning users (re-opening the app) see no transition — existing behavior unchanged
- [ ] Verify the `--skip-onboarding` debug flag still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
