### PR TITLE
fix: validate command input type before CC command lookup

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -104,6 +104,12 @@ export const claudeCodeTool: Tool = {
 
     // Resolve prompt: either from direct prompt input or by loading a CC command template
     let prompt: string;
+    if (input.command != null && typeof input.command !== 'string') {
+      return {
+        content: `Error: "command" must be a string, got ${typeof input.command}`,
+        isError: true,
+      };
+    }
     const commandName = input.command as string | undefined;
     if (commandName) {
       // Command-template execution path: load .claude/commands/<command>.md,


### PR DESCRIPTION
## Summary
- Add a runtime type guard to validate that `input.command` is a string before passing it to `getCCCommand`
- If `input.command` is present but not a string, return a descriptive `isError` response instead of crashing

## Context
Addresses P2 review feedback from PR #6882. The `execute` method treated any truthy `input.command` as valid and immediately passed it to `getCCCommand`, which calls `name.toLowerCase()`. A non-string value (e.g. from malformed model/tool-calling JSON) would throw a `TypeError`, crashing tool execution instead of returning a recoverable error response.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- Verified that the guard correctly catches non-string types and returns an `isError` response
- The string and undefined paths remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
