### PR TITLE
fix: gate truncated-frontmatter fallback on SUMMARY_READ_BYTES

### DIFF
--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -303,6 +303,20 @@ describe('summary extraction', () => {
     expect(entry!.summary).toBe('');
   });
 
+  test('returns summary for small file starting with thematic break ---', () => {
+    // A small markdown file that starts with "---" as a thematic break (not
+    // frontmatter) should still have its first content line extracted as a
+    // summary, rather than being treated as truncated frontmatter.
+    createCommandsDir(tmpDir, {
+      'thematic-break.md': '---\nThis is a valid summary after a thematic break.',
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const entry = registry.entries.get('thematic-break');
+    expect(entry).toBeDefined();
+    expect(entry!.summary).toBe('This is a valid summary after a thematic break.');
+  });
+
   test('handles frontmatter with Windows-style line endings', () => {
     createCommandsDir(tmpDir, {
       'crlf.md': '---\r\ntitle: Test\r\n---\r\n\r\nSummary with CRLF.',

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -81,10 +81,18 @@ function extractSummary(content: string): string {
   if (fmMatch) {
     body = content.slice(fmMatch[0].length);
   } else if (/^---\r?\n/.test(content)) {
-    // Content starts with a frontmatter opening delimiter but the closing
-    // delimiter was not found — the frontmatter was truncated by the partial
-    // read (SUMMARY_READ_BYTES). Return empty rather than surfacing "---".
-    return '';
+    if (content.length >= SUMMARY_READ_BYTES) {
+      // Content starts with a frontmatter opening delimiter but the closing
+      // delimiter was not found. The content length reached SUMMARY_READ_BYTES,
+      // so the read was likely truncated — the missing closing `---` is
+      // probably just beyond the read boundary. Return empty rather than
+      // surfacing partial frontmatter fields as a summary.
+      return '';
+    }
+    // Small file that starts with `---` (thematic break or unclosed
+    // frontmatter opener). Skip the leading `---` line and extract the
+    // first real content line from the remainder.
+    body = content.replace(/^---\r?\n/, '');
   }
 
   // Find first non-empty line


### PR DESCRIPTION
## Summary
- Gates the truncated-frontmatter empty-summary fallback in `extractSummary` by checking `content.length >= SUMMARY_READ_BYTES`, so it only triggers when the partial read was actually truncated
- For small files starting with `---` (thematic break), the `---` line is now skipped and the first real content line is extracted as the summary
- Adds a regression test for small files starting with a thematic break `---`

## Context
Addresses Codex P2 review feedback on PR #6879: the previous logic returned an empty summary for *all* files starting with `---` when `FRONTMATTER_REGEX` did not match, which regressed summary extraction for valid markdown files beginning with a thematic break.

## Test plan
- [x] Existing truncated-frontmatter tests still pass (large frontmatter > 1024 bytes returns empty summary)
- [x] New test: small file starting with `---\n` thematic break correctly returns the first content line as summary
- [x] All 25 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
