### PR TITLE
fix: include 5th conversation in personalized thinking indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -559,7 +559,7 @@ struct ChatView: View {
                             RunningIndicator(
                                 label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
                                     ? "Waking up..."
-                                    : completedConversationCount < 5 && identity?.name != nil
+                                    : completedConversationCount <= 5 && identity?.name != nil
                                         ? "\(identity!.name) is thinking"
                                         : "Thinking",
                                 showIcon: false

--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -10,7 +10,7 @@ struct ThinkingIndicatorView: View {
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
 
     private var thinkingText: String {
-        if completedConversationCount < 5, let name = IdentityInfo.load()?.name {
+        if completedConversationCount <= 5, let name = IdentityInfo.load()?.name {
             return "\(name) is thinking..."
         }
         return "Thinking..."


### PR DESCRIPTION
## Summary
- Fix off-by-one error in personalized thinking indicator conversation count
- Change `< 5` to `<= 5` in both `ChatView.swift` and `ThinkingIndicatorWindow.swift`

## Context
The `completedConversationCount` is incremented in `onFirstUserMessage` (ThreadManager.swift) synchronously before the thinking indicator renders. Both `ChatView.swift` and `ThinkingIndicatorWindow.swift` check this count to decide whether to show a personalized thinking message ("X is thinking") or the generic "Thinking".

Using `< 5` meant the personalized indicator only appeared for 4 conversations instead of the intended 5, because by the time the indicator renders, the count already includes the current conversation.

## Test plan
- [ ] Verify personalized thinking indicator ("X is thinking") appears for the first 5 conversations
- [ ] Verify generic "Thinking" appears starting from the 6th conversation
- [ ] Verify both in-chat indicator and floating thinking indicator window show consistent behavior

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/6884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
