### PR TITLE
fix: prevent flash of chat UI before coming-alive overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -57,7 +57,7 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     /// Whether the "coming alive" overlay is currently showing.
-    @State private var showComingAlive: Bool = false
+    @State private var showComingAlive: Bool
 
     init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
@@ -74,6 +74,7 @@ struct MainWindowView: View {
         self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager
         self.onSendWakeUp = onSendWakeUp
+        self._showComingAlive = State(initialValue: onSendWakeUp != nil)
     }
 
     // MARK: - Layout Constants
@@ -309,12 +310,6 @@ struct MainWindowView: View {
                         }
                     })
                     .transition(.opacity)
-                }
-            }
-            .onAppear {
-                // Trigger the "coming alive" transition on first launch
-                if onSendWakeUp != nil {
-                    showComingAlive = true
                 }
             }
             .onChange(of: windowState.selection) { oldSelection, newSelection in


### PR DESCRIPTION
## Summary
- Initialize `showComingAlive` in `init` via `State(initialValue:)` instead of setting it in `.onAppear`, preventing a one-frame flash of the chat UI before the overlay appears
- Remove the `.onAppear` block that unconditionally re-triggered the animation, preventing the coming-alive transition from replaying when the window is hidden and re-shown

## Changes
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift`
  - Changed `@State private var showComingAlive: Bool = false` to `@State private var showComingAlive: Bool` (no default)
  - Added `self._showComingAlive = State(initialValue: onSendWakeUp != nil)` in `init`
  - Removed the `.onAppear` block that set `showComingAlive = true`

## Test plan
- [ ] First launch with onboarding: coming-alive overlay should appear immediately with no flash of the chat UI underneath
- [ ] Returning user launch (no `onSendWakeUp`): chat UI should appear normally with no overlay
- [ ] Hide and re-show the main window during the same session: coming-alive transition should NOT replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
