### PR TITLE
feat: fetch vellum-skills catalog from GitHub at runtime

### DIFF
--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -1,4 +1,5 @@
 {
+  "_description": "Manifest of first-party Vellum skills. Fetched from GitHub at runtime so the desktop app can discover new skills without a release. The bundled copy serves as an offline fallback.",
   "version": 1,
   "skills": [
     {

--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -1,5 +1,5 @@
 {
-  "_description": "Manifest of first-party Vellum skills. Fetched from GitHub at runtime so the desktop app can discover new skills without a release. The bundled copy serves as an offline fallback.",
+  "description": "Manifest of first-party Vellum skills. Fetched from GitHub at runtime so the assistant can discover and install new skills maintained by Vellum.",
   "version": 1,
   "skills": [
     {

--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "skills": [
+    {
+      "id": "chatgpt-import",
+      "name": "ChatGPT Import",
+      "description": "Import conversation history from ChatGPT into Vellum",
+      "emoji": "\ud83d\udce5"
+    },
+    {
+      "id": "deploy-fullstack-vercel",
+      "name": "Deploy Fullstack to Vercel",
+      "description": "Build and deploy a full-stack app (React frontend + Python/FastAPI backend) to Vercel as a serverless demo with seeded data",
+      "emoji": "\ud83d\ude80"
+    },
+    {
+      "id": "document-writer",
+      "name": "Document Writer",
+      "description": "Create and edit long-form documents like blog posts, articles, essays, and reports using the built-in rich text editor",
+      "emoji": "\ud83d\udcdd"
+    },
+    {
+      "id": "google-oauth-setup",
+      "name": "Google OAuth Setup",
+      "description": "Create Google Cloud OAuth credentials for Gmail integration using browser automation",
+      "emoji": "\ud83d\udd11",
+      "includes": ["browser", "public-ingress"]
+    },
+    {
+      "id": "slack-oauth-setup",
+      "name": "Slack OAuth Setup",
+      "description": "Create Slack App and OAuth credentials for Slack integration using browser automation",
+      "emoji": "\ud83d\udd11",
+      "includes": ["browser", "public-ingress"]
+    },
+    {
+      "id": "telegram-setup",
+      "name": "Telegram Setup",
+      "description": "Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage",
+      "emoji": "\ud83e\udd16",
+      "includes": ["public-ingress"]
+    },
+    {
+      "id": "twilio-setup",
+      "name": "Twilio Setup",
+      "description": "Configure Twilio credentials and phone numbers for voice calls and SMS messaging",
+      "emoji": "\ud83d\udcf1",
+      "includes": ["public-ingress"]
+    }
+  ]
+}

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -7,7 +7,7 @@ import { resolveSkillStates } from '../../config/skill-state.js';
 import { getWorkspaceSkillsDir } from '../../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect, type ClawhubSearchResultItem } from '../../skills/clawhub.js';
 import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } from '../../skills/managed-store.js';
-import { listCatalogEntries, installFromVellumCatalog, isVellumSkill } from '../../tools/skills/vellum-catalog.js';
+import { listCatalogEntries, installFromVellumCatalog, checkVellumSkill } from '../../tools/skills/vellum-catalog.js';
 import type {
   SkillDetailRequest,
   SkillsEnableRequest,
@@ -188,11 +188,11 @@ export async function handleSkillsInstall(
 ): Promise<void> {
   try {
     // Check if the slug matches a vellum-skills catalog entry first
-    const isVellum = await isVellumSkill(msg.slug);
+    const isVellumSkill = await checkVellumSkill(msg.slug);
 
     let skillId: string;
 
-    if (isVellum) {
+    if (isVellumSkill) {
       // Install from vellum-skills catalog (remote with bundled fallback)
       const result = await installFromVellumCatalog(msg.slug);
       if (!result.success) {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -7,7 +7,7 @@ import { resolveSkillStates } from '../../config/skill-state.js';
 import { getWorkspaceSkillsDir } from '../../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect, type ClawhubSearchResultItem } from '../../skills/clawhub.js';
 import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } from '../../skills/managed-store.js';
-import { listCatalogEntries, installFromVellumCatalog } from '../../tools/skills/vellum-catalog.js';
+import { listCatalogEntries, installFromVellumCatalog, isVellumSkill } from '../../tools/skills/vellum-catalog.js';
 import type {
   SkillDetailRequest,
   SkillsEnableRequest,
@@ -188,14 +188,13 @@ export async function handleSkillsInstall(
 ): Promise<void> {
   try {
     // Check if the slug matches a vellum-skills catalog entry first
-    const catalogEntries = listCatalogEntries();
-    const isVellumSkill = catalogEntries.some((e) => e.id === msg.slug);
+    const isVellum = await isVellumSkill(msg.slug);
 
     let skillId: string;
 
-    if (isVellumSkill) {
-      // Install from vellum-skills catalog (local copy)
-      const result = installFromVellumCatalog(msg.slug);
+    if (isVellum) {
+      // Install from vellum-skills catalog (remote with bundled fallback)
+      const result = await installFromVellumCatalog(msg.slug);
       if (!result.success) {
         ctx.send(socket, {
           type: 'skills_operation_response',
@@ -424,8 +423,8 @@ export async function handleSkillsSearch(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    // Search vellum-skills catalog locally
-    const catalogEntries = listCatalogEntries();
+    // Search vellum-skills catalog (remote with bundled fallback)
+    const catalogEntries = await listCatalogEntries();
     const query = (msg.query ?? '').toLowerCase();
     const matchingCatalog = catalogEntries.filter((e) => {
       if (!query) return true;

--- a/assistant/src/skills/vellum-catalog-remote.ts
+++ b/assistant/src/skills/vellum-catalog-remote.ts
@@ -61,7 +61,11 @@ export async function fetchCatalogEntries(): Promise<CatalogEntry[]> {
     }
 
     const manifest: CatalogManifest = await response.json();
-    cachedEntries = manifest.skills ?? [];
+    const skills = manifest.skills;
+    if (!Array.isArray(skills) || skills.length === 0) {
+      throw new Error('Remote catalog has invalid or empty skills array');
+    }
+    cachedEntries = skills;
     cacheTimestamp = now;
     log.info({ count: cachedEntries.length }, 'Fetched remote vellum-skills catalog');
     return cachedEntries;
@@ -97,7 +101,7 @@ export async function fetchSkillContent(skillId: string): Promise<string | null>
 }
 
 /** Check if a skill ID exists in the remote catalog. */
-export async function isVellumSkill(skillId: string): Promise<boolean> {
+export async function checkVellumSkill(skillId: string): Promise<boolean> {
   const entries = await fetchCatalogEntries();
   return entries.some((e) => e.id === skillId);
 }

--- a/assistant/src/skills/vellum-catalog-remote.ts
+++ b/assistant/src/skills/vellum-catalog-remote.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CatalogEntry } from '../tools/skills/vellum-catalog.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('vellum-catalog-remote');
+
+const GITHUB_RAW_BASE =
+  'https://raw.githubusercontent.com/vellum-ai/vellum-assistant/main/assistant/src/config/vellum-skills';
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CatalogManifest {
+  version: number;
+  skills: CatalogEntry[];
+}
+
+let cachedEntries: CatalogEntry[] | null = null;
+let cacheTimestamp = 0;
+
+function getBundledCatalogPath(): string {
+  return join(import.meta.dir, '..', 'config', 'vellum-skills', 'catalog.json');
+}
+
+function loadBundledCatalog(): CatalogEntry[] {
+  try {
+    const raw = readFileSync(getBundledCatalogPath(), 'utf-8');
+    const manifest: CatalogManifest = JSON.parse(raw);
+    return manifest.skills ?? [];
+  } catch (err) {
+    log.warn({ err }, 'Failed to read bundled catalog.json');
+    return [];
+  }
+}
+
+function getBundledSkillContent(skillId: string): string | null {
+  try {
+    const skillPath = join(import.meta.dir, '..', 'config', 'vellum-skills', skillId, 'SKILL.md');
+    return readFileSync(skillPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch catalog entries (cached, async). Falls back to bundled copy. */
+export async function fetchCatalogEntries(): Promise<CatalogEntry[]> {
+  const now = Date.now();
+  if (cachedEntries && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedEntries;
+  }
+
+  try {
+    const url = `${GITHUB_RAW_BASE}/catalog.json`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const manifest: CatalogManifest = await response.json();
+    cachedEntries = manifest.skills ?? [];
+    cacheTimestamp = now;
+    log.info({ count: cachedEntries.length }, 'Fetched remote vellum-skills catalog');
+    return cachedEntries;
+  } catch (err) {
+    log.warn({ err }, 'Failed to fetch remote catalog, falling back to bundled copy');
+    const bundled = loadBundledCatalog();
+    // Cache the bundled result too so we don't re-fetch on every call during outage
+    cachedEntries = bundled;
+    cacheTimestamp = now;
+    return bundled;
+  }
+}
+
+/** Fetch a skill's SKILL.md content from GitHub. Falls back to bundled copy. */
+export async function fetchSkillContent(skillId: string): Promise<string | null> {
+  try {
+    const url = `${GITHUB_RAW_BASE}/${encodeURIComponent(skillId)}/SKILL.md`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const content = await response.text();
+    log.info({ skillId }, 'Fetched remote SKILL.md');
+    return content;
+  } catch (err) {
+    log.warn({ err, skillId }, 'Failed to fetch remote SKILL.md, falling back to bundled copy');
+    return getBundledSkillContent(skillId);
+  }
+}
+
+/** Check if a skill ID exists in the remote catalog. */
+export async function isVellumSkill(skillId: string): Promise<boolean> {
+  const entries = await fetchCatalogEntries();
+  return entries.some((e) => e.id === skillId);
+}

--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { createManagedSkill } from '../../skills/managed-store.js';
-import { fetchCatalogEntries, fetchSkillContent, isVellumSkill } from '../../skills/vellum-catalog-remote.js';
+import { fetchCatalogEntries, fetchSkillContent, checkVellumSkill } from '../../skills/vellum-catalog-remote.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
@@ -14,18 +14,18 @@ export interface CatalogEntry {
   includes?: string[];
 }
 
-export { fetchCatalogEntries as listCatalogEntries, isVellumSkill };
+export { fetchCatalogEntries as listCatalogEntries, checkVellumSkill };
 
 /**
  * Install a skill from the vellum-skills catalog by ID.
  * Fetches SKILL.md from GitHub (with bundled fallback) and creates a managed skill.
  * Returns { success, skillName, error }.
  */
-export async function installFromVellumCatalog(skillId: string): Promise<{ success: boolean; skillName?: string; error?: string }> {
+export async function installFromVellumCatalog(skillId: string, options?: { overwrite?: boolean }): Promise<{ success: boolean; skillName?: string; error?: string }> {
   const trimmedId = skillId.trim();
 
   // Verify skill exists in catalog
-  const exists = await isVellumSkill(trimmedId);
+  const exists = await checkVellumSkill(trimmedId);
   if (!exists) {
     return { success: false, error: `Skill "${trimmedId}" not found in the Vellum catalog` };
   }
@@ -98,7 +98,7 @@ export async function installFromVellumCatalog(skillId: string): Promise<{ succe
     bodyMarkdown,
     emoji,
     includes,
-    overwrite: true,
+    overwrite: options?.overwrite ?? true,
     addToIndex: true,
   });
 
@@ -159,7 +159,7 @@ class VellumSkillsCatalogTool implements Tool {
           return { content: 'Error: skill_id is required for install action', isError: true };
         }
 
-        const result = await installFromVellumCatalog(skillId);
+        const result = await installFromVellumCatalog(skillId, { overwrite: input.overwrite === true });
         if (!result.success) {
           return { content: `Error: ${result.error}`, isError: true };
         }

--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -1,19 +1,10 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, join } from 'node:path';
-
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { createManagedSkill } from '../../skills/managed-store.js';
-import { getLogger } from '../../util/logger.js';
+import { fetchCatalogEntries, fetchSkillContent, isVellumSkill } from '../../skills/vellum-catalog-remote.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 
-const log = getLogger('vellum-skills-catalog');
-
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
-
-function getVellumSkillsDir(): string {
-  return join(import.meta.dir, '..', '..', 'config', 'vellum-skills');
-}
 
 export interface CatalogEntry {
   id: string;
@@ -23,122 +14,90 @@ export interface CatalogEntry {
   includes?: string[];
 }
 
-function parseCatalogEntry(directory: string): CatalogEntry | null {
-  const skillFilePath = join(directory, 'SKILL.md');
-  if (!existsSync(skillFilePath)) return null;
-
-  try {
-    const stat = statSync(skillFilePath);
-    if (!stat.isFile()) return null;
-
-    const content = readFileSync(skillFilePath, 'utf-8');
-    const match = content.match(FRONTMATTER_REGEX);
-    if (!match) return null;
-
-    const fields: Record<string, string> = {};
-    for (const line of match[1].split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) continue;
-      const separatorIndex = trimmed.indexOf(':');
-      if (separatorIndex === -1) continue;
-
-      const key = trimmed.slice(0, separatorIndex).trim();
-      let value = trimmed.slice(separatorIndex + 1).trim();
-      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
-      }
-      fields[key] = value;
-    }
-
-    const name = fields.name?.trim();
-    const description = fields.description?.trim();
-    if (!name || !description) return null;
-
-    let emoji: string | undefined;
-    const metadataRaw = fields.metadata?.trim();
-    if (metadataRaw) {
-      try {
-        const parsed = JSON.parse(metadataRaw);
-        if (parsed?.vellum?.emoji) {
-          emoji = parsed.vellum.emoji as string;
-        }
-      } catch {
-        // ignore malformed metadata
-      }
-    }
-
-    let includes: string[] | undefined;
-    const includesRaw = fields.includes?.trim();
-    if (includesRaw) {
-      try {
-        const parsed = JSON.parse(includesRaw);
-        if (Array.isArray(parsed) && parsed.every((item: unknown) => typeof item === 'string')) {
-          const filtered = (parsed as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
-          if (filtered.length > 0) includes = filtered;
-        }
-      } catch {
-        // ignore malformed includes
-      }
-    }
-
-    return { id: basename(directory), name, description, emoji, includes };
-  } catch (err) {
-    log.warn({ err, directory }, 'Failed to read catalog entry');
-    return null;
-  }
-}
-
-export function listCatalogEntries(): CatalogEntry[] {
-  const catalogDir = getVellumSkillsDir();
-  if (!existsSync(catalogDir)) return [];
-
-  const entries: CatalogEntry[] = [];
-  try {
-    const dirEntries = readdirSync(catalogDir, { withFileTypes: true });
-    for (const entry of dirEntries) {
-      if (!entry.isDirectory()) continue;
-      const parsed = parseCatalogEntry(join(catalogDir, entry.name));
-      if (parsed) entries.push(parsed);
-    }
-  } catch (err) {
-    log.warn({ err, catalogDir }, 'Failed to list catalog entries');
-  }
-
-  return entries.sort((a, b) => a.id.localeCompare(b.id));
-}
+export { fetchCatalogEntries as listCatalogEntries, isVellumSkill };
 
 /**
  * Install a skill from the vellum-skills catalog by ID.
+ * Fetches SKILL.md from GitHub (with bundled fallback) and creates a managed skill.
  * Returns { success, skillName, error }.
  */
-export function installFromVellumCatalog(skillId: string): { success: boolean; skillName?: string; error?: string } {
-  const catalogDir = getVellumSkillsDir();
-  const skillDir = join(catalogDir, skillId.trim());
-  const skillFilePath = join(skillDir, 'SKILL.md');
+export async function installFromVellumCatalog(skillId: string): Promise<{ success: boolean; skillName?: string; error?: string }> {
+  const trimmedId = skillId.trim();
 
-  if (!existsSync(skillFilePath)) {
-    return { success: false, error: `Skill "${skillId}" not found in the Vellum catalog` };
+  // Verify skill exists in catalog
+  const exists = await isVellumSkill(trimmedId);
+  if (!exists) {
+    return { success: false, error: `Skill "${trimmedId}" not found in the Vellum catalog` };
   }
 
-  const content = readFileSync(skillFilePath, 'utf-8');
+  // Fetch SKILL.md content (remote with bundled fallback)
+  const content = await fetchSkillContent(trimmedId);
+  if (!content) {
+    return { success: false, error: `Skill "${trimmedId}" SKILL.md not found` };
+  }
+
   const match = content.match(FRONTMATTER_REGEX);
   if (!match) {
-    return { success: false, error: `Skill "${skillId}" has invalid SKILL.md` };
+    return { success: false, error: `Skill "${trimmedId}" has invalid SKILL.md` };
   }
 
-  const entry = parseCatalogEntry(skillDir);
-  if (!entry) {
-    return { success: false, error: `Skill "${skillId}" has invalid SKILL.md` };
+  // Parse frontmatter to get name/description/emoji/includes
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    fields[key] = value;
+  }
+
+  const name = fields.name?.trim();
+  const description = fields.description?.trim();
+  if (!name || !description) {
+    return { success: false, error: `Skill "${trimmedId}" has invalid SKILL.md (missing name or description)` };
+  }
+
+  let emoji: string | undefined;
+  const metadataRaw = fields.metadata?.trim();
+  if (metadataRaw) {
+    try {
+      const parsed = JSON.parse(metadataRaw);
+      if (parsed?.vellum?.emoji) {
+        emoji = parsed.vellum.emoji as string;
+      }
+    } catch {
+      // ignore malformed metadata
+    }
+  }
+
+  let includes: string[] | undefined;
+  const includesRaw = fields.includes?.trim();
+  if (includesRaw) {
+    try {
+      const parsed = JSON.parse(includesRaw);
+      if (Array.isArray(parsed) && parsed.every((item: unknown) => typeof item === 'string')) {
+        const filtered = (parsed as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
+        if (filtered.length > 0) includes = filtered;
+      }
+    } catch {
+      // ignore malformed includes
+    }
   }
 
   const bodyMarkdown = content.slice(match[0].length);
   const result = createManagedSkill({
-    id: entry.id,
-    name: entry.name,
-    description: entry.description,
+    id: trimmedId,
+    name,
+    description,
     bodyMarkdown,
-    emoji: entry.emoji,
-    includes: entry.includes,
+    emoji,
+    includes,
     overwrite: true,
     addToIndex: true,
   });
@@ -147,7 +106,7 @@ export function installFromVellumCatalog(skillId: string): { success: boolean; s
     return { success: false, error: result.error };
   }
 
-  return { success: true, skillName: entry.id };
+  return { success: true, skillName: trimmedId };
 }
 
 class VellumSkillsCatalogTool implements Tool {
@@ -187,7 +146,7 @@ class VellumSkillsCatalogTool implements Tool {
 
     switch (action) {
       case 'list': {
-        const entries = listCatalogEntries();
+        const entries = await fetchCatalogEntries();
         if (entries.length === 0) {
           return { content: 'No Vellum-provided skills available in the catalog.', isError: false };
         }
@@ -200,52 +159,15 @@ class VellumSkillsCatalogTool implements Tool {
           return { content: 'Error: skill_id is required for install action', isError: true };
         }
 
-        const catalogDir = getVellumSkillsDir();
-        const skillDir = join(catalogDir, skillId.trim());
-        const skillFilePath = join(skillDir, 'SKILL.md');
-
-        if (!existsSync(skillFilePath)) {
-          const available = listCatalogEntries().map((e) => e.id);
-          return {
-            content: `Error: skill "${skillId}" not found in the Vellum catalog. Available: ${available.join(', ') || 'none'}`,
-            isError: true,
-          };
-        }
-
-        const content = readFileSync(skillFilePath, 'utf-8');
-        const match = content.match(FRONTMATTER_REGEX);
-        if (!match) {
-          return { content: `Error: skill "${skillId}" has invalid SKILL.md (missing frontmatter)`, isError: true };
-        }
-
-        const entry = parseCatalogEntry(skillDir);
-        if (!entry) {
-          return { content: `Error: skill "${skillId}" has invalid SKILL.md`, isError: true };
-        }
-
-        const bodyMarkdown = content.slice(match[0].length);
-
-        const result = createManagedSkill({
-          id: entry.id,
-          name: entry.name,
-          description: entry.description,
-          bodyMarkdown,
-          emoji: entry.emoji,
-          includes: entry.includes,
-          overwrite: input.overwrite === true,
-          addToIndex: true,
-        });
-
-        if (!result.created) {
+        const result = await installFromVellumCatalog(skillId);
+        if (!result.success) {
           return { content: `Error: ${result.error}`, isError: true };
         }
 
         return {
           content: JSON.stringify({
             installed: true,
-            skill_id: entry.id,
-            name: entry.name,
-            path: result.path,
+            skill_id: result.skillName,
           }),
           isError: false,
         };


### PR DESCRIPTION
## Summary
- Adds a `catalog.json` manifest to the vellum-skills directory listing all 7 catalog skills with metadata
- Creates a remote fetcher module (`vellum-catalog-remote.ts`) that fetches catalog data from `raw.githubusercontent.com` with 1-hour in-memory caching and offline fallback to the bundled copy
- Converts `listCatalogEntries` and `installFromVellumCatalog` from sync to async, delegating to the remote fetcher
- Updates the daemon skills handler to await the now-async catalog functions

## Test plan
- [ ] **Online**: Run the daemon, open Available Skills tab — verify vellum-skills appear (fetched from GitHub)
- [ ] **Offline**: Disconnect network, restart daemon — verify vellum-skills still appear (from bundled fallback)
- [ ] **Install**: Click Install on a vellum skill — verify SKILL.md is fetched and skill is installed
- [ ] **Search**: Type a query in the search bar — verify vellum skills are filtered and appear before ClawHub results
- [ ] **Cache**: Check that repeated searches within 1 hour don't trigger new GitHub fetches (verify via daemon logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
