### PR TITLE
fix: use Buffer.byteLength for truncation detection in extractSummary

### DIFF
--- a/assistant/src/commands/__tests__/cc-command-registry.test.ts
+++ b/assistant/src/commands/__tests__/cc-command-registry.test.ts
@@ -303,6 +303,32 @@ describe('summary extraction', () => {
     expect(entry!.summary).toBe('');
   });
 
+  test('returns empty summary when frontmatter is truncated with multibyte UTF-8 characters', () => {
+    // When frontmatter contains multibyte UTF-8 characters (e.g., CJK text),
+    // the JavaScript string length (UTF-16 code units) is smaller than the
+    // byte length. The truncation guard must compare byte length, not
+    // string length, against SUMMARY_READ_BYTES (1024).
+    //
+    // Each CJK character is 3 bytes in UTF-8 but 1 code unit in UTF-16.
+    // We need the total byte count to reach 1024 while string length stays
+    // well below 1024 to exercise the bug.
+    const cjkChars = '\u4e00'.repeat(340); // 340 chars * 3 bytes = 1020 bytes
+    // '---\n' is 4 bytes, so total = 4 + 1020 = 1024 bytes, but string
+    // length = 4 + 340 = 344 chars — well under 1024.
+    const truncatedContent = '---\n' + cjkChars;
+    createCommandsDir(tmpDir, {
+      'multibyte-frontmatter.md': truncatedContent,
+    });
+
+    const registry = discoverCCCommands(tmpDir);
+    const entry = registry.entries.get('multibyte-frontmatter');
+    expect(entry).toBeDefined();
+    // Should return '' because the frontmatter opening delimiter is present
+    // but the closing delimiter is missing and the byte length reached the
+    // read limit — indicating truncation.
+    expect(entry!.summary).toBe('');
+  });
+
   test('returns summary for small file starting with thematic break ---', () => {
     // A small markdown file that starts with "---" as a thematic break (not
     // frontmatter) should still have its first content line extracted as a

--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -81,7 +81,7 @@ function extractSummary(content: string): string {
   if (fmMatch) {
     body = content.slice(fmMatch[0].length);
   } else if (/^---\r?\n/.test(content)) {
-    if (content.length >= SUMMARY_READ_BYTES) {
+    if (Buffer.byteLength(content, 'utf-8') >= SUMMARY_READ_BYTES) {
       // Content starts with a frontmatter opening delimiter but the closing
       // delimiter was not found. The content length reached SUMMARY_READ_BYTES,
       // so the read was likely truncated — the missing closing `---` is


### PR DESCRIPTION
## Summary
- Fixed truncation detection in `extractSummary` to use `Buffer.byteLength(content, 'utf-8')` instead of `content.length`, which measures UTF-16 code units rather than bytes
- The mismatch caused the truncation guard to be skipped for files with multibyte UTF-8 characters (e.g., CJK text in frontmatter), allowing partial frontmatter to be surfaced as the summary
- Added a regression test with CJK content that exercises the discrepancy between string length and byte length

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 26 tests pass including the new multibyte regression test (`bun test src/commands/__tests__/cc-command-registry.test.ts`)
- [x] New test verifies that a file starting with `---\n` followed by 340 CJK characters (1024 bytes total, but only 344 string length) correctly returns an empty summary

Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/6888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
