### PR TITLE
fix: cancel bootstrap polling timer once auto-enable is set

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -399,11 +399,14 @@ struct MainWindowView: View {
             // Poll for bootstrap completion so the dashboard is enabled even when
             // BOOTSTRAP.md is deleted via tool execution that only mutates
             // existing messages in place (no message-ID change to trigger
-            // the .onChange above). Stops automatically once the auto-enable
-            // flag is set.
-            .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
-                guard !homeBaseDashboardAutoEnabled else { return }
-                requestHomeBaseDashboardIfNeeded()
+            // the .onChange above). The task exits once the auto-enable flag
+            // is set, ensuring zero overhead after first-launch bootstrap.
+            .task {
+                while !homeBaseDashboardAutoEnabled {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    requestHomeBaseDashboardIfNeeded()
+                }
             }
             .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
             .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in


### PR DESCRIPTION
## Summary
- Replace `.onReceive(Timer.publish(...).autoconnect())` with a `.task` async loop that terminates once `homeBaseDashboardAutoEnabled` is set
- The previous `Timer.publish` pattern kept firing every 2 seconds for the entire view lifetime even after bootstrap completed -- the `guard` only skipped the body while timer events continued waking the main run loop indefinitely
- The new `.task` loop exits cleanly when the flag is set, achieving true zero overhead after first-launch bootstrap

## Test plan
- [ ] Fresh install: verify Home Base dashboard auto-enables after BOOTSTRAP.md is deleted
- [ ] Returning user (already bootstrapped): verify no polling occurs at all (task exits immediately on first iteration)
- [ ] Verify no run loop wake-ups from this timer after bootstrap completion

Addresses feedback from PR #6890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
