### PR TITLE
feat: add ssh command to @vellumai/cli

### DIFF
--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -1,0 +1,111 @@
+import { spawn } from "child_process";
+
+import { findAssistantByName, loadLatestAssistant } from "../lib/assistant-config";
+import type { AssistantEntry } from "../lib/assistant-config";
+
+const SSH_OPTS = [
+  "-o", "StrictHostKeyChecking=no",
+  "-o", "UserKnownHostsFile=/dev/null",
+  "-o", "ConnectTimeout=10",
+  "-o", "LogLevel=ERROR",
+];
+
+function resolveCloud(entry: AssistantEntry): string {
+  if (entry.cloud) {
+    return entry.cloud;
+  }
+  if (entry.project) {
+    return "gcp";
+  }
+  if (entry.sshUser) {
+    return "custom";
+  }
+  return "local";
+}
+
+function extractHostFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname;
+  } catch {
+    return url.replace(/^https?:\/\//, "").split(":")[0];
+  }
+}
+
+export async function ssh(): Promise<void> {
+  const name = process.argv[3];
+  const entry = name ? findAssistantByName(name) : loadLatestAssistant();
+
+  if (!entry) {
+    if (name) {
+      console.error(`No assistant instance found with name '${name}'.`);
+    } else {
+      console.error("No assistant instance found. Run `vellum-cli hatch` first.");
+    }
+    process.exit(1);
+  }
+
+  const cloud = resolveCloud(entry);
+
+  if (cloud === "local") {
+    console.error(
+      "Cannot SSH into a local assistant. Local assistants run directly on this machine.\n" +
+      `Use 'vellum-cli ps ${entry.assistantId}' to check its processes instead.`,
+    );
+    process.exit(1);
+  }
+
+  if (cloud === "aws") {
+    console.error("SSH to AWS instances is not yet supported.");
+    process.exit(1);
+  }
+
+  let child;
+
+  if (cloud === "gcp") {
+    const project = entry.project;
+    const zone = entry.zone;
+    if (!project || !zone) {
+      console.error("Error: GCP project and zone not found in assistant config.");
+      process.exit(1);
+    }
+
+    const sshTarget = entry.sshUser
+      ? `${entry.sshUser}@${entry.assistantId}`
+      : entry.assistantId;
+
+    console.log(`🔗 Connecting to ${entry.assistantId} via gcloud...\n`);
+
+    child = spawn(
+      "gcloud",
+      ["compute", "ssh", sshTarget, `--project=${project}`, `--zone=${zone}`],
+      { stdio: "inherit" },
+    );
+  } else if (cloud === "custom") {
+    const host = extractHostFromUrl(entry.runtimeUrl);
+    const sshUser = entry.sshUser ?? "root";
+    const sshTarget = `${sshUser}@${host}`;
+
+    console.log(`🔗 Connecting to ${entry.assistantId} via ssh...\n`);
+
+    child = spawn(
+      "ssh",
+      [...SSH_OPTS, sshTarget],
+      { stdio: "inherit" },
+    );
+  } else {
+    console.error(`Error: Unknown cloud type '${cloud}'.`);
+    process.exit(1);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ssh exited with code ${code}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { hatch } from "./commands/hatch";
 import { ps } from "./commands/ps";
 import { retire } from "./commands/retire";
 import { sleep } from "./commands/sleep";
+import { ssh } from "./commands/ssh";
 import { wake } from "./commands/wake";
 
 const commands = {
@@ -18,6 +19,7 @@ const commands = {
   ps,
   retire,
   sleep,
+  ssh,
   wake,
 } as const;
 
@@ -62,6 +64,7 @@ async function main() {
     console.log("  ps       List assistants (or processes for a specific assistant)");
     console.log("  retire   Delete an assistant instance");
     console.log("  sleep    Stop the daemon process");
+    console.log("  ssh      SSH into a remote assistant instance");
     console.log("  wake     Start the daemon and gateway");
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- Adds `ssh` command to `@vellumai/cli` with multi-cloud support
- GCP: connects via `gcloud compute ssh` with project/zone
- Custom: connects via `ssh` with standard security opts
- AWS: returns "not yet supported" error
- Local: returns human-readable error suggesting `vellum-cli ps` instead

## Test plan
- [ ] `vellum-cli ssh` with a local assistant → human-readable error
- [ ] `vellum-cli ssh <gcp-name>` → connects via gcloud
- [ ] `vellum-cli ssh <custom-name>` → connects via ssh
- [ ] `vellum-cli --help` shows the ssh command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
