### PR TITLE
Revert sidebar animation to if/else, keep color updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -304,7 +304,7 @@ final class MainWindow {
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.backgroundColor = NSColor(VColor.background)
+        window.backgroundColor = NSColor(adaptiveColor(light: Moss._50, dark: Moss._950))
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
         window.setFrame(windowRect, display: false)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -482,8 +482,7 @@ struct MainWindowView: View {
                     .padding(.leading, trafficLightPadding)
                     .padding(.trailing, VSpacing.lg)
                     .frame(height: 36)
-
-                    Divider().background(VColor.surfaceBorder)
+                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
 
                     // Content area: sidebar always pushes chat content right
                     HStack(spacing: 0) {
@@ -859,8 +858,8 @@ struct MainWindowView: View {
                 collapsedSidebarContent
             }
         }
-        .padding(sidebarExpanded ? VSpacing.xs : VSpacing.xs)
-        .background(adaptiveColor(light: Moss._50, dark: Moss._700))
+        .padding(VSpacing.xs)
+        .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .padding(sidebarOuterMargin)
         .frame(width: sidebarExpanded ? sidebarExpandedWidth + sidebarOuterMargin * 2 : sidebarCollapsedWidth + sidebarOuterMargin * 2)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -126,9 +126,9 @@ public enum Forest {
 
 public enum VColor {
     // Backgrounds
-    public static let background = adaptiveColor(light: Moss._100, dark: Moss._950)
+    public static let background = adaptiveColor(light: Moss._100, dark: Moss._900)
     public static let backgroundSubtle = adaptiveColor(light: Moss._50, dark: Moss._950)
-    public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._950)
+    public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._900)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)
     public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)


### PR DESCRIPTION
## Summary
- Reverts the sidebar expand/collapse from `ZStack` + `opacity` + `allowsHitTesting` back to `VStack` with `if/else` branching — the ZStack approach broke the animation
- Restores `.animation(VAnimation.panel, value: sidebarExpanded)` on the `sidebarView` call site for smooth width transitions
- Retains all intentional color changes: Moss._950 dark backgrounds, removed divider, updated `VColor.background`/`chatBackground` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
