### PR TITLE
feat: convert iOS settings sections to NavigationLink sub-pages

### DIFF
--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -8,46 +8,50 @@ struct IntegrationsSection: View {
     @State private var connectingIntegrationId: String?
 
     var body: some View {
-        Section("Integrations") {
-            if integrations.isEmpty {
-                Text("No integrations available")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            } else {
-                ForEach(integrations, id: \.id) { integration in
-                    HStack {
-                        Text(integrationIcon(integration.id))
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(integrationDisplayName(integration.id))
-                                .font(.body)
-                            if let account = integration.accountInfo {
-                                Text(account)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+        Form {
+            Section {
+                if integrations.isEmpty {
+                    Text("No integrations available")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(integrations, id: \.id) { integration in
+                        HStack {
+                            Text(integrationIcon(integration.id))
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(integrationDisplayName(integration.id))
+                                    .font(.body)
+                                if let account = integration.accountInfo {
+                                    Text(account)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
-                        }
-                        Spacer()
-                        if connectingIntegrationId == integration.id {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else if integration.connected {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(VColor.success)
-                            Button("Disconnect") {
-                                disconnectIntegration(integration.id)
+                            Spacer()
+                            if connectingIntegrationId == integration.id {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else if integration.connected {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(VColor.success)
+                                Button("Disconnect") {
+                                    disconnectIntegration(integration.id)
+                                }
+                                .font(.caption)
+                                .foregroundColor(VColor.error)
+                            } else {
+                                Button("Connect") {
+                                    connectIntegration(integration.id)
+                                }
+                                .font(.caption)
                             }
-                            .font(.caption)
-                            .foregroundColor(VColor.error)
-                        } else {
-                            Button("Connect") {
-                                connectIntegration(integration.id)
-                            }
-                            .font(.caption)
                         }
                     }
                 }
             }
         }
+        .navigationTitle("Integrations")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear { loadIntegrations() }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { loadIntegrations() }

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -8,29 +8,33 @@ struct RemindersSection: View {
     @State private var loading = false
 
     var body: some View {
-        Section("Reminders") {
-            if loading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-            } else if reminders.isEmpty {
-                Text("No active reminders")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            } else {
-                ForEach(reminders, id: \.id) { reminder in
-                    reminderRow(reminder)
-                }
-                .onDelete { indexSet in
-                    let remindersToCancel = indexSet.map { reminders[$0] }
-                    for reminder in remindersToCancel {
-                        cancelReminder(reminder.id)
+        Form {
+            Section {
+                if loading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                } else if reminders.isEmpty {
+                    Text("No active reminders")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(reminders, id: \.id) { reminder in
+                        reminderRow(reminder)
+                    }
+                    .onDelete { indexSet in
+                        let remindersToCancel = indexSet.map { reminders[$0] }
+                        for reminder in remindersToCancel {
+                            cancelReminder(reminder.id)
+                        }
                     }
                 }
             }
         }
+        .navigationTitle("Reminders")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear { loadReminders() }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { loadReminders() }

--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -8,29 +8,33 @@ struct SchedulesSection: View {
     @State private var loading = false
 
     var body: some View {
-        Section("Scheduled Tasks") {
-            if loading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-            } else if schedules.isEmpty {
-                Text("No scheduled tasks")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            } else {
-                ForEach(schedules, id: \.id) { schedule in
-                    scheduleRow(schedule)
-                }
-                .onDelete { indexSet in
-                    let schedulesToDelete = indexSet.map { schedules[$0] }
-                    for schedule in schedulesToDelete {
-                        deleteSchedule(schedule.id)
+        Form {
+            Section {
+                if loading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                } else if schedules.isEmpty {
+                    Text("No scheduled tasks")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(schedules, id: \.id) { schedule in
+                        scheduleRow(schedule)
+                    }
+                    .onDelete { indexSet in
+                        let schedulesToDelete = indexSet.map { schedules[$0] }
+                        for schedule in schedulesToDelete {
+                            deleteSchedule(schedule.id)
+                        }
                     }
                 }
             }
         }
+        .navigationTitle("Scheduled Tasks")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear { loadSchedules() }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { loadSchedules() }

--- a/clients/ios/Views/Settings/TrustRulesSection.swift
+++ b/clients/ios/Views/Settings/TrustRulesSection.swift
@@ -9,29 +9,33 @@ struct TrustRulesSection: View {
     @State private var editingRule: TrustRuleItem?
 
     var body: some View {
-        Section("Trust Rules") {
-            if trustRules.isEmpty {
-                Text("No trust rules configured")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            } else {
-                ForEach(trustRules, id: \.id) { rule in
-                    trustRuleRow(rule)
-                }
-                .onDelete { indexSet in
-                    let rulesToDelete = indexSet.map { trustRules[$0] }
-                    for rule in rulesToDelete {
-                        deleteRule(rule)
+        Form {
+            Section {
+                if trustRules.isEmpty {
+                    Text("No trust rules configured")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(trustRules, id: \.id) { rule in
+                        trustRuleRow(rule)
+                    }
+                    .onDelete { indexSet in
+                        let rulesToDelete = indexSet.map { trustRules[$0] }
+                        for rule in rulesToDelete {
+                            deleteRule(rule)
+                        }
                     }
                 }
-            }
 
-            Button {
-                showingAddRule = true
-            } label: {
-                Label("Add Rule", systemImage: "plus")
+                Button {
+                    showingAddRule = true
+                } label: {
+                    Label("Add Rule", systemImage: "plus")
+                }
             }
         }
+        .navigationTitle("Trust Rules")
+        .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showingAddRule) {
             TrustRuleFormView(daemon: clientProvider.client as? DaemonClient) { _ in
                 loadTrustRules()

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -17,11 +17,30 @@ struct SettingsView: View {
                     AccountSection(authManager: authManager)
                 }
                 DaemonConnectionSection()
-                IntegrationsSection()
                 TwilioSettingsSection()
-                TrustRulesSection()
-                SchedulesSection()
-                RemindersSection()
+
+                Section {
+                    NavigationLink {
+                        IntegrationsSection()
+                    } label: {
+                        Label("Integrations", systemImage: "link")
+                    }
+                    NavigationLink {
+                        SchedulesSection()
+                    } label: {
+                        Label("Scheduled Tasks", systemImage: "clock")
+                    }
+                    NavigationLink {
+                        TrustRulesSection()
+                    } label: {
+                        Label("Trust Rules", systemImage: "shield.lefthalf.filled")
+                    }
+                    NavigationLink {
+                        RemindersSection()
+                    } label: {
+                        Label("Reminders", systemImage: "bell")
+                    }
+                }
 
                 Section("Appearance") {
                     Picker("Theme", selection: $appearanceMode) {


### PR DESCRIPTION
## Summary
Converts the iOS Settings screen from showing all sections inline to using NavigationLink sub-pages for Integrations, Scheduled Tasks, Trust Rules, and Reminders — following the standard iOS Settings drill-down pattern.

## Implementation
- **SettingsView.swift**: Replaced 4 direct section inclusions with a `Section` containing `NavigationLink` rows, each with an SF Symbol icon and auto-chevron
- **IntegrationsSection, SchedulesSection, TrustRulesSection, RemindersSection**: Each converted from an inline `Section("Title")` to a full page wrapped in `Form { Section { ... } }` with `.navigationTitle()` and `.navigationBarTitleDisplayMode(.inline)`

All existing functionality is preserved: swipe-to-delete, toggles, sheets (Add/Edit Trust Rule), data loading/cleanup lifecycle.

## Key Technical Choices
- Used the existing `NavigationStack` already in SettingsView — no new navigation containers needed
- Each detail view uses `.navigationBarTitleDisplayMode(.inline)` for the standard iOS drilldown feel
- Sections that are simple (Account, Daemon Connection, Twilio, Appearance, Permissions, About) remain inline

## Testing
1. Open the iOS app, go to Settings tab
2. Verify Integrations, Scheduled Tasks, Trust Rules, and Reminders appear as rows with chevrons
3. Tap each — should navigate to a detail page with the full content
4. Verify back navigation, swipe-to-delete, toggles, and sheets all work
5. Verify inline sections (Account, Twilio, Appearance, etc.) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
