### PR TITLE
feat: simplify iOS settings with QR-first Connect and Twilio sub-pages

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @Bindable var authManager: AuthManager
     @State private var connectPhase: ConnectPhase = .initial
     @State private var selectedTab: Tab = .home
+    @State private var navigateToConnect = false
 
     private enum Tab { case home, chats, identity, settings }
 
@@ -112,6 +113,7 @@ struct ContentView: View {
                 Button {
                     selectedTab = .settings
                     connectPhase = .ready
+                    navigateToConnect = true
                 } label: {
                     Text("Go to Settings")
                 }
@@ -149,7 +151,7 @@ struct ContentView: View {
                     Label("Identity", systemImage: "person.text.rectangle")
                 }
 
-            SettingsView(authManager: authManager)
+            SettingsView(authManager: authManager, navigateToConnect: $navigateToConnect)
                 .environmentObject(clientProvider)
                 .tag(Tab.settings)
                 .tabItem {

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -54,72 +54,87 @@ struct DaemonConnectionSection: View {
     @State private var alertMessage = ""
     @State private var showingQRPairing = false
 
+    @State private var showManualSetup = false
+
     var body: some View {
-        Section("Mac Daemon") {
-            Button {
-                showingQRPairing = true
-            } label: {
-                HStack {
-                    Image(systemName: "qrcode.viewfinder")
-                    Text("Scan QR Code")
+        Form {
+            Section {
+                Button {
+                    showingQRPairing = true
+                } label: {
+                    HStack {
+                        Spacer()
+                        VStack(spacing: 8) {
+                            Image(systemName: "qrcode.viewfinder")
+                                .font(.system(size: 40))
+                            Text("Scan QR Code")
+                                .font(.headline)
+                        }
+                        Spacer()
+                    }
+                    .padding(.vertical, 12)
                 }
+            } footer: {
+                Text("Open Vellum on your Mac, then go to Settings > Show QR Code.")
             }
 
-            HStack {
-                Text("Hostname")
-                Spacer()
-                TextField("e.g. 192.168.1.100", text: $daemonHostname)
-                    .multilineTextAlignment(.trailing)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-            }
-            HStack {
-                Text("Port")
-                Spacer()
-                TextField("8765", text: $daemonPort)
-                    .multilineTextAlignment(.trailing)
-                    .keyboardType(.numberPad)
-            }
-            HStack {
-                Text("Session Token")
-                Spacer()
-                SecureField("From ~/.vellum/session-token", text: $sessionToken)
-                    .multilineTextAlignment(.trailing)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-            }
-            Text("Or scan the QR code from Mac app > Settings > Show QR Code.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Button("Update") {
-                guard let port = Int(daemonPort), port > 0, port <= 65535 else {
-                    alertMessage = "Port must be a valid number between 1 and 65535"
-                    showingAlert = true
-                    return
+            Section {
+                DisclosureGroup("Manual Setup", isExpanded: $showManualSetup) {
+                    HStack {
+                        Text("Hostname")
+                        Spacer()
+                        TextField("e.g. 192.168.1.100", text: $daemonHostname)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                    HStack {
+                        Text("Port")
+                        Spacer()
+                        TextField("8765", text: $daemonPort)
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.numberPad)
+                    }
+                    HStack {
+                        Text("Session Token")
+                        Spacer()
+                        SecureField("From ~/.vellum/session-token", text: $sessionToken)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                    Button("Update") {
+                        guard let port = Int(daemonPort), port > 0, port <= 65535 else {
+                            alertMessage = "Port must be a valid number between 1 and 65535"
+                            showingAlert = true
+                            return
+                        }
+                        UserDefaults.standard.set(daemonHostname, forKey: UserDefaultsKeys.daemonHostname)
+                        UserDefaults.standard.set(port, forKey: UserDefaultsKeys.daemonPort)
+                        // iOS always uses TLS for TCP connections
+                        UserDefaults.standard.set(true, forKey: UserDefaultsKeys.daemonTLSEnabled)
+                        if sessionToken.isEmpty {
+                            _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
+                            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.legacyDaemonToken)
+                        } else {
+                            _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
+                        }
+                        // Rebuild the client so the new transport config takes effect,
+                        // then reconnect. DaemonClient transport is fixed at init, so
+                        // just calling connect() wouldn't pick up hostname/port changes.
+                        clientProvider.rebuildClient()
+                        Task {
+                            try? await clientProvider.client.connect()
+                        }
+                        alertMessage = "Daemon connection settings updated"
+                        showingAlert = true
+                    }
+                    .disabled(daemonHostname.isEmpty || daemonPort.isEmpty)
                 }
-                UserDefaults.standard.set(daemonHostname, forKey: UserDefaultsKeys.daemonHostname)
-                UserDefaults.standard.set(port, forKey: UserDefaultsKeys.daemonPort)
-                // iOS always uses TLS for TCP connections
-                UserDefaults.standard.set(true, forKey: UserDefaultsKeys.daemonTLSEnabled)
-                if sessionToken.isEmpty {
-                    _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
-                    UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.legacyDaemonToken)
-                } else {
-                    _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
-                }
-                // Rebuild the client so the new transport config takes effect,
-                // then reconnect. DaemonClient transport is fixed at init, so
-                // just calling connect() wouldn't pick up hostname/port changes.
-                clientProvider.rebuildClient()
-                Task {
-                    try? await clientProvider.client.connect()
-                }
-                alertMessage = "Daemon connection settings updated"
-                showingAlert = true
             }
-            .disabled(daemonHostname.isEmpty || daemonPort.isEmpty)
         }
+        .navigationTitle("Connect")
+        .navigationBarTitleDisplayMode(.inline)
         .alert("Daemon Settings", isPresented: $showingAlert) {
             Button("OK") {}
         } message: {

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -22,158 +22,162 @@ struct TwilioSettingsSection: View {
     @State private var assigningNumber: String?
 
     var body: some View {
-        Section("Twilio (Calls & SMS)") {
-            if isLoading {
-                HStack {
-                    Text("Loading...")
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.small)
-                }
-            } else {
-                // Connection status
-                HStack {
-                    Text("Credentials")
-                    Spacer()
-                    if hasCredentials {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                        Text("Connected")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Image(systemName: "xmark.circle")
-                            .foregroundColor(VColor.error)
-                        Text("Not configured")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+        Form {
+            Section {
+                if isLoading {
+                    HStack {
+                        Text("Loading...")
+                        Spacer()
+                        ProgressView()
+                            .controlSize(.small)
                     }
-                }
-
-                // Phone number
-                HStack {
-                    Text("Phone Number")
-                    Spacer()
-                    if let number = phoneNumber {
-                        Text(number)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Text("None assigned")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                // Actions when credentials are configured
-                if hasCredentials {
-                    // List available numbers
-                    Button {
-                        listNumbers()
-                    } label: {
-                        HStack {
-                            Text("List Account Numbers")
-                            Spacer()
-                            if isLoadingNumbers {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Image(systemName: "phone.badge.waveform")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .disabled(isLoadingNumbers)
-
-                    // Show available numbers for assignment
-                    if !availableNumbers.isEmpty {
-                        ForEach(availableNumbers, id: \.phoneNumber) { number in
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(number.phoneNumber)
-                                        .font(.body)
-                                    HStack(spacing: 4) {
-                                        Text(number.friendlyName)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        if number.capabilities.voice {
-                                            Text("Voice")
-                                                .font(.caption2)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(Color.blue.opacity(0.15))
-                                                .cornerRadius(4)
-                                        }
-                                        if number.capabilities.sms {
-                                            Text("SMS")
-                                                .font(.caption2)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(Color.green.opacity(0.15))
-                                                .cornerRadius(4)
-                                        }
-                                    }
-                                }
-                                Spacer()
-                                if number.phoneNumber == phoneNumber {
-                                    Text("Active")
-                                        .font(.caption)
-                                        .foregroundColor(VColor.success)
-                                } else if assigningNumber == number.phoneNumber {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                } else {
-                                    Button("Assign") {
-                                        assignNumber(number.phoneNumber)
-                                    }
-                                    .font(.caption)
-                                    .disabled(isAssigning)
-                                }
-                            }
-                        }
-                    }
-
-                    // Provision new number
-                    Button {
-                        showProvisionSheet = true
-                    } label: {
-                        HStack {
-                            Text("Provision New Number")
-                            Spacer()
-                            Image(systemName: "plus.circle")
+                } else {
+                    // Connection status
+                    HStack {
+                        Text("Credentials")
+                        Spacer()
+                        if hasCredentials {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                            Text("Connected")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Image(systemName: "xmark.circle")
+                                .foregroundColor(VColor.error)
+                            Text("Not configured")
+                                .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .disabled(isProvisioning)
 
-                    // Clear credentials
-                    Button(role: .destructive) {
-                        showClearConfirmation = true
-                    } label: {
-                        HStack {
-                            if isClearing {
-                                ProgressView()
-                                    .controlSize(.small)
-                                Text("Clearing...")
-                            } else {
-                                Text("Clear Credentials")
-                            }
+                    // Phone number
+                    HStack {
+                        Text("Phone Number")
+                        Spacer()
+                        if let number = phoneNumber {
+                            Text(number)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("None assigned")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
-                    .disabled(isClearing)
-                } else {
-                    Text("Use the Twilio Setup skill in chat to configure credentials and phone number.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
 
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundColor(VColor.error)
+                    // Actions when credentials are configured
+                    if hasCredentials {
+                        // List available numbers
+                        Button {
+                            listNumbers()
+                        } label: {
+                            HStack {
+                                Text("List Account Numbers")
+                                Spacer()
+                                if isLoadingNumbers {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Image(systemName: "phone.badge.waveform")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .disabled(isLoadingNumbers)
+
+                        // Show available numbers for assignment
+                        if !availableNumbers.isEmpty {
+                            ForEach(availableNumbers, id: \.phoneNumber) { number in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(number.phoneNumber)
+                                            .font(.body)
+                                        HStack(spacing: 4) {
+                                            Text(number.friendlyName)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                            if number.capabilities.voice {
+                                                Text("Voice")
+                                                    .font(.caption2)
+                                                    .padding(.horizontal, 4)
+                                                    .padding(.vertical, 1)
+                                                    .background(Color.blue.opacity(0.15))
+                                                    .cornerRadius(4)
+                                            }
+                                            if number.capabilities.sms {
+                                                Text("SMS")
+                                                    .font(.caption2)
+                                                    .padding(.horizontal, 4)
+                                                    .padding(.vertical, 1)
+                                                    .background(Color.green.opacity(0.15))
+                                                    .cornerRadius(4)
+                                            }
+                                        }
+                                    }
+                                    Spacer()
+                                    if number.phoneNumber == phoneNumber {
+                                        Text("Active")
+                                            .font(.caption)
+                                            .foregroundColor(VColor.success)
+                                    } else if assigningNumber == number.phoneNumber {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                    } else {
+                                        Button("Assign") {
+                                            assignNumber(number.phoneNumber)
+                                        }
+                                        .font(.caption)
+                                        .disabled(isAssigning)
+                                    }
+                                }
+                            }
+                        }
+
+                        // Provision new number
+                        Button {
+                            showProvisionSheet = true
+                        } label: {
+                            HStack {
+                                Text("Provision New Number")
+                                Spacer()
+                                Image(systemName: "plus.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .disabled(isProvisioning)
+
+                        // Clear credentials
+                        Button(role: .destructive) {
+                            showClearConfirmation = true
+                        } label: {
+                            HStack {
+                                if isClearing {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text("Clearing...")
+                                } else {
+                                    Text("Clear Credentials")
+                                }
+                            }
+                        }
+                        .disabled(isClearing)
+                    } else {
+                        Text("Use the Twilio Setup skill in chat to configure credentials and phone number.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let error = errorMessage {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(VColor.error)
+                    }
                 }
             }
         }
+        .navigationTitle("Twilio")
+        .navigationBarTitleDisplayMode(.inline)
         .confirmationDialog("Clear Twilio Credentials", isPresented: $showClearConfirmation, titleVisibility: .visible) {
             Button("Clear", role: .destructive) {
                 clearCredentials()

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @Bindable var authManager: AuthManager
     @AppStorage(UserDefaultsKeys.appearanceMode) private var appearanceMode: String = "system"
+    @Binding var navigateToConnect: Bool
 
     var body: some View {
         NavigationStack {
@@ -16,13 +17,17 @@ struct SettingsView: View {
                 if authManager.isAuthenticated {
                     AccountSection(authManager: authManager)
                 }
-                TwilioSettingsSection()
 
                 Section {
                     NavigationLink {
                         DaemonConnectionSection()
                     } label: {
                         Label("Connect", systemImage: "desktopcomputer")
+                    }
+                    NavigationLink {
+                        TwilioSettingsSection()
+                    } label: {
+                        Label("Twilio", systemImage: "phone")
                     }
                     NavigationLink {
                         IntegrationsSection()
@@ -65,6 +70,9 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+            .navigationDestination(isPresented: $navigateToConnect) {
+                DaemonConnectionSection()
+            }
         }
     }
 }
@@ -125,7 +133,7 @@ extension Bundle {
 }
 
 #Preview {
-    SettingsView(authManager: AuthManager())
+    SettingsView(authManager: AuthManager(), navigateToConnect: .constant(false))
         .environmentObject(ClientProvider(client: DaemonClient(config: .fromUserDefaults())))
 }
 #endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -16,10 +16,14 @@ struct SettingsView: View {
                 if authManager.isAuthenticated {
                     AccountSection(authManager: authManager)
                 }
-                DaemonConnectionSection()
                 TwilioSettingsSection()
 
                 Section {
+                    NavigationLink {
+                        DaemonConnectionSection()
+                    } label: {
+                        Label("Connect", systemImage: "desktopcomputer")
+                    }
                     NavigationLink {
                         IntegrationsSection()
                     } label: {


### PR DESCRIPTION
## Summary
Continues the iOS Settings cleanup by moving the Mac Daemon connection and Twilio sections to NavigationLink sub-pages, and adding a deep link from the connection-failed screen directly to the Connect page.

## Implementation

### Connect page (DaemonConnectionSection)
- Moved from inline section to a NavigationLink sub-page labeled "Connect"
- QR scan button is centered and prominent as the primary action
- Manual setup (hostname, port, session token, Update) tucked behind a collapsed `DisclosureGroup`
- QR scan is fully self-contained — no "Update" needed after scanning

### Twilio page (TwilioSettingsSection)
- Moved from inline section to a NavigationLink sub-page labeled "Twilio"
- All existing functionality preserved (credentials status, phone number, list/assign/provision numbers, clear credentials)

### Deep link from connection-failed screen
- "Go to Settings" button on the "Unable to Connect" screen now navigates directly to the Connect detail page
- Uses `navigationDestination(isPresented:)` with a binding passed from ContentView to SettingsView

### Settings main page
All configuration sections are now NavigationLink rows in a single section:
- Connect, Twilio, Integrations, Scheduled Tasks, Trust Rules, Reminders

Simple sections remain inline: Account, Appearance, Permissions, About.

## Files Changed
- `clients/ios/Views/SettingsView.swift` — Added `navigateToConnect` binding, moved Twilio to NavigationLink section, added `navigationDestination(isPresented:)` for deep link
- `clients/ios/Views/Settings/ConnectionSettingsSection.swift` — QR-first layout with DisclosureGroup for manual setup
- `clients/ios/Views/Settings/TwilioSettingsSection.swift` — Converted from inline Section to full page
- `clients/ios/Views/ContentView.swift` — Added `navigateToConnect` state, wired "Go to Settings" button to set it

## Testing
1. Settings tab: verify Connect, Twilio, Integrations, etc. all appear as NavigationLink rows
2. Tap Connect — prominent QR scan button, manual setup collapsed
3. Tap Twilio — full Twilio config page with credentials status, phone number, etc.
4. Trigger connection failure (disconnect Mac) — tap "Go to Settings" — should land directly on the Connect page
5. Verify QR scan and manual setup flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)