### PR TITLE
M2: Daemon Finalization Handler + CU Metadata Plumbing

### DIFF
--- a/assistant/src/__tests__/cu-session-finalized.test.ts
+++ b/assistant/src/__tests__/cu-session-finalized.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect, mock } from 'bun:test';
+import * as net from 'node:net';
+
+// Mock the conversation store before importing the handler.
+const mockConversations = new Map<string, { id: string }>();
+const mockAddedMessages: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}> = [];
+
+mock.module('../memory/conversation-store.js', () => ({
+  getConversation: (id: string) => mockConversations.get(id) ?? null,
+  addMessage: (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => {
+    const msg = { conversationId, role, content, metadata };
+    mockAddedMessages.push(msg);
+    return { id: 'mock-msg-id', conversationId, role, content, createdAt: Date.now() };
+  },
+}));
+
+// Mock the config loader (required by shared.ts transitively).
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    permissions: { mode: 'legacy' },
+    apiKeys: {},
+    sandbox: { enabled: false },
+    timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
+    skills: { load: { extraDirs: [] } },
+    secretDetection: { enabled: false },
+    memory: {},
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+import type { CuSessionFinalized, ServerMessage } from '../daemon/ipc-contract.js';
+import type { HandlerContext, CuSessionMetadata } from '../daemon/handlers/shared.js';
+import { handleCuSessionFinalized } from '../daemon/handlers/computer-use.js';
+import type { ComputerUseSession } from '../daemon/computer-use-session.js';
+
+/** Create a minimal HandlerContext for testing. */
+function makeCtx(overrides?: Partial<HandlerContext>): HandlerContext {
+  return {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new Map() as unknown as HandlerContext['debounceTimers'],
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: () => {},
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: async () => { throw new Error('not implemented in test'); },
+    touchSession: () => {},
+    ...overrides,
+  };
+}
+
+describe('handleCuSessionFinalized', () => {
+  test('injects summary into reporting session when reportToSessionId is set', () => {
+    // Set up a reporting session conversation.
+    const reportSessionId = 'report-session-1';
+    mockConversations.set(reportSessionId, { id: reportSessionId });
+    mockAddedMessages.length = 0;
+
+    // Create a mock socket for the reporting session.
+    const reportSocket = new net.Socket();
+    const sentMessages: Array<{ socket: net.Socket; msg: ServerMessage }> = [];
+
+    const ctx = makeCtx({
+      send: (socket: net.Socket, msg: ServerMessage) => { sentMessages.push({ socket, msg }); },
+      socketToSession: new Map([[reportSocket, reportSessionId]]),
+    });
+
+    // Simulate a CU session with metadata.
+    const cuSessionId = 'cu-session-1';
+    ctx.cuSessions.set(cuSessionId, {} as ComputerUseSession);
+    ctx.cuSessionMetadata.set(cuSessionId, {
+      reportToSessionId: reportSessionId,
+      qaMode: true,
+    });
+
+    const msg: CuSessionFinalized = {
+      type: 'cu_session_finalized',
+      sessionId: cuSessionId,
+      status: 'completed',
+      summary: 'QA test passed: login flow works correctly.',
+      stepCount: 5,
+    };
+
+    handleCuSessionFinalized(msg, new net.Socket(), ctx);
+
+    // Verify the assistant message was persisted.
+    expect(mockAddedMessages.length).toBe(1);
+    expect(mockAddedMessages[0].conversationId).toBe(reportSessionId);
+    expect(mockAddedMessages[0].role).toBe('assistant');
+    const parsedContent = JSON.parse(mockAddedMessages[0].content);
+    expect(parsedContent).toEqual([{ type: 'text', text: msg.summary }]);
+    expect(mockAddedMessages[0].metadata).toMatchObject({
+      source: 'cu_session_finalized',
+      cuSessionId,
+      cuStatus: 'completed',
+      cuStepCount: 5,
+      qaMode: true,
+    });
+
+    // Verify IPC messages were sent to the reporting socket.
+    expect(sentMessages.length).toBe(2);
+    expect(sentMessages[0].msg).toMatchObject({
+      type: 'assistant_text_delta',
+      text: msg.summary,
+      sessionId: reportSessionId,
+    });
+    expect(sentMessages[1].msg).toMatchObject({
+      type: 'message_complete',
+      sessionId: reportSessionId,
+    });
+    expect(sentMessages[0].socket).toBe(reportSocket);
+
+    // Verify CU session state was cleaned up.
+    expect(ctx.cuSessions.has(cuSessionId)).toBe(false);
+    expect(ctx.cuSessionMetadata.has(cuSessionId)).toBe(false);
+  });
+
+  test('cleans up CU session state even without reportToSessionId', () => {
+    const ctx = makeCtx();
+    const cuSessionId = 'cu-session-2';
+    ctx.cuSessions.set(cuSessionId, {} as ComputerUseSession);
+    // No metadata set — this is a non-QA CU session.
+
+    const msg: CuSessionFinalized = {
+      type: 'cu_session_finalized',
+      sessionId: cuSessionId,
+      status: 'completed',
+      summary: 'Task done.',
+      stepCount: 3,
+    };
+
+    mockAddedMessages.length = 0;
+    handleCuSessionFinalized(msg, new net.Socket(), ctx);
+
+    // No message should be persisted (no reportToSessionId).
+    expect(mockAddedMessages.length).toBe(0);
+
+    // CU session state should still be cleaned up.
+    expect(ctx.cuSessions.has(cuSessionId)).toBe(false);
+  });
+
+  test('handles missing reporting conversation gracefully', () => {
+    const ctx = makeCtx();
+    const cuSessionId = 'cu-session-3';
+    ctx.cuSessions.set(cuSessionId, {} as ComputerUseSession);
+    ctx.cuSessionMetadata.set(cuSessionId, {
+      reportToSessionId: 'nonexistent-session',
+      qaMode: true,
+    });
+
+    // Make sure the conversation does NOT exist in the mock store.
+    mockConversations.delete('nonexistent-session');
+    mockAddedMessages.length = 0;
+
+    const msg: CuSessionFinalized = {
+      type: 'cu_session_finalized',
+      sessionId: cuSessionId,
+      status: 'failed',
+      summary: 'QA test failed.',
+      stepCount: 2,
+    };
+
+    // Should not throw even if the conversation is missing.
+    handleCuSessionFinalized(msg, new net.Socket(), ctx);
+
+    expect(mockAddedMessages.length).toBe(0);
+    expect(ctx.cuSessions.has(cuSessionId)).toBe(false);
+    expect(ctx.cuSessionMetadata.has(cuSessionId)).toBe(false);
+  });
+
+  test('logs recording metadata without crashing', () => {
+    const reportSessionId = 'report-session-rec';
+    mockConversations.set(reportSessionId, { id: reportSessionId });
+    mockAddedMessages.length = 0;
+
+    const ctx = makeCtx();
+    const cuSessionId = 'cu-session-rec';
+    ctx.cuSessions.set(cuSessionId, {} as ComputerUseSession);
+    ctx.cuSessionMetadata.set(cuSessionId, {
+      reportToSessionId: reportSessionId,
+    });
+
+    const msg: CuSessionFinalized = {
+      type: 'cu_session_finalized',
+      sessionId: cuSessionId,
+      status: 'completed',
+      summary: 'Done with recording.',
+      stepCount: 4,
+      recording: {
+        localPath: '/tmp/recording.mp4',
+        mimeType: 'video/mp4',
+        sizeBytes: 1024000,
+        durationMs: 30000,
+        width: 1920,
+        height: 1080,
+        captureScope: 'window',
+        includeAudio: false,
+      },
+    };
+
+    handleCuSessionFinalized(msg, new net.Socket(), ctx);
+
+    // Message should be persisted with recording path in metadata.
+    expect(mockAddedMessages.length).toBe(1);
+    expect(mockAddedMessages[0].metadata).toMatchObject({
+      recordingPath: '/tmp/recording.mp4',
+    });
+  });
+
+  test('stores and retrieves CU session metadata', () => {
+    const ctx = makeCtx();
+
+    const cuSessionId = 'cu-meta-test';
+    const meta: CuSessionMetadata = {
+      reportToSessionId: 'parent-123',
+      qaMode: true,
+    };
+    ctx.cuSessionMetadata.set(cuSessionId, meta);
+
+    const stored = ctx.cuSessionMetadata.get(cuSessionId);
+    expect(stored).toEqual(meta);
+    expect(stored?.reportToSessionId).toBe('parent-123');
+    expect(stored?.qaMode).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -71,6 +71,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -84,6 +84,7 @@ function createTestContext(sessionId: string): {
     socketToSession: new Map(),
     cuSessions,
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
+++ b/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
@@ -61,6 +61,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-slack-config.test.ts
+++ b/assistant/src/__tests__/handlers-slack-config.test.ts
@@ -91,6 +91,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -138,6 +138,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -152,6 +152,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -124,6 +124,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/ingress-reconcile.test.ts
+++ b/assistant/src/__tests__/ingress-reconcile.test.ts
@@ -89,6 +89,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -69,6 +69,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -160,6 +160,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
     socketToSession: new Map(),
     cuSessions: new Map(),
     socketToCuSession: new Map(),
+    cuSessionMetadata: new Map(),
     cuObservationParseSequence: new Map(),
     socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -11,7 +11,8 @@ import type {
   CuObservation,
   ServerMessage,
 } from '../ipc-protocol.js';
-import { log, defineHandlers, type HandlerContext } from './shared.js';
+import * as conversationStore from '../../memory/conversation-store.js';
+import { log, defineHandlers, findSocketForSession, type HandlerContext, type CuSessionMetadata } from './shared.js';
 
 const cuObservationSequenceBySession = new Map<string, number>();
 
@@ -25,6 +26,7 @@ function removeCuSessionReferences(
     return;
   }
   ctx.cuSessions.delete(sessionId);
+  ctx.cuSessionMetadata.delete(sessionId);
   cuObservationSequenceBySession.delete(sessionId);
   ctx.cuObservationParseSequence.delete(sessionId);
   for (const [sock, ids] of ctx.socketToCuSession) {
@@ -78,6 +80,15 @@ export function handleCuSessionCreate(
   sessionRef.current = session;
 
   ctx.cuSessions.set(msg.sessionId, session);
+
+  // Store QA metadata so handleCuSessionFinalized can inject results
+  // into the originating chat session.
+  if (msg.reportToSessionId || msg.qaMode) {
+    const meta: CuSessionMetadata = {};
+    if (msg.reportToSessionId) meta.reportToSessionId = msg.reportToSessionId;
+    if (msg.qaMode) meta.qaMode = msg.qaMode;
+    ctx.cuSessionMetadata.set(msg.sessionId, meta);
+  }
 
   // Track all CU sessions per socket so disconnect cleans up all of them
   let sessionIds = ctx.socketToCuSession.get(socket);
@@ -184,8 +195,10 @@ export async function handleCuObservation(
 export function handleCuSessionFinalized(
   msg: CuSessionFinalized,
   _socket: net.Socket,
-  _ctx: HandlerContext,
+  ctx: HandlerContext,
 ): void {
+  const meta = ctx.cuSessionMetadata.get(msg.sessionId);
+
   log.info(
     {
       sessionId: msg.sessionId,
@@ -194,9 +207,76 @@ export function handleCuSessionFinalized(
       hasRecording: !!msg.recording,
       recordingSizeBytes: msg.recording?.sizeBytes,
       recordingDurationMs: msg.recording?.durationMs,
+      reportToSessionId: meta?.reportToSessionId,
+      qaMode: meta?.qaMode,
     },
     'CU session finalized by client',
   );
+
+  // If recording metadata is present, log it for future M3 file-backed attachment support.
+  if (msg.recording) {
+    log.info(
+      {
+        sessionId: msg.sessionId,
+        localPath: msg.recording.localPath,
+        mimeType: msg.recording.mimeType,
+        sizeBytes: msg.recording.sizeBytes,
+        durationMs: msg.recording.durationMs,
+        width: msg.recording.width,
+        height: msg.recording.height,
+        captureScope: msg.recording.captureScope,
+      },
+      'CU session recording metadata (stored for M3)',
+    );
+  }
+
+  // Inject a summary message into the originating chat session if configured.
+  if (meta?.reportToSessionId && msg.summary) {
+    const reportSessionId = meta.reportToSessionId;
+    const reportSocket = findSocketForSession(reportSessionId, ctx);
+
+    // Persist the assistant message in the conversation store so it appears
+    // in history even if the client is not currently connected.
+    const conversation = conversationStore.getConversation(reportSessionId);
+    if (conversation) {
+      const assistantContent = JSON.stringify([{ type: 'text', text: msg.summary }]);
+      conversationStore.addMessage(reportSessionId, 'assistant', assistantContent, {
+        source: 'cu_session_finalized',
+        cuSessionId: msg.sessionId,
+        cuStatus: msg.status,
+        cuStepCount: msg.stepCount,
+        qaMode: meta.qaMode ?? false,
+        ...(msg.recording ? { recordingPath: msg.recording.localPath } : {}),
+      });
+
+      // If the reporting session has a connected client, stream the summary
+      // so it appears in real time.
+      if (reportSocket) {
+        ctx.send(reportSocket, {
+          type: 'assistant_text_delta',
+          text: msg.summary,
+          sessionId: reportSessionId,
+        });
+        ctx.send(reportSocket, {
+          type: 'message_complete',
+          sessionId: reportSessionId,
+        });
+      }
+
+      log.info(
+        { cuSessionId: msg.sessionId, reportToSessionId: reportSessionId },
+        'Injected CU finalization summary into reporting session',
+      );
+    } else {
+      log.warn(
+        { cuSessionId: msg.sessionId, reportToSessionId: reportSessionId },
+        'Reporting session conversation not found; summary not persisted',
+      );
+    }
+  }
+
+  // Clean up all CU session state.
+  removeCuSessionReferences(ctx, msg.sessionId);
 }
 
 export const computerUseHandlers = defineHandlers({

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -26,6 +26,7 @@ import { identityHandlers } from './identity.js';
 // Re-export types and utilities for backwards compatibility
 export type {
   HandlerContext,
+  CuSessionMetadata,
   SessionCreateOptions,
   HistoryToolCall,
   HistorySurface,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -104,6 +104,14 @@ export interface SessionCreateOptions {
   strictPrivateSideEffects?: boolean;
 }
 
+/** Metadata stored alongside a CU session for QA workflow plumbing. */
+export interface CuSessionMetadata {
+  /** Origin chat session to inject results into on finalization. */
+  reportToSessionId?: string;
+  /** Whether this CU run is a QA/test workflow. */
+  qaMode?: boolean;
+}
+
 /**
  * Shared context that handlers need from the DaemonServer.
  * Keeps handlers decoupled from the server class itself.
@@ -113,6 +121,7 @@ export interface HandlerContext {
   socketToSession: Map<net.Socket, string>;
   cuSessions: Map<string, ComputerUseSession>;
   socketToCuSession: Map<net.Socket, Set<string>>;
+  cuSessionMetadata: Map<string, CuSessionMetadata>;
   cuObservationParseSequence: Map<string, number>;
   socketSandboxOverride: Map<net.Socket, boolean>;
   sharedRequestTimestamps: number[];

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -66,6 +66,7 @@ export class DaemonServer {
   private socketToSession = new Map<net.Socket, string>();
   private cuSessions = new Map<string, ComputerUseSession>();
   private socketToCuSession = new Map<net.Socket, Set<string>>();
+  private cuSessionMetadata = new Map<string, import('./handlers/shared.js').CuSessionMetadata>();
   private connectedSockets = new Set<net.Socket>();
   private socketSandboxOverride = new Map<net.Socket, boolean>();
   private cuObservationParseSequence = new Map<string, number>();
@@ -353,6 +354,7 @@ export class DaemonServer {
     }
     this.cuSessions.clear();
     this.socketToCuSession.clear();
+    this.cuSessionMetadata.clear();
 
     for (const socket of this.connectedSockets) {
       socket.destroy();
@@ -963,6 +965,7 @@ export class DaemonServer {
       socketToSession: this.socketToSession,
       cuSessions: this.cuSessions,
       socketToCuSession: this.socketToCuSession,
+      cuSessionMetadata: this.cuSessionMetadata,
       cuObservationParseSequence: this.cuObservationParseSequence,
       socketSandboxOverride: this.socketSandboxOverride,
       sharedRequestTimestamps: this.sharedRequestTimestamps,


### PR DESCRIPTION
Implements the full cu_session_finalized handler: stores reportToSessionId and qaMode during CU session creation, injects QA summary into the originating chat session on finalization, cleans up session state. Part of #6899.

## Changes

- **`assistant/src/daemon/handlers/shared.ts`**: Added `CuSessionMetadata` interface and `cuSessionMetadata` map to `HandlerContext`
- **`assistant/src/daemon/server.ts`**: Added `cuSessionMetadata` map instance and plumbed it into `handlerContext()`
- **`assistant/src/daemon/handlers/computer-use.ts`**: 
  - Store `reportToSessionId` and `qaMode` from `CuSessionCreate` into metadata map
  - Implemented full `handleCuSessionFinalized`: looks up metadata, persists assistant message in reporting session's conversation, streams summary to connected client via `assistant_text_delta` + `message_complete`, logs recording metadata for M3, cleans up all CU session state
  - Updated `removeCuSessionReferences` to clean up metadata map
- **`assistant/src/daemon/handlers/index.ts`**: Re-exported `CuSessionMetadata` type
- **`assistant/src/__tests__/cu-session-finalized.test.ts`**: New test file with 5 tests covering summary injection, cleanup, missing conversation handling, recording metadata, and metadata storage
- **10 existing test files**: Added `cuSessionMetadata: new Map()` to HandlerContext mocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
