### PR TITLE
Fix M1 review feedback: Swift init + codegen INT_PATTERNS

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -180,6 +180,7 @@ const INT_PATTERNS = [
   /[Ii]ndex$/,
   /[Ee]xpected$/,
   /[Uu]ndos$/,
+  /Ms$/,
 ];
 
 function shouldBeInt(propName: string): boolean {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -495,7 +495,7 @@ public struct IPCCuSessionFinalizedRecording: Codable, Sendable {
     public let localPath: String
     public let mimeType: String
     public let sizeBytes: Int
-    public let durationMs: Double
+    public let durationMs: Int
     public let width: Int
     public let height: Int
     public let captureScope: String
@@ -1024,7 +1024,7 @@ public struct IPCMemoryRecalled: Codable, Sendable {
     public let selectedCount: Int
     public let rerankApplied: Bool
     public let injectedTokens: Int
-    public let latencyMs: Double
+    public let latencyMs: Int
     public let topCandidates: [IPCMemoryRecalledCandidateDebug]
 }
 
@@ -1047,7 +1047,7 @@ public struct IPCMemoryStatus: Codable, Sendable {
     public let model: String?
     public let conflictsPending: Double
     public let conflictsResolved: Double
-    public let oldestPendingConflictAgeMs: Double?
+    public let oldestPendingConflictAgeMs: Int?
     public let cleanupResolvedJobsPending: Double
     public let cleanupSupersededJobsPending: Double
     public let cleanupResolvedJobsCompleted24h: Double

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -155,8 +155,8 @@ extension IPCUserMessageAttachment {
 public typealias CuSessionCreateMessage = IPCCuSessionCreate
 
 extension IPCCuSessionCreate {
-    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?) {
-        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType)
+    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?, reportToSessionId: String? = nil, qaMode: Bool? = nil) {
+        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType, reportToSessionId: reportToSessionId, qaMode: qaMode)
     }
 }
 


### PR DESCRIPTION
Addresses review feedback from #6907: updates CuSessionCreate convenience init with new optional fields, adds Ms suffix to INT_PATTERNS so durationMs generates as Int. Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
