### PR TITLE
Fix M2 + M1-fix review feedback: metadata race + latencyMs type

### DIFF
--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -26,7 +26,11 @@ function removeCuSessionReferences(
     return;
   }
   ctx.cuSessions.delete(sessionId);
-  ctx.cuSessionMetadata.delete(sessionId);
+  // NOTE: cuSessionMetadata is intentionally NOT deleted here.
+  // onTerminal fires before cu_session_finalized arrives from the client,
+  // so deleting metadata here would race with handleCuSessionFinalized
+  // which still needs to read it. Metadata is cleaned up explicitly at the
+  // end of handleCuSessionFinalized instead.
   cuObservationSequenceBySession.delete(sessionId);
   ctx.cuObservationParseSequence.delete(sessionId);
   for (const [sock, ids] of ctx.socketToCuSession) {
@@ -48,6 +52,9 @@ export function handleCuSessionCreate(
   if (existingSession) {
     existingSession.abort();
     removeCuSessionReferences(ctx, msg.sessionId, existingSession);
+    // Clean up stale metadata from the replaced session; the new session
+    // will set its own metadata below if needed.
+    ctx.cuSessionMetadata.delete(msg.sessionId);
   }
 
   const config = getConfig();
@@ -113,6 +120,8 @@ export function handleCuSessionAbort(
   }
   session.abort();
   removeCuSessionReferences(ctx, msg.sessionId, session);
+  // On explicit abort, clean up metadata too — no finalized event is guaranteed.
+  ctx.cuSessionMetadata.delete(msg.sessionId);
   log.info({ sessionId: msg.sessionId }, 'Computer-use session aborted by client');
 }
 
@@ -249,6 +258,16 @@ export function handleCuSessionFinalized(
         ...(msg.recording ? { recordingPath: msg.recording.localPath } : {}),
       });
 
+      // Also append to the in-memory Session.messages so subsequent turns
+      // in the same session see the injected summary without a reload.
+      const activeSession = ctx.sessions.get(reportSessionId);
+      if (activeSession) {
+        activeSession.messages.push({
+          role: 'assistant',
+          content: [{ type: 'text', text: msg.summary }],
+        });
+      }
+
       // If the reporting session has a connected client, stream the summary
       // so it appears in real time.
       if (reportSocket) {
@@ -277,6 +296,9 @@ export function handleCuSessionFinalized(
 
   // Clean up all CU session state.
   removeCuSessionReferences(ctx, msg.sessionId);
+  // Delete metadata last — after it has been consumed for summary injection
+  // above and after removeCuSessionReferences (which intentionally skips it).
+  ctx.cuSessionMetadata.delete(msg.sessionId);
 }
 
 export const computerUseHandlers = defineHandlers({

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -769,7 +769,7 @@ extension IPCMemoryRecalled {
         selectedCount: Int,
         rerankApplied: Bool,
         injectedTokens: Int,
-        latencyMs: Double,
+        latencyMs: Int,
         topCandidates: [IPCMemoryRecalledCandidateDebug]
     ) {
         self.init(


### PR DESCRIPTION
## Summary

- **Metadata race fix:** Removed `ctx.cuSessionMetadata.delete(sessionId)` from `removeCuSessionReferences` so that `onTerminal` (which fires before `cu_session_finalized`) does not delete metadata that `handleCuSessionFinalized` still needs. Metadata is now explicitly deleted at the end of `handleCuSessionFinalized`, and also in `handleCuSessionAbort` and `handleCuSessionCreate` (replacement case) where no finalized event is expected.
- **In-memory sync:** After persisting the CU finalization summary to the conversation store, the handler now also appends it to the in-memory `Session.messages` array so subsequent turns see the injected summary without a reload.
- **latencyMs type fix:** Updated the `IPCMemoryRecalled` convenience init in `IPCMessages.swift` from `latencyMs: Double` to `latencyMs: Int` to match the generated `IPCContractGenerated.swift`.

## Test plan

- [x] TypeScript typecheck passes (`bunx tsc --noEmit`)
- [x] All tests pass (pre-existing failures are unrelated: browser-manager timeouts, Docker integration, git identity, sandbox parity)
- [ ] Manual: trigger a CU session that produces a finalized summary, verify the summary appears in the reporting chat session

Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
