### PR TITLE
Fix M3 feedback: legacy migration + RFC 7233 range clamping

### DIFF
--- a/assistant/src/__tests__/attachment-content-route.test.ts
+++ b/assistant/src/__tests__/attachment-content-route.test.ts
@@ -136,7 +136,7 @@ describe('handleGetAttachmentContent — file-backed', () => {
     expect(Buffer.from(body).toString()).toBe('fghij');
   });
 
-  test('returns 416 for unsatisfiable range', () => {
+  test('returns 416 when start is beyond file size', () => {
     const filePath = join(testDir, 'test-416.mp4');
     const content = Buffer.from('short');
     writeFileSync(filePath, content);
@@ -154,6 +154,32 @@ describe('handleGetAttachmentContent — file-backed', () => {
     const res = handleGetAttachmentContent(attachment.id, req);
 
     expect(res.status).toBe(416);
+  });
+
+  test('clamps oversized end to fileSize-1 per RFC 7233', async () => {
+    const filePath = join(testDir, 'test-clamp.mp4');
+    const content = Buffer.from('0123456789');
+    writeFileSync(filePath, content);
+
+    const attachment = createFileBackedAttachment({
+      filename: 'test-clamp.mp4',
+      mimeType: 'video/mp4',
+      sizeBytes: content.length,
+      filePath,
+    });
+
+    // Request bytes=5-999 on a 10-byte file; end should be clamped to 9
+    const req = new Request('http://localhost/v1/attachments/' + attachment.id + '/content', {
+      headers: { Range: 'bytes=5-999' },
+    });
+    const res = handleGetAttachmentContent(attachment.id, req);
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes 5-9/${content.length}`);
+    expect(res.headers.get('Content-Length')).toBe('5');
+
+    const body = await res.arrayBuffer();
+    expect(Buffer.from(body).toString()).toBe('56789');
   });
 
   test('returns 404 when file is missing from disk', () => {

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1672,12 +1672,18 @@ function migrateRemoveAssistantIdColumns(database: ReturnType<typeof drizzle<typ
           data_base64 TEXT NOT NULL,
           content_hash TEXT,
           thumbnail_base64 TEXT,
-          created_at INTEGER NOT NULL
+          created_at INTEGER NOT NULL,
+          storage_kind TEXT DEFAULT 'inline_base64',
+          file_path TEXT,
+          sha256 TEXT,
+          expires_at INTEGER
         )
       `);
       raw.exec(/*sql*/ `
-        INSERT INTO attachments_new (id, original_filename, mime_type, size_bytes, kind, data_base64, content_hash, thumbnail_base64, created_at)
-        SELECT id, original_filename, mime_type, size_bytes, kind, data_base64, content_hash, thumbnail_base64, created_at FROM attachments
+        INSERT INTO attachments_new (id, original_filename, mime_type, size_bytes, kind, data_base64, content_hash, thumbnail_base64, created_at, storage_kind, file_path, sha256, expires_at)
+        SELECT id, original_filename, mime_type, size_bytes, kind, data_base64, content_hash, thumbnail_base64, created_at,
+          COALESCE(storage_kind, 'inline_base64'), file_path, sha256, expires_at
+        FROM attachments
       `);
       raw.exec(/*sql*/ `DROP TABLE attachments`);
       raw.exec(/*sql*/ `ALTER TABLE attachments_new RENAME TO attachments`);

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -206,9 +206,9 @@ function handleFileContent(
   }
 
   const start = parseInt(rangeMatch[1], 10);
-  const end = rangeMatch[2] ? parseInt(rangeMatch[2], 10) : fileSize - 1;
+  const end = rangeMatch[2] ? Math.min(parseInt(rangeMatch[2], 10), fileSize - 1) : fileSize - 1;
 
-  if (start >= fileSize || end >= fileSize || start > end) {
+  if (start >= fileSize || start > end) {
     return new Response('Range not satisfiable', {
       status: 416,
       headers: { 'Content-Range': `bytes */${fileSize}` },


### PR DESCRIPTION
## Summary
- Adds `storage_kind`, `file_path`, `sha256`, and `expires_at` columns to the hardcoded attachments table rebuild in `migrateRemoveAssistantIdColumns`, so legacy databases preserve the new columns through the migration.
- Clamps oversized byte-range `end` to `fileSize - 1` per RFC 7233, instead of returning 416 for valid requests with an oversized end.
- Adds test coverage for the range clamping behavior.

Part of #6899.

## Test plan
- [x] TypeScript type-check passes
- [x] Attachment content route tests pass (8/8), including new clamping test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
