### PR TITLE
fix: guard against premature window creation during first-launch readiness wait

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -265,16 +265,19 @@ extension AppDelegate {
     }
 
     @objc func openCurrentThread() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
     }
 
     @objc func openNewChat() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
         mainWindow?.threadManager.createThread()
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
 
     @objc func openAppCollection() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
         mainWindow?.windowState.selection = .panel(.directory)
     }
@@ -331,6 +334,7 @@ extension AppDelegate {
     }
 
     @objc func openAppById(_ sender: NSMenuItem) {
+        guard !isAwaitingFirstLaunchReady else { return }
         guard let info = sender.representedObject as? [String: String],
               let appId = info["id"] else { return }
         showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,6 +148,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hasSetupApp = false
     private var hasSetupDaemon = false
 
+    /// True while the first-launch readiness gate (`awaitDaemonReady`) is in
+    /// progress.  Other entry points (`applicationShouldHandleReopen`,
+    /// hotkey handler, menu bar actions) must not call `showMainWindow()`
+    /// while this flag is set, because doing so would create the window
+    /// without the wake-up greeting.  The readiness task clears this flag
+    /// before it calls `showMainWindow(initialMessage:isFirstLaunch:)`.
+    var isAwaitingFirstLaunchReady = false
+
     private func proceedToApp(isFirstLaunch: Bool = false) {
         authWindow?.close()
         authWindow = nil
@@ -184,11 +192,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if isFirstLaunch {
             // Gate showMainWindow on daemon readiness so the wake-up
             // message isn't sent before the daemon is connected.
+            // Set the flag so other entry points (dock reopen, hotkey)
+            // don't create the window prematurely and swallow the greeting.
+            isAwaitingFirstLaunchReady = true
             Task {
                 let ready = await awaitDaemonReady(timeout: 15)
                 if !ready {
                     log.warning("Daemon not ready after timeout — proceeding without connection")
                 }
+                isAwaitingFirstLaunchReady = false
                 showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
                 debugStateWriter.start(appDelegate: self)
             }
@@ -948,6 +960,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
+        // Don't create the main window while the first-launch readiness
+        // gate is in progress — the readiness task will create it with
+        // the wake-up greeting once the daemon is connected.
+        if isAwaitingFirstLaunchReady { return true }
+
         showMainWindow()
         return true
     }
@@ -963,6 +980,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
                   event.charactersIgnoringModifiers?.lowercased() == "g" else { return }
             Task { @MainActor in
+                // Don't create the main window while the first-launch
+                // readiness gate is in progress.
+                guard self?.isAwaitingFirstLaunchReady != true else { return }
                 self?.showMainWindow()
             }
         }


### PR DESCRIPTION
Addresses review feedback on #6917. During the first-launch daemon readiness wait, other entry points (applicationShouldHandleReopen, hotkey handlers, menu bar actions) could create the main window before the readiness gate finishes, causing the wake-up greeting to be lost. Adds isAwaitingFirstLaunchReady flag to prevent premature window creation during the wait. Part of #6914.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
