### PR TITLE
fix: first-launch daemon readiness gate for wake-up message

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -265,16 +265,19 @@ extension AppDelegate {
     }
 
     @objc func openCurrentThread() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
     }
 
     @objc func openNewChat() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
         mainWindow?.threadManager.createThread()
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
 
     @objc func openAppCollection() {
+        guard !isAwaitingFirstLaunchReady else { return }
         showMainWindow()
         mainWindow?.windowState.selection = .panel(.directory)
     }
@@ -331,6 +334,7 @@ extension AppDelegate {
     }
 
     @objc func openAppById(_ sender: NSMenuItem) {
+        guard !isAwaitingFirstLaunchReady else { return }
         guard let info = sender.representedObject as? [String: String],
               let appId = info["id"] else { return }
         showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -108,6 +108,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Handle activity completion notifications
         if categoryId == "ACTIVITY_COMPLETE" {
             await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
             }
             return
@@ -127,7 +128,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             default:
                 // Default action (clicked banner) — deny and bring app forward
                 decision = "deny"
-                await MainActor.run { self.showMainWindow() }
+                await MainActor.run {
+                    guard !self.isAwaitingFirstLaunchReady else { return }
+                    self.showMainWindow()
+                }
             }
             await MainActor.run {
                 self.toolConfirmationNotificationService.handleResponse(requestId: requestId, decision: decision)
@@ -138,6 +142,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Handle voice response complete notifications
         if categoryId == "VOICE_RESPONSE_COMPLETE" {
             await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
             }
             return

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -203,6 +203,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     log.warning("Daemon not ready after timeout — opening window without wake-up greeting")
                     showMainWindow(isFirstLaunch: true)
+                    mainWindow?.windowState.showToast(
+                        message: "Still connecting to your assistant — it may take a moment.",
+                        style: .warning
+                    )
                 }
                 debugStateWriter.start(appDelegate: self)
             }
@@ -838,7 +842,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Route dynamic pages to workspace
         surfaceManager.onDynamicPageShow = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isAwaitingFirstLaunchReady else { return }
             self.showMainWindow()
             NotificationCenter.default.post(
                 name: .openDynamicWorkspace,
@@ -1349,7 +1353,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if tasksWindow == nil {
             let window = TasksWindow(daemonClient: daemonClient)
             window.onOpenInChat = { [weak self] conversationId, workItemId, title in
-                guard let self else { return }
+                guard let self, !self.isAwaitingFirstLaunchReady else { return }
                 self.mainWindow?.threadManager.createTaskRunThread(
                     conversationId: conversationId,
                     workItemId: workItemId,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,6 +148,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hasSetupApp = false
     private var hasSetupDaemon = false
 
+    /// True while the first-launch readiness gate (`awaitDaemonReady`) is in
+    /// progress.  Other entry points (`applicationShouldHandleReopen`,
+    /// hotkey handler, menu bar actions) must not call `showMainWindow()`
+    /// while this flag is set, because doing so would create the window
+    /// without the wake-up greeting.  The readiness task clears this flag
+    /// before it calls `showMainWindow(initialMessage:isFirstLaunch:)`.
+    var isAwaitingFirstLaunchReady = false
+
     private func proceedToApp(isFirstLaunch: Bool = false) {
         authWindow?.close()
         authWindow = nil
@@ -184,11 +192,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if isFirstLaunch {
             // Gate showMainWindow on daemon readiness so the wake-up
             // message isn't sent before the daemon is connected.
+            // Set the flag so other entry points (dock reopen, hotkey)
+            // don't create the window prematurely and swallow the greeting.
+            isAwaitingFirstLaunchReady = true
             Task {
                 let ready = await awaitDaemonReady(timeout: 15)
                 if !ready {
                     log.warning("Daemon not ready after timeout — proceeding without connection")
                 }
+                isAwaitingFirstLaunchReady = false
                 showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
                 debugStateWriter.start(appDelegate: self)
             }
@@ -948,6 +960,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
+        // Don't create the main window while the first-launch readiness
+        // gate is in progress — the readiness task will create it with
+        // the wake-up greeting once the daemon is connected.
+        if isAwaitingFirstLaunchReady { return true }
+
         showMainWindow()
         return true
     }
@@ -963,6 +980,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
                   event.charactersIgnoringModifiers?.lowercased() == "g" else { return }
             Task { @MainActor in
+                // Don't create the main window while the first-launch
+                // readiness gate is in progress.
+                guard self?.isAwaitingFirstLaunchReady != true else { return }
                 self?.showMainWindow()
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -180,41 +180,63 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupWindowObserver()
         setupNotifications()
         setupAutoUpdate()
-        showMainWindow(initialMessage: isFirstLaunch ? wakeUpGreeting() : nil, isFirstLaunch: isFirstLaunch)
-        debugStateWriter.start(appDelegate: self)
 
         if isFirstLaunch {
-            ensureDaemonConnected()
+            // Gate showMainWindow on daemon readiness so the wake-up
+            // message isn't sent before the daemon is connected.
+            Task {
+                let ready = await awaitDaemonReady(timeout: 15)
+                if !ready {
+                    log.warning("Daemon not ready after timeout — proceeding without connection")
+                }
+                showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
+                debugStateWriter.start(appDelegate: self)
+            }
+        } else {
+            showMainWindow()
+            debugStateWriter.start(appDelegate: self)
         }
     }
 
-    private func ensureDaemonConnected() {
-        // Skip if already connected or if a connection attempt is in progress
-        // (setupDaemonClient already started connecting — don't interfere).
-        guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
+    /// Waits for the daemon to become connected, with bounded retries.
+    ///
+    /// Polls daemon connection state at ~0.5s intervals. If a connection
+    /// attempt is already in flight (from `setupDaemonClient()`), waits
+    /// for it to finish. Otherwise, attempts a single `connect()` call
+    /// per loop iteration. Returns once connected or the timeout elapses.
+    private func awaitDaemonReady(timeout: TimeInterval) async -> Bool {
+        log.info("Waiting for daemon to become ready (timeout: \(timeout)s)")
+        let start = CFAbsoluteTimeGetCurrent()
 
-        Task {
-            if !isCurrentAssistantRemote {
-                do {
-                    try await assistantCli.hatch(daemonOnly: true)
-                } catch {
-                    log.error("Failed to hatch assistant in ensureDaemonConnected: \(error)")
-                }
-                assistantCli.startMonitoring()
+        while CFAbsoluteTimeGetCurrent() - start < timeout {
+            if daemonClient.isConnected {
+                log.info("Daemon is connected")
+                return true
             }
-            // Only connect if setupDaemonClient's connect hasn't already started
-            guard !daemonClient.isConnected, !daemonClient.isConnecting else { return }
+
+            if daemonClient.isConnecting {
+                // Let the in-flight connect from setupDaemonClient() finish
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                continue
+            }
+
+            // Not connected and not connecting — try one connect attempt
             do {
                 try await daemonClient.connect()
             } catch {
-                log.error("Failed to connect to daemon in ensureDaemonConnected: \(error)")
+                log.error("awaitDaemonReady connect attempt failed: \(error)")
             }
+
             if daemonClient.isConnected {
-                setupAmbientAgent()
-                refreshAppsCache()
-                refreshSkillsCache()
+                log.info("Daemon is connected after retry")
+                return true
             }
+
+            try? await Task.sleep(nanoseconds: 500_000_000)
         }
+
+        log.warning("awaitDaemonReady timed out after \(timeout)s")
+        return daemonClient.isConnected
     }
 
     private func showAuthWindow() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -197,11 +197,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             isAwaitingFirstLaunchReady = true
             Task {
                 let ready = await awaitDaemonReady(timeout: 15)
-                if !ready {
-                    log.warning("Daemon not ready after timeout — proceeding without connection")
-                }
                 isAwaitingFirstLaunchReady = false
-                showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
+                if ready {
+                    showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
+                } else {
+                    log.warning("Daemon not ready after timeout — opening window without wake-up greeting")
+                    showMainWindow(isFirstLaunch: true)
+                }
                 debugStateWriter.start(appDelegate: self)
             }
         } else {


### PR DESCRIPTION
## Summary
Fixes a race condition where the wake-up message on fresh installs was sent before the daemon was connected, causing the BOOTSTRAP.md-driven first response to never appear. The daemon is now confirmed ready before the main window opens on first launch.

## Changes
- Added `awaitDaemonReady(timeout: 15)` bounded polling helper that waits for daemon connection with 0.5s intervals and retry logic
- Modified `proceedToApp(isFirstLaunch: true)` to await daemon readiness before `showMainWindow`
- Removed redundant `ensureDaemonConnected()` that created duplicate connect races with `setupDaemonClient()` and `bootstrapSession()`
- Added `isAwaitingFirstLaunchReady` flag to prevent premature window creation by **all** entry points (dock reopen, hotkey, menu bar actions, notification handlers, dynamic page show, Tasks "Open in Chat") during the readiness wait
- On timeout, skips wake-up greeting entirely (opens window without auto-send) and shows a warning toast

## Milestone PRs (merged into feature branch)
- #6917: Add bounded daemon readiness gate and remove duplicate connect path
- #6918: Guard against premature window creation during first-launch readiness wait
- #6923: Skip wake-up greeting on daemon timeout to avoid sending to disconnected daemon
- #6930: Guard remaining showMainWindow entry points (notifications, dynamic pages, tasks) + timeout toast

## Project issue
Closes #6914

## Test plan
- [ ] Fresh install: verify wake-up message triggers BOOTSTRAP.md response
- [ ] Fresh install: click dock icon / press hotkey during readiness wait — window should not appear until daemon is ready
- [ ] Fresh install: trigger notification during readiness wait — should not create window prematurely
- [ ] Non-first-launch: verify window opens immediately as before
- [ ] Daemon timeout scenario: verify window opens without wake-up greeting and shows warning toast

Generated with [Claude Code](https://claude.com/claude-code)