### PR TITLE
fix: skip wake-up greeting on daemon timeout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -197,11 +197,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             isAwaitingFirstLaunchReady = true
             Task {
                 let ready = await awaitDaemonReady(timeout: 15)
-                if !ready {
-                    log.warning("Daemon not ready after timeout — proceeding without connection")
-                }
                 isAwaitingFirstLaunchReady = false
-                showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
+                if ready {
+                    showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)
+                } else {
+                    log.warning("Daemon not ready after timeout — opening window without wake-up greeting")
+                    showMainWindow(isFirstLaunch: true)
+                }
                 debugStateWriter.start(appDelegate: self)
             }
         } else {


### PR DESCRIPTION
On timeout, `showMainWindow` is now called without the `initialMessage` so the wake-up greeting isn't fired into a disconnected daemon (reproducing the original failure). The user still sees the chat UI but without the doomed auto-send.

Without this fix, the timeout path still calls `showMainWindow(initialMessage: wakeUpGreeting(), isFirstLaunch: true)`, which sends the greeting to a disconnected daemon — the same user-visible failure mode this feature branch is meant to fix.

Part of #6914.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
