### PR TITLE
Fix feedback: metadata leak on disconnect + storage_kind NOT NULL

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -756,6 +756,7 @@ export class DaemonServer {
       if (cuSessionIds) {
         for (const cuSessionId of cuSessionIds) {
           this.cuObservationParseSequence.delete(cuSessionId);
+          this.cuSessionMetadata.delete(cuSessionId);
           const cuSession = this.cuSessions.get(cuSessionId);
           if (cuSession) {
             cuSession.abort();

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1673,7 +1673,7 @@ function migrateRemoveAssistantIdColumns(database: ReturnType<typeof drizzle<typ
           content_hash TEXT,
           thumbnail_base64 TEXT,
           created_at INTEGER NOT NULL,
-          storage_kind TEXT DEFAULT 'inline_base64',
+          storage_kind TEXT NOT NULL DEFAULT 'inline_base64',
           file_path TEXT,
           sha256 TEXT,
           expires_at INTEGER


### PR DESCRIPTION
Addresses feedback from #6912 (socket disconnect metadata leak) and #6913 (storage_kind NOT NULL in legacy migration). Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
