### PR TITLE
Fix M5 feedback: bound cleanup interval to prevent overflow

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1064,6 +1064,7 @@ export const QaRecordingConfigSchema = z.object({
     .number({ error: 'qaRecording.cleanupIntervalMs must be a number' })
     .int('qaRecording.cleanupIntervalMs must be an integer')
     .positive('qaRecording.cleanupIntervalMs must be a positive integer')
+    .max(2_147_483_647, 'qaRecording.cleanupIntervalMs must be at most 2147483647 (setInterval-safe limit)')
     .default(6 * 60 * 60 * 1000),
 });
 

--- a/assistant/src/daemon/recording-cleanup.ts
+++ b/assistant/src/daemon/recording-cleanup.ts
@@ -75,13 +75,18 @@ export function startRecordingCleanup(intervalMs: number): void {
     log.warn({ err }, 'Initial recording cleanup pass failed');
   }
 
+  // setInterval uses a 32-bit signed int internally; values above 2^31-1 ms
+  // (~24.8 days) wrap around and fire near-continuously.
+  const MAX_INTERVAL_MS = 2_147_483_647;
+  const safeInterval = Math.min(intervalMs, MAX_INTERVAL_MS);
+
   cleanupTimer = setInterval(() => {
     try {
       runCleanupPass();
     } catch (err) {
       log.warn({ err }, 'Periodic recording cleanup pass failed');
     }
-  }, intervalMs);
+  }, safeInterval);
 
   // Don't keep the process alive just for cleanup
   cleanupTimer.unref();


### PR DESCRIPTION
Clamps cleanupIntervalMs to 2^31-1 ms before passing to setInterval to prevent near-continuous execution from timer overflow. Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
