### PR TITLE
Fix cancel ordering: send abort after finalization for QA sessions

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -279,6 +279,17 @@ final class ComputerUseSession: ObservableObject {
         // Finalize QA recording and send cu_session_finalized
         if qaMode {
             await finalizeQARecording()
+
+            // Now that finalization is complete, send the deferred abort for cancelled
+            // QA sessions. cancel() skips sending it so cu_session_finalized arrives
+            // before the abort (the daemon's handleCuSessionAbort deletes metadata).
+            if isCancelled {
+                do {
+                    try daemonClient.send(CuSessionAbortMessage(sessionId: id))
+                } catch {
+                    log.error("Failed to send deferred session abort after QA finalization: \(error)")
+                }
+            }
         }
     }
 
@@ -1034,11 +1045,15 @@ final class ComputerUseSession: ObservableObject {
         messageLoopTask?.cancel()
         confirmationContinuation?.resume(returning: false)
         confirmationContinuation = nil
-        // Tell the daemon to abort the server-side CU session so it stops burning tokens
-        do {
-            try daemonClient.send(CuSessionAbortMessage(sessionId: id))
-        } catch {
-            log.error("Failed to send session abort on cancel: \(error)")
+        // In QA mode, defer the abort until after finalizeQARecording() in run(),
+        // because the daemon's handleCuSessionAbort deletes cuSessionMetadata and
+        // cu_session_finalized must arrive first for summary injection to work.
+        if !qaMode {
+            do {
+                try daemonClient.send(CuSessionAbortMessage(sessionId: id))
+            } catch {
+                log.error("Failed to send session abort on cancel: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
In QA mode, cancel() no longer sends CuSessionAbortMessage immediately. Instead, the abort is deferred until after finalizeQARecording() in run(), ensuring cu_session_finalized arrives before the abort. Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
