### PR TITLE
fix: guard remaining showMainWindow entry points during first-launch wait

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -108,6 +108,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Handle activity completion notifications
         if categoryId == "ACTIVITY_COMPLETE" {
             await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
             }
             return
@@ -127,7 +128,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             default:
                 // Default action (clicked banner) — deny and bring app forward
                 decision = "deny"
-                await MainActor.run { self.showMainWindow() }
+                await MainActor.run {
+                    guard !self.isAwaitingFirstLaunchReady else { return }
+                    self.showMainWindow()
+                }
             }
             await MainActor.run {
                 self.toolConfirmationNotificationService.handleResponse(requestId: requestId, decision: decision)
@@ -138,6 +142,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Handle voice response complete notifications
         if categoryId == "VOICE_RESPONSE_COMPLETE" {
             await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
             }
             return

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -203,6 +203,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     log.warning("Daemon not ready after timeout — opening window without wake-up greeting")
                     showMainWindow(isFirstLaunch: true)
+                    mainWindow?.windowState.showToast(
+                        message: "Still connecting to your assistant — it may take a moment.",
+                        style: .warning
+                    )
                 }
                 debugStateWriter.start(appDelegate: self)
             }
@@ -838,7 +842,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Route dynamic pages to workspace
         surfaceManager.onDynamicPageShow = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isAwaitingFirstLaunchReady else { return }
             self.showMainWindow()
             NotificationCenter.default.post(
                 name: .openDynamicWorkspace,
@@ -1349,7 +1353,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if tasksWindow == nil {
             let window = TasksWindow(daemonClient: daemonClient)
             window.onOpenInChat = { [weak self] conversationId, workItemId, title in
-                guard let self else { return }
+                guard let self, !self.isAwaitingFirstLaunchReady else { return }
                 self.mainWindow?.threadManager.createTaskRunThread(
                     conversationId: conversationId,
                     workItemId: workItemId,


### PR DESCRIPTION
Addresses remaining review findings on the first-launch readiness gate:

**P2: Notification handlers bypass** — Added `isAwaitingFirstLaunchReady` guard to three notification handlers in `AppDelegate+Notifications.swift`:
- Activity complete (line 111)
- Tool confirmation banner click (line 130)
- Voice response complete (line 141)

**P2: Dynamic page callback unguarded** — Added guard to `surfaceManager.onDynamicPageShow` in `AppDelegate.swift`.

**P3: Tasks "Open in Chat" callback unguarded** — Added guard to `window.onOpenInChat` in `AppDelegate.swift`.

**P3: Timeout path silent to user** — Added a warning toast ("Still connecting to your assistant — it may take a moment.") when `awaitDaemonReady` times out, so the user gets visible feedback instead of just a log warning.

Part of #6914.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
