### PR TITLE
Fix metadata race: let socket close handler own socketToCuSession cleanup

### DIFF
--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -33,11 +33,13 @@ function removeCuSessionReferences(
   // end of handleCuSessionFinalized instead.
   cuObservationSequenceBySession.delete(sessionId);
   ctx.cuObservationParseSequence.delete(sessionId);
-  for (const [sock, ids] of ctx.socketToCuSession) {
-    if (ids.delete(sessionId) && ids.size === 0) {
-      ctx.socketToCuSession.delete(sock);
-    }
-  }
+  // NOTE: socketToCuSession is intentionally NOT cleaned up here.
+  // The socket close handler in server.ts is the sole owner of
+  // socketToCuSession cleanup — it uses the mapping to find and delete
+  // cuSessionMetadata entries. Removing the session here would race:
+  // if a CU session reaches terminal state (triggering this function)
+  // and then the socket disconnects before cu_session_finalized,
+  // the close handler wouldn't see the session and metadata would leak.
 }
 
 export function handleCuSessionCreate(


### PR DESCRIPTION
Removes socketToCuSession cleanup from removeCuSessionReferences so the socket close handler can always find and clean up cuSessionMetadata entries, even after terminal state. Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
