### PR TITLE
Fix cancel safety: deferred abort fallback for QA sessions

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -280,9 +280,9 @@ final class ComputerUseSession: ObservableObject {
         if qaMode {
             await finalizeQARecording()
 
-            // Now that finalization is complete, send the deferred abort for cancelled
-            // QA sessions. cancel() skips sending it so cu_session_finalized arrives
-            // before the abort (the daemon's handleCuSessionAbort deletes metadata).
+            // Send the abort immediately after finalization for cancelled QA sessions.
+            // This arrives before cancel()'s 2-second safety-net abort fires.
+            // The daemon deduplicates aborts, so the safety net is harmless if we get here.
             if isCancelled {
                 do {
                     try daemonClient.send(CuSessionAbortMessage(sessionId: id))
@@ -1045,10 +1045,17 @@ final class ComputerUseSession: ObservableObject {
         messageLoopTask?.cancel()
         confirmationContinuation?.resume(returning: false)
         confirmationContinuation = nil
-        // In QA mode, defer the abort until after finalizeQARecording() in run(),
-        // because the daemon's handleCuSessionAbort deletes cuSessionMetadata and
-        // cu_session_finalized must arrive first for summary injection to work.
-        if !qaMode {
+
+        if qaMode {
+            // Deferred abort: give run() a chance to send finalization first,
+            // but guarantee abort eventually fires as a safety net in case
+            // run() never reaches the post-loop block (e.g., throws or gets stuck).
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                guard self.isCancelled else { return } // in case state changed
+                try? self.daemonClient.send(CuSessionAbortMessage(sessionId: self.id))
+            }
+        } else {
             do {
                 try daemonClient.send(CuSessionAbortMessage(sessionId: id))
             } catch {


### PR DESCRIPTION
Adds a 2-second delayed abort in cancel() as a safety net for QA sessions, ensuring the daemon session is always cleaned up even if run() doesn't reach the post-loop block. Part of #6899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
