### PR TITLE
Fix session replacement: remove stale socket-to-session mapping

### DIFF
--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -57,6 +57,13 @@ export function handleCuSessionCreate(
     // Clean up stale metadata from the replaced session; the new session
     // will set its own metadata below if needed.
     ctx.cuSessionMetadata.delete(msg.sessionId);
+    // Remove the session ID from the old socket's set so the old socket's
+    // close handler won't abort the replacement session.
+    for (const [sock, ids] of ctx.socketToCuSession) {
+      if (ids.delete(msg.sessionId) && ids.size === 0) {
+        ctx.socketToCuSession.delete(sock);
+      }
+    }
   }
 
   const config = getConfig();


### PR DESCRIPTION
When a CU session is replaced on a different socket, the old socket's socketToCuSession entry retained the session ID. When the old socket closed, its close handler would find and abort the replacement session. Fix: explicitly remove the session ID from the old socket's set in handleCuSessionCreate before adding it to the new socket.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
