### PR TITLE
Fix cancel race: disarm safety-net timer before QA finalization

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -48,6 +48,7 @@ final class ComputerUseSession: ObservableObject {
     private var isPaused = false
     private var confirmationContinuation: CheckedContinuation<Bool, Never>?
     private var messageLoopTask: Task<Void, Never>?
+    private var cancelSafetyNetTask: Task<Void, Never>?
 
     private let enumerator: AccessibilityTreeProviding
     private let screenCapture: ScreenCaptureProviding
@@ -182,6 +183,11 @@ final class ComputerUseSession: ObservableObject {
         } else {
             state = .failed(reason: "No focused window and screen capture failed")
             logger.finishSession(result: "failed: no window")
+            // Disarm the cancel safety net — run() reached the post-loop and will
+            // handle finalization + abort itself.
+            cancelSafetyNetTask?.cancel()
+            cancelSafetyNetTask = nil
+
             // Finalize QA recording BEFORE sending abort — the daemon's handleCuSessionAbort
             // deletes cuSessionMetadata, so cu_session_finalized must arrive first for
             // summary injection to work.
@@ -275,6 +281,11 @@ final class ComputerUseSession: ObservableObject {
                 logger.finishSession(result: "failed: stream ended unexpectedly")
             }
         }
+
+        // Disarm the cancel safety net — run() reached the post-loop and will
+        // handle finalization + abort itself.
+        cancelSafetyNetTask?.cancel()
+        cancelSafetyNetTask = nil
 
         // Finalize QA recording and send cu_session_finalized
         if qaMode {
@@ -1050,7 +1061,7 @@ final class ComputerUseSession: ObservableObject {
             // Deferred abort: give run() a chance to send finalization first,
             // but guarantee abort eventually fires as a safety net in case
             // run() never reaches the post-loop block (e.g., throws or gets stuck).
-            Task { @MainActor in
+            cancelSafetyNetTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
                 guard self.isCancelled else { return } // in case state changed
                 try? self.daemonClient.send(CuSessionAbortMessage(sessionId: self.id))


### PR DESCRIPTION
The 2-second cancel safety-net timer could fire before finalizeQARecording() completes on slow paths, sending cu_session_abort before cu_session_finalized. The daemon's handleCuSessionAbort deletes cuSessionMetadata, so the later cu_session_finalized can't inject the summary. Fix: store the safety-net Task and cancel it when run() reaches the finalization code path, since run() handles finalization + abort itself.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
