### PR TITLE
M1: Wrap full-window panels in rounded container (#6928)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -240,6 +240,9 @@ extension MainWindowView {
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -334,6 +337,9 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
         case .agent:
             AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
@@ -352,6 +358,9 @@ extension MainWindowView {
                 windowState.dismissOverlay()
             }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -360,14 +369,26 @@ extension MainWindowView {
                 onClose: { windowState.dismissOverlay() }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
+            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .padding(16)
         case .doctor:
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .padding(16)
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
             // if we reach here, isDynamicExpanded is false — clear selection so

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1006,7 +1006,6 @@ struct AgentPanel: View {
             .padding(.horizontal, VSpacing.xxl)
             .frame(maxWidth: .infinity)
         }
-        .background(VColor.backgroundSubtle)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -78,7 +78,6 @@ struct IdentityPanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(VColor.background)
         }
-        .background(VColor.backgroundSubtle)
         .overlay {
             if let path = viewingFilePath {
                 // Dismiss backdrop

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -85,7 +85,6 @@ struct SettingsPanel: View {
                 }
             }
         }
-        .background(VColor.backgroundSubtle)
         .task {
             // Refresh permission status when the view appears
             refreshPermissionStatus()

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -55,7 +55,6 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             }
             .layoutPriority(-1)
         }
-        .background(VColor.backgroundSubtle)
     }
 }
 


### PR DESCRIPTION
Wraps Settings, Identity, Skills, and Home Base panels in a rounded container with Moss._50 background and VRadius.xl corners, matching the sidebar aesthetic. Removes individual panel backgrounds so the container shows through. Part of #6927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
