### PR TITLE
Fix: Use background shape instead of clipShape for panel containers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -240,8 +240,10 @@ extension MainWindowView {
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
@@ -337,8 +339,10 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
         case .agent:
             AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
@@ -358,8 +362,10 @@ extension MainWindowView {
                 windowState.dismissOverlay()
             }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
         case .debug:
             DebugPanel(
@@ -369,25 +375,33 @@ extension MainWindowView {
                 onClose: { windowState.dismissOverlay() }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
-            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+            )
             .padding(16)
         case .doctor:
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl)
+                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
+                )
                 .padding(16)
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;


### PR DESCRIPTION
Replaces .clipShape with a background-only RoundedRectangle approach so panel overlays (like IdentityPanel's file viewer) are not clipped. Addresses feedback from #6936. Part of #6927.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
