### PR TITLE
Fix remaining Telegram approval review gaps

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2938,7 +2938,8 @@ describe('guardian enforcement independence from approval flag', () => {
         if (typeof call[1] !== 'object') return false;
         const text = (call[1] as { text?: string }).text ?? '';
         return text.includes('requires guardian approval') &&
-          (text.includes('identity could not be determined') || text.includes('no guardian has been set up'));
+          text.includes('identity could not be determined') &&
+          text.includes('denied');
       },
     );
     expect(denialCalls.length).toBeGreaterThanOrEqual(1);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -191,74 +191,80 @@ class BrowserManager {
     if (this.contextCreating) return this.contextCreating;
 
     this.contextCreating = (async () => {
-      // Try to detect or negotiate CDP before falling back to headless.
-      // This auto-detects an existing Chrome with --remote-debugging-port,
-      // or asks the client to restart Chrome with CDP enabled.
-      let useCdp = this._browserMode === 'cdp';
-      const sender = invokingSessionId ? this.sessionSenders.get(invokingSessionId) : undefined;
-      if (!useCdp) {
-        const cdpAvailable = await this.detectCDP();
-        if (cdpAvailable) {
-          useCdp = true;
-        } else if (invokingSessionId && sender) {
-          log.info({ sessionId: invokingSessionId }, 'Requesting CDP from client');
-          const accepted = await this.requestCDPFromClient(invokingSessionId, sender);
-          if (accepted) {
-            const nowAvailable = await this.detectCDP();
-            if (nowAvailable) {
-              useCdp = true;
+      // Deterministic test mode: when launch is injected via setLaunchFn,
+      // bypass ambient CDP probing/negotiation and use the injected launcher.
+      const hasInjectedLaunchFn = launchPersistentContext !== null;
+
+      if (!hasInjectedLaunchFn) {
+        // Try to detect or negotiate CDP before falling back to headless.
+        // This auto-detects an existing Chrome with --remote-debugging-port,
+        // or asks the client to restart Chrome with CDP enabled.
+        let useCdp = this._browserMode === 'cdp';
+        const sender = invokingSessionId ? this.sessionSenders.get(invokingSessionId) : undefined;
+        if (!useCdp) {
+          const cdpAvailable = await this.detectCDP();
+          if (cdpAvailable) {
+            useCdp = true;
+          } else if (invokingSessionId && sender) {
+            log.info({ sessionId: invokingSessionId }, 'Requesting CDP from client');
+            const accepted = await this.requestCDPFromClient(invokingSessionId, sender);
+            if (accepted) {
+              const nowAvailable = await this.detectCDP();
+              if (nowAvailable) {
+                useCdp = true;
+              } else {
+                log.warn('Client accepted CDP request but CDP not detected');
+              }
             } else {
-              log.warn('Client accepted CDP request but CDP not detected');
+              log.info('Client declined CDP request');
             }
-          } else {
-            log.info('Client declined CDP request');
           }
         }
-      }
 
-      if (useCdp) {
-        try {
-          const pw = await import('playwright');
-          const browser = await pw.chromium.connectOverCDP(this.cdpUrl, { timeout: 10_000 });
-          this.cdpBrowser = browser;
-          this._browserLaunched = false;
-          const contexts = browser.contexts();
-          const ctx = contexts[0] || await browser.newContext();
-          this.setBrowserMode('cdp');
-          await this.initBrowserCdpSession();
-          log.info({ cdpUrl: this.cdpUrl }, 'Connected to Chrome via CDP');
-          return ctx as unknown as BrowserContext;
-        } catch (err) {
-          log.warn({ err }, 'CDP connectOverCDP failed');
-          this._browserMode = 'headless';
+        if (useCdp) {
+          try {
+            const pw = await import('playwright');
+            const browser = await pw.chromium.connectOverCDP(this.cdpUrl, { timeout: 10_000 });
+            this.cdpBrowser = browser;
+            this._browserLaunched = false;
+            const contexts = browser.contexts();
+            const ctx = contexts[0] || await browser.newContext();
+            this.setBrowserMode('cdp');
+            await this.initBrowserCdpSession();
+            log.info({ cdpUrl: this.cdpUrl }, 'Connected to Chrome via CDP');
+            return ctx as unknown as BrowserContext;
+          } catch (err) {
+            log.warn({ err }, 'CDP connectOverCDP failed');
+            this._browserMode = 'headless';
+          }
         }
-      }
 
-      // If a client is connected, launch headed Chromium (minimized) so the user
-      // can interact directly when handoff triggers (e.g. CAPTCHAs).
-      // The window stays offscreen until bringToFront() is called during handoff.
-      const hasSender = !!(invokingSessionId && this.sessionSenders.get(invokingSessionId));
-      if (hasSender && this._browserMode === 'headless') {
-        try {
-          const pw2 = await import('playwright');
-          const headedBrowser = await pw2.chromium.launch({
-            channel: 'chrome',
-            headless: false,
-            args: [
-              '--window-position=-32000,-32000',
-              '--window-size=1,1',
-              '--disable-blink-features=AutomationControlled',
-            ],
-          });
-          const ctx = headedBrowser.contexts()[0] || await headedBrowser.newContext();
-          this.cdpBrowser = headedBrowser as unknown as typeof this.cdpBrowser;
-          this._browserLaunched = true;
-          this.setBrowserMode('cdp');
-          await this.initBrowserCdpSession();
-          log.info('Launched headed Chromium (minimized) for interactive handoff support');
-          return ctx as unknown as BrowserContext;
-        } catch (err2) {
-          log.warn({ err: err2 }, 'Headed Chromium launch failed, falling back to headless');
+        // If a client is connected, launch headed Chromium (minimized) so the user
+        // can interact directly when handoff triggers (e.g. CAPTCHAs).
+        // The window stays offscreen until bringToFront() is called during handoff.
+        const hasSender = !!(invokingSessionId && this.sessionSenders.get(invokingSessionId));
+        if (hasSender && this._browserMode === 'headless') {
+          try {
+            const pw2 = await import('playwright');
+            const headedBrowser = await pw2.chromium.launch({
+              channel: 'chrome',
+              headless: false,
+              args: [
+                '--window-position=-32000,-32000',
+                '--window-size=1,1',
+                '--disable-blink-features=AutomationControlled',
+              ],
+            });
+            const ctx = headedBrowser.contexts()[0] || await headedBrowser.newContext();
+            this.cdpBrowser = headedBrowser as unknown as typeof this.cdpBrowser;
+            this._browserLaunched = true;
+            this.setBrowserMode('cdp');
+            await this.initBrowserCdpSession();
+            log.info('Launched headed Chromium (minimized) for interactive handoff support');
+            return ctx as unknown as BrowserContext;
+          } catch (err2) {
+            log.warn({ err: err2 }, 'Headed Chromium launch failed, falling back to headless');
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- make `BrowserManager.ensureContext` deterministic when `setLaunchFn` is injected by skipping ambient CDP probing/negotiation in that mode
- tighten the `missing senderExternalUserId with guardian binding fails closed` assertion to require the explicit `no_identity` denial branch

## Why
- closes the remaining review gap where browser-manager tests were timing out based on local CDP availability, reducing confidence in broader assistant suite health
- prevents a stale fallback phrase from masking regressions in the `no_identity` denial path

## Validation
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/browser-manager.test.ts`
- `cd assistant && bun test src/__tests__/channel-approval-routes.test.ts -t "same user is guardian for one assistant but not another|missing senderExternalUserId with guardian binding fails closed"`
- `cd assistant && bun test src/__tests__/browser-manager.test.ts src/__tests__/run-orchestrator-assistant-events.test.ts src/__tests__/workspace-git-service.test.ts`
- `cd assistant && bun test src/__tests__/channel-approval.test.ts src/__tests__/channel-approvals.test.ts src/__tests__/channel-approval-routes.test.ts src/__tests__/channel-guardian.test.ts src/__tests__/run-orchestrator.test.ts`