### PR TITLE
Create file-backed attachment on QA finalize + video /content streaming

### DIFF
--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -12,6 +12,7 @@ import type {
   ServerMessage,
 } from '../ipc-protocol.js';
 import * as conversationStore from '../../memory/conversation-store.js';
+import { createFileBackedAttachment, linkAttachmentToMessage } from '../../memory/attachments-store.js';
 import { log, defineHandlers, findSocketForSession, type HandlerContext, type CuSessionMetadata } from './shared.js';
 
 const cuObservationSequenceBySession = new Map<string, number>();
@@ -231,23 +232,6 @@ export function handleCuSessionFinalized(
     'CU session finalized by client',
   );
 
-  // If recording metadata is present, log it for future M3 file-backed attachment support.
-  if (msg.recording) {
-    log.info(
-      {
-        sessionId: msg.sessionId,
-        localPath: msg.recording.localPath,
-        mimeType: msg.recording.mimeType,
-        sizeBytes: msg.recording.sizeBytes,
-        durationMs: msg.recording.durationMs,
-        width: msg.recording.width,
-        height: msg.recording.height,
-        captureScope: msg.recording.captureScope,
-      },
-      'CU session recording metadata (stored for M3)',
-    );
-  }
-
   // Inject a summary message into the originating chat session if configured.
   if (meta?.reportToSessionId && msg.summary) {
     const reportSessionId = meta.reportToSessionId;
@@ -258,7 +242,7 @@ export function handleCuSessionFinalized(
     const conversation = conversationStore.getConversation(reportSessionId);
     if (conversation) {
       const assistantContent = JSON.stringify([{ type: 'text', text: msg.summary }]);
-      conversationStore.addMessage(reportSessionId, 'assistant', assistantContent, {
+      const persistedMessage = conversationStore.addMessage(reportSessionId, 'assistant', assistantContent, {
         source: 'cu_session_finalized',
         cuSessionId: msg.sessionId,
         cuStatus: msg.status,
@@ -266,6 +250,42 @@ export function handleCuSessionFinalized(
         qaMode: meta.qaMode ?? false,
         ...(msg.recording ? { recordingPath: msg.recording.localPath } : {}),
       });
+
+      // Create a file-backed attachment from the recording and link it to the message.
+      let recordingAttachment: { id: string; filename: string; mimeType: string; sizeBytes: number } | undefined;
+      if (msg.recording) {
+        try {
+          const attachment = createFileBackedAttachment({
+            filename: `qa-recording-${msg.sessionId}.mp4`,
+            mimeType: msg.recording.mimeType || 'video/mp4',
+            sizeBytes: msg.recording.sizeBytes,
+            filePath: msg.recording.localPath,
+            sha256: undefined,
+            expiresAt: msg.recording.expiresAt,
+          });
+          linkAttachmentToMessage(persistedMessage.id, attachment.id, 0);
+          recordingAttachment = {
+            id: attachment.id,
+            filename: attachment.originalFilename,
+            mimeType: attachment.mimeType,
+            sizeBytes: attachment.sizeBytes,
+          };
+          log.info(
+            {
+              sessionId: msg.sessionId,
+              attachmentId: attachment.id,
+              filePath: msg.recording.localPath,
+              sizeBytes: msg.recording.sizeBytes,
+            },
+            'Created file-backed attachment for CU session recording',
+          );
+        } catch (err) {
+          log.error(
+            { err, sessionId: msg.sessionId, localPath: msg.recording.localPath },
+            'Failed to create file-backed attachment for recording',
+          );
+        }
+      }
 
       // Also append to the in-memory Session.messages so subsequent turns
       // in the same session see the injected summary without a reload.
@@ -288,6 +308,15 @@ export function handleCuSessionFinalized(
         ctx.send(reportSocket, {
           type: 'message_complete',
           sessionId: reportSessionId,
+          ...(recordingAttachment ? {
+            attachments: [{
+              id: recordingAttachment.id,
+              filename: recordingAttachment.filename,
+              mimeType: recordingAttachment.mimeType,
+              data: '',
+              sizeBytes: recordingAttachment.sizeBytes,
+            }],
+          } : {}),
         });
       }
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -395,10 +395,12 @@ export function handleHistoryRequest(
         // the client, so non-video attachments always keep their inline data.
         const MAX_INLINE_B64_SIZE = 512 * 1024;
         attachments = linked.map((a) => {
-          const omit = a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE;
+          const isFileBacked = a.storageKind === 'file';
+          const omit = isFileBacked || (a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE);
 
           // Lazily generate thumbnails for existing video attachments on first history load.
-          if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {
+          // Skip for file-backed attachments since they have no inline base64 to extract from.
+          if (a.mimeType.startsWith('video/') && !a.thumbnailBase64 && !isFileBacked) {
             const attachmentId = a.id;
             const base64 = a.dataBase64;
             generateVideoThumbnail(base64).then((thumb) => {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -173,8 +173,15 @@ struct InlineVideoAttachmentView: View {
         // Server thumbnail and aspect ratio are set eagerly in init.
         if thumbnailImage != nil { return }
 
-        // Fallback: extract thumbnail from inline video data.
-        guard !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) else { return }
+        // Try inline base64 first, then fall back to /content for lazy-loaded attachments.
+        var videoData: Data?
+        if !attachment.data.isEmpty {
+            videoData = Data(base64Encoded: attachment.data)
+        } else if attachment.isLazyLoad, let port = daemonHttpPort, !attachment.id.isEmpty {
+            videoData = try? await fetchAttachmentContent(port: port, attachmentId: attachment.id)
+        }
+
+        guard let data = videoData else { return }
 
         let fileURL = safeTempURL()
         do {
@@ -272,9 +279,11 @@ struct InlineVideoAttachmentView: View {
         isLoading = true
         Task {
             do {
-                let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
+                let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+                let fileURL = safeTempURL()
+                try data.write(to: fileURL)
                 await MainActor.run { isLoading = false }
-                await playFromBase64(base64)
+                await playFromFile(fileURL)
             } catch {
                 log.error("Failed to fetch attachment \(attachmentId): \(error.localizedDescription)")
                 await MainActor.run {
@@ -318,11 +327,7 @@ struct InlineVideoAttachmentView: View {
             }
             Task {
                 do {
-                    let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-                    guard let data = Data(base64Encoded: base64) else {
-                        await MainActor.run { isSaving = false }
-                        return
-                    }
+                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
                     try data.write(to: destURL)
                     await MainActor.run { isSaving = false }
                 } catch {
@@ -373,11 +378,7 @@ struct InlineVideoAttachmentView: View {
             ) { completion in
                 Task {
                     do {
-                        let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-                        guard let data = Data(base64Encoded: base64) else {
-                            completion(nil, false, URLError(.cannotDecodeContentData))
-                            return
-                        }
+                        let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
                         try data.write(to: fileURL)
                         completion(fileURL, true, nil)
                     } catch {
@@ -400,14 +401,7 @@ struct InlineVideoAttachmentView: View {
             isLoading = true
             Task {
                 do {
-                    let base64 = try await fetchAttachmentData(port: port, attachmentId: attachmentId)
-                    guard let data = Data(base64Encoded: base64) else {
-                        await MainActor.run {
-                            isLoading = false
-                            failed = true
-                        }
-                        return
-                    }
+                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
                     let fileURL = safeTempURL()
                     try data.write(to: fileURL)
                     await MainActor.run {
@@ -415,7 +409,10 @@ struct InlineVideoAttachmentView: View {
                         NSWorkspace.shared.open(fileURL)
                     }
                 } catch {
-                    await MainActor.run { isLoading = false }
+                    await MainActor.run {
+                        isLoading = false
+                        failed = true
+                    }
                 }
             }
         } else {
@@ -427,8 +424,8 @@ struct InlineVideoAttachmentView: View {
     }
 }
 
-/// Fetch attachment base64 data from the daemon HTTP endpoint.
-private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
+/// Read the daemon HTTP auth token from disk.
+private func readDaemonToken() throws -> String {
     let tokenBase: String
     if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
        !baseDir.isEmpty {
@@ -442,6 +439,12 @@ private func fetchAttachmentData(port: Int, attachmentId: String) async throws -
           !token.isEmpty else {
         throw URLError(.userAuthenticationRequired)
     }
+    return token
+}
+
+/// Fetch attachment base64 data from the daemon HTTP endpoint.
+private func fetchAttachmentData(port: Int, attachmentId: String) async throws -> String {
+    let token = try readDaemonToken()
     let url = URL(string: "http://localhost:\(port)/v1/attachments/\(attachmentId)")!
     var request = URLRequest(url: url)
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -456,6 +459,20 @@ private func fetchAttachmentData(port: Int, attachmentId: String) async throws -
     }
     let decoded = try JSONDecoder().decode(AttachmentResponse.self, from: data)
     return decoded.data
+}
+
+/// Fetch attachment binary content from the daemon /content endpoint.
+/// Returns raw bytes suitable for writing to disk or AVPlayer consumption.
+private func fetchAttachmentContent(port: Int, attachmentId: String) async throws -> Data {
+    let token = try readDaemonToken()
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/attachments/\(attachmentId)/content")!)
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+        throw URLError(.badServerResponse)
+    }
+    return data
 }
 
 /// NSViewRepresentable wrapper for AVPlayerView.


### PR DESCRIPTION
P0: handleCuSessionFinalized now creates a file-backed attachment from recording metadata and links it to the injected message. Removes 'for future M3' placeholder. P1: InlineVideoAttachmentView fetches binary from /v1/attachments/:id/content for file-backed attachments instead of trying to decode empty base64. Updates sessions.ts lazy detection to handle file-backed storage kind.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
