### PR TITLE
Wire QA mode in macOS client: create recorder when daemon signals QA intent

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -53,7 +53,10 @@ extension AppDelegate {
                 maxSteps: maxSteps,
                 sessionId: routed.sessionId,
                 skipSessionCreate: true,
-                notificationService: self.services.activityNotificationService
+                notificationService: self.services.activityNotificationService,
+                screenRecorder: (routed.qaMode == true) ? ScreenRecorder() : nil,
+                reportToSessionId: routed.reportToSessionId,
+                qaMode: routed.qaMode ?? false
             )
             // Don't bind relatedViewModel for escalated sessions — the active view model
             // may be unrelated if the user switched threads. Tool calls for escalated
@@ -193,7 +196,10 @@ extension AppDelegate {
                     attachments: submission.attachments,
                     sessionId: routed.sessionId,
                     skipSessionCreate: true,
-                    notificationService: self.services.activityNotificationService
+                    notificationService: self.services.activityNotificationService,
+                    screenRecorder: (routed.qaMode == true) ? ScreenRecorder() : nil,
+                    reportToSessionId: routed.reportToSessionId,
+                    qaMode: routed.qaMode ?? false
                 )
                 // Don't bind relatedViewModel — sessions started via startSession() don't
                 // originate from a chat thread, so there's no ChatViewModel to extract


### PR DESCRIPTION
When the daemon routes a task with qaMode=true in task_routed, the client now creates a ScreenRecorder and passes qaMode/reportToSessionId to ComputerUseSession. This enables screen recording for QA sessions and cu_session_finalized delivery on completion. Both session creation paths (escalation + direct startSession) are wired.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
