### PR TITLE
fix: apply slash command highlighting when text is set programmatically

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -645,6 +645,7 @@ private struct ComposerTextView: NSViewRepresentable {
 
         if context.coordinator.isWritingFromView == false, textView.string != text {
             textView.string = text
+            textView.highlightSlashCommand()
             textView.needsDisplay = true
         }
 
@@ -779,7 +780,7 @@ private final class ComposerNativeTextView: NSTextView {
         highlightSlashCommand()
     }
 
-    private func highlightSlashCommand() {
+    func highlightSlashCommand() {
         guard let layoutManager = layoutManager, let textStorage = textStorage else { return }
         let fullRange = NSRange(location: 0, length: textStorage.length)
         guard fullRange.length > 0 else { return }


### PR DESCRIPTION
## Summary
- Make `highlightSlashCommand()` internal (non-private) so it can be called from the representable coordinator
- Call `highlightSlashCommand()` when the text view's string is updated programmatically, so slash commands like `/commit` render with proper highlighting immediately

## Test plan
- [ ] Type a slash command in the composer — verify highlighting works as before
- [ ] Trigger a programmatic text set (e.g. selecting a slash command from the menu) — verify the slash command text is highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
