### PR TITLE
fix: add warning case to ToastInfo.Style

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -240,6 +240,7 @@ struct ToastInfo {
     enum Style {
         case success
         case error
+        case warning
     }
 
     let message: String


### PR DESCRIPTION
## Summary
- Add `warning` case to `ToastInfo.Style` enum so callers like `AppDelegate` can show warning-style toasts

## Test plan
- [ ] Build succeeds without the `.warning` compile error in AppDelegate.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
