### PR TITLE
Close final SMS/Twilio parity gaps

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -71,6 +71,9 @@ mock.module('../config/loader.js', () => ({
     ingress: {
       publicBaseUrl: 'https://test.example.com',
     },
+    sms: {
+      phoneNumber: '+15550001111',
+    },
   }),
   getConfig: () => ({
     model: 'test',
@@ -81,6 +84,9 @@ mock.module('../config/loader.js', () => ({
     secretDetection: { enabled: false },
     ingress: {
       publicBaseUrl: 'https://test.example.com',
+    },
+    sms: {
+      phoneNumber: '+15550001111',
     },
   }),
   invalidateConfigCache: () => {},
@@ -96,21 +102,21 @@ mock.module('../calls/twilio-provider.js', () => ({
   },
 }));
 
-// Mock Twilio config
-mock.module('../calls/twilio-config.js', () => ({
-  getTwilioConfig: () => ({
-    accountSid: 'AC_test',
-    authToken: 'test_token',
-    phoneNumber: '+15550001111',
-    webhookBaseUrl: 'https://test.example.com',
-    wssBaseUrl: 'wss://test.example.com',
-  }),
-}));
+const secureKeyStore: Record<string, string | undefined> = {
+  'credential:twilio:account_sid': 'AC_test',
+  'credential:twilio:auth_token': 'test_token',
+  'credential:twilio:phone_number': '+15550001111',
+};
 
 mock.module('../security/secure-keys.js', () => ({
-  getSecureKey: () => null,
-  setSecureKey: () => true,
-  deleteSecureKey: () => {},
+  getSecureKey: (key: string) => secureKeyStore[key] ?? null,
+  setSecureKey: (key: string, value: string) => {
+    secureKeyStore[key] = value;
+    return true;
+  },
+  deleteSecureKey: (key: string) => {
+    delete secureKeyStore[key];
+  },
 }));
 
 // NOTE: Do NOT mock '../inbound/public-ingress-urls.js' here.

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -52,7 +52,8 @@ export async function deliverApprovalPrompt(
   chatId: string,
   text: string,
   approval: ApprovalUIMetadata,
+  assistantId?: string,
   bearerToken?: string,
 ): Promise<void> {
-  await deliverChannelReply(callbackUrl, { chatId, text, approval }, bearerToken);
+  await deliverChannelReply(callbackUrl, { chatId, text, approval, assistantId }, bearerToken);
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -939,8 +939,16 @@ export class RuntimeHttpServer {
           const externalChatId = typeof payload.externalChatId === 'string'
             ? payload.externalChatId
             : undefined;
+          const assistantId = typeof payload.assistantId === 'string'
+            ? payload.assistantId
+            : undefined;
           if (externalChatId) {
-            await this.deliverReplyViaCallback(event.conversationId, externalChatId, replyCallbackUrl);
+            await this.deliverReplyViaCallback(
+              event.conversationId,
+              externalChatId,
+              replyCallbackUrl,
+              assistantId,
+            );
           }
         }
       } catch (err) {
@@ -954,6 +962,7 @@ export class RuntimeHttpServer {
     conversationId: string,
     externalChatId: string,
     callbackUrl: string,
+    assistantId?: string,
   ): Promise<void> {
     const msgs = conversationStore.getMessages(conversationId);
     for (let i = msgs.length - 1; i >= 0; i--) {
@@ -976,6 +985,7 @@ export class RuntimeHttpServer {
             chatId: externalChatId,
             text: rendered.text || undefined,
             attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
+            assistantId,
           }, this.bearerToken);
         }
         break;

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -384,6 +384,7 @@ export async function handleChannelInbound(
         await deliverChannelReply(replyCallbackUrl, {
           chatId: externalChatId,
           text: replyText,
+          assistantId,
         }, bearerToken);
       } catch (err) {
         log.error({ err, externalChatId }, 'Failed to deliver guardian verification reply');
@@ -507,6 +508,7 @@ export async function handleChannelInbound(
       senderExternalUserId: body.senderExternalUserId,
       senderUsername: body.senderUsername,
       replyCallbackUrl,
+      assistantId,
     });
 
     const contentToCheck = content ?? '';
@@ -557,6 +559,7 @@ export async function handleChannelInbound(
         metadataUxBrief,
         replyCallbackUrl,
         bearerToken,
+        assistantId,
       });
     }
   }
@@ -580,6 +583,7 @@ interface BackgroundProcessingParams {
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
   bearerToken?: string;
+  assistantId?: string;
 }
 
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
@@ -595,6 +599,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     metadataUxBrief,
     replyCallbackUrl,
     bearerToken,
+    assistantId,
   } = params;
 
   (async () => {
@@ -616,7 +621,13 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
       channelDeliveryStore.markProcessed(eventId);
 
       if (replyCallbackUrl) {
-        await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+        await deliverReplyViaCallback(
+          conversationId,
+          externalChatId,
+          replyCallbackUrl,
+          bearerToken,
+          assistantId,
+        );
       }
     } catch (err) {
       log.error({ err, conversationId }, 'Background channel message processing failed');
@@ -734,6 +745,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               await deliverChannelReply(replyCallbackUrl, {
                 chatId: externalChatId,
                 text: denialText,
+                assistantId,
               }, bearerToken);
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver unverified-channel denial notice');
@@ -774,6 +786,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                 guardianCtx.guardianChatId,
                 guardianText,
                 uiMetadata,
+                assistantId,
                 bearerToken,
               );
               guardianNotified = true;
@@ -789,6 +802,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                 await deliverChannelReply(replyCallbackUrl, {
                   chatId: guardianCtx.requesterChatId ?? externalChatId,
                   text: `Your request to run "${pending[0].toolName}" could not be sent to the guardian for approval. The action has been denied.`,
+                  assistantId,
                 }, bearerToken);
               } catch (notifyErr) {
                 log.error({ err: notifyErr, runId: run.id }, 'Failed to notify requester of guardian delivery failure');
@@ -801,6 +815,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                 await deliverChannelReply(replyCallbackUrl, {
                   chatId: guardianCtx.requesterChatId ?? externalChatId,
                   text: `Your request to run "${pending[0].toolName}" has been sent to the guardian for approval.`,
+                  assistantId,
                 }, bearerToken);
               } catch (err) {
                 log.error({ err, runId: run.id }, 'Failed to notify requester of pending guardian approval');
@@ -823,6 +838,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                   externalChatId,
                   promptTextForChannel,
                   uiMetadata,
+                  assistantId,
                   bearerToken,
                 );
               } catch (err) {
@@ -867,7 +883,13 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         // rather than permanently losing the reply.
         if (channelDeliveryStore.claimRunDelivery(run.id)) {
           try {
-            await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+            await deliverReplyViaCallback(
+              conversationId,
+              externalChatId,
+              replyCallbackUrl,
+              bearerToken,
+              assistantId,
+            );
           } catch (deliveryErr) {
             channelDeliveryStore.resetRunDeliveryClaim(run.id);
             throw deliveryErr;
@@ -1003,6 +1025,7 @@ async function handleApprovalInterception(
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
             text: `You have ${allPending.length} pending approval requests. Please use the approval buttons to respond to a specific request.`,
+            assistantId,
           }, bearerToken);
         } catch (err) {
           log.error({ err, externalChatId }, 'Failed to deliver disambiguation notice');
@@ -1035,6 +1058,7 @@ async function handleApprovalInterception(
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
             text: 'Only the verified guardian can approve or deny this request.',
+            assistantId,
           }, bearerToken);
         } catch (err) {
           log.error({ err, externalChatId }, 'Failed to deliver guardian identity rejection notice');
@@ -1075,6 +1099,7 @@ async function handleApprovalInterception(
             await deliverChannelReply(replyCallbackUrl, {
               chatId: guardianApproval.requesterChatId,
               text: outcomeText,
+              assistantId,
             }, bearerToken);
           } catch (err) {
             log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to notify requester of guardian decision');
@@ -1090,6 +1115,7 @@ async function handleApprovalInterception(
               guardianApproval.requesterChatId,
               replyCallbackUrl,
               bearerToken,
+              assistantId,
             );
           }
         }
@@ -1117,6 +1143,7 @@ async function handleApprovalInterception(
             externalChatId,
             reminderText,
             uiMetadata,
+            assistantId,
             bearerToken,
           );
         } catch (err) {
@@ -1150,6 +1177,7 @@ async function handleApprovalInterception(
         await deliverChannelReply(replyCallbackUrl, {
           chatId: externalChatId,
           text: denialText,
+          assistantId,
         }, bearerToken);
       } catch (err) {
         log.error({ err, conversationId }, 'Failed to deliver unverified-channel denial notice during interception');
@@ -1170,6 +1198,7 @@ async function handleApprovalInterception(
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
             text: 'Your request is pending guardian approval. Only the verified guardian can approve or deny this request.',
+            assistantId,
           }, bearerToken);
         } catch (err) {
           log.error({ err, conversationId }, 'Failed to deliver guardian-pending notice to requester');
@@ -1196,6 +1225,7 @@ async function handleApprovalInterception(
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
             text: 'Your guardian approval request has expired and the action has been denied. Please try again.',
+            assistantId,
           }, bearerToken);
         } catch (err) {
           log.error({ err, conversationId }, 'Failed to deliver guardian-expiry notice to requester');
@@ -1247,6 +1277,7 @@ async function handleApprovalInterception(
         externalChatId,
         replyCallbackUrl,
         bearerToken,
+        assistantId,
       );
     }
 
@@ -1269,6 +1300,7 @@ async function handleApprovalInterception(
         externalChatId,
         reminderText,
         uiMetadata,
+        assistantId,
         bearerToken,
       );
     } catch (err) {
@@ -1296,6 +1328,7 @@ function schedulePostDecisionDelivery(
   externalChatId: string,
   replyCallbackUrl: string,
   bearerToken?: string,
+  assistantId?: string,
 ): void {
   (async () => {
     try {
@@ -1307,7 +1340,13 @@ function schedulePostDecisionDelivery(
         if (current.status === 'completed' || current.status === 'failed') {
           if (channelDeliveryStore.claimRunDelivery(runId)) {
             try {
-              await deliverReplyViaCallback(conversationId, externalChatId, replyCallbackUrl, bearerToken);
+              await deliverReplyViaCallback(
+                conversationId,
+                externalChatId,
+                replyCallbackUrl,
+                bearerToken,
+                assistantId,
+              );
             } catch (deliveryErr) {
               channelDeliveryStore.resetRunDeliveryClaim(runId);
               throw deliveryErr;
@@ -1331,6 +1370,7 @@ async function deliverReplyViaCallback(
   externalChatId: string,
   callbackUrl: string,
   bearerToken?: string,
+  assistantId?: string,
 ): Promise<void> {
   const msgs = conversationStore.getMessages(conversationId);
   for (let i = msgs.length - 1; i >= 0; i--) {
@@ -1353,6 +1393,7 @@ async function deliverReplyViaCallback(
           chatId: externalChatId,
           text: rendered.text || undefined,
           attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
+          assistantId,
         }, bearerToken);
       }
       break;
@@ -1453,6 +1494,7 @@ export function sweepExpiredGuardianApprovals(
     deliverChannelReply(deliverUrl, {
       chatId: approval.requesterChatId,
       text: `Your guardian approval request for "${approval.toolName}" has expired and the action has been denied. Please try again.`,
+      assistantId: approval.assistantId,
     }, bearerToken).catch((err) => {
       log.error({ err, runId: approval.runId }, 'Failed to notify requester of guardian approval expiry');
     });
@@ -1461,6 +1503,7 @@ export function sweepExpiredGuardianApprovals(
     deliverChannelReply(deliverUrl, {
       chatId: approval.guardianChatId,
       text: `The approval request for "${approval.toolName}" from user ${approval.requesterExternalUserId} has expired and was automatically denied.`,
+      assistantId: approval.assistantId,
     }, bearerToken).catch((err) => {
       log.error({ err, runId: approval.runId }, 'Failed to notify guardian of approval expiry');
     });

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -27,6 +27,11 @@ struct SettingsPanel: View {
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
     @State private var telegramBotTokenText: String = ""
+    @State private var twilioAccountSidText: String = ""
+    @State private var twilioAuthTokenText: String = ""
+    @State private var twilioPhoneNumberText: String = ""
+    @State private var twilioAreaCodeText: String = ""
+    @State private var twilioCountryText: String = "US"
     @State private var ingressUrlText: String = ""
     @FocusState private var isIngressUrlFocused: Bool
     @State private var checkingGateway: Bool = false
@@ -94,6 +99,7 @@ struct SettingsPanel: View {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
             store.refreshTelegramStatus()
+            store.refreshTwilioStatus()
             store.refreshIngressConfig()
             ingressUrlText = store.ingressPublicBaseUrl
             setupIntegrationCallbacks()
@@ -767,6 +773,9 @@ struct SettingsPanel: View {
 
             // TELEGRAM section
             telegramSection
+
+            // TWILIO / SMS section
+            twilioSection
         }
     }
 
@@ -992,6 +1001,204 @@ struct SettingsPanel: View {
             }
 
             if let error = store.telegramError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Twilio Section
+
+    private var twilioSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("SMS (Twilio)")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            if store.twilioHasCredentials {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                        .font(.system(size: 14))
+                    Text("Credentials configured")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    if store.twilioSaveInProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        VButton(label: "Clear Credentials", style: .danger) {
+                            store.clearTwilioCredentials()
+                        }
+                    }
+                }
+            } else {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Enter Account SID and Auth Token")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                TextField("Account SID", text: $twilioAccountSidText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                SecureField("Auth Token", text: $twilioAuthTokenText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                if store.twilioSaveInProgress {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Saving...")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                } else {
+                    VButton(label: "Save Credentials", style: .primary) {
+                        store.saveTwilioCredentials(
+                            accountSid: twilioAccountSidText,
+                            authToken: twilioAuthTokenText
+                        )
+                        twilioAuthTokenText = ""
+                    }
+                    .disabled(
+                        twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                        twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
+                }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            HStack {
+                Text("Assigned Number")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                Text(store.twilioPhoneNumber ?? "Not assigned")
+                    .font(VFont.mono)
+                    .foregroundColor(store.twilioPhoneNumber == nil ? VColor.textMuted : VColor.textPrimary)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                TextField("Assign existing (+1555...)", text: $twilioPhoneNumberText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                VButton(label: "Assign", style: .secondary) {
+                    store.assignTwilioNumber(phoneNumber: twilioPhoneNumberText)
+                    twilioPhoneNumberText = ""
+                }
+                .disabled(
+                    twilioPhoneNumberText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                    store.twilioSaveInProgress
+                )
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                TextField("Area code (optional)", text: $twilioAreaCodeText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                TextField("Country", text: $twilioCountryText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .frame(width: 90)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+
+                VButton(label: "Provision", style: .secondary) {
+                    store.provisionTwilioNumber(
+                        areaCode: twilioAreaCodeText,
+                        country: twilioCountryText
+                    )
+                }
+                .disabled(store.twilioSaveInProgress)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                if store.twilioListInProgress {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                VButton(label: "Refresh Numbers", style: .tertiary) {
+                    store.refreshTwilioNumbers()
+                }
+                .disabled(store.twilioListInProgress)
+            }
+
+            if !store.twilioNumbers.isEmpty {
+                ForEach(store.twilioNumbers, id: \.phoneNumber) { number in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(number.phoneNumber)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                            Text(number.friendlyName)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Use", style: .secondary) {
+                            store.assignTwilioNumber(phoneNumber: number.phoneNumber)
+                        }
+                        .disabled(store.twilioSaveInProgress)
+                    }
+                }
+            }
+
+            if let warning = store.twilioWarning {
+                Text(warning)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.warning)
+            }
+
+            if let error = store.twilioError {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.error)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -91,6 +91,16 @@ public final class SettingsStore: ObservableObject {
     @Published var telegramSaveInProgress: Bool = false
     @Published var telegramError: String?
 
+    // MARK: - Twilio SMS Integration State
+
+    @Published var twilioHasCredentials: Bool = false
+    @Published var twilioPhoneNumber: String?
+    @Published var twilioNumbers: [TwilioNumberInfo] = []
+    @Published var twilioSaveInProgress: Bool = false
+    @Published var twilioListInProgress: Bool = false
+    @Published var twilioWarning: String?
+    @Published var twilioError: String?
+
     // MARK: - Ingress Config State
 
     @Published var ingressEnabled: Bool = false
@@ -120,6 +130,9 @@ public final class SettingsStore: ObservableObject {
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
     private var lastDaemonModel: String?
+    private let twilioAssistantScope = "self"
+    private var twilioPhoneRefreshPending = false
+    private var twilioNumbersRefreshPending = false
 
     init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
         self.daemonClient = daemonClient
@@ -265,6 +278,31 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
+        // Wire up Twilio config IPC response
+        daemonClient?.onTwilioConfigResponse = { [weak self] response in
+            guard let self else { return }
+            self.twilioSaveInProgress = false
+            self.twilioListInProgress = false
+            if response.success {
+                self.twilioHasCredentials = response.hasCredentials
+                if self.twilioPhoneRefreshPending || response.phoneNumber != nil {
+                    self.twilioPhoneNumber = response.phoneNumber
+                }
+                if self.twilioNumbersRefreshPending {
+                    self.twilioNumbers = response.numbers ?? []
+                } else if let numbers = response.numbers {
+                    self.twilioNumbers = numbers
+                }
+                self.twilioWarning = response.warning
+                self.twilioError = nil
+            } else {
+                self.twilioWarning = response.warning
+                self.twilioError = response.error
+            }
+            self.twilioPhoneRefreshPending = false
+            self.twilioNumbersRefreshPending = false
+        }
+
         // Refresh Vercel key state on init
         refreshVercelKeyState()
 
@@ -280,6 +318,9 @@ public final class SettingsStore: ObservableObject {
 
         // Refresh Telegram integration status on init
         refreshTelegramStatus()
+
+        // Refresh Twilio integration status on init
+        refreshTwilioStatus()
 
         // Ingress config is refreshed by onAppear in SettingsPanel /
         // SettingsView, not here, to avoid duplicate get requests whose
@@ -546,6 +587,135 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendTelegramConfig(action: "clear")
         } catch {
             log.error("Failed to send Telegram config clear: \(error)")
+        }
+    }
+
+    // MARK: - Twilio SMS Actions
+
+    func refreshTwilioStatus() {
+        twilioSaveInProgress = true
+        twilioPhoneRefreshPending = true
+        twilioError = nil
+        do {
+            guard let daemonClient else {
+                twilioSaveInProgress = false
+                twilioPhoneRefreshPending = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(action: "get", assistantId: twilioAssistantScope)
+        } catch {
+            twilioSaveInProgress = false
+            twilioPhoneRefreshPending = false
+            twilioError = "Failed to load Twilio config: \(error.localizedDescription)"
+        }
+    }
+
+    func saveTwilioCredentials(accountSid: String, authToken: String) {
+        let trimmedSid = accountSid.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedToken = authToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSid.isEmpty, !trimmedToken.isEmpty else { return }
+        twilioSaveInProgress = true
+        twilioError = nil
+        twilioWarning = nil
+        do {
+            guard let daemonClient else {
+                twilioSaveInProgress = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(
+                action: "set_credentials",
+                accountSid: trimmedSid,
+                authToken: trimmedToken,
+                assistantId: twilioAssistantScope
+            )
+        } catch {
+            twilioSaveInProgress = false
+            twilioError = "Failed to save Twilio credentials: \(error.localizedDescription)"
+        }
+    }
+
+    func clearTwilioCredentials() {
+        twilioSaveInProgress = true
+        twilioError = nil
+        twilioWarning = nil
+        do {
+            guard let daemonClient else {
+                twilioSaveInProgress = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(action: "clear_credentials", assistantId: twilioAssistantScope)
+        } catch {
+            twilioSaveInProgress = false
+            twilioError = "Failed to clear Twilio credentials: \(error.localizedDescription)"
+        }
+    }
+
+    func assignTwilioNumber(phoneNumber: String) {
+        let trimmed = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        twilioSaveInProgress = true
+        twilioPhoneRefreshPending = true
+        twilioError = nil
+        twilioWarning = nil
+        do {
+            guard let daemonClient else {
+                twilioSaveInProgress = false
+                twilioPhoneRefreshPending = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(
+                action: "assign_number",
+                phoneNumber: trimmed,
+                assistantId: twilioAssistantScope
+            )
+        } catch {
+            twilioSaveInProgress = false
+            twilioPhoneRefreshPending = false
+            twilioError = "Failed to assign Twilio number: \(error.localizedDescription)"
+        }
+    }
+
+    func provisionTwilioNumber(areaCode: String?, country: String?) {
+        let trimmedAreaCode = areaCode?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedCountry = country?.trimmingCharacters(in: .whitespacesAndNewlines)
+        twilioSaveInProgress = true
+        twilioPhoneRefreshPending = true
+        twilioError = nil
+        twilioWarning = nil
+        do {
+            guard let daemonClient else {
+                twilioSaveInProgress = false
+                twilioPhoneRefreshPending = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(
+                action: "provision_number",
+                areaCode: (trimmedAreaCode?.isEmpty == false) ? trimmedAreaCode : nil,
+                country: (trimmedCountry?.isEmpty == false) ? trimmedCountry?.uppercased() : nil,
+                assistantId: twilioAssistantScope
+            )
+        } catch {
+            twilioSaveInProgress = false
+            twilioPhoneRefreshPending = false
+            twilioError = "Failed to provision Twilio number: \(error.localizedDescription)"
+        }
+    }
+
+    func refreshTwilioNumbers() {
+        twilioListInProgress = true
+        twilioNumbersRefreshPending = true
+        twilioError = nil
+        do {
+            guard let daemonClient else {
+                twilioListInProgress = false
+                twilioNumbersRefreshPending = false
+                return
+            }
+            try daemonClient.sendTwilioConfig(action: "list_numbers", assistantId: twilioAssistantScope)
+        } catch {
+            twilioListInProgress = false
+            twilioNumbersRefreshPending = false
+            twilioError = "Failed to load Twilio numbers: \(error.localizedDescription)"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -13,6 +13,11 @@ public struct SettingsView: View {
     @State private var twitterClientId = ""
     @State private var twitterClientSecret = ""
     @State private var telegramBotTokenText = ""
+    @State private var twilioAccountSidText = ""
+    @State private var twilioAuthTokenText = ""
+    @State private var twilioPhoneNumberText = ""
+    @State private var twilioAreaCodeText = ""
+    @State private var twilioCountryText = "US"
     @State private var ingressUrlText = ""
     @FocusState private var isIngressUrlFocused: Bool
     @State private var accessibilityGranted = false
@@ -407,6 +412,133 @@ public struct SettingsView: View {
                 }
             }
 
+            Section("SMS (Twilio)") {
+                if store.twilioHasCredentials {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.system(size: 14))
+                        Text("Credentials configured")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        if store.twilioSaveInProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Button("Clear Credentials") {
+                                store.clearTwilioCredentials()
+                            }
+                            .tint(.red)
+                        }
+                    }
+                } else {
+                    TextField("Account SID", text: $twilioAccountSidText)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Auth Token", text: $twilioAuthTokenText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Spacer()
+                        if store.twilioSaveInProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Button("Save Credentials") {
+                                store.saveTwilioCredentials(
+                                    accountSid: twilioAccountSidText,
+                                    authToken: twilioAuthTokenText
+                                )
+                                twilioAuthTokenText = ""
+                            }
+                            .disabled(
+                                twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                                twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            )
+                        }
+                    }
+                }
+
+                Divider()
+
+                HStack {
+                    Text("Assigned Number")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(store.twilioPhoneNumber ?? "Not assigned")
+                        .font(.body.monospaced())
+                        .foregroundStyle(store.twilioPhoneNumber == nil ? .tertiary : .primary)
+                }
+
+                HStack {
+                    TextField("Assign existing number (+1555...)", text: $twilioPhoneNumberText)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Assign") {
+                        store.assignTwilioNumber(phoneNumber: twilioPhoneNumberText)
+                        twilioPhoneNumberText = ""
+                    }
+                    .disabled(
+                        twilioPhoneNumberText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                        store.twilioSaveInProgress
+                    )
+                }
+
+                HStack {
+                    TextField("Area code (optional)", text: $twilioAreaCodeText)
+                        .textFieldStyle(.roundedBorder)
+                    TextField("Country", text: $twilioCountryText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 80)
+                    Button("Provision") {
+                        store.provisionTwilioNumber(
+                            areaCode: twilioAreaCodeText,
+                            country: twilioCountryText
+                        )
+                    }
+                    .disabled(store.twilioSaveInProgress)
+                }
+
+                HStack {
+                    if store.twilioListInProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Button("Refresh Numbers") {
+                        store.refreshTwilioNumbers()
+                    }
+                    .disabled(store.twilioListInProgress)
+                }
+
+                if !store.twilioNumbers.isEmpty {
+                    ForEach(store.twilioNumbers, id: \.phoneNumber) { number in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(number.phoneNumber)
+                                    .font(.body.monospaced())
+                                Text(number.friendlyName)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button("Use") {
+                                store.assignTwilioNumber(phoneNumber: number.phoneNumber)
+                            }
+                            .disabled(store.twilioSaveInProgress)
+                        }
+                    }
+                }
+
+                if let warning = store.twilioWarning {
+                    Text(warning)
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+
+                if let error = store.twilioError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+
             Section("Public Ingress") {
                 Toggle("Enable Public Ingress", isOn: Binding(
                     get: { store.ingressEnabled },
@@ -662,6 +794,7 @@ public struct SettingsView: View {
             store.refreshVercelKeyState()
             store.refreshTwitterStatus()
             store.refreshTelegramStatus()
+            store.refreshTwilioStatus()
             store.refreshIngressConfig()
             ingressUrlText = store.ingressPublicBaseUrl
             checkPermissions()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -972,7 +972,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         authToken: String? = nil,
         phoneNumber: String? = nil,
         areaCode: String? = nil,
-        country: String? = nil
+        country: String? = nil,
+        assistantId: String? = nil
     ) throws {
         try send(TwilioConfigRequestMessage(
             action: action,
@@ -980,7 +981,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             authToken: authToken,
             phoneNumber: phoneNumber,
             areaCode: areaCode,
-            country: country
+            country: country,
+            assistantId: assistantId
         ))
     }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -46,13 +46,6 @@ import Foundation
 // │                                 │ generated contract                      │
 // │ SubagentEventMessage            │ Contains recursive ServerMessage ref;   │
 // │                                 │ codegen skips ServerMessage              │
-// │ TwilioConfigRequestMessage      │ Code generator has not yet produced     │
-// │                                 │ this type from the TS contract          │
-// │ TwilioConfigResponseMessage     │ Code generator has not yet produced     │
-// │                                 │ this type from the TS contract          │
-// │ TwilioNumberInfo                │ Nested type within                      │
-// │                                 │ TwilioConfigResponseMessage             │
-// │ TwilioNumberCapabilities        │ Nested type within TwilioNumberInfo     │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1830,55 +1823,41 @@ public typealias TelegramConfigResponseMessage = IPCTelegramConfigResponse
 // MARK: - Twilio Config Messages
 
 /// Sent to get/set/clear Twilio credentials and manage phone numbers.
-/// Manually defined because the code generator has not yet produced this type.
-public struct TwilioConfigRequestMessage: Encodable, Sendable {
-    public let type: String = "twilio_config"
-    public let action: String
-    public let accountSid: String?
-    public let authToken: String?
-    public let phoneNumber: String?
-    public let areaCode: String?
-    public let country: String?
+/// Backed by generated `IPCTwilioConfigRequest`.
+public typealias TwilioConfigRequestMessage = IPCTwilioConfigRequest
 
+extension IPCTwilioConfigRequest {
     public init(
         action: String,
         accountSid: String? = nil,
         authToken: String? = nil,
         phoneNumber: String? = nil,
         areaCode: String? = nil,
-        country: String? = nil
+        country: String? = nil,
+        assistantId: String? = nil
     ) {
-        self.action = action
-        self.accountSid = accountSid
-        self.authToken = authToken
-        self.phoneNumber = phoneNumber
-        self.areaCode = areaCode
-        self.country = country
+        self.init(
+            type: "twilio_config",
+            action: action,
+            accountSid: accountSid,
+            authToken: authToken,
+            phoneNumber: phoneNumber,
+            areaCode: areaCode,
+            country: country,
+            assistantId: assistantId
+        )
     }
 }
 
 /// Number entry returned in `twilio_config_response` `numbers` array.
-public struct TwilioNumberInfo: Decodable, Sendable {
-    public let phoneNumber: String
-    public let friendlyName: String
-    public let capabilities: TwilioNumberCapabilities
-}
+public typealias TwilioNumberInfo = IPCTwilioConfigResponseNumber
 
 /// Capabilities of a Twilio phone number.
-public struct TwilioNumberCapabilities: Decodable, Sendable {
-    public let voice: Bool
-    public let sms: Bool
-}
+public typealias TwilioNumberCapabilities = IPCTwilioConfigResponseNumberCapabilities
 
 /// Response from Twilio config operations.
-/// Manually defined because the code generator has not yet produced this type.
-public struct TwilioConfigResponseMessage: Decodable, Sendable {
-    public let success: Bool
-    public let hasCredentials: Bool
-    public let phoneNumber: String?
-    public let numbers: [TwilioNumberInfo]?
-    public let error: String?
-}
+/// Backed by generated `IPCTwilioConfigResponse`.
+public typealias TwilioConfigResponseMessage = IPCTwilioConfigResponse
 
 // MARK: - Twitter Integration Config Messages
 

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -271,4 +271,89 @@ describe("/deliver/sms", () => {
     expect(sentParams.get("To")).toBe("+15559876543");
     expect(sentParams.get("Body")).toBe("Test SMS body");
   });
+
+  it("uses assistant-specific From number when assistantId mapping exists", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, init: init ?? {} });
+      return new Response(JSON.stringify({ sid: "SM-sent" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const handler = createSmsDeliverHandler(
+      makeConfig({
+        runtimeProxyBearerToken: undefined,
+        smsDeliverAuthBypass: true,
+        assistantPhoneNumbers: { "ast-alpha": "+15550001111" },
+      }),
+    );
+    const req = makeRequest({
+      to: "+15559876543",
+      text: "assistant scoped",
+      assistantId: "ast-alpha",
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toHaveLength(1);
+    const sentBody = fetchCalls[0].init.body as string;
+    const sentParams = new URLSearchParams(sentBody);
+    expect(sentParams.get("From")).toBe("+15550001111");
+  });
+
+  it("falls back to global From number when assistant mapping is missing", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, init: init ?? {} });
+      return new Response(JSON.stringify({ sid: "SM-sent" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const handler = createSmsDeliverHandler(
+      makeConfig({
+        runtimeProxyBearerToken: undefined,
+        smsDeliverAuthBypass: true,
+        assistantPhoneNumbers: { "ast-beta": "+15550002222" },
+      }),
+    );
+    const req = makeRequest({
+      to: "+15559876543",
+      text: "fallback",
+      assistantId: "ast-alpha",
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toHaveLength(1);
+    const sentBody = fetchCalls[0].init.body as string;
+    const sentParams = new URLSearchParams(sentBody);
+    expect(sentParams.get("From")).toBe("+15551234567");
+  });
+
+  it("returns 503 when no From number is available", async () => {
+    const handler = createSmsDeliverHandler(
+      makeConfig({
+        runtimeProxyBearerToken: undefined,
+        smsDeliverAuthBypass: true,
+        twilioPhoneNumber: undefined,
+        assistantPhoneNumbers: undefined,
+      }),
+    );
+    const req = makeRequest({
+      to: "+15559876543",
+      text: "no from",
+      assistantId: "ast-alpha",
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("SMS integration not configured");
+  });
 });

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -34,6 +34,17 @@ async function sendTwilioSms(
   }
 }
 
+function resolveFromNumber(
+  config: GatewayConfig,
+  assistantId?: string,
+): string | undefined {
+  if (assistantId) {
+    const mapped = config.assistantPhoneNumbers?.[assistantId];
+    if (mapped) return mapped;
+  }
+  return config.twilioPhoneNumber;
+}
+
 export function createSmsDeliverHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
@@ -66,7 +77,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
     }
 
     // Verify Twilio SMS sending is configured
-    if (!config.twilioAccountSid || !config.twilioAuthToken || !config.twilioPhoneNumber) {
+    if (!config.twilioAccountSid || !config.twilioAuthToken) {
       tlog.error("Twilio SMS credentials not configured");
       return Response.json(
         { error: "SMS integration not configured" },
@@ -78,6 +89,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       to?: string;
       chatId?: string;
       text?: string;
+      assistantId?: string;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -86,6 +98,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
     }
 
     const { text } = body;
+    const assistantId = typeof body.assistantId === "string" ? body.assistantId : undefined;
     // Accept `chatId` as an alias for `to` so runtime channel callbacks
     // (which send `{ chatId, text }`) work without translation.
     const to = body.to ?? body.chatId;
@@ -98,11 +111,20 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "text is required" }, { status: 400 });
     }
 
+    const from = resolveFromNumber(config, assistantId);
+    if (!from) {
+      tlog.error({ assistantId }, "Twilio SMS phone number not configured");
+      return Response.json(
+        { error: "SMS integration not configured" },
+        { status: 503 },
+      );
+    }
+
     try {
       await sendTwilioSms(
         config.twilioAccountSid,
         config.twilioAuthToken,
-        config.twilioPhoneNumber,
+        from,
         to,
         text,
       );


### PR DESCRIPTION
## Summary
- Use assistant-scoped Twilio sender numbers for outbound SMS in gateway delivery, with fallback to the global Twilio number.
- Thread `assistantId` through runtime callback delivery paths (standard replies, approval flow, guardian paths, and dead-letter replay) so outbound SMS can resolve assistant-specific numbers.
- Remove cross-suite Twilio config mock leakage in assistant tests by replacing the module-level mock with local secure-key/config mocks.
- Align shared Swift Twilio IPC wrappers with generated contract types and add `assistantId` passthrough.
- Add macOS Settings UI + store wiring for Twilio credentials, number assignment/provisioning, number listing, and status/warning/error states.

## Files changed
- `gateway/src/http/routes/sms-deliver.ts`
- `gateway/src/http/routes/sms-deliver.test.ts`
- `assistant/src/runtime/routes/channel-routes.ts`
- `assistant/src/runtime/gateway-client.ts`
- `assistant/src/runtime/http-server.ts`
- `assistant/src/__tests__/gateway-only-enforcement.test.ts`
- `clients/shared/IPC/IPCMessages.swift`
- `clients/shared/IPC/DaemonClient.swift`
- `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift`
- `clients/macos/vellum-assistant/Features/Settings/SettingsView.swift`
- `clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift`

## Validation
- `cd gateway && bun test src/http/routes/sms-deliver.test.ts src/http/routes/twilio-sms-webhook.test.ts src/__tests__/sms-ingress-guard.test.ts`
- `cd assistant && bun test src/__tests__/handlers-twilio-config.test.ts src/__tests__/gateway-only-enforcement.test.ts src/__tests__/ingress-url-consistency.test.ts`
- `cd assistant && bun test src/__tests__/channel-approval-routes.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bunx tsc --noEmit`

## Notes
- macOS/Xcode build was not run in this environment.