### PR TITLE
fix: move skill install button to top-right of detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -479,6 +479,10 @@ struct AgentPanelContent: View {
                         .font(VFont.small)
                         .foregroundColor(Amber._500)
                 }
+
+                Spacer()
+
+                detailInstallButton(slug: slug)
             }
 
             // Author/source row
@@ -590,8 +594,6 @@ struct AgentPanelContent: View {
                 }
             }
 
-            // Install button — always visible
-            detailInstallButton(slug: slug)
         }
     }
 
@@ -697,7 +699,8 @@ struct AgentPanelContent: View {
             label: isSuccess ? "Installed!" : (isInstalling ? "Installing..." : "Install"),
             icon: isSuccess ? "checkmark.circle.fill" : (isInstalling ? nil : "arrow.down.circle.fill"),
             style: .primary,
-            isFullWidth: true,
+            size: .small,
+            isFullWidth: false,
             isDisabled: isInstalling || isSuccess
         ) {
             guard installingSlug == nil, !isSuccess else { return }


### PR DESCRIPTION
## Summary
- Moves the Install button from the bottom of the skill detail panel to inline with the title row (top-right)
- Makes the button compact (small size, not full-width) so it fits alongside the title
- Button is now immediately visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
