### PR TITLE
fix: move skill detail action buttons to top-right

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -862,6 +862,20 @@ struct AgentPanelContent: View {
                         .font(VFont.small)
                         .foregroundColor(Amber._500)
                 }
+
+                Spacer()
+
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Use", icon: "bolt.fill", style: .primary, size: .small) {
+                        onInvokeSkill?(skill)
+                    }
+
+                    if skill.source == "managed" {
+                        VButton(label: "Delete", icon: "trash", style: .danger, size: .small) {
+                            skillToDelete = skill
+                        }
+                    }
+                }
             }
 
             // Description
@@ -906,18 +920,6 @@ struct AgentPanelContent: View {
                     .stroke(VColor.surfaceBorder, lineWidth: 1)
             )
 
-            // Action buttons
-            HStack(spacing: VSpacing.md) {
-                VButton(label: "Use", icon: "bolt.fill", style: .primary, isFullWidth: true) {
-                    onInvokeSkill?(skill)
-                }
-
-                if skill.source == "managed" {
-                    VButton(label: "Delete", icon: "trash", style: .danger) {
-                        skillToDelete = skill
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Moves Install button (available skills) and Use/Delete buttons (installed skills) from the bottom of the detail panel to the title row (top-right)
- Buttons are now compact (small size) and immediately visible without scrolling
- Supersedes #6949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
