### PR TITLE
Fix ARCHITECTURE.md: clarify QA recording conditional paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4201,14 +4201,16 @@ Keep-alive heartbeats (every 30 s by default):
 ### QA Recording Data Flow
 
 ```
-User asks to test → QA intent detection → CU session created with qaMode + reportToSessionId
+User asks to test → QA intent detection (regex/keyword) → CU session created with qaMode
+→ reportToSessionId set if conversationId available (chat context) or sourceSessionId (escalation)
 → macOS ScreenRecorder starts → CU action loop executes
 → Session terminates → ScreenRecorder stops → .mp4 saved to ~/Library/Application Support/vellum-assistant/recordings/
 → cu_session_finalized sent to daemon with recording metadata
-→ Daemon handler creates file-backed attachment + assistant message in source chat
+→ Daemon handler creates file-backed attachment (always, for cleanup tracking)
+→ If reportToSessionId present: also injects assistant message + attachment into source chat
 → Client loads video from GET /v1/attachments/:id/content (with Range support)
 → Video playable inline + draggable to Finder
-→ Retention cleanup removes expired recordings after configurable period (default 7 days)
+→ Retention cleanup removes expired recordings after configurable period (qaRecording.defaultRetentionDays)
 ```
 
 ### File-Backed Attachment Storage


### PR DESCRIPTION
Update QA Recording data flow diagram to reflect that:
1. reportToSessionId is set conditionally (requires conversationId from chat or sourceSessionId from escalation)
2. File-backed attachment is always created for cleanup tracking
3. Message injection into source chat only happens when reportToSessionId is present
4. Retention uses configurable qaRecording.defaultRetentionDays
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
