### PR TITLE
fix: stack install error message below button in skill detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -695,32 +695,34 @@ struct AgentPanelContent: View {
         let isError = result?.slug == slug && result?.success == false
         let errorMessage = result?.error
 
-        VButton(
-            label: isSuccess ? "Installed!" : (isInstalling ? "Installing..." : "Install"),
-            icon: isSuccess ? "checkmark.circle.fill" : (isInstalling ? nil : "arrow.down.circle.fill"),
-            style: .primary,
-            size: .small,
-            isFullWidth: false,
-            isDisabled: isInstalling || isSuccess
-        ) {
-            guard installingSlug == nil, !isSuccess else { return }
-            let attemptId = UUID()
-            installingSlug = slug
-            installAttemptId = attemptId
-            skillsManager.installSkill(slug: slug)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                if installingSlug == slug && installAttemptId == attemptId {
-                    installingSlug = nil
-                    installAttemptId = nil
+        VStack(alignment: .trailing, spacing: VSpacing.xs) {
+            VButton(
+                label: isSuccess ? "Installed!" : (isInstalling ? "Installing..." : "Install"),
+                icon: isSuccess ? "checkmark.circle.fill" : (isInstalling ? nil : "arrow.down.circle.fill"),
+                style: .primary,
+                size: .small,
+                isFullWidth: false,
+                isDisabled: isInstalling || isSuccess
+            ) {
+                guard installingSlug == nil, !isSuccess else { return }
+                let attemptId = UUID()
+                installingSlug = slug
+                installAttemptId = attemptId
+                skillsManager.installSkill(slug: slug)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                    if installingSlug == slug && installAttemptId == attemptId {
+                        installingSlug = nil
+                        installAttemptId = nil
+                    }
                 }
             }
-        }
 
-        // Error message
-        if isError, let msg = errorMessage {
-            Text(msg)
-                .font(VFont.caption)
-                .foregroundColor(Danger._500)
+            // Error message
+            if isError, let msg = errorMessage {
+                Text(msg)
+                    .font(VFont.caption)
+                    .foregroundColor(Danger._500)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Wrap `detailInstallButton` contents in a `VStack(alignment: .trailing, spacing: VSpacing.xs)` so the error message renders below the button instead of inline in the title-row HStack
- Addresses review feedback from #6949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
