### PR TITLE
Simplify layout: uniform 16px padding with sidebar + content structure

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -484,13 +484,15 @@ struct MainWindowView: View {
                     .frame(height: 36)
                     .background(adaptiveColor(light: Moss._50, dark: Moss._950))
 
-                    // Content area: sidebar always pushes chat content right
-                    HStack(spacing: 0) {
+                    // Main container: sidebar + content with uniform padding
+                    HStack(spacing: 16) {
                         sidebarView
                             .animation(VAnimation.panel, value: sidebarExpanded)
 
                         chatContentView(geometry: geometry)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
                     }
+                    .padding(16)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer
@@ -522,7 +524,7 @@ struct MainWindowView: View {
                             }
                         )
                         .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
-                        .offset(x: sidebarOuterMargin + VSpacing.sm, y: -52)
+                        .offset(x: 16 + VSpacing.sm, y: -52)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -861,8 +863,7 @@ struct MainWindowView: View {
         .padding(VSpacing.xs)
         .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .padding(sidebarOuterMargin)
-        .frame(width: sidebarExpanded ? sidebarExpandedWidth + sidebarOuterMargin * 2 : sidebarCollapsedWidth + sidebarOuterMargin * 2)
+        .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -240,11 +240,6 @@ extension MainWindowView {
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -338,11 +333,6 @@ extension MainWindowView {
         switch panel {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
         case .agent:
             AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
@@ -361,11 +351,6 @@ extension MainWindowView {
                 windowState.dismissOverlay()
             }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -374,34 +359,14 @@ extension MainWindowView {
                 onClose: { windowState.dismissOverlay() }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.xl)
-                    .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-            )
-            .padding(16)
         case .doctor:
             DoctorPanel(onClose: { windowState.dismissOverlay() })
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .fill(adaptiveColor(light: Moss._50, dark: Moss._950))
-                )
-                .padding(16)
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
             // if we reach here, isDynamicExpanded is false — clear selection so

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -145,9 +145,9 @@ private struct VButtonStyle: ButtonStyle {
             if isHovered { return VColor.buttonPrimaryHover }
             return VColor.buttonPrimary
         case .secondary:
-            if isPressed { return adaptiveColor(light: Color(hex: 0xC0CEBC), dark: Forest._800) }
-            if isHovered { return adaptiveColor(light: Color(hex: 0xCAD7C6), dark: Forest._900) }
-            return adaptiveColor(light: Forest._200, dark: Forest._950)
+            if isPressed { return adaptiveColor(light: Color(hex: 0xC0CEBC), dark: Color(hex: 0x4A4A46)) }
+            if isHovered { return adaptiveColor(light: Color(hex: 0xCAD7C6), dark: Color(hex: 0x424240)) }
+            return adaptiveColor(light: Forest._200, dark: Color(hex: 0x3A3A37))
         case .danger:
             if isPressed { return Color(hex: 0xE0745A) }
             if isHovered { return Color(hex: 0xD4582F) }


### PR DESCRIPTION
## Summary
- Restructure main layout to use a single container with 16px padding around sidebar + content
- Remove per-panel background/padding from PanelCoordinator — the outer container handles it
- Right content area has rounded corners via clipShape, no explicit background or border
- Sidebar frame width simplified (no longer includes outer margin math)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
