### PR TITLE
fix: address review feedback on PR #6711

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1063,7 +1063,7 @@ describe('poll timeout handling by run state', () => {
   test('marks event as processed when run is in needs_confirmation state after poll timeout', async () => {
     // Use a short poll timeout so the test can exercise the timeout path
     // without waiting 5 minutes.
-    _setTestPollMaxWait(600);
+    _setTestPollMaxWait(100);
 
     const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
@@ -1085,23 +1085,92 @@ describe('poll timeout handling by run state', () => {
       updatedAt: Date.now(),
     };
 
-    // getRun returns needs_confirmation — run is waiting for approval decision.
-    // The event should be marked as processed because the post-decision delivery
-    // in handleApprovalInterception will deliver the reply when the user decides.
+    // getRun returns null on the first call (causing the poll loop to break
+    // immediately), then returns needs_confirmation on the post-loop call.
+    // This exercises the timeout path deterministically without spinning for
+    // the full poll duration.
+    let getRunCalls = 0;
     const orchestrator = {
       submitDecision: mock(() => 'applied' as const),
-      getRun: mock(() => ({ ...mockRun, status: 'needs_confirmation' as const })),
+      getRun: mock(() => {
+        getRunCalls++;
+        if (getRunCalls <= 1) return null;
+        return { ...mockRun, status: 'needs_confirmation' as const };
+      }),
       startRun: mock(async () => mockRun),
     } as unknown as RunOrchestrator;
 
     const req = makeInboundRequest({ content: 'hello needs_confirm' });
     await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
 
-    // Wait for the background async to complete (poll timeout is 600ms + one poll interval of 500ms)
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // Wait for the background async to complete
+    await new Promise((resolve) => setTimeout(resolve, 800));
 
     // markProcessed SHOULD have been called — the run is waiting for approval,
     // and the post-decision delivery path will handle the final reply.
+    expect(markSpy).toHaveBeenCalled();
+
+    // recordProcessingFailure should NOT have been called
+    expect(failureSpy).not.toHaveBeenCalled();
+
+    linkSpy.mockRestore();
+    markSpy.mockRestore();
+    failureSpy.mockRestore();
+    deliverSpy.mockRestore();
+    _setTestPollMaxWait(null);
+  });
+
+  test('marks event as processed when run transitions from needs_confirmation to running at poll timeout', async () => {
+    // When an approval is applied near the poll deadline, the run transitions
+    // from needs_confirmation to running. The post-decision delivery path
+    // in handleApprovalInterception handles the final reply, so the main poll
+    // should mark the event as processed rather than recording a failure.
+    _setTestPollMaxWait(100);
+
+    const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
+    const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
+    const failureSpy = spyOn(channelDeliveryStore, 'recordProcessingFailure').mockImplementation(() => {});
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const mockRun = {
+      id: 'run-post-approval',
+      conversationId: 'conv-1',
+      messageId: 'user-msg-203',
+      status: 'running' as const,
+      pendingConfirmation: null,
+      pendingSecret: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+      error: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // Simulate a run that transitions from needs_confirmation back to running
+    // (approval applied) before the poll exits, then stays running past timeout.
+    let getRunCalls = 0;
+    const orchestrator = {
+      submitDecision: mock(() => 'applied' as const),
+      getRun: mock(() => {
+        getRunCalls++;
+        // First call inside the loop: needs_confirmation (triggers approval prompt delivery)
+        if (getRunCalls <= 1) return { ...mockRun, status: 'needs_confirmation' as const };
+        // Subsequent calls: running (approval was applied, run resumed)
+        return { ...mockRun, status: 'running' as const };
+      }),
+      startRun: mock(async () => mockRun),
+    } as unknown as RunOrchestrator;
+
+    const req = makeInboundRequest({ content: 'hello post-approval running' });
+    await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+
+    // Wait for background async to complete (poll timeout + buffer)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // markProcessed SHOULD have been called — the run was in needs_confirmation
+    // and then transitioned to running (post-approval), so the post-decision
+    // delivery path handles the final reply.
     expect(markSpy).toHaveBeenCalled();
 
     // recordProcessingFailure should NOT have been called

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -743,6 +743,12 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
       const startTime = Date.now();
       const pollMaxWait = getEffectivePollMaxWait();
       let lastStatus = run.status;
+      // Track whether the run entered the approval-waiting state at any point
+      // during polling. When true, a post-decision delivery path has been (or
+      // will be) scheduled by handleApprovalInterception, so non-terminal
+      // states at timeout (e.g. running after approval) should not trigger
+      // the retry/dead-letter machinery.
+      let sawNeedsConfirmation = false;
 
       while (Date.now() - startTime < pollMaxWait) {
         await new Promise((resolve) => setTimeout(resolve, RUN_POLL_INTERVAL_MS));
@@ -751,6 +757,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         if (!current) break;
 
         if (current.status === 'needs_confirmation' && lastStatus !== 'needs_confirmation') {
+          sawNeedsConfirmation = true;
           const pending = getPendingConfirmationsByConversation(conversationId);
 
           if (isUnverifiedChannel && pending.length > 0) {
@@ -924,23 +931,35 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
             updateApprovalDecision(approvalReq.id, { status: outcomeStatus });
           }
         }
-      } else if (finalRun?.status === 'needs_confirmation') {
-        // The run is waiting for an approval decision but the poll window has
-        // elapsed. Mark the event as processed rather than failed — the run
-        // will resume when the user clicks approve/reject, and
-        // `handleApprovalInterception` will deliver the reply via its own
-        // post-decision poll. Marking it failed would cause the generic retry
-        // sweep to replay through `processMessage`, which throws "Session is
+      } else if (
+        finalRun?.status === 'needs_confirmation' ||
+        (sawNeedsConfirmation && finalRun?.status === 'running')
+      ) {
+        // The run is either still waiting for an approval decision or was
+        // recently approved and has resumed execution. In both cases, mark
+        // the event as processed rather than failed:
+        //
+        // - needs_confirmation: the run will resume when the user clicks
+        //   approve/reject, and `handleApprovalInterception` will deliver
+        //   the reply via `schedulePostDecisionDelivery`.
+        //
+        // - running (after needs_confirmation): an approval was applied near
+        //   the poll deadline and the run resumed but hasn't reached terminal
+        //   state yet. `handleApprovalInterception` has already scheduled
+        //   post-decision delivery, so the final reply will be delivered.
+        //
+        // Marking either state as failed would cause the generic retry sweep
+        // to replay through `processMessage`, which throws "Session is
         // already processing a message" and dead-letters a valid conversation.
         log.warn(
-          { runId: run.id, status: finalRun.status, conversationId },
-          'Approval-path poll loop timed out while run awaits approval decision; marking event as processed',
+          { runId: run.id, status: finalRun.status, conversationId, sawNeedsConfirmation },
+          'Approval-path poll loop timed out while run is in approval-related state; marking event as processed',
         );
         channelDeliveryStore.markProcessed(eventId);
       } else {
-        // The run is in a non-terminal, non-approval state (e.g. running,
-        // needs_secret, or disappeared). Record a processing failure so the
-        // retry/dead-letter machinery can handle it.
+        // The run is in a non-terminal, non-approval state (e.g. running
+        // without prior approval, needs_secret, or disappeared). Record a
+        // processing failure so the retry/dead-letter machinery can handle it.
         const timeoutErr = new Error(
           `Approval poll timeout: run did not reach terminal state within ${pollMaxWait}ms (status: ${finalRun?.status ?? 'null'})`,
         );


### PR DESCRIPTION
Addresses reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/6711

- Fix test for needs_confirmation timeout to be deterministic (Devin review on #6726): getRun now returns null first to break the poll loop immediately, then returns needs_confirmation on the post-loop call, avoiding the need to spin for the full poll duration.
- Handle post-approval running state at poll timeout (Codex review on #6726): when the run was in needs_confirmation during the poll and transitions to running (approval applied), mark the event as processed instead of recording a failure. The post-decision delivery path in handleApprovalInterception handles the final reply.
- Add new test covering the running-after-needs_confirmation timeout scenario.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
