### PR TITLE
Fix remaining SMS/Twilio parity gaps

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -2,3 +2,4 @@
 https://github.com/vellum-ai/vellum-assistant/pull/6939
 https://github.com/vellum-ai/vellum-assistant/pull/6956
 https://github.com/vellum-ai/vellum-assistant/pull/6958
+https://github.com/vellum-ai/vellum-assistant/pull/6970

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -958,6 +958,79 @@ describe('Twilio config handler', () => {
     expect(body).toContain('new-tunnel.ngrok.io');
   });
 
+  test('ingress config update reconciles all unique assigned Twilio numbers (legacy + assistant mapping)', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = {
+      sms: {
+        phoneNumber: '+15551234567',
+        assistantPhoneNumbers: {
+          'ast-alpha': '+15551234567', // duplicate of legacy; should only sync once
+          'ast-beta': '+15553333333',
+        },
+      },
+    };
+
+    const fetchCalls: Array<{ url: string; method: string; body?: string }> = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, method: init?.method ?? 'GET', body: init?.body?.toString() });
+
+      if (urlStr.includes('/internal/telegram/reconcile')) {
+        return new Response('{}', { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers.json?PhoneNumber=')) {
+        if (urlStr.includes('%2B15551234567')) {
+          return new Response(JSON.stringify({
+            incoming_phone_numbers: [{ sid: 'PN-legacy', phone_number: '+15551234567' }],
+          }), { status: 200 });
+        }
+        if (urlStr.includes('%2B15553333333')) {
+          return new Response(JSON.stringify({
+            incoming_phone_numbers: [{ sid: 'PN-beta', phone_number: '+15553333333' }],
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ incoming_phone_numbers: [] }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers/PN-legacy.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ sid: 'PN-legacy' }), { status: 200 });
+      }
+      if (urlStr.includes('IncomingPhoneNumbers/PN-beta.json') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ sid: 'PN-beta' }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const msg: IngressConfigRequest = {
+      type: 'ingress_config',
+      action: 'set',
+      publicBaseUrl: 'https://multi-number.ngrok.io',
+      enabled: true,
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleIngressConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { type: string; success: boolean; enabled: boolean };
+    expect(res.type).toBe('ingress_config_response');
+    expect(res.success).toBe(true);
+    expect(res.enabled).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const lookupCalls = fetchCalls.filter((c) => c.url.includes('IncomingPhoneNumbers.json?PhoneNumber='));
+    const lookedUpNumbers = lookupCalls
+      .map((c) => decodeURIComponent(c.url.split('PhoneNumber=')[1] ?? ''))
+      .sort();
+    expect(lookedUpNumbers).toEqual(['+15551234567', '+15553333333']);
+
+    const updateCalls = fetchCalls.filter((c) => c.method === 'POST' && c.url.includes('IncomingPhoneNumbers/PN-'));
+    const updatedSids = updateCalls.map((c) => (c.url.includes('PN-legacy') ? 'PN-legacy' : 'PN-beta')).sort();
+    expect(updatedSids).toEqual(['PN-beta', 'PN-legacy']);
+    expect(updateCalls[0]?.body ?? '').toContain('multi-number.ngrok.io');
+  });
+
   test('webhook sync failure on ingress update does not fail the ingress update', async () => {
     secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
     secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -628,20 +628,36 @@ export async function handleIngressConfig(
       triggerGatewayReconcile(effectiveUrl);
 
       // Best-effort Twilio webhook reconciliation: when ingress is being
-      // enabled/updated and a Twilio number is assigned with valid credentials,
+      // enabled/updated and Twilio numbers are assigned with valid credentials,
       // push the new webhook URLs to Twilio so calls and SMS route correctly.
       if (isEnabled && hasTwilioCredentials()) {
         const currentConfig = loadRawConfig();
         const smsConfig = (currentConfig?.sms ?? {}) as Record<string, unknown>;
-        const assignedNumber = (smsConfig.phoneNumber as string) ?? '';
-        if (assignedNumber) {
+        const assignedNumbers = new Set<string>();
+        const legacyNumber = (smsConfig.phoneNumber as string) ?? '';
+        if (legacyNumber) assignedNumbers.add(legacyNumber);
+
+        const assistantPhoneNumbers = smsConfig.assistantPhoneNumbers;
+        if (assistantPhoneNumbers && typeof assistantPhoneNumbers === 'object' && !Array.isArray(assistantPhoneNumbers)) {
+          for (const number of Object.values(assistantPhoneNumbers as Record<string, unknown>)) {
+            if (typeof number === 'string' && number) {
+              assignedNumbers.add(number);
+            }
+          }
+        }
+
+        if (assignedNumbers.size > 0) {
           const acctSid = getSecureKey('credential:twilio:account_sid')!;
           const acctToken = getSecureKey('credential:twilio:auth_token')!;
-          // Fire-and-forget: webhook sync failure must not block the ingress save
-          syncTwilioWebhooks(assignedNumber, acctSid, acctToken, currentConfig as IngressConfig)
-            .catch(() => {
-              // Already logged inside syncTwilioWebhooks
-            });
+          // Fire-and-forget: webhook sync failure must not block the ingress save.
+          // Reconcile every assigned number so assistant-scoped mappings do not
+          // retain stale Twilio webhook URLs after ingress URL changes.
+          for (const assignedNumber of assignedNumbers) {
+            syncTwilioWebhooks(assignedNumber, acctSid, acctToken, currentConfig as IngressConfig)
+              .catch(() => {
+                // Already logged inside syncTwilioWebhooks
+              });
+          }
         }
       }
     } else {

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -366,9 +366,10 @@ describe("twilio-sms-webhook", () => {
 
     // Confirmation SMS should have been sent
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
-    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    const [, to, text, replyAssistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(to).toBe("+15551234567");
     expect(text).toBe("Starting a new conversation!");
+    expect(replyAssistantId).toBe("ast-default");
 
     // handleInbound should NOT have been called
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
@@ -417,10 +418,11 @@ describe("twilio-sms-webhook", () => {
 
     // Rejection notice SMS should have been sent
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
-    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    const [, to, text, assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(to).toBe("+15551234567");
     expect(typeof text).toBe("string");
     expect((text as string).toLowerCase()).toContain("could not be routed");
+    expect(assistantId).toBeUndefined();
 
     // handleInbound should NOT have been called
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
@@ -447,10 +449,11 @@ describe("twilio-sms-webhook", () => {
 
     // Unsupported notice should have been sent
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
-    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    const [, to, text, assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(to).toBe("+15551234567");
     expect(typeof text).toBe("string");
     expect((text as string).toLowerCase()).toContain("not supported");
+    expect(assistantId).toBe("ast-default");
 
     // handleInbound should NOT have been called
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
@@ -475,10 +478,11 @@ describe("twilio-sms-webhook", () => {
 
     // Unsupported notice should have been sent
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
-    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    const [, to, text, assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(to).toBe("+15551234567");
     expect(typeof text).toBe("string");
     expect((text as string).toLowerCase()).toContain("not supported");
+    expect(assistantId).toBe("ast-default");
 
     // handleInbound should NOT have been called
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
@@ -533,6 +537,37 @@ describe("twilio-sms-webhook", () => {
     expect(resetConversationMock).toHaveBeenCalledTimes(1);
     const [, assistantId] = resetConversationMock.mock.calls[0] as unknown[];
     expect(assistantId).toBe("ast-beta");
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, , , replyAssistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(replyAssistantId).toBe("ast-beta");
+  });
+
+  it("MMS notices use phone-number routed assistant for sender resolution", async () => {
+    const phoneConfig: GatewayConfig = {
+      ...baseConfig,
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+      assistantPhoneNumbers: { "ast-beta": "+15559876543" },
+    };
+    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "MMS inbound",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-mms-phone-route",
+      NumMedia: "1",
+      MediaUrl0: "https://api.twilio.com/media/999",
+      MediaContentType0: "image/jpeg",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, , , assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(assistantId).toBe("ast-beta");
+    expect(handleInboundMock).toHaveBeenCalledTimes(0);
   });
 
   it("falls through to standard routing when To number is not in assistantPhoneNumbers", async () => {
@@ -627,10 +662,11 @@ describe("twilio-sms-webhook", () => {
 
     // Unsupported notice should have been sent
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
-    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    const [, to, text, assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(to).toBe("+15551234567");
     expect(typeof text).toBe("string");
     expect((text as string).toLowerCase()).toContain("not supported");
+    expect(assistantId).toBe("ast-default");
 
     // handleInbound should NOT have been called
     expect(handleInboundMock).toHaveBeenCalledTimes(0);

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -93,6 +93,12 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       "SMS webhook received",
     );
 
+    // Phone-number routing takes priority, then fall through to standard routing.
+    // We resolve once so gateway-originated replies (/new + MMS notices) can use
+    // the correct assistant-scoped Twilio sender number.
+    const routing = resolveAssistantByPhoneNumber(config, params.To || "")
+      ?? resolveAssistant(config, params.From || "", params.From || "");
+
     // --- MMS intercept: detect media attachments and reply with unsupported notice ---
     // Treat as MMS when NumMedia > 0, or when any MediaUrl/MediaContentType
     // fields are present (some Twilio configurations omit NumMedia).
@@ -104,11 +110,14 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
     );
     if (numMedia > 0 || hasMediaFields) {
       tlog.info({ messageSid, numMedia, hasMediaFields }, "MMS payload detected, replying with unsupported notice");
-      sendSmsReply(config, params.From, "MMS (images, video, and other media) is not supported yet. Please send a text-only message.").catch(
-        (err) => {
-          tlog.error({ err, to: params.From }, "Failed to send MMS unsupported notice");
-        },
-      );
+      sendSmsReply(
+        config,
+        params.From,
+        "MMS (images, video, and other media) is not supported yet. Please send a text-only message.",
+        isRejection(routing) ? undefined : routing.assistantId,
+      ).catch((err) => {
+        tlog.error({ err, to: params.From }, "Failed to send MMS unsupported notice");
+      });
       dedupCache.mark(messageSid);
       return Response.json({ ok: true });
     }
@@ -117,14 +126,6 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
 
     // --- /new intercept: reset conversation before it reaches the runtime ---
     if (normalized.message.content.trim().toLowerCase() === "/new") {
-      // Phone-number routing takes priority: match the "To" number to an assistant
-      const routing = resolveAssistantByPhoneNumber(config, params.To || "")
-        ?? resolveAssistant(
-          config,
-          normalized.message.externalChatId,
-          normalized.sender.externalUserId,
-        );
-
       if (isRejection(routing)) {
         tlog.warn(
           { from: params.From, reason: routing.reason },
@@ -145,28 +146,21 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
             normalized.sourceChannel,
             normalized.message.externalChatId,
           );
-          sendSmsReply(config, params.From, "Starting a new conversation!").catch((err) => {
+          sendSmsReply(config, params.From, "Starting a new conversation!", routing.assistantId).catch((err) => {
             tlog.error({ err }, "Failed to send /new confirmation");
           });
         } catch (err) {
           tlog.error({ err }, "Failed to reset conversation");
-          sendSmsReply(config, params.From, "Failed to reset conversation. Please try again.").catch((replyErr) => {
-            tlog.error({ err: replyErr }, "Failed to send /new error reply");
-          });
+          sendSmsReply(config, params.From, "Failed to reset conversation. Please try again.", routing.assistantId)
+            .catch((replyErr) => {
+              tlog.error({ err: replyErr }, "Failed to send /new error reply");
+            });
         }
       }
 
       dedupCache.mark(messageSid);
       return Response.json({ ok: true });
     }
-
-    // Phone-number routing takes priority, then fall through to standard routing
-    const routing = resolveAssistantByPhoneNumber(config, params.To || "")
-      ?? resolveAssistant(
-        config,
-        normalized.message.externalChatId,
-        normalized.sender.externalUserId,
-      );
 
     if (isRejection(routing)) {
       tlog.warn(

--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -5,22 +5,32 @@ const log = getLogger("twilio-send-sms");
 
 /**
  * Send an SMS message via the Twilio Messages API.
- * Requires `twilioAccountSid`, `twilioAuthToken`, and `twilioPhoneNumber`
- * to be configured. Silently returns if any are missing.
+ * Requires `twilioAccountSid` and `twilioAuthToken`, plus either an
+ * assistant-scoped phone number mapping or `twilioPhoneNumber`.
+ * Silently returns if any required values are missing.
  */
 export async function sendSmsReply(
   config: GatewayConfig,
   to: string,
   body: string,
+  assistantId?: string,
 ): Promise<void> {
-  if (!config.twilioAccountSid || !config.twilioAuthToken || !config.twilioPhoneNumber) {
+  if (!config.twilioAccountSid || !config.twilioAuthToken) {
     log.warn("Cannot send SMS reply: Twilio credentials not configured");
+    return;
+  }
+
+  const from = assistantId
+    ? (config.assistantPhoneNumbers?.[assistantId] ?? config.twilioPhoneNumber)
+    : config.twilioPhoneNumber;
+  if (!from) {
+    log.warn({ assistantId }, "Cannot send SMS reply: Twilio phone number not configured");
     return;
   }
 
   const url = `https://api.twilio.com/2010-04-01/Accounts/${config.twilioAccountSid}/Messages.json`;
   const params = new URLSearchParams({
-    From: config.twilioPhoneNumber,
+    From: from,
     To: to,
     Body: body,
   });


### PR DESCRIPTION
## Summary
- make gateway-originated SMS replies (`/new` and MMS notices) use assistant-scoped Twilio sender numbers when available
- reconcile Twilio webhooks for all unique assigned SMS numbers on ingress URL changes (legacy `sms.phoneNumber` plus `sms.assistantPhoneNumbers`)
- add regression tests for sender assistant-ID propagation and multi-number ingress reconciliation

## Validation
- `cd gateway && bun test src/http/routes/twilio-sms-webhook.test.ts src/http/routes/sms-deliver.test.ts`
- `cd assistant && bun test src/__tests__/handlers-twilio-config.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
