### PR TITLE
fix: acknowledge Telegram callback queries on forward failures

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -138,7 +138,7 @@ These fields are forwarded to the runtime in the `/channels/inbound` payload alo
 
 **Normalization constraints:** Only DM-only (`private` chat type) callback queries are processed. Group and channel callbacks are dropped and acknowledged with `answerCallbackQuery` so the Telegram button spinner clears. Callback queries with no `data` field or no associated `message` are also dropped.
 
-**Stale callback blocking:** When the runtime receives `callbackData` that does not match any pending approval (e.g., a button from an old prompt), it returns `stale_ignored` and does not process the payload as a regular message. This is enforced regardless of whether the callback has non-empty content. The gateway acknowledges all callback queries via `answerCallbackQuery` to clear the button spinner.
+**Stale callback blocking:** When the runtime receives `callbackData` that does not match any pending approval (e.g., a button from an old prompt), it returns `stale_ignored` and does not process the payload as a regular message. This is enforced regardless of whether the callback has non-empty content. The gateway sends a best-effort `answerCallbackQuery` acknowledgment for normalized callback updates (including stale, rejected, and forward-failure paths) so the button spinner clears promptly. Transient forwarding failures may still return `500` so Telegram retries update delivery.
 
 ## Approval Buttons and Inline Keyboard
 

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -155,6 +155,42 @@ describe("telegram-webhook callback query acknowledgment", () => {
     });
   });
 
+  it("acknowledges callback query when forwarding fails with forwarded=false", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: false, rejected: false }),
+    );
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve", 304);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(500);
+    const answerCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "answerCallbackQuery",
+    );
+    expect(answerCalls.length).toBe(1);
+    expect(answerCalls[0][2]).toEqual({
+      callback_query_id: "cbq-42",
+    });
+  });
+
+  it("acknowledges callback query when forwarding throws", async () => {
+    handleInboundMock.mockImplementation(() => Promise.reject(new Error("boom")));
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve", 305);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(500);
+    const answerCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "answerCallbackQuery",
+    );
+    expect(answerCalls.length).toBe(1);
+    expect(answerCalls[0][2]).toEqual({
+      callback_query_id: "cbq-42",
+    });
+  });
+
   it("acknowledges callback query when /new command is triggered via callback", async () => {
     const handler = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("/new", 302);

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -153,6 +153,15 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       });
     };
 
+    const acknowledgeCallbackQuery = (callbackQueryId: string | undefined, phase: string): void => {
+      if (!callbackQueryId) return;
+      callTelegramApi(config, "answerCallbackQuery", {
+        callback_query_id: callbackQueryId,
+      }).catch((err) => {
+        tlog.error({ err, callbackQueryId, phase }, "Failed to acknowledge callback query");
+      });
+    };
+
     // Normalize the update
     const normalized = normalizeTelegramUpdate(payload);
     if (!normalized) {
@@ -164,13 +173,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         "id" in (payload.callback_query as Record<string, unknown>)
           ? String((payload.callback_query as Record<string, unknown>).id)
           : undefined;
-      if (cbqId) {
-        callTelegramApi(config, "answerCallbackQuery", {
-          callback_query_id: cbqId,
-        }).catch((err) => {
-          tlog.error({ err, callbackQueryId: cbqId }, "Failed to acknowledge dropped callback query");
-        });
-      }
+      acknowledgeCallbackQuery(cbqId, "dropped_update");
       return respond({ ok: true });
     }
 
@@ -226,13 +229,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       }
 
       // Acknowledge callback query so the button spinner clears
-      if (normalized.message.callbackQueryId) {
-        callTelegramApi(config, "answerCallbackQuery", {
-          callback_query_id: normalized.message.callbackQueryId,
-        }).catch((err) => {
-          tlog.error({ err, callbackQueryId: normalized.message.callbackQueryId }, "Failed to acknowledge callback query");
-        });
-      }
+      acknowledgeCallbackQuery(normalized.message.callbackQueryId, "new_command");
 
       return respond({ ok: true });
     }
@@ -332,18 +329,13 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           });
         }
         // Acknowledge rejected callback queries so the button spinner clears
-        if (isCallback && normalized.message.callbackQueryId) {
-          callTelegramApi(config, "answerCallbackQuery", {
-            callback_query_id: normalized.message.callbackQueryId,
-          }).catch((err) => {
-            tlog.error({ err, callbackQueryId: normalized.message.callbackQueryId }, "Failed to acknowledge callback query");
-          });
-        }
+        if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "routing_rejected");
         return respond({ ok: true });
       }
 
       if (!result.forwarded) {
         tlog.error({ updateId: payload.update_id }, "Failed to forward inbound event");
+        if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forward_not_forwarded");
         if (updateId !== undefined) dedupCache.unreserve(updateId);
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
@@ -352,15 +344,10 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
 
       // Acknowledge the callback query to clear the button spinner in the
       // Telegram client. Best-effort — log errors but don't fail the flow.
-      if (isCallback && normalized.message.callbackQueryId) {
-        callTelegramApi(config, "answerCallbackQuery", {
-          callback_query_id: normalized.message.callbackQueryId,
-        }).catch((err) => {
-          tlog.error({ err, callbackQueryId: normalized.message.callbackQueryId }, "Failed to acknowledge callback query");
-        });
-      }
+      if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forwarded");
     } catch (err) {
       tlog.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forward_exception");
       if (updateId !== undefined) dedupCache.unreserve(updateId);
       return Response.json({ error: "Internal error" }, { status: 500 });
     }


### PR DESCRIPTION
## Summary
- add a shared best-effort callback acknowledgment helper in the Telegram webhook handler
- acknowledge callback queries in forward-failure paths (`forwarded=false` and thrown forwarding errors) while preserving `500` responses for retry behavior
- add regression tests for both failure paths and update callback handling docs in gateway README

## Validation
- `cd gateway && bunx tsc --noEmit`
- `cd gateway && bun test src/http/routes/telegram-webhook.test.ts`
- `cd gateway && bun test`