### PR TITLE
M1: macOS QR payload v2 — ingress publicBaseUrl + bearer token

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -2,18 +2,22 @@ import CryptoKit
 import SwiftUI
 import VellumAssistantShared
 
-/// Displays a QR code containing the connection payload for iOS pairing.
-/// Payload format: `{"type":"vellum-daemon","h":"<ip>","p":8765,"t":"<token>","f":"<fingerprint>","id":"<mac-hash>","v":1}`
+/// Displays a QR code containing the v2 connection payload for iOS pairing.
+/// Payload format: `{"type":"vellum-daemon","v":2,"id":"<mac-hash>","g":"<ingress-url>","bt":"<bearer-token>"}`
 @MainActor
 struct PairingQRCodeSheet: View {
     @Environment(\.dismiss) var dismiss
 
-    let sessionToken: String
-    let fingerprint: String
-    let tcpPort: Int
+    let ingressEnabled: Bool
+    let ingressPublicBaseUrl: String
 
-    @State private var localIP: String = "..."
     @State private var hostId: String = ""
+    @State private var bearerToken: String = ""
+
+    /// Whether the ingress configuration is sufficient for pairing.
+    private var canGenerateQR: Bool {
+        ingressEnabled && !ingressPublicBaseUrl.isEmpty && !bearerToken.isEmpty
+    }
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -25,7 +29,7 @@ struct PairingQRCodeSheet: View {
                 Button("Done") { dismiss() }
             }
 
-            if let qrImage = generateQRImage() {
+            if canGenerateQR, let qrImage = generateQRImage() {
                 Image(nsImage: qrImage)
                     .resizable()
                     .interpolation(.none)
@@ -35,10 +39,16 @@ struct PairingQRCodeSheet: View {
                     .background(Color.white)
                     .cornerRadius(VRadius.md)
             } else {
-                Text("Failed to generate QR code")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.error)
-                    .frame(width: 220, height: 220)
+                VStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(VColor.error)
+                    Text("Enable ingress and set a public URL in Settings to pair with iOS")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.error)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(width: 220, height: 220)
             }
 
             Text("Scan this QR code with the Vellum iOS app to connect.")
@@ -47,15 +57,14 @@ struct PairingQRCodeSheet: View {
                 .multilineTextAlignment(.center)
 
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                infoRow(label: "IP Address", value: localIP)
-                infoRow(label: "Port", value: "\(tcpPort)")
-                infoRow(label: "TLS", value: "Enabled")
+                infoRow(label: "Gateway URL", value: ingressPublicBaseUrl.isEmpty ? "Not configured" : ingressPublicBaseUrl)
+                infoRow(label: "Ingress", value: ingressEnabled ? "Enabled" : "Disabled")
             }
             .padding(VSpacing.md)
             .background(VColor.surfaceSubtle)
             .cornerRadius(VRadius.md)
 
-            Text("Pairing persists until you regenerate the session token.")
+            Text("Pairing persists until you regenerate the bearer token.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .multilineTextAlignment(.center)
@@ -63,8 +72,8 @@ struct PairingQRCodeSheet: View {
         .padding(VSpacing.xl)
         .frame(width: 340)
         .onAppear {
-            localIP = NetworkInterfaceResolver.getLocalIPv4() ?? "unknown"
             hostId = Self.computeHostId()
+            bearerToken = Self.readBearerToken()
         }
     }
 
@@ -73,25 +82,25 @@ struct PairingQRCodeSheet: View {
             Text(label)
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
-                .frame(width: 80, alignment: .leading)
+                .frame(width: 90, alignment: .leading)
             Text(value)
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
             Spacer()
         }
     }
 
     private func generateQRImage() -> NSImage? {
-        guard localIP != "..." && localIP != "unknown" else { return nil }
+        guard canGenerateQR else { return nil }
 
         let payload: [String: Any] = [
             "type": "vellum-daemon",
-            "h": localIP,
-            "p": tcpPort,
-            "t": sessionToken,
-            "f": fingerprint,
+            "v": 2,
             "id": hostId,
-            "v": 1,
+            "g": ingressPublicBaseUrl,
+            "bt": bearerToken,
         ]
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
@@ -100,6 +109,14 @@ struct PairingQRCodeSheet: View {
         }
 
         return QRCodeGenerator.generate(from: jsonString, size: 220)
+    }
+
+    /// Read the HTTP bearer token from ~/.vellum/http-token (same file the gateway uses).
+    private static func readBearerToken() -> String {
+        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum/http-token").path
+        return (try? String(contentsOfFile: tokenPath, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
     /// Compute a stable, privacy-safe host identifier.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import SwiftUI
 import VellumAssistantShared
@@ -15,7 +14,6 @@ struct SettingsAdvancedTab: View {
     @State private var sessionToken: String = ""
     @State private var tokenCopied: Bool = false
     @State private var tokenRevealed: Bool = false
-    @State private var fingerprint: String = ""
     @State private var iosPairingEnabled: Bool = false
     @State private var showingPairingQR: Bool = false
     @State private var showingPairingWarning: Bool = false
@@ -51,7 +49,6 @@ struct SettingsAdvancedTab: View {
         }
         .onAppear {
             refreshSessionToken()
-            refreshFingerprint()
             let flagPath = NSHomeDirectory() + "/.vellum/ios-pairing-enabled"
             iosPairingEnabled = FileManager.default.fileExists(atPath: flagPath)
             lockfileAssistants = LockfileAssistant.loadAll()
@@ -312,8 +309,6 @@ struct SettingsAdvancedTab: View {
                         VButton(label: "Show QR Code", style: .primary) {
                             showingPairingQR = true
                         }
-                        .disabled(sessionToken.isEmpty || fingerprint.isEmpty)
-
                         Spacer()
 
                         Button(tokenCopied ? "Copied!" : "Copy Token") {
@@ -347,8 +342,8 @@ struct SettingsAdvancedTab: View {
                         }
                     }
 
-                    if fingerprint.isEmpty {
-                        Text("TLS fingerprint not ready. Restart the daemon to generate certificates.")
+                    if !store.ingressEnabled || store.ingressPublicBaseUrl.isEmpty {
+                        Text("Enable ingress and set a public URL in Settings to pair with iOS.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
@@ -384,9 +379,8 @@ struct SettingsAdvancedTab: View {
         }
         .sheet(isPresented: $showingPairingQR) {
             PairingQRCodeSheet(
-                sessionToken: sessionToken,
-                fingerprint: fingerprint,
-                tcpPort: getTCPPort()
+                ingressEnabled: store.ingressEnabled,
+                ingressPublicBaseUrl: store.ingressPublicBaseUrl
             )
         }
     }
@@ -418,10 +412,6 @@ struct SettingsAdvancedTab: View {
         }
     }
 
-    private func refreshFingerprint() {
-        let fingerprintPath = NSHomeDirectory() + "/.vellum/tls/fingerprint"
-        fingerprint = (try? String(contentsOfFile: fingerprintPath, encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    }
 
     private func regenerateSessionToken() {
         let tokenPath = NSHomeDirectory() + "/.vellum/session-token"
@@ -442,12 +432,6 @@ struct SettingsAdvancedTab: View {
         }
     }
 
-    private func getTCPPort() -> Int {
-        // Read TCP port from daemon config or use default
-        let envPort = ProcessInfo.processInfo.environment["VELLUM_DAEMON_TCP_PORT"]
-        if let envPort, let port = Int(envPort) { return port }
-        return 8765
-    }
 
     // MARK: - Switch Assistant
 


### PR DESCRIPTION
## Summary
Part of #6961. Updates macOS QR pairing to generate v2 payload with ingress publicBaseUrl and HTTP bearer token. Drops v1 TCP fields (h, p, t, f). Blocks QR generation if ingress is disabled or publicBaseUrl is empty.

## Implementation
- **PairingQRCodeSheet.swift**: Changed from v1 payload (`h`, `p`, `t`, `f`, `id`, `v:1`) to v2 payload (`g`, `bt`, `id`, `v:2`). The gateway URL (`g`) comes from the ingress `publicBaseUrl` passed by the parent view. The bearer token (`bt`) is read directly from `~/.vellum/http-token` using FileManager. When ingress is not configured, an error message is shown instead of the QR code.
- **SettingsAdvancedTab.swift**: Updated the PairingQRCodeSheet callsite to pass `store.ingressEnabled` and `store.ingressPublicBaseUrl` instead of the old v1 fields (sessionToken, fingerprint, tcpPort). Removed orphaned `fingerprint` state, `refreshFingerprint()`, `getTCPPort()`, and the CryptoKit import. Added an inline hint when ingress is not configured.

## Key Technical Choices
- Bearer token is read from `~/.vellum/http-token` (the same file the gateway uses for `RUNTIME_PROXY_BEARER_TOKEN`), not the session token. This ensures the iOS client authenticates the same way as any other HTTP client going through the gateway.
- Old iOS clients scanning a v2 QR code will fail to parse the missing v1 fields, which prompts an app update -- this is the intended behavior per the task spec.
- The QR sheet itself handles the error state (ingress not configured) rather than disabling the button, so users can see the sheet and understand what needs to be configured.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift` — v2 payload, bearer token reader, ingress validation
- `clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift` — updated callsite, removed orphaned v1 code

## Testing
1. Enable ingress in Settings and set a public URL
2. Enable iOS pairing and click "Show QR Code"
3. Verify the QR code contains a v2 payload with `g` (gateway URL) and `bt` (bearer token)
4. Disable ingress or clear the public URL -- verify the error message appears instead of the QR code

## Deferred Work
- iOS client v2 payload parsing (separate milestone)
- Bearer token regeneration UI (currently only session token can be regenerated)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
