### PR TITLE
fix: exclude own PID from window capture resolution

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -146,22 +146,23 @@ final class ComputerUseSession: ObservableObject {
                 var windowID: CGWindowID?
                 var displayID: CGDirectDisplayID?
                 if captureScope == "window" {
-                    // Resolve the frontmost window's CGWindowID for window-scoped capture.
-                    if let frontApp = NSWorkspace.shared.frontmostApplication {
-                        let pid = frontApp.processIdentifier
-                        if let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] {
-                            for info in windowList {
-                                if let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
-                                   ownerPID == pid,
-                                   let wid = info[kCGWindowNumber as String] as? CGWindowID {
-                                    windowID = wid
-                                    break
-                                }
+                    // Resolve a target window's CGWindowID for window-scoped capture.
+                    // Exclude our own PID so we never accidentally record Vellum's
+                    // window or overlay (which may still be frontmost in direct-start flow).
+                    let myPID = ProcessInfo.processInfo.processIdentifier
+                    if let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] {
+                        for info in windowList {
+                            if let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
+                               ownerPID != myPID,
+                               let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
+                               let wid = info[kCGWindowNumber as String] as? CGWindowID {
+                                windowID = wid
+                                break
                             }
                         }
                     }
                     if windowID == nil {
-                        log.warning("QA mode: captureScope is 'window' but no frontmost window found — falling back to display capture")
+                        log.warning("QA mode: captureScope is 'window' but no suitable target window found — falling back to display capture")
                     }
                 } else {
                     displayID = CGMainDisplayID()


### PR DESCRIPTION
In direct-start flow, Vellum's window may still be frontmost when recording starts. The window capture resolution was picking the frontmost app's window, which could be Vellum itself. Now excludes our own PID and filters to layer-0 windows, picking the topmost non-self window. Falls back to display capture if no suitable window found.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
