### PR TITLE
M4: Ingress enforcement + runtime proxy + token persistence

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -429,11 +429,23 @@ export async function runDaemon(): Promise<void> {
   if (httpPortEnv) {
     const port = parseInt(httpPortEnv, 10);
     if (!isNaN(port) && port > 0) {
-      // Use an explicit env var if provided; otherwise generate a fresh
-      // random token. Either way, write it to disk so HTTP clients and
-      // the gateway can authenticate.
-      const bearerToken = process.env.RUNTIME_PROXY_BEARER_TOKEN || randomBytes(32).toString('hex');
+      // Resolve the bearer token in priority order:
+      //   1. Explicit env var (e.g. cloud deploys)
+      //   2. Existing token file on disk (preserves QR-paired iOS devices across restarts)
+      //   3. Fresh random token (first-time startup)
       const httpTokenPath = getHttpTokenPath();
+      let bearerToken = process.env.RUNTIME_PROXY_BEARER_TOKEN;
+      if (!bearerToken) {
+        try {
+          const existing = readFileSync(httpTokenPath, 'utf-8').trim();
+          if (existing) bearerToken = existing;
+        } catch {
+          // File doesn't exist or can't be read — will generate below
+        }
+      }
+      if (!bearerToken) {
+        bearerToken = randomBytes(32).toString('hex');
+      }
       writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
       chmodSync(httpTokenPath, 0o600);
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -302,12 +302,27 @@ export async function startGateway(): Promise<string> {
   const assistants = loadAllAssistants();
   const isSingleAssistant = assistants.length === 1;
 
+  // Read the bearer token from ~/.vellum/http-token so the gateway can
+  // authenticate proxied requests (e.g. from paired iOS devices).
+  const httpTokenPath = join(homedir(), ".vellum", "http-token");
+  let runtimeProxyBearerToken: string | undefined;
+  try {
+    const tok = readFileSync(httpTokenPath, "utf-8").trim();
+    if (tok) runtimeProxyBearerToken = tok;
+  } catch {
+    // Token file doesn't exist yet — daemon hasn't written it.
+  }
+
   const gatewayEnv: Record<string, string> = {
     ...process.env as Record<string, string>,
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
-    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
+    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
   };
+
+  if (runtimeProxyBearerToken) {
+    gatewayEnv.RUNTIME_PROXY_BEARER_TOKEN = runtimeProxyBearerToken;
+  }
 
   if (process.env.GATEWAY_UNMAPPED_POLICY) {
     gatewayEnv.GATEWAY_UNMAPPED_POLICY = process.env.GATEWAY_UNMAPPED_POLICY;

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -94,7 +94,7 @@ struct ContentView: View {
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("Could not reach your assistant. Check that your Mac is running and try again.")
+            Text("Unable to reach your Mac's gateway. This could mean your Mac is offline, the tunnel is down, or ingress is disabled.")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -56,8 +56,44 @@ struct DaemonConnectionSection: View {
 
     @State private var showManualSetup = false
 
+    /// The gateway URL from UserDefaults, if the user paired via QR code (HTTP transport).
+    private var gatewayURL: String? {
+        UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL).flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// Whether the current transport is HTTP (gateway-based).
+    private var isHTTPTransport: Bool {
+        gatewayURL != nil
+    }
+
     var body: some View {
         Form {
+            // Show gateway connection status when connected via HTTP transport
+            if isHTTPTransport, clientProvider.isConnected {
+                Section {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Connected via gateway")
+                            .font(VFont.body)
+                    }
+                    if let url = gatewayURL {
+                        HStack {
+                            Text("Gateway URL")
+                                .foregroundColor(VColor.textSecondary)
+                            Spacer()
+                            Text(url)
+                                .font(.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                } header: {
+                    Text("Connection")
+                }
+            }
+
             Section {
                 Button {
                     showingQRPairing = true


### PR DESCRIPTION
Part of #6961. Persists HTTP bearer token across daemon restarts. Ensures runtime proxy is enabled with auth for iOS gateway connections. Updates iOS error messaging for gateway-aware failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
