### PR TITLE
Fix remaining guardian verification and approval routing gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3683,7 +3683,7 @@ When a message arrives on a channel, the runtime resolves the sender's role. Rol
 
 - **Guardian**: `externalUserId` matches the binding's `guardianExternalUserId` for the `(assistantId, channel)` pair. Generic self-approval UX is controlled by `CHANNEL_APPROVALS_ENABLED`.
 - **Non-guardian**: A known sender who is not the guardian. Side-effect tools are forced through the confirmation flow (`forceStrictSideEffects`), and approval prompts are routed to the guardian's chat instead of the requester's chat.
-- **Unverified channel**: No guardian binding exists for the channel, or `senderExternalUserId` is absent while a binding exists. Sensitive actions are auto-denied immediately (fail-closed). This prevents unverified senders from self-approving actions or bypassing guardian enforcement by omitting identity data.
+- **Unverified channel**: No guardian binding exists for the channel, or `senderExternalUserId` is absent. Sensitive actions are auto-denied immediately (fail-closed). This prevents unverified senders from self-approving actions or bypassing guardian enforcement by omitting identity data.
 
 #### Sensitive Action Gating (Non-Guardian Approval)
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -181,7 +181,7 @@ Guardian actor-role *classification* (determining whether a sender is guardian, 
 | `CHANNEL_APPROVALS_ENABLED=true` | Enables generic self-approval UX: approval prompts, callback/text decisions, and reminder messages for guardian actors. |
 | `forceStrictSideEffects` | Automatically set on runs triggered by non-guardian or unverified-channel senders so all side-effect tools require approval. Applied regardless of `CHANNEL_APPROVALS_ENABLED` for guardian-enforced actors. |
 | **Fail-closed no-binding** | When no guardian binding exists for a channel, the sender is classified as `unverified_channel`. Any sensitive action is auto-denied with a notice that no guardian has been configured. Enforced regardless of `CHANNEL_APPROVALS_ENABLED`. |
-| **Fail-closed no-identity** | When `senderExternalUserId` is absent but a guardian binding exists for the channel, the actor is classified as `unverified_channel`. Enforced regardless of `CHANNEL_APPROVALS_ENABLED`. |
+| **Fail-closed no-identity** | When `senderExternalUserId` is absent, the actor is classified as `unverified_channel` (even if no guardian binding exists yet). Enforced regardless of `CHANNEL_APPROVALS_ENABLED`. |
 | **Guardian-only approval** | Non-guardian senders cannot approve their own pending actions. Only the verified guardian can approve or deny. |
 | **Expired approval auto-deny** | A proactive sweep runs every 60 seconds to find expired guardian approval requests (30-minute TTL). Expired approvals are auto-denied, and both the requester and guardian are notified. If a non-guardian interacts before the sweep runs, the expiry is also detected reactively. |
 

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -142,6 +142,7 @@ function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
   const body = {
     sourceChannel: 'telegram',
     externalChatId: 'chat-123',
+    senderExternalUserId: 'telegram-user-default',
     externalMessageId: `msg-${Date.now()}-${Math.random()}`,
     content: 'hello',
     replyCallbackUrl: 'https://gateway.test/deliver',
@@ -233,6 +234,12 @@ describe('feature flag disabled → normal flow', () => {
 describe('inbound callback metadata triggers decision handling', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('callback data "apr:<runId>:approve_once" is parsed and applied', async () => {
@@ -325,6 +332,12 @@ describe('inbound callback metadata triggers decision handling', () => {
 describe('inbound text matching approval phrases triggers decision handling', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('text "approve" triggers approve_once decision', async () => {
@@ -390,6 +403,12 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 describe('non-decision messages during pending approval trigger reminder', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('sends a reminder prompt when message is not a decision', async () => {
@@ -564,6 +583,12 @@ describe('empty content with callbackData bypasses validation', () => {
 describe('callback run ID validation', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('ignores stale callback when run ID does not match pending run', async () => {
@@ -868,6 +893,12 @@ describe('terminal state check before markProcessed', () => {
 describe('no immediate reply after approval decision', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('deliverChannelReply is NOT called from interception after decision is applied', async () => {
@@ -1409,12 +1440,19 @@ describe('sourceChannel passed to orchestrator.startRun', () => {
 describe('SMS channel approval decisions', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: 'sms-user-default',
+      guardianDeliveryChatId: 'sms-chat-123',
+    });
   });
 
   function makeSmsInboundRequest(overrides: Record<string, unknown> = {}): Request {
     const body = {
       sourceChannel: 'sms',
       externalChatId: 'sms-chat-123',
+      senderExternalUserId: 'sms-user-default',
       externalMessageId: `msg-${Date.now()}-${Math.random()}`,
       content: 'hello',
       replyCallbackUrl: 'https://gateway.test/deliver',
@@ -1716,6 +1754,18 @@ describe('SMS non-guardian actor gating', () => {
 describe('plain-text fallback surfacing for non-rich channels', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+    createBinding({
+      assistantId: 'self',
+      channel: 'http-api',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('reminder prompt includes plainTextFallback for non-rich channel (http-api)', async () => {
@@ -2074,6 +2124,53 @@ describe('guardian-with-binding path regression', () => {
 
     deliverSpy.mockRestore();
     approvalSpy.mockRestore();
+  });
+
+  test('guardian callback for own pending run is handled by standard interception', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-self-callback',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Establish the conversation mapping for chat-123.
+    const initReq = makeInboundRequest({
+      content: 'init',
+      senderExternalUserId: 'guardian-user-self-callback',
+      externalChatId: 'chat-123',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Button callback includes a runId but there is no guardian approval request
+    // because this is the guardian's own approval flow.
+    const req = makeInboundRequest({
+      content: '',
+      senderExternalUserId: 'guardian-user-self-callback',
+      externalChatId: 'chat-123',
+      callbackData: `apr:${run.id}:approve_once`,
+    });
+
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+    expect(getPendingApprovalForRun(run.id)).toBeNull();
+
+    deliverSpy.mockRestore();
   });
 });
 
@@ -2544,6 +2641,12 @@ describe('deliver-once idempotency guard', () => {
 describe('final reply idempotency — no duplicate delivery', () => {
   beforeEach(() => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
   });
 
   test('main poll wins: deliverChannelReply called exactly once when main poll delivers first', async () => {
@@ -3051,25 +3154,40 @@ describe('guardian enforcement independence from approval flag', () => {
     approvalSpy.mockRestore();
   });
 
-  test('missing senderExternalUserId without guardian binding uses default flow', async () => {
+  test('missing senderExternalUserId without guardian binding fails closed', async () => {
     delete process.env.CHANNEL_APPROVALS_ENABLED;
 
-    // No guardian binding exists — default behavior should be preserved
-    const orchestrator = makeMockOrchestrator();
+    // No guardian binding exists, but identity is missing — treat sender as
+    // unverified_channel and auto-deny sensitive actions.
+    const orchestrator = makeSensitiveOrchestrator({ runId: 'run-failclosed-noid-nobinding', terminalStatus: 'failed' });
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
 
     const req = makeInboundRequest({
-      content: 'hello world',
+      content: 'do something dangerous',
       senderExternalUserId: undefined,
     });
 
     const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     expect(res.status).toBe(200);
 
-    const body = await res.json() as Record<string, unknown>;
-    expect(body.accepted).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    expect(deliverSpy).toHaveBeenCalled();
+    const denialCalls = deliverSpy.mock.calls.filter(
+      (call) => {
+        if (typeof call[1] !== 'object') return false;
+        const text = (call[1] as { text?: string }).text ?? '';
+        return text.includes('requires guardian approval')
+          && text.includes('identity could not be determined')
+          && text.includes('denied');
+      },
+    );
+    expect(denialCalls.length).toBeGreaterThanOrEqual(1);
+    expect(approvalSpy).not.toHaveBeenCalled();
 
     deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
   });
 });
 

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -298,6 +298,53 @@ describe('handleChannelDecision', () => {
     expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
   });
 
+  test('uses decision.runId to target the matching pending run', () => {
+    ensureConversation('conv-1');
+    const olderRun = createRun('conv-1');
+    setRunConfirmation(olderRun.id, {
+      ...sampleConfirmation,
+      toolName: 'shell',
+      toolUseId: 'req-older',
+    });
+    const newerRun = createRun('conv-1');
+    setRunConfirmation(newerRun.id, {
+      ...sampleConfirmation,
+      toolName: 'browser',
+      toolUseId: 'req-newer',
+    });
+
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_once',
+      source: 'telegram_button',
+      runId: newerRun.id,
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(true);
+    expect(result.runId).toBe(newerRun.id);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(newerRun.id, 'allow');
+    expect(orchestrator.submitDecision).not.toHaveBeenCalledWith(olderRun.id, 'allow');
+  });
+
+  test('returns applied: false when decision.runId does not match a pending run', () => {
+    ensureConversation('conv-1');
+    const run = createRun('conv-1');
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    const orchestrator = makeMockOrchestrator();
+    const decision: ApprovalDecisionResult = {
+      action: 'approve_once',
+      source: 'telegram_button',
+      runId: 'run-missing',
+    };
+
+    const result = handleChannelDecision('conv-1', decision, orchestrator);
+    expect(result.applied).toBe(false);
+    expect(result.runId).toBeUndefined();
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+  });
+
   test('approve_always adds a trust rule and submits "allow"', () => {
     ensureConversation('conv-1');
     const run = createRun('conv-1');

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -105,7 +105,12 @@ export function handleChannelDecision(
   const pending = getPendingConfirmationsByConversation(conversationId);
   if (pending.length === 0) return { applied: false };
 
-  const info = pending[0];
+  // Callback-based decisions include a run ID and must resolve to that exact
+  // pending confirmation. Plain-text decisions still apply to the first prompt.
+  const info = decision.runId
+    ? pending.find((candidate) => candidate.runId === decision.runId)
+    : pending[0];
+  if (!info) return { applied: false };
 
   if (decision.action === 'approve_always') {
     // Only persist a trust rule when the confirmation explicitly allows persistence

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -449,18 +449,15 @@ export async function handleChannelInbound(
       }
     }
   } else {
-    // No sender identity available — fail-closed when guardian enforcement
-    // is active for this channel. If a binding exists, unknown actors must
-    // not be granted default guardian permissions.
-    const binding = getGuardianBinding(assistantId, sourceChannel);
-    if (binding) {
-      guardianCtx = {
-        actorRole: 'unverified_channel',
-        denialReason: 'no_identity',
-        requesterExternalUserId: undefined,
-        requesterChatId: externalChatId,
-      };
-    }
+    // No sender identity available — treat as unverified and fail closed.
+    // Multi-actor channels must not grant default guardian permissions when
+    // the inbound actor cannot be identified.
+    guardianCtx = {
+      actorRole: 'unverified_channel',
+      denialReason: 'no_identity',
+      requesterExternalUserId: undefined,
+      requesterChatId: externalChatId,
+    };
   }
 
   // ── Approval interception ──
@@ -1189,11 +1186,6 @@ async function handleApprovalInterception(
       }
 
       return { handled: true, type: 'reminder_sent' };
-    }
-
-    // Callback with a run ID that no longer has a pending approval — stale button
-    if (decision?.runId) {
-      return { handled: true, type: 'stale_ignored' };
     }
   }
 


### PR DESCRIPTION
## Summary
- fail closed for missing  by classifying as  even when no guardian binding exists
- allow guardian callback decisions with run IDs to fall through to standard interception when they are for the guardian's own pending run
- make  honor  so callback decisions target the exact pending run
- update guardian docs in README + ARCHITECTURE for no-identity fail-closed semantics
- add regression coverage for the above behaviors

## Validation
- 
- bun test v1.3.9 (cf6cdbbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
