### PR TITLE
fix: narrow QA intent detection + fix safety-net timer race

### DIFF
--- a/assistant/src/daemon/qa-intent.ts
+++ b/assistant/src/daemon/qa-intent.ts
@@ -5,16 +5,18 @@
 export function detectQaIntent(taskText: string): boolean {
   const lower = taskText.toLowerCase().trim();
 
-  // Direct QA/test commands
-  if (/^(qa|test|verify|check)\b/.test(lower)) return true;
+  // Direct QA/test commands — "check" excluded because it's too common
+  // in everyday tasks ("check my email", "check the weather").
+  if (/^(qa|test|verify)\b/.test(lower)) return true;
 
-  // Natural language QA patterns
+  // Natural language QA patterns — intentionally narrow to avoid false positives.
   const qaPatterns = [
-    /\b(run|do|perform|execute)\s+(a\s+)?(qa|test|check|verification)\b/,
-    /\b(test|qa|verify|check)\s+(this|the|that|my)\b/,
-    /\bhelp\s+me\s+(test|qa|verify|check)\b/,
-    /\b(can you|could you|please)\s+(test|qa|verify|check)\b/,
+    /\b(run|do|perform|execute)\s+(a\s+)?(qa|test|verification)\b/,
+    /\b(test|qa|verify)\s+(this|the|that|my)\b/,
+    /\bhelp\s+me\s+(test|qa|verify)\b/,
+    /\b(can you|could you|please)\s+(test|qa|verify)\b/,
     /\btesting\s+(the|this|that|my)\b/,
+    /\bcheck\s+for\s+(bugs|errors|issues|regressions)\b/,
   ];
 
   return qaPatterns.some(p => p.test(lower));

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -1099,6 +1099,7 @@ final class ComputerUseSession: ObservableObject {
             // run() never reaches the post-loop block (e.g., throws or gets stuck).
             cancelSafetyNetTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                guard !Task.isCancelled else { return } // disarmed by run() post-loop
                 guard self.isCancelled else { return } // in case state changed
                 try? self.daemonClient.send(CuSessionAbortMessage(sessionId: self.id))
             }


### PR DESCRIPTION
Two fixes from PR review feedback:

1. **QA intent false positives**: Removed 'check' from direct prefix regex and natural language patterns. 'check my email', 'check the weather' no longer trigger QA mode. Added 'check for bugs/errors/issues/regressions' as a narrow QA-specific pattern.

2. **Safety-net timer race**: The cancel safety-net task used try? to swallow CancellationError from Task.sleep, then checked self.isCancelled (always true after cancel()). When run() cancelled the task and yielded at await finalizeQARecording(), the safety-net could resume and send abort before finalization. Added guard !Task.isCancelled to properly respect task cancellation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
