### PR TITLE
M3: iOS transport — HTTP+SSE only, remove TCP

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -19,11 +19,12 @@ struct ContentView: View {
     }
 
     /// Whether the user has previously saved daemon connection settings.
+    /// iOS uses HTTP+SSE only — checks for gateway URL or runtime URL.
     private var hasSavedSettings: Bool {
-        if let url = UserDefaults.standard.string(forKey: "runtime_url"), !url.isEmpty {
+        if let url = UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL), !url.isEmpty {
             return true
         }
-        if let hostname = UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname), !hostname.isEmpty {
+        if let url = UserDefaults.standard.string(forKey: "runtime_url"), !url.isEmpty {
             return true
         }
         return false

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -47,14 +47,14 @@ struct APIKeySection: View {
 
 struct DaemonConnectionSection: View {
     @EnvironmentObject var clientProvider: ClientProvider
-    @State private var daemonHostname: String = ""
-    @State private var daemonPort: String = ""
-    @State private var sessionToken: String = ""
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var showingQRPairing = false
 
-    @State private var showManualSetup = false
+    /// The currently configured gateway URL, shown as read-only status.
+    private var gatewayURL: String? {
+        UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL).flatMap { $0.isEmpty ? nil : $0 }
+    }
 
     var body: some View {
         Form {
@@ -78,60 +78,21 @@ struct DaemonConnectionSection: View {
                 Text("Open Vellum on your Mac, then go to Settings > Show QR Code.")
             }
 
-            Section {
-                DisclosureGroup("Manual Setup", isExpanded: $showManualSetup) {
+            if let url = gatewayURL {
+                Section("Connection") {
                     HStack {
-                        Text("Hostname")
+                        Text("Gateway")
                         Spacer()
-                        TextField("e.g. 192.168.1.100", text: $daemonHostname)
-                            .multilineTextAlignment(.trailing)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
+                        Text(url)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
                     }
-                    HStack {
-                        Text("Port")
-                        Spacer()
-                        TextField("8765", text: $daemonPort)
-                            .multilineTextAlignment(.trailing)
-                            .keyboardType(.numberPad)
-                    }
-                    HStack {
-                        Text("Session Token")
-                        Spacer()
-                        SecureField("From ~/.vellum/session-token", text: $sessionToken)
-                            .multilineTextAlignment(.trailing)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                    }
-                    Button("Update") {
-                        guard let port = Int(daemonPort), port > 0, port <= 65535 else {
-                            alertMessage = "Port must be a valid number between 1 and 65535"
-                            showingAlert = true
-                            return
-                        }
-                        UserDefaults.standard.set(daemonHostname, forKey: UserDefaultsKeys.daemonHostname)
-                        UserDefaults.standard.set(port, forKey: UserDefaultsKeys.daemonPort)
-                        // iOS always uses TLS for TCP connections
-                        UserDefaults.standard.set(true, forKey: UserDefaultsKeys.daemonTLSEnabled)
-                        if sessionToken.isEmpty {
-                            _ = APIKeyManager.shared.deleteAPIKey(provider: "daemon-token")
-                            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.legacyDaemonToken)
-                        } else {
-                            _ = APIKeyManager.shared.setAPIKey(sessionToken, provider: "daemon-token")
-                        }
-                        // Rebuild the client so the new transport config takes effect,
-                        // then reconnect. DaemonClient transport is fixed at init, so
-                        // just calling connect() wouldn't pick up hostname/port changes.
-                        clientProvider.rebuildClient()
-                        Task {
-                            try? await clientProvider.client.connect()
-                        }
-                        alertMessage = "Daemon connection settings updated"
-                        showingAlert = true
-                    }
-                    .disabled(daemonHostname.isEmpty || daemonPort.isEmpty)
                 }
             }
+
+            // Manual TCP setup removed — iOS uses HTTP+SSE exclusively via the gateway.
+            // Gateway URL configuration will be added in M5.
         }
         .navigationTitle("Connect")
         .navigationBarTitleDisplayMode(.inline)
@@ -140,22 +101,9 @@ struct DaemonConnectionSection: View {
         } message: {
             Text(alertMessage)
         }
-        .sheet(isPresented: $showingQRPairing, onDismiss: {
-            // Re-read settings after QR pairing in case they changed
-            reloadSettings()
-        }) {
+        .sheet(isPresented: $showingQRPairing) {
             QRPairingSheet()
         }
-        .onAppear {
-            reloadSettings()
-        }
-    }
-
-    private func reloadSettings() {
-        daemonHostname = UserDefaults.standard.string(forKey: UserDefaultsKeys.daemonHostname) ?? ""
-        let portValue = UserDefaults.standard.integer(forKey: UserDefaultsKeys.daemonPort)
-        daemonPort = portValue > 0 ? String(portValue) : "8765"
-        sessionToken = APIKeyManager.shared.getAPIKey(provider: "daemon-token") ?? ""
     }
 }
 #endif

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -41,9 +41,9 @@ public struct DaemonConfig {
         /// Local Unix domain socket (macOS only).
         #if os(macOS)
         case socket(path: String)
-        #endif
-        /// TCP connection to a daemon (typically iOS → Mac).
+        /// TCP connection to a daemon (macOS only — iOS uses HTTP+SSE exclusively).
         case tcp(hostname: String, port: UInt16, tlsEnabled: Bool, authToken: String?)
+        #endif
         /// HTTP + SSE via a remote gateway URL (for cloud/custom assistants).
         case http(baseURL: String, bearerToken: String?, conversationKey: String)
     }
@@ -77,43 +77,16 @@ public struct DaemonConfig {
     }
 
     #if os(iOS)
-    // MARK: - iOS convenience accessors (backwards compatible)
+    // MARK: - iOS defaults (HTTP+SSE only — no TCP)
 
-    /// Hostname for TCP transport. Returns "localhost" for non-TCP transports.
-    public var hostname: String {
-        if case .tcp(let h, _, _, _) = transport { return h }
-        return "localhost"
-    }
-
-    /// Port for TCP transport. Returns 8765 for non-TCP transports.
-    public var port: UInt16 {
-        if case .tcp(_, let p, _, _) = transport { return p }
-        return 8765
-    }
-
-    /// TLS setting for TCP transport.
-    public var tlsEnabled: Bool {
-        if case .tcp(_, _, let tls, _) = transport { return tls }
-        return false
-    }
-
-    /// Auth token for TCP transport.
-    public var authToken: String? {
-        if case .tcp(_, _, _, let token) = transport { return token }
-        return nil
-    }
-
-    /// Backwards-compatible initializer for TCP transport.
-    public init(hostname: String, port: UInt16, tlsEnabled: Bool = false, authToken: String? = nil) {
-        self.transport = .tcp(hostname: hostname, port: port, tlsEnabled: tlsEnabled, authToken: authToken)
-    }
-
+    /// iOS uses HTTP+SSE exclusively. Default returns an HTTP config if a gateway/runtime
+    /// URL is configured, otherwise a non-connecting placeholder.
     public static var `default`: DaemonConfig {
-        return DaemonConfig(hostname: "localhost", port: 8765)
+        return fromUserDefaults()
     }
 
-    /// Create a `DaemonConfig` populated from UserDefaults / Keychain, falling back to safe defaults.
-    /// Checks for gateway URL (QR pairing v2) or runtime URL, then falls back to TCP.
+    /// Create a `DaemonConfig` populated from UserDefaults / Keychain.
+    /// iOS only supports HTTP+SSE transport via the gateway — no TCP fallback.
     public static func fromUserDefaults() -> DaemonConfig {
         // Check for a stored gateway or runtime URL — if present, use HTTP transport.
         // gateway_base_url is set by QR pairing v2; runtime_url is the legacy/cloud key.
@@ -131,32 +104,9 @@ public struct DaemonConfig {
             return DaemonConfig(transport: .http(baseURL: baseURL, bearerToken: bearerToken, conversationKey: conversationKey))
         }
 
-        // Fall back to TCP transport (connect to Mac daemon)
-        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
-        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
-        let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
-        let tlsEnabled = UserDefaults.standard.bool(forKey: "daemon_tls_enabled")
-        // Check host-specific Keychain key first (QR pairing), fall back to bare key (single-Mac compat)
-        let hostSpecificProvider = "daemon-token:\(hostname):\(finalPort)"
-        let authToken = APIKeyManager.shared.getAPIKey(provider: hostSpecificProvider)
-            ?? APIKeyManager.shared.getAPIKey(provider: "daemon-token")
-            ?? migrateAuthToken()
-        return DaemonConfig(hostname: hostname, port: finalPort, tlsEnabled: tlsEnabled, authToken: authToken)
-    }
-
-    /// One-time migration: reads the legacy `daemon_auth_token` UserDefaults key, persists it
-    /// to Keychain, removes the old key, and returns the value. Returns nil if no legacy token exists.
-    static func migrateAuthToken() -> String? {
-        // Constructed at runtime to avoid pre-commit hook false positive
-        let legacyKey = ["daemon", "auth", "token"].joined(separator: "_")
-        guard let legacy = UserDefaults.standard.string(forKey: legacyKey), !legacy.isEmpty else {
-            return nil
-        }
-        guard APIKeyManager.shared.setAPIKey(legacy, provider: "daemon-token") else {
-            return legacy
-        }
-        UserDefaults.standard.removeObject(forKey: legacyKey)
-        return legacy
+        // No gateway URL configured — return a placeholder HTTP config that won't connect.
+        // The user needs to pair via QR code (which sets gateway_base_url) before connecting.
+        return DaemonConfig(transport: .http(baseURL: "", bearerToken: nil, conversationKey: ""))
     }
     #endif
 }

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Network
 import os
-#if os(iOS)
-import CryptoKit
-#endif
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DaemonClient")
 
@@ -19,8 +16,9 @@ extension DaemonClient {
 
     /// Connect to the daemon. If already connected, disconnects first.
     /// - macOS (socket): Connects to Unix domain socket at `~/.vellum/vellum.sock`
+    /// - macOS (tcp): Connects to TCP endpoint
     /// - HTTP: Connects to remote assistant via HTTP REST + SSE (both platforms)
-    /// - iOS (tcp): Connects to TCP endpoint (hostname from UserDefaults or localhost:8765)
+    /// - iOS: Uses HTTP+SSE exclusively (no TCP)
     public func connect() async throws {
         // Disconnect any existing connection without triggering reconnect.
         disconnectInternal(triggerReconnect: false)
@@ -37,10 +35,10 @@ extension DaemonClient {
             return
         }
 
+        #if os(macOS)
         let endpoint: NWEndpoint
         let parameters: NWParameters
 
-        #if os(macOS)
         if case .socket(let path) = config.transport {
             log.info("Connecting to daemon socket at \(path, privacy: .public)")
             endpoint = NWEndpoint.unix(path: path)
@@ -54,42 +52,6 @@ extension DaemonClient {
             isConnecting = false
             return
         }
-        #elseif os(iOS)
-        // HTTP transport is already handled above; only TCP should reach here on iOS.
-        guard case .tcp(let configHostname, let configPort, _, _) = config.transport else {
-            log.error("Unexpected transport type on iOS — HTTP should have been handled above")
-            isConnecting = false
-            return
-        }
-
-        // Check UserDefaults first to pick up runtime changes, fall back to config
-        // This allows reconnects to pick up changed settings while preserving custom configs for tests
-        let hostname: String
-        let port: UInt16
-
-        if let userHostname = UserDefaults.standard.string(forKey: "daemon_hostname"), !userHostname.isEmpty {
-            hostname = userHostname
-        } else {
-            hostname = configHostname
-        }
-
-        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
-        if rawPort > 0 && rawPort <= 65535 {
-            port = UInt16(rawPort)
-        } else {
-            port = configPort
-        }
-
-        // iOS always enforces TLS for TCP connections with certificate pinning
-        log.info("Connecting to daemon at \(hostname):\(port) (tls=true)")
-        endpoint = NWEndpoint.hostPort(
-            host: NWEndpoint.Host(hostname),
-            port: NWEndpoint.Port(integerLiteral: port)
-        )
-        parameters = Self.makePinnedTLSParameters(hostname: hostname, port: port)
-        #else
-        #error("DaemonClient is only supported on macOS and iOS")
-        #endif
 
         let conn = NWConnection(to: endpoint, using: parameters)
         self.connection = conn
@@ -127,22 +89,14 @@ extension DaemonClient {
                             self.startReceiveLoop()
                             Task { @MainActor in
                                 do {
-                                    #if os(macOS)
                                     try await self.authenticate()
-                                    #elseif os(iOS)
-                                    try await self.authenticateIfNeeded()
-                                    #else
-                                    self.isAuthenticated = true
-                                    #endif
                                     self.isConnected = true
                                     self.isConnecting = false
                                     self.startNetworkMonitor()
                                     NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
                                     self.reconnectDelay = 1.0
                                     self.startPingTimer()
-                                    #if os(macOS)
                                     self.runBlobProbe()
-                                    #endif
                                     checkedContinuation.resume()
                                 } catch {
                                     log.error("Daemon authentication failed: \(error.localizedDescription)")
@@ -196,6 +150,11 @@ extension DaemonClient {
 
             conn.start(queue: self.queue)
         }
+        #else
+        // iOS: only HTTP transport reaches connect(). If we get here, something is wrong.
+        log.error("Non-HTTP transport is not supported on iOS")
+        isConnecting = false
+        #endif
     }
 
     // MARK: - Authentication
@@ -241,103 +200,10 @@ extension DaemonClient {
     }
     #endif
 
-    #if os(iOS)
-    /// Perform token-based authentication if `config.authToken` is set.
-    /// Sends an `AuthMessage` and waits for an `auth_result` response before
-    /// allowing the connection to be marked as ready.
-    /// If no token is configured, marks the connection as authenticated immediately.
-    func authenticateIfNeeded() async throws {
-        // Re-read hostname/port from UserDefaults to match connect()'s resolution logic,
-        // so the token lookup key matches the actual connection target.
-        let resolvedHostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? config.hostname
-        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
-        let resolvedPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : config.port
-        // Check host-specific key first (QR pairing), fall back to bare key (single-Mac compat),
-        // then legacy UserDefaults migration — same precedence as DaemonConfig.fromUserDefaults().
-        let hostSpecificProvider = "daemon-token:\(resolvedHostname):\(resolvedPort)"
-        let tokenFromKeychain = APIKeyManager.shared.getAPIKey(provider: hostSpecificProvider)
-            ?? APIKeyManager.shared.getAPIKey(provider: "daemon-token")
-            ?? DaemonConfig.migrateAuthToken()
-        guard let token = tokenFromKeychain ?? config.authToken else {
-            // No token configured — treat as unauthenticated (plain TCP, no handshake).
-            isAuthenticated = true
-            return
-        }
-
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            authContinuation?.resume(throwing: AuthError.rejected("Authentication superseded"))
-            authContinuation = continuation
-
-            authTimeoutTask?.cancel()
-            authTimeoutTask = Task { @MainActor [weak self] in
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(Self.authTimeout * 1_000_000_000))
-                } catch {
-                    return
-                }
-                guard let self, let pending = self.authContinuation else { return }
-                self.authContinuation = nil
-                self.authTimeoutTask = nil
-                self.isAuthenticated = false
-                pending.resume(throwing: AuthError.timeout)
-            }
-
-            do {
-                try self.send(AuthMessage(token: token))
-            } catch {
-                authContinuation = nil
-                authTimeoutTask?.cancel()
-                authTimeoutTask = nil
-                continuation.resume(throwing: error)
-            }
-        }
-    }
-    #endif
-
-    // MARK: - TLS Certificate Pinning (iOS)
-
-    #if os(iOS)
-    /// Create NWParameters with TLS and optional certificate pinning.
-    /// If a fingerprint is stored for this host:port, the TLS verify block
-    /// compares the server's leaf certificate SHA-256 against the stored value.
-    /// If no fingerprint is stored, accepts any valid TLS connection (TOFU model).
-    static func makePinnedTLSParameters(hostname: String, port: UInt16) -> NWParameters {
-        let fpKey = "daemon_fingerprint:\(hostname):\(port)"
-        let storedFingerprint = UserDefaults.standard.string(forKey: fpKey)
-
-        let tlsOptions = NWProtocolTLS.Options()
-
-        sec_protocol_options_set_verify_block(
-            tlsOptions.securityProtocolOptions,
-            { metadata, trust, completionHandler in
-                // If no fingerprint stored, accept any cert (first connection / TOFU)
-                guard let expected = storedFingerprint, !expected.isEmpty else {
-                    completionHandler(true)
-                    return
-                }
-
-                // Extract the leaf certificate
-                let secTrust = sec_trust_copy_ref(trust).takeRetainedValue()
-                guard SecTrustGetCertificateCount(secTrust) > 0,
-                      let leafCert = SecTrustCopyCertificateChain(secTrust) as? [SecCertificate],
-                      let cert = leafCert.first else {
-                    completionHandler(false)
-                    return
-                }
-
-                // Compute SHA-256 fingerprint of the DER-encoded certificate
-                let certData = SecCertificateCopyData(cert) as Data
-                let hash = SHA256.hash(data: certData)
-                let fingerprint = hash.compactMap { String(format: "%02x", $0) }.joined()
-
-                completionHandler(fingerprint == expected)
-            },
-            .main
-        )
-
-        return NWParameters(tls: tlsOptions)
-    }
-    #endif
+    // NOTE: iOS TCP authentication (authenticateIfNeeded) and TLS certificate pinning
+    // (makePinnedTLSParameters) have been removed. iOS now uses HTTP+SSE exclusively
+    // via the gateway. Bearer token auth is handled by HTTPTransport at the HTTP level.
+    // System TLS handles HTTPS certificate validation — no custom pinning needed.
 
     // MARK: - HTTP Transport
 


### PR DESCRIPTION
Part of #6961. Removes TCP transport fallback for iOS. iOS now exclusively uses HTTP+SSE via the gateway. TCP/TLS code gated behind os(macOS). Manual setup fields hidden pending M5 update.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
