### PR TITLE
fix: gate running-timeout bypass on actual post-decision delivery

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1156,27 +1156,33 @@ describe('poll timeout handling by run state', () => {
     // from needs_confirmation to running. The post-decision delivery path
     // in handleApprovalInterception handles the final reply, so the main poll
     // should mark the event as processed rather than recording a failure.
+    //
+    // The hasPostDecisionDelivery flag is only set when the approval prompt
+    // is actually delivered successfully — not in auto-deny paths. This test
+    // sets up a guardian actor with a real DB run so the standard approval
+    // prompt is delivered and the flag is set.
     _setTestPollMaxWait(100);
 
     const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
     const failureSpy = spyOn(channelDeliveryStore, 'recordProcessingFailure').mockImplementation(() => {});
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
 
-    const mockRun = {
-      id: 'run-post-approval',
-      conversationId: 'conv-1',
-      messageId: 'user-msg-203',
-      status: 'running' as const,
-      pendingConfirmation: null,
-      pendingSecret: null,
-      inputTokens: 0,
-      outputTokens: 0,
-      estimatedCost: 0,
-      error: null,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    };
+    // Set up a guardian binding so the sender is a guardian (standard approval
+    // path, not auto-deny). This ensures the approval prompt is delivered and
+    // hasPostDecisionDelivery is set to true.
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    const conversationId = `conv-post-approval-${Date.now()}`;
+    ensureConversation(conversationId);
+
+    let realRunId: string | undefined;
 
     // Simulate a run that transitions from needs_confirmation back to running
     // (approval applied) before the poll exits, then stays running past timeout.
@@ -1186,11 +1192,55 @@ describe('poll timeout handling by run state', () => {
       getRun: mock(() => {
         getRunCalls++;
         // First call inside the loop: needs_confirmation (triggers approval prompt delivery)
-        if (getRunCalls <= 1) return { ...mockRun, status: 'needs_confirmation' as const };
+        if (getRunCalls <= 1) return {
+          id: realRunId ?? 'run-post-approval',
+          conversationId,
+          messageId: 'user-msg-203',
+          status: 'needs_confirmation' as const,
+          pendingConfirmation: sampleConfirmation,
+          pendingSecret: null,
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
         // Subsequent calls: running (approval was applied, run resumed)
-        return { ...mockRun, status: 'running' as const };
+        return {
+          id: realRunId ?? 'run-post-approval',
+          conversationId,
+          messageId: 'user-msg-203',
+          status: 'running' as const,
+          pendingConfirmation: null,
+          pendingSecret: null,
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
       }),
-      startRun: mock(async () => mockRun),
+      startRun: mock(async (_convId: string) => {
+        const run = createRun(conversationId);
+        realRunId = run.id;
+        setRunConfirmation(run.id, sampleConfirmation);
+        return {
+          id: run.id,
+          conversationId,
+          messageId: null,
+          status: 'running' as const,
+          pendingConfirmation: null,
+          pendingSecret: null,
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCost: 0,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+      }),
     } as unknown as RunOrchestrator;
 
     const req = makeInboundRequest({ content: 'hello post-approval running' });
@@ -1199,9 +1249,12 @@ describe('poll timeout handling by run state', () => {
     // Wait for background async to complete (poll timeout + buffer)
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // markProcessed SHOULD have been called — the run was in needs_confirmation
-    // and then transitioned to running (post-approval), so the post-decision
-    // delivery path handles the final reply.
+    // The approval prompt should have been delivered (standard path for guardian actor)
+    expect(approvalSpy).toHaveBeenCalled();
+
+    // markProcessed SHOULD have been called — the approval prompt was delivered
+    // (hasPostDecisionDelivery is true) and the run transitioned to running
+    // (post-approval), so the post-decision delivery path handles the final reply.
     expect(markSpy).toHaveBeenCalled();
 
     // recordProcessingFailure should NOT have been called
@@ -1211,6 +1264,7 @@ describe('poll timeout handling by run state', () => {
     markSpy.mockRestore();
     failureSpy.mockRestore();
     deliverSpy.mockRestore();
+    approvalSpy.mockRestore();
     _setTestPollMaxWait(null);
   });
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -740,12 +740,14 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
       const startTime = Date.now();
       const pollMaxWait = getEffectivePollMaxWait();
       let lastStatus = run.status;
-      // Track whether the run entered the approval-waiting state at any point
-      // during polling. When true, a post-decision delivery path has been (or
-      // will be) scheduled by handleApprovalInterception, so non-terminal
-      // states at timeout (e.g. running after approval) should not trigger
-      // the retry/dead-letter machinery.
-      let sawNeedsConfirmation = false;
+      // Track whether a post-decision delivery path is guaranteed for this
+      // run. Set to true only when the approval prompt is successfully
+      // delivered (guardian or standard path), meaning
+      // handleApprovalInterception will schedule schedulePostDecisionDelivery
+      // when a decision arrives. Auto-deny paths (unverified channel, prompt
+      // delivery failures) do NOT set this flag because no post-decision
+      // delivery is scheduled in those cases.
+      let hasPostDecisionDelivery = false;
 
       while (Date.now() - startTime < pollMaxWait) {
         await new Promise((resolve) => setTimeout(resolve, RUN_POLL_INTERVAL_MS));
@@ -754,7 +756,6 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         if (!current) break;
 
         if (current.status === 'needs_confirmation' && lastStatus !== 'needs_confirmation') {
-          sawNeedsConfirmation = true;
           const pending = getPendingConfirmationsByConversation(conversationId);
 
           if (isUnverifiedChannel && pending.length > 0) {
@@ -812,6 +813,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                 bearerToken,
               );
               guardianNotified = true;
+              hasPostDecisionDelivery = true;
             } catch (err) {
               log.error({ err, runId: run.id }, 'Failed to deliver guardian approval prompt');
               // Deny the approval and the underlying run — fail-closed. If
@@ -863,6 +865,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
                   assistantId,
                   bearerToken,
                 );
+                hasPostDecisionDelivery = true;
               } catch (err) {
                 // Fail-closed: if we cannot deliver the approval prompt, the
                 // user will never see it and the run would hang indefinitely
@@ -930,7 +933,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         }
       } else if (
         finalRun?.status === 'needs_confirmation' ||
-        (sawNeedsConfirmation && finalRun?.status === 'running')
+        (hasPostDecisionDelivery && finalRun?.status === 'running')
       ) {
         // The run is either still waiting for an approval decision or was
         // recently approved and has resumed execution. In both cases, mark
@@ -940,16 +943,20 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         //   approve/reject, and `handleApprovalInterception` will deliver
         //   the reply via `schedulePostDecisionDelivery`.
         //
-        // - running (after needs_confirmation): an approval was applied near
-        //   the poll deadline and the run resumed but hasn't reached terminal
-        //   state yet. `handleApprovalInterception` has already scheduled
-        //   post-decision delivery, so the final reply will be delivered.
+        // - running (after successful prompt delivery): an approval was
+        //   applied near the poll deadline and the run resumed but hasn't
+        //   reached terminal state yet. `handleApprovalInterception` has
+        //   already scheduled post-decision delivery, so the final reply
+        //   will be delivered. This condition is only true when the approval
+        //   prompt was actually delivered (not in auto-deny paths), ensuring
+        //   we don't suppress retry/dead-letter for cases where no
+        //   post-decision delivery path exists.
         //
         // Marking either state as failed would cause the generic retry sweep
         // to replay through `processMessage`, which throws "Session is
         // already processing a message" and dead-letters a valid conversation.
         log.warn(
-          { runId: run.id, status: finalRun.status, conversationId, sawNeedsConfirmation },
+          { runId: run.id, status: finalRun.status, conversationId, hasPostDecisionDelivery },
           'Approval-path poll loop timed out while run is in approval-related state; marking event as processed',
         );
         channelDeliveryStore.markProcessed(eventId);


### PR DESCRIPTION
Addresses Codex review feedback on PR #6956. The sawNeedsConfirmation flag was being set in auto-deny paths (unverified channels, prompt delivery failures) where no schedulePostDecisionDelivery is called. Renamed to hasPostDecisionDelivery and moved the flag to only be set when the approval prompt is successfully delivered, ensuring the timeout bypass only applies when a post-decision delivery path actually exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
