### PR TITLE
fix: untrack .private/ directory from git

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,6 +1,0 @@
-
-https://github.com/vellum-ai/vellum-assistant/pull/6939
-https://github.com/vellum-ai/vellum-assistant/pull/6956
-https://github.com/vellum-ai/vellum-assistant/pull/6958
-https://github.com/vellum-ai/vellum-assistant/pull/6970
-https://github.com/vellum-ai/vellum-assistant/pull/6971


### PR DESCRIPTION
## Summary

- Removes `.private/UNREVIEWED_PRS.md` from git tracking via `git rm --cached`
- The `.private/` directory is already in `.gitignore` (line 37), but the ignore rule had no effect because the file was already tracked
- Once untracked, the existing `.gitignore` rule prevents `git add -A` from re-staging these files

## Context

A previous untracking attempt was made in PR #6094 (commit `83dfc1288`), but subsequent automated commits that ran `git add -A` re-added the file because it was still tracked at that point. The root cause was that `.gitignore` does not apply to already-tracked files.

## Why no script changes are needed

I audited all scripts using `git add -A` or `git add .`:
- `.claude/ship` (line 96)
- `.claude/commands/ship-and-merge.md` (lines 39, 110)
- `.claude/commands/safe-check-review.md` (line 92)
- `.github/workflows/release.yml` (line 55)

None of these need changes because `.gitignore` will now correctly prevent `.private/` from being staged, since the files are no longer tracked. The `git check-ignore` command confirms the rule matches:
```
.gitignore:37:.private/    .private/UNREVIEWED_PRS.md
```

## Testing

After merging, verify with:
```bash
git ls-files .private/   # should return nothing
```

To confirm `.gitignore` protects against re-addition:
```bash
git check-ignore -v .private/UNREVIEWED_PRS.md
# Should output: .gitignore:37:.private/    .private/UNREVIEWED_PRS.md
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
