### PR TITLE
fix(calls): suppress false technical-issue fallback on aborted turns

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -414,6 +414,68 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('LLM APIUserAbortError: treats as expected abort without technical-issue fallback', async () => {
+    mockStreamFn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      return {
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          emitter.on(event, handler);
+          return { on: () => ({ on: () => ({}) }) };
+        },
+        finalMessage: () => {
+          const err = new Error('user abort');
+          err.name = 'APIUserAbortError';
+          return Promise.reject(err);
+        },
+      };
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+
+    const errorTokens = relay.sentTokens.filter((t) => t.token.includes('technical issue'));
+    expect(errorTokens.length).toBe(0);
+    expect(orchestrator.getState()).toBe('idle');
+
+    orchestrator.destroy();
+  });
+
+  test('stale superseded turn errors do not emit technical-issue fallback', async () => {
+    let callCount = 0;
+    mockStreamFn.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        const emitter = new EventEmitter();
+        return {
+          on: (event: string, handler: (...args: unknown[]) => void) => {
+            emitter.on(event, handler);
+            return { on: () => ({ on: () => ({}) }) };
+          },
+          finalMessage: () =>
+            new Promise((_, reject) => {
+              setTimeout(() => reject(new Error('stale stream failure')), 20);
+            }),
+        };
+      }
+      return createMockStream(['Second turn response.']);
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+
+    const firstTurnPromise = orchestrator.handleCallerUtterance('First utterance');
+    // Allow the first turn to enter runLlm before the second utterance interrupts it.
+    await new Promise((r) => setTimeout(r, 5));
+    const secondTurnPromise = orchestrator.handleCallerUtterance('Second utterance');
+
+    await Promise.all([firstTurnPromise, secondTurnPromise]);
+
+    const allTokens = relay.sentTokens.map((t) => t.token).join('');
+    expect(allTokens).toContain('Second turn response.');
+    expect(allTokens).not.toContain('technical issue');
+
+    orchestrator.destroy();
+  });
+
   test('handleUserAnswer: returns false when not in waiting_on_user state', async () => {
     const { orchestrator } = setupOrchestrator();
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -43,6 +43,8 @@ export class CallOrchestrator {
   private task: string | null;
   /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
   private pendingInstructions: string[] = [];
+  /** Monotonic run id used to suppress stale turn side effects after interruption. */
+  private llmRunVersion = 0;
 
   constructor(callSessionId: string, relay: RelayConnection, task: string | null) {
     this.callSessionId = callSessionId;
@@ -239,6 +241,8 @@ export class CallOrchestrator {
     }
 
     const client = new Anthropic({ apiKey });
+    const runVersion = ++this.llmRunVersion;
+    const runSignal = this.abortController.signal;
 
     try {
       this.state = 'speaking';
@@ -255,7 +259,7 @@ export class CallOrchestrator {
             content: m.content,
           })),
         },
-        { signal: this.abortController.signal },
+        { signal: runSignal },
       );
 
       // Buffer incoming tokens so we can strip control markers ([ASK_USER:...], [END_CALL])
@@ -264,6 +268,7 @@ export class CallOrchestrator {
       let ttsBuffer = '';
 
       const flushSafeText = (_force: boolean): void => {
+        if (!this.isCurrentRun(runVersion)) return;
         if (ttsBuffer.length === 0) return;
         const bracketIdx = ttsBuffer.indexOf('[');
         if (bracketIdx === -1) {
@@ -312,6 +317,7 @@ export class CallOrchestrator {
       };
 
       stream.on('text', (text) => {
+        if (!this.isCurrentRun(runVersion)) return;
         ttsBuffer += text;
 
         // If the buffer contains a complete control marker, strip it
@@ -326,6 +332,7 @@ export class CallOrchestrator {
       });
 
       const finalMessage = await stream.finalMessage();
+      if (!this.isCurrentRun(runVersion)) return;
 
       // Final sweep: strip any remaining control markers from the buffer
       ttsBuffer = ttsBuffer.replace(ASK_USER_REGEX, '').replace(END_CALL_MARKER, '');
@@ -412,8 +419,25 @@ export class CallOrchestrator {
       this.flushPendingInstructions();
     } catch (err: unknown) {
       // Aborted requests are expected (interruptions, rapid utterances)
-      if (err instanceof Error && err.name === 'AbortError') {
-        log.debug({ callSessionId: this.callSessionId }, 'LLM request aborted');
+      if (this.isExpectedAbortError(err) || runSignal.aborted) {
+        log.debug(
+          {
+            callSessionId: this.callSessionId,
+            errName: err instanceof Error ? err.name : typeof err,
+            stale: !this.isCurrentRun(runVersion),
+          },
+          'LLM request aborted',
+        );
+        if (this.isCurrentRun(runVersion)) {
+          this.state = 'idle';
+        }
+        return;
+      }
+      if (!this.isCurrentRun(runVersion)) {
+        log.debug(
+          { callSessionId: this.callSessionId, errName: err instanceof Error ? err.name : typeof err },
+          'Ignoring stale LLM streaming error from superseded turn',
+        );
         return;
       }
       log.error({ err, callSessionId: this.callSessionId }, 'LLM streaming error');
@@ -421,6 +445,15 @@ export class CallOrchestrator {
       this.state = 'idle';
       this.flushPendingInstructions();
     }
+  }
+
+  private isExpectedAbortError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    return err.name === 'AbortError' || err.name === 'APIUserAbortError';
+  }
+
+  private isCurrentRun(runVersion: number): boolean {
+    return runVersion === this.llmRunVersion;
   }
 
   /**


### PR DESCRIPTION
## Summary\n- treat  as expected cancellation in call orchestrator\n- suppress stale superseded-turn side effects via per-run version guards\n- add regression tests for APIUserAbortError and stale interrupted turn race\n\n## Validation\n- bun test v1.3.9 (cf6cdbbb)\n- 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
