### PR TITLE
fix: PairingQRCodeSheet — use shared token reader and improve error messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -47,10 +47,17 @@ struct PairingQRCodeSheet: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 32))
                         .foregroundColor(VColor.error)
-                    Text("Enable ingress and set a public URL in Settings to pair with iOS")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.error)
-                        .multilineTextAlignment(.center)
+                    if !ingressEnabled || ingressPublicBaseUrl.isEmpty {
+                        Text("Enable ingress and set a public URL in Settings to pair with iOS")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    } else {
+                        Text("Bearer token not found. Restart the daemon to generate it.")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    }
                 }
                 .frame(width: 220, height: 220)
             }
@@ -182,12 +189,9 @@ struct PairingQRCodeSheet: View {
         return QRCodeGenerator.generate(from: jsonString, size: 220)
     }
 
-    /// Read the HTTP bearer token from ~/.vellum/http-token (same file the gateway uses).
+    /// Read the HTTP bearer token using the shared helper that respects `BASE_DATA_DIR`.
     private static func readBearerToken() -> String {
-        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".vellum/http-token").path
-        return (try? String(contentsOfFile: tokenPath, encoding: .utf8))?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return readHttpToken() ?? ""
     }
 
     /// Compute a stable, privacy-safe host identifier.


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #6973:

1. **Use shared `readHttpToken()`**: Replaced hardcoded `~/.vellum/http-token` path in `readBearerToken()` with the shared `readHttpToken()` function from DaemonClient.swift, which respects `BASE_DATA_DIR` env var.

2. **Context-specific error messages**: The error UI now shows different messages depending on what's missing:
   - Missing ingress config: "Enable ingress and set a public URL..."
   - Missing bearer token: "Bearer token not found. Restart the daemon to generate it."

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift`

Addresses feedback from #6973.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
