### PR TITLE
fix: gateway token path resolution and first-startup race

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -302,9 +302,11 @@ export async function startGateway(): Promise<string> {
   const assistants = loadAllAssistants();
   const isSingleAssistant = assistants.length === 1;
 
-  // Read the bearer token from ~/.vellum/http-token so the gateway can
-  // authenticate proxied requests (e.g. from paired iOS devices).
-  const httpTokenPath = join(homedir(), ".vellum", "http-token");
+  // Read the bearer token so the gateway can authenticate proxied requests
+  // (e.g. from paired iOS devices). Respect VELLUM_HTTP_TOKEN_PATH and
+  // BASE_DATA_DIR for consistency with gateway/config.ts and the daemon.
+  const httpTokenPath = process.env.VELLUM_HTTP_TOKEN_PATH
+    ?? join(process.env.BASE_DATA_DIR?.trim() || homedir(), ".vellum", "http-token");
   let runtimeProxyBearerToken: string | undefined;
   try {
     const tok = readFileSync(httpTokenPath, "utf-8").trim();
@@ -313,10 +315,18 @@ export async function startGateway(): Promise<string> {
     // Token file doesn't exist yet — daemon hasn't written it.
   }
 
+  // If no token is available (first startup — daemon hasn't written it yet),
+  // disable proxy auth so the gateway doesn't crash. The gateway's own
+  // readHttpTokenFile() will pick up the token once the daemon writes it.
+  const proxyRequireAuth = runtimeProxyBearerToken ? "true" : "false";
+  if (!runtimeProxyBearerToken) {
+    console.log("   ⚠️  Bearer token not found — gateway proxy auth disabled until daemon writes token");
+  }
+
   const gatewayEnv: Record<string, string> = {
     ...process.env as Record<string, string>,
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
-    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
+    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: proxyRequireAuth,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
   };
 


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #6976:

1. **Respect BASE_DATA_DIR for token path**: Updated `startGateway()` to resolve the HTTP token path using `VELLUM_HTTP_TOKEN_PATH` or `BASE_DATA_DIR` env vars instead of hardcoding `~/.vellum/http-token`.

2. **Handle first-startup race**: If the token file doesn't exist when the gateway starts, fall back to disabling proxy auth (`GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false`) with a warning, instead of letting the gateway crash.

## Files Changed
- `cli/src/lib/local.ts`

Addresses feedback from #6976.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
