### PR TITLE
fix: iOS manual setup URL validation and duplicate section removal

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -152,18 +152,6 @@ struct DaemonConnectionSection: View {
                 Text("Enter the gateway URL and bearer token shown in your Mac's Settings.")
             }
 
-            if let url = gatewayURL {
-                Section("Connection") {
-                    HStack {
-                        Text("Gateway")
-                        Spacer()
-                        Text(url)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                }
-            }
         }
         .navigationTitle("Connect")
         .navigationBarTitleDisplayMode(.inline)
@@ -182,7 +170,9 @@ struct DaemonConnectionSection: View {
     private func connectManually() {
         // Validate the URL format
         let trimmedURL = manualGatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let url = URL(string: trimmedURL), url.scheme == "https" || url.scheme == "http" else {
+        guard let url = URL(string: trimmedURL),
+              url.scheme == "https" || url.scheme == "http",
+              url.host != nil && !url.host!.isEmpty else {
             alertMessage = "Please enter a valid URL (e.g., https://my-mac.example.com)."
             showingAlert = true
             return


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #6981:

1. **Validate gateway URL host**: Added `url.host != nil && !url.host!.isEmpty` check to `connectManually()` so malformed URLs like `https://` (no host) are rejected.

2. **Remove duplicate Connection section**: Removed the second "Connection" section that duplicated the gateway URL display when connected via HTTP transport. The first section (lines 72-95) already shows the gateway URL and connection status.

## Files Changed
- `clients/ios/Views/Settings/ConnectionSettingsSection.swift`

Addresses feedback from #6981.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
