### PR TITLE
fix: poll for bearer token file before gateway startup

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -316,11 +316,35 @@ export async function startGateway(): Promise<string> {
   }
 
   // If no token is available (first startup — daemon hasn't written it yet),
-  // disable proxy auth so the gateway doesn't crash. The gateway's own
-  // readHttpTokenFile() will pick up the token once the daemon writes it.
+  // poll for the file to appear. The daemon writes the token shortly after
+  // startup, so a short wait avoids starting the gateway without auth
+  // (which would leave it permanently unauthenticated since the gateway
+  // config is loaded once at startup and never reloads).
+  if (!runtimeProxyBearerToken) {
+    console.log("   Waiting for bearer token file...");
+    const maxWait = 10000;
+    const pollInterval = 500;
+    const start = Date.now();
+    while (Date.now() - start < maxWait) {
+      await new Promise((r) => setTimeout(r, pollInterval));
+      try {
+        const tok = readFileSync(httpTokenPath, "utf-8").trim();
+        if (tok) {
+          runtimeProxyBearerToken = tok;
+          break;
+        }
+      } catch {
+        // File still doesn't exist, keep polling.
+      }
+    }
+  }
+
+  // If the token still isn't available after polling, fall back to starting
+  // the gateway without auth so it doesn't block forever. This is a degraded
+  // mode — the proxy will be broken because the runtime expects a token.
   const proxyRequireAuth = runtimeProxyBearerToken ? "true" : "false";
   if (!runtimeProxyBearerToken) {
-    console.log("   ⚠️  Bearer token not found — gateway proxy auth disabled until daemon writes token");
+    console.log("   ⚠️  Bearer token not found after 10s — gateway proxy auth disabled");
   }
 
   const gatewayEnv: Record<string, string> = {


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #6987.

Instead of immediately disabling gateway proxy auth when the bearer token file is missing, adds a polling loop (up to 10s, 500ms intervals) that waits for the daemon to write the token file. This handles the first-startup race where the daemon hasn't written `~/.vellum/http-token` yet when `startGateway()` runs.

If the token appears within the timeout, the gateway starts normally with auth enabled. Only if the timeout expires does it fall back to starting without auth (preserving the graceful degradation from PR #6987).

## Files Changed
- `cli/src/lib/local.ts`

Addresses feedback from #6987.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
