### PR TITLE
fix: export shared token helpers for cross-module access

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -66,7 +66,7 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
 /// Resolve the runtime HTTP bearer token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 /// Available on all platforms since HTTP transport is used on both macOS and iOS.
-func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
+public func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
     let env = environment ?? ProcessInfo.processInfo.environment
     if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
         let resolved = baseDir.hasPrefix("~/") ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2)) : baseDir
@@ -77,7 +77,7 @@ func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
 
 /// Read the runtime HTTP bearer token from disk.
 /// Available on all platforms since HTTP transport is used on both macOS and iOS.
-func readHttpToken(environment: [String: String]? = nil) -> String? {
+public func readHttpToken(environment: [String: String]? = nil) -> String? {
     let tokenPath = resolveHttpTokenPath(environment: environment)
     let data: Data
     do {


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #6986.

Makes `readHttpToken()` and `resolveHttpTokenPath()` in `DaemonClient.swift` `public` so they can be called from the macOS `VellumAssistantLib` target which imports `VellumAssistantShared` as a separate module. Without this, `PairingQRCodeSheet.readBearerToken()` (which calls `readHttpToken()`) would fail to compile due to `internal` access.

## Files Changed
- `clients/shared/IPC/DaemonClient.swift`

Addresses feedback from #6986.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/6998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
