### PR TITLE
fix: preserve jitter when enforcing 1s floor for 429 retries

### DIFF
--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -58,10 +58,11 @@ export function getHttpRetryDelay(
     const parsed = parseRetryAfterMs(retryAfter);
     if (parsed !== undefined) return parsed;
   }
-  // Enforce a minimum floor of baseDelayMs when Retry-After is missing.
-  // computeRetryDelay uses equal jitter (cap/2 + random*cap/2) which can
-  // dip to ~500ms on attempt 0 — too aggressive for 429 rate limits.
-  return Math.max(baseDelayMs, computeRetryDelay(attempt, baseDelayMs));
+  // Double the base so that computeRetryDelay's equal-jitter range on attempt 0
+  // becomes [baseDelayMs, baseDelayMs*2) — above the floor AND with jitter preserved.
+  // Without the *2, Math.max clamps attempt-0 to exactly baseDelayMs (no jitter),
+  // causing all clients to retry simultaneously (thundering herd).
+  return Math.max(baseDelayMs, computeRetryDelay(attempt, baseDelayMs * 2));
 }
 
 /**


### PR DESCRIPTION
Addresses review feedback from PR #6569:

The Math.max(baseDelayMs, computeRetryDelay(attempt, baseDelayMs)) approach clamped all attempt-0 retries to exactly 1000ms, eliminating jitter and enabling thundering herd. Fix by doubling the base delay input to computeRetryDelay so the jitter range [baseDelayMs, baseDelayMs*2) naturally stays above the floor while maintaining randomization.

Prompt: Address the feedback on #6569
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
