### PR TITLE
fix: catch errors from handleJobError to prevent abandoning sibling jobs

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -123,7 +123,11 @@ export async function runMemoryJobsOnce(
             completeMemoryJob(job.id);
             groupProcessed += 1;
           } catch (err) {
-            handleJobError(job, err);
+            try {
+              handleJobError(job, err);
+            } catch (handlerErr) {
+              log.error({ err: handlerErr, jobId: job.id, type: job.type }, 'handleJobError itself threw, job left in running status');
+            }
           }
         }
         return groupProcessed;


### PR DESCRIPTION
Addresses review feedback from PR #6572:

If handleJobError() throws (e.g., DB error in deferMemoryJob/failMemoryJob), the exception propagated out of the sequential type-group loop, abandoning remaining jobs in running status. Wrap handleJobError in try/catch to isolate error handling failures and log them without affecting sibling jobs.

Prompt: Address the feedback on #6572
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
