### PR TITLE
fix: memoize invalid patterns in trust store to prevent repeated compilation

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -27,13 +27,17 @@ let cachedStarterBundleAccepted: boolean | null = null;
  * on every tool-call permission check.
  */
 const compiledPatterns = new Map<string, Minimatch>();
+/** Patterns that failed compilation — cached to avoid repeated attempts and log spam. */
+const invalidPatterns = new Set<string>();
 
 /** Get or compile a Minimatch object for the given pattern. Returns null if the pattern is invalid. */
 function getCompiledPattern(pattern: string): Minimatch | null {
+  if (invalidPatterns.has(pattern)) return null;
   let compiled = compiledPatterns.get(pattern);
   if (!compiled) {
     if (typeof pattern !== 'string') {
       log.warn({ pattern }, 'Cannot compile non-string pattern');
+      invalidPatterns.add(pattern as string);
       return null;
     }
     try {
@@ -41,6 +45,7 @@ function getCompiledPattern(pattern: string): Minimatch | null {
       compiledPatterns.set(pattern, compiled);
     } catch (err) {
       log.warn({ pattern, err }, 'Failed to compile pattern');
+      invalidPatterns.add(pattern);
       return null;
     }
   }
@@ -50,6 +55,7 @@ function getCompiledPattern(pattern: string): Minimatch | null {
 /** Rebuild the compiled pattern cache from the current rule set. */
 function rebuildPatternCache(rules: TrustRule[]): void {
   compiledPatterns.clear();
+  invalidPatterns.clear();
   for (const rule of rules) {
     if (typeof rule.pattern !== 'string') {
       log.warn({ ruleId: rule.id, pattern: rule.pattern }, 'Skipping rule with non-string pattern during cache rebuild');
@@ -509,6 +515,7 @@ export function clearCache(): void {
   cachedRules = null;
   cachedStarterBundleAccepted = null;
   compiledPatterns.clear();
+  invalidPatterns.clear();
 }
 
 // ─── Starter approval bundle ────────────────────────────────────────────────


### PR DESCRIPTION
Addresses review feedback from PR #6573:

When getCompiledPattern encounters a malformed pattern, it logged a warning and returned null but didn't cache the failure. This caused repeated compilation attempts and log spam on every permission check involving that rule. Now caches invalid patterns so they're only attempted once.

Prompt: Address the feedback on #6573
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
