### PR TITLE
fix: handle non-scalar types and validate required fields in Permission Simulator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -42,6 +42,7 @@ struct ToolFieldDescriptor: Identifiable {
         case integer
         case boolean
         case enumeration([String])
+        case json
     }
 }
 
@@ -198,6 +199,7 @@ final class ToolPermissionTesterModel: ObservableObject {
                 case "boolean": fieldType = .boolean
                 case "number": fieldType = .number
                 case "integer": fieldType = .integer
+                case "object", "array": fieldType = .json
                 default: fieldType = .string
                 }
             }
@@ -233,6 +235,38 @@ final class ToolPermissionTesterModel: ObservableObject {
         fieldEnabled = newEnabled
     }
 
+    // MARK: - Validation
+
+    /// Whether the form is valid for simulation. False when the tool name is
+    /// empty or any required field has an empty/unparseable value.
+    var canSimulate: Bool {
+        guard !toolName.isEmpty, !isSimulating else { return false }
+        for field in fieldDescriptors {
+            guard field.isRequired else { continue }
+            let value = fieldValues[field.id] ?? ""
+            switch field.fieldType {
+            case .boolean:
+                // Always valid — stored as "true"/"false"
+                continue
+            case .number:
+                if Double(value) == nil { return false }
+            case .integer:
+                if Int(value) == nil { return false }
+            case .enumeration:
+                if value.isEmpty { return false }
+            case .json:
+                guard !value.isEmpty,
+                      let data = value.data(using: .utf8),
+                      (try? JSONSerialization.jsonObject(with: data)) != nil
+                else { return false }
+            case .string:
+                // Strings are always valid (empty string is a legitimate value)
+                continue
+            }
+        }
+        return true
+    }
+
     // MARK: - Building Input
 
     /// Build the input dictionary from the dynamic field values.
@@ -265,6 +299,12 @@ final class ToolPermissionTesterModel: ObservableObject {
             case .enumeration:
                 if !value.isEmpty {
                     result[field.id] = AnyCodable(value)
+                }
+            case .json:
+                if !value.isEmpty,
+                   let data = value.data(using: .utf8),
+                   let parsed = try? JSONSerialization.jsonObject(with: data) {
+                    result[field.id] = AnyCodable(parsed)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -186,6 +186,20 @@ struct ToolPermissionTesterView: View {
                 RoundedRectangle(cornerRadius: VRadius.sm)
                     .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
             )
+
+        case .json:
+            TextEditor(text: fieldValueBinding(for: field.id))
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 60, maxHeight: 120)
+                .padding(VSpacing.sm)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
         }
     }
 
@@ -220,7 +234,7 @@ struct ToolPermissionTesterView: View {
             VButton(label: model.isSimulating ? "Simulating..." : "Simulate", style: .primary) {
                 model.simulate()
             }
-            .disabled(model.toolName.isEmpty || model.isSimulating)
+            .disabled(!model.canSimulate)
 
             if model.isSimulating {
                 ProgressView()


### PR DESCRIPTION
Addresses review feedback from PR #6565:

1. Add .json field type for object/array schema properties so structured parameters can be simulated with their real payload shape instead of being coerced to strings.
2. Validate required fields before simulation — disable the Simulate button when any required field has an empty or unparseable value (e.g. empty number/integer, unselected enum, invalid JSON), preventing incomplete payloads from producing misleading permission decisions.

Prompt: Address the feedback on #6565
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
