### PR TITLE
fix: extend secret scanner allowlist to cover descriptive doc placeholders

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -63,7 +63,7 @@ declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
     "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
     "private[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
-    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here)>['\"]"
+    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here|[a-zA-Z][a-zA-Z_-]* [a-zA-Z '/._-]+)>['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -131,6 +131,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
     SAFE_SWIFT_DECL_LINE='public let clientSecret: String?'
     SAFE_DOC_PLACEHOLDER_LINE='  oauth2ClientSecret: "<optional>",'
+    SAFE_DESC_PLACEHOLDER_LINE='client_secret: "<the extracted Client Secret>"'
+    SAFE_DESC_PLACEHOLDER_LINE2='  "authToken": "<value from credential_store for twilio/auth_token>"'
     UNSAFE_ANGLEBRACKET_SECRET='clientSecret: "<abcDEF1234567890>"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
@@ -255,6 +257,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_DOC_PLACEHOLDER_LINE" && ! matches_safe_line_pattern "$SAFE_DOC_PLACEHOLDER_LINE"; then
         echo -e "${RED}Self-test failed:${NC} doc placeholder clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DESC_PLACEHOLDER_LINE" && ! matches_safe_line_pattern "$SAFE_DESC_PLACEHOLDER_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} descriptive doc placeholder '<the extracted Client Secret>' false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DESC_PLACEHOLDER_LINE2" && ! matches_safe_line_pattern "$SAFE_DESC_PLACEHOLDER_LINE2"; then
+        echo -e "${RED}Self-test failed:${NC} descriptive doc placeholder '<value from credential_store ...>' false positive"
         exit 1
     fi
     if matches_secret_pattern "$UNSAFE_ANGLEBRACKET_SECRET" && matches_safe_line_pattern "$UNSAFE_ANGLEBRACKET_SECRET"; then


### PR DESCRIPTION
Addresses review feedback from PR #6574:

The narrowed allowlist pattern dropped support for descriptive placeholders like `<the extracted Client Secret>` used in SKILL.md documentation. Extends the allowlist to also match descriptive angle-bracket placeholders (multi-word English phrases with spaces) while still blocking real secrets wrapped in angle brackets.

The new pattern requires at least one space inside the angle brackets, which reliably distinguishes human-readable doc placeholders from real secret values.

Prompt: Address the feedback on #6574
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
