### PR TITLE
fix: only persist executionTarget for skill-origin trust rules

### DIFF
--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -5,6 +5,7 @@ import { getOrCreateConversation } from '../../memory/conversation-key-store.js'
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as runsStore from '../../memory/runs-store.js';
 import { addRule } from '../../permissions/trust-store.js';
+import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import type { RunOrchestrator } from '../run-orchestrator.js';
 
@@ -200,8 +201,13 @@ export async function handleAddTrustRule(
   }
 
   try {
+    // Only persist executionTarget for skill-origin tools — core tools don't
+    // set it in their PolicyContext, so a persisted value would prevent the
+    // rule from ever matching on subsequent permission checks.
+    const tool = getTool(confirmation.toolName);
+    const executionTarget = tool?.origin === 'skill' ? confirmation.executionTarget : undefined;
     addRule(confirmation.toolName, pattern, scope, decision, undefined, {
-      executionTarget: confirmation.executionTarget,
+      executionTarget,
     });
     log.info(
       { tool: confirmation.toolName, pattern, scope, decision, runId },


### PR DESCRIPTION
Addresses review feedback from PR #6576:

The executionTarget was being persisted for all trust rules including core tools, but core tools don't set executionTarget in their PolicyContext. This caused saved rules for core tools (bash, file_*, etc.) to never match on subsequent permission checks, re-prompting the user every time. Now only includes executionTarget when the tool's origin is 'skill' (i.e., when buildPolicyContext will also set it in the matching context).

Prompt: Address the feedback on #6576
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
