### PR TITLE
fix: widen secret scanner safe-line pattern to allow descriptive doc placeholders

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -63,7 +63,7 @@ declare -a SAFE_LINE_PATTERNS=(
     "[A-Za-z0-9_\"']*(sha256|SHA256|checksum|digest|hash|nonceSha256|observedNonceSha256)[A-Za-z0-9_\"']*[[:space:]]*[:=][[:space:]]*['\"][a-fA-F0-9]{32,}['\"]"
     "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
     "private[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
-    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here)>['\"]"
+    "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here|[a-zA-Z ]+)>['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -131,6 +131,7 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_CALL_LINE='self.init(type: "twitter_integration_config", action: action, clientSecret: clientSecret, strategy: strategy)'
     SAFE_SWIFT_DECL_LINE='public let clientSecret: String?'
     SAFE_DOC_PLACEHOLDER_LINE='  oauth2ClientSecret: "<optional>",'
+    SAFE_DESCRIPTIVE_PLACEHOLDER='client_secret: "<the extracted Client Secret>"'
     UNSAFE_ANGLEBRACKET_SECRET='clientSecret: "<abcDEF1234567890>"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
@@ -255,6 +256,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_DOC_PLACEHOLDER_LINE" && ! matches_safe_line_pattern "$SAFE_DOC_PLACEHOLDER_LINE"; then
         echo -e "${RED}Self-test failed:${NC} doc placeholder clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DESCRIPTIVE_PLACEHOLDER" && ! matches_safe_line_pattern "$SAFE_DESCRIPTIVE_PLACEHOLDER"; then
+        echo -e "${RED}Self-test failed:${NC} descriptive doc placeholder client_secret false positive"
         exit 1
     fi
     if matches_secret_pattern "$UNSAFE_ANGLEBRACKET_SECRET" && matches_safe_line_pattern "$UNSAFE_ANGLEBRACKET_SECRET"; then

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -27,13 +27,17 @@ let cachedStarterBundleAccepted: boolean | null = null;
  * on every tool-call permission check.
  */
 const compiledPatterns = new Map<string, Minimatch>();
+/** Patterns that failed compilation — cached to avoid repeated attempts and log spam. */
+const invalidPatterns = new Set<string>();
 
 /** Get or compile a Minimatch object for the given pattern. Returns null if the pattern is invalid. */
 function getCompiledPattern(pattern: string): Minimatch | null {
+  if (invalidPatterns.has(pattern)) return null;
   let compiled = compiledPatterns.get(pattern);
   if (!compiled) {
     if (typeof pattern !== 'string') {
       log.warn({ pattern }, 'Cannot compile non-string pattern');
+      invalidPatterns.add(pattern as string);
       return null;
     }
     try {
@@ -41,6 +45,7 @@ function getCompiledPattern(pattern: string): Minimatch | null {
       compiledPatterns.set(pattern, compiled);
     } catch (err) {
       log.warn({ pattern, err }, 'Failed to compile pattern');
+      invalidPatterns.add(pattern);
       return null;
     }
   }
@@ -50,6 +55,7 @@ function getCompiledPattern(pattern: string): Minimatch | null {
 /** Rebuild the compiled pattern cache from the current rule set. */
 function rebuildPatternCache(rules: TrustRule[]): void {
   compiledPatterns.clear();
+  invalidPatterns.clear();
   for (const rule of rules) {
     if (typeof rule.pattern !== 'string') {
       log.warn({ ruleId: rule.id, pattern: rule.pattern }, 'Skipping rule with non-string pattern during cache rebuild');
@@ -509,6 +515,7 @@ export function clearCache(): void {
   cachedRules = null;
   cachedStarterBundleAccepted = null;
   compiledPatterns.clear();
+  invalidPatterns.clear();
 }
 
 // ─── Starter approval bundle ────────────────────────────────────────────────


### PR DESCRIPTION
Addresses review feedback from PR #6574:

The safe-line regex only accepted a fixed set of sentinel words inside angle brackets (optional, required, placeholder, etc.), causing false positives for descriptive doc placeholders like `client_secret: "<the extracted Client Secret>"`. Now also matches angle-bracket content with spaces and letters (human-readable text), which are clearly not real secrets. Angle-bracket values with digits/special chars are still flagged.

Added a self-test case for the specific false positive pattern.

Prompt: Address the feedback on #6574
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
