### PR TITLE
fix: add bottom padding to skills panel scroll content

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1011,6 +1011,7 @@ struct AgentPanel: View {
             }
             .frame(maxWidth: maxContentWidth)
             .padding(.horizontal, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxl)
             .frame(maxWidth: .infinity)
         }
     }


### PR DESCRIPTION
## Summary
- Add bottom padding to the skills panel so the last skill card isn't cut off at the scroll edge

## Test plan
- [ ] Open Skills panel, scroll to bottom, verify the last card has breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
