### PR TITLE
fix: scope retry jitter doubling to attempt 0 only

### DIFF
--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -58,11 +58,10 @@ export function getHttpRetryDelay(
     const parsed = parseRetryAfterMs(retryAfter);
     if (parsed !== undefined) return parsed;
   }
-  // Double the base so that computeRetryDelay's equal-jitter range on attempt 0
-  // becomes [baseDelayMs, baseDelayMs*2) — above the floor AND with jitter preserved.
-  // Without the *2, Math.max clamps attempt-0 to exactly baseDelayMs (no jitter),
-  // causing all clients to retry simultaneously (thundering herd).
-  return Math.max(baseDelayMs, computeRetryDelay(attempt, baseDelayMs * 2));
+  // For attempt 0, double the base so jitter range [baseDelayMs, 2*baseDelayMs) stays above the floor.
+  // For attempt >= 1, use the original base — jitter is already above baseDelayMs.
+  const effectiveBase = attempt === 0 ? baseDelayMs * 2 : baseDelayMs;
+  return Math.max(baseDelayMs, computeRetryDelay(attempt, effectiveBase));
 }
 
 /**


### PR DESCRIPTION
Addresses review feedback from PR #7000:

The baseDelayMs * 2 was passed to computeRetryDelay for all attempts, doubling the backoff windows for retries beyond the first. Now only applies the doubling on attempt 0 (where jitter dips below the floor), preserving the original backoff scale for subsequent attempts.

Prompt: Address the feedback on #7000
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
