### PR TITLE
Fix duplicate Telegram guardian-denial messaging

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -48,6 +48,7 @@ import {
   setRunConfirmation,
 } from '../memory/runs-store.js';
 import type { PendingConfirmation } from '../memory/runs-store.js';
+import { setConversationKeyIfAbsent } from '../memory/conversation-key-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import {
@@ -95,6 +96,7 @@ function resetTables(): void {
   db.run('DELETE FROM channel_guardian_approval_requests');
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM conversation_keys');
   db.run('DELETE FROM message_runs');
   db.run('DELETE FROM channel_inbound_events');
   db.run('DELETE FROM messages');
@@ -1093,8 +1095,8 @@ describe('poll timeout handling by run state', () => {
 
   test('marks event as processed when run is in needs_confirmation state after poll timeout', async () => {
     // Use a short poll timeout so the test can exercise the timeout path
-    // without waiting 5 minutes.
-    _setTestPollMaxWait(100);
+    // without waiting 5 minutes. Must exceed one poll interval (500ms).
+    _setTestPollMaxWait(700);
 
     const linkSpy = spyOn(channelDeliveryStore, 'linkMessage').mockImplementation(() => {});
     const markSpy = spyOn(channelDeliveryStore, 'markProcessed');
@@ -1181,6 +1183,8 @@ describe('poll timeout handling by run state', () => {
 
     const conversationId = `conv-post-approval-${Date.now()}`;
     ensureConversation(conversationId);
+    setConversationKeyIfAbsent('asst:self:telegram:chat-123', conversationId);
+    setConversationKeyIfAbsent('telegram:chat-123', conversationId);
 
     let realRunId: string | undefined;
 
@@ -1978,7 +1982,7 @@ describe('fail-closed guardian gate — unverified channel', () => {
     process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
-  test('no binding + sensitive action → auto-deny and setup notice', async () => {
+  test('no binding + sensitive action → auto-deny with contextual assistant guidance', async () => {
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
     const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
 
@@ -1998,11 +2002,15 @@ describe('fail-closed guardian gate — unverified channel', () => {
     const decisionArgs = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls[0];
     expect(decisionArgs[1]).toBe('deny');
 
-    // The requester should have been notified about missing guardian setup
-    const replyCalls = deliverSpy.mock.calls.filter(
+    // The deny decision should carry guardian setup context for assistant reply generation.
+    expect(typeof decisionArgs[2]).toBe('string');
+    expect((decisionArgs[2] as string)).toContain('no guardian is configured');
+
+    // The runtime should not send a second deterministic denial notice.
+    const deterministicNoticeCalls = deliverSpy.mock.calls.filter(
       (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
     );
-    expect(replyCalls.length).toBeGreaterThanOrEqual(1);
+    expect(deterministicNoticeCalls.length).toBe(0);
 
     // No approval prompt should have been sent to a guardian (none exists)
     expect(approvalSpy).not.toHaveBeenCalled();
@@ -2091,11 +2099,19 @@ describe('fail-closed guardian gate — unverified channel', () => {
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe('decision_applied');
 
-    // The denial notice should have been sent
+    // The deny decision should carry guardian setup context for the assistant.
+    const submitCalls = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls;
+    expect(submitCalls.length).toBeGreaterThanOrEqual(1);
+    const lastDecision = submitCalls[submitCalls.length - 1];
+    expect(lastDecision[1]).toBe('deny');
+    expect(typeof lastDecision[2]).toBe('string');
+    expect((lastDecision[2] as string)).toContain('no guardian is configured');
+
+    // Interception should not emit a separate deterministic denial notice.
     const denialCalls = deliverSpy.mock.calls.filter(
       (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
     );
-    expect(denialCalls.length).toBeGreaterThanOrEqual(1);
+    expect(denialCalls.length).toBe(0);
 
     deliverSpy.mockRestore();
   });
@@ -3185,21 +3201,21 @@ describe('guardian enforcement independence from approval flag', () => {
     // Wait for background processing
     await new Promise((resolve) => setTimeout(resolve, 1200));
 
-    // The unknown actor should be treated as unverified_channel and
-    // sensitive actions should be auto-denied via the no_identity branch.
-    // deliverChannelReply args: (callbackUrl, payload, bearerToken?)
-    // The denial notice is in payload.text (index 1 of the call args).
-    expect(deliverSpy).toHaveBeenCalled();
+    // The unknown actor should be treated as unverified_channel and denied,
+    // with context passed into the tool-denial response for assistant phrasing.
+    const submitCalls = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls;
+    expect(submitCalls.length).toBeGreaterThanOrEqual(1);
+    const lastDecision = submitCalls[submitCalls.length - 1];
+    expect(lastDecision[1]).toBe('deny');
+    expect(typeof lastDecision[2]).toBe('string');
+    expect((lastDecision[2] as string)).toContain('identity could not be verified');
+
+    // No separate deterministic denial notice should be emitted here.
     const denialCalls = deliverSpy.mock.calls.filter(
-      (call) => {
-        if (typeof call[1] !== 'object') return false;
-        const text = (call[1] as { text?: string }).text ?? '';
-        return text.includes('requires guardian approval') &&
-          text.includes('identity could not be determined') &&
-          text.includes('denied');
-      },
+      (call) => typeof call[1] === 'object'
+        && ((call[1] as { text?: string }).text ?? '').includes('identity could not be determined'),
     );
-    expect(denialCalls.length).toBeGreaterThanOrEqual(1);
+    expect(denialCalls.length).toBe(0);
 
     // Auto-deny path should never prompt for approval
     expect(approvalSpy).not.toHaveBeenCalled();
@@ -3227,17 +3243,18 @@ describe('guardian enforcement independence from approval flag', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1200));
 
-    expect(deliverSpy).toHaveBeenCalled();
+    const submitCalls = (orchestrator.submitDecision as ReturnType<typeof mock>).mock.calls;
+    expect(submitCalls.length).toBeGreaterThanOrEqual(1);
+    const lastDecision = submitCalls[submitCalls.length - 1];
+    expect(lastDecision[1]).toBe('deny');
+    expect(typeof lastDecision[2]).toBe('string');
+    expect((lastDecision[2] as string)).toContain('identity could not be verified');
+
     const denialCalls = deliverSpy.mock.calls.filter(
-      (call) => {
-        if (typeof call[1] !== 'object') return false;
-        const text = (call[1] as { text?: string }).text ?? '';
-        return text.includes('requires guardian approval')
-          && text.includes('identity could not be determined')
-          && text.includes('denied');
-      },
+      (call) => typeof call[1] === 'object'
+        && ((call[1] as { text?: string }).text ?? '').includes('identity could not be determined'),
     );
-    expect(denialCalls.length).toBeGreaterThanOrEqual(1);
+    expect(denialCalls.length).toBe(0);
     expect(approvalSpy).not.toHaveBeenCalled();
 
     deliverSpy.mockRestore();

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -143,7 +143,12 @@ function makeContext(events: ToolLifecycleEvent[]) {
   };
 }
 
-function makePrompter(promptImpl?: () => Promise<{ decision: 'allow' | 'always_allow' | 'deny' | 'always_deny' }>) {
+function makePrompter(
+  promptImpl?: () => Promise<{
+    decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
+    decisionContext?: string;
+  }>,
+) {
   return {
     prompt: promptImpl ?? (async () => ({ decision: promptDecision })),
     resolveConfirmation: () => {},
@@ -223,6 +228,34 @@ describe('ToolExecutor lifecycle events', () => {
     expect(deniedEvent.executionTarget).toBe('sandbox');
     expect(deniedEvent.decision).toBe('deny');
     expect(deniedEvent.reason).toBe('Permission denied by user');
+  });
+
+  test('uses contextual deny messaging when provided by prompter', async () => {
+    checkerDecision = 'prompt';
+    checkerReason = 'guardrail prompt';
+    checkerRisk = 'high';
+    sandboxed = true;
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(
+      makePrompter(async () => ({
+        decision: 'deny',
+        decisionContext:
+          'Permission denied: this action requires guardian setup before retrying. Explain this and provide setup steps.',
+      })),
+    );
+
+    const result = await executor.execute('bash', { command: 'echo hi' }, makeContext(events));
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('requires guardian setup');
+    expect(result.content).not.toContain('Permission denied by user');
+
+    const deniedEvent = events.find((event) => event.type === 'permission_denied');
+    if (!deniedEvent || deniedEvent.type !== 'permission_denied') {
+      throw new Error('Expected permission_denied event');
+    }
+    expect(deniedEvent.reason).toBe('Permission denied (bash): contextual policy');
   });
 
   test('emits host executionTarget for host tools', async () => {

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -897,7 +897,14 @@ export class ComputerUseSession {
     decision: UserDecision,
     selectedPattern?: string,
     selectedScope?: string,
+    decisionContext?: string,
   ): void {
-    this.prompter?.resolveConfirmation(requestId, decision, selectedPattern, selectedScope);
+    this.prompter?.resolveConfirmation(
+      requestId,
+      decision,
+      selectedPattern,
+      selectedScope,
+      decisionContext,
+    );
   }
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -308,8 +308,15 @@ export class Session {
     decision: UserDecision,
     selectedPattern?: string,
     selectedScope?: string,
+    decisionContext?: string,
   ): void {
-    this.prompter.resolveConfirmation(requestId, decision, selectedPattern, selectedScope);
+    this.prompter.resolveConfirmation(
+      requestId,
+      decision,
+      selectedPattern,
+      selectedScope,
+      decisionContext,
+    );
   }
 
   handleSecretResponse(requestId: string, value?: string, delivery?: 'store' | 'transient_send'): void {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -10,7 +10,12 @@ import { redactSensitiveFields } from '../security/redaction.js';
 const log = getLogger('permission-prompter');
 
 interface PendingPrompt {
-  resolve: (value: { decision: UserDecision; selectedPattern?: string; selectedScope?: string }) => void;
+  resolve: (value: {
+    decision: UserDecision;
+    selectedPattern?: string;
+    selectedScope?: string;
+    decisionContext?: string;
+  }) => void;
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
 }
@@ -38,7 +43,12 @@ export class PermissionPrompter {
     sessionId?: string,
     executionTarget?: ExecutionTarget,
     persistentDecisionsAllowed?: boolean,
-  ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
+  ): Promise<{
+    decision: UserDecision;
+    selectedPattern?: string;
+    selectedScope?: string;
+    decisionContext?: string;
+  }> {
     const requestId = uuid();
 
     return new Promise((resolve, reject) => {
@@ -77,6 +87,7 @@ export class PermissionPrompter {
     decision: UserDecision,
     selectedPattern?: string,
     selectedScope?: string,
+    decisionContext?: string,
   ): void {
     const pending = this.pending.get(requestId);
     if (!pending) {
@@ -85,7 +96,7 @@ export class PermissionPrompter {
     }
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
-    pending.resolve({ decision, selectedPattern, selectedScope });
+    pending.resolve({ decision, selectedPattern, selectedScope, decisionContext });
   }
 
   dispose(): void {

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -101,6 +101,7 @@ export function handleChannelDecision(
   conversationId: string,
   decision: ApprovalDecisionResult,
   orchestrator: RunOrchestrator,
+  decisionContext?: string,
 ): HandleDecisionResult {
   const pending = getPendingConfirmationsByConversation(conversationId);
   if (pending.length === 0) return { applied: false };
@@ -136,7 +137,9 @@ export function handleChannelDecision(
 
   // Map channel-level action to the permission system's UserDecision type.
   const userDecision = decision.action === 'reject' ? 'deny' as const : 'allow' as const;
-  const result = orchestrator.submitDecision(info.runId, userDecision);
+  const result = decisionContext === undefined
+    ? orchestrator.submitDecision(info.runId, userDecision)
+    : orchestrator.submitDecision(info.runId, userDecision, decisionContext);
 
   return {
     applied: result === 'applied',

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -127,6 +127,23 @@ function effectivePromptText(
   return plainTextFallback;
 }
 
+/**
+ * Build contextual deny guidance for guardian-gated auto-deny paths.
+ * This is passed through the confirmation pipeline so the assistant can
+ * produce a single, user-facing message with next steps.
+ */
+function buildGuardianDenyContext(
+  toolName: string,
+  denialReason: DenialReason,
+  sourceChannel: string,
+): string {
+  if (denialReason === 'no_identity') {
+    return `Permission denied: the action "${toolName}" requires guardian approval, but your identity could not be verified on ${sourceChannel}. Do not retry yet. Explain this clearly, ask the user to message from a verifiable direct account/chat, and then retry after identity is available.`;
+  }
+
+  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first, and if the user is the guardian/admin, instruct them to run /guardian_verify from an existing ${sourceChannel} chat with the assistant before retrying.`;
+}
+
 // ---------------------------------------------------------------------------
 // Feature flag
 // ---------------------------------------------------------------------------
@@ -760,19 +777,16 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
 
           if (isUnverifiedChannel && pending.length > 0) {
             // Unverified channel — auto-deny the sensitive action (fail-closed).
-            handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
-            const denialText = guardianCtx.denialReason === 'no_identity'
-              ? `The action "${pending[0].toolName}" requires guardian approval, but your identity could not be determined. The action has been denied. Please ensure your messaging client sends user identity information.`
-              : `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied. Please ask an administrator to configure a guardian.`;
-            try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: externalChatId,
-                text: denialText,
-                assistantId,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, runId: run.id }, 'Failed to deliver unverified-channel denial notice');
-            }
+            handleChannelDecision(
+              conversationId,
+              { action: 'reject', source: 'plain_text' },
+              orchestrator,
+              buildGuardianDenyContext(
+                pending[0].toolName,
+                guardianCtx.denialReason ?? 'no_binding',
+                sourceChannel,
+              ),
+            );
           } else if (isNonGuardian && guardianCtx.guardianChatId && pending.length > 0) {
             // Non-guardian actor: route the approval prompt to the guardian's chat
             const guardianPrompt = buildGuardianApprovalPrompt(
@@ -1205,18 +1219,26 @@ async function handleApprovalInterception(
   if (guardianCtx.actorRole === 'unverified_channel') {
     const pending = getPendingConfirmationsByConversation(conversationId);
     if (pending.length > 0) {
-      handleChannelDecision(conversationId, { action: 'reject', source: 'plain_text' }, orchestrator);
-      const denialText = guardianCtx.denialReason === 'no_identity'
-        ? `The action "${pending[0].toolName}" requires guardian approval, but your identity could not be determined. The action has been denied.`
-        : `The action "${pending[0].toolName}" requires guardian approval, but no guardian has been set up for this channel. The action has been denied.`;
-      try {
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: externalChatId,
-          text: denialText,
+      const denyResult = handleChannelDecision(
+        conversationId,
+        { action: 'reject', source: 'plain_text' },
+        orchestrator,
+        buildGuardianDenyContext(
+          pending[0].toolName,
+          guardianCtx.denialReason ?? 'no_binding',
+          sourceChannel,
+        ),
+      );
+      if (denyResult.applied && denyResult.runId) {
+        schedulePostDecisionDelivery(
+          orchestrator,
+          denyResult.runId,
+          conversationId,
+          externalChatId,
+          replyCallbackUrl,
+          bearerToken,
           assistantId,
-        }, bearerToken);
-      } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver unverified-channel denial notice during interception');
+        );
       }
       return { handled: true, type: 'decision_applied' };
     }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -251,13 +251,20 @@ export class RunOrchestrator {
    * - `'run_not_found'`   – no run exists with the given ID
    * - `'no_pending_decision'` – run exists but is not awaiting a confirmation
    */
-  submitDecision(runId: string, decision: UserDecision): 'applied' | 'run_not_found' | 'no_pending_decision' {
+  submitDecision(
+    runId: string,
+    decision: UserDecision,
+    decisionContext?: string,
+  ): 'applied' | 'run_not_found' | 'no_pending_decision' {
     const pendingState = this.pending.get(runId);
     if (pendingState) {
       runsStore.clearRunConfirmation(runId);
       pendingState.session.handleConfirmationResponse(
         pendingState.prompterRequestId,
         decision,
+        undefined,
+        undefined,
+        decisionContext,
       );
       this.pending.delete(runId);
       return 'applied';

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -268,7 +268,15 @@ export class ToolExecutor {
         });
 
         if (response.decision === 'deny') {
-          const denialMessage = `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+          const contextualDenial = typeof response.decisionContext === 'string'
+            ? response.decisionContext.trim()
+            : '';
+          const denialMessage = contextualDenial.length > 0
+            ? contextualDenial
+            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+          const denialReason = contextualDenial.length > 0
+            ? `Permission denied (${name}): contextual policy`
+            : 'Permission denied by user';
           const durationMs = Date.now() - startTime;
           emitLifecycleEvent(context, {
             type: 'permission_denied',
@@ -281,7 +289,7 @@ export class ToolExecutor {
             requestId: context.requestId,
             riskLevel,
             decision: 'deny',
-            reason: 'Permission denied by user',
+            reason: denialReason,
             durationMs,
           });
           return { content: denialMessage, isError: true };


### PR DESCRIPTION
## Summary
- Remove deterministic unverified-channel guardian denial sends in Telegram approval paths.
- Pass contextual denial guidance through approval decision plumbing so the assistant generates one actionable response.
- Add regression coverage for contextual deny messaging and guardian fail-closed routing.

## Original prompt
This is what it looks like currently when I try to perform an action through telegram that requires approval. I first got one deterministic message with the error, then got a message from the assistant that says it was blocked.

Ideally, I should have only received one message and that message should have come from the assistant and been generated, but the assistant should have the context from the first message to guide me on what to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
