### PR TITLE
M2: Shared Swift IPC Plumbing for Guardian Verification

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -290,6 +290,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `vercel_api_config_response` message.
     public var onVercelApiConfigResponse: ((VercelApiConfigResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `guardian_verification_response` message.
+    public var onGuardianVerificationResponse: ((GuardianVerificationResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `telegram_config_response` message.
     public var onTelegramConfigResponse: ((TelegramConfigResponseMessage) -> Void)?
 
@@ -958,6 +961,21 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Get, set, or delete the Vercel API token configuration.
     public func sendVercelApiConfig(action: String, apiToken: String? = nil) throws {
         try send(VercelApiConfigRequestMessage(action: action, apiToken: apiToken))
+    }
+
+    /// Create a guardian verification challenge, check status, or revoke for a channel.
+    public func sendGuardianVerification(
+        action: String,
+        channel: String? = nil,
+        sessionId: String? = nil,
+        assistantId: String? = nil
+    ) throws {
+        try send(GuardianVerificationRequestMessage(
+            action: action,
+            channel: channel,
+            sessionId: sessionId,
+            assistantId: assistantId
+        ))
     }
 
     /// Get, set, or clear Telegram bot token configuration.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -133,6 +133,8 @@ extension DaemonClient {
             onIngressConfigResponse?(msg)
         case .vercelApiConfigResponse(let msg):
             onVercelApiConfigResponse?(msg)
+        case .guardianVerificationResponse(let msg):
+            onGuardianVerificationResponse?(msg)
         case .telegramConfigResponse(let msg):
             onTelegramConfigResponse?(msg)
         case .twilioConfigResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1859,6 +1859,33 @@ public typealias TwilioNumberCapabilities = IPCTwilioConfigResponseNumberCapabil
 /// Backed by generated `IPCTwilioConfigResponse`.
 public typealias TwilioConfigResponseMessage = IPCTwilioConfigResponse
 
+// MARK: - Guardian Verification Messages
+
+/// Guardian verification request (create challenge, check status, revoke).
+/// Backed by generated `IPCGuardianVerificationRequest`.
+public typealias GuardianVerificationRequestMessage = IPCGuardianVerificationRequest
+
+extension IPCGuardianVerificationRequest {
+    public init(
+        action: String,
+        channel: String? = nil,
+        sessionId: String? = nil,
+        assistantId: String? = nil
+    ) {
+        self.init(
+            type: "guardian_verification",
+            action: action,
+            channel: channel,
+            sessionId: sessionId,
+            assistantId: assistantId
+        )
+    }
+}
+
+/// Guardian verification response.
+/// Backed by generated `IPCGuardianVerificationResponse`.
+public typealias GuardianVerificationResponseMessage = IPCGuardianVerificationResponse
+
 // MARK: - Twitter Integration Config Messages
 
 /// Sent to get/set Twitter integration config.
@@ -2066,6 +2093,7 @@ public enum ServerMessage: Decodable, Sendable {
     case slackWebhookConfigResponse(SlackWebhookConfigResponseMessage)
     case ingressConfigResponse(IngressConfigResponseMessage)
     case vercelApiConfigResponse(VercelApiConfigResponseMessage)
+    case guardianVerificationResponse(GuardianVerificationResponseMessage)
     case telegramConfigResponse(TelegramConfigResponseMessage)
     case twilioConfigResponse(TwilioConfigResponseMessage)
     case twitterIntegrationConfigResponse(TwitterIntegrationConfigResponseMessage)
@@ -2342,6 +2370,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "vercel_api_config_response":
             let message = try VercelApiConfigResponseMessage(from: decoder)
             self = .vercelApiConfigResponse(message)
+        case "guardian_verification_response":
+            let message = try GuardianVerificationResponseMessage(from: decoder)
+            self = .guardianVerificationResponse(message)
         case "telegram_config_response":
             let message = try TelegramConfigResponseMessage(from: decoder)
             self = .telegramConfigResponse(message)


### PR DESCRIPTION
## Summary
- Adds GuardianVerificationRequestMessage typealias and convenience init in IPCMessages.swift
- Adds GuardianVerificationResponseMessage typealias in IPCMessages.swift
- Adds guardianVerificationResponse case to ServerMessage enum with decoding
- Adds sendGuardianVerification helper in DaemonClient.swift
- Adds onGuardianVerificationResponse callback in DaemonClient.swift
- Adds routing in DaemonMessageRouter.swift

Part of #7007: Channels Settings Section
Closes #7010
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
