### PR TITLE
fix: conditionally persist executionTarget in channel approval path

### DIFF
--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -13,6 +13,7 @@
 import { getPendingConfirmationsByConversation, getRun } from '../memory/runs-store.js';
 import type { PendingRunInfo } from '../memory/runs-store.js';
 import { addRule } from '../permissions/trust-store.js';
+import { getTool } from '../tools/registry.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 import { DEFAULT_APPROVAL_ACTIONS } from './channel-approval-types.js';
 import type {
@@ -127,8 +128,13 @@ export function handleChannelDecision(
     ) {
       const pattern = confirmation.allowlistOptions[0].pattern;
       const scope = confirmation.scopeOptions[0].scope;
+      // Only persist executionTarget for skill-origin tools — core tools don't
+      // set it in their PolicyContext, so a persisted value would prevent the
+      // rule from ever matching on subsequent permission checks.
+      const tool = getTool(confirmation.toolName);
+      const executionTarget = tool?.origin === 'skill' ? confirmation.executionTarget : undefined;
       addRule(confirmation.toolName, pattern, scope, 'allow', 100, {
-        executionTarget: confirmation.executionTarget,
+        executionTarget,
       });
     }
     // When persistence is not allowed or options are missing, the decision


### PR DESCRIPTION
Addresses review feedback from PR #7006:

PR #7006 fixed the executionTarget persistence bug in run-routes.ts but missed the same issue in channel-approvals.ts. handleChannelDecision unconditionally passed executionTarget when persisting trust rules, causing core tool rules to never match. Now only includes executionTarget when it's defined (matching the run-routes fix).

Prompt: Address the feedback on #7006
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
