### PR TITLE
fix: update channel approval test expectations for executionTarget

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -366,14 +366,16 @@ describe('handleChannelDecision', () => {
     expect(result.applied).toBe(true);
     expect(result.runId).toBe(run.id);
 
-    // Trust rule added with first allowlist and scope option
+    // Trust rule added with first allowlist and scope option.
+    // executionTarget is undefined for core tools like 'shell' — only
+    // skill-origin tools persist it (see channel-approvals.ts).
     expect(addRuleSpy).toHaveBeenCalledWith(
       'shell',
       'rm -rf *',
       '/tmp/project',
       'allow',
       100,
-      { executionTarget: 'sandbox' },
+      { executionTarget: undefined },
     );
 
     // The run is still approved with a simple "allow"


### PR DESCRIPTION
Addresses review feedback from PR #7021:

The test expected executionTarget: 'sandbox' for the core tool 'shell', but the new code correctly omits executionTarget for non-skill tools. Updated test assertions to match the current behavior.

Prompt: Address the feedback on #7021
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
