### PR TITLE
Fix guardian status ordering in twilio-setup skill

### DIFF
--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -169,7 +169,7 @@ Confirm:
 - `hasCredentials` is `true`
 - `phoneNumber` is set to the expected number
 
-Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging. Guardian identity: {verified | not configured}."**
+Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
 
 ## Step 5.5: Guardian Verification (SMS)
 
@@ -206,6 +206,8 @@ Now link the user's phone number as the trusted SMS guardian for this assistant.
 **Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 6 without blocking.
 
 To re-check guardian status later, send `guardian_verification` with `action: "status"` and `channel: "sms"`.
+
+Report the guardian verification result: **"Guardian identity: {verified | not configured}."**
 
 ## Step 6: Enable Features
 


### PR DESCRIPTION
## Summary
- Remove premature guardian identity status from Step 5 message (reported before Step 5.5 runs verification)
- Add guardian status reporting after Step 5.5 completes, so the status reflects the actual verification result

Addresses feedback on #7017.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
