### PR TITLE
Fix guardian verification response handling and nil daemonClient guard

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1500,12 +1500,12 @@ export function handleGuardianVerification(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  try {
-    // Use the assistant ID from the request when available; fall back to
-    // 'self' for backward compatibility with single-assistant mode.
-    const assistantId = msg.assistantId ?? 'self';
-    const channel = msg.channel ?? 'telegram';
+  // Use the assistant ID from the request when available; fall back to
+  // 'self' for backward compatibility with single-assistant mode.
+  const assistantId = msg.assistantId ?? 'self';
+  const channel = msg.channel ?? 'telegram';
 
+  try {
     if (msg.action === 'create_challenge') {
       const result = createVerificationChallenge(assistantId, channel, msg.sessionId);
 
@@ -1514,6 +1514,7 @@ export function handleGuardianVerification(
         success: true,
         secret: result.secret,
         instruction: result.instruction,
+        channel,
       });
     } else if (msg.action === 'status') {
       const binding = getGuardianBinding(assistantId, channel);
@@ -1532,12 +1533,14 @@ export function handleGuardianVerification(
         type: 'guardian_verification_response',
         success: true,
         bound: false,
+        channel,
       });
     } else {
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: false,
         error: `Unknown action: ${String(msg.action)}`,
+        channel,
       });
     }
   } catch (err) {
@@ -1547,6 +1550,7 @@ export function handleGuardianVerification(
       type: 'guardian_verification_response',
       success: false,
       error: message,
+      channel,
     });
   }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -792,7 +792,18 @@ public final class SettingsStore: ObservableObject {
             return
         }
         do {
-            try daemonClient?.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: "self")
+            guard let daemonClient else {
+                switch channel {
+                case "telegram":
+                    telegramGuardianVerificationInProgress = false
+                case "sms":
+                    smsGuardianVerificationInProgress = false
+                default:
+                    break
+                }
+                return
+            }
+            try daemonClient.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: "self")
         } catch {
             log.error("Failed to start \(channel) guardian verification: \(error)")
             switch channel {


### PR DESCRIPTION
## Summary
- Include `channel` field in all `guardian_verification_response` paths in the daemon handler (create_challenge, revoke, errors) so the Swift callback can route responses correctly
- Add `guard let daemonClient` check in `startChannelGuardianVerification` to prevent stuck spinner state when daemonClient is nil, matching the existing `connectTwitter()` pattern

Addresses feedback on #7022.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
