### PR TITLE
Design polish: input backgrounds, card tokens, app container layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -135,20 +135,10 @@ struct ChatBubble: View {
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }
 
-            // Inner HStack: avatar/button and bubble are grouped so the button
-            // is always immediately adjacent to the bubble, not the screen edge.
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                if !isUser && isLatestAssistantMessage {
-                    Image(nsImage: appearance.chatAvatarImage)
-                        .interpolation(.none)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 28, height: 28)
-                        .clipShape(Circle())
-                        .padding(.top, 2)
-                }
-
-                VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
+            // Content group with absolutely-positioned avatar so text alignment
+            // stays consistent whether or not the avatar is visible.
+            // Assistant messages reserve left space (28pt avatar + 8pt gap) for the overlay avatar.
+            VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
                     if !isUser && hasInterleavedContent {
                         interleavedContent
                     } else {
@@ -199,8 +189,18 @@ struct ChatBubble: View {
                             .offset(x: 24 + VSpacing.sm)
                     }
                 }
-
-            }
+                .overlay(alignment: .topLeading) {
+                    if !isUser && isLatestAssistantMessage {
+                        Image(nsImage: appearance.chatAvatarImage)
+                            .interpolation(.none)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 28, height: 28)
+                            .clipShape(Circle())
+                            .offset(x: -(28 + VSpacing.sm), y: 2)
+                    }
+                }
+                .padding(.leading, isUser ? 0 : 28 + VSpacing.sm)
 
             if !isUser { Spacer(minLength: 0) }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -192,7 +192,7 @@ struct ChatView: View {
         let topPad: CGFloat = expanded ? VSpacing.md : VSpacing.sm
         let bottomPad: CGFloat = expanded ? VSpacing.sm : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 34 + VSpacing.xs : 0
-        let base: CGFloat = VSpacing.sm + VSpacing.md + topPad + bottomPad + contentHeight + buttonRow
+        let base: CGFloat = VSpacing.sm + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
         return base + attachments + error

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -158,7 +158,6 @@ struct ComposerView: View {
         .animation(VAnimation.fast, value: showSlashMenu)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
-        .padding(.bottom, VSpacing.md)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
         .animation(VAnimation.fast, value: editorContentHeight)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -773,7 +773,8 @@ struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Close workspace")
                     }
                 }
-                .padding(.horizontal, VSpacing.md)
+                .padding(.leading, isChatDockOpen ? VSpacing.md : trafficLightPadding)
+                .padding(.trailing, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
                 .background(
                     adaptiveColor(light: Moss._50, dark: Moss._950)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -173,7 +173,6 @@ extension MainWindowView {
                 dynamicWorkspaceView(surface: surface, data: dpData)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding(VSpacing.sm)
             } else {
                 // Gallery mode fallback
                 GeneratedPanel(
@@ -210,6 +209,8 @@ extension MainWindowView {
                     },
                     panel: {
                         dynamicWorkspaceView(surface: surface, data: dpData)
+                            .background(adaptiveColor(light: Moss._100, dark: Moss._900))
+                            .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.xl, bottomLeadingRadius: VRadius.xl))
                     }
                 )
             } else {
@@ -240,6 +241,7 @@ extension MainWindowView {
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -333,6 +335,7 @@ extension MainWindowView {
         switch panel {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         case .agent:
             AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
@@ -351,6 +354,7 @@ extension MainWindowView {
                 windowState.dismissOverlay()
             }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -769,9 +773,12 @@ struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Close workspace")
                     }
                 }
-                .padding(.leading, isChatDockOpen ? VSpacing.lg : trafficLightPadding)
-                .padding(.trailing, VSpacing.xl)
-                .padding(.top, VSpacing.md)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(
+                    adaptiveColor(light: Moss._50, dark: Moss._950)
+                        .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.lg, topTrailingRadius: VRadius.lg))
+                )
 
                 if let error = publishError {
                     HStack {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -72,16 +72,7 @@ struct SettingsAppearanceTab: View {
 
                     HStack(spacing: VSpacing.sm) {
                         TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                            .textFieldStyle(.plain)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
+                            .textFieldStyle(VInputStyle())
 
                         VButton(label: "Add", style: .primary) {
                             let domain = newAllowlistDomain

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -65,7 +65,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter API key", text: $apiKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API key at console.anthropic.com")
                             .font(.caption)
@@ -111,7 +111,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter Perplexity API key", text: $perplexityKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API key at perplexity.ai/settings/api")
                             .font(.caption)
@@ -143,7 +143,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter Brave Search API key", text: $braveKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API key at brave.com/search/api")
                             .font(.caption)
@@ -185,7 +185,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter Gemini API key", text: $imageGenKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API key at aistudio.google.com/apikey")
                             .font(.caption)
@@ -217,7 +217,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter OpenAI API key", text: $openaiKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API key at platform.openai.com/api-keys")
                             .font(.caption)
@@ -246,7 +246,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter Vercel API token", text: $vercelKeyText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Text("Get your API token at vercel.com/account/tokens")
                             .font(.caption)
@@ -284,9 +284,9 @@ public struct SettingsView: View {
                     if !store.twitterLocalClientConfigured {
                         VStack(alignment: .leading, spacing: 6) {
                             TextField("OAuth Client ID", text: $twitterClientId)
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(VInputStyle())
                             SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(VInputStyle())
                             HStack {
                                 Text("Create an app at developer.x.com")
                                     .font(.caption)
@@ -382,6 +382,7 @@ public struct SettingsView: View {
                     }
                 } else {
                     SecureField("Enter bot token", text: $telegramBotTokenText)
+                        .textFieldStyle(VInputStyle())
                     Text("Get your bot token from @BotFather on Telegram")
                         .font(.caption).foregroundStyle(.secondary)
                     HStack {
@@ -427,9 +428,9 @@ public struct SettingsView: View {
                     }
                 } else {
                     TextField("Account SID", text: $twilioAccountSidText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     SecureField("Auth Token", text: $twilioAuthTokenText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     HStack {
                         Spacer()
                         if store.twilioSaveInProgress {
@@ -464,7 +465,7 @@ public struct SettingsView: View {
 
                 HStack {
                     TextField("Assign existing number (+1555...)", text: $twilioPhoneNumberText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     Button("Assign") {
                         store.assignTwilioNumber(phoneNumber: twilioPhoneNumberText)
                         twilioPhoneNumberText = ""
@@ -477,9 +478,9 @@ public struct SettingsView: View {
 
                 HStack {
                     TextField("Area code (optional)", text: $twilioAreaCodeText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                     TextField("Country", text: $twilioCountryText)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(VInputStyle())
                         .frame(width: 80)
                     Button("Provision") {
                         store.provisionTwilioNumber(
@@ -556,7 +557,7 @@ public struct SettingsView: View {
 
                 TextField("Public Ingress URL (e.g. https://abc123.ngrok-free.app)", text: $ingressUrlText)
                     .focused($isIngressUrlFocused)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(VInputStyle())
 
                 HStack {
                     Spacer()
@@ -649,7 +650,7 @@ public struct SettingsView: View {
 
                     HStack {
                         TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(VInputStyle())
                         Button("Add") {
                             let domain = newAllowlistDomain
                                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -265,7 +265,7 @@ struct SkillsSettingsView: View {
                     // Browse section (placeholder)
                     Section("Browse") {
                         TextField("Search skills...", text: $searchText)
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(VInputStyle())
 
                         HStack {
                             Image(systemName: "sparkles")

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -47,7 +47,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
                 .padding(VSpacing.sm)
-                .background(VColor.surface)
+                .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
@@ -140,7 +140,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
                 .padding(VSpacing.sm)
-                .background(VColor.surface)
+                .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
@@ -153,7 +153,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
                 .padding(VSpacing.sm)
-                .background(VColor.surface)
+                .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
@@ -180,7 +180,7 @@ struct ToolPermissionTesterView: View {
             .font(VFont.mono)
             .padding(.vertical, VSpacing.xs)
             .padding(.horizontal, VSpacing.sm)
-            .background(VColor.surface)
+            .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.sm)
@@ -194,7 +194,7 @@ struct ToolPermissionTesterView: View {
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: 60, maxHeight: 120)
                 .padding(VSpacing.sm)
-                .background(VColor.surface)
+                .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
@@ -345,7 +345,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
                 .padding(VSpacing.sm)
-                .background(VColor.surface)
+                .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
@@ -366,7 +366,7 @@ struct ToolPermissionTesterView: View {
             .font(VFont.mono)
             .padding(.vertical, VSpacing.xs)
             .padding(.horizontal, VSpacing.sm)
-            .background(VColor.surface)
+            .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.sm)

--- a/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
@@ -35,7 +35,7 @@ public struct VTextEditor: View {
                 .accessibilityLabel(text.isEmpty ? placeholder : text)
         }
         .padding(VSpacing.xs)
-        .background(VColor.surface)
+        .background(VColor.inputBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+/// A TextFieldStyle that matches the design system input background.
+/// Use on raw TextField / SecureField instances: `.textFieldStyle(VInputStyle())`
+public struct VInputStyle: TextFieldStyle {
+    public init() {}
+
+    public func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(VSpacing.md)
+            .background(VColor.inputBackground)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+    }
+}
+
 public struct VTextField: View {
     public let placeholder: String
     @Binding public var text: String
@@ -43,7 +60,7 @@ public struct VTextField: View {
             }
         }
         .padding(VSpacing.md)
-        .background(VColor.surface)
+        .background(VColor.inputBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -130,8 +130,9 @@ public enum VColor {
     public static let backgroundSubtle = adaptiveColor(light: Moss._50, dark: Moss._950)
     public static let chatBackground = adaptiveColor(light: Moss._100, dark: Moss._900)
     public static let surface = adaptiveColor(light: .white, dark: Moss._700)
-    public static let surfaceBorder = adaptiveColor(light: Stone._200, dark: Moss._600)
-    public static let surfaceSubtle = adaptiveColor(light: Stone._50, dark: Moss._900)
+    public static let surfaceBorder = adaptiveColor(light: Moss._100, dark: Moss._600)
+    public static let surfaceSubtle = adaptiveColor(light: Moss._50, dark: Moss._900)
+    public static let inputBackground = adaptiveColor(light: Moss._100, dark: Moss._700)
 
     // Text
     public static let textPrimary = adaptiveColor(light: Stone._900, dark: Moss._50)


### PR DESCRIPTION
## Summary
- Add `VColor.inputBackground` token (`#E8E6DA` light / Moss._700 dark) and `VInputStyle` TextFieldStyle
- Update all settings inputs from white `.roundedBorder` to design system `VInputStyle`
- Update `surfaceBorder` and `surfaceSubtle` light-mode tokens to Moss scale
- Fix app container spacing, rounded corners, and toolbar button alignment
- Remove bottom padding from composer input

## Test plan
- [ ] Open settings — all text fields and secure fields should have `#E8E6DA` background
- [ ] Card components in settings should have `#F5F3EB` background with `#E8E6DA` borders
- [ ] Open an app — no extra spacing between nav and app container, no bottom padding
- [ ] Edit an app — left corners of workspace should be rounded
- [ ] App toolbar top-right corner should be properly rounded
- [ ] Edit button should be flush left, right buttons flush right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
