### PR TITLE
Fix guardian instruction visibility in channel settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1254,20 +1254,19 @@ struct SettingsPanel: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
-                if let instruction {
-                    Text(instruction)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
-                        .textSelection(.enabled)
-                }
+            } else if let instruction {
+                Text(instruction)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+                    .textSelection(.enabled)
             } else {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "shield.slash")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -876,14 +876,13 @@ public struct SettingsView: View {
                     ProgressView().controlSize(.small)
                     Text("Verification in progress...")
                 }
-                if let instruction {
-                    Text(instruction)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .padding(4)
-                        .background(Color.secondary.opacity(0.1))
-                        .cornerRadius(4)
-                }
+            } else if let instruction {
+                Text(instruction)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(4)
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(4)
             } else {
                 HStack {
                     Image(systemName: "shield.slash").foregroundStyle(.secondary)


### PR DESCRIPTION
The guardian verification instruction was gated on inProgress being true, but the IPC response handler clears inProgress before storing the instruction. This meant users never saw the verification instruction after clicking Verify Guardian. Fix by adding a dedicated else-if branch that shows the instruction when present and not yet verified, independent of the inProgress flag. Both SettingsPanel and SettingsView are updated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
