### PR TITLE
Fix guardian deny context to describe full verification flow

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -141,7 +141,7 @@ function buildGuardianDenyContext(
     return `Permission denied: the action "${toolName}" requires guardian approval, but your identity could not be verified on ${sourceChannel}. Do not retry yet. Explain this clearly, ask the user to message from a verifiable direct account/chat, and then retry after identity is available.`;
   }
 
-  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first, and if the user is the guardian/admin, instruct them to run /guardian_verify from an existing ${sourceChannel} chat with the assistant before retrying.`;
+  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first. The guardian/admin should open the Channels section in Settings and click "Verify Guardian", or ask the assistant to set up guardian verification. The setup flow will provide a verification token to send as /guardian_verify <token> in the ${sourceChannel} chat.`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The no_binding denial context told the assistant to instruct users to run /guardian_verify, but that command requires a token from a challenge flow. Updated the context to describe the actual multi-step flow: open Settings > Channels > Verify Guardian, or ask the assistant to set up verification, then use the provided token with /guardian_verify <token>.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
