### PR TITLE
Fix Channels guardian verification spinner hang

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1247,12 +1247,17 @@ struct SettingsPanel: View {
                     }
                 }
             } else if inProgress {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Verification in progress...")
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Generating verification code...")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    Text("You will get a code to send as /guardian_verify <code> from your \(channel == "telegram" ? "Telegram account" : "SMS number").")
                         .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
+                        .foregroundColor(VColor.textMuted)
                 }
             } else if let instruction {
                 Text(instruction)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -149,6 +149,8 @@ public final class SettingsStore: ObservableObject {
     private let twilioAssistantScope = "self"
     private var twilioPhoneRefreshPending = false
     private var twilioNumbersRefreshPending = false
+    private var pendingGuardianChallengeChannel: String?
+    private var guardianChallengeTimeoutWorkItem: DispatchWorkItem?
 
     init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
         self.daemonClient = daemonClient
@@ -322,7 +324,8 @@ public final class SettingsStore: ObservableObject {
         // Wire up guardian verification IPC response
         daemonClient?.onGuardianVerificationResponse = { [weak self] response in
             guard let self else { return }
-            guard let channel = response.channel else { return }
+            guard let channel = self.resolveGuardianResponseChannel(response.channel) else { return }
+            self.clearGuardianChallengePending(for: channel)
 
             switch channel {
             case "telegram":
@@ -785,32 +788,42 @@ public final class SettingsStore: ObservableObject {
         case "telegram":
             telegramGuardianVerificationInProgress = true
             telegramGuardianError = nil
+            telegramGuardianInstruction = nil
         case "sms":
             smsGuardianVerificationInProgress = true
             smsGuardianError = nil
+            smsGuardianInstruction = nil
         default:
             return
         }
         do {
             guard let daemonClient else {
+                clearGuardianChallengePending(for: channel)
                 switch channel {
                 case "telegram":
                     telegramGuardianVerificationInProgress = false
+                    telegramGuardianError = "Daemon is not connected. Reconnect and try again."
                 case "sms":
                     smsGuardianVerificationInProgress = false
+                    smsGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
                 return
             }
+            pendingGuardianChallengeChannel = channel
+            armGuardianChallengeTimeout(for: channel)
             try daemonClient.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: "self")
         } catch {
             log.error("Failed to start \(channel) guardian verification: \(error)")
+            clearGuardianChallengePending(for: channel)
             switch channel {
             case "telegram":
                 telegramGuardianVerificationInProgress = false
+                telegramGuardianError = "Failed to start verification. Try again."
             case "sms":
                 smsGuardianVerificationInProgress = false
+                smsGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -823,6 +836,52 @@ public final class SettingsStore: ObservableObject {
         } catch {
             log.error("Failed to revoke \(channel) guardian: \(error)")
         }
+    }
+
+    private func resolveGuardianResponseChannel(_ channel: String?) -> String? {
+        if let channel {
+            return channel
+        }
+        if let pendingGuardianChallengeChannel {
+            return pendingGuardianChallengeChannel
+        }
+        if telegramGuardianVerificationInProgress != smsGuardianVerificationInProgress {
+            return telegramGuardianVerificationInProgress ? "telegram" : "sms"
+        }
+        return nil
+    }
+
+    private func clearGuardianChallengePending(for channel: String) {
+        if pendingGuardianChallengeChannel == channel {
+            pendingGuardianChallengeChannel = nil
+        }
+        guardianChallengeTimeoutWorkItem?.cancel()
+        guardianChallengeTimeoutWorkItem = nil
+    }
+
+    private func armGuardianChallengeTimeout(for channel: String) {
+        guardianChallengeTimeoutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard self.pendingGuardianChallengeChannel == channel else { return }
+            self.pendingGuardianChallengeChannel = nil
+            switch channel {
+            case "telegram":
+                self.telegramGuardianVerificationInProgress = false
+                if self.telegramGuardianError == nil {
+                    self.telegramGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
+            case "sms":
+                self.smsGuardianVerificationInProgress = false
+                if self.smsGuardianError == nil {
+                    self.smsGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
+            default:
+                break
+            }
+        }
+        guardianChallengeTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 12, execute: workItem)
     }
 
     // MARK: - Ingress Config Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -873,9 +873,14 @@ public struct SettingsView: View {
                     }
                 }
             } else if inProgress {
-                HStack {
-                    ProgressView().controlSize(.small)
-                    Text("Verification in progress...")
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text("Generating verification code...")
+                    }
+                    Text("You will get a code to send as /guardian_verify <code> from your \(channel == "telegram" ? "Telegram account" : "SMS number").")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             } else if let instruction {
                 Text(instruction)

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -239,7 +239,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertFalse(store.smsGuardianVerified)
     }
 
-    func testResponseWithNilChannelIsIgnored() {
+    func testResponseWithNilChannelAndNoPendingStateIsIgnored() {
         daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
             type: "guardian_verification_response",
             success: true,
@@ -257,6 +257,32 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertFalse(store.telegramGuardianVerified)
         XCTAssertNil(store.smsGuardianIdentity)
         XCTAssertFalse(store.smsGuardianVerified)
+    }
+
+    func testResponseWithNilChannelUsesPendingVerificationChannel() {
+        store.startChannelGuardianVerification(channel: "telegram")
+        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: "abc123",
+            instruction: "Send /guardian_verify abc123 on Telegram",
+            bound: false,
+            guardianExternalUserId: nil,
+            channel: nil,
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in !self.store.telegramGuardianVerificationInProgress }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(store.telegramGuardianInstruction, "Send /guardian_verify abc123 on Telegram")
+        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
+        XCTAssertNil(store.telegramGuardianError)
     }
 
     // MARK: - revokeChannelGuardian


### PR DESCRIPTION
## Summary
- fix Channels guardian verification flow getting stuck on loading when guardian responses arrive without `channel`
- add pending-channel fallback and timeout/error handling in `SettingsStore`
- improve in-progress UI copy to tell users what action to take next
- add regression test for nil-channel response handling

## Validation
- `cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsStoreChannelVerificationTests`
- `cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsStoreTelegramTests`

## Original Prompt
"Okay this is all on main now and Im trying to manually test. When I click on the new "Verify Guardian" button on either Telegram or SMS, I just see a loading spinner and nothing else happens. I don't get a text or telegram message and the UI doesn't tell me what to expect or do next. It just sits there with a spinner. Help me fix by following the /do command"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
