### PR TITLE
refactor: consolidate frontmatter parsing into shared utility

### DIFF
--- a/assistant/src/commands/cc-command-registry.ts
+++ b/assistant/src/commands/cc-command-registry.ts
@@ -1,5 +1,6 @@
 import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
+import { FRONTMATTER_REGEX } from '../skills/frontmatter.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('cc-commands');
@@ -27,7 +28,6 @@ export interface CCCommandRegistry {
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const COMMAND_NAME_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
 const DEFAULT_CACHE_TTL_MS = 30_000;
 const MAX_SUMMARY_LENGTH = 100;
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -5,12 +5,11 @@ import { getConfig } from './loader.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { stripCommentLines } from './system-prompt.js';
+import { parseFrontmatterFields } from '../skills/frontmatter.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
 
 const log = getLogger('skills');
-
-const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 // ─── New interfaces for extended skill metadata ──────────────────────────────
 
@@ -266,39 +265,13 @@ function parseIncludes(raw: string | undefined, skillFilePath: string): string[]
 }
 
 function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontmatter | null {
-  const match = content.match(FRONTMATTER_REGEX);
-  if (!match) {
+  const result = parseFrontmatterFields(content);
+  if (!result) {
     log.warn({ skillFilePath }, 'Skipping skill without YAML frontmatter');
     return null;
   }
 
-  const frontmatter = match[1];
-  const fields: Record<string, string> = {};
-  for (const line of frontmatter.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const separatorIndex = trimmed.indexOf(':');
-    if (separatorIndex === -1) continue;
-
-    const key = trimmed.slice(0, separatorIndex).trim();
-    let value = trimmed.slice(separatorIndex + 1).trim();
-    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
-    const isSingleQuoted = value.startsWith('\'') && value.endsWith('\'');
-    if (isDoubleQuoted || isSingleQuoted) {
-      value = value.slice(1, -1);
-      if (isDoubleQuoted) {
-        // Unescape sequences produced by buildSkillMarkdown's esc().
-        // Only for double-quoted values — single-quoted YAML treats backslashes literally.
-        // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
-        value = value.replace(/\\(["\\nr])/g, (_, ch) => {
-          if (ch === 'n') return '\n';
-          if (ch === 'r') return '\r';
-          return ch; // handles \\ → \ and \" → "
-        });
-      }
-    }
-    fields[key] = value;
-  }
+  const { fields, body } = result;
 
   const name = fields.name?.trim();
   const description = fields.description?.trim();
@@ -335,7 +308,7 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
   return {
     name,
     description,
-    body: stripCommentLines(content.slice(match[0].length)),
+    body: stripCommentLines(body),
     homepage,
     userInvocable,
     disableModelInvocation,

--- a/assistant/src/skills/frontmatter.ts
+++ b/assistant/src/skills/frontmatter.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared frontmatter parsing for SKILL.md files.
+ *
+ * Frontmatter is a YAML-like block delimited by `---` at the top of a file.
+ * This module provides a single implementation used by the skill catalog loader,
+ * the Vellum catalog installer, and the CC command registry.
+ */
+
+/** Matches a `---` delimited frontmatter block at the start of a file. */
+export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+export interface FrontmatterParseResult {
+  /** Key-value pairs extracted from the frontmatter block. */
+  fields: Record<string, string>;
+  /** The remaining file content after the frontmatter block. */
+  body: string;
+}
+
+/**
+ * Parse frontmatter fields from file content.
+ *
+ * Extracts key-value pairs from the `---` delimited block at the top of the
+ * file. Handles single- and double-quoted values, and unescapes common escape
+ * sequences (`\n`, `\r`, `\\`, `\"`) in double-quoted values.
+ *
+ * Returns `null` if no frontmatter block is found.
+ */
+export function parseFrontmatterFields(content: string): FrontmatterParseResult | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+  const fields: Record<string, string> = {};
+
+  for (const line of frontmatter.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+
+    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+    const isSingleQuoted = value.startsWith("'") && value.endsWith("'");
+    if (isDoubleQuoted || isSingleQuoted) {
+      value = value.slice(1, -1);
+      if (isDoubleQuoted) {
+        // Unescape sequences produced by buildSkillMarkdown's esc().
+        // Only for double-quoted values — single-quoted YAML treats backslashes literally.
+        // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
+        value = value.replace(/\\(["\\nr])/g, (_, ch) => {
+          if (ch === 'n') return '\n';
+          if (ch === 'r') return '\r';
+          return ch; // handles \\ → \ and \" → "
+        });
+      }
+    }
+    fields[key] = value;
+  }
+
+  return { fields, body: content.slice(match[0].length) };
+}

--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -1,10 +1,9 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolDefinition } from '../../providers/types.js';
+import { parseFrontmatterFields } from '../../skills/frontmatter.js';
 import { createManagedSkill } from '../../skills/managed-store.js';
 import { fetchCatalogEntries, fetchSkillContent, checkVellumSkill } from '../../skills/vellum-catalog-remote.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-
-const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 export interface CatalogEntry {
   id: string;
@@ -36,26 +35,12 @@ export async function installFromVellumCatalog(skillId: string, options?: { over
     return { success: false, error: `Skill "${trimmedId}" SKILL.md not found` };
   }
 
-  const match = content.match(FRONTMATTER_REGEX);
-  if (!match) {
+  const parsed = parseFrontmatterFields(content);
+  if (!parsed) {
     return { success: false, error: `Skill "${trimmedId}" has invalid SKILL.md` };
   }
 
-  // Parse frontmatter to get name/description/emoji/includes
-  const fields: Record<string, string> = {};
-  for (const line of match[1].split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const separatorIndex = trimmed.indexOf(':');
-    if (separatorIndex === -1) continue;
-
-    const key = trimmed.slice(0, separatorIndex).trim();
-    let value = trimmed.slice(separatorIndex + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    fields[key] = value;
-  }
+  const { fields, body: bodyMarkdown } = parsed;
 
   const name = fields.name?.trim();
   const description = fields.description?.trim();
@@ -67,9 +52,9 @@ export async function installFromVellumCatalog(skillId: string, options?: { over
   const metadataRaw = fields.metadata?.trim();
   if (metadataRaw) {
     try {
-      const parsed = JSON.parse(metadataRaw);
-      if (parsed?.vellum?.emoji) {
-        emoji = parsed.vellum.emoji as string;
+      const metaObj = JSON.parse(metadataRaw);
+      if (metaObj?.vellum?.emoji) {
+        emoji = metaObj.vellum.emoji as string;
       }
     } catch {
       // ignore malformed metadata
@@ -80,17 +65,15 @@ export async function installFromVellumCatalog(skillId: string, options?: { over
   const includesRaw = fields.includes?.trim();
   if (includesRaw) {
     try {
-      const parsed = JSON.parse(includesRaw);
-      if (Array.isArray(parsed) && parsed.every((item: unknown) => typeof item === 'string')) {
-        const filtered = (parsed as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
+      const includesObj = JSON.parse(includesRaw);
+      if (Array.isArray(includesObj) && includesObj.every((item: unknown) => typeof item === 'string')) {
+        const filtered = (includesObj as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
         if (filtered.length > 0) includes = filtered;
       }
     } catch {
       // ignore malformed includes
     }
   }
-
-  const bodyMarkdown = content.slice(match[0].length);
   const result = createManagedSkill({
     id: trimmedId,
     name,


### PR DESCRIPTION
## Summary
- Extract `FRONTMATTER_REGEX` and key-value parsing logic into `assistant/src/skills/frontmatter.ts`
- Update `skills.ts` and `vellum-catalog.ts` to use `parseFrontmatterFields()` instead of inline parsing
- Update `cc-command-registry.ts` to import the shared `FRONTMATTER_REGEX` instead of defining its own copy
- `vellum-catalog.ts` gains double-quote escape handling it previously lacked

## Original prompt
Consolidate frontmatter parsing — SKILL.md frontmatter is parsed independently in both vellum-catalog.ts and skills.ts with separate regex implementations. Extract to a single parseFrontmatter() utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
