### PR TITLE
refactor: consolidate strip functions into declarative pipeline

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -31,10 +31,7 @@ import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
 import {
   applyRuntimeInjections,
-  stripActiveSurfaceContext,
-  stripWorkspaceTopLevelContext,
-  stripChannelCapabilityContext,
-  stripTemporalContext,
+  stripInjectedContext,
 } from './session-runtime-assembly.js';
 import { buildTemporalContext } from './date-context.js';
 import type { ActiveSurfaceContext, ChannelCapabilities } from './session-runtime-assembly.js';
@@ -740,16 +737,10 @@ export async function runAgentLoopImpl(
     }
 
     const restoredHistory = [...preRepairMessages, ...newMessages];
-    const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-    ctx.messages = stripTemporalContext(
-      stripChannelCapabilityContext(
-        stripWorkspaceTopLevelContext(
-          stripActiveSurfaceContext(
-            stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
-          ),
-        ),
-      ),
-    );
+    ctx.messages = stripInjectedContext(restoredHistory, {
+      stripRecall: (msgs) => stripMemoryRecallMessages(msgs, recall.injectedText, recallInjectionStrategy),
+      stripDynamicProfile: (msgs) => stripDynamicProfileMessages(msgs, dynamicProfile.text),
+    });
 
     emitUsage(ctx, exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
 

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -264,21 +264,38 @@ export function injectChannelCapabilityContext(message: Message, caps: ChannelCa
   };
 }
 
+// ---------------------------------------------------------------------------
+// Prefix-based stripping primitive
+// ---------------------------------------------------------------------------
+
 /**
- * Strip `<channel_capabilities>` blocks injected by
- * `injectChannelCapabilityContext`.
+ * Remove text blocks from user messages whose text starts with any of the
+ * given prefixes.  If stripping removes all content blocks from a message,
+ * the message itself is dropped.
+ *
+ * This is the shared primitive behind the individual strip* functions and
+ * the `stripInjectedContext` pipeline.
  */
-export function stripChannelCapabilityContext(messages: Message[]): Message[] {
+export function stripUserTextBlocksByPrefix(messages: Message[], prefixes: string[]): Message[] {
   return messages.map((message) => {
     if (message.role !== 'user') return message;
     const nextContent = message.content.filter((block) => {
       if (block.type !== 'text') return true;
-      return !block.text.startsWith('<channel_capabilities>');
+      return !prefixes.some((p) => block.text.startsWith(p));
     });
     if (nextContent.length === message.content.length) return message;
     if (nextContent.length === 0) return null;
     return { ...message, content: nextContent };
   }).filter((message): message is NonNullable<typeof message> => message !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Individual strip functions (thin wrappers around the primitive)
+// ---------------------------------------------------------------------------
+
+/** Strip `<channel_capabilities>` blocks injected by `injectChannelCapabilityContext`. */
+export function stripChannelCapabilityContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ['<channel_capabilities>']);
 }
 
 /**
@@ -294,22 +311,9 @@ export function injectWorkspaceTopLevelContext(message: Message, contextText: st
   };
 }
 
-/**
- * Strip `<workspace_top_level>` blocks injected by
- * `injectWorkspaceTopLevelContext`.  Called after the agent run to prevent
- * workspace context from persisting in session history.
- */
+/** Strip `<workspace_top_level>` blocks injected by `injectWorkspaceTopLevelContext`. */
 export function stripWorkspaceTopLevelContext(messages: Message[]): Message[] {
-  return messages.map((message) => {
-    if (message.role !== 'user') return message;
-    const nextContent = message.content.filter((block) => {
-      if (block.type !== 'text') return true;
-      return !block.text.startsWith('<workspace_top_level>');
-    });
-    if (nextContent.length === message.content.length) return message;
-    if (nextContent.length === 0) return null;
-    return { ...message, content: nextContent };
-  }).filter((message): message is NonNullable<typeof message> => message !== null);
+  return stripUserTextBlocksByPrefix(messages, ['<workspace_top_level>']);
 }
 
 /**
@@ -328,8 +332,6 @@ export function injectTemporalContext(message: Message, temporalContext: string)
 
 /**
  * Strip `<temporal_context>` blocks injected by `injectTemporalContext`.
- * Called after the agent run to prevent temporal context from persisting
- * in session history.
  *
  * Uses a specific prefix (`<temporal_context>\nToday:`) so that
  * user-authored text that happens to start with `<temporal_context>`
@@ -338,35 +340,49 @@ export function injectTemporalContext(message: Message, temporalContext: string)
 const TEMPORAL_INJECTED_PREFIX = '<temporal_context>\nToday:';
 
 export function stripTemporalContext(messages: Message[]): Message[] {
-  return messages.map((message) => {
-    if (message.role !== 'user') return message;
-    const nextContent = message.content.filter((block) => {
-      if (block.type !== 'text') return true;
-      return !block.text.startsWith(TEMPORAL_INJECTED_PREFIX);
-    });
-    if (nextContent.length === message.content.length) return message;
-    if (nextContent.length === 0) return null;
-    return { ...message, content: nextContent };
-  }).filter((message): message is NonNullable<typeof message> => message !== null);
+  return stripUserTextBlocksByPrefix(messages, [TEMPORAL_INJECTED_PREFIX]);
 }
 
 /**
  * Strip `<active_workspace>` (and legacy `<active_dynamic_page>`) blocks
- * injected by `injectActiveSurfaceContext`.  Called after the agent run to
- * prevent the (potentially 100 KB) surface HTML from persisting in session
- * history.
+ * injected by `injectActiveSurfaceContext`.
  */
 export function stripActiveSurfaceContext(messages: Message[]): Message[] {
-  return messages.map((message) => {
-    if (message.role !== 'user') return message;
-    const nextContent = message.content.filter((block) => {
-      if (block.type !== 'text') return true;
-      return !block.text.startsWith('<active_workspace>') && !block.text.startsWith('<active_dynamic_page>');
-    });
-    if (nextContent.length === message.content.length) return message;
-    if (nextContent.length === 0) return null;
-    return { ...message, content: nextContent };
-  }).filter((message): message is NonNullable<typeof message> => message !== null);
+  return stripUserTextBlocksByPrefix(messages, ['<active_workspace>', '<active_dynamic_page>']);
+}
+
+// ---------------------------------------------------------------------------
+// Declarative strip pipeline
+// ---------------------------------------------------------------------------
+
+/** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
+const RUNTIME_INJECTION_PREFIXES = [
+  '<channel_capabilities>',
+  '<workspace_top_level>',
+  TEMPORAL_INJECTED_PREFIX,
+  '<active_workspace>',
+  '<active_dynamic_page>',
+];
+
+/**
+ * Strip all runtime-injected context from message history in a single pass.
+ *
+ * Composes:
+ * 1. `stripMemoryRecallMessages` (caller-supplied, handles its own logic)
+ * 2. `stripDynamicProfileMessages` (caller-supplied, handles its own logic)
+ * 3. Prefix-based stripping for channel capabilities, workspace top-level,
+ *    temporal context, and active surface context (single pass).
+ */
+export function stripInjectedContext(
+  messages: Message[],
+  options: {
+    stripRecall: (msgs: Message[]) => Message[];
+    stripDynamicProfile: (msgs: Message[]) => Message[];
+  },
+): Message[] {
+  const afterRecall = options.stripRecall(messages);
+  const afterProfile = options.stripDynamicProfile(afterRecall);
+  return stripUserTextBlocksByPrefix(afterProfile, RUNTIME_INJECTION_PREFIXES);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extract `stripUserTextBlocksByPrefix` primitive that captures the shared pattern across 4 identical strip functions (channel capabilities, workspace top-level, temporal context, active surface)
- Add `stripInjectedContext` pipeline that composes all 6 strip operations (memory recall, dynamic profile, and prefix-based) into a single declarative call
- Replace the nested 5-deep strip call chain in `session-agent-loop.ts` with the pipeline

## Original prompt
Consolidate message history strip functions — 6+ ordering-dependent strip functions (stripOldImageBlocks, stripMemoryRecallMessages, stripDynamicProfileMessages, stripActiveSurfaceContext, stripWorkspaceTopLevelContext, stripChannelCapabilityContext, stripTemporalContext) should be composed into a single declarative transformation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
