### PR TITLE
fix: validate IPC socket permissions and lock down ~/.vellum root dir

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import * as tls from 'node:tls';
 import { randomBytes } from 'node:crypto';
-import { existsSync, chmodSync, readFileSync, writeFileSync, readdirSync, watch, type FSWatcher } from 'node:fs';
+import { existsSync, chmodSync, statSync, readFileSync, writeFileSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 import { getSocketPath, getSessionTokenPath, getRootDir, getWorkspaceDir, getWorkspaceSkillsDir, getSandboxWorkingDir, removeSocketFile, getTCPPort, getTCPHost, isTCPEnabled, isIOSPairingEnabled } from '../util/platform.js';
 import { ensureTlsCert } from './tls-certs.js';
@@ -259,6 +259,16 @@ export class DaemonServer {
           log.error({ err, socketPath: this.socketPath }, 'Server socket error while running');
         });
         chmodSync(this.socketPath, 0o600);
+        // Validate the chmod actually took effect — some filesystems
+        // (e.g. FAT32 mounts, container overlays) silently ignore chmod.
+        const socketStat = statSync(this.socketPath);
+        if ((socketStat.mode & 0o077) !== 0) {
+          const actual = '0o' + (socketStat.mode & 0o777).toString(8);
+          log.error(
+            { socketPath: this.socketPath, mode: actual },
+            'IPC socket is accessible by other users (expected 0600) — filesystem may not support Unix permissions',
+          );
+        }
         log.info({ socketPath: this.socketPath }, 'Daemon server listening');
 
         // Start TLS-encrypted TCP listener for iOS clients (alongside the Unix socket)

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync, readdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 /**
@@ -564,6 +564,13 @@ export function ensureDataDir(): void {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
+  }
+  // Lock down the root directory so only the owner can traverse it.
+  // Runtime files (socket, session token, PID) live directly under root.
+  try {
+    chmodSync(root, 0o700);
+  } catch {
+    // Non-fatal: some filesystems don't support Unix permissions
   }
 }
 


### PR DESCRIPTION
## Summary
- Add post-creation permission validation on the IPC socket — logs an error if chmod to 0600 didn't take effect (e.g. on filesystems that don't support Unix permissions)
- Lock down the ~/.vellum root directory to 0700 in ensureDataDir() so runtime files (socket, session token, PID) aren't world-readable

## Original prompt
Validate IPC socket permissions — Unix socket at ~/.vellum/vellum.sock has no visible permission validation ensuring it's not world-readable (should be 0600).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
