### PR TITLE
feat: add Go to Settings button to iOS disconnect empty states

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -53,6 +53,11 @@ struct ContentView: View {
         }
     }
 
+    private func navigateToConnectSettings() {
+        selectedTab = .settings
+        navigateToConnect = true
+    }
+
     // MARK: - Initial Connection
 
     private func attemptInitialConnection() async {
@@ -112,9 +117,8 @@ struct ContentView: View {
                 .tint(VColor.accent)
 
                 Button {
-                    selectedTab = .settings
                     connectPhase = .ready
-                    navigateToConnect = true
+                    navigateToConnectSettings()
                 } label: {
                     Text("Go to Settings")
                 }
@@ -129,7 +133,7 @@ struct ContentView: View {
 
     private var tabContent: some View {
         TabView(selection: $selectedTab) {
-            HomeBaseView()
+            HomeBaseView(onConnectTapped: navigateToConnectSettings)
                 .environmentObject(clientProvider)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
                 .tag(Tab.home)
@@ -144,7 +148,7 @@ struct ContentView: View {
                     Label("Chats", systemImage: "message")
                 }
 
-            IdentityView()
+            IdentityView(onConnectTapped: navigateToConnectSettings)
                 .environmentObject(clientProvider)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
                 .tag(Tab.identity)

--- a/clients/ios/Views/HomeBaseView.swift
+++ b/clients/ios/Views/HomeBaseView.swift
@@ -57,6 +57,7 @@ final class HomeBaseViewModel {
 struct HomeBaseView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @State private var viewModel = HomeBaseViewModel()
+    var onConnectTapped: (() -> Void)?
 
     var body: some View {
         NavigationStack {
@@ -281,6 +282,15 @@ struct HomeBaseView: View {
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
+
+            if onConnectTapped != nil {
+                Button {
+                    onConnectTapped?()
+                } label: {
+                    Text("Go to Settings")
+                }
+                .buttonStyle(.bordered)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -92,6 +92,7 @@ struct IdentityView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @State private var viewModel = IdentityViewModel()
     @State private var viewingFile: WorkspaceFileInfo?
+    var onConnectTapped: (() -> Void)?
 
     var body: some View {
         NavigationStack {
@@ -411,6 +412,15 @@ struct IdentityView: View {
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
+
+            if onConnectTapped != nil {
+                Button {
+                    onConnectTapped?()
+                } label: {
+                    Text("Go to Settings")
+                }
+                .buttonStyle(.bordered)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }


### PR DESCRIPTION
## Summary
- Adds a "Go to Settings" button to the "Connect to Your Mac" empty states on the Home and Identity tabs
- Tapping the button switches to the Settings tab and navigates directly into the Connect sub-page
- Reuses the existing `navigateToConnect` binding mechanism already in SettingsView

## Implementation
- Added `navigateToConnectSettings()` helper to ContentView that sets `selectedTab = .settings` and `navigateToConnect = true`
- Passed this as an `onConnectTapped` closure to HomeBaseView and IdentityView
- Both views show a "Go to Settings" bordered button when the closure is provided
- Existing `connectionFailedView` in ContentView also refactored to use the same helper

## Files Changed
- `clients/ios/Views/ContentView.swift` — navigation helper, passes closure to child views
- `clients/ios/Views/HomeBaseView.swift` — optional `onConnectTapped` closure, button in disconnect state
- `clients/ios/Views/IdentityView.swift` — same pattern as HomeBaseView

## Test Plan
- [ ] Launch iOS app without a connection configured
- [ ] Verify Home tab shows "Connect to Your Mac" with a "Go to Settings" button
- [ ] Tap the button — verify it switches to Settings tab and pushes the Connect page
- [ ] Navigate back, switch to Identity tab — verify same button appears
- [ ] Tap it — verify same navigation behavior
- [ ] Verify the connection failed screen still works (Retry + Go to Settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
