### PR TITLE
feat: add memory recall cache for repeated context

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -7,6 +7,7 @@ import { getDb } from './db.js';
 import { enqueueMemoryJob, enqueueResolvePendingConflictsForMessageJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { segmentText } from './segmenter.js';
+import { bumpMemoryVersion } from './recall-cache.js';
 import { memorySegments } from './schema.js';
 
 const log = getLogger('memory-indexer');
@@ -108,6 +109,7 @@ export function indexMessageNow(
     log.debug(`Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`);
   }
 
+  bumpMemoryVersion();
   enqueueSummaryRollupJobsIfDue();
 
   const enqueuedJobs = (segments.length - skippedEmbedJobs) + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -18,6 +18,7 @@ import {
   retryDelayForAttempt,
   RETRY_MAX_ATTEMPTS,
 } from './job-utils.js';
+import { bumpMemoryVersion } from './recall-cache.js';
 
 // ── Per-job-type handlers ──────────────────────────────────────────
 
@@ -121,6 +122,7 @@ export async function runMemoryJobsOnce(
           try {
             await processJob(job, config);
             completeMemoryJob(job.id);
+            bumpMemoryVersion();
             groupProcessed += 1;
           } catch (err) {
             try {

--- a/assistant/src/memory/recall-cache.ts
+++ b/assistant/src/memory/recall-cache.ts
@@ -1,0 +1,90 @@
+import { createHash } from 'crypto';
+import type { MemoryRecallResult, MemoryRecallOptions } from './search/types.js';
+
+/**
+ * In-memory cache for memory recall results.
+ *
+ * The full retrieval pipeline (FTS5 + Qdrant + entity graph + RRF merge) is
+ * expensive. When the same query is issued multiple turns in a row (common
+ * when the conversation context hasn't changed), we can serve the cached
+ * result instantly.
+ *
+ * Invalidation: a monotonic version counter is bumped whenever new memory
+ * is indexed (segments, items, embeddings). Cache entries are only valid
+ * when their version matches the current global version.
+ */
+
+interface CacheEntry {
+  version: number;
+  createdAt: number;
+  result: MemoryRecallResult;
+}
+
+const MAX_ENTRIES = 32;
+const TTL_MS = 60_000; // 60 seconds
+
+let _version = 0;
+const _cache = new Map<string, CacheEntry>();
+
+/** Bump the global memory version, invalidating all cached recall results. */
+export function bumpMemoryVersion(): void {
+  _version++;
+}
+
+/** Build a deterministic cache key from the recall inputs. */
+function buildCacheKey(
+  query: string,
+  conversationId: string,
+  options?: MemoryRecallOptions,
+): string {
+  const parts = [
+    query,
+    conversationId,
+    options?.scopeId ?? '',
+    options?.scopePolicyOverride
+      ? `${options.scopePolicyOverride.scopeId}:${options.scopePolicyOverride.fallbackToDefault}`
+      : '',
+    options?.excludeMessageIds ? [...options.excludeMessageIds].sort().join(',') : '',
+    options?.maxInjectTokensOverride != null ? String(options.maxInjectTokensOverride) : '',
+  ];
+  return createHash('sha256').update(parts.join('\0')).digest('hex');
+}
+
+/** Look up a cached recall result. Returns undefined on miss or stale entry. */
+export function getCachedRecall(
+  query: string,
+  conversationId: string,
+  options?: MemoryRecallOptions,
+): MemoryRecallResult | undefined {
+  const key = buildCacheKey(query, conversationId, options);
+  const entry = _cache.get(key);
+  if (!entry) return undefined;
+  if (entry.version !== _version || Date.now() - entry.createdAt > TTL_MS) {
+    _cache.delete(key);
+    return undefined;
+  }
+  return entry.result;
+}
+
+/** Store a recall result in the cache. Evicts oldest entries when full. */
+export function setCachedRecall(
+  query: string,
+  conversationId: string,
+  options: MemoryRecallOptions | undefined,
+  result: MemoryRecallResult,
+): void {
+  const key = buildCacheKey(query, conversationId, options);
+
+  // Evict oldest entries if at capacity
+  if (_cache.size >= MAX_ENTRIES && !_cache.has(key)) {
+    const oldest = _cache.keys().next().value;
+    if (oldest !== undefined) _cache.delete(oldest);
+  }
+
+  _cache.set(key, { version: _version, createdAt: Date.now(), result });
+}
+
+/** Clear the entire cache (useful for testing). */
+export function clearRecallCache(): void {
+  _cache.clear();
+}

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -19,6 +19,7 @@ import { semanticSearch, isQdrantConnectionError } from './search/semantic.js';
 import { entitySearch } from './search/entity.js';
 import { mergeCandidates, applySourceCaps, rerankWithLLM, trimToTokenBudget, markItemUsage } from './search/ranking.js';
 import { buildInjectedText, MEMORY_CONTEXT_ACK } from './search/formatting.js';
+import { getCachedRecall, setCachedRecall } from './recall-cache.js';
 
 // Re-export public types and functions so existing importers continue to work
 export type {
@@ -234,6 +235,14 @@ export async function buildMemoryRecall(
     return emptyResult({ enabled: true, degraded: false, reason: 'memory.aborted', latencyMs: Date.now() - start });
   }
 
+  // Check recall cache — serves identical results instantly when the query
+  // and memory state haven't changed since the last recall.
+  const cached = getCachedRecall(query, conversationId, options);
+  if (cached) {
+    log.debug({ query: truncate(query, 120), latencyMs: Date.now() - start }, 'Memory recall served from cache');
+    return { ...cached, latencyMs: Date.now() - start };
+  }
+
   const backendStatus = getMemoryBackendStatus(config);
   let queryVector: number[] | null = null;
   let provider: string | undefined;
@@ -395,7 +404,7 @@ export async function buildMemoryRecall(
     latencyMs,
   }, 'Memory recall completed');
 
-  return {
+  const result: MemoryRecallResult = {
     enabled: true,
     degraded,
     reason,
@@ -418,6 +427,9 @@ export async function buildMemoryRecall(
     latencyMs,
     topCandidates,
   };
+
+  setCachedRecall(query, conversationId, options, result);
+  return result;
 }
 
 export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(


### PR DESCRIPTION
## Summary

- Add `recall-cache.ts` with version-gated in-memory cache (32 entries, 60s TTL) for `buildMemoryRecall` results
- Cache key is a SHA-256 of query + conversationId + scope + excludeMessageIds + maxInjectTokensOverride
- Invalidation via `bumpMemoryVersion()` called from `indexMessageNow` (new segments) and the jobs worker (embedding/extraction/cleanup job completion)
- Cache hits return instantly with fresh `latencyMs`, skipping the entire retrieval pipeline

## Original prompt
Add memory recall cache for repeated context — Every turn re-computes the full retrieval pipeline (FTS5 + Qdrant + entity graph + RRF merge) even when conversation context hasn't changed. Cache recent recall results with invalidation on new memory items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
