### PR TITLE
fix: harden webhook replay prevention with high-water mark and longer nonce TTL

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -125,6 +125,48 @@ describe("DedupCache", () => {
 
     expect(shortCache.reserve(90)).toBe(true);
   });
+
+  test("high-water mark rejects update_ids at or below the max finalized", () => {
+    cache.reserve(100);
+    cache.set(100, '{"ok":true}', 200);
+
+    // update_id below the high-water mark is permanently rejected
+    expect(cache.reserve(99)).toBe(false);
+    // same update_id is also rejected (even if TTL entry expired)
+    expect(cache.reserve(100)).toBe(false);
+    // update_id above the high-water mark is accepted
+    expect(cache.reserve(101)).toBe(true);
+  });
+
+  test("high-water mark persists after cache TTL expires", () => {
+    const shortCache = new DedupCache(1, 100);
+    shortCache.reserve(50);
+    shortCache.set(50, '{"ok":true}', 200);
+
+    // Wait for the TTL entry to expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+
+    // TTL entry is gone, but high-water mark still blocks replay
+    expect(shortCache.get(50)).toBeUndefined();
+    expect(shortCache.reserve(50)).toBe(false);
+    expect(shortCache.reserve(49)).toBe(false);
+    // Higher ID still works
+    expect(shortCache.reserve(51)).toBe(true);
+  });
+
+  test("high-water mark advances to the max across non-sequential sets", () => {
+    cache.set(200, "a", 200);
+    cache.set(100, "b", 200);
+    cache.set(150, "c", 200);
+
+    // High-water mark should be 200 (the max), not 150 (the last set)
+    expect(cache.reserve(199)).toBe(false);
+    expect(cache.reserve(200)).toBe(false);
+    expect(cache.reserve(201)).toBe(true);
+  });
 });
 
 describe("StringDedupCache", () => {

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -19,6 +19,14 @@ export class DedupCache {
   private cache = new Map<number, CacheEntry>();
   private readonly ttlMs: number;
   private readonly maxSize: number;
+  /**
+   * Monotonic high-water mark: the highest update_id that has been fully
+   * processed (finalized via set()). Any update_id at or below this value
+   * is rejected permanently, even after the TTL cache evicts the entry.
+   * This closes the replay window that existed when entries expired from
+   * the TTL cache.
+   */
+  private highWaterMark = -Infinity;
 
   constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
     this.ttlMs = ttlMs;
@@ -53,6 +61,12 @@ export class DedupCache {
    * finalized cache hit and respond accordingly (e.g. 503 Retry-After).
    */
   reserve(updateId: number): boolean {
+    // Reject any update_id at or below the high-water mark — these have
+    // already been fully processed and are replay attempts.
+    if (updateId <= this.highWaterMark) {
+      return false;
+    }
+
     const existing = this.cache.get(updateId);
     if (existing && Date.now() <= existing.expiresAt) {
       return false;
@@ -88,8 +102,14 @@ export class DedupCache {
     }
   }
 
-  /** Store a response for the given update_id. */
+  /** Store a response for the given update_id and advance the high-water mark. */
   set(updateId: number, body: string, status: number): void {
+    // Advance monotonic high-water mark so this update_id (and all lower
+    // ones) are permanently rejected even after the TTL cache evicts them.
+    if (updateId > this.highWaterMark) {
+      this.highWaterMark = updateId;
+    }
+
     // Evict expired entries if we're at capacity
     if (this.cache.size >= this.maxSize) {
       this.evictExpired();

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -58,7 +58,9 @@ function normalizeSmsPayload(
 }
 
 export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
-  const dedupCache = new StringDedupCache();
+  // 24-hour TTL — MessageSids are globally unique and never reused, so a
+  // longer window hardens replay prevention beyond the default 5 minutes.
+  const dedupCache = new StringDedupCache(24 * 60 * 60_000);
 
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;


### PR DESCRIPTION
## Summary
- **Telegram**: Added monotonic high-water mark to `DedupCache` — tracks the max finalized `update_id` and permanently rejects any `update_id` at or below it, even after TTL cache entries expire. Closes the 5-minute replay window.
- **Twilio SMS**: Increased `StringDedupCache` TTL from 5 minutes to 24 hours. Since `MessageSid` values are globally unique and never reused, the longer window hardens replay prevention without requiring a persistent store.
- Added tests for high-water mark: persistence after TTL expiry, non-sequential ID ordering, and boundary conditions.

## Original prompt
Harden webhook replay prevention — Telegram dedup cache allows replay within 5-minute cooldown window. Twilio HMAC validation present but no request body replay prevention. Add nonces or tighter expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
