### PR TITLE
feat: add encoded secret detection (decode + re-scan pass)

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -6,6 +6,10 @@ import {
   _isPlaceholder,
   _redact,
   _hasSecretContext,
+  _tryDecodeBase64,
+  _tryDecodePercentEncoded,
+  _tryDecodeHexEscapes,
+  _tryDecodeContinuousHex,
   type SecretMatch,
 } from '../security/secret-scanner.js';
 
@@ -896,5 +900,224 @@ describe('word-boundary context keywords', () => {
     const matches = scanText(input);
     const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
     expect(entropy.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Encoded secret detection — decode + re-scan
+// ---------------------------------------------------------------------------
+describe('encoded secret detection', () => {
+  // -- Base64-encoded secrets --
+  describe('base64-encoded', () => {
+    test('detects base64-encoded Stripe key', () => {
+      const secret = 'sk_live_abcdefghijklmnopqrstuvwx';
+      const encoded = Buffer.from(secret).toString('base64');
+      const input = `config: ${encoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'Stripe Secret Key (base64-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('detects base64-encoded GitHub token', () => {
+      const secret = `ghp_${'A'.repeat(36)}`;
+      const encoded = Buffer.from(secret).toString('base64');
+      const input = `value=${encoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'GitHub Token (base64-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('detects base64-encoded private key header', () => {
+      const secret = '-----BEGIN RSA PRIVATE KEY-----';
+      const encoded = Buffer.from(secret).toString('base64');
+      const input = `data: ${encoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'Private Key (base64-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('does not flag base64 that decodes to non-secret text', () => {
+      const encoded = Buffer.from('Hello, this is just normal text!').toString('base64');
+      const input = `data: ${encoded}`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('base64-encoded'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+
+    test('does not flag base64 that decodes to binary data', () => {
+      // Create a base64 string that decodes to non-printable bytes
+      const binary = Buffer.from([0x00, 0x01, 0x02, 0x80, 0xff, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15]);
+      const encoded = binary.toString('base64');
+      const input = `data: ${encoded}`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('base64-encoded'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+
+    test('does not double-count secrets already detected by raw patterns', () => {
+      // A JWT is already detected directly — should not be re-detected as base64-encoded
+      const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+      const payload = 'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ';
+      const signature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const jwt = `${header}.${payload}.${signature}`;
+      const input = `token: ${jwt}`;
+      const matches = scanText(input);
+      const jwtMatches = matches.filter((m) => m.type === 'JSON Web Token');
+      const encodedMatches = matches.filter((m) => m.type.includes('base64-encoded'));
+      expect(jwtMatches).toHaveLength(1);
+      expect(encodedMatches).toHaveLength(0);
+    });
+  });
+
+  // -- Percent-encoded secrets --
+  describe('percent-encoded', () => {
+    test('detects percent-encoded database connection string', () => {
+      const secret = 'postgres://user:secret@db.example.com:5432/mydb';
+      const encoded = encodeURIComponent(secret);
+      const input = `url=${encoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'Database Connection String (percent-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('detects percent-encoded secret assignment', () => {
+      const encoded = 'password%3D%22SuperSecret123%21%22';
+      const input = `data=${encoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type.includes('percent-encoded'));
+      expect(found).toBeDefined();
+    });
+
+    test('does not flag percent-encoded non-secret text', () => {
+      const encoded = 'hello%20world%20this%20is%20normal';
+      const input = `text=${encoded}`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('percent-encoded'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+  });
+
+  // -- Hex-escaped secrets --
+  describe('hex-escaped', () => {
+    test('detects hex-escaped Stripe key', () => {
+      const secret = 'sk_live_abcdefghijklmnopqrstuvwx';
+      const escaped = Array.from(secret).map((c) => `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`).join('');
+      const input = `value = "${escaped}"`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'Stripe Secret Key (hex-escaped)');
+      expect(found).toBeDefined();
+    });
+
+    test('does not flag hex-escaped non-secret text', () => {
+      const escaped = '\\x48\\x65\\x6c\\x6c\\x6f';
+      const input = `value = "${escaped}"`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('hex-escaped'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+  });
+
+  // -- Continuous hex-encoded secrets --
+  describe('hex-encoded (continuous)', () => {
+    test('detects hex-encoded GitHub token', () => {
+      const secret = `ghp_${'A'.repeat(36)}`;
+      const hexEncoded = Buffer.from(secret).toString('hex');
+      const input = `payload: ${hexEncoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'GitHub Token (hex-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('detects hex-encoded AWS access key', () => {
+      const secret = 'AKIAIOSFODNN7REALKEY';
+      const hexEncoded = Buffer.from(secret).toString('hex');
+      const input = `data: ${hexEncoded}`;
+      const matches = scanText(input);
+      const found = matches.find((m) => m.type === 'AWS Access Key (hex-encoded)');
+      expect(found).toBeDefined();
+    });
+
+    test('does not flag hex strings that decode to non-secret text', () => {
+      const hexEncoded = Buffer.from('This is just normal harmless text').toString('hex');
+      const input = `data: ${hexEncoded}`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('hex-encoded'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+
+    test('does not flag git SHAs or similar hex hashes', () => {
+      // 40-char hex SHA — too short to decode to a meaningful secret
+      const sha = '4b825dc642cb6eb9a060e54bf899d15f13fe1d7a';
+      const input = `commit: ${sha}`;
+      const matches = scanText(input);
+      const encoded_matches = matches.filter((m) => m.type.includes('hex-encoded'));
+      expect(encoded_matches).toHaveLength(0);
+    });
+  });
+
+  // -- Redaction of encoded secrets --
+  describe('redaction of encoded secrets', () => {
+    test('redactSecrets replaces base64-encoded secrets', () => {
+      const secret = 'sk_live_abcdefghijklmnopqrstuvwx';
+      const encoded = Buffer.from(secret).toString('base64');
+      const input = `config: ${encoded}`;
+      const result = redactSecrets(input);
+      expect(result).toContain('<redacted type="Stripe Secret Key (base64-encoded)" />');
+      expect(result).not.toContain(encoded);
+    });
+
+    test('redactSecrets replaces hex-encoded secrets', () => {
+      const secret = `ghp_${'A'.repeat(36)}`;
+      const hexEncoded = Buffer.from(secret).toString('hex');
+      const input = `data: ${hexEncoded}`;
+      const result = redactSecrets(input);
+      expect(result).toContain('<redacted type="GitHub Token (hex-encoded)" />');
+      expect(result).not.toContain(hexEncoded);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decode helper unit tests
+// ---------------------------------------------------------------------------
+describe('decode helpers', () => {
+  test('tryDecodeBase64 returns decoded text for valid base64', () => {
+    const encoded = Buffer.from('sk_live_abcdefghijklmnopqrstuvwx').toString('base64');
+    expect(_tryDecodeBase64(encoded)).toBe('sk_live_abcdefghijklmnopqrstuvwx');
+  });
+
+  test('tryDecodeBase64 returns null for binary content', () => {
+    const binary = Buffer.from([0x00, 0x01, 0x80, 0xff]).toString('base64');
+    expect(_tryDecodeBase64(binary)).toBeNull();
+  });
+
+  test('tryDecodeBase64 returns null for invalid base64', () => {
+    expect(_tryDecodeBase64('not!!valid!!base64!!')).toBeNull();
+  });
+
+  test('tryDecodePercentEncoded returns decoded text', () => {
+    expect(_tryDecodePercentEncoded('hello%20world%21')).toBe('hello world!');
+  });
+
+  test('tryDecodePercentEncoded returns null when nothing to decode', () => {
+    expect(_tryDecodePercentEncoded('no-encoding-here')).toBeNull();
+  });
+
+  test('tryDecodeHexEscapes returns decoded text', () => {
+    expect(_tryDecodeHexEscapes('\\x48\\x65\\x6c\\x6c\\x6f')).toBe('Hello');
+  });
+
+  test('tryDecodeHexEscapes returns null when no escapes', () => {
+    expect(_tryDecodeHexEscapes('plain text')).toBeNull();
+  });
+
+  test('tryDecodeContinuousHex returns decoded text', () => {
+    const hex = Buffer.from('Hello').toString('hex');
+    expect(_tryDecodeContinuousHex(hex)).toBe('Hello');
+  });
+
+  test('tryDecodeContinuousHex returns null for non-printable result', () => {
+    // Hex that decodes to binary
+    expect(_tryDecodeContinuousHex('0001ff80')).toBeNull();
   });
 });

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -458,6 +458,163 @@ function scanEntropy(
 }
 
 // ---------------------------------------------------------------------------
+// Encoded secret detection — decode + re-scan pass
+// ---------------------------------------------------------------------------
+
+/** Percent-encoded segments: 3+ encoded bytes mixed with normal URL chars.
+ *  Quick-check for '%' before running to avoid catastrophic backtracking. */
+const PERCENT_ENCODED_RE = /(?:[A-Za-z0-9_.~+\/-]*%[0-9A-Fa-f]{2}){3,}[A-Za-z0-9_.~+\/-]*/g;
+
+/** Hex-escape sequences: \xHH patterns (3+ consecutive) */
+const HEX_ESCAPE_RE = /(?:\\x[0-9A-Fa-f]{2}){3,}/g;
+
+/** Candidate base64 segments — 24+ chars that could encode a secret (≥18 decoded bytes) */
+const ENCODED_BASE64_RE = /\b([A-Za-z0-9+/\-_]{24,}={0,3})(?=\W|$)/g;
+
+/** Continuous hex-encoded bytes — 32+ hex chars (16+ bytes decoded) */
+const CONTINUOUS_HEX_RE = /\b([0-9a-fA-F]{32,})\b/g;
+
+/** Check if decoded content is printable ASCII text */
+function isPrintableText(s: string): boolean {
+  return s.length > 0 && /^[\x20-\x7E\t\n\r]+$/.test(s);
+}
+
+function tryDecodeBase64(encoded: string): string | null {
+  try {
+    // Handle both standard and URL-safe base64
+    const standardized = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = Buffer.from(standardized, 'base64').toString('utf-8');
+    if (!isPrintableText(decoded)) return null;
+    // Verify round-trip to reject garbage decodes
+    const reEncoded = Buffer.from(decoded, 'utf-8').toString('base64').replace(/=+$/, '');
+    if (standardized.replace(/=+$/, '') !== reEncoded) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function tryDecodePercentEncoded(encoded: string): string | null {
+  try {
+    const decoded = decodeURIComponent(encoded);
+    if (decoded === encoded) return null;
+    if (!isPrintableText(decoded)) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function tryDecodeHexEscapes(encoded: string): string | null {
+  try {
+    const decoded = encoded.replace(/\\x([0-9A-Fa-f]{2})/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16)),
+    );
+    if (decoded === encoded) return null;
+    if (!isPrintableText(decoded)) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function tryDecodeContinuousHex(encoded: string): string | null {
+  try {
+    // Decode pairs of hex digits to bytes
+    const bytes: number[] = [];
+    for (let i = 0; i < encoded.length; i += 2) {
+      bytes.push(parseInt(encoded.slice(i, i + 2), 16));
+    }
+    const decoded = String.fromCharCode(...bytes);
+    if (!isPrintableText(decoded)) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+/** Check if an encoded segment overlaps with any existing match range */
+function overlapsExisting(start: number, end: number, ranges: Set<string>): boolean {
+  for (const rangeKey of ranges) {
+    const sep = rangeKey.indexOf(':');
+    const rStart = Number(rangeKey.slice(0, sep));
+    const rEnd = Number(rangeKey.slice(sep + 1));
+    if (start < rEnd && end > rStart) return true;
+  }
+  return false;
+}
+
+/**
+ * Scan for encoded secrets by decoding candidate segments and running
+ * pattern matching on the decoded content. Catches base64-encoded,
+ * hex-encoded, and percent-encoded secrets that raw regex would miss.
+ */
+function scanEncoded(
+  text: string,
+  existingRanges: Set<string>,
+): SecretMatch[] {
+  const matches: SecretMatch[] = [];
+
+  const decoders: Array<{
+    regex: RegExp;
+    decode: (s: string) => string | null;
+    encoding: string;
+    /** Fast check before running the regex — skip entirely if absent */
+    quickCheck?: (t: string) => boolean;
+  }> = [
+    { regex: PERCENT_ENCODED_RE, decode: tryDecodePercentEncoded, encoding: 'percent-encoded', quickCheck: (t) => t.includes('%') },
+    { regex: HEX_ESCAPE_RE, decode: tryDecodeHexEscapes, encoding: 'hex-escaped', quickCheck: (t) => t.includes('\\x') },
+    { regex: ENCODED_BASE64_RE, decode: tryDecodeBase64, encoding: 'base64-encoded' },
+    { regex: CONTINUOUS_HEX_RE, decode: tryDecodeContinuousHex, encoding: 'hex-encoded' },
+  ];
+
+  for (const { regex, decode, encoding, quickCheck } of decoders) {
+    if (quickCheck && !quickCheck(text)) continue;
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) !== null) {
+      const encoded = m[1] ?? m[0];
+      // No realistic encoded secret exceeds ~500 chars; skip huge matches for performance
+      if (encoded.length > 1000) continue;
+      const startIndex = m.index + (m[0].indexOf(encoded));
+      const endIndex = startIndex + encoded.length;
+
+      // Skip if overlapping with an existing match
+      if (overlapsExisting(startIndex, endIndex, existingRanges)) continue;
+
+      const decoded = decode(encoded);
+      if (!decoded) continue;
+
+      // Re-scan decoded content against known patterns
+      for (const pattern of PATTERNS) {
+        pattern.regex.lastIndex = 0;
+        let pm: RegExpExecArray | null;
+        while ((pm = pattern.regex.exec(decoded)) !== null) {
+          const value = pm[1] ?? pm[0];
+          if (isPlaceholder(value)) continue;
+          if (isAllowlisted(value)) continue;
+          if (pattern.type === 'AWS Secret Key' && !isLikelyAwsSecret(value)) continue;
+
+          const key = `${startIndex}:${endIndex}`;
+          existingRanges.add(key);
+          matches.push({
+            type: `${pattern.type} (${encoding})`,
+            startIndex,
+            endIndex,
+            redactedValue: redact(encoded),
+          });
+          break;
+        }
+        // Stop checking patterns once we've found a match for this segment
+        if (existingRanges.has(`${startIndex}:${endIndex}`)) break;
+      }
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Scan function
 // ---------------------------------------------------------------------------
 
@@ -508,6 +665,10 @@ export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): 
   const entropyMatches = scanEntropy(text, eConfig, seen);
   matches.push(...entropyMatches);
 
+  // Encoded secret detection — decode candidate segments and re-scan
+  const encodedMatches = scanEncoded(text, seen);
+  matches.push(...encodedMatches);
+
   // Sort by position; at same start, wider match first so redaction covers the full span
   matches.sort((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
   return matches;
@@ -547,4 +708,8 @@ export {
   redact as _redact,
   PATTERNS as _PATTERNS,
   hasSecretContext as _hasSecretContext,
+  tryDecodeBase64 as _tryDecodeBase64,
+  tryDecodePercentEncoded as _tryDecodePercentEncoded,
+  tryDecodeHexEscapes as _tryDecodeHexEscapes,
+  tryDecodeContinuousHex as _tryDecodeContinuousHex,
 };


### PR DESCRIPTION
## Summary
- Adds a decode + re-scan pass to the secret scanner that catches base64-encoded, hex-encoded, percent-encoded, and hex-escaped secrets
- Decodes candidate segments, verifies they contain printable text (with round-trip validation for base64), then runs existing pattern matching on the decoded content
- Includes quick-check guards and a 1000-char length limit to preserve O(n) performance on large inputs

## Original prompt
Add encoded secret detection — Secret scanner uses regex patterns that may miss base64-encoded, hex-encoded, or percent-encoded secrets. Add decoding + re-scan pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
