### PR TITLE
feat: add embedding cache to avoid redundant API calls / local compute

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -528,6 +528,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN metadata TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_embeddings ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -563,6 +564,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_last_seen_at ON memory_items(last_seen_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_jobs_conflict_resolve_dedupe

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { AssistantConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { GeminiEmbeddingBackend } from './embedding-gemini.js';
@@ -10,9 +11,41 @@ const log = getLogger('memory-embeddings');
 /** Global cache of embedding backend instances, keyed by "provider:model". */
 const backendCache = new Map<string, EmbeddingBackend>();
 
-/** Clear cached embedding backends so new instances pick up fresh credentials. */
+// ── In-memory embedding vector cache ──────────────────────────────
+// LRU cache keyed by sha256(provider + model + text) → embedding vector.
+// Avoids redundant API calls / local compute for identical content.
+const VECTOR_CACHE_MAX_ENTRIES = 4096;
+const vectorCache = new Map<string, number[]>();
+
+function vectorCacheKey(provider: string, model: string, text: string): string {
+  return createHash('sha256').update(`${provider}\0${model}\0${text}`).digest('hex');
+}
+
+function getFromVectorCache(provider: string, model: string, text: string): number[] | undefined {
+  const key = vectorCacheKey(provider, model, text);
+  const v = vectorCache.get(key);
+  if (v !== undefined) {
+    // LRU refresh: move to end of insertion order
+    vectorCache.delete(key);
+    vectorCache.set(key, v);
+  }
+  return v;
+}
+
+function putInVectorCache(provider: string, model: string, text: string, vector: number[]): void {
+  const key = vectorCacheKey(provider, model, text);
+  vectorCache.delete(key);
+  if (vectorCache.size >= VECTOR_CACHE_MAX_ENTRIES) {
+    const oldest = vectorCache.keys().next().value;
+    if (oldest !== undefined) vectorCache.delete(oldest);
+  }
+  vectorCache.set(key, vector);
+}
+
+/** Clear cached embedding backends and the in-memory vector cache. */
 export function clearEmbeddingBackendCache(): void {
   backendCache.clear();
+  vectorCache.clear();
 }
 
 function cacheKey(provider: string, model: string): string {
@@ -153,7 +186,23 @@ export async function embedWithBackend(
     throw new Error(selection.reason ?? 'No memory embedding backend configured');
   }
 
-  // In auto mode, build a fallback list of backends to try
+  const expectedDim = config.memory.qdrant.vectorSize;
+  const { provider: primaryProvider, model: primaryModel } = selection.backend;
+
+  // ── In-memory cache check ───────────────────────────────────────
+  const cached: (number[] | null)[] = texts.map(t => {
+    const v = getFromVectorCache(primaryProvider, primaryModel, t);
+    return v && v.length === expectedDim ? v : null;
+  });
+  const uncachedIndices: number[] = [];
+  for (let i = 0; i < cached.length; i++) {
+    if (!cached[i]) uncachedIndices.push(i);
+  }
+  if (uncachedIndices.length === 0) {
+    return { provider: primaryProvider, model: primaryModel, vectors: cached as number[][] };
+  }
+
+  // ── Embed uncached texts ────────────────────────────────────────
   const backends: EmbeddingBackend[] = [selection.backend];
   if (config.memory.embeddings.provider === 'auto' && selection.backend.provider === 'local') {
     for (const fallback of selectFallbackBackends(config, 'local')) {
@@ -163,18 +212,35 @@ export async function embedWithBackend(
 
   let lastErr: unknown;
   for (const backend of backends) {
+    const isPrimary = backend === selection.backend;
+    // For the primary backend, only embed uncached texts and merge with cached.
+    // For fallback backends, embed ALL texts since the cache was keyed to the primary.
+    const textsToEmbed = isPrimary ? uncachedIndices.map(i => texts[i]) : texts;
+
     try {
-      const vectors = await backend.embed(texts, options);
-      if (vectors.length !== texts.length) {
-        throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
+      const vectors = await backend.embed(textsToEmbed, options);
+      if (vectors.length !== textsToEmbed.length) {
+        throw new Error(`Embedding backend returned ${vectors.length} vectors for ${textsToEmbed.length} texts`);
       }
-      const expectedDim = config.memory.qdrant.vectorSize;
       for (const vec of vectors) {
         if (vec.length !== expectedDim) {
           throw new Error(
             `Embedding backend "${backend.provider}" (model ${backend.model}) returned vectors of dimension ${vec.length}, but Qdrant collection expects ${expectedDim}`,
           );
         }
+      }
+
+      // Populate cache with freshly embedded vectors
+      for (let i = 0; i < textsToEmbed.length; i++) {
+        putInVectorCache(backend.provider, backend.model, textsToEmbed[i], vectors[i]);
+      }
+
+      if (isPrimary) {
+        const merged = [...cached] as number[][];
+        for (let i = 0; i < uncachedIndices.length; i++) {
+          merged[uncachedIndices[i]] = vectors[i];
+        }
+        return { provider: backend.provider, model: backend.model, vectors: merged };
       }
       return { provider: backend.provider, model: backend.model, vectors };
     } catch (err) {

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -1,6 +1,10 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { eq, and } from 'drizzle-orm';
 import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';
+import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
+import { memoryEmbeddings } from './schema.js';
 import type { AssistantConfig } from '../config/types.js';
 
 const log = getLogger('memory-jobs-worker');
@@ -111,9 +115,64 @@ export async function embedAndUpsert(
     );
   }
 
-  const embedded = await embedWithBackend(config, [text]);
-  const vector = embedded.vectors[0];
-  if (!vector) return;
+  const contentHash = createHash('sha256').update(text).digest('hex');
+  let provider = status.provider;
+  let model = status.model!;
+  let vector: number[];
+
+  // Check SQLite embedding cache for a matching content hash
+  const db = getDb();
+  const cachedRow = db
+    .select({ vectorJson: memoryEmbeddings.vectorJson, dimensions: memoryEmbeddings.dimensions })
+    .from(memoryEmbeddings)
+    .where(
+      and(
+        eq(memoryEmbeddings.contentHash, contentHash),
+        eq(memoryEmbeddings.provider, provider),
+        eq(memoryEmbeddings.model, model),
+      ),
+    )
+    .get();
+
+  if (cachedRow && cachedRow.dimensions === config.memory.qdrant.vectorSize) {
+    vector = JSON.parse(cachedRow.vectorJson);
+  } else {
+    const embedded = await embedWithBackend(config, [text]);
+    vector = embedded.vectors[0];
+    if (!vector) return;
+    provider = embedded.provider;
+    model = embedded.model;
+  }
+
+  // Persist embedding in SQLite for cross-restart cache
+  const now = Date.now();
+  try {
+    db.insert(memoryEmbeddings)
+      .values({
+        id: randomUUID(),
+        targetType,
+        targetId,
+        provider,
+        model,
+        dimensions: vector.length,
+        vectorJson: JSON.stringify(vector),
+        contentHash,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [memoryEmbeddings.targetType, memoryEmbeddings.targetId, memoryEmbeddings.provider, memoryEmbeddings.model],
+        set: {
+          vectorJson: JSON.stringify(vector),
+          dimensions: vector.length,
+          contentHash,
+          updatedAt: now,
+        },
+      })
+      .run();
+  } catch (err) {
+    log.warn({ err, targetType, targetId }, 'Failed to write embedding cache');
+  }
 
   let qdrant;
   try {
@@ -123,7 +182,6 @@ export async function embedAndUpsert(
   }
 
   try {
-    const now = Date.now();
     await qdrant.upsert(targetType, targetId, vector, {
       text,
       created_at: (extraPayload?.created_at as number) ?? now,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -129,6 +129,7 @@ export const memoryEmbeddings = sqliteTable('memory_embeddings', {
   model: text('model').notNull(),
   dimensions: integer('dimensions').notNull(),
   vectorJson: text('vector_json').notNull(),
+  contentHash: text('content_hash'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });


### PR DESCRIPTION
## Summary
- Add in-memory LRU cache (4096 entries) in `embedWithBackend` keyed by sha256(provider+model+text) — catches duplicate content across all embedding paths (indexing and search queries)
- Add SQLite-backed cache in `embedAndUpsert` using the existing `memory_embeddings` table with a new `content_hash` column — persists vectors across daemon restarts
- Correctly handles fallback backends: cache is keyed to the primary backend; on fallback, all texts are re-embedded with the fallback provider

## Original prompt
Add embedding cache — Every message triggers embedding jobs with no caching. Identical content re-embeds. Add an in-memory or SQLite-backed embedding cache to avoid redundant API calls / local compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
