### PR TITLE
Fix Telegram guardian verification failure from settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -151,6 +151,14 @@ public final class SettingsStore: ObservableObject {
     private var twilioNumbersRefreshPending = false
     private var pendingGuardianChallengeChannel: String?
     private var guardianChallengeTimeoutWorkItem: DispatchWorkItem?
+    private var guardianAssistantScope: String {
+        let stored = UserDefaults.standard.string(forKey: "connectedAssistantId")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let stored, !stored.isEmpty {
+            return stored
+        }
+        return "self"
+    }
 
     init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
         self.daemonClient = daemonClient
@@ -777,7 +785,7 @@ public final class SettingsStore: ObservableObject {
 
     func refreshChannelGuardianStatus(channel: String) {
         do {
-            try daemonClient?.sendGuardianVerification(action: "status", channel: channel, assistantId: "self")
+            try daemonClient?.sendGuardianVerification(action: "status", channel: channel, assistantId: guardianAssistantScope)
         } catch {
             log.error("Failed to refresh \(channel) guardian status: \(error)")
         }
@@ -813,7 +821,7 @@ public final class SettingsStore: ObservableObject {
             }
             pendingGuardianChallengeChannel = channel
             armGuardianChallengeTimeout(for: channel)
-            try daemonClient.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: "self")
+            try daemonClient.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: guardianAssistantScope)
         } catch {
             log.error("Failed to start \(channel) guardian verification: \(error)")
             clearGuardianChallengePending(for: channel)
@@ -832,7 +840,7 @@ public final class SettingsStore: ObservableObject {
 
     func revokeChannelGuardian(channel: String) {
         do {
-            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: "self")
+            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
         } catch {
             log.error("Failed to revoke \(channel) guardian: \(error)")
         }

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -8,10 +8,15 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     private var daemonClient: DaemonClient!
     private var sentMessages: [Any] = []
     private var store: SettingsStore!
+    private let connectedAssistantIdDefaultsKey = "connectedAssistantId"
+    private let testAssistantId = "ast-settings-tests"
+    private var previousConnectedAssistantId: String?
 
     override func setUp() {
         super.setUp()
         sentMessages = []
+        previousConnectedAssistantId = UserDefaults.standard.string(forKey: connectedAssistantIdDefaultsKey)
+        UserDefaults.standard.set(testAssistantId, forKey: connectedAssistantIdDefaultsKey)
         daemonClient = DaemonClient()
         daemonClient.isConnected = true
         daemonClient.sendOverride = { [weak self] message in
@@ -24,6 +29,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store = nil
         daemonClient = nil
         sentMessages = []
+        if let previousConnectedAssistantId {
+            UserDefaults.standard.set(previousConnectedAssistantId, forKey: connectedAssistantIdDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: connectedAssistantIdDefaultsKey)
+        }
+        previousConnectedAssistantId = nil
         super.tearDown()
     }
 
@@ -71,7 +82,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "telegram" }
         XCTAssertEqual(challengeMessages.count, 1)
-        XCTAssertEqual(challengeMessages.first?.assistantId, "self")
+        XCTAssertEqual(challengeMessages.first?.assistantId, testAssistantId)
     }
 
     // MARK: - startChannelGuardianVerification (SMS)
@@ -85,7 +96,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "sms" }
         XCTAssertEqual(challengeMessages.count, 1)
-        XCTAssertEqual(challengeMessages.first?.assistantId, "self")
+        XCTAssertEqual(challengeMessages.first?.assistantId, testAssistantId)
     }
 
     // MARK: - Successful status response
@@ -297,7 +308,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "telegram" }
         XCTAssertEqual(revokeMessages.count, 1)
-        XCTAssertEqual(revokeMessages.first?.assistantId, "self")
+        XCTAssertEqual(revokeMessages.first?.assistantId, testAssistantId)
     }
 
     func testRevokeSmsGuardianSendsRevokeAction() {
@@ -306,7 +317,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "sms" }
         XCTAssertEqual(revokeMessages.count, 1)
-        XCTAssertEqual(revokeMessages.first?.assistantId, "self")
+        XCTAssertEqual(revokeMessages.first?.assistantId, testAssistantId)
     }
 
     // MARK: - No daemon client doesn't crash
@@ -383,5 +394,25 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
         XCTAssertEqual(telegramStatus.count, 1)
         XCTAssertEqual(smsStatus.count, 1)
+        XCTAssertEqual(telegramStatus.first?.assistantId, testAssistantId)
+        XCTAssertEqual(smsStatus.first?.assistantId, testAssistantId)
+    }
+
+    func testGuardianRequestsFallBackToSelfWhenNoConnectedAssistantId() {
+        UserDefaults.standard.removeObject(forKey: connectedAssistantIdDefaultsKey)
+        sentMessages.removeAll()
+
+        let localStore = SettingsStore(daemonClient: daemonClient)
+        localStore.startChannelGuardianVerification(channel: "telegram")
+        localStore.revokeChannelGuardian(channel: "sms")
+
+        let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+        let statusMessages = guardianMessages.filter { $0.action == "status" }
+        let createMessages = guardianMessages.filter { $0.action == "create_challenge" }
+        let revokeMessages = guardianMessages.filter { $0.action == "revoke" }
+
+        XCTAssertTrue(statusMessages.allSatisfy { $0.assistantId == "self" })
+        XCTAssertTrue(createMessages.allSatisfy { $0.assistantId == "self" })
+        XCTAssertTrue(revokeMessages.allSatisfy { $0.assistantId == "self" })
     }
 }


### PR DESCRIPTION
## Summary\n- scope channel guardian settings IPC requests to the active connected assistant ID instead of always using `self`\n- keep a safe fallback to `self` when no assistant is selected\n- add/update macOS tests to verify scoped assistant behavior and fallback behavior\n\n## Validation\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreChannelVerificationTests\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreTelegramTests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
