### PR TITLE
fix(calls): coalesce barge-in turns to avoid false technical fallback

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -476,6 +476,54 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('rapid caller barge-in coalesces contiguous user turns for role alternation', async () => {
+    let callCount = 0;
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      callCount++;
+      if (callCount === 1) {
+        const emitter = new EventEmitter();
+        const options = args[1] as { signal?: AbortSignal } | undefined;
+        return {
+          on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
+            emitter.on(event, handler);
+            return { on: () => ({ on: () => ({}) }) };
+          },
+          finalMessage: () =>
+            new Promise((_, reject) => {
+              options?.signal?.addEventListener('abort', () => {
+                const err = new Error('aborted');
+                err.name = 'AbortError';
+                reject(err);
+              }, { once: true });
+            }),
+        };
+      }
+
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const roles = firstArg.messages.map((m) => m.role);
+      for (let i = 1; i < roles.length; i++) {
+        expect(!(roles[i - 1] === 'user' && roles[i] === 'user')).toBe(true);
+      }
+      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const lastUser = userMessages[userMessages.length - 1];
+      expect(lastUser?.content).toContain('First caller utterance');
+      expect(lastUser?.content).toContain('Second caller utterance');
+      return createMockStream(['Merged turn handled.']);
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+    const firstTurnPromise = orchestrator.handleCallerUtterance('First caller utterance');
+    await new Promise((r) => setTimeout(r, 5));
+    const secondTurnPromise = orchestrator.handleCallerUtterance('Second caller utterance');
+
+    await Promise.all([firstTurnPromise, secondTurnPromise]);
+
+    const allTokens = relay.sentTokens.map((t) => t.token).join('');
+    expect(allTokens).toContain('Merged turn handled.');
+
+    orchestrator.destroy();
+  });
+
   test('handleUserAnswer: returns false when not in waiting_on_user state', async () => {
     const { orchestrator } = setupOrchestrator();
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -66,20 +66,29 @@ export class CallOrchestrator {
    * Handle a final caller utterance from the ConversationRelay.
    */
   async handleCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): Promise<void> {
+    const interruptedInFlight = this.state === 'processing' || this.state === 'speaking';
     // If we're already processing or speaking, abort the in-flight generation
-    if (this.state === 'processing' || this.state === 'speaking') {
+    if (interruptedInFlight) {
       this.abortController.abort();
       this.abortController = new AbortController();
     }
 
     this.state = 'processing';
     this.resetSilenceTimer();
+    const callerContent = this.formatCallerUtterance(transcript, speaker);
 
-    // Append caller utterance
-    this.conversationHistory.push({
-      role: 'user',
-      content: this.formatCallerUtterance(transcript, speaker),
-    });
+    // If a caller barges in while the assistant turn is still in flight,
+    // the interrupted run may never append an assistant message. Coalesce
+    // contiguous caller turns to preserve role alternation for Anthropic.
+    const lastMessage = this.conversationHistory[this.conversationHistory.length - 1];
+    if (interruptedInFlight && lastMessage?.role === 'user') {
+      lastMessage.content = `${lastMessage.content}\n${callerContent}`;
+    } else {
+      this.conversationHistory.push({
+        role: 'user',
+        content: callerContent,
+      });
+    }
 
     await this.runLlm();
   }


### PR DESCRIPTION
## Summary
- coalesce contiguous caller user turns when barge-in interrupts an in-flight assistant turn
- preserve Anthropic role alternation to avoid false stream errors on rapid caller responses
- add regression coverage for rapid barge-in alternation behavior

## Validation
- cd assistant && bun test src/__tests__/call-orchestrator.test.ts
- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
