### PR TITLE
fix(calls): restore barge-in interruption by closing active TTS turn

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -594,6 +594,38 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('handleInterrupt: sends turn terminator when interrupting active speech', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const emitter = new EventEmitter();
+      const options = args[1] as { signal?: AbortSignal } | undefined;
+      return {
+        on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
+          emitter.on(event, handler);
+          return { on: () => ({ on: () => ({}) }) };
+        },
+        finalMessage: () =>
+          new Promise((_, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            }, { once: true });
+          }),
+      };
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+    const turnPromise = orchestrator.handleCallerUtterance('Start speaking');
+    await new Promise((r) => setTimeout(r, 5));
+    orchestrator.handleInterrupt();
+    await turnPromise;
+
+    const endTurnMarkers = relay.sentTokens.filter((t) => t.token === '' && t.last === true);
+    expect(endTurnMarkers.length).toBeGreaterThan(0);
+
+    orchestrator.destroy();
+  });
+
   // ── destroy ───────────────────────────────────────────────────────
 
   test('destroy: unregisters orchestrator', () => {

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -179,9 +179,15 @@ export class CallOrchestrator {
    * Handle caller interrupting the assistant's speech.
    */
   handleInterrupt(): void {
+    const wasSpeaking = this.state === 'speaking';
     this.abortController.abort();
     this.abortController = new AbortController();
     this.llmRunVersion++;
+    // Explicitly terminate the in-progress TTS turn so the relay can
+    // immediately hand control back to the caller after barge-in.
+    if (wasSpeaking) {
+      this.relay.sendTextToken('', true);
+    }
     this.state = 'idle';
   }
 


### PR DESCRIPTION
## Summary
- emit relay turn terminator (, ) when caller interrupts while assistant is speaking
- keep stale-run suppression and abort handling intact
- add regression test that asserts interrupt emits a turn terminator

## Validation
- cd assistant && bun test src/__tests__/call-orchestrator.test.ts
- full typecheck currently has unrelated pre-existing failures in daemon-lifecycle tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
