### PR TITLE
Auto-refresh guardian verification status in settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -151,6 +151,10 @@ public final class SettingsStore: ObservableObject {
     private var twilioNumbersRefreshPending = false
     private var pendingGuardianChallengeChannel: String?
     private var guardianChallengeTimeoutWorkItem: DispatchWorkItem?
+    private var guardianStatusPollingWorkItems: [String: DispatchWorkItem] = [:]
+    private var guardianStatusPollingDeadlines: [String: Date] = [:]
+    private let guardianStatusPollInterval: TimeInterval
+    private let guardianStatusPollWindow: TimeInterval
     private var guardianAssistantScope: String {
         let stored = UserDefaults.standard.string(forKey: "connectedAssistantId")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -160,9 +164,16 @@ public final class SettingsStore: ObservableObject {
         return "self"
     }
 
-    init(daemonClient: DaemonClient? = nil, configPath: String? = nil) {
+    init(
+        daemonClient: DaemonClient? = nil,
+        configPath: String? = nil,
+        guardianStatusPollInterval: TimeInterval = 2,
+        guardianStatusPollWindow: TimeInterval = 600
+    ) {
         self.daemonClient = daemonClient
         self.configPath = configPath
+        self.guardianStatusPollInterval = max(0.05, guardianStatusPollInterval)
+        self.guardianStatusPollWindow = max(self.guardianStatusPollInterval, guardianStatusPollWindow)
 
         // Seed from UserDefaults / Keychain
         let anthropicKey = APIKeyManager.getKey()
@@ -358,6 +369,16 @@ public final class SettingsStore: ObservableObject {
                 }
             default:
                 break
+            }
+
+            if response.success {
+                if response.secret != nil || response.instruction != nil {
+                    self.startGuardianStatusPolling(for: channel)
+                } else if response.bound == true {
+                    self.stopGuardianStatusPolling(for: channel)
+                }
+            } else {
+                self.stopGuardianStatusPolling(for: channel)
             }
         }
 
@@ -792,6 +813,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func startChannelGuardianVerification(channel: String) {
+        stopGuardianStatusPolling(for: channel)
         switch channel {
         case "telegram":
             telegramGuardianVerificationInProgress = true
@@ -839,6 +861,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func revokeChannelGuardian(channel: String) {
+        stopGuardianStatusPolling(for: channel)
         do {
             try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
         } catch {
@@ -890,6 +913,35 @@ public final class SettingsStore: ObservableObject {
         }
         guardianChallengeTimeoutWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 12, execute: workItem)
+    }
+
+    private func startGuardianStatusPolling(for channel: String) {
+        guard channel == "telegram" || channel == "sms" else { return }
+        stopGuardianStatusPolling(for: channel)
+        guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
+        scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)
+    }
+
+    private func stopGuardianStatusPolling(for channel: String) {
+        guardianStatusPollingWorkItems[channel]?.cancel()
+        guardianStatusPollingWorkItems[channel] = nil
+        guardianStatusPollingDeadlines[channel] = nil
+    }
+
+    private func scheduleGuardianStatusPoll(for channel: String, delay: TimeInterval) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard let deadline = self.guardianStatusPollingDeadlines[channel] else { return }
+            if Date() >= deadline {
+                self.stopGuardianStatusPolling(for: channel)
+                return
+            }
+            self.refreshChannelGuardianStatus(channel: channel)
+            self.scheduleGuardianStatusPoll(for: channel, delay: self.guardianStatusPollInterval)
+        }
+        guardianStatusPollingWorkItems[channel]?.cancel()
+        guardianStatusPollingWorkItems[channel] = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     // MARK: - Ingress Config Actions

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -296,6 +296,105 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.telegramGuardianError)
     }
 
+    func testChallengeResponseStartsGuardianStatusPolling() {
+        sentMessages.removeAll()
+        let pollingStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+        pollingStore.startChannelGuardianVerification(channel: "telegram")
+
+        let statusCountBefore = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+            .filter { $0.action == "status" && $0.channel == "telegram" }
+            .count
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: "poll-me",
+            instruction: "Send /guardian_verify poll-me on Telegram",
+            bound: false,
+            guardianExternalUserId: nil,
+            channel: "telegram",
+            assistantId: testAssistantId,
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in
+            let statusCountAfter = self.sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+                .filter { $0.action == "status" && $0.channel == "telegram" }
+                .count
+            return statusCountAfter > statusCountBefore
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testVerifiedResponseStopsGuardianStatusPolling() {
+        sentMessages.removeAll()
+        let pollingStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+        pollingStore.startChannelGuardianVerification(channel: "telegram")
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: "poll-me",
+            instruction: "Send /guardian_verify poll-me on Telegram",
+            bound: false,
+            guardianExternalUserId: nil,
+            channel: "telegram",
+            assistantId: testAssistantId,
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let pollingStartedPredicate = NSPredicate { _, _ in
+            let statusCount = self.sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+                .filter { $0.action == "status" && $0.channel == "telegram" }
+                .count
+            return statusCount > 1
+        }
+        let pollingStartedExpectation = XCTNSPredicateExpectation(predicate: pollingStartedPredicate, object: nil)
+        wait(for: [pollingStartedExpectation], timeout: 2.0)
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "tg_user_123",
+            channel: "telegram",
+            assistantId: testAssistantId,
+            guardianDeliveryChatId: "chat_456",
+            error: nil
+        ))
+
+        let settleOne = expectation(description: "settleOne")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { settleOne.fulfill() }
+        wait(for: [settleOne], timeout: 1.0)
+
+        let statusCountAfterVerification = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+            .filter { $0.action == "status" && $0.channel == "telegram" }
+            .count
+
+        let settleTwo = expectation(description: "settleTwo")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { settleTwo.fulfill() }
+        wait(for: [settleTwo], timeout: 1.0)
+
+        let statusCountFinal = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+            .filter { $0.action == "status" && $0.channel == "telegram" }
+            .count
+
+        XCTAssertEqual(statusCountFinal, statusCountAfterVerification)
+    }
+
     // MARK: - revokeChannelGuardian
 
     func testRevokeChannelGuardianSendsRevokeAction() {


### PR DESCRIPTION
## Summary\n- start short background status polling for a channel after guardian verification challenge instructions are created\n- stop polling when verification succeeds, and cancel any stale polling when a new verify/revoke action is triggered\n- add macOS tests proving polling starts after challenge and stops after successful verification\n\n## Validation\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreChannelVerificationTests\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreTelegramTests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
