### PR TITLE
M1: Add user-reference resolver helper

### DIFF
--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { join } from 'node:path';
+
+const TEST_DIR = '/tmp/vellum-user-ref-test';
+
+mock.module('../util/platform.js', () => ({
+  getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
+}));
+
+// Mutable state the tests control
+let mockFileExists = false;
+let mockFileContent = '';
+
+mock.module('node:fs', () => ({
+  existsSync: (path: string) => {
+    if (path === join(TEST_DIR, 'USER.md')) return mockFileExists;
+    return false;
+  },
+  readFileSync: (path: string, _encoding: string) => {
+    if (path === join(TEST_DIR, 'USER.md') && mockFileExists) return mockFileContent;
+    throw new Error(`ENOENT: no such file: ${path}`);
+  },
+}));
+
+// Import after mocks are in place
+const { resolveUserReference } = await import('../config/user-reference.js');
+
+describe('resolveUserReference', () => {
+  beforeEach(() => {
+    mockFileExists = false;
+    mockFileContent = '';
+  });
+
+  test('returns "my human" when USER.md does not exist', () => {
+    mockFileExists = false;
+    expect(resolveUserReference()).toBe('my human');
+  });
+
+  test('returns "my human" when preferred name field is empty', () => {
+    mockFileExists = true;
+    mockFileContent = [
+      '## Onboarding Snapshot',
+      '',
+      '- Preferred name/reference:',
+      '- Goals:',
+      '- Locale:',
+    ].join('\n');
+    expect(resolveUserReference()).toBe('my human');
+  });
+
+  test('returns the configured name when it is set', () => {
+    mockFileExists = true;
+    mockFileContent = [
+      '## Onboarding Snapshot',
+      '',
+      '- Preferred name/reference: John',
+      '- Goals: ship fast',
+      '- Locale: en-US',
+    ].join('\n');
+    expect(resolveUserReference()).toBe('John');
+  });
+
+  test('trims whitespace around the configured name', () => {
+    mockFileExists = true;
+    mockFileContent = '- Preferred name/reference:   Alice   \n';
+    expect(resolveUserReference()).toBe('Alice');
+  });
+});

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -1,0 +1,29 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { getWorkspacePromptPath } from '../util/platform.js';
+
+const DEFAULT_USER_REFERENCE = 'my human';
+
+/**
+ * Resolve the name/reference the assistant uses when referring to
+ * the human it represents in external communications.
+ *
+ * Reads the "Preferred name/reference:" field from the Onboarding
+ * Snapshot section of USER.md.  Falls back to "my human" when the
+ * file is missing, unreadable, or the field is empty.
+ */
+export function resolveUserReference(): string {
+  const userPath = getWorkspacePromptPath('USER.md');
+  if (!existsSync(userPath)) return DEFAULT_USER_REFERENCE;
+
+  try {
+    const content = readFileSync(userPath, 'utf-8');
+    const match = content.match(/Preferred name\/reference:\s*(.+)/);
+    if (match && match[1].trim()) {
+      return match[1].trim();
+    }
+  } catch {
+    // Fallback on any read error
+  }
+
+  return DEFAULT_USER_REFERENCE;
+}


### PR DESCRIPTION
Add a reusable helper that resolves the human name the assistant represents in external communications. Reads the 'Preferred name/reference' field from USER.md, falling back to 'my human' when unconfigured. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
