### PR TITLE
fix: make guardian timeout cancellation channel-aware

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -885,9 +885,9 @@ public final class SettingsStore: ObservableObject {
     private func clearGuardianChallengePending(for channel: String) {
         if pendingGuardianChallengeChannel == channel {
             pendingGuardianChallengeChannel = nil
+            guardianChallengeTimeoutWorkItem?.cancel()
+            guardianChallengeTimeoutWorkItem = nil
         }
-        guardianChallengeTimeoutWorkItem?.cancel()
-        guardianChallengeTimeoutWorkItem = nil
     }
 
     private func armGuardianChallengeTimeout(for channel: String) {


### PR DESCRIPTION
Address review feedback from PR #7034. Move timeout cancellation inside the channel-matching guard so concurrent verifications don't cancel each other's timeouts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
