### PR TITLE
fix: prevent caching degraded recall results and fix version race condition

### DIFF
--- a/assistant/src/memory/recall-cache.ts
+++ b/assistant/src/memory/recall-cache.ts
@@ -31,6 +31,11 @@ export function bumpMemoryVersion(): void {
   _version++;
 }
 
+/** Return the current memory version (for snapshot-based staleness checks). */
+export function getMemoryVersion(): number {
+  return _version;
+}
+
 /** Build a deterministic cache key from the recall inputs. */
 function buildCacheKey(
   query: string,
@@ -66,13 +71,25 @@ export function getCachedRecall(
   return entry.result;
 }
 
-/** Store a recall result in the cache. Evicts oldest entries when full. */
+/**
+ * Store a recall result in the cache. Evicts oldest entries when full.
+ *
+ * When `snapshotVersion` is provided, the entry is only stored if the
+ * snapshot still matches the current global version — this prevents a
+ * stale result from being cached under a version that was bumped while
+ * the retrieval pipeline was in flight.
+ */
 export function setCachedRecall(
   query: string,
   conversationId: string,
   options: MemoryRecallOptions | undefined,
   result: MemoryRecallResult,
+  snapshotVersion?: number,
 ): void {
+  // If a snapshot version was provided, only cache when it still matches
+  // the current version — otherwise the result may be stale.
+  if (snapshotVersion !== undefined && snapshotVersion !== _version) return;
+
   const key = buildCacheKey(query, conversationId, options);
 
   // Evict oldest entries if at capacity

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -19,7 +19,7 @@ import { semanticSearch, isQdrantConnectionError } from './search/semantic.js';
 import { entitySearch } from './search/entity.js';
 import { mergeCandidates, applySourceCaps, rerankWithLLM, trimToTokenBudget, markItemUsage } from './search/ranking.js';
 import { buildInjectedText, MEMORY_CONTEXT_ACK } from './search/formatting.js';
-import { getCachedRecall, setCachedRecall } from './recall-cache.js';
+import { getCachedRecall, setCachedRecall, getMemoryVersion } from './recall-cache.js';
 
 // Re-export public types and functions so existing importers continue to work
 export type {
@@ -226,6 +226,7 @@ export async function buildMemoryRecall(
   options?: MemoryRecallOptions,
 ): Promise<MemoryRecallResult> {
   const start = Date.now();
+  const versionSnapshot = getMemoryVersion();
   const excludeMessageIds = options?.excludeMessageIds?.filter((id) => id.length > 0) ?? [];
   const signal = options?.signal;
   if (!config.memory.enabled) {
@@ -428,7 +429,12 @@ export async function buildMemoryRecall(
     topCandidates,
   };
 
-  setCachedRecall(query, conversationId, options, result);
+  // Only cache non-degraded results — degraded results (e.g. lexical-only
+  // fallback when embeddings fail) would delay quality recovery once the
+  // embedding backend comes back.
+  if (!result.degraded) {
+    setCachedRecall(query, conversationId, options, result, versionSnapshot);
+  }
   return result;
 }
 


### PR DESCRIPTION
Address review feedback from PR #7041. Skip caching degraded recall results and fix race condition where stale results could be cached with a bumped version number.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
