### PR TITLE
fix: check fallback providers in embedding cache lookups

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -189,10 +189,24 @@ export async function embedWithBackend(
   const expectedDim = config.memory.qdrant.vectorSize;
   const { provider: primaryProvider, model: primaryModel } = selection.backend;
 
+  // ── Build fallback backends list (needed for both cache check and embed) ──
+  const fallbacks: EmbeddingBackend[] =
+    config.memory.embeddings.provider === 'auto' && selection.backend.provider === 'local'
+      ? selectFallbackBackends(config, 'local')
+      : [];
+
   // ── In-memory cache check ───────────────────────────────────────
   const cached: (number[] | null)[] = texts.map(t => {
+    // Try primary provider first
     const v = getFromVectorCache(primaryProvider, primaryModel, t);
-    return v && v.length === expectedDim ? v : null;
+    if (v && v.length === expectedDim) return v;
+    // Also check fallback providers — embeddings may have been cached under
+    // a fallback's key during a previous primary backend failure.
+    for (const fb of fallbacks) {
+      const fv = getFromVectorCache(fb.provider, fb.model, t);
+      if (fv && fv.length === expectedDim) return fv;
+    }
+    return null;
   });
   const uncachedIndices: number[] = [];
   for (let i = 0; i < cached.length; i++) {
@@ -203,12 +217,7 @@ export async function embedWithBackend(
   }
 
   // ── Embed uncached texts ────────────────────────────────────────
-  const backends: EmbeddingBackend[] = [selection.backend];
-  if (config.memory.embeddings.provider === 'auto' && selection.backend.provider === 'local') {
-    for (const fallback of selectFallbackBackends(config, 'local')) {
-      backends.push(fallback);
-    }
-  }
+  const backends: EmbeddingBackend[] = [selection.backend, ...fallbacks];
 
   let lastErr: unknown;
   for (const backend of backends) {
@@ -255,6 +264,16 @@ export async function embedWithBackend(
 
 export function logMemoryEmbeddingWarning(err: unknown, context: string): void {
   log.warn({ err }, `Memory embeddings failed (${context})`);
+}
+
+/** Return fallback provider/model pairs for the given config (excluding the primary). */
+export function getFallbackProviders(config: AssistantConfig): { provider: EmbeddingProviderName; model: string }[] {
+  const primary = selectEmbeddingBackend(config);
+  if (!primary.backend || config.memory.embeddings.provider !== 'auto') return [];
+  return selectFallbackBackends(config, primary.backend.provider).map(b => ({
+    provider: b.provider,
+    model: b.model,
+  }));
 }
 
 function selectFallbackBackends(config: AssistantConfig, exclude: EmbeddingProviderName): EmbeddingBackend[] {

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
 import { getLogger } from '../util/logger.js';
-import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';
+import { embedWithBackend, getMemoryBackendStatus, getFallbackProviders } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
 import { memoryEmbeddings } from './schema.js';
@@ -120,21 +120,30 @@ export async function embedAndUpsert(
   let model = status.model!;
   let vector: number[];
 
-  // Check SQLite embedding cache for a matching content hash
+  // Check SQLite embedding cache for a matching content hash.
+  // Try the primary provider first, then fallback providers — embeddings may
+  // have been persisted under a fallback's key during a prior primary failure.
   const db = getDb();
-  const cachedRow = db
-    .select({ vectorJson: memoryEmbeddings.vectorJson, dimensions: memoryEmbeddings.dimensions })
-    .from(memoryEmbeddings)
-    .where(
-      and(
-        eq(memoryEmbeddings.contentHash, contentHash),
-        eq(memoryEmbeddings.provider, provider),
-        eq(memoryEmbeddings.model, model),
-      ),
-    )
-    .get();
+  const expectedDim = config.memory.qdrant.vectorSize;
+  const providersToCheck = [{ provider, model }, ...getFallbackProviders(config)];
+  let cachedRow: { vectorJson: string; dimensions: number } | undefined;
+  for (const { provider: p, model: m } of providersToCheck) {
+    cachedRow = db
+      .select({ vectorJson: memoryEmbeddings.vectorJson, dimensions: memoryEmbeddings.dimensions })
+      .from(memoryEmbeddings)
+      .where(
+        and(
+          eq(memoryEmbeddings.contentHash, contentHash),
+          eq(memoryEmbeddings.provider, p),
+          eq(memoryEmbeddings.model, m),
+        ),
+      )
+      .get();
+    if (cachedRow && cachedRow.dimensions === expectedDim) break;
+    cachedRow = undefined;
+  }
 
-  if (cachedRow && cachedRow.dimensions === config.memory.qdrant.vectorSize) {
+  if (cachedRow && cachedRow.dimensions === expectedDim) {
     vector = JSON.parse(cachedRow.vectorJson);
   } else {
     const embedded = await embedWithBackend(config, [text]);


### PR DESCRIPTION
Address review feedback from PR #7048. Both in-memory and SQLite embedding cache lookups now also check fallback provider/model keys, so cache hits work correctly during primary backend failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
