### PR TITLE
M2: Update global system prompt for external comms identity

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -50,8 +50,12 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
+mock.module('../config/user-reference.js', () => ({
+  resolveUserReference: () => 'John',
+}));
+
 // Import after mock
-const { buildSystemPrompt, ensurePromptFiles, stripCommentLines } = await import('../config/system-prompt.js');
+const { buildSystemPrompt, ensurePromptFiles, stripCommentLines, buildExternalCommsIdentitySection } = await import('../config/system-prompt.js');
 
 /** Strip the Configuration and Skills sections so base-prompt tests stay focused. */
 function basePrompt(result: string): string {
@@ -165,6 +169,26 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('## External Service Access Preference');
     expect(result).toContain('CLI tools via host_bash');
     expect(result).toContain('Browser automation as last resort');
+  });
+
+  test('includes external comms identity section', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('## External Communications Identity');
+  });
+
+  test('external comms identity section contains assistant guidance and resolved user reference', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('Refer to yourself as an **assistant**');
+    expect(result).toContain('on behalf of **John**');
+  });
+
+  test('buildExternalCommsIdentitySection returns section with expected content', () => {
+    const section = buildExternalCommsIdentitySection();
+    expect(section).toContain('## External Communications Identity');
+    expect(section).toContain('assistant');
+    expect(section).toContain('John');
+    expect(section).toContain('Do not volunteer that you are an AI unless directly asked');
+    expect(section).toContain('Occasional variations are acceptable');
   });
 
   test('config section uses workspace directory from platform util', () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../util/logger.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { getConfig } from './loader.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import { resolveUserReference } from './user-reference.js';
 
 const log = getLogger('system-prompt');
 
@@ -116,6 +117,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildChannelAwarenessSection());
+  parts.push(buildExternalCommsIdentitySection());
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildAccessPreferenceSection());
   parts.push(buildIntegrationSection());
@@ -375,6 +377,20 @@ export function buildChannelAwarenessSection(): string {
     '- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.',
     '- Do not ask for computer-control permissions on non-dashboard channels.',
     '- When you do request a permission, be transparent about what it enables and why you need it.',
+  ].join('\n');
+}
+
+export function buildExternalCommsIdentitySection(): string {
+  const userRef = resolveUserReference();
+  return [
+    '## External Communications Identity',
+    '',
+    'When communicating with people outside your user\'s household (phone calls, messages to non-guardian contacts, emails to third parties, etc.):',
+    '',
+    `- Refer to yourself as an **assistant**, not an "AI assistant" or "artificial intelligence". Keep identity framing simple and natural.`,
+    `- When introducing who you represent, say you are acting on behalf of **${userRef}**.`,
+    '- Do not volunteer that you are an AI unless directly asked. If asked, answer honestly.',
+    '- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.',
   ].join('\n');
 }
 


### PR DESCRIPTION
Add an External Communications Identity section to the system prompt that biases the model to use 'assistant' (not 'AI assistant') and reference the configured user name when communicating with third parties. Uses the resolveUserReference() helper from M1. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
