### PR TITLE
M4: Align config defaults and schema wording

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -681,7 +681,7 @@ describe('AssistantConfigSchema', () => {
       userConsultTimeoutSeconds: 120,
       disclosure: {
         enabled: true,
-        text: 'At the very beginning of the call, disclose that you are an AI assistant calling on behalf of the user.',
+        text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
       },
       safety: {
         denyCategories: [],

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -224,7 +224,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     userConsultTimeoutSeconds: 120,
     disclosure: {
       enabled: true,
-      text: 'At the very beginning of the call, disclose that you are an AI assistant calling on behalf of the user.',
+      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
     },
     safety: {
       denyCategories: [],

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -907,7 +907,7 @@ export const CallsDisclosureConfigSchema = z.object({
     .default(true),
   text: z
     .string({ error: 'calls.disclosure.text must be a string' })
-    .default('At the very beginning of the call, disclose that you are an AI assistant calling on behalf of the user.'),
+    .default('At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.'),
 });
 
 export const CallsSafetyConfigSchema = z.object({
@@ -1017,7 +1017,7 @@ export const CallsConfigSchema = z.object({
     .default(120),
   disclosure: CallsDisclosureConfigSchema.default({
     enabled: true,
-    text: 'At the very beginning of the call, disclose that you are an AI assistant calling on behalf of the user.',
+    text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
   }),
   safety: CallsSafetyConfigSchema.default({
     denyCategories: [],
@@ -1340,7 +1340,7 @@ export const AssistantConfigSchema = z.object({
     userConsultTimeoutSeconds: 120,
     disclosure: {
       enabled: true,
-      text: 'At the very beginning of the call, disclose that you are an AI assistant calling on behalf of the user.',
+      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
     },
     safety: {
       denyCategories: [],


### PR DESCRIPTION
Update default calls.disclosure.text from 'AI assistant' to 'assistant' phrasing and from 'disclose' to 'introduce yourself as'. Schema shape unchanged — only default values updated. Existing custom disclosure strings are unaffected. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
