### PR TITLE
M3: Update call-specific prompt bias

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -27,6 +27,14 @@ mock.module('../util/logger.js', () => ({
     }),
 }));
 
+// ── User reference mock ──────────────────────────────────────────────
+
+let mockUserReference = 'my human';
+
+mock.module('../config/user-reference.js', () => ({
+  resolveUserReference: () => mockUserReference,
+}));
+
 // ── Config mock ─────────────────────────────────────────────────────
 
 let mockCallModel: string | undefined = undefined;
@@ -197,6 +205,7 @@ describe('call-orchestrator', () => {
   beforeEach(() => {
     resetTables();
     mockCallModel = undefined;
+    mockUserReference = 'my human';
     // Reset the stream mock to default behaviour
     mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
   });
@@ -811,6 +820,77 @@ describe('call-orchestrator', () => {
     const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
     expect(instructionEvents.length).toBe(1);
 
+    orchestrator.destroy();
+  });
+
+  // ── System prompt: identity phrasing ────────────────────────────────
+
+  test('system prompt contains resolved user reference (default)', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('on behalf of my human');
+      return createMockStream(['Hello.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('system prompt contains resolved user reference when set to a name', async () => {
+    mockUserReference = 'John';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('on behalf of John');
+      return createMockStream(['Hello John\'s contact.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('system prompt does not hardcode "your user" in the opening line', async () => {
+    mockUserReference = 'Alice';
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).not.toContain('on behalf of your user');
+      expect(firstArg.system).toContain('on behalf of Alice');
+      return createMockStream(['Hi there.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
+    orchestrator.destroy();
+  });
+
+  test('system prompt includes assistant identity bias rule', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('refer to yourself as an assistant');
+      expect(firstArg.system).toContain('Avoid the phrase "AI assistant" unless directly asked');
+      return createMockStream(['Sure thing.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('assistant identity rule appears before disclosure rule in prompt', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      const prompt = firstArg.system;
+      const identityIdx = prompt.indexOf('refer to yourself as an assistant');
+      const disclosureIdx = prompt.indexOf('Be concise');
+      expect(identityIdx).toBeGreaterThan(-1);
+      expect(disclosureIdx).toBeGreaterThan(-1);
+      expect(identityIdx).toBeLessThan(disclosureIdx);
+      return createMockStream(['OK.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Test');
     orchestrator.destroy();
   });
 });

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -8,6 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from '../config/loader.js';
+import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
 import {
   getCallSession,
@@ -214,13 +215,14 @@ export class CallOrchestrator {
       : '1. Begin the conversation naturally.';
 
     return [
-      'You are on a live phone call on behalf of your user.',
+      `You are on a live phone call on behalf of ${resolveUserReference()}.`,
       this.task ? `Task: ${this.task}` : '',
       '',
       'You are speaking directly to the person who answered the phone.',
       'Respond naturally and conversationally — speak as you would in a real phone conversation.',
       '',
       'IMPORTANT RULES:',
+      '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',
       disclosureRule,
       '2. Be concise — phone conversations should be brief and natural.',
       '3. If the callee asks something you don\'t know, include [ASK_USER: your question here] in your response along with a hold message like "Let me check on that for you."',


### PR DESCRIPTION
Update the call orchestrator system prompt to reference the resolved user name (via resolveUserReference()) and bias toward 'assistant' phrasing instead of 'AI assistant'. Keeps existing disclosure toggle intact. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
