### PR TITLE
refactor: unify macOS settings entry points into single panel

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -7,7 +7,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(store: appDelegate.services.settingsStore, daemonClient: appDelegate.services.daemonClient)
+            EmptyView()
         }
         .commands {
             CommandGroup(replacing: .appInfo) {
@@ -18,6 +18,14 @@ struct VellumAssistantApp: App {
                     appDelegate.updateManager.checkForUpdates()
                 }
                 .disabled(!appDelegate.updateManager.canCheckForUpdates)
+            }
+            // Replace the default Settings menu item (which opens the SwiftUI
+            // Settings scene window) with one that opens the in-app panel.
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings...") {
+                    appDelegate.showSettingsWindow(nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -84,7 +84,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var authWindow: NSWindow?
     let authManager = AuthManager()
     var mainWindow: MainWindow?
-    private var settingsWindow: NSWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
     private var tasksWindow: TasksWindow?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
@@ -95,7 +94,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var galleryWindow: ComponentGalleryWindow?
     #endif
     private var windowObserver: Any?
-    private var settingsWindowObserver: Any?
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
     var cachedSkills: [SkillInfo] = []
@@ -316,8 +314,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
             mainWindow?.close()
             mainWindow = nil
-            settingsWindow?.close()
-            settingsWindow = nil
 
             if let hotKeyMonitor {
                 NSEvent.removeMonitor(hotKeyMonitor)
@@ -408,8 +404,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
         if let next = remaining.first {
             // Auto-switch to the next available assistant
-            settingsWindow?.close()
-            settingsWindow = nil
             performSwitchAssistant(to: next)
             return true
         }
@@ -419,8 +413,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         mainWindow?.close()
         mainWindow = nil
-        settingsWindow?.close()
-        settingsWindow = nil
 
         if let hotKeyMonitor {
             NSEvent.removeMonitor(hotKeyMonitor)
@@ -1298,52 +1290,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Settings
 
-    /// Explicit settings window entrypoint for NSApp.sendAction("showSettingsWindow:")
-    /// and direct calls from SwiftUI views. This avoids responder-chain misses.
+    /// Opens the settings panel in the main window.
+    /// All entry points (Cmd+,, menu bar, onboarding skip, task input) use this.
     @objc public func showSettingsWindow(_ sender: Any?) {
-        NSApp.setActivationPolicy(.regular)
-
-        if let existing = settingsWindow {
-            existing.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
-            return
-        }
-
-        let hostingController = NSHostingController(rootView: SettingsView(store: services.settingsStore, daemonClient: services.daemonClient))
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 450, height: 700),
-            styleMask: [.titled, .closable, .miniaturizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "Vellum Settings"
-        window.contentViewController = hostingController
-        window.isReleasedWhenClosed = false
-        window.center()
-
-        if let existing = settingsWindowObserver {
-            NotificationCenter.default.removeObserver(existing)
-            settingsWindowObserver = nil
-        }
-
-        settingsWindowObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            guard let self else { return }
-            Task { @MainActor [weak self] in
-                self?.settingsWindow = nil
-                if let observer = self?.settingsWindowObserver {
-                    NotificationCenter.default.removeObserver(observer)
-                }
-                self?.settingsWindowObserver = nil
-            }
-        }
-
-        settingsWindow = window
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        showMainWindow()
+        mainWindow?.windowState.selection = .panel(.settings)
     }
 
     // MARK: - Tasks Window
@@ -1379,9 +1330,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(monitor)
         }
         if let observer = windowObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = settingsWindowObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         statusIconCancellable?.cancel()


### PR DESCRIPTION
## Summary

All settings entry points (Cmd+,, menu bar, onboarding skip, task input) now open the SettingsPanel in the main window instead of creating a separate NSWindow. This eliminates the divergent SettingsView window and ensures a consistent settings experience.

## Implementation

- **`AppDelegate.showSettingsWindow()`** — replaced 45-line NSWindow creation with `mainWindow?.show()` + `mainWindow?.windowState.selection = .panel(.settings)`
- **Removed `settingsWindow` and `settingsWindowObserver` properties** — no longer needed since we reuse the main window's panel
- **Cleaned up all references** in `performLogout`, `retireAssistant`, and teardown paths
- **`VellumAssistantApp.swift`** — replaced `SettingsView` with `EmptyView()` in the SwiftUI Settings scene (kept the scene so `.commands` modifier still attaches for the About menu)

## Key Technical Choices

The existing `MainWindow.show()` + `windowState.selection` mechanism already supports panel-based navigation, so no new navigation system was needed. The `showSettingsWindow` ObjC selector is preserved so all callers (`NSApp.sendAction` from onboarding, task input, menu bar) work unchanged.

## Deferred Work

SettingsView has sections not yet in SettingsPanel that will be migrated in follow-up PRs: Computer Use, Voice Activation, Notifications, Media Embeds, Skills, Vercel API Key, Twitter/X. The file is kept in the codebase for reference.

## Testing

1. Press **Cmd+,** — verify main window opens with SettingsPanel visible
2. Click **Control Center → Settings** — same SettingsPanel
3. Menu bar tray → **Settings...** — same behavior
4. Onboarding "Skip" → settings still works
5. Verify no separate 450×700 settings window appears
6. Verify logout doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
