### PR TITLE
fix(calls): prevent false technical fallback after interrupt

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -524,6 +524,56 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('interrupt then next caller prompt still preserves role alternation', async () => {
+    let callCount = 0;
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      callCount++;
+      if (callCount === 1) {
+        const emitter = new EventEmitter();
+        const options = args[1] as { signal?: AbortSignal } | undefined;
+        return {
+          on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
+            emitter.on(event, handler);
+            return { on: () => ({ on: () => ({}) }) };
+          },
+          finalMessage: () =>
+            new Promise((_, reject) => {
+              options?.signal?.addEventListener('abort', () => {
+                const err = new Error('aborted');
+                err.name = 'AbortError';
+                reject(err);
+              }, { once: true });
+            }),
+        };
+      }
+
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const roles = firstArg.messages.map((m) => m.role);
+      for (let i = 1; i < roles.length; i++) {
+        expect(!(roles[i - 1] === 'user' && roles[i] === 'user')).toBe(true);
+      }
+      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const lastUser = userMessages[userMessages.length - 1];
+      expect(lastUser?.content).toContain('First caller utterance');
+      expect(lastUser?.content).toContain('Second caller utterance');
+      return createMockStream(['Post-interrupt response.']);
+    });
+
+    const { relay, orchestrator } = setupOrchestrator();
+    const firstTurnPromise = orchestrator.handleCallerUtterance('First caller utterance');
+    await new Promise((r) => setTimeout(r, 5));
+    orchestrator.handleInterrupt();
+    const secondTurnPromise = orchestrator.handleCallerUtterance('Second caller utterance');
+
+    await Promise.all([firstTurnPromise, secondTurnPromise]);
+
+    const allTokens = relay.sentTokens.map((t) => t.token).join('');
+    expect(allTokens).toContain('Post-interrupt response.');
+    expect(allTokens).not.toContain('technical issue');
+
+    orchestrator.destroy();
+  });
+
   test('handleUserAnswer: returns false when not in waiting_on_user state', async () => {
     const { orchestrator } = setupOrchestrator();
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -77,11 +77,12 @@ export class CallOrchestrator {
     this.resetSilenceTimer();
     const callerContent = this.formatCallerUtterance(transcript, speaker);
 
-    // If a caller barges in while the assistant turn is still in flight,
-    // the interrupted run may never append an assistant message. Coalesce
-    // contiguous caller turns to preserve role alternation for Anthropic.
+    // Preserve strict role alternation for Anthropic. If the last message
+    // is already user-role (e.g. interrupted run never appended assistant,
+    // or a second caller prompt arrives before assistant completion), merge
+    // this utterance into that same user turn.
     const lastMessage = this.conversationHistory[this.conversationHistory.length - 1];
-    if (interruptedInFlight && lastMessage?.role === 'user') {
+    if (lastMessage?.role === 'user') {
       lastMessage.content = `${lastMessage.content}\n${callerContent}`;
     } else {
       this.conversationHistory.push({


### PR DESCRIPTION
## Root cause\nTwilio emits interrupt first, then caller prompt. The interrupt path set orchestrator state to idle before the next prompt arrived. Because the interrupted assistant turn had not appended an assistant message yet, conversation history ended with a user turn; the next caller prompt was appended as a second user turn.\n\nThat violated Anthropic role alternation and triggered an error path that speaks the technical issue fallback, even though the subsequent turn often recovered and responded.\n\n## Fix\n- preserve role alternation by coalescing caller utterances whenever the most recent history role is user\n- keep the existing stale-run suppression and interrupt turn terminator behavior\n- add regression test that reproduces real event ordering: caller utterance, interrupt, next caller prompt\n\n## Validation\n- cd assistant && bun test src/__tests__/call-orchestrator.test.ts\n- full typecheck currently has unrelated pre-existing failures in src/__tests__/daemon-lifecycle.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
