### PR TITLE
Keep guardian verify instruction visible until bound

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -351,8 +351,13 @@ public final class SettingsStore: ObservableObject {
                 self.telegramGuardianVerificationInProgress = false
                 if response.success {
                     self.telegramGuardianIdentity = response.guardianExternalUserId
-                    self.telegramGuardianVerified = response.bound ?? false
-                    self.telegramGuardianInstruction = response.instruction
+                    let isVerified = response.bound ?? false
+                    self.telegramGuardianVerified = isVerified
+                    if isVerified {
+                        self.telegramGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.telegramGuardianInstruction = instruction
+                    }
                     self.telegramGuardianError = nil
                 } else {
                     self.telegramGuardianError = response.error
@@ -361,8 +366,13 @@ public final class SettingsStore: ObservableObject {
                 self.smsGuardianVerificationInProgress = false
                 if response.success {
                     self.smsGuardianIdentity = response.guardianExternalUserId
-                    self.smsGuardianVerified = response.bound ?? false
-                    self.smsGuardianInstruction = response.instruction
+                    let isVerified = response.bound ?? false
+                    self.smsGuardianVerified = isVerified
+                    if isVerified {
+                        self.smsGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.smsGuardianInstruction = instruction
+                    }
                     self.smsGuardianError = nil
                 } else {
                     self.smsGuardianError = response.error

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -177,6 +177,46 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.telegramGuardianError)
     }
 
+    func testUnverifiedStatusResponseDoesNotClearExistingTelegramInstruction() {
+        store.telegramGuardianInstruction = "Send /guardian_verify abc123 on Telegram"
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: false,
+            guardianExternalUserId: nil,
+            channel: "telegram",
+            assistantId: testAssistantId,
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        XCTAssertEqual(store.telegramGuardianInstruction, "Send /guardian_verify abc123 on Telegram")
+        XCTAssertFalse(store.telegramGuardianVerified)
+    }
+
+    func testVerifiedStatusResponseClearsExistingTelegramInstruction() {
+        store.telegramGuardianInstruction = "Send /guardian_verify abc123 on Telegram"
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "tg_user_123",
+            channel: "telegram",
+            assistantId: testAssistantId,
+            guardianDeliveryChatId: "chat_456",
+            error: nil
+        ))
+
+        XCTAssertNil(store.telegramGuardianInstruction)
+        XCTAssertTrue(store.telegramGuardianVerified)
+    }
+
     // MARK: - Failed response sets error
 
     func testFailedResponseSetsTelegramError() {


### PR DESCRIPTION
## Summary\n- preserve existing guardian verification instruction text during unverified status polling responses\n- clear instruction only when guardian binding is verified\n- add regression tests for preserving and clearing instruction behavior\n\n## Validation\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreChannelVerificationTests\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients/macos --filter SettingsStoreTelegramTests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
