### PR TITLE
Remove CHANNEL_APPROVALS_ENABLED and always-on channel approvals

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3636,7 +3636,7 @@ The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-clos
 
 ### Channel Approval Flow
 
-When the assistant requires tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. Generic self-approval UX is gated behind `CHANNEL_APPROVALS_ENABLED`; guardian enforcement (fail-closed denial for unknown actors, `forceStrictSideEffects`, guardian-routed approval prompts) for non-guardian/unverified actors remains active regardless of the flag when orchestrator + callback context are available.
+When the assistant requires tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. This approval-aware path is always active when orchestrator + callback context are available. Guardian enforcement (fail-closed denial for unknown actors, `forceStrictSideEffects`, guardian-routed approval prompts) applies consistently to non-guardian/unverified actors.
 
 **State machine:**
 
@@ -3728,9 +3728,9 @@ The raw secret is shown only once in the desktop UI. Only the SHA-256 hash is pe
 
 #### Actor Role Resolution
 
-When a message arrives on a channel, the runtime resolves the sender's role. Role *classification* runs unconditionally. Guardian enforcement (`forceStrictSideEffects`, fail-closed denial, guardian approval routing) applies to non-guardian/unverified actors regardless of `CHANNEL_APPROVALS_ENABLED` when orchestrator + callback context are available:
+When a message arrives on a channel, the runtime resolves the sender's role. Role *classification* runs unconditionally. Guardian enforcement (`forceStrictSideEffects`, fail-closed denial, guardian approval routing) applies to non-guardian/unverified actors whenever orchestrator + callback context are available:
 
-- **Guardian**: `externalUserId` matches the binding's `guardianExternalUserId` for the `(assistantId, channel)` pair. Generic self-approval UX is controlled by `CHANNEL_APPROVALS_ENABLED`.
+- **Guardian**: `externalUserId` matches the binding's `guardianExternalUserId` for the `(assistantId, channel)` pair. Self-approval is handled through the same approval-aware channel flow.
 - **Non-guardian**: A known sender who is not the guardian. Side-effect tools are forced through the confirmation flow (`forceStrictSideEffects`), and approval prompts are routed to the guardian's chat instead of the requester's chat.
 - **Unverified channel**: No guardian binding exists for the channel, or `senderExternalUserId` is absent. Sensitive actions are auto-denied immediately (fail-closed). This prevents unverified senders from self-approving actions or bypassing guardian enforcement by omitting identity data.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -46,7 +46,6 @@ cp .env.example .env
 | `OLLAMA_BASE_URL` | No | `http://127.0.0.1:11434/v1` | Ollama base URL |
 | `RUNTIME_HTTP_PORT` | No | — | Enable the HTTP server (required for gateway/web) |
 | `RUNTIME_GATEWAY_ORIGIN_SECRET` | No | — | Dedicated secret for the `X-Gateway-Origin` proof header on `/channels/inbound`. When not set, falls back to the bearer token. Both gateway and runtime must share the same value. |
-| `CHANNEL_APPROVALS_ENABLED` | No | `false` | Enable generic channel approval UX (self-approval prompts, callback/text interception, reminders). Guardian actor-role classification always runs; guardian enforcement for non-guardian/unverified actors remains active regardless of this flag when orchestrator + callback context are available. |
 | `VELLUM_DAEMON_SOCKET` | No | `~/.vellum/vellum.sock` | Override the daemon socket path |
 
 ## Usage
@@ -124,7 +123,7 @@ assistant/
 
 ## Channel Approval Flow
 
-When the assistant needs tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. Generic self-approval UX is gated behind `CHANNEL_APPROVALS_ENABLED=true`; guardian enforcement for non-guardian/unverified actors remains active even when the flag is off.
+When the assistant needs tool-use confirmation during a channel session (e.g., Telegram), the approval flow intercepts the run and surfaces an interactive prompt to the user. This approval-aware path is always enabled whenever orchestrator + callback context are available.
 
 ### How it works
 
@@ -164,24 +163,17 @@ Channels that do not support rich inline approval UI (e.g., inline keyboards) re
 
 ### Enabling
 
-Set the environment variable before starting the daemon:
-
-```bash
-CHANNEL_APPROVALS_ENABLED=true
-```
-
-When disabled (the default), guardian senders follow the standard fire-and-forget processing path; non-guardian/unverified senders still use guardian-enforced approval handling for sensitive actions.
+Channel approvals are always enabled for channel traffic when orchestrator + callback context are available.
 
 ### Guardian-Specific Behavior
 
-Guardian actor-role *classification* (determining whether a sender is guardian, non-guardian, or unverified) runs unconditionally. Guardian *enforcement* for non-guardian/unverified actors (`forceStrictSideEffects`, fail-closed denial for unverified channels, and approval prompt routing to guardians) also remains active even when `CHANNEL_APPROVALS_ENABLED=false`, as long as orchestrator + callback context are available. The flag controls generic self-approval UX for guardian actors.
+Guardian actor-role *classification* (determining whether a sender is guardian, non-guardian, or unverified) runs unconditionally. Guardian *enforcement* for non-guardian/unverified actors (`forceStrictSideEffects`, fail-closed denial for unverified channels, and approval prompt routing to guardians) is always active when orchestrator + callback context are available.
 
 | Flag / Behavior | Description |
 |-----------------|-------------|
-| `CHANNEL_APPROVALS_ENABLED=true` | Enables generic self-approval UX: approval prompts, callback/text decisions, and reminder messages for guardian actors. |
-| `forceStrictSideEffects` | Automatically set on runs triggered by non-guardian or unverified-channel senders so all side-effect tools require approval. Applied regardless of `CHANNEL_APPROVALS_ENABLED` for guardian-enforced actors. |
-| **Fail-closed no-binding** | When no guardian binding exists for a channel, the sender is classified as `unverified_channel`. Any sensitive action is auto-denied with a notice that no guardian has been configured. Enforced regardless of `CHANNEL_APPROVALS_ENABLED`. |
-| **Fail-closed no-identity** | When `senderExternalUserId` is absent, the actor is classified as `unverified_channel` (even if no guardian binding exists yet). Enforced regardless of `CHANNEL_APPROVALS_ENABLED`. |
+| `forceStrictSideEffects` | Automatically set on runs triggered by non-guardian or unverified-channel senders so all side-effect tools require approval. |
+| **Fail-closed no-binding** | When no guardian binding exists for a channel, the sender is classified as `unverified_channel`. Any sensitive action is auto-denied with a notice that no guardian has been configured. |
+| **Fail-closed no-identity** | When `senderExternalUserId` is absent, the actor is classified as `unverified_channel` (even if no guardian binding exists yet). |
 | **Guardian-only approval** | Non-guardian senders cannot approve their own pending actions. Only the verified guardian can approve or deny. |
 | **Expired approval auto-deny** | A proactive sweep runs every 60 seconds to find expired guardian approval requests (30-minute TTL). Expired approvals are auto-denied, and both the requester and guardian are notified. If a non-guardian interacts before the sweep runs, the expiry is also detected reactively. |
 

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterAll, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -60,7 +60,6 @@ import {
 import type { RunOrchestrator } from '../runtime/run-orchestrator.js';
 import {
   handleChannelInbound,
-  isChannelApprovalsEnabled,
   sweepExpiredGuardianApprovals,
   verifyGatewayOrigin,
   _setTestPollMaxWait,
@@ -162,52 +161,11 @@ function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
 
 const noopProcessMessage = mock(async () => ({ messageId: 'msg-1' }));
 
-// ---------------------------------------------------------------------------
-// Set up / tear down feature flag for each test
-// ---------------------------------------------------------------------------
-
-let originalEnv: string | undefined;
-
 beforeEach(() => {
   resetTables();
-  originalEnv = process.env.CHANNEL_APPROVALS_ENABLED;
   noopProcessMessage.mockClear();
 });
-
-afterEach(() => {
-  if (originalEnv === undefined) {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
-  } else {
-    process.env.CHANNEL_APPROVALS_ENABLED = originalEnv;
-  }
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// 1. Feature flag gating
-// ═══════════════════════════════════════════════════════════════════════════
-
-describe('isChannelApprovalsEnabled', () => {
-  test('returns false when env var is not set', () => {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
-    expect(isChannelApprovalsEnabled()).toBe(false);
-  });
-
-  test('returns false when env var is "false"', () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'false';
-    expect(isChannelApprovalsEnabled()).toBe(false);
-  });
-
-  test('returns true when env var is "true"', () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
-    expect(isChannelApprovalsEnabled()).toBe(true);
-  });
-});
-
-describe('feature flag disabled → normal flow', () => {
-  beforeEach(() => {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
-  });
-
+describe('stale callback handling without matching pending approval', () => {
   test('ignores stale callback payloads even when pending approvals exist', async () => {
     ensureConversation('conv-1');
     const run = createRun('conv-1');
@@ -222,8 +180,8 @@ describe('feature flag disabled → normal flow', () => {
     const res = await handleChannelInbound(req, noopProcessMessage, undefined, orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
-    // With generic approvals disabled, callback payloads without a matching
-    // pending approval are still treated as stale and ignored.
+    // Callback payloads without a matching pending approval are treated as
+    // stale and ignored.
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe('stale_ignored');
   });
@@ -235,7 +193,6 @@ describe('feature flag disabled → normal flow', () => {
 
 describe('inbound callback metadata triggers decision handling', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -333,7 +290,6 @@ describe('inbound callback metadata triggers decision handling', () => {
 
 describe('inbound text matching approval phrases triggers decision handling', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -404,7 +360,6 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 
 describe('non-decision messages during pending approval trigger reminder', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -458,7 +413,6 @@ describe('non-decision messages during pending approval trigger reminder', () =>
 
 describe('messages without pending approval proceed normally', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('proceeds to normal processing when no pending approval exists', async () => {
@@ -502,7 +456,6 @@ describe('empty content with callbackData bypasses validation', () => {
   });
 
   test('allows empty content when callbackData is present', async () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     const orchestrator = makeMockOrchestrator();
 
     // Establish the conversation first
@@ -535,7 +488,6 @@ describe('empty content with callbackData bypasses validation', () => {
   });
 
   test('allows undefined content when callbackData is present', async () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     const orchestrator = makeMockOrchestrator();
 
     // Establish the conversation first
@@ -584,7 +536,6 @@ describe('empty content with callbackData bypasses validation', () => {
 
 describe('callback run ID validation', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -698,7 +649,6 @@ describe('callback run ID validation', () => {
 
 describe('linkMessage in approval-aware processing path', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('linkMessage is called when run has a messageId and reaches terminal state', async () => {
@@ -755,7 +705,6 @@ describe('linkMessage in approval-aware processing path', () => {
 
 describe('terminal state check before markProcessed', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('records processing failure when run disappears (non-approval non-terminal state)', async () => {
@@ -894,7 +843,6 @@ describe('terminal state check before markProcessed', () => {
 
 describe('no immediate reply after approval decision', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -978,7 +926,6 @@ describe('no immediate reply after approval decision', () => {
 
 describe('stale callback handling', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('callback with no pending approval returns stale_ignored and does not start a run', async () => {
@@ -1042,7 +989,6 @@ describe('stale callback handling', () => {
 
 describe('poll timeout handling by run state', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('records processing failure when run disappears (getRun returns null) before terminal state', async () => {
@@ -1325,7 +1271,6 @@ describe('poll timeout handling by run state', () => {
 
 describe('post-decision delivery after poll timeout', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('delivers reply via callback after a late approval decision', async () => {
@@ -1439,7 +1384,6 @@ describe('post-decision delivery after poll timeout', () => {
 
 describe('sourceChannel passed to orchestrator.startRun', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('startRun is called with sourceChannel from inbound event', async () => {
@@ -1497,7 +1441,6 @@ describe('sourceChannel passed to orchestrator.startRun', () => {
 
 describe('SMS channel approval decisions', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'sms',
@@ -1737,7 +1680,6 @@ describe('SMS guardian verify intercept', () => {
 
 describe('SMS non-guardian actor gating', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('non-guardian SMS actor gets stricter controls when guardian binding exists', async () => {
@@ -1811,7 +1753,6 @@ describe('SMS non-guardian actor gating', () => {
 
 describe('plain-text fallback surfacing for non-rich channels', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -1979,7 +1920,6 @@ function makeSensitiveOrchestrator(opts: {
 
 describe('fail-closed guardian gate — unverified channel', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('no binding + sensitive action → auto-deny with contextual assistant guidance', async () => {
@@ -2123,7 +2063,6 @@ describe('fail-closed guardian gate — unverified channel', () => {
 
 describe('guardian-with-binding path regression', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('non-guardian with binding routes approval to guardian chat', async () => {
@@ -2250,7 +2189,6 @@ describe('guardian-with-binding path regression', () => {
 
 describe('guardian delivery failure → denial', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('delivery failure denies run and notifies requester', async () => {
@@ -2346,7 +2284,6 @@ describe('guardian delivery failure → denial', () => {
 
 describe('standard approval prompt delivery failure → auto-deny', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('standard prompt delivery failure auto-denies the run (fail-closed)', async () => {
@@ -2392,7 +2329,6 @@ describe('standard approval prompt delivery failure → auto-deny', () => {
 
 describe('guardian decision scoping — multiple pending approvals', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('callback for older run resolves to the correct approval request', async () => {
@@ -2479,7 +2415,6 @@ describe('guardian decision scoping — multiple pending approvals', () => {
 
 describe('ambiguous plain-text decision with multiple pending requests', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('does not apply plain-text decision to wrong run when multiple pending', async () => {
@@ -2566,7 +2501,6 @@ describe('ambiguous plain-text decision with multiple pending requests', () => {
 
 describe('expired guardian approval auto-denies via sweep', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('sweepExpiredGuardianApprovals auto-denies and notifies both parties', async () => {
@@ -2710,7 +2644,6 @@ describe('deliver-once idempotency guard', () => {
 
 describe('final reply idempotency — no duplicate delivery', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
     createBinding({
       assistantId: 'self',
       channel: 'telegram',
@@ -3010,7 +2943,6 @@ describe('assistant-scoped guardian verification via handleChannelInbound', () =
   });
 
   test('actor role resolution uses threaded assistantId', async () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
 
     // Create guardian binding for asst-role-X
     createBinding({
@@ -3044,7 +2976,6 @@ describe('assistant-scoped guardian verification via handleChannelInbound', () =
   });
 
   test('same user is guardian for one assistant but not another', async () => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
 
     // user-multi is guardian for asst-M1 but not asst-M2
     createBinding({
@@ -3134,13 +3065,53 @@ describe('assistant-scoped guardian verification via handleChannelInbound', () =
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 27. Guardian enforcement decoupled from CHANNEL_APPROVALS_ENABLED
+// 27. Guardian enforcement behavior
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian enforcement independence from approval flag', () => {
-  test('non-guardian sensitive action routes approval to guardian when CHANNEL_APPROVALS_ENABLED is off', async () => {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
+describe('guardian enforcement behavior', () => {
+  test('guardian sender on telegram uses approval-aware path', async () => {
 
+    // Default senderExternalUserId in makeInboundRequest is telegram-user-default.
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
+    const processSpy = mock(async () => ({ messageId: 'msg-bg-guardian' }));
+    const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const orchestrator = makeSensitiveOrchestrator({
+      runId: 'run-guardian-flag-off-telegram',
+      terminalStatus: 'completed',
+    });
+
+    const req = makeInboundRequest({
+      content: 'place a call',
+      senderExternalUserId: 'telegram-user-default',
+      sourceChannel: 'telegram',
+    });
+
+    const res = await handleChannelInbound(req, processSpy, 'token', orchestrator);
+    expect(res.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Regression guard: this must use the orchestrator approval path, not
+    // fire-and-forget processMessage, otherwise prompts can time out.
+    expect(orchestrator.startRun).toHaveBeenCalled();
+    expect(processSpy).not.toHaveBeenCalled();
+
+    // Guardian self-approval prompt should be delivered to the requester's chat.
+    expect(approvalSpy).toHaveBeenCalled();
+
+    approvalSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test('non-guardian sensitive action routes approval to guardian', async () => {
     // Create a guardian binding — user-guardian is the guardian
     createBinding({
       assistantId: 'self',
@@ -3171,7 +3142,6 @@ describe('guardian enforcement independence from approval flag', () => {
   });
 
   test('missing senderExternalUserId with guardian binding fails closed', async () => {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
 
     // Create a guardian binding — guardian enforcement is active
     createBinding({
@@ -3225,7 +3195,6 @@ describe('guardian enforcement independence from approval flag', () => {
   });
 
   test('missing senderExternalUserId without guardian binding fails closed', async () => {
-    delete process.env.CHANNEL_APPROVALS_ENABLED;
 
     // No guardian binding exists, but identity is missing — treat sender as
     // unverified_channel and auto-deny sensitive actions.
@@ -3409,7 +3378,6 @@ describe('handleChannelInbound gatewayOriginSecret integration', () => {
 
 describe('unknown actor identity — forceStrictSideEffects', () => {
   beforeEach(() => {
-    process.env.CHANNEL_APPROVALS_ENABLED = 'true';
   });
 
   test('unknown sender (no senderExternalUserId) with guardian binding gets forceStrictSideEffects', async () => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -41,7 +41,6 @@ import {
   handleChannelDeliveryAck,
   handleListDeadLetters,
   handleReplayDeadLetters,
-  isChannelApprovalsEnabled,
   startGuardianExpirySweep,
   stopGuardianExpirySweep,
 } from './routes/channel-routes.js';

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -145,14 +145,6 @@ function buildGuardianDenyContext(
 }
 
 // ---------------------------------------------------------------------------
-// Feature flag
-// ---------------------------------------------------------------------------
-
-export function isChannelApprovalsEnabled(): boolean {
-  return process.env.CHANNEL_APPROVALS_ENABLED === 'true';
-}
-
-// ---------------------------------------------------------------------------
 // Callback data parser — format: "apr:<runId>:<action>"
 // ---------------------------------------------------------------------------
 
@@ -434,9 +426,7 @@ export async function handleChannelInbound(
   // When a guardian binding exists, non-guardian actors get stricter
   // side-effect controls and their approvals route to the guardian's chat.
   //
-  // Guardian actor-role resolution always runs. Guardian enforcement for
-  // non-guardian/unverified actors is active even when
-  // CHANNEL_APPROVALS_ENABLED is disabled.
+  // Guardian actor-role resolution always runs.
   let guardianCtx: GuardianContext = { actorRole: 'guardian' };
   if (body.senderExternalUserId) {
     const senderIsGuardian = isGuardian(assistantId, sourceChannel, body.senderExternalUserId);
@@ -478,9 +468,7 @@ export async function handleChannelInbound(
   }
 
   // ── Approval interception ──
-  // Keep this active whenever orchestrator + callback context are available so
-  // guardian decisions can still be applied even when CHANNEL_APPROVALS_ENABLED
-  // is disabled for generic self-approval UX.
+  // Keep this active whenever orchestrator + callback context are available.
   if (
     runOrchestrator &&
     replyCallbackUrl &&
@@ -553,13 +541,12 @@ export async function handleChannelInbound(
       throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
     }
 
-    // Use the approval-aware orchestrator path when:
-    // 1) generic channel approvals are enabled, or
-    // 2) guardian enforcement is required for non-guardian/unverified actors.
+    // Use the approval-aware orchestrator path whenever orchestration and a
+    // callback delivery target are available. This keeps approval handling
+    // consistent across all channels and avoids silent prompt timeouts.
     const useApprovalPath = Boolean(
       runOrchestrator &&
-      replyCallbackUrl &&
-      (isChannelApprovalsEnabled() || guardianCtx.actorRole !== 'guardian'),
+      replyCallbackUrl,
     );
 
     if (useApprovalPath && runOrchestrator && replyCallbackUrl) {


### PR DESCRIPTION
## Summary
- Remove `CHANNEL_APPROVALS_ENABLED` entirely and make channel approval orchestration always-on when callback/orchestrator context exists.
- Simplify channel routing by always using the approval-aware path instead of splitting by flag state.
- Update tests and docs (`assistant/README.md`, `ARCHITECTURE.md`) to reflect flag removal and the new default behavior.

## Original prompt
Lets just remove the CHANNEL_APPROVALS_ENABLED flag entirely. It's causing too much trouble

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
