### PR TITLE
chore: remove .private from git tracking

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,5 +1,0 @@
-
-https://github.com/vellum-ai/vellum-assistant/pull/7034
-https://github.com/vellum-ai/vellum-assistant/pull/7050
-https://github.com/vellum-ai/vellum-assistant/pull/7061
-https://github.com/vellum-ai/vellum-assistant/pull/7075


### PR DESCRIPTION
## Summary
- Remove .private/UNREVIEWED_PRS.md from git tracking (it was already in .gitignore but still tracked)
- .private/ directory was already listed in .gitignore, so no .gitignore changes needed

## Original prompt
remove UNREVIEWED_PRS.md and all of `/.private` from git and make sure its git ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
