### PR TITLE
fix: set degraded flag when semantic search fails to prevent caching fallback results

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -162,10 +162,12 @@ async function collectAndMergeCandidates(
 
   // -- Phase 2: expensive searches (skipped on early termination) --
   let semantic: Candidate[] = [];
+  let semanticSearchFailed = false;
   if (queryVector && !canTerminateEarly) {
     try {
       semantic = await semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds);
     } catch (err) {
+      semanticSearchFailed = true;
       if (isQdrantConnectionError(err)) {
         log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
       } else {
@@ -215,6 +217,7 @@ async function collectAndMergeCandidates(
     relationNeighborEntityCount,
     relationExpandedItemCount,
     earlyTerminated: canTerminateEarly,
+    semanticSearchFailed,
     merged,
   };
 }
@@ -336,7 +339,15 @@ export async function buildMemoryRecall(
     relationNeighborEntityCount,
     relationExpandedItemCount,
     earlyTerminated,
+    semanticSearchFailed,
   } = collected;
+
+  // Mark as degraded when semantic search failed — the recall is based on
+  // lexical/recency only and should not be cached.
+  if (semanticSearchFailed) {
+    degraded = true;
+    reason = reason ?? 'memory.semantic_search_failure';
+  }
   let merged = applySourceCaps(collected.merged, config);
 
   // LLM re-ranking: send top candidates to Haiku for relevance scoring

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -94,6 +94,8 @@ export interface CollectedCandidates {
   relationNeighborEntityCount: number;
   relationExpandedItemCount: number;
   earlyTerminated: boolean;
+  /** True when semantic search was attempted but threw an error. */
+  semanticSearchFailed: boolean;
   merged: Candidate[];
 }
 


### PR DESCRIPTION
Address review feedback from PR #7065. Ensure degraded=true when semanticSearch throws, so the recall cache guard correctly skips caching lower-quality lexical-only results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
