### PR TITLE
fix: check in-flight entries before high-water mark in DedupCache.reserve()

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -74,11 +74,25 @@ describe("DedupCache", () => {
     expect(cache.reserve(60)).toBe("duplicate");
   });
 
-  test("reserve returns 'already_processed' for already-cached update_id", () => {
-    // set() advances the high-water mark, so reserve() for the same ID
-    // hits the high-water mark check and returns "already_processed"
+  test("reserve returns 'duplicate' for already-cached update_id still in cache", () => {
+    // set() advances the high-water mark, but the cache entry is checked
+    // first — since it's still within TTL, reserve() returns "duplicate"
     cache.set(70, '{"done":true}', 200);
-    expect(cache.reserve(70)).toBe("already_processed");
+    expect(cache.reserve(70)).toBe("duplicate");
+  });
+
+  test("reserve returns 'already_processed' for finalized update_id after TTL expires", () => {
+    const shortCache = new DedupCache(1, 100);
+    shortCache.set(70, '{"done":true}', 200);
+
+    // Wait for the TTL entry to expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+
+    // Cache entry expired, but high-water mark still blocks replay
+    expect(shortCache.reserve(70)).toBe("already_processed");
   });
 
   test("reserve returns 'duplicate' for in-cache entry above high-water mark", () => {
@@ -145,8 +159,8 @@ describe("DedupCache", () => {
 
     // update_id below the high-water mark is permanently rejected
     expect(cache.reserve(99)).toBe("already_processed");
-    // same update_id hits high-water mark check first
-    expect(cache.reserve(100)).toBe("already_processed");
+    // same update_id is still in cache — returns "duplicate" (cache checked first)
+    expect(cache.reserve(100)).toBe("duplicate");
     // update_id above the high-water mark is accepted
     expect(cache.reserve(101)).toBe("reserved");
   });
@@ -177,8 +191,24 @@ describe("DedupCache", () => {
 
     // High-water mark should be 200 (the max), not 150 (the last set)
     expect(cache.reserve(199)).toBe("already_processed");
-    expect(cache.reserve(200)).toBe("already_processed");
+    // 200 is still in the cache — returns "duplicate" (cache checked first)
+    expect(cache.reserve(200)).toBe("duplicate");
     expect(cache.reserve(201)).toBe("reserved");
+  });
+
+  test("in-flight entry returns 'duplicate' even when high-water mark has advanced past it", () => {
+    // Simulate concurrent processing: reserve 101, then 102 finalizes first
+    cache.reserve(101);
+    cache.reserve(102);
+    cache.set(102, '{"ok":true}', 200); // advances high-water mark to 102
+
+    // 101 is still in-flight (reserved but not finalized). A retry for 101
+    // should return "duplicate" (not "already_processed") so the caller
+    // returns 503 and Telegram retries, rather than returning 200 which
+    // would suppress retries if the original 101 handler fails.
+    expect(cache.reserve(101)).toBe("duplicate");
+    // get() still returns undefined because 101 is in processing state
+    expect(cache.get(101)).toBeUndefined();
   });
 });
 

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -63,18 +63,24 @@ export class DedupCache {
    *   (fully processed, TTL entry may have expired)
    */
   reserve(updateId: number): ReserveResult {
-    // Reject any update_id at or below the high-water mark — these have
-    // already been fully processed and are replay attempts.
-    if (updateId <= this.highWaterMark) {
-      return "already_processed";
-    }
-
+    // Check existing cache entries FIRST — an active (non-expired) entry
+    // takes priority over the high-water mark. This prevents a race where
+    // a higher update_id finalizes first (advancing the high-water mark)
+    // while a lower update_id is still in-flight: without this ordering,
+    // the in-flight entry would be reported as "already_processed" instead
+    // of "duplicate", causing the caller to return 200 and suppress retries.
     const existing = this.cache.get(updateId);
     if (existing && Date.now() <= existing.expiresAt) {
       return "duplicate";
     }
     // Clean up expired entry if present
     if (existing) this.cache.delete(updateId);
+
+    // Reject any update_id at or below the high-water mark — these have
+    // already been fully processed and are replay attempts.
+    if (updateId <= this.highWaterMark) {
+      return "already_processed";
+    }
 
     // Evict if at capacity
     if (this.cache.size >= this.maxSize) {


### PR DESCRIPTION
Address review feedback from PR #7069. Reorder checks in reserve() so active cache entries take priority over high-water mark, preventing premature 200 responses for in-flight updates during concurrent processing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
