### PR TITLE
feat: notify Slack when release starts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   notify-start:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Notify Slack of release start
         uses: slackapi/slack-github-action@v2.1.0
@@ -41,7 +42,6 @@ jobs:
                     url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   bump-and-tag:
-    needs: notify-start
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  notify-start:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack of release start
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            unfurl_links: false
+            unfurl_media: false
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "\U0001F680 Release v${{ inputs.version }} Started"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Workflow:* Unified Release\n*Version:* `${{ inputs.version }}`\n*Triggered by:* ${{ github.actor }}"
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: "View Run"
+                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   bump-and-tag:
+    needs: notify-start
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
## Summary
- Adds a `notify-start` job at the beginning of the release workflow
- Posts to the same Slack releases channel when a release is kicked off
- `bump-and-tag` now depends on `notify-start` so the notification fires before any work begins
- Complements the existing `notify-failure` job at the end

## Test plan
- [ ] Trigger a release → Slack message appears immediately with version, actor, and link to the run
- [ ] Release continues normally after notification (bump-and-tag runs after notify-start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
