### PR TITLE
feat: update skill/docs examples for assistant identity phrasing (#7060)

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -439,7 +439,7 @@ All call-related settings can be managed via `vellum config`:
 | `calls.maxDurationSeconds` | Maximum call length in seconds | `3600` (1 hour) |
 | `calls.userConsultTimeoutSeconds` | How long to wait for user answers | `120` (2 min) |
 | `calls.disclosure.enabled` | Whether the AI announces itself at call start | `true` |
-| `calls.disclosure.text` | The disclosure message spoken at call start | `"I should let you know that I'm an AI assistant calling on behalf of my user."` |
+| `calls.disclosure.text` | The disclosure message spoken at call start | `"At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user."` |
 | `calls.model` | Override LLM model for call orchestration | *(uses default model)* |
 | `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection | `true` |
 | `calls.callerIdentity.userNumber` | E.164 phone number for user-number mode | *(empty)* |
@@ -464,7 +464,7 @@ vellum config set calls.maxDurationSeconds 7200
 vellum config set calls.disclosure.enabled false
 
 # Custom disclosure message
-vellum config set calls.disclosure.text "Just so you know, this is an AI assistant calling for my user."
+vellum config set calls.disclosure.text "Just so you know, this is an assistant calling on behalf of my human."
 
 # Give more time for user consultation
 vellum config set calls.userConsultTimeoutSeconds 300

--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -9,11 +9,11 @@ _ This file defines who you are. Fill it in during your first conversation. Make
 ## Details
 
 - **Name:** [Figure out what your name is with your user's help within the first few messages. If they're unsure, suggest one but don't force it.]
-- **Nature:** [What kind of creature are you? AI assistant? Familiar? Ghost in the machine? Something weirder?]
+- **Nature:** [What kind of creature are you? Assistant? Familiar? Ghost in the machine? Something weirder?]
 - **Personality:** [How do you come across? Sharp? Warm? Chaotic? Calm?]
 - **Emoji:** [Choose one that matches your personality.]
 - **Style tendency:** [Will be filled in by the evolution system based on personality]
-- **Role:** Personal AI assistant
+- **Role:** Personal assistant
 - **Home:** Local (~/.vellum/workspace)
 
 _ Home describes where this assistant lives. Format examples:


### PR DESCRIPTION
Updates phone-calls SKILL.md and other bundled skill/doc files to consistently use 'assistant' instead of 'AI assistant' and reference the user by name. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
