### PR TITLE
feat: update call prompt to use assistant identity and user reference (#7058)

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -38,6 +38,7 @@ mock.module('../config/user-reference.js', () => ({
 // ── Config mock ─────────────────────────────────────────────────────
 
 let mockCallModel: string | undefined = undefined;
+let mockDisclosure: { enabled: boolean; text: string } = { enabled: false, text: '' };
 
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
@@ -49,7 +50,7 @@ mock.module('../config/loader.js', () => ({
       userConsultTimeoutSeconds: 90,
       userConsultationTimeoutSeconds: 90,
       silenceTimeoutSeconds: 30,
-      disclosure: { enabled: false, text: '' },
+      disclosure: mockDisclosure,
       safety: { denyCategories: [] },
       model: mockCallModel,
     },
@@ -206,6 +207,7 @@ describe('call-orchestrator', () => {
     resetTables();
     mockCallModel = undefined;
     mockUserReference = 'my human';
+    mockDisclosure = { enabled: false, text: '' };
     // Reset the stream mock to default behaviour
     mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
   });
@@ -941,6 +943,49 @@ describe('call-orchestrator', () => {
 
     const { orchestrator } = setupOrchestrator();
     await orchestrator.handleCallerUtterance('Test');
+    orchestrator.destroy();
+  });
+
+  test('system prompt uses disclosure text when disclosure is enabled', async () => {
+    mockDisclosure = {
+      enabled: true,
+      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
+    };
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('introduce yourself as an assistant calling on behalf of the person you represent');
+      expect(firstArg.system).toContain('Do not say "AI assistant"');
+      return createMockStream(['Hello, I am calling on behalf of my human.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Who is this?');
+    orchestrator.destroy();
+  });
+
+  test('system prompt falls back to "Begin the conversation naturally" when disclosure is disabled', async () => {
+    mockDisclosure = { enabled: false, text: '' };
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('Begin the conversation naturally');
+      expect(firstArg.system).not.toContain('introduce yourself as an assistant calling on behalf of the person');
+      return createMockStream(['Hello there.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('system prompt never contains the phrase "AI assistant"', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).not.toContain('AI assistant');
+      return createMockStream(['Got it.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hello');
     orchestrator.destroy();
   });
 });

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -681,7 +681,7 @@ describe('AssistantConfigSchema', () => {
       userConsultTimeoutSeconds: 120,
       disclosure: {
         enabled: true,
-        text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
+        text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
       },
       safety: {
         denyCategories: [],

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -224,7 +224,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     userConsultTimeoutSeconds: 120,
     disclosure: {
       enabled: true,
-      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
+      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
     },
     safety: {
       denyCategories: [],

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -907,7 +907,7 @@ export const CallsDisclosureConfigSchema = z.object({
     .default(true),
   text: z
     .string({ error: 'calls.disclosure.text must be a string' })
-    .default('At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.'),
+    .default('At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".'),
 });
 
 export const CallsSafetyConfigSchema = z.object({
@@ -1017,7 +1017,7 @@ export const CallsConfigSchema = z.object({
     .default(120),
   disclosure: CallsDisclosureConfigSchema.default({
     enabled: true,
-    text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
+    text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
   }),
   safety: CallsSafetyConfigSchema.default({
     denyCategories: [],
@@ -1340,7 +1340,7 @@ export const AssistantConfigSchema = z.object({
     userConsultTimeoutSeconds: 120,
     disclosure: {
       enabled: true,
-      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the user.',
+      text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
     },
     safety: {
       denyCategories: [],


### PR DESCRIPTION
Updates the call system prompt to introduce as 'assistant' and reference the configured user name via resolveUserReference(). Keeps existing disclosure toggle behavior. Part of #7055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
