### PR TITLE
fix: clear stale guardian instruction on revoke and challenge expiry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -878,6 +878,17 @@ public final class SettingsStore: ObservableObject {
 
     func revokeChannelGuardian(channel: String) {
         stopGuardianStatusPolling(for: channel)
+        // Eagerly clear instruction so the "Verify Guardian" button reappears
+        // immediately instead of waiting for the daemon's response (which
+        // looks identical to a status poll and won't clear it).
+        switch channel {
+        case "telegram":
+            telegramGuardianInstruction = nil
+        case "sms":
+            smsGuardianInstruction = nil
+        default:
+            break
+        }
         do {
             try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
         } catch {
@@ -904,6 +915,16 @@ public final class SettingsStore: ObservableObject {
             guardianChallengeTimeoutWorkItem?.cancel()
             guardianChallengeTimeoutWorkItem = nil
         }
+        // Clear stale instruction so the "Verify Guardian" button reappears
+        // when a challenge is no longer active (timeout, revoke, or error).
+        switch channel {
+        case "telegram":
+            telegramGuardianInstruction = nil
+        case "sms":
+            smsGuardianInstruction = nil
+        default:
+            break
+        }
     }
 
     private func armGuardianChallengeTimeout(for channel: String) {
@@ -915,11 +936,13 @@ public final class SettingsStore: ObservableObject {
             switch channel {
             case "telegram":
                 self.telegramGuardianVerificationInProgress = false
+                self.telegramGuardianInstruction = nil
                 if self.telegramGuardianError == nil {
                     self.telegramGuardianError = "Timed out waiting for verification instructions. Try again."
                 }
             case "sms":
                 self.smsGuardianVerificationInProgress = false
+                self.smsGuardianInstruction = nil
                 if self.smsGuardianError == nil {
                     self.smsGuardianError = "Timed out waiting for verification instructions. Try again."
                 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -591,6 +591,77 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertTrue(revokeMessages.allSatisfy { $0.assistantId == "self" })
     }
 
+    // MARK: - Revoke clears instruction
+
+    func testRevokeTelegramGuardianClearsInstruction() {
+        store.telegramGuardianInstruction = "Send /guardian_verify abc123 on Telegram"
+
+        store.revokeChannelGuardian(channel: "telegram")
+
+        XCTAssertNil(store.telegramGuardianInstruction)
+    }
+
+    func testRevokeSmsGuardianClearsInstruction() {
+        store.smsGuardianInstruction = "Send /guardian_verify abc123 via SMS"
+
+        store.revokeChannelGuardian(channel: "sms")
+
+        XCTAssertNil(store.smsGuardianInstruction)
+    }
+
+    // MARK: - Timeout clears instruction
+
+    func testTimeoutClearsTelegramInstruction() {
+        sentMessages.removeAll()
+        let shortTimeoutStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianChallengeTimeoutDuration: 0.15,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+
+        shortTimeoutStore.startChannelGuardianVerification(channel: "telegram")
+
+        // Manually set instruction to simulate a previous challenge's stale text
+        // that persists when a new challenge times out before the daemon responds.
+        shortTimeoutStore.telegramGuardianInstruction = "Send /guardian_verify stale on Telegram"
+
+        // Wait for the timeout to fire
+        let predicate = NSPredicate { _, _ in
+            shortTimeoutStore.telegramGuardianError != nil
+        }
+        let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [timeoutExpectation], timeout: 2.0)
+
+        XCTAssertNil(shortTimeoutStore.telegramGuardianInstruction)
+        XCTAssertFalse(shortTimeoutStore.telegramGuardianVerificationInProgress)
+    }
+
+    func testTimeoutClearsSmsInstruction() {
+        sentMessages.removeAll()
+        let shortTimeoutStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianChallengeTimeoutDuration: 0.15,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+
+        shortTimeoutStore.startChannelGuardianVerification(channel: "sms")
+
+        // Manually set instruction to simulate a previous challenge's stale text
+        shortTimeoutStore.smsGuardianInstruction = "Send /guardian_verify stale via SMS"
+
+        // Wait for the timeout to fire
+        let predicate = NSPredicate { _, _ in
+            shortTimeoutStore.smsGuardianError != nil
+        }
+        let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [timeoutExpectation], timeout: 2.0)
+
+        XCTAssertNil(shortTimeoutStore.smsGuardianInstruction)
+        XCTAssertFalse(shortTimeoutStore.smsGuardianVerificationInProgress)
+    }
+
     // MARK: - Cross-channel timeout isolation
 
     func testResponseForChannelADoesNotCancelTimeoutForChannelB() {


### PR DESCRIPTION
Clears the guardian verification instruction text when a challenge is revoked or times out, preventing users from getting stuck with a stale instruction that hides the Verify Guardian button. Addresses review feedback from PR #7075.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
