### PR TITLE
fix: add response.success check to isStatusPoll condition

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -347,7 +347,7 @@ public final class SettingsStore: ObservableObject {
         daemonClient?.onGuardianVerificationResponse = { [weak self] response in
             guard let self else { return }
             guard let channel = self.resolveGuardianResponseChannel(response.channel) else { return }
-            let isStatusPoll = response.secret == nil && response.instruction == nil && response.bound != true
+            let isStatusPoll = response.success && response.secret == nil && response.instruction == nil && response.bound != true
             if !isStatusPoll {
                 self.clearGuardianChallengePending(for: channel)
             }


### PR DESCRIPTION
Addresses review feedback from PR #7082. Failure responses (success=false) should not be classified as status polls, as they may carry error information that needs to be processed differently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
