### PR TITLE
Telegram: clear approval buttons after callback decision

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -112,6 +112,10 @@ function postRequest(body: string): Request {
 describe("telegram-webhook callback query acknowledgment", () => {
   beforeEach(() => {
     callTelegramApiMock.mockClear();
+    callTelegramApiMock.mockImplementation(
+      (_config: GatewayConfig, _method: string, _body: Record<string, unknown>) =>
+        Promise.resolve({}),
+    );
     sendTelegramReplyMock.mockClear();
     handleInboundMock.mockClear();
     resetConversationMock.mockClear();
@@ -224,5 +228,116 @@ describe("telegram-webhook callback query acknowledgment", () => {
       (c) => c[1] === "answerCallbackQuery",
     );
     expect(answerCalls.length).toBe(0);
+  });
+
+  it("clears inline approval buttons after a standard approval decision", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-1",
+          approval: "decision_applied",
+        },
+      }),
+    );
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve", 306);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(1);
+    expect(clearCalls[0][2]).toEqual({
+      chat_id: "42",
+      message_id: 10,
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
+  it("clears inline approval buttons for stale callback queries", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-2",
+          approval: "stale_ignored",
+        },
+      }),
+    );
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:stale:approve", 307);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(1);
+  });
+
+  it("does not clear inline approval buttons for non-decision callback handling", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-3",
+          approval: "reminder_sent",
+        },
+      }),
+    );
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve", 308);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(0);
+  });
+
+  it("does not fail webhook when clearing inline approval buttons fails", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-4",
+          approval: "guardian_decision_applied",
+        },
+      }),
+    );
+    callTelegramApiMock.mockImplementation((_config: GatewayConfig, method: string) => {
+      if (method === "editMessageReplyMarkup") {
+        return Promise.reject(new Error("edit failed"));
+      }
+      return Promise.resolve({});
+    });
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("gapr:run1:approve", 309);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(1);
   });
 });

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -170,6 +170,29 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       });
     };
 
+    const clearInlineApprovalButtons = (
+      chatId: string,
+      messageId: string | undefined,
+      phase: string,
+    ): void => {
+      if (!messageId) return;
+      const parsedMessageId = Number(messageId);
+      if (!Number.isFinite(parsedMessageId)) {
+        tlog.warn({ messageId, phase }, "Skipping inline approval button clear due to invalid message id");
+        return;
+      }
+      callTelegramApi(config, "editMessageReplyMarkup", {
+        chat_id: chatId,
+        message_id: parsedMessageId,
+        reply_markup: { inline_keyboard: [] },
+      }).catch((err) => {
+        tlog.error(
+          { err, chatId, messageId: parsedMessageId, phase },
+          "Failed to clear inline approval buttons",
+        );
+      });
+    };
+
     // Normalize the update
     const normalized = normalizeTelegramUpdate(payload);
     if (!normalized) {
@@ -353,6 +376,20 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       // Acknowledge the callback query to clear the button spinner in the
       // Telegram client. Best-effort — log errors but don't fail the flow.
       if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forwarded");
+
+      // Once a callback decision is consumed, remove the inline keyboard so
+      // users cannot click obsolete approval buttons again.
+      const approval = result.runtimeResponse?.approval;
+      const shouldClearInlineButtons = approval === "decision_applied" ||
+        approval === "guardian_decision_applied" ||
+        approval === "stale_ignored";
+      if (isCallback && shouldClearInlineButtons) {
+        clearInlineApprovalButtons(
+          normalized.message.externalChatId,
+          normalized.source.messageId,
+          approval,
+        );
+      }
     } catch (err) {
       tlog.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forward_exception");

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -70,6 +70,7 @@ export type RuntimeInboundResponse = {
   accepted: boolean;
   duplicate: boolean;
   eventId: string;
+  approval?: "decision_applied" | "reminder_sent" | "guardian_decision_applied" | "stale_ignored";
   assistantMessage?: {
     id: string;
     role: "assistant";


### PR DESCRIPTION
## Summary
- remove Telegram approval inline buttons after callback decisions are consumed
- keep callback spinner acknowledgment behavior unchanged
- treat keyboard removal as best-effort so webhook success is unaffected
- add callback webhook tests covering decision/stale/non-decision/failure paths

## Validation
- cd gateway && bun test src/http/routes/telegram-webhook.test.ts
- cd gateway && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
