### PR TITLE
fix(test): use targeted regex for AI assistant identity check

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -977,10 +977,10 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  test('system prompt never contains the phrase "AI assistant"', async () => {
+  test('system prompt does not use "AI assistant" as a self-identity label', async () => {
     mockStreamFn.mockImplementation((...args: unknown[]) => {
       const firstArg = args[0] as { system: string };
-      expect(firstArg.system).not.toContain('AI assistant');
+      expect(firstArg.system).not.toMatch(/(?:you are|call yourself|introduce yourself as).*AI assistant/i);
       return createMockStream(['Got it.']);
     });
 


### PR DESCRIPTION
Addresses review feedback from PR #7088. The test 'system prompt never contains the phrase AI assistant' used not.toContain which fails because rule 0 in the call prompt mentions the phrase in a negative instruction. Replaced with a targeted regex that only catches positive self-identity usage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
