### PR TITLE
fix: forward transport metadata through channel approval path

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -790,8 +790,8 @@ export class DaemonServer {
 
   createRunOrchestrator(): RunOrchestrator {
     return new RunOrchestrator({
-      getOrCreateSession: (conversationId) =>
-        this.getOrCreateSession(conversationId),
+      getOrCreateSession: (conversationId, transport) =>
+        this.getOrCreateSession(conversationId, undefined, true, transport ? { transport } : undefined),
       resolveAttachments: (attachmentIds) =>
         attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
           id: a.id,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -562,6 +562,8 @@ export async function handleChannelInbound(
         bearerToken,
         guardianCtx,
         assistantId,
+        metadataHints,
+        metadataUxBrief,
       });
     } else {
       // Fire-and-forget: process the message and deliver the reply in the background.
@@ -695,6 +697,8 @@ interface ApprovalProcessingParams {
   bearerToken?: string;
   guardianCtx: GuardianContext;
   assistantId: string;
+  metadataHints: string[];
+  metadataUxBrief?: string;
 }
 
 /**
@@ -722,6 +726,8 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
     bearerToken,
     guardianCtx,
     assistantId,
+    metadataHints,
+    metadataUxBrief,
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
@@ -736,6 +742,8 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         {
           ...((isNonGuardian || isUnverifiedChannel) ? { forceStrictSideEffects: true } : {}),
           sourceChannel,
+          hints: metadataHints.length > 0 ? metadataHints : undefined,
+          uxBrief: metadataUxBrief,
         },
       );
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -37,7 +37,11 @@ interface PendingRunState {
 }
 
 export interface RunOrchestratorDeps {
-  getOrCreateSession: (conversationId: string) => Promise<Session>;
+  getOrCreateSession: (conversationId: string, transport?: {
+    channelId: string;
+    hints?: string[];
+    uxBrief?: string;
+  }) => Promise<Session>;
   resolveAttachments: (attachmentIds: string[]) => Array<{
     id: string;
     filename: string;
@@ -67,6 +71,16 @@ export interface RunStartOptions {
    * default 'http-api'.
    */
   sourceChannel?: string;
+  /**
+   * Transport hints from sourceMetadata (e.g. reply-context cues).
+   * Forwarded to the session so the agent loop can incorporate them.
+   */
+  hints?: string[];
+  /**
+   * Brief UX context from sourceMetadata (e.g. UI surface description).
+   * Forwarded to the session so the agent loop can tailor its response.
+   */
+  uxBrief?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +118,17 @@ export class RunOrchestrator {
       throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
     }
 
-    const session = await this.deps.getOrCreateSession(conversationId);
+    // Build transport metadata when channel context is available so the
+    // session receives the same hints/uxBrief as the non-orchestrator path.
+    const transport = options?.sourceChannel
+      ? {
+          channelId: options.sourceChannel,
+          hints: options.hints,
+          uxBrief: options.uxBrief,
+        }
+      : undefined;
+
+    const session = await this.deps.getOrCreateSession(conversationId, transport);
 
     if (session.isProcessing()) {
       throw new Error('Session is already processing a message');


### PR DESCRIPTION
Addresses review feedback from PR #7077. Both Codex and Devin flagged that after removing CHANNEL_APPROVALS_ENABLED, transport metadata (hints and uxBrief from sourceMetadata) was silently dropped for messages routed through processChannelMessageWithApprovals. This adds the metadata fields to ApprovalProcessingParams and RunStartOptions, forwarding them through to the session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
