### PR TITLE
Telegram: make approval-button clearing robust

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -256,7 +256,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
     expect(clearCalls[0][2]).toEqual({
       chat_id: "42",
       message_id: 10,
-      reply_markup: { inline_keyboard: [] },
+      reply_markup: null,
     });
   });
 
@@ -310,6 +310,83 @@ describe("telegram-webhook callback query acknowledgment", () => {
     expect(clearCalls.length).toBe(0);
   });
 
+  it("clears inline approval buttons when approval field is omitted for approval callback data", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-omitted",
+        },
+      }),
+    );
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve_once", 310);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(1);
+    expect(clearCalls[0][2]).toEqual({
+      chat_id: "42",
+      message_id: 10,
+      reply_markup: null,
+    });
+  });
+
+  it("falls back to empty inline keyboard payload when null reply_markup fails", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-fallback",
+          approval: "decision_applied",
+        },
+      }),
+    );
+
+    let editAttempts = 0;
+    callTelegramApiMock.mockImplementation((_config: GatewayConfig, method: string) => {
+      if (method === "editMessageReplyMarkup") {
+        editAttempts++;
+        if (editAttempts === 1) {
+          return Promise.reject(new Error("Telegram editMessageReplyMarkup failed: can't parse reply markup JSON object"));
+        }
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    });
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve_once", 311);
+    const res = await handler(postRequest(body));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(2);
+    expect(clearCalls[0][2]).toEqual({
+      chat_id: "42",
+      message_id: 10,
+      reply_markup: null,
+    });
+    expect(clearCalls[1][2]).toEqual({
+      chat_id: "42",
+      message_id: 10,
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
   it("does not fail webhook when clearing inline approval buttons fails", async () => {
     handleInboundMock.mockImplementation(() =>
       Promise.resolve({
@@ -333,11 +410,12 @@ describe("telegram-webhook callback query acknowledgment", () => {
     const handler = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("gapr:run1:approve", 309);
     const res = await handler(postRequest(body));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(res.status).toBe(200);
     const clearCalls = callTelegramApiMock.mock.calls.filter(
       (c) => c[1] === "editMessageReplyMarkup",
     );
-    expect(clearCalls.length).toBe(1);
+    expect(clearCalls.length).toBe(2);
   });
 });

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -181,16 +181,33 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         tlog.warn({ messageId, phase }, "Skipping inline approval button clear due to invalid message id");
         return;
       }
-      callTelegramApi(config, "editMessageReplyMarkup", {
+      const basePayload = {
         chat_id: chatId,
         message_id: parsedMessageId,
-        reply_markup: { inline_keyboard: [] },
-      }).catch((err) => {
-        tlog.error(
-          { err, chatId, messageId: parsedMessageId, phase },
-          "Failed to clear inline approval buttons",
-        );
-      });
+      };
+
+      // Bot API behavior differs across wrappers/clients for "remove markup".
+      // Try the explicit null form first, then fall back to an empty inline
+      // keyboard payload if needed.
+      callTelegramApi(config, "editMessageReplyMarkup", {
+        ...basePayload,
+        reply_markup: null,
+      }).catch((primaryErr) =>
+        callTelegramApi(config, "editMessageReplyMarkup", {
+          ...basePayload,
+          reply_markup: { inline_keyboard: [] },
+        }).catch((fallbackErr) => {
+          tlog.error(
+            { primaryErr, fallbackErr, chatId, messageId: parsedMessageId, phase },
+            "Failed to clear inline approval buttons",
+          );
+        })
+      );
+    };
+
+    const isApprovalCallbackData = (callbackData: string | undefined): boolean => {
+      if (!callbackData) return false;
+      return callbackData.startsWith("apr:");
     };
 
     // Normalize the update
@@ -380,14 +397,17 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       // Once a callback decision is consumed, remove the inline keyboard so
       // users cannot click obsolete approval buttons again.
       const approval = result.runtimeResponse?.approval;
-      const shouldClearInlineButtons = approval === "decision_applied" ||
+      const consumedApprovalDecision = approval === "decision_applied" ||
         approval === "guardian_decision_applied" ||
         approval === "stale_ignored";
+      const fallbackApprovalCallback =
+        approval === undefined && isApprovalCallbackData(normalized.message.callbackData);
+      const shouldClearInlineButtons = consumedApprovalDecision || fallbackApprovalCallback;
       if (isCallback && shouldClearInlineButtons) {
         clearInlineApprovalButtons(
           normalized.message.externalChatId,
           normalized.source.messageId,
-          approval,
+          approval ?? "callback_data_fallback",
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- make Telegram inline-button clearing more resilient after approval callbacks
- try `reply_markup: null` first, then fall back to `inline_keyboard: []`
- clear approval buttons even when runtime omits `approval` but callback data is an approval payload (`apr:*`)
- keep flow best-effort and non-blocking for webhook success

## Validation
- cd gateway && bun test src/http/routes/telegram-webhook.test.ts
- cd gateway && bunx tsc --noEmit