### PR TITLE
refactor: use TraversalOptions object for findNeighborEntities

### DIFF
--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -100,14 +100,14 @@ describe('entity search', () => {
 
   describe('findNeighborEntities', () => {
     test('returns empty for empty seed list', () => {
-      const result = findNeighborEntities([], 10, 10, 3);
+      const result = findNeighborEntities([], { maxEdges: 10, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.neighborEntityIds).toEqual([]);
       expect(result.traversedEdgeCount).toBe(0);
     });
 
     test('returns empty when no edges exist', () => {
       const entityId = upsertEntity({ name: 'Lonely', type: 'concept', aliases: [] });
-      const result = findNeighborEntities([entityId], 10, 10, 3);
+      const result = findNeighborEntities([entityId], { maxEdges: 10, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.neighborEntityIds).toEqual([]);
       expect(result.traversedEdgeCount).toBe(0);
     });
@@ -123,7 +123,7 @@ describe('entity search', () => {
         evidence: 'Alpha uses Beta',
       });
 
-      const result = findNeighborEntities([a], 10, 10, 3);
+      const result = findNeighborEntities([a], { maxEdges: 10, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.neighborEntityIds).toContain(b);
       expect(result.neighborEntityIds).toHaveLength(1);
       expect(result.traversedEdgeCount).toBeGreaterThan(0);
@@ -147,7 +147,7 @@ describe('entity search', () => {
         evidence: null,
       });
 
-      const result = findNeighborEntities([a], 20, 10, 2);
+      const result = findNeighborEntities([a], { maxEdges: 20, maxNeighborEntities: 10, maxDepth: 2 });
       expect(result.neighborEntityIds).toContain(b);
       expect(result.neighborEntityIds).toContain(c);
       expect(result.neighborEntityIds).toHaveLength(2);
@@ -170,7 +170,7 @@ describe('entity search', () => {
         evidence: null,
       });
 
-      const result = findNeighborEntities([a], 20, 10, 5);
+      const result = findNeighborEntities([a], { maxEdges: 20, maxNeighborEntities: 10, maxDepth: 5 });
       expect(result.neighborEntityIds).toEqual([b]);
     });
 
@@ -192,7 +192,7 @@ describe('entity search', () => {
         evidence: null,
       });
 
-      const result = findNeighborEntities([a], 20, 10, 1);
+      const result = findNeighborEntities([a], { maxEdges: 20, maxNeighborEntities: 10, maxDepth: 1 });
       expect(result.neighborEntityIds).toContain(b);
       expect(result.neighborEntityIds).not.toContain(c);
       expect(result.neighborEntityIds).toHaveLength(1);
@@ -209,7 +209,7 @@ describe('entity search', () => {
       upsertEntityRelation({ sourceEntityId: b, targetEntityId: d, relation: 'related_to', evidence: null });
 
       // Allow only 1 edge total, so BFS can't explore much
-      const result = findNeighborEntities([a], 1, 10, 3);
+      const result = findNeighborEntities([a], { maxEdges: 1, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.traversedEdgeCount).toBeLessThanOrEqual(1);
     });
 
@@ -222,7 +222,7 @@ describe('entity search', () => {
         upsertEntityRelation({ sourceEntityId: seed, targetEntityId: n, relation: 'related_to', evidence: null });
       }
 
-      const result = findNeighborEntities([seed], 20, 2, 3);
+      const result = findNeighborEntities([seed], { maxEdges: 20, maxNeighborEntities: 2, maxDepth: 3 });
       expect(result.neighborEntityIds).toHaveLength(2);
     });
 
@@ -237,7 +237,7 @@ describe('entity search', () => {
         evidence: null,
       });
 
-      const result = findNeighborEntities([a], 10, 10, 3);
+      const result = findNeighborEntities([a], { maxEdges: 10, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.neighborEntityIds).toContain(x);
     });
 
@@ -250,7 +250,7 @@ describe('entity search', () => {
       upsertEntityRelation({ sourceEntityId: a, targetEntityId: na, relation: 'uses', evidence: null });
       upsertEntityRelation({ sourceEntityId: b, targetEntityId: nb, relation: 'uses', evidence: null });
 
-      const result = findNeighborEntities([a, b], 20, 10, 3);
+      const result = findNeighborEntities([a, b], { maxEdges: 20, maxNeighborEntities: 10, maxDepth: 3 });
       expect(result.neighborEntityIds).toContain(na);
       expect(result.neighborEntityIds).toContain(nb);
     });

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -8,7 +8,7 @@ import {
   memoryItems,
   memoryItemSources,
 } from '../schema.js';
-import type { Candidate, CandidateSource, CandidateType, EntitySearchResult, MatchedEntityRow } from './types.js';
+import type { Candidate, CandidateSource, CandidateType, EntitySearchResult, MatchedEntityRow, TraversalOptions } from './types.js';
 import { computeRecencyScore } from './ranking.js';
 
 const log = getLogger('memory-retriever');
@@ -54,12 +54,11 @@ export function entitySearch(
   const {
     neighborEntityIds,
     traversedEdgeCount: relationTraversedEdgeCount,
-  } = findNeighborEntities(
-    seedEntityIds,
-    relationConfig.maxEdges,
-    relationConfig.maxNeighborEntities,
-    relationConfig.maxDepth,
-  );
+  } = findNeighborEntities(seedEntityIds, {
+    maxEdges: relationConfig.maxEdges,
+    maxNeighborEntities: relationConfig.maxNeighborEntities,
+    maxDepth: relationConfig.maxDepth,
+  });
   const relationNeighborEntityCount = neighborEntityIds.length;
   const directItemIds = new Set(directCandidates.map((candidate) => candidate.id));
   const relationCandidates = getEntityLinkedItemCandidates(neighborEntityIds, {
@@ -152,10 +151,9 @@ export function findMatchedEntities(query: string, maxMatches: number): MatchedE
  */
 export function findNeighborEntities(
   seedEntityIds: string[],
-  maxEdges: number,
-  maxNeighborEntities: number,
-  maxDepth: number = 3,
+  opts: TraversalOptions,
 ): { neighborEntityIds: string[]; traversedEdgeCount: number } {
+  const { maxEdges, maxNeighborEntities, maxDepth = 3 } = opts;
   if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0 || maxDepth <= 0) {
     return { neighborEntityIds: [], traversedEdgeCount: 0 };
   }

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -137,3 +137,9 @@ export interface MemorySearchResult {
     recency: number;
   };
 }
+
+export interface TraversalOptions {
+  maxEdges: number;
+  maxNeighborEntities: number;
+  maxDepth?: number; // default 3
+}


### PR DESCRIPTION
## Summary

Refactor `findNeighborEntities` from positional parameters to a `TraversalOptions` object, making it easy to add optional filter parameters (relation types, entity types) in subsequent PRs without breaking the call site.

Part 2 of the entity graph complex queries rollout plan.

## Changes
- Add `TraversalOptions` interface to `types.ts`
- Refactor `findNeighborEntities` signature in `entity.ts`
- Update caller in `entitySearch()`
- Update all test calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
