### PR TITLE
feat: add relation type filter to BFS traversal

### DIFF
--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -254,6 +254,43 @@ describe('entity search', () => {
       expect(result.neighborEntityIds).toContain(na);
       expect(result.neighborEntityIds).toContain(nb);
     });
+
+    test('relationTypes filter: only follows specified edge types', () => {
+      const idA = upsertEntity({ name: 'PersonAlpha', type: 'person', aliases: [] });
+      const idB = upsertEntity({ name: 'ToolBeta', type: 'tool', aliases: [] });
+      const idC = upsertEntity({ name: 'ProjectGamma', type: 'project', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: idA, targetEntityId: idB, relation: 'uses' });
+      upsertEntityRelation({ sourceEntityId: idA, targetEntityId: idC, relation: 'works_on' });
+
+      const result = findNeighborEntities([idA], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 1,
+        relationTypes: ['uses'],
+      });
+
+      expect(result.neighborEntityIds).toContain(idB);
+      expect(result.neighborEntityIds).not.toContain(idC);
+    });
+
+    test('relationTypes filter: omitting filter follows all edge types', () => {
+      const idA = upsertEntity({ name: 'PersonDelta', type: 'person', aliases: [] });
+      const idB = upsertEntity({ name: 'ToolEpsilon', type: 'tool', aliases: [] });
+      const idC = upsertEntity({ name: 'ProjectZeta', type: 'project', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: idA, targetEntityId: idB, relation: 'uses' });
+      upsertEntityRelation({ sourceEntityId: idA, targetEntityId: idC, relation: 'works_on' });
+
+      const result = findNeighborEntities([idA], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 1,
+      });
+
+      expect(result.neighborEntityIds).toContain(idB);
+      expect(result.neighborEntityIds).toContain(idC);
+    });
   });
 
   // ── findMatchedEntities ────────────────────────────────────────────

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -153,7 +153,7 @@ export function findNeighborEntities(
   seedEntityIds: string[],
   opts: TraversalOptions,
 ): { neighborEntityIds: string[]; traversedEdgeCount: number } {
-  const { maxEdges, maxNeighborEntities, maxDepth = 3 } = opts;
+  const { maxEdges, maxNeighborEntities, maxDepth = 3, relationTypes } = opts;
   if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0 || maxDepth <= 0) {
     return { neighborEntityIds: [], traversedEdgeCount: 0 };
   }
@@ -172,16 +172,21 @@ export function findNeighborEntities(
     const edgeBudget = maxEdges - totalEdgesTraversed;
     if (edgeBudget <= 0) break;
 
+    const frontierCondition = or(
+      inArray(memoryEntityRelations.sourceEntityId, frontier),
+      inArray(memoryEntityRelations.targetEntityId, frontier),
+    );
+    const whereCondition = relationTypes && relationTypes.length > 0
+      ? and(frontierCondition, inArray(memoryEntityRelations.relation, relationTypes))
+      : frontierCondition;
+
     const rows = db
       .select({
         sourceEntityId: memoryEntityRelations.sourceEntityId,
         targetEntityId: memoryEntityRelations.targetEntityId,
       })
       .from(memoryEntityRelations)
-      .where(or(
-        inArray(memoryEntityRelations.sourceEntityId, frontier),
-        inArray(memoryEntityRelations.targetEntityId, frontier),
-      ))
+      .where(whereCondition)
       .orderBy(desc(memoryEntityRelations.lastSeenAt))
       .limit(Math.max(1, edgeBudget))
       .all();

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -138,8 +138,11 @@ export interface MemorySearchResult {
   };
 }
 
+import type { EntityRelationType } from '../entity-extractor.js';
+
 export interface TraversalOptions {
   maxEdges: number;
   maxNeighborEntities: number;
   maxDepth?: number; // default 3
+  relationTypes?: EntityRelationType[];
 }


### PR DESCRIPTION
## Summary

Add optional `relationTypes` filter to `TraversalOptions`, allowing BFS to follow only specific edge types (e.g., only `uses` edges). When omitted, all edge types are followed (existing behavior unchanged).

Part 3 of the entity graph complex queries rollout plan.

## Changes
- Add `relationTypes?: EntityRelationType[]` to `TraversalOptions` in `types.ts`
- Filter edges by relation type in `findNeighborEntities` when `relationTypes` is provided
- Add 2 tests: filtered traversal and omitting filter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
