### PR TITLE
feat: add entity type filter to BFS traversal

### DIFF
--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -291,6 +291,43 @@ describe('entity search', () => {
       expect(result.neighborEntityIds).toContain(idB);
       expect(result.neighborEntityIds).toContain(idC);
     });
+
+    test('entityTypes filter: only returns entities of specified types', () => {
+      const idPerson = upsertEntity({ name: 'PersonEta', type: 'person', aliases: [] });
+      const idProject = upsertEntity({ name: 'ProjectTheta', type: 'project', aliases: [] });
+      const idTool = upsertEntity({ name: 'ToolIota', type: 'tool', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: idPerson, targetEntityId: idProject, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: idPerson, targetEntityId: idTool, relation: 'uses' });
+
+      const result = findNeighborEntities([idPerson], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 1,
+        entityTypes: ['project'],
+      });
+
+      expect(result.neighborEntityIds).toContain(idProject);
+      expect(result.neighborEntityIds).not.toContain(idTool);
+    });
+
+    test('entityTypes filter: omitting filter returns all entity types', () => {
+      const idPerson = upsertEntity({ name: 'PersonKappa', type: 'person', aliases: [] });
+      const idProject = upsertEntity({ name: 'ProjectLambda', type: 'project', aliases: [] });
+      const idTool = upsertEntity({ name: 'ToolMu', type: 'tool', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: idPerson, targetEntityId: idProject, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: idPerson, targetEntityId: idTool, relation: 'uses' });
+
+      const result = findNeighborEntities([idPerson], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 1,
+      });
+
+      expect(result.neighborEntityIds).toContain(idProject);
+      expect(result.neighborEntityIds).toContain(idTool);
+    });
   });
 
   // ── findMatchedEntities ────────────────────────────────────────────

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -2,7 +2,9 @@ import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm';
 import type { MemoryEntityConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
 import { getDb } from '../db.js';
+import type { EntityType } from '../entity-extractor.js';
 import {
+  memoryEntities,
   memoryEntityRelations,
   memoryItemEntities,
   memoryItems,
@@ -153,7 +155,7 @@ export function findNeighborEntities(
   seedEntityIds: string[],
   opts: TraversalOptions,
 ): { neighborEntityIds: string[]; traversedEdgeCount: number } {
-  const { maxEdges, maxNeighborEntities, maxDepth = 3, relationTypes } = opts;
+  const { maxEdges, maxNeighborEntities, maxDepth = 3, relationTypes, entityTypes } = opts;
   if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0 || maxDepth <= 0) {
     return { neighborEntityIds: [], traversedEdgeCount: 0 };
   }
@@ -162,6 +164,15 @@ export function findNeighborEntities(
   const visited = new Set<string>(seedEntityIds);
   const neighbors: string[] = [];
   let totalEdgesTraversed = 0;
+
+  // Cache entity types to avoid repeated DB lookups when filtering by type
+  const entityTypeCache = new Map<string, string>();
+  function getEntityType(entityId: string): string | undefined {
+    if (entityTypeCache.has(entityId)) return entityTypeCache.get(entityId);
+    const entity = db.select({ type: memoryEntities.type }).from(memoryEntities).where(eq(memoryEntities.id, entityId)).get();
+    if (entity) entityTypeCache.set(entityId, entity.type);
+    return entity?.type;
+  }
 
   // BFS frontier starts with seed entities
   let frontier = [...seedEntityIds];
@@ -198,12 +209,26 @@ export function findNeighborEntities(
     for (const row of rows) {
       if (neighbors.length >= maxNeighborEntities) break;
       if (frontierSet.has(row.sourceEntityId) && !visited.has(row.targetEntityId)) {
+        if (entityTypes && entityTypes.length > 0) {
+          const targetType = getEntityType(row.targetEntityId);
+          if (!targetType || !entityTypes.includes(targetType as EntityType)) {
+            visited.add(row.targetEntityId);
+            continue;
+          }
+        }
         visited.add(row.targetEntityId);
         neighbors.push(row.targetEntityId);
         nextFrontier.push(row.targetEntityId);
       }
       if (neighbors.length >= maxNeighborEntities) break;
       if (frontierSet.has(row.targetEntityId) && !visited.has(row.sourceEntityId)) {
+        if (entityTypes && entityTypes.length > 0) {
+          const sourceType = getEntityType(row.sourceEntityId);
+          if (!sourceType || !entityTypes.includes(sourceType as EntityType)) {
+            visited.add(row.sourceEntityId);
+            continue;
+          }
+        }
         visited.add(row.sourceEntityId);
         neighbors.push(row.sourceEntityId);
         nextFrontier.push(row.sourceEntityId);

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -138,11 +138,12 @@ export interface MemorySearchResult {
   };
 }
 
-import type { EntityRelationType } from '../entity-extractor.js';
+import type { EntityRelationType, EntityType } from '../entity-extractor.js';
 
 export interface TraversalOptions {
   maxEdges: number;
   maxNeighborEntities: number;
   maxDepth?: number; // default 3
   relationTypes?: EntityRelationType[];
+  entityTypes?: EntityType[];
 }


### PR DESCRIPTION
## Summary

Add optional `entityTypes` filter to `TraversalOptions`, allowing BFS to only return neighbor entities of specified types (e.g., only `project` entities). Uses inline type checking during expansion to avoid wasting edge budget on filtered-out entities.

Part 4 of the entity graph complex queries rollout plan.

## Changes
- Add `entityTypes?: EntityType[]` to `TraversalOptions` in `types.ts`
- Filter neighbors by entity type in `findNeighborEntities` during BFS expansion
- Add 2 tests: filtered by entity type and omitting filter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
