### PR TITLE
feat: return neighbor depth metadata from BFS traversal

### DIFF
--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -328,6 +328,37 @@ describe('entity search', () => {
       expect(result.neighborEntityIds).toContain(idProject);
       expect(result.neighborEntityIds).toContain(idTool);
     });
+
+    test('neighborDepths tracks BFS depth for each neighbor', () => {
+      // A -> B -> C (chain)
+      const idA = upsertEntity({ name: 'DepthAlpha', type: 'person', aliases: [] });
+      const idB = upsertEntity({ name: 'DepthBeta', type: 'tool', aliases: [] });
+      const idC = upsertEntity({ name: 'DepthGamma', type: 'project', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: idA, targetEntityId: idB, relation: 'uses' });
+      upsertEntityRelation({ sourceEntityId: idB, targetEntityId: idC, relation: 'depends_on' });
+
+      const result = findNeighborEntities([idA], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 2,
+      });
+
+      expect(result.neighborEntityIds).toContain(idB);
+      expect(result.neighborEntityIds).toContain(idC);
+      expect(result.neighborDepths.get(idB)).toBe(1);
+      expect(result.neighborDepths.get(idC)).toBe(2);
+    });
+
+    test('neighborDepths is empty when no neighbors found', () => {
+      const idA = upsertEntity({ name: 'DepthDelta', type: 'person', aliases: [] });
+      const result = findNeighborEntities([idA], {
+        maxEdges: 10,
+        maxNeighborEntities: 10,
+        maxDepth: 1,
+      });
+      expect(result.neighborDepths.size).toBe(0);
+    });
   });
 
   // ── findMatchedEntities ────────────────────────────────────────────

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -10,7 +10,7 @@ import {
   memoryItems,
   memoryItemSources,
 } from '../schema.js';
-import type { Candidate, CandidateSource, CandidateType, EntitySearchResult, MatchedEntityRow, TraversalOptions } from './types.js';
+import type { Candidate, CandidateSource, CandidateType, EntitySearchResult, MatchedEntityRow, TraversalOptions, TraversalResult } from './types.js';
 import { computeRecencyScore } from './ranking.js';
 
 const log = getLogger('memory-retriever');
@@ -154,15 +154,16 @@ export function findMatchedEntities(query: string, maxMatches: number): MatchedE
 export function findNeighborEntities(
   seedEntityIds: string[],
   opts: TraversalOptions,
-): { neighborEntityIds: string[]; traversedEdgeCount: number } {
+): TraversalResult {
   const { maxEdges, maxNeighborEntities, maxDepth = 3, relationTypes, entityTypes } = opts;
   if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0 || maxDepth <= 0) {
-    return { neighborEntityIds: [], traversedEdgeCount: 0 };
+    return { neighborEntityIds: [], traversedEdgeCount: 0, neighborDepths: new Map() };
   }
 
   const db = getDb();
   const visited = new Set<string>(seedEntityIds);
   const neighbors: string[] = [];
+  const neighborDepths = new Map<string, number>();
   let totalEdgesTraversed = 0;
 
   // Cache entity types to avoid repeated DB lookups when filtering by type
@@ -219,6 +220,7 @@ export function findNeighborEntities(
         visited.add(row.targetEntityId);
         neighbors.push(row.targetEntityId);
         nextFrontier.push(row.targetEntityId);
+        neighborDepths.set(row.targetEntityId, depth + 1);
       }
       if (neighbors.length >= maxNeighborEntities) break;
       if (frontierSet.has(row.targetEntityId) && !visited.has(row.sourceEntityId)) {
@@ -232,6 +234,7 @@ export function findNeighborEntities(
         visited.add(row.sourceEntityId);
         neighbors.push(row.sourceEntityId);
         nextFrontier.push(row.sourceEntityId);
+        neighborDepths.set(row.sourceEntityId, depth + 1);
       }
     }
 
@@ -241,6 +244,7 @@ export function findNeighborEntities(
   return {
     neighborEntityIds: neighbors.slice(0, maxNeighborEntities),
     traversedEdgeCount: totalEdgesTraversed,
+    neighborDepths,
   };
 }
 

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -147,3 +147,9 @@ export interface TraversalOptions {
   relationTypes?: EntityRelationType[];
   entityTypes?: EntityType[];
 }
+
+export interface TraversalResult {
+  neighborEntityIds: string[];
+  traversedEdgeCount: number;
+  neighborDepths: Map<string, number>; // entityId → depth (1-based)
+}


### PR DESCRIPTION
## Summary

Add `neighborDepths: Map<string, number>` to the BFS traversal result, tracking at which depth (1-based) each neighbor entity was discovered. This enables depth-aware scoring in a subsequent PR.

Part 5 of the entity graph complex queries rollout plan.

## Changes
- Add `TraversalResult` interface to `types.ts`
- Track and return `neighborDepths` in `findNeighborEntities`
- Add 2 tests for depth tracking
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
