### PR TITLE
M1: Media asset registry schema + ingest tool + processing status lifecycle

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "Media Processing"
+description: "Ingest and process media files (video, audio, image) through multi-stage pipelines"
+metadata: {"vellum": {"emoji": "🎬"}}
+---
+
+Ingest and track processing of media files (video, audio, images) through configurable multi-stage pipelines.
+
+## Tools
+
+### ingest_media
+
+Register a media file for processing. Accepts an absolute file path, validates the file exists, detects MIME type, extracts duration (for video/audio via ffprobe), and registers the asset with content-hash deduplication.
+
+### media_status
+
+Query the processing status of a media asset. Returns the asset metadata along with per-stage progress details.
+
+## Usage Notes
+
+- The `ingest_media` tool requires an absolute path to a local file.
+- Supported media types: video (mp4, mov, avi, mkv, webm, etc.), audio (mp3, wav, m4a, etc.), and images (png, jpg, gif, webp, etc.).
+- For video and audio files, duration is automatically extracted via ffprobe (requires ffmpeg to be installed).
+- Duplicate files are detected by content hash and return the existing asset record.
+- After ingestion, processing stages are tracked in the database. Use `media_status` to monitor progress.

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "ingest_media",
+      "description": "Ingest a media file (video, audio, or image) for processing. Validates the file, detects MIME type, extracts duration for video/audio, registers the asset with content-hash dedup, and enqueues an initial processing job.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "file_path": {
+            "type": "string",
+            "description": "Absolute path to a local media file (video, audio, or image)"
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional human-readable title for the media asset. Defaults to the filename."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Optional JSON metadata to attach to the asset (e.g., pipeline config, source info)"
+          }
+        },
+        "required": ["file_path"]
+      },
+      "executor": "tools/ingest-media.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "media_status",
+      "description": "Query the processing status of one or more media assets, including per-stage progress details.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of a specific media asset to query"
+          },
+          "file_path": {
+            "type": "string",
+            "description": "File path to look up a media asset by its original path"
+          },
+          "status_filter": {
+            "type": "string",
+            "enum": ["registered", "processing", "indexed", "failed"],
+            "description": "Filter assets by processing status"
+          }
+        }
+      },
+      "executor": "tools/media-status.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -1,0 +1,196 @@
+import { basename, extname } from 'node:path';
+import { access, readFile } from 'node:fs/promises';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import {
+  registerMediaAsset,
+  computeFileHash,
+  getMediaAssetByHash,
+  createProcessingStage,
+  updateMediaAssetStatus,
+  type MediaType,
+} from '../../../../memory/media-store.js';
+import { enqueueMemoryJob } from '../../../../memory/jobs-store.js';
+
+// ---------------------------------------------------------------------------
+// MIME detection
+// ---------------------------------------------------------------------------
+
+const MIME_MAP: Record<string, string> = {
+  // Video
+  '.mp4': 'video/mp4', '.mov': 'video/quicktime', '.avi': 'video/x-msvideo',
+  '.mkv': 'video/x-matroska', '.webm': 'video/webm', '.m4v': 'video/x-m4v',
+  '.mpeg': 'video/mpeg', '.mpg': 'video/mpeg', '.ts': 'video/mp2t',
+  '.flv': 'video/x-flv', '.wmv': 'video/x-ms-wmv',
+  // Audio
+  '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.m4a': 'audio/x-m4a',
+  '.aac': 'audio/aac', '.ogg': 'audio/ogg', '.flac': 'audio/flac',
+  '.aiff': 'audio/aiff', '.wma': 'audio/x-ms-wma',
+  // Image
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif', '.webp': 'image/webp', '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff', '.svg': 'image/svg+xml', '.heic': 'image/heic',
+};
+
+function detectMimeType(filePath: string): string | null {
+  const ext = extname(filePath).toLowerCase();
+  return MIME_MAP[ext] ?? null;
+}
+
+function classifyMediaType(mimeType: string): MediaType | null {
+  if (mimeType.startsWith('video/')) return 'video';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('image/')) return 'image';
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// ffprobe duration extraction
+// ---------------------------------------------------------------------------
+
+function spawnWithTimeout(
+  cmd: string[],
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Process timed out after ${timeoutMs}ms: ${cmd[0]}`));
+    }, timeoutMs);
+    proc.exited.then(async (exitCode) => {
+      clearTimeout(timer);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+async function extractDuration(filePath: string): Promise<number | null> {
+  try {
+    const result = await spawnWithTimeout([
+      'ffprobe', '-v', 'error',
+      '-show_entries', 'format=duration',
+      '-of', 'csv=p=0',
+      filePath,
+    ], 15_000);
+    if (result.exitCode !== 0) return null;
+    const duration = parseFloat(result.stdout.trim());
+    return Number.isFinite(duration) ? duration : null;
+  } catch {
+    // ffprobe not available or timed out
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const filePath = input.file_path as string | undefined;
+  if (!filePath) {
+    return { content: 'file_path is required. Provide an absolute path to a local media file.', isError: true };
+  }
+
+  // Validate file exists
+  try {
+    await access(filePath);
+  } catch {
+    return { content: `File not found: ${filePath}`, isError: true };
+  }
+
+  // Detect MIME type
+  const mimeType = detectMimeType(filePath);
+  if (!mimeType) {
+    return {
+      content: `Unsupported file type: ${extname(filePath)}. Supported: video (mp4, mov, avi, mkv, webm, etc.), audio (mp3, wav, m4a, etc.), image (png, jpg, gif, webp, etc.).`,
+      isError: true,
+    };
+  }
+
+  const mediaType = classifyMediaType(mimeType);
+  if (!mediaType) {
+    return { content: `Could not classify media type for MIME: ${mimeType}`, isError: true };
+  }
+
+  // Compute content hash for dedup
+  context.onOutput?.('Reading file and computing content hash...\n');
+  const fileData = await readFile(filePath);
+  const fileHash = computeFileHash(fileData);
+
+  // Check for existing asset with same hash
+  const existingAsset = getMediaAssetByHash(fileHash);
+  if (existingAsset) {
+    return {
+      content: JSON.stringify({
+        message: 'Media asset already registered (duplicate detected by content hash)',
+        asset: existingAsset,
+        deduplicated: true,
+      }, null, 2),
+      isError: false,
+    };
+  }
+
+  // Extract duration for video/audio
+  let durationSeconds: number | null = null;
+  if (mediaType === 'video' || mediaType === 'audio') {
+    context.onOutput?.('Extracting duration via ffprobe...\n');
+    durationSeconds = await extractDuration(filePath);
+  }
+
+  // Determine title
+  const title = (input.title as string) || basename(filePath);
+
+  // Parse optional metadata
+  let metadata: Record<string, unknown> | undefined;
+  if (input.metadata && typeof input.metadata === 'object') {
+    metadata = input.metadata as Record<string, unknown>;
+  }
+
+  // Register the asset
+  const asset = registerMediaAsset({
+    title,
+    filePath,
+    mimeType,
+    durationSeconds,
+    fileHash,
+    mediaType,
+    metadata,
+  });
+
+  // Create an initial processing stage
+  createProcessingStage({
+    assetId: asset.id,
+    stage: 'ingest',
+  });
+
+  // Update status to processing
+  updateMediaAssetStatus(asset.id, 'processing');
+
+  // Enqueue a processing job via the existing jobs framework
+  enqueueMemoryJob('embed_segment' as any, {
+    mediaAssetId: asset.id,
+    stage: 'ingest',
+    filePath,
+    mimeType,
+    mediaType,
+  });
+
+  context.onOutput?.(`Registered media asset: ${asset.id}\n`);
+
+  return {
+    content: JSON.stringify({
+      message: 'Media asset registered and processing enqueued',
+      asset: {
+        ...asset,
+        status: 'processing',
+      },
+      deduplicated: false,
+    }, null, 2),
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/media-status.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/media-status.ts
@@ -1,0 +1,75 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import {
+  getMediaAssetById,
+  getMediaAssetByFilePath,
+  getMediaAssetsByStatus,
+  getProcessingStagesForAsset,
+  type MediaAssetStatus,
+} from '../../../../memory/media-store.js';
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  const filePath = input.file_path as string | undefined;
+  const statusFilter = input.status_filter as MediaAssetStatus | undefined;
+
+  // Query by asset ID
+  if (assetId) {
+    const asset = getMediaAssetById(assetId);
+    if (!asset) {
+      return { content: `Media asset not found: ${assetId}`, isError: true };
+    }
+    const stages = getProcessingStagesForAsset(asset.id);
+    return {
+      content: JSON.stringify({ asset, stages }, null, 2),
+      isError: false,
+    };
+  }
+
+  // Query by file path
+  if (filePath) {
+    const asset = getMediaAssetByFilePath(filePath);
+    if (!asset) {
+      return { content: `No media asset found for path: ${filePath}`, isError: true };
+    }
+    const stages = getProcessingStagesForAsset(asset.id);
+    return {
+      content: JSON.stringify({ asset, stages }, null, 2),
+      isError: false,
+    };
+  }
+
+  // Query by status filter
+  if (statusFilter) {
+    const validStatuses: MediaAssetStatus[] = ['registered', 'processing', 'indexed', 'failed'];
+    if (!validStatuses.includes(statusFilter)) {
+      return {
+        content: `Invalid status filter: ${statusFilter}. Valid values: ${validStatuses.join(', ')}`,
+        isError: true,
+      };
+    }
+    const assets = getMediaAssetsByStatus(statusFilter);
+    const results = assets.map((asset) => ({
+      asset,
+      stages: getProcessingStagesForAsset(asset.id),
+    }));
+    return {
+      content: JSON.stringify({
+        count: results.length,
+        assets: results,
+      }, null, 2),
+      isError: false,
+    };
+  }
+
+  return {
+    content: 'Provide at least one query parameter: asset_id, file_path, or status_filter.',
+    isError: true,
+  };
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1015,5 +1015,41 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(assistant_id, channel, actor_external_user_id, actor_chat_id)`);
 
+  // ── Media Assets ───────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_assets (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      duration_seconds REAL,
+      file_hash TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'registered',
+      media_type TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_assets_file_hash ON media_assets(file_hash)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_assets_status ON media_assets(status)`);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS processing_stages (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      stage TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      progress INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      started_at INTEGER,
+      completed_at INTEGER
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processing_stages_asset_id ON processing_stages(asset_id)`);
+
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -1,0 +1,223 @@
+/**
+ * Media asset storage and processing stage tracking.
+ *
+ * Provides CRUD operations for the media_assets and processing_stages tables.
+ * Uses content-hash deduplication (same pattern as attachments-store.ts).
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { mediaAssets, processingStages } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MediaAssetStatus = 'registered' | 'processing' | 'indexed' | 'failed';
+export type MediaType = 'video' | 'audio' | 'image';
+export type StageStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface MediaAsset {
+  id: string;
+  title: string;
+  filePath: string;
+  mimeType: string;
+  durationSeconds: number | null;
+  fileHash: string;
+  status: MediaAssetStatus;
+  mediaType: MediaType;
+  metadata: Record<string, unknown> | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ProcessingStage {
+  id: string;
+  assetId: string;
+  stage: string;
+  status: StageStatus;
+  progress: number;
+  lastError: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Content hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a content hash for deduplication. Uses Bun.hash (wyhash) for speed,
+ * encoded as base-36 for compact storage.
+ */
+export function computeFileHash(data: Buffer | Uint8Array): string {
+  return Bun.hash(data).toString(36);
+}
+
+// ---------------------------------------------------------------------------
+// Media asset CRUD
+// ---------------------------------------------------------------------------
+
+export function registerMediaAsset(params: {
+  title: string;
+  filePath: string;
+  mimeType: string;
+  durationSeconds: number | null;
+  fileHash: string;
+  mediaType: MediaType;
+  metadata?: Record<string, unknown>;
+}): MediaAsset {
+  const db = getDb();
+
+  // Dedup: if an asset with the same content hash already exists, return it
+  const existing = db
+    .select()
+    .from(mediaAssets)
+    .where(eq(mediaAssets.fileHash, params.fileHash))
+    .get();
+
+  if (existing) {
+    return parseAssetRow(existing);
+  }
+
+  const now = Date.now();
+  const record = {
+    id: uuid(),
+    title: params.title,
+    filePath: params.filePath,
+    mimeType: params.mimeType,
+    durationSeconds: params.durationSeconds,
+    fileHash: params.fileHash,
+    status: 'registered' as const,
+    mediaType: params.mediaType,
+    metadata: params.metadata ? JSON.stringify(params.metadata) : null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(mediaAssets).values(record).run();
+
+  return {
+    ...record,
+    metadata: params.metadata ?? null,
+  };
+}
+
+export function getMediaAssetById(id: string): MediaAsset | null {
+  const db = getDb();
+  const row = db.select().from(mediaAssets).where(eq(mediaAssets.id, id)).get();
+  return row ? parseAssetRow(row) : null;
+}
+
+export function getMediaAssetByFilePath(filePath: string): MediaAsset | null {
+  const db = getDb();
+  const row = db.select().from(mediaAssets).where(eq(mediaAssets.filePath, filePath)).get();
+  return row ? parseAssetRow(row) : null;
+}
+
+export function getMediaAssetByHash(fileHash: string): MediaAsset | null {
+  const db = getDb();
+  const row = db.select().from(mediaAssets).where(eq(mediaAssets.fileHash, fileHash)).get();
+  return row ? parseAssetRow(row) : null;
+}
+
+export function getMediaAssetsByStatus(status: MediaAssetStatus): MediaAsset[] {
+  const db = getDb();
+  const rows = db.select().from(mediaAssets).where(eq(mediaAssets.status, status)).all();
+  return rows.map(parseAssetRow);
+}
+
+export function updateMediaAssetStatus(id: string, status: MediaAssetStatus): void {
+  const db = getDb();
+  db.update(mediaAssets)
+    .set({ status, updatedAt: Date.now() })
+    .where(eq(mediaAssets.id, id))
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Processing stage CRUD
+// ---------------------------------------------------------------------------
+
+export function createProcessingStage(params: {
+  assetId: string;
+  stage: string;
+}): ProcessingStage {
+  const db = getDb();
+  const record = {
+    id: uuid(),
+    assetId: params.assetId,
+    stage: params.stage,
+    status: 'pending' as const,
+    progress: 0,
+    lastError: null,
+    startedAt: null,
+    completedAt: null,
+  };
+
+  db.insert(processingStages).values(record).run();
+  return record;
+}
+
+export function getProcessingStagesForAsset(assetId: string): ProcessingStage[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(processingStages)
+    .where(eq(processingStages.assetId, assetId))
+    .all();
+  return rows.map(parseStageRow);
+}
+
+export function updateProcessingStage(
+  id: string,
+  updates: Partial<Pick<ProcessingStage, 'status' | 'progress' | 'lastError' | 'startedAt' | 'completedAt'>>,
+): void {
+  const db = getDb();
+  db.update(processingStages)
+    .set(updates)
+    .where(eq(processingStages.id, id))
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Row parsing
+// ---------------------------------------------------------------------------
+
+function parseAssetRow(row: typeof mediaAssets.$inferSelect): MediaAsset {
+  let metadata: Record<string, unknown> | null = null;
+  if (row.metadata) {
+    try {
+      metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+    } catch {
+      metadata = null;
+    }
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    filePath: row.filePath,
+    mimeType: row.mimeType,
+    durationSeconds: row.durationSeconds,
+    fileHash: row.fileHash,
+    status: row.status as MediaAssetStatus,
+    mediaType: row.mediaType as MediaType,
+    metadata,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function parseStageRow(row: typeof processingStages.$inferSelect): ProcessingStage {
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    stage: row.stage,
+    status: row.status as StageStatus,
+    progress: row.progress,
+    lastError: row.lastError,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+  };
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -680,3 +680,31 @@ export const channelGuardianRateLimits = sqliteTable('channel_guardian_rate_limi
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
+
+// ── Media Assets ─────────────────────────────────────────────────────
+
+export const mediaAssets = sqliteTable('media_assets', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  filePath: text('file_path').notNull(),
+  mimeType: text('mime_type').notNull(),
+  durationSeconds: real('duration_seconds'),
+  fileHash: text('file_hash').notNull(),
+  status: text('status').notNull().default('registered'),       // registered | processing | indexed | failed
+  mediaType: text('media_type').notNull(),                      // video | audio | image
+  metadata: text('metadata'),                                   // JSON
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const processingStages = sqliteTable('processing_stages', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  stage: text('stage').notNull(),
+  status: text('status').notNull().default('pending'),          // pending | running | completed | failed
+  progress: integer('progress').notNull().default(0),           // 0-100
+  lastError: text('last_error'),
+  startedAt: integer('started_at'),
+  completedAt: integer('completed_at'),
+});


### PR DESCRIPTION
Part of #6985: Vision-First Basketball Film Assistant MVP

## Changes
- Created media-processing bundled skill structure (SKILL.md, TOOLS.json, tools/)
- Added Drizzle schema tables: media_assets, processing_stages
- Created media-store.ts with CRUD and content-hash dedup
- Created ingest-media.ts tool (validate, ffprobe duration, register, enqueue job)
- Created media-status.ts tool (per-stage processing status query)
- All primitives are generic media-processing — not basketball-specific

Closes #6989
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
