### PR TITLE
feat: add knowledge-graph bundled skill for explicit graph queries

### DIFF
--- a/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
+++ b/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
@@ -1,0 +1,15 @@
+# Knowledge Graph
+
+Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory.
+
+## When to use
+
+- When the user asks about relationships between entities ("what tools does project X use?", "who works on project Y?")
+- When the user wants to explore connected entities across the knowledge graph
+- When automatic memory recall doesn't surface the right relationship-based information
+
+## Capabilities
+
+- **Neighbors**: Find entities directly connected to seed entities (optionally filtered by relation and entity type)
+- **Typed traversal**: Multi-step traversal with type constraints at each step (e.g., "me -> works_on -> projects -> uses -> tools")
+- **Intersection**: Find entities reachable from ALL given seeds (e.g., "projects both Alice and Bob work on")

--- a/assistant/src/config/bundled-skills/knowledge-graph/TOOLS.json
+++ b/assistant/src/config/bundled-skills/knowledge-graph/TOOLS.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "knowledge_graph_query",
+      "description": "Query the entity knowledge graph to find related entities and their associated memory items. Supports three query types: 'neighbors' (direct connections), 'typed_traversal' (multi-step with type filters), and 'intersection' (entities reachable from ALL seeds).",
+      "category": "memory",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query_type": {
+            "type": "string",
+            "enum": ["neighbors", "typed_traversal", "intersection"],
+            "description": "Type of graph query to execute"
+          },
+          "seeds": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Entity names or aliases to use as starting points"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "relation_types": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Relation types to follow (e.g., 'uses', 'works_on', 'depends_on')"
+                },
+                "entity_types": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Entity types to include (e.g., 'person', 'project', 'tool')"
+                }
+              }
+            },
+            "description": "Traversal steps for typed_traversal and intersection queries. Each step defines type filters for one hop."
+          },
+          "max_results": {
+            "type": "number",
+            "description": "Maximum number of entities to return (default: 20)"
+          },
+          "include_items": {
+            "type": "boolean",
+            "description": "Include associated memory items for each found entity (default: true)"
+          }
+        },
+        "required": ["query_type", "seeds"]
+      },
+      "executor": "tools/graph-query.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/knowledge-graph/tools/graph-query.ts
+++ b/assistant/src/config/bundled-skills/knowledge-graph/tools/graph-query.ts
@@ -1,0 +1,168 @@
+import { initializeDb, getDb } from '../../../../memory/db.js';
+import { findMatchedEntities, findNeighborEntities, getEntityLinkedItemCandidates, collectTypedNeighbors } from '../../../../memory/search/entity.js';
+import { memoryEntities } from '../../../../memory/schema.js';
+import { inArray } from 'drizzle-orm';
+import type { TraversalStep } from '../../../../memory/search/types.js';
+import type { EntityRelationType, EntityType } from '../../../../memory/entity-extractor.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+
+interface GraphQueryInput {
+  query_type: 'neighbors' | 'typed_traversal' | 'intersection';
+  seeds: string[];
+  steps?: Array<{
+    relation_types?: string[];
+    entity_types?: string[];
+  }>;
+  max_results?: number;
+  include_items?: boolean;
+}
+
+interface EntityResult {
+  id: string;
+  name: string;
+  type: string;
+  aliases: string[];
+  items?: Array<{ subject: string; statement: string }>;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const params = input as unknown as GraphQueryInput;
+
+  initializeDb();
+
+  const maxResults = params.max_results ?? 20;
+  const includeItems = params.include_items ?? true;
+
+  // Resolve seed entity names to IDs
+  const seedEntityIds: string[] = [];
+  const resolvedSeeds: Array<{ name: string; id: string }> = [];
+  for (const seedName of params.seeds) {
+    const matched = findMatchedEntities(seedName, 5);
+    if (matched.length > 0) {
+      seedEntityIds.push(matched[0].id);
+      resolvedSeeds.push({ name: seedName, id: matched[0].id });
+    }
+  }
+
+  if (seedEntityIds.length === 0) {
+    return {
+      content: JSON.stringify({
+        error: 'No matching entities found for the provided seed names',
+        seeds: params.seeds,
+      }),
+      isError: true,
+    };
+  }
+
+  let resultEntityIds: string[];
+
+  switch (params.query_type) {
+    case 'neighbors': {
+      const steps = params.steps?.[0];
+      const result = findNeighborEntities(seedEntityIds, {
+        maxEdges: 40,
+        maxNeighborEntities: maxResults,
+        maxDepth: 1,
+        relationTypes: steps?.relation_types as EntityRelationType[] | undefined,
+        entityTypes: steps?.entity_types as EntityType[] | undefined,
+      });
+      resultEntityIds = result.neighborEntityIds;
+      break;
+    }
+
+    case 'typed_traversal': {
+      const traversalSteps: TraversalStep[] = (params.steps ?? []).map(s => ({
+        relationTypes: s.relation_types as EntityRelationType[] | undefined,
+        entityTypes: s.entity_types as EntityType[] | undefined,
+      }));
+      resultEntityIds = collectTypedNeighbors(seedEntityIds, traversalSteps, {
+        maxResultsPerStep: maxResults,
+        maxEdgesPerStep: 40,
+      });
+      break;
+    }
+
+    case 'intersection': {
+      // Run typed traversal from each seed independently, then intersect
+      const traversalSteps: TraversalStep[] = (params.steps ?? []).map(s => ({
+        relationTypes: s.relation_types as EntityRelationType[] | undefined,
+        entityTypes: s.entity_types as EntityType[] | undefined,
+      }));
+
+      const resultSets: Set<string>[] = [];
+      for (const seedId of seedEntityIds) {
+        const result = collectTypedNeighbors([seedId], traversalSteps, {
+          maxResultsPerStep: maxResults,
+          maxEdgesPerStep: 40,
+        });
+        resultSets.push(new Set(result));
+      }
+
+      if (resultSets.length === 0) {
+        resultEntityIds = [];
+      } else {
+        // Intersect all sets
+        const intersection = [...resultSets[0]].filter(id =>
+          resultSets.every(set => set.has(id))
+        );
+        resultEntityIds = intersection;
+      }
+      break;
+    }
+
+    default:
+      return {
+        content: JSON.stringify({ error: `Unknown query_type: ${params.query_type}` }),
+        isError: true,
+      };
+  }
+
+  // Look up entity details
+  const db = getDb();
+  const entities: EntityResult[] = [];
+
+  if (resultEntityIds.length > 0) {
+    const entityRows = db
+      .select()
+      .from(memoryEntities)
+      .where(inArray(memoryEntities.id, resultEntityIds.slice(0, maxResults)))
+      .all();
+
+    for (const row of entityRows) {
+      const entity: EntityResult = {
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        aliases: row.aliases ? JSON.parse(row.aliases) as string[] : [],
+      };
+
+      if (includeItems) {
+        const candidates = getEntityLinkedItemCandidates([row.id], {
+          source: 'entity_direct',
+        });
+        entity.items = candidates.slice(0, 5).map(c => {
+          const parts = c.text.split(': ');
+          return {
+            subject: parts[0] ?? '',
+            statement: parts.slice(1).join(': ') ?? c.text,
+          };
+        });
+      }
+
+      entities.push(entity);
+    }
+  }
+
+  return {
+    content: JSON.stringify({
+      query_type: params.query_type,
+      resolved_seeds: resolvedSeeds,
+      result_count: entities.length,
+      entities,
+    }, null, 2),
+    isError: false,
+  };
+}


### PR DESCRIPTION
## Summary

Add a new bundled skill `knowledge-graph` that exposes the entity graph query capabilities as a tool the assistant can explicitly invoke. Supports three query types:
- **neighbors**: Direct connections filtered by relation/entity type
- **typed_traversal**: Multi-step traversal with type constraints per step
- **intersection**: Find entities reachable from ALL seeds

Part 9 of the entity graph complex queries rollout plan.

## Changes
- New `assistant/src/config/bundled-skills/knowledge-graph/SKILL.md`
- New `assistant/src/config/bundled-skills/knowledge-graph/TOOLS.json`
- New `assistant/src/config/bundled-skills/knowledge-graph/tools/graph-query.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
