### PR TITLE
feat: add depth-aware scoring decay for entity relation candidates

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -206,6 +206,7 @@ describe('AssistantConfigSchema', () => {
       maxEdges: 40,
       neighborScoreMultiplier: 0.7,
       maxDepth: 3,
+      depthDecay: true,
     });
   });
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -110,6 +110,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         maxEdges: 40,
         neighborScoreMultiplier: 0.7,
         maxDepth: 3,
+        depthDecay: true,
       },
     },
     conflicts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -533,6 +533,9 @@ export const MemoryEntityConfigSchema = z.object({
       .int('memory.entity.relationRetrieval.maxDepth must be an integer')
       .positive('memory.entity.relationRetrieval.maxDepth must be a positive integer')
       .default(3),
+    depthDecay: z
+      .boolean({ error: 'memory.entity.relationRetrieval.depthDecay must be a boolean' })
+      .default(true),
   }).default({
     enabled: true,
     maxSeedEntities: 8,
@@ -540,6 +543,7 @@ export const MemoryEntityConfigSchema = z.object({
     maxEdges: 40,
     neighborScoreMultiplier: 0.7,
     maxDepth: 3,
+    depthDecay: true,
   }),
 });
 
@@ -688,6 +692,7 @@ export const MemoryConfigSchema = z.object({
       maxEdges: 40,
       neighborScoreMultiplier: 0.7,
       maxDepth: 3,
+      depthDecay: true,
     },
   }),
   conflicts: MemoryConflictsConfigSchema.default({
@@ -1226,6 +1231,7 @@ export const AssistantConfigSchema = z.object({
         maxEdges: 40,
         neighborScoreMultiplier: 0.7,
         maxDepth: 3,
+        depthDecay: true,
       },
     },
     conflicts: {

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -177,6 +177,7 @@ async function collectAndMergeCandidates(
   }
 
   let entity: Candidate[] = [];
+  let candidateDepths: Map<string, number> | undefined;
   let relationSeedEntityCount = 0;
   let relationTraversedEdgeCount = 0;
   let relationNeighborEntityCount = 0;
@@ -189,6 +190,7 @@ async function collectAndMergeCandidates(
       excludeMessageIds,
     );
     entity = entitySearchResult.candidates;
+    candidateDepths = entitySearchResult.candidateDepths;
     relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
     relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
     relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
@@ -205,7 +207,10 @@ async function collectAndMergeCandidates(
   const relationScoreMultiplier = config.memory.entity.enabled && config.memory.entity.relationRetrieval.enabled
     ? config.memory.entity.relationRetrieval.neighborScoreMultiplier
     : undefined;
-  const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness, relationScoreMultiplier);
+  const depthMap = config.memory.entity.enabled && config.memory.entity.relationRetrieval.depthDecay
+    ? candidateDepths
+    : undefined;
+  const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness, relationScoreMultiplier, depthMap);
 
   return {
     lexical,

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -56,6 +56,7 @@ export function entitySearch(
   const {
     neighborEntityIds,
     traversedEdgeCount: relationTraversedEdgeCount,
+    neighborDepths,
   } = findNeighborEntities(seedEntityIds, {
     maxEdges: relationConfig.maxEdges,
     maxNeighborEntities: relationConfig.maxNeighborEntities,
@@ -71,12 +72,47 @@ export function entitySearch(
   });
   const relationExpandedItemCount = relationCandidates.length;
 
+  // Build candidate key → BFS depth map so ranking can apply distance-based decay
+  const candidateDepths = new Map<string, number>();
+  if (relationCandidates.length > 0 && neighborDepths.size > 0) {
+    const db = getDb();
+    const itemIds = relationCandidates.map((c) => c.id);
+    const links = db
+      .select({
+        memoryItemId: memoryItemEntities.memoryItemId,
+        entityId: memoryItemEntities.entityId,
+      })
+      .from(memoryItemEntities)
+      .where(inArray(memoryItemEntities.memoryItemId, itemIds))
+      .all();
+
+    // For each item, find the minimum depth among its linked neighbor entities
+    const itemDepthMap = new Map<string, number>();
+    for (const link of links) {
+      const depth = neighborDepths.get(link.entityId);
+      if (depth !== undefined) {
+        const existing = itemDepthMap.get(link.memoryItemId);
+        if (existing === undefined || depth < existing) {
+          itemDepthMap.set(link.memoryItemId, depth);
+        }
+      }
+    }
+
+    for (const candidate of relationCandidates) {
+      const depth = itemDepthMap.get(candidate.id);
+      if (depth !== undefined) {
+        candidateDepths.set(candidate.key, depth);
+      }
+    }
+  }
+
   return {
     candidates: [...directCandidates, ...relationCandidates],
     relationSeedEntityCount,
     relationTraversedEdgeCount,
     relationNeighborEntityCount,
     relationExpandedItemCount,
+    candidateDepths,
   };
 }
 
@@ -87,6 +123,7 @@ export function emptyEntitySearchResult(): EntitySearchResult {
     relationTraversedEdgeCount: 0,
     relationNeighborEntityCount: 0,
     relationExpandedItemCount: 0,
+    candidateDepths: new Map(),
   };
 }
 

--- a/assistant/src/memory/search/ranking.ts
+++ b/assistant/src/memory/search/ranking.ts
@@ -53,6 +53,7 @@ export function mergeCandidates(
   entity: Candidate[] = [],
   freshnessConfig?: { enabled: boolean; maxAgeDays: Record<string, number>; staleDecay: number; reinforcementShieldDays: number },
   relationScoreMultiplier?: number,
+  candidateDepthMap?: Map<string, number>,
 ): Candidate[] {
   // Build effective weight map that reflects the actual scoring weight for
   // each source.  For entity_relation the static SOURCE_WEIGHTS entry is 1.0
@@ -126,7 +127,11 @@ export function mergeCandidates(
     const lastUsedAt = meta?.lastUsedAt ?? null;
     const freshnessWeight = computeFreshnessWeight(row, accessCount, lastUsedAt, freshnessConfig);
 
-    const sourceWeight = effectiveWeights[row.source] ?? 1.0;
+    let sourceWeight = effectiveWeights[row.source] ?? 1.0;
+    if (row.source === 'entity_relation' && candidateDepthMap && relationScoreMultiplier != null) {
+      const depth = candidateDepthMap.get(row.key) ?? 1;
+      sourceWeight = Math.pow(relationScoreMultiplier, depth);
+    }
     row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight * freshnessWeight * sourceWeight;
   }
 

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -105,6 +105,7 @@ export interface EntitySearchResult {
   relationTraversedEdgeCount: number;
   relationNeighborEntityCount: number;
   relationExpandedItemCount: number;
+  candidateDepths?: Map<string, number>; // candidate key → BFS hop depth (1-based)
 }
 
 export interface MatchedEntityRow {


### PR DESCRIPTION
## Summary

Apply distance-based scoring decay for entity_relation candidates: closer neighbors (1 hop) score higher than distant ones (3 hops). Uses `neighborScoreMultiplier ^ depth` instead of a flat multiplier.

- depth=1: 0.7, depth=2: 0.49, depth=3: 0.343

Controlled by `relationRetrieval.depthDecay` config flag (default: true).

Part 6 of the entity graph complex queries rollout plan.

## Changes
- Add `depthDecay` boolean config option to `relationRetrieval`
- Add `candidateDepths` to `EntitySearchResult`
- Build candidate depth map from BFS `neighborDepths` in `entitySearch()`
- Thread depth map through retriever to `mergeCandidates()`
- Apply `Math.pow(multiplier, depth)` decay in ranking
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
