### PR TITLE
M2: Vision keyframe analysis pipeline + timeline generation

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "Media Processing"
-description: "Ingest and process media files (video, audio, image) through multi-stage pipelines"
+description: "Ingest and process media files (video, audio, image) through multi-stage pipelines including keyframe extraction, vision analysis, and timeline generation"
 metadata: {"vellum": {"emoji": "🎬"}}
 ---
 
@@ -16,6 +16,20 @@ Register a media file for processing. Accepts an absolute file path, validates t
 
 Query the processing status of a media asset. Returns the asset metadata along with per-stage progress details.
 
+### extract_keyframes
+
+Extract keyframes from a video asset at regular intervals using ffmpeg. Frames are saved as JPEG images and registered in the database for subsequent vision analysis.
+
+### analyze_keyframes
+
+Analyze extracted keyframes using Claude VLM (vision language model). Produces structured JSON output with scene descriptions, subjects, actions, and context. Supports resumability by skipping already-analyzed frames.
+
+## Services
+
+### Timeline Generation
+
+The timeline service (services/timeline-service.ts) aggregates vision analysis outputs into coherent timeline segments. Call `generateTimeline(assetId)` after keyframe analysis is complete to produce a structured timeline.
+
 ## Usage Notes
 
 - The `ingest_media` tool requires an absolute path to a local file.
@@ -23,3 +37,6 @@ Query the processing status of a media asset. Returns the asset metadata along w
 - For video and audio files, duration is automatically extracted via ffprobe (requires ffmpeg to be installed).
 - Duplicate files are detected by content hash and return the existing asset record.
 - After ingestion, processing stages are tracked in the database. Use `media_status` to monitor progress.
+- Keyframe extraction requires ffmpeg. Vision analysis requires the ANTHROPIC_API_KEY environment variable.
+- The `analyze_keyframes` tool is marked as medium risk because it makes external API calls to Claude VLM, which incur costs.
+- All schema tables, services, and tool interfaces are media-generic. Domain-specific interpretation belongs in VLM prompt templates.

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -52,6 +52,54 @@
       },
       "executor": "tools/media-status.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "extract_keyframes",
+      "description": "Extract keyframes from a video asset at regular intervals using ffmpeg. Stores frame images and registers each in the database for subsequent vision analysis.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset (must be a video)"
+          },
+          "interval_seconds": {
+            "type": "number",
+            "description": "Interval between keyframes in seconds. Default: 3"
+          }
+        },
+        "required": ["asset_id"]
+      },
+      "executor": "tools/extract-keyframes.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "analyze_keyframes",
+      "description": "Analyze extracted keyframes using Claude VLM (vision language model). Produces structured scene descriptions with subjects, actions, and context for each frame. Supports resumability — skips already-analyzed frames.",
+      "category": "media",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset whose keyframes to analyze"
+          },
+          "analysis_type": {
+            "type": "string",
+            "description": "Type of analysis to perform. Default: 'scene_description'"
+          },
+          "batch_size": {
+            "type": "number",
+            "description": "Number of keyframes to process per batch. Default: 10"
+          }
+        },
+        "required": ["asset_id"]
+      },
+      "executor": "tools/analyze-keyframes.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/media-processing/services/timeline-service.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/timeline-service.ts
@@ -1,0 +1,262 @@
+/**
+ * Timeline generation service.
+ *
+ * Aggregates sequential vision outputs into coherent timeline segments.
+ * Each segment groups adjacent keyframes that share similar scene characteristics
+ * into a single time range with merged attributes.
+ */
+
+import {
+  getMediaAssetById,
+  getKeyframesForAsset,
+  getVisionOutputsForAsset,
+  deleteTimelineForAsset,
+  insertTimelineSegmentsBatch,
+  createProcessingStage,
+  updateProcessingStage,
+  getProcessingStagesForAsset,
+  type MediaVisionOutput,
+  type MediaKeyframe,
+  type MediaTimeline,
+} from '../../../../memory/media-store.js';
+
+export interface TimelineGenerationResult {
+  assetId: string;
+  segmentCount: number;
+  segments: MediaTimeline[];
+}
+
+/**
+ * Generate a timeline for a media asset from its vision analysis outputs.
+ *
+ * Groups consecutive keyframes with similar scene descriptions into segments.
+ * If a timeline already exists for this asset, it is replaced.
+ */
+export function generateTimeline(
+  assetId: string,
+  options?: {
+    analysisType?: string;
+    onProgress?: (message: string) => void;
+  },
+): TimelineGenerationResult {
+  const analysisType = options?.analysisType ?? 'scene_description';
+  const onProgress = options?.onProgress;
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    throw new Error(`Media asset not found: ${assetId}`);
+  }
+
+  const keyframes = getKeyframesForAsset(assetId);
+  if (keyframes.length === 0) {
+    throw new Error('No keyframes found for this asset. Run extract_keyframes first.');
+  }
+
+  const visionOutputs = getVisionOutputsForAsset(assetId, analysisType);
+  if (visionOutputs.length === 0) {
+    throw new Error(`No vision outputs found for analysis type "${analysisType}". Run analyze_keyframes first.`);
+  }
+
+  // Find or create the timeline_generation processing stage
+  const existingStages = getProcessingStagesForAsset(assetId);
+  let stage = existingStages.find((s) => s.stage === 'timeline_generation');
+  if (!stage) {
+    stage = createProcessingStage({ assetId, stage: 'timeline_generation' });
+  }
+  updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
+
+  try {
+    // Build a map of keyframeId -> keyframe for timestamp lookup
+    const keyframeMap = new Map<string, MediaKeyframe>();
+    for (const kf of keyframes) {
+      keyframeMap.set(kf.id, kf);
+    }
+
+    // Build a map of keyframeId -> vision output
+    const outputByKeyframe = new Map<string, MediaVisionOutput>();
+    for (const vo of visionOutputs) {
+      outputByKeyframe.set(vo.keyframeId, vo);
+    }
+
+    // Sort keyframes by timestamp to ensure sequential processing
+    const sortedKeyframes = [...keyframes]
+      .filter((kf) => outputByKeyframe.has(kf.id))
+      .sort((a, b) => a.timestamp - b.timestamp);
+
+    if (sortedKeyframes.length === 0) {
+      updateProcessingStage(stage.id, {
+        status: 'completed',
+        progress: 100,
+        completedAt: Date.now(),
+      });
+      return { assetId, segmentCount: 0, segments: [] };
+    }
+
+    onProgress?.('Aggregating vision outputs into timeline segments...');
+
+    // Aggregate consecutive frames into segments based on scene similarity
+    const segmentRows: Array<{
+      assetId: string;
+      startTime: number;
+      endTime: number;
+      segmentType: string;
+      attributes: Record<string, unknown>;
+      confidence: number;
+    }> = [];
+
+    let currentSegment = createSegmentFromOutput(
+      assetId,
+      sortedKeyframes[0],
+      outputByKeyframe.get(sortedKeyframes[0].id)!,
+    );
+
+    for (let i = 1; i < sortedKeyframes.length; i++) {
+      const kf = sortedKeyframes[i];
+      const vo = outputByKeyframe.get(kf.id)!;
+
+      if (shouldMergeIntoSegment(currentSegment, vo)) {
+        // Extend the current segment
+        currentSegment.endTime = kf.timestamp;
+        currentSegment.confidence = (currentSegment.confidence + (vo.confidence ?? 0.5)) / 2;
+        mergeSubjects(currentSegment.attributes, vo.output);
+        mergeActions(currentSegment.attributes, vo.output);
+      } else {
+        // Finalize current segment and start a new one
+        segmentRows.push(currentSegment);
+        currentSegment = createSegmentFromOutput(assetId, kf, vo);
+      }
+
+      // Update progress
+      const progress = Math.round((i / sortedKeyframes.length) * 100);
+      updateProcessingStage(stage.id, { progress });
+    }
+
+    // Don't forget the last segment
+    segmentRows.push(currentSegment);
+
+    // Clear existing timeline and insert new segments
+    deleteTimelineForAsset(assetId);
+    const segments = insertTimelineSegmentsBatch(segmentRows);
+
+    updateProcessingStage(stage.id, {
+      status: 'completed',
+      progress: 100,
+      completedAt: Date.now(),
+    });
+
+    onProgress?.(`Generated ${segments.length} timeline segments.`);
+
+    return { assetId, segmentCount: segments.length, segments };
+  } catch (err) {
+    updateProcessingStage(stage.id, {
+      status: 'failed',
+      lastError: (err as Error).message.slice(0, 500),
+    });
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface PendingSegment {
+  assetId: string;
+  startTime: number;
+  endTime: number;
+  segmentType: string;
+  attributes: Record<string, unknown>;
+  confidence: number;
+}
+
+function createSegmentFromOutput(
+  assetId: string,
+  keyframe: MediaKeyframe,
+  vo: MediaVisionOutput,
+): PendingSegment {
+  const sceneDescription = (vo.output.sceneDescription as string) ?? '';
+  const segmentType = deriveSegmentType(vo.output);
+  return {
+    assetId,
+    startTime: keyframe.timestamp,
+    endTime: keyframe.timestamp,
+    segmentType,
+    attributes: {
+      sceneDescription,
+      subjects: Array.isArray(vo.output.subjects) ? [...(vo.output.subjects as string[])] : [],
+      actions: Array.isArray(vo.output.actions) ? [...(vo.output.actions as string[])] : [],
+      context: (vo.output.context as string) ?? '',
+    },
+    confidence: vo.confidence ?? 0.5,
+  };
+}
+
+/**
+ * Derive a generic segment type from vision output.
+ * Uses simple heuristics on the scene description — domain-specific
+ * interpretation belongs in the VLM prompt, not here.
+ */
+function deriveSegmentType(output: Record<string, unknown>): string {
+  const actions = output.actions as string[] | undefined;
+  if (actions && actions.length > 0) {
+    return 'activity';
+  }
+  const subjects = output.subjects as string[] | undefined;
+  if (subjects && subjects.length > 0) {
+    return 'scene';
+  }
+  return 'static';
+}
+
+/**
+ * Decide whether a new vision output is similar enough to merge
+ * into the current segment.
+ *
+ * Uses a simple heuristic: same segment type and overlapping subjects.
+ */
+function shouldMergeIntoSegment(
+  segment: PendingSegment,
+  vo: MediaVisionOutput,
+): boolean {
+  const newType = deriveSegmentType(vo.output);
+  if (newType !== segment.segmentType) return false;
+
+  // Check subject overlap
+  const existingSubjects = new Set(
+    (segment.attributes.subjects as string[]) ?? [],
+  );
+  const newSubjects = (vo.output.subjects as string[]) ?? [];
+
+  if (existingSubjects.size === 0 && newSubjects.length === 0) return true;
+  if (existingSubjects.size === 0 || newSubjects.length === 0) return false;
+
+  const overlap = newSubjects.filter((s) => existingSubjects.has(s)).length;
+  const unionSize = new Set([...existingSubjects, ...newSubjects]).size;
+
+  // Merge if at least 30% overlap (Jaccard similarity)
+  return unionSize > 0 && overlap / unionSize >= 0.3;
+}
+
+function mergeSubjects(
+  attributes: Record<string, unknown>,
+  newOutput: Record<string, unknown>,
+): void {
+  const existing = new Set((attributes.subjects as string[]) ?? []);
+  const incoming = (newOutput.subjects as string[]) ?? [];
+  for (const s of incoming) {
+    existing.add(s);
+  }
+  attributes.subjects = [...existing];
+}
+
+function mergeActions(
+  attributes: Record<string, unknown>,
+  newOutput: Record<string, unknown>,
+): void {
+  const existing = new Set((attributes.actions as string[]) ?? []);
+  const incoming = (newOutput.actions as string[]) ?? [];
+  for (const a of incoming) {
+    existing.add(a);
+  }
+  attributes.actions = [...existing];
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,0 +1,249 @@
+import { readFile } from 'node:fs/promises';
+import Anthropic from '@anthropic-ai/sdk';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import {
+  getMediaAssetById,
+  getKeyframesForAsset,
+  getVisionOutputsForAsset,
+  insertVisionOutputsBatch,
+  createProcessingStage,
+  updateProcessingStage,
+  getProcessingStagesForAsset,
+  type MediaKeyframe,
+  type ProcessingStage,
+} from '../../../../memory/media-store.js';
+
+const VLM_PROMPT = `Analyze this image frame extracted from a video. Return a JSON object with the following fields:
+
+{
+  "sceneDescription": "A concise description of the overall scene",
+  "subjects": ["List of identifiable subjects/objects/people in the frame"],
+  "actions": ["List of actions or activities occurring"],
+  "context": "Environmental or situational context (setting, conditions, etc.)"
+}
+
+Return ONLY the JSON object, no additional text.`;
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
+  const analysisType = (input.analysis_type as string) || 'scene_description';
+  const batchSize = (input.batch_size as number) || 10;
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    return { content: `Media asset not found: ${assetId}`, isError: true };
+  }
+
+  // Get all keyframes for this asset
+  const keyframes = getKeyframesForAsset(assetId);
+  if (keyframes.length === 0) {
+    return {
+      content: 'No keyframes found for this asset. Run extract_keyframes first.',
+      isError: true,
+    };
+  }
+
+  // Resumability: find already-analyzed keyframe IDs for this analysis type
+  const existingOutputs = getVisionOutputsForAsset(assetId, analysisType);
+  const analyzedKeyframeIds = new Set(existingOutputs.map((o) => o.keyframeId));
+  const pendingKeyframes = keyframes.filter((kf) => !analyzedKeyframeIds.has(kf.id));
+
+  if (pendingKeyframes.length === 0) {
+    return {
+      content: JSON.stringify({
+        message: 'All keyframes already analyzed',
+        assetId,
+        analysisType,
+        totalKeyframes: keyframes.length,
+        alreadyAnalyzed: existingOutputs.length,
+      }, null, 2),
+      isError: false,
+    };
+  }
+
+  // Find or create the vision_analysis processing stage
+  let stage: ProcessingStage | undefined;
+  const existingStages = getProcessingStagesForAsset(assetId);
+  stage = existingStages.find((s) => s.stage === 'vision_analysis');
+  if (!stage) {
+    stage = createProcessingStage({ assetId, stage: 'vision_analysis' });
+  }
+
+  updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    updateProcessingStage(stage.id, {
+      status: 'failed',
+      lastError: 'ANTHROPIC_API_KEY not set',
+    });
+    return {
+      content: 'ANTHROPIC_API_KEY environment variable is not set. Required for vision analysis.',
+      isError: true,
+    };
+  }
+
+  const client = new Anthropic({ apiKey });
+  let analyzedCount = analyzedKeyframeIds.size;
+  const totalKeyframes = keyframes.length;
+  let errorCount = 0;
+
+  context.onOutput?.(`Analyzing ${pendingKeyframes.length} keyframes (${analyzedKeyframeIds.size} already done)...\n`);
+
+  try {
+    // Process in batches
+    for (let i = 0; i < pendingKeyframes.length; i += batchSize) {
+      if (context.signal?.aborted) {
+        context.onOutput?.('Analysis cancelled.\n');
+        break;
+      }
+
+      const batch = pendingKeyframes.slice(i, i + batchSize);
+      const batchResults: Array<{
+        assetId: string;
+        keyframeId: string;
+        analysisType: string;
+        output: Record<string, unknown>;
+        confidence?: number;
+      }> = [];
+
+      for (const keyframe of batch) {
+        if (context.signal?.aborted) break;
+
+        try {
+          const result = await analyzeKeyframe(client, keyframe);
+          batchResults.push({
+            assetId,
+            keyframeId: keyframe.id,
+            analysisType,
+            output: result.output,
+            confidence: result.confidence,
+          });
+          analyzedCount++;
+        } catch (err) {
+          errorCount++;
+          context.onOutput?.(`  Warning: failed to analyze frame at ${keyframe.timestamp}s: ${(err as Error).message}\n`);
+        }
+      }
+
+      // Batch insert results
+      if (batchResults.length > 0) {
+        insertVisionOutputsBatch(batchResults);
+      }
+
+      // Update progress
+      const progress = Math.round((analyzedCount / totalKeyframes) * 100);
+      updateProcessingStage(stage.id, { progress });
+
+      context.onOutput?.(`  Batch ${Math.floor(i / batchSize) + 1}: analyzed ${batchResults.length}/${batch.length} frames (${progress}% total)\n`);
+    }
+
+    const finalProgress = Math.round((analyzedCount / totalKeyframes) * 100);
+    const isComplete = analyzedCount >= totalKeyframes;
+
+    updateProcessingStage(stage.id, {
+      status: isComplete ? 'completed' : 'running',
+      progress: finalProgress,
+      ...(isComplete ? { completedAt: Date.now() } : {}),
+    });
+
+    return {
+      content: JSON.stringify({
+        message: `Vision analysis ${isComplete ? 'completed' : 'in progress'}`,
+        assetId,
+        analysisType,
+        totalKeyframes,
+        analyzedCount,
+        newlyAnalyzed: analyzedCount - analyzedKeyframeIds.size,
+        errorCount,
+        progress: finalProgress,
+      }, null, 2),
+      isError: false,
+    };
+  } catch (err) {
+    updateProcessingStage(stage.id, {
+      status: 'failed',
+      lastError: (err as Error).message.slice(0, 500),
+    });
+    return {
+      content: `Vision analysis failed: ${(err as Error).message}`,
+      isError: true,
+    };
+  }
+}
+
+async function analyzeKeyframe(
+  client: Anthropic,
+  keyframe: MediaKeyframe,
+): Promise<{ output: Record<string, unknown>; confidence: number }> {
+  // Read the image file and encode as base64
+  const imageData = await readFile(keyframe.filePath);
+  const base64 = imageData.toString('base64');
+
+  // Determine media type from file extension
+  const ext = keyframe.filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
+  const mediaTypeMap: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+  };
+  const mediaType = mediaTypeMap[ext] ?? 'image/jpeg';
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1024,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+              data: base64,
+            },
+          },
+          {
+            type: 'text',
+            text: VLM_PROMPT,
+          },
+        ],
+      },
+    ],
+  });
+
+  // Extract text from response
+  const textBlock = response.content.find((block) => block.type === 'text');
+  const responseText = textBlock && 'text' in textBlock ? textBlock.text : '';
+
+  // Parse JSON from response
+  let output: Record<string, unknown>;
+  try {
+    // Try to extract JSON from the response (handle markdown code fences)
+    const jsonMatch = responseText.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, responseText];
+    output = JSON.parse(jsonMatch[1]!.trim()) as Record<string, unknown>;
+  } catch {
+    // If JSON parsing fails, wrap raw text as output
+    output = {
+      sceneDescription: responseText,
+      subjects: [],
+      actions: [],
+      context: '',
+    };
+  }
+
+  // Add timestamp context to the output
+  output.timestamp = keyframe.timestamp;
+
+  return { output, confidence: 0.8 };
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -1,0 +1,146 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdir, readdir } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import {
+  getMediaAssetById,
+  insertKeyframesBatch,
+  createProcessingStage,
+  updateProcessingStage,
+  getProcessingStagesForAsset,
+  type ProcessingStage,
+} from '../../../../memory/media-store.js';
+
+const FFMPEG_TIMEOUT_MS = 300_000;
+
+function spawnWithTimeout(
+  cmd: string[],
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Process timed out after ${timeoutMs}ms: ${cmd[0]}`));
+    }, timeoutMs);
+    proc.exited.then(async (exitCode) => {
+      clearTimeout(timer);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
+  const intervalSeconds = (input.interval_seconds as number) || 3;
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    return { content: `Media asset not found: ${assetId}`, isError: true };
+  }
+
+  if (asset.mediaType !== 'video') {
+    return { content: `Keyframe extraction requires a video asset. Got: ${asset.mediaType}`, isError: true };
+  }
+
+  // Find or create the keyframe_extraction processing stage
+  let stage: ProcessingStage | undefined;
+  const existingStages = getProcessingStagesForAsset(assetId);
+  stage = existingStages.find((s) => s.stage === 'keyframe_extraction');
+  if (!stage) {
+    stage = createProcessingStage({ assetId, stage: 'keyframe_extraction' });
+  }
+
+  updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
+
+  // Create output directory for frames
+  const outputDir = join(tmpdir(), `vellum-keyframes-${randomUUID()}`);
+  await mkdir(outputDir, { recursive: true });
+
+  try {
+    context.onOutput?.(`Extracting keyframes every ${intervalSeconds}s from ${asset.title}...\n`);
+
+    // Use ffmpeg to extract frames at the specified interval
+    const result = await spawnWithTimeout([
+      'ffmpeg', '-y',
+      '-i', asset.filePath,
+      '-vf', `fps=1/${intervalSeconds}`,
+      '-q:v', '2',
+      join(outputDir, 'frame-%06d.jpg'),
+    ], FFMPEG_TIMEOUT_MS);
+
+    if (result.exitCode !== 0) {
+      updateProcessingStage(stage.id, {
+        status: 'failed',
+        lastError: result.stderr.slice(0, 500),
+      });
+      return { content: `ffmpeg failed: ${result.stderr.slice(0, 500)}`, isError: true };
+    }
+
+    // List extracted frames
+    const files = await readdir(outputDir);
+    const frameFiles = files
+      .filter((f) => f.startsWith('frame-') && f.endsWith('.jpg'))
+      .sort();
+
+    if (frameFiles.length === 0) {
+      updateProcessingStage(stage.id, {
+        status: 'failed',
+        lastError: 'No frames extracted',
+      });
+      return { content: 'No frames were extracted from the video.', isError: true };
+    }
+
+    context.onOutput?.(`Extracted ${frameFiles.length} frames. Registering in database...\n`);
+
+    // Build keyframe rows
+    const keyframeRows = frameFiles.map((file, index) => ({
+      assetId,
+      timestamp: index * intervalSeconds,
+      filePath: join(outputDir, file),
+      metadata: { frameIndex: index, intervalSeconds },
+    }));
+
+    // Batch insert
+    const keyframes = insertKeyframesBatch(keyframeRows);
+
+    // Update progress
+    updateProcessingStage(stage.id, {
+      status: 'completed',
+      progress: 100,
+      completedAt: Date.now(),
+    });
+
+    context.onOutput?.(`Registered ${keyframes.length} keyframes.\n`);
+
+    return {
+      content: JSON.stringify({
+        message: `Extracted and registered ${keyframes.length} keyframes`,
+        assetId,
+        keyframeCount: keyframes.length,
+        intervalSeconds,
+        outputDir,
+      }, null, 2),
+      isError: false,
+    };
+  } catch (err) {
+    updateProcessingStage(stage.id, {
+      status: 'failed',
+      lastError: (err as Error).message.slice(0, 500),
+    });
+    return {
+      content: `Keyframe extraction failed: ${(err as Error).message}`,
+      isError: true,
+    };
+  }
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1051,5 +1051,57 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_processing_stages_asset_id ON processing_stages(asset_id)`);
 
+  // ── Media Keyframes ─────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_keyframes (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      timestamp REAL NOT NULL,
+      file_path TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_keyframes_asset_id ON media_keyframes(asset_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_keyframes_asset_timestamp ON media_keyframes(asset_id, timestamp)`);
+
+  // ── Media Vision Outputs ────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_vision_outputs (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      keyframe_id TEXT NOT NULL REFERENCES media_keyframes(id) ON DELETE CASCADE,
+      analysis_type TEXT NOT NULL,
+      output TEXT NOT NULL,
+      confidence REAL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_vision_outputs_asset_id ON media_vision_outputs(asset_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_vision_outputs_keyframe_id ON media_vision_outputs(keyframe_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_vision_outputs_asset_type ON media_vision_outputs(asset_id, analysis_type)`);
+
+  // ── Media Timelines ─────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_timelines (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      start_time REAL NOT NULL,
+      end_time REAL NOT NULL,
+      segment_type TEXT NOT NULL,
+      attributes TEXT,
+      confidence REAL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_timelines_asset_id ON media_timelines(asset_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_timelines_asset_time ON media_timelines(asset_id, start_time)`);
+
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -5,10 +5,10 @@
  * Uses content-hash deduplication (same pattern as attachments-store.ts).
  */
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { mediaAssets, processingStages } from './schema.js';
+import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, mediaTimelines } from './schema.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -219,5 +219,302 @@ function parseStageRow(row: typeof processingStages.$inferSelect): ProcessingSta
     lastError: row.lastError,
     startedAt: row.startedAt,
     completedAt: row.completedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Keyframe types & CRUD
+// ---------------------------------------------------------------------------
+
+export interface MediaKeyframe {
+  id: string;
+  assetId: string;
+  timestamp: number;
+  filePath: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: number;
+}
+
+export function insertKeyframe(params: {
+  assetId: string;
+  timestamp: number;
+  filePath: string;
+  metadata?: Record<string, unknown>;
+}): MediaKeyframe {
+  const db = getDb();
+  const now = Date.now();
+  const record = {
+    id: uuid(),
+    assetId: params.assetId,
+    timestamp: params.timestamp,
+    filePath: params.filePath,
+    metadata: params.metadata ? JSON.stringify(params.metadata) : null,
+    createdAt: now,
+  };
+  db.insert(mediaKeyframes).values(record).run();
+  return { ...record, metadata: params.metadata ?? null };
+}
+
+export function insertKeyframesBatch(
+  rows: Array<{
+    assetId: string;
+    timestamp: number;
+    filePath: string;
+    metadata?: Record<string, unknown>;
+  }>,
+): MediaKeyframe[] {
+  const db = getDb();
+  const now = Date.now();
+  const records = rows.map((r) => ({
+    id: uuid(),
+    assetId: r.assetId,
+    timestamp: r.timestamp,
+    filePath: r.filePath,
+    metadata: r.metadata ? JSON.stringify(r.metadata) : null,
+    createdAt: now,
+  }));
+  if (records.length > 0) {
+    db.insert(mediaKeyframes).values(records).run();
+  }
+  return records.map((rec, i) => ({
+    ...rec,
+    metadata: rows[i].metadata ?? null,
+  }));
+}
+
+export function getKeyframesForAsset(assetId: string): MediaKeyframe[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(mediaKeyframes)
+    .where(eq(mediaKeyframes.assetId, assetId))
+    .all();
+  return rows.map(parseKeyframeRow);
+}
+
+export function getKeyframeById(id: string): MediaKeyframe | null {
+  const db = getDb();
+  const row = db.select().from(mediaKeyframes).where(eq(mediaKeyframes.id, id)).get();
+  return row ? parseKeyframeRow(row) : null;
+}
+
+function parseKeyframeRow(row: typeof mediaKeyframes.$inferSelect): MediaKeyframe {
+  let metadata: Record<string, unknown> | null = null;
+  if (row.metadata) {
+    try { metadata = JSON.parse(row.metadata) as Record<string, unknown>; } catch { metadata = null; }
+  }
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    timestamp: row.timestamp,
+    filePath: row.filePath,
+    metadata,
+    createdAt: row.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Vision output types & CRUD
+// ---------------------------------------------------------------------------
+
+export interface MediaVisionOutput {
+  id: string;
+  assetId: string;
+  keyframeId: string;
+  analysisType: string;
+  output: Record<string, unknown>;
+  confidence: number | null;
+  createdAt: number;
+}
+
+export function insertVisionOutput(params: {
+  assetId: string;
+  keyframeId: string;
+  analysisType: string;
+  output: Record<string, unknown>;
+  confidence?: number;
+}): MediaVisionOutput {
+  const db = getDb();
+  const now = Date.now();
+  const record = {
+    id: uuid(),
+    assetId: params.assetId,
+    keyframeId: params.keyframeId,
+    analysisType: params.analysisType,
+    output: JSON.stringify(params.output),
+    confidence: params.confidence ?? null,
+    createdAt: now,
+  };
+  db.insert(mediaVisionOutputs).values(record).run();
+  return { ...record, output: params.output };
+}
+
+export function insertVisionOutputsBatch(
+  rows: Array<{
+    assetId: string;
+    keyframeId: string;
+    analysisType: string;
+    output: Record<string, unknown>;
+    confidence?: number;
+  }>,
+): MediaVisionOutput[] {
+  const db = getDb();
+  const now = Date.now();
+  const records = rows.map((r) => ({
+    id: uuid(),
+    assetId: r.assetId,
+    keyframeId: r.keyframeId,
+    analysisType: r.analysisType,
+    output: JSON.stringify(r.output),
+    confidence: r.confidence ?? null,
+    createdAt: now,
+  }));
+  if (records.length > 0) {
+    db.insert(mediaVisionOutputs).values(records).run();
+  }
+  return records.map((rec, i) => ({
+    ...rec,
+    output: rows[i].output,
+  }));
+}
+
+export function getVisionOutputsForAsset(assetId: string, analysisType?: string): MediaVisionOutput[] {
+  const db = getDb();
+  const conditions = [eq(mediaVisionOutputs.assetId, assetId)];
+  if (analysisType) {
+    conditions.push(eq(mediaVisionOutputs.analysisType, analysisType));
+  }
+  const rows = db
+    .select()
+    .from(mediaVisionOutputs)
+    .where(and(...conditions))
+    .all();
+  return rows.map(parseVisionOutputRow);
+}
+
+export function getVisionOutputsByKeyframeIds(keyframeIds: string[]): MediaVisionOutput[] {
+  if (keyframeIds.length === 0) return [];
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(mediaVisionOutputs)
+    .where(inArray(mediaVisionOutputs.keyframeId, keyframeIds))
+    .all();
+  return rows.map(parseVisionOutputRow);
+}
+
+function parseVisionOutputRow(row: typeof mediaVisionOutputs.$inferSelect): MediaVisionOutput {
+  let output: Record<string, unknown> = {};
+  try { output = JSON.parse(row.output) as Record<string, unknown>; } catch { output = {}; }
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    keyframeId: row.keyframeId,
+    analysisType: row.analysisType,
+    output,
+    confidence: row.confidence,
+    createdAt: row.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeline types & CRUD
+// ---------------------------------------------------------------------------
+
+export interface MediaTimeline {
+  id: string;
+  assetId: string;
+  startTime: number;
+  endTime: number;
+  segmentType: string;
+  attributes: Record<string, unknown> | null;
+  confidence: number | null;
+  createdAt: number;
+}
+
+export function insertTimelineSegment(params: {
+  assetId: string;
+  startTime: number;
+  endTime: number;
+  segmentType: string;
+  attributes?: Record<string, unknown>;
+  confidence?: number;
+}): MediaTimeline {
+  const db = getDb();
+  const now = Date.now();
+  const record = {
+    id: uuid(),
+    assetId: params.assetId,
+    startTime: params.startTime,
+    endTime: params.endTime,
+    segmentType: params.segmentType,
+    attributes: params.attributes ? JSON.stringify(params.attributes) : null,
+    confidence: params.confidence ?? null,
+    createdAt: now,
+  };
+  db.insert(mediaTimelines).values(record).run();
+  return { ...record, attributes: params.attributes ?? null };
+}
+
+export function insertTimelineSegmentsBatch(
+  rows: Array<{
+    assetId: string;
+    startTime: number;
+    endTime: number;
+    segmentType: string;
+    attributes?: Record<string, unknown>;
+    confidence?: number;
+  }>,
+): MediaTimeline[] {
+  const db = getDb();
+  const now = Date.now();
+  const records = rows.map((r) => ({
+    id: uuid(),
+    assetId: r.assetId,
+    startTime: r.startTime,
+    endTime: r.endTime,
+    segmentType: r.segmentType,
+    attributes: r.attributes ? JSON.stringify(r.attributes) : null,
+    confidence: r.confidence ?? null,
+    createdAt: now,
+  }));
+  if (records.length > 0) {
+    db.insert(mediaTimelines).values(records).run();
+  }
+  return records.map((rec, i) => ({
+    ...rec,
+    attributes: rows[i].attributes ?? null,
+  }));
+}
+
+export function getTimelineForAsset(assetId: string): MediaTimeline[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(mediaTimelines)
+    .where(eq(mediaTimelines.assetId, assetId))
+    .all();
+  return rows.map(parseTimelineRow);
+}
+
+export function deleteTimelineForAsset(assetId: string): void {
+  const db = getDb();
+  db.delete(mediaTimelines).where(eq(mediaTimelines.assetId, assetId)).run();
+}
+
+function parseTimelineRow(row: typeof mediaTimelines.$inferSelect): MediaTimeline {
+  let attributes: Record<string, unknown> | null = null;
+  if (row.attributes) {
+    try { attributes = JSON.parse(row.attributes) as Record<string, unknown>; } catch { attributes = null; }
+  }
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    startTime: row.startTime,
+    endTime: row.endTime,
+    segmentType: row.segmentType,
+    attributes,
+    confidence: row.confidence,
+    createdAt: row.createdAt,
   };
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -708,3 +708,37 @@ export const processingStages = sqliteTable('processing_stages', {
   startedAt: integer('started_at'),
   completedAt: integer('completed_at'),
 });
+
+export const mediaKeyframes = sqliteTable('media_keyframes', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  timestamp: real('timestamp').notNull(),
+  filePath: text('file_path').notNull(),
+  metadata: text('metadata'),                                   // JSON
+  createdAt: integer('created_at').notNull(),
+});
+
+export const mediaVisionOutputs = sqliteTable('media_vision_outputs', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  keyframeId: text('keyframe_id').notNull()
+    .references(() => mediaKeyframes.id, { onDelete: 'cascade' }),
+  analysisType: text('analysis_type').notNull(),
+  output: text('output').notNull(),                             // JSON
+  confidence: real('confidence'),
+  createdAt: integer('created_at').notNull(),
+});
+
+export const mediaTimelines = sqliteTable('media_timelines', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  startTime: real('start_time').notNull(),
+  endTime: real('end_time').notNull(),
+  segmentType: text('segment_type').notNull(),
+  attributes: text('attributes'),                               // JSON
+  confidence: real('confidence'),
+  createdAt: integer('created_at').notNull(),
+});


### PR DESCRIPTION
Part of #6985: Vision-First Basketball Film Assistant MVP

## Changes
- Added Drizzle schema tables: media_keyframes, media_vision_outputs, media_timelines
- Added CREATE TABLE + indexes to db-init.ts
- Extended media-store.ts with CRUD for keyframes, vision outputs, timelines
- Created tools/extract-keyframes.ts (ffmpeg frame extraction at configurable intervals)
- Created tools/analyze-keyframes.ts (Claude VLM batch analysis with structured JSON output)
- Created services/timeline-service.ts (aggregate vision outputs into timeline segments)
- Updated TOOLS.json with new tool definitions
- All primitives are generic media-processing, not basketball-specific

Closes #6990
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
