### PR TITLE
feat: add intersectReachable for multi-seed set queries

### DIFF
--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
 
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
-import { findNeighborEntities, findMatchedEntities, getEntityLinkedItemCandidates, collectTypedNeighbors } from '../memory/search/entity.js';
+import { findNeighborEntities, findMatchedEntities, getEntityLinkedItemCandidates, collectTypedNeighbors, intersectReachable } from '../memory/search/entity.js';
 import { memoryItems, memoryItemEntities } from '../memory/schema.js';
 import { Database } from 'bun:sqlite';
 
@@ -547,6 +547,67 @@ describe('entity search', () => {
         ],
       );
 
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── intersectReachable ───────────────────────────────────────────────
+
+  describe('intersectReachable', () => {
+    test('finds shared projects between two people', () => {
+      const alice = upsertEntity({ name: 'IntersectAlice', type: 'person', aliases: [] });
+      const bob = upsertEntity({ name: 'IntersectBob', type: 'person', aliases: [] });
+      const sharedProject = upsertEntity({ name: 'IntersectSharedProj', type: 'project', aliases: [] });
+      const aliceOnly = upsertEntity({ name: 'IntersectAliceProj', type: 'project', aliases: [] });
+      const bobOnly = upsertEntity({ name: 'IntersectBobProj', type: 'project', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: alice, targetEntityId: sharedProject, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: alice, targetEntityId: aliceOnly, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: bob, targetEntityId: sharedProject, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: bob, targetEntityId: bobOnly, relation: 'works_on' });
+
+      const result = intersectReachable([
+        { seedEntityIds: [alice], steps: [{ relationTypes: ['works_on'], entityTypes: ['project'] }] },
+        { seedEntityIds: [bob], steps: [{ relationTypes: ['works_on'], entityTypes: ['project'] }] },
+      ]);
+
+      expect(result).toContain(sharedProject);
+      expect(result).not.toContain(aliceOnly);
+      expect(result).not.toContain(bobOnly);
+    });
+
+    test('returns empty when no overlap', () => {
+      const alice = upsertEntity({ name: 'IntersectAlice2', type: 'person', aliases: [] });
+      const bob = upsertEntity({ name: 'IntersectBob2', type: 'person', aliases: [] });
+      const projA = upsertEntity({ name: 'IntersectProjA', type: 'project', aliases: [] });
+      const projB = upsertEntity({ name: 'IntersectProjB', type: 'project', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: alice, targetEntityId: projA, relation: 'works_on' });
+      upsertEntityRelation({ sourceEntityId: bob, targetEntityId: projB, relation: 'works_on' });
+
+      const result = intersectReachable([
+        { seedEntityIds: [alice], steps: [{ relationTypes: ['works_on'], entityTypes: ['project'] }] },
+        { seedEntityIds: [bob], steps: [{ relationTypes: ['works_on'], entityTypes: ['project'] }] },
+      ]);
+
+      expect(result).toEqual([]);
+    });
+
+    test('single query is equivalent to collectTypedNeighbors', () => {
+      const person = upsertEntity({ name: 'IntersectSingle', type: 'person', aliases: [] });
+      const tool = upsertEntity({ name: 'IntersectTool', type: 'tool', aliases: [] });
+
+      upsertEntityRelation({ sourceEntityId: person, targetEntityId: tool, relation: 'uses' });
+
+      const result = intersectReachable([
+        { seedEntityIds: [person], steps: [{ relationTypes: ['uses'], entityTypes: ['tool'] }] },
+      ]);
+
+      expect(result).toContain(tool);
+    });
+
+    test('returns empty for empty queries array', () => {
+      const result = intersectReachable([]);
       expect(result).toEqual([]);
     });
   });

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -399,3 +399,36 @@ export function collectTypedNeighbors(
 
   return currentSeeds;
 }
+
+/**
+ * Find entities reachable from ALL given seeds via their respective
+ * typed traversal steps, then return the intersection.
+ */
+export function intersectReachable(
+  queries: Array<{
+    seedEntityIds: string[];
+    steps: TraversalStep[];
+  }>,
+  opts?: { maxResultsPerStep?: number; maxEdgesPerStep?: number },
+): string[] {
+  if (queries.length === 0) return [];
+
+  const resultSets: Set<string>[] = [];
+  for (const query of queries) {
+    const result = collectTypedNeighbors(
+      query.seedEntityIds,
+      query.steps,
+      opts,
+    );
+    resultSets.push(new Set(result));
+  }
+
+  if (resultSets.length === 0) return [];
+
+  // Intersect all sets: keep only entities present in ALL sets
+  const intersection = [...resultSets[0]].filter(id =>
+    resultSets.every(set => set.has(id)),
+  );
+
+  return intersection;
+}


### PR DESCRIPTION
## Summary

Add `intersectReachable` function that finds entities reachable from ALL given seeds via typed traversal, then intersects the results. Enables answering queries like "projects both Alice and Bob work on".

Part 8 of the entity graph complex queries rollout plan.

## Changes
- Add `intersectReachable()` function to `entity.ts`
- Add 4 tests: shared projects, no overlap, single query equivalence, empty queries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
