### PR TITLE
Export CLI commands subpath for downstream consumers

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.ts",
     "./package.json": "./package.json",
     "./src/components/DefaultMainScreen": "./src/components/DefaultMainScreen.tsx",
-    "./src/lib/constants": "./src/lib/constants.ts"
+    "./src/lib/constants": "./src/lib/constants.ts",
+    "./src/commands/*": "./src/commands/*.ts"
   },
   "bin": {
     "vellum-cli": "./src/index.ts"


### PR DESCRIPTION
## Summary
- Adds `"./src/commands/*": "./src/commands/*.ts"` wildcard export to `@vellumai/cli` package.json
- Allows downstream packages (like `vel` in vellum-assistant-platform) to import individual commands via `@vellumai/cli/src/commands/<name>`
- Fixes TypeScript `TS2307: Cannot find module` error when using `moduleResolution: "bundler"` with deep imports

## Test plan
- [ ] Verify `bun run typecheck` passes in the cli package
- [ ] Verify downstream `vel` can import `@vellumai/cli/src/commands/ssh` after version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
