### PR TITLE
M3: Event detection from timelines + confidence ranking

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -100,6 +100,50 @@
       },
       "executor": "tools/analyze-keyframes.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "detect_events",
+      "description": "Detect events from a media asset's timeline segments using configurable detection rules with weighted confidence ranking. Supports built-in rule types: segment_transition (field changes between adjacent segments), short_segment (segments below a duration threshold), and attribute_match (regex matching on segment attributes). If no rules are provided, sensible defaults are used based on the event type.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset to detect events in"
+          },
+          "event_type": {
+            "type": "string",
+            "description": "Type label for detected events (e.g., 'turnover', 'scene_change', 'highlight')"
+          },
+          "detection_rules": {
+            "type": "array",
+            "description": "Optional array of detection rule objects. Each rule has: ruleType (string: 'segment_transition', 'short_segment', or 'attribute_match'), params (object with rule-specific parameters), and weight (number: contribution to confidence score). If omitted, defaults are used based on event_type.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ruleType": {
+                  "type": "string",
+                  "description": "Rule type: 'segment_transition', 'short_segment', or 'attribute_match'"
+                },
+                "params": {
+                  "type": "object",
+                  "description": "Rule-specific parameters (e.g., { field: 'subjects' }, { maxDurationSeconds: 5 }, { field: 'actions', pattern: 'steal|turnover' })"
+                },
+                "weight": {
+                  "type": "number",
+                  "description": "Weight for this rule's contribution to the confidence score"
+                }
+              },
+              "required": ["ruleType", "params", "weight"]
+            }
+          }
+        },
+        "required": ["asset_id", "event_type"]
+      },
+      "executor": "tools/detect-events.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/media-processing/services/event-detection-service.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/event-detection-service.ts
@@ -1,0 +1,280 @@
+/**
+ * Generic event detection service.
+ *
+ * Evaluates configurable detection rules against timeline segments and produces
+ * scored event candidates. The rule system is fully pluggable — callers supply
+ * a DetectionConfig that specifies which rules to evaluate and how to weight them.
+ *
+ * Example configurations (not hardcoded — these are passed in by the caller):
+ *
+ *   Basketball turnovers:
+ *     eventType: 'turnover'
+ *     rules: [
+ *       { ruleType: 'segment_transition', params: { field: 'subjects' }, weight: 0.5 },
+ *       { ruleType: 'short_segment', params: { maxDurationSeconds: 5 }, weight: 0.3 },
+ *       { ruleType: 'attribute_match', params: { field: 'actions', pattern: 'steal|turnover' }, weight: 0.2 },
+ *     ]
+ *
+ *   Scene changes:
+ *     eventType: 'scene_change'
+ *     rules: [
+ *       { ruleType: 'segment_transition', params: { field: 'segmentType' }, weight: 1.0 },
+ *     ]
+ */
+
+import {
+  getMediaAssetById,
+  getTimelineForAsset,
+  insertEventsBatch,
+  deleteEventsForAsset,
+  type MediaTimeline,
+  type MediaEvent,
+} from '../../../../memory/media-store.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface DetectionRule {
+  ruleType: string;
+  params: Record<string, unknown>;
+  weight: number;
+}
+
+export interface DetectionConfig {
+  eventType: string;
+  rules: DetectionRule[];
+}
+
+export interface EventCandidate {
+  startTime: number;
+  endTime: number;
+  confidence: number;
+  reasons: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface DetectionResult {
+  assetId: string;
+  eventType: string;
+  candidateCount: number;
+  events: MediaEvent[];
+}
+
+// ---------------------------------------------------------------------------
+// Rule evaluation
+// ---------------------------------------------------------------------------
+
+interface RuleMatch {
+  matched: boolean;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+type RuleEvaluator = (
+  segment: MediaTimeline,
+  prevSegment: MediaTimeline | null,
+  nextSegment: MediaTimeline | null,
+  params: Record<string, unknown>,
+) => RuleMatch;
+
+const RULE_EVALUATORS: Record<string, RuleEvaluator> = {
+  /**
+   * Fires when a specified field changes between adjacent segments.
+   * params.field: which attribute to compare ('subjects', 'segmentType', etc.)
+   */
+  segment_transition: (segment, prevSegment, _next, params) => {
+    if (!prevSegment) return { matched: false, reason: '' };
+    const field = (params.field as string) ?? 'segmentType';
+
+    if (field === 'segmentType') {
+      const changed = segment.segmentType !== prevSegment.segmentType;
+      return {
+        matched: changed,
+        reason: changed
+          ? `Segment type changed from "${prevSegment.segmentType}" to "${segment.segmentType}"`
+          : '',
+      };
+    }
+
+    // Compare attribute arrays (e.g., subjects)
+    const prevAttrs = prevSegment.attributes ?? {};
+    const currAttrs = segment.attributes ?? {};
+    const prevValues = new Set(Array.isArray(prevAttrs[field]) ? (prevAttrs[field] as string[]) : []);
+    const currValues = Array.isArray(currAttrs[field]) ? (currAttrs[field] as string[]) : [];
+
+    if (prevValues.size === 0 && currValues.length === 0) {
+      return { matched: false, reason: '' };
+    }
+
+    const overlap = currValues.filter((v) => prevValues.has(v)).length;
+    const unionSize = new Set([...prevValues, ...currValues]).size;
+    const similarity = unionSize > 0 ? overlap / unionSize : 0;
+
+    // A transition is detected when similarity drops below 50%
+    const changed = similarity < 0.5;
+    return {
+      matched: changed,
+      reason: changed
+        ? `${field} changed between segments (similarity: ${(similarity * 100).toFixed(0)}%)`
+        : '',
+      metadata: changed ? { similarity, prevValues: [...prevValues], currValues } : undefined,
+    };
+  },
+
+  /**
+   * Fires when a segment's duration is below a threshold.
+   * params.maxDurationSeconds: maximum segment duration to trigger (default: 5)
+   */
+  short_segment: (segment, _prev, _next, params) => {
+    const maxDuration = (params.maxDurationSeconds as number) ?? 5;
+    const duration = segment.endTime - segment.startTime;
+    const matched = duration > 0 && duration <= maxDuration;
+    return {
+      matched,
+      reason: matched
+        ? `Short segment (${duration.toFixed(1)}s <= ${maxDuration}s threshold)`
+        : '',
+      metadata: matched ? { duration } : undefined,
+    };
+  },
+
+  /**
+   * Fires when a segment's attribute values match a regex pattern.
+   * params.field: which attribute array to search (default: 'actions')
+   * params.pattern: regex pattern to match against values
+   */
+  attribute_match: (segment, _prev, _next, params) => {
+    const field = (params.field as string) ?? 'actions';
+    const pattern = params.pattern as string;
+    if (!pattern) return { matched: false, reason: 'No pattern specified' };
+
+    const attrs = segment.attributes ?? {};
+    const values = Array.isArray(attrs[field]) ? (attrs[field] as string[]) : [];
+    const regex = new RegExp(pattern, 'i');
+    const matchedValues = values.filter((v) => regex.test(v));
+
+    return {
+      matched: matchedValues.length > 0,
+      reason: matchedValues.length > 0
+        ? `${field} matched pattern /${pattern}/: [${matchedValues.join(', ')}]`
+        : '',
+      metadata: matchedValues.length > 0 ? { matchedValues } : undefined,
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Main detection logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect events in a media asset's timeline using the provided configuration.
+ *
+ * For each timeline segment, evaluates all rules and computes a weighted
+ * confidence score. Segments where at least one rule matches are emitted
+ * as event candidates. Results are stored in the media_events table (previous
+ * events of the same type for this asset are replaced).
+ */
+export function detectEvents(
+  assetId: string,
+  config: DetectionConfig,
+  options?: { onProgress?: (message: string) => void },
+): DetectionResult {
+  const onProgress = options?.onProgress;
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    throw new Error(`Media asset not found: ${assetId}`);
+  }
+
+  const segments = getTimelineForAsset(assetId);
+  if (segments.length === 0) {
+    throw new Error('No timeline segments found. Run timeline generation first.');
+  }
+
+  // Sort segments by start time
+  const sorted = [...segments].sort((a, b) => a.startTime - b.startTime);
+
+  onProgress?.(`Evaluating ${config.rules.length} detection rules against ${sorted.length} segments...`);
+
+  // Normalize weights so they sum to 1
+  const totalWeight = config.rules.reduce((sum, r) => sum + r.weight, 0);
+  const normalizedRules = totalWeight > 0
+    ? config.rules.map((r) => ({ ...r, weight: r.weight / totalWeight }))
+    : config.rules;
+
+  const candidates: EventCandidate[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const segment = sorted[i];
+    const prev = i > 0 ? sorted[i - 1] : null;
+    const next = i < sorted.length - 1 ? sorted[i + 1] : null;
+
+    let weightedScore = 0;
+    const reasons: string[] = [];
+    const candidateMetadata: Record<string, unknown> = {};
+    let anyMatched = false;
+
+    for (const rule of normalizedRules) {
+      const evaluator = RULE_EVALUATORS[rule.ruleType];
+      if (!evaluator) {
+        reasons.push(`Unknown rule type: ${rule.ruleType}`);
+        continue;
+      }
+
+      const result = evaluator(segment, prev, next, rule.params);
+      if (result.matched) {
+        anyMatched = true;
+        weightedScore += rule.weight;
+        reasons.push(result.reason);
+        if (result.metadata) {
+          candidateMetadata[rule.ruleType] = result.metadata;
+        }
+      }
+    }
+
+    if (anyMatched) {
+      candidates.push({
+        startTime: segment.startTime,
+        endTime: segment.endTime,
+        confidence: Math.min(weightedScore, 1),
+        reasons,
+        metadata: {
+          segmentId: segment.id,
+          segmentType: segment.segmentType,
+          ...candidateMetadata,
+        },
+      });
+    }
+  }
+
+  // Sort by confidence descending
+  candidates.sort((a, b) => b.confidence - a.confidence);
+
+  onProgress?.(`Found ${candidates.length} event candidates. Storing results...`);
+
+  // Replace existing events of this type for the asset
+  deleteEventsForAsset(assetId);
+
+  const eventRows = candidates.map((c) => ({
+    assetId,
+    eventType: config.eventType,
+    startTime: c.startTime,
+    endTime: c.endTime,
+    confidence: c.confidence,
+    reasons: c.reasons,
+    metadata: c.metadata,
+  }));
+
+  const events = eventRows.length > 0 ? insertEventsBatch(eventRows) : [];
+
+  onProgress?.(`Stored ${events.length} events.`);
+
+  return {
+    assetId,
+    eventType: config.eventType,
+    candidateCount: candidates.length,
+    events,
+  };
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/detect-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/detect-events.ts
@@ -1,0 +1,106 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { detectEvents, type DetectionConfig, type DetectionRule } from '../services/event-detection-service.js';
+
+/**
+ * Sensible default detection rules for common event types.
+ * These are fallbacks when the caller doesn't provide explicit rules —
+ * the system is not limited to these event types.
+ */
+const DEFAULT_RULES_BY_EVENT_TYPE: Record<string, DetectionRule[]> = {
+  turnover: [
+    { ruleType: 'segment_transition', params: { field: 'subjects' }, weight: 0.5 },
+    { ruleType: 'short_segment', params: { maxDurationSeconds: 5 }, weight: 0.3 },
+    { ruleType: 'attribute_match', params: { field: 'actions', pattern: 'steal|turnover|loss|intercept' }, weight: 0.2 },
+  ],
+  scene_change: [
+    { ruleType: 'segment_transition', params: { field: 'segmentType' }, weight: 1.0 },
+  ],
+  short_play: [
+    { ruleType: 'short_segment', params: { maxDurationSeconds: 3 }, weight: 0.6 },
+    { ruleType: 'segment_transition', params: { field: 'subjects' }, weight: 0.4 },
+  ],
+};
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
+  const eventType = input.event_type as string | undefined;
+  if (!eventType) {
+    return { content: 'event_type is required.', isError: true };
+  }
+
+  // Parse detection rules: use provided rules or fall back to defaults
+  let rules: DetectionRule[];
+  const rawRules = input.detection_rules;
+
+  if (rawRules) {
+    // Accept rules as a JSON string or as an already-parsed array
+    if (typeof rawRules === 'string') {
+      try {
+        rules = JSON.parse(rawRules) as DetectionRule[];
+      } catch {
+        return { content: 'detection_rules must be a valid JSON array of rule objects.', isError: true };
+      }
+    } else if (Array.isArray(rawRules)) {
+      rules = rawRules as DetectionRule[];
+    } else {
+      return { content: 'detection_rules must be an array of rule objects.', isError: true };
+    }
+
+    // Validate each rule has the required shape
+    for (const rule of rules) {
+      if (!rule.ruleType || typeof rule.ruleType !== 'string') {
+        return { content: 'Each detection rule must have a "ruleType" string.', isError: true };
+      }
+      if (rule.weight === undefined || typeof rule.weight !== 'number') {
+        return { content: 'Each detection rule must have a "weight" number.', isError: true };
+      }
+      if (!rule.params || typeof rule.params !== 'object') {
+        return { content: 'Each detection rule must have a "params" object.', isError: true };
+      }
+    }
+  } else {
+    // Use defaults for known event types, or a generic transition-based fallback
+    rules = DEFAULT_RULES_BY_EVENT_TYPE[eventType] ?? [
+      { ruleType: 'segment_transition', params: { field: 'segmentType' }, weight: 0.6 },
+      { ruleType: 'short_segment', params: { maxDurationSeconds: 5 }, weight: 0.4 },
+    ];
+  }
+
+  const config: DetectionConfig = { eventType, rules };
+
+  try {
+    const result = detectEvents(assetId, config, {
+      onProgress: (msg) => context.onOutput?.(`${msg}\n`),
+    });
+
+    return {
+      content: JSON.stringify({
+        message: `Detected ${result.candidateCount} ${result.eventType} events`,
+        assetId: result.assetId,
+        eventType: result.eventType,
+        totalEvents: result.candidateCount,
+        rulesUsed: rules.map((r) => r.ruleType),
+        events: result.events.map((e) => ({
+          id: e.id,
+          startTime: e.startTime,
+          endTime: e.endTime,
+          confidence: e.confidence,
+          reasons: e.reasons,
+        })),
+      }, null, 2),
+      isError: false,
+    };
+  } catch (err) {
+    return {
+      content: `Event detection failed: ${(err as Error).message}`,
+      isError: true,
+    };
+  }
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1103,5 +1103,25 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_timelines_asset_id ON media_timelines(asset_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_timelines_asset_time ON media_timelines(asset_id, start_time)`);
 
+  // ── Media Events ──────────────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_events (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      event_type TEXT NOT NULL,
+      start_time REAL NOT NULL,
+      end_time REAL NOT NULL,
+      confidence REAL NOT NULL,
+      reasons TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_events_asset_id ON media_events(asset_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_events_asset_type ON media_events(asset_id, event_type)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_events_confidence ON media_events(confidence DESC)`);
+
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -5,10 +5,10 @@
  * Uses content-hash deduplication (same pattern as attachments-store.ts).
  */
 
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, gte, desc, asc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, mediaTimelines } from './schema.js';
+import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, mediaTimelines, mediaEvents } from './schema.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -515,6 +515,151 @@ function parseTimelineRow(row: typeof mediaTimelines.$inferSelect): MediaTimelin
     segmentType: row.segmentType,
     attributes,
     confidence: row.confidence,
+    createdAt: row.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Media event types & CRUD
+// ---------------------------------------------------------------------------
+
+export interface MediaEvent {
+  id: string;
+  assetId: string;
+  eventType: string;
+  startTime: number;
+  endTime: number;
+  confidence: number;
+  reasons: string[];
+  metadata: Record<string, unknown> | null;
+  createdAt: number;
+}
+
+export function insertEvent(params: {
+  assetId: string;
+  eventType: string;
+  startTime: number;
+  endTime: number;
+  confidence: number;
+  reasons: string[];
+  metadata?: Record<string, unknown>;
+}): MediaEvent {
+  const db = getDb();
+  const now = Date.now();
+  const record = {
+    id: uuid(),
+    assetId: params.assetId,
+    eventType: params.eventType,
+    startTime: params.startTime,
+    endTime: params.endTime,
+    confidence: params.confidence,
+    reasons: JSON.stringify(params.reasons),
+    metadata: params.metadata ? JSON.stringify(params.metadata) : null,
+    createdAt: now,
+  };
+  db.insert(mediaEvents).values(record).run();
+  return { ...record, reasons: params.reasons, metadata: params.metadata ?? null };
+}
+
+export function insertEventsBatch(
+  rows: Array<{
+    assetId: string;
+    eventType: string;
+    startTime: number;
+    endTime: number;
+    confidence: number;
+    reasons: string[];
+    metadata?: Record<string, unknown>;
+  }>,
+): MediaEvent[] {
+  const db = getDb();
+  const now = Date.now();
+  const records = rows.map((r) => ({
+    id: uuid(),
+    assetId: r.assetId,
+    eventType: r.eventType,
+    startTime: r.startTime,
+    endTime: r.endTime,
+    confidence: r.confidence,
+    reasons: JSON.stringify(r.reasons),
+    metadata: r.metadata ? JSON.stringify(r.metadata) : null,
+    createdAt: now,
+  }));
+  if (records.length > 0) {
+    db.insert(mediaEvents).values(records).run();
+  }
+  return records.map((rec, i) => ({
+    ...rec,
+    reasons: rows[i].reasons,
+    metadata: rows[i].metadata ?? null,
+  }));
+}
+
+export function getEventsForAsset(
+  assetId: string,
+  filters?: {
+    eventType?: string;
+    minConfidence?: number;
+    limit?: number;
+    sortBy?: 'confidence' | 'startTime';
+  },
+): MediaEvent[] {
+  const db = getDb();
+  const conditions = [eq(mediaEvents.assetId, assetId)];
+  if (filters?.eventType) {
+    conditions.push(eq(mediaEvents.eventType, filters.eventType));
+  }
+  if (filters?.minConfidence !== undefined) {
+    conditions.push(gte(mediaEvents.confidence, filters.minConfidence));
+  }
+
+  let query = db
+    .select()
+    .from(mediaEvents)
+    .where(and(...conditions))
+    .$dynamic();
+
+  if (filters?.sortBy === 'confidence') {
+    query = query.orderBy(desc(mediaEvents.confidence));
+  } else {
+    query = query.orderBy(asc(mediaEvents.startTime));
+  }
+
+  if (filters?.limit) {
+    query = query.limit(filters.limit);
+  }
+
+  const rows = query.all();
+  return rows.map(parseEventRow);
+}
+
+export function getEventById(id: string): MediaEvent | null {
+  const db = getDb();
+  const row = db.select().from(mediaEvents).where(eq(mediaEvents.id, id)).get();
+  return row ? parseEventRow(row) : null;
+}
+
+export function deleteEventsForAsset(assetId: string): void {
+  const db = getDb();
+  db.delete(mediaEvents).where(eq(mediaEvents.assetId, assetId)).run();
+}
+
+function parseEventRow(row: typeof mediaEvents.$inferSelect): MediaEvent {
+  let reasons: string[] = [];
+  try { reasons = JSON.parse(row.reasons) as string[]; } catch { reasons = []; }
+  let metadata: Record<string, unknown> | null = null;
+  if (row.metadata) {
+    try { metadata = JSON.parse(row.metadata) as Record<string, unknown>; } catch { metadata = null; }
+  }
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    eventType: row.eventType,
+    startTime: row.startTime,
+    endTime: row.endTime,
+    confidence: row.confidence,
+    reasons,
+    metadata,
     createdAt: row.createdAt,
   };
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -742,3 +742,16 @@ export const mediaTimelines = sqliteTable('media_timelines', {
   confidence: real('confidence'),
   createdAt: integer('created_at').notNull(),
 });
+
+export const mediaEvents = sqliteTable('media_events', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  eventType: text('event_type').notNull(),
+  startTime: real('start_time').notNull(),
+  endTime: real('end_time').notNull(),
+  confidence: real('confidence').notNull(),
+  reasons: text('reasons').notNull(),                            // JSON array
+  metadata: text('metadata'),                                    // JSON
+  createdAt: integer('created_at').notNull(),
+});


### PR DESCRIPTION
Part of #6985: Vision-First Basketball Film Assistant MVP

## Changes
- Added media_events schema table + DB init + indexes
- Extended media-store.ts with event CRUD (insert, batch insert, query with filters, delete)
- Created services/event-detection-service.ts with configurable detection rules (segment_transition, short_segment, attribute_match) and weighted confidence ranking
- Created tools/detect-events.ts as the tool entry point
- Updated TOOLS.json with detect_events tool definition
- Detection system is fully generic — basketball turnovers are one config, not hardcoded

Closes #6991
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
