### PR TITLE
Telegram: hard fallback to remove stale approval buttons

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -385,6 +385,10 @@ describe("telegram-webhook callback query acknowledgment", () => {
       message_id: 10,
       reply_markup: { inline_keyboard: [] },
     });
+    const deleteCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "deleteMessage",
+    );
+    expect(deleteCalls.length).toBe(0);
   });
 
   it("does not fail webhook when clearing inline approval buttons fails", async () => {
@@ -417,5 +421,49 @@ describe("telegram-webhook callback query acknowledgment", () => {
       (c) => c[1] === "editMessageReplyMarkup",
     );
     expect(clearCalls.length).toBe(2);
+    const deleteCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "deleteMessage",
+    );
+    expect(deleteCalls.length).toBe(1);
+    expect(deleteCalls[0][2]).toEqual({
+      chat_id: "42",
+      message_id: 10,
+    });
+  });
+
+  it("does not fail webhook if delete fallback also fails", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: true,
+        rejected: false,
+        runtimeResponse: {
+          accepted: true,
+          duplicate: false,
+          eventId: "evt-5",
+          approval: "decision_applied",
+        },
+      }),
+    );
+    callTelegramApiMock.mockImplementation((_config: GatewayConfig, method: string) => {
+      if (method === "editMessageReplyMarkup" || method === "deleteMessage") {
+        return Promise.reject(new Error("hard failure"));
+      }
+      return Promise.resolve({});
+    });
+
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("apr:run1:approve_once", 312);
+    const res = await handler(postRequest(body));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(res.status).toBe(200);
+    const clearCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "editMessageReplyMarkup",
+    );
+    expect(clearCalls.length).toBe(2);
+    const deleteCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "deleteMessage",
+    );
+    expect(deleteCalls.length).toBe(1);
   });
 });

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -185,10 +185,19 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         chat_id: chatId,
         message_id: parsedMessageId,
       };
+      const deleteApprovalPrompt = (primaryErr: unknown, fallbackErr: unknown): void => {
+        callTelegramApi(config, "deleteMessage", basePayload).catch((deleteErr) => {
+          tlog.error(
+            { primaryErr, fallbackErr, deleteErr, chatId, messageId: parsedMessageId, phase },
+            "Failed to clear inline approval buttons and delete prompt message",
+          );
+        });
+      };
 
       // Bot API behavior differs across wrappers/clients for "remove markup".
       // Try the explicit null form first, then fall back to an empty inline
-      // keyboard payload if needed.
+      // keyboard payload if needed. If both fail, delete the prompt message
+      // so users are not left with stale actionable buttons.
       callTelegramApi(config, "editMessageReplyMarkup", {
         ...basePayload,
         reply_markup: null,
@@ -196,12 +205,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         callTelegramApi(config, "editMessageReplyMarkup", {
           ...basePayload,
           reply_markup: { inline_keyboard: [] },
-        }).catch((fallbackErr) => {
-          tlog.error(
-            { primaryErr, fallbackErr, chatId, messageId: parsedMessageId, phase },
-            "Failed to clear inline approval buttons",
-          );
-        })
+        }).catch((fallbackErr) => deleteApprovalPrompt(primaryErr, fallbackErr))
       );
     };
 


### PR DESCRIPTION
## Summary
- preserve existing inline keyboard clear flow (`editMessageReplyMarkup` null -> empty keyboard)
- add hard UX fallback: if both edits fail, delete the original approval prompt message
- keep callback processing best-effort and non-blocking
- add tests for delete fallback and delete failure behavior

## Validation
- cd gateway && bun test src/http/routes/telegram-webhook.test.ts
- cd gateway && bunx tsc --noEmit