### PR TITLE
M4: NL query mapping + retrieval + clip materialization

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -144,6 +144,67 @@
       },
       "executor": "tools/detect-events.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "query_media_events",
+      "description": "Query media events using natural language. Parses the query into structured filters (event type, count, confidence threshold, time range) and retrieves matching events ranked by confidence. Supports domain-specific keyword mapping (e.g., 'turnovers' → eventType='turnover').",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Natural language query describing the events to find (e.g., 'top 5 turnovers', 'high confidence goals in the first half')"
+          },
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset to search within"
+          }
+        },
+        "required": ["query", "asset_id"]
+      },
+      "executor": "tools/query-media-events.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "generate_clip",
+      "description": "Extract a video clip from a media asset using ffmpeg. Applies configurable pre/post-roll padding (clamped to file boundaries), outputs the clip as a temporary file, and registers it as an attachment for in-chat delivery.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset (must be a video)"
+          },
+          "start_time": {
+            "type": "number",
+            "description": "Start time of the clip in seconds"
+          },
+          "end_time": {
+            "type": "number",
+            "description": "End time of the clip in seconds"
+          },
+          "pre_roll": {
+            "type": "number",
+            "description": "Seconds of padding before start_time. Default: 3"
+          },
+          "post_roll": {
+            "type": "number",
+            "description": "Seconds of padding after end_time. Default: 2"
+          },
+          "output_format": {
+            "type": "string",
+            "enum": ["mp4", "webm", "mov"],
+            "description": "Output video format. Default: 'mp4'"
+          }
+        },
+        "required": ["asset_id", "start_time", "end_time"]
+      },
+      "executor": "tools/generate-clip.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/media-processing/services/retrieval-service.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/retrieval-service.ts
@@ -1,0 +1,95 @@
+/**
+ * Generic media event retrieval service.
+ *
+ * Pure data retrieval with configurable filters and ranking — no
+ * domain-specific logic. Callers (e.g. a query tool) are responsible
+ * for translating domain concepts into filter parameters.
+ */
+
+import {
+  getEventsForAsset,
+  type MediaEvent,
+} from '../../../../memory/media-store.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RetrievalFilters {
+  /** Scope results to a specific media asset. */
+  assetId?: string;
+  /** Filter by event type label. */
+  eventType?: string;
+  /** Minimum confidence threshold (0–1). */
+  minConfidence?: number;
+  /** Maximum number of results to return. */
+  limit?: number;
+  /** Sort order for results. */
+  sortBy?: 'confidence' | 'startTime';
+  /** Only return events that start at or after this time (seconds). */
+  startTimeMin?: number;
+  /** Only return events that start at or before this time (seconds). */
+  startTimeMax?: number;
+}
+
+export interface RetrievalResult {
+  events: MediaEvent[];
+  totalReturned: number;
+  filters: RetrievalFilters;
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval
+// ---------------------------------------------------------------------------
+
+/**
+ * Query the media_events table with the given filters and return ranked
+ * results with full event metadata.
+ *
+ * When `assetId` is not provided the function returns an empty result set
+ * because the underlying store requires an asset scope. Callers that want
+ * cross-asset queries should iterate over asset IDs externally.
+ */
+export function retrieveEvents(filters: RetrievalFilters): RetrievalResult {
+  const {
+    assetId,
+    eventType,
+    minConfidence,
+    limit = 10,
+    sortBy = 'confidence',
+    startTimeMin,
+    startTimeMax,
+  } = filters;
+
+  if (!assetId) {
+    return { events: [], totalReturned: 0, filters };
+  }
+
+  // Fetch from the store with the subset of filters it supports natively
+  let events = getEventsForAsset(assetId, {
+    eventType,
+    minConfidence,
+    sortBy,
+    // Fetch more than needed so we can apply time-range filtering locally
+    limit: startTimeMin !== undefined || startTimeMax !== undefined ? undefined : limit,
+  });
+
+  // Apply time-range filters that the store doesn't support directly
+  if (startTimeMin !== undefined) {
+    events = events.filter((e) => e.startTime >= startTimeMin);
+  }
+  if (startTimeMax !== undefined) {
+    events = events.filter((e) => e.startTime <= startTimeMax);
+  }
+
+  // Re-apply limit after local filtering
+  if (limit && events.length > limit) {
+    events = events.slice(0, limit);
+  }
+
+  return {
+    events,
+    totalReturned: events.length,
+    filters,
+  };
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -1,0 +1,194 @@
+/**
+ * Clip generation tool — extract a video segment from a media asset.
+ *
+ * Uses ffmpeg to cut a segment with configurable pre/post-roll padding,
+ * then registers the resulting clip as an attachment for in-chat delivery.
+ * This is a generic media-processing primitive with no domain-specific logic.
+ */
+
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { mkdir, unlink, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getMediaAssetById } from '../../../../memory/media-store.js';
+import { uploadAttachment } from '../../../../memory/attachments-store.js';
+
+const FFMPEG_TIMEOUT_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spawnWithTimeout(
+  cmd: string[],
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Process timed out after ${timeoutMs}ms: ${cmd[0]}`));
+    }, timeoutMs);
+    proc.exited.then(async (exitCode) => {
+      clearTimeout(timer);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+/**
+ * Get the duration of a media file in seconds via ffprobe.
+ */
+async function getMediaDuration(filePath: string): Promise<number> {
+  const result = await spawnWithTimeout([
+    'ffprobe', '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'csv=p=0',
+    filePath,
+  ], 10_000);
+  if (result.exitCode !== 0) return 0;
+  return parseFloat(result.stdout.trim()) || 0;
+}
+
+function formatTimestamp(seconds: number): string {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${hrs.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+const MIME_BY_FORMAT: Record<string, string> = {
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+};
+
+// ---------------------------------------------------------------------------
+// Tool entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
+  const startTime = input.start_time as number | undefined;
+  if (startTime === undefined || startTime === null) {
+    return { content: 'start_time is required (seconds).', isError: true };
+  }
+
+  const endTime = input.end_time as number | undefined;
+  if (endTime === undefined || endTime === null) {
+    return { content: 'end_time is required (seconds).', isError: true };
+  }
+
+  if (endTime <= startTime) {
+    return { content: 'end_time must be greater than start_time.', isError: true };
+  }
+
+  const preRoll = (input.pre_roll as number) ?? 3;
+  const postRoll = (input.post_roll as number) ?? 2;
+  const outputFormat = (input.output_format as string) ?? 'mp4';
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    return { content: `Media asset not found: ${assetId}`, isError: true };
+  }
+
+  if (asset.mediaType !== 'video') {
+    return { content: `Clip generation requires a video asset. Got: ${asset.mediaType}`, isError: true };
+  }
+
+  // Get the file duration so we can clamp pre/post-roll to file boundaries
+  const fileDuration = asset.durationSeconds ?? await getMediaDuration(asset.filePath);
+
+  // Calculate actual clip boundaries with pre/post-roll, clamped to file
+  const clipStart = Math.max(0, startTime - preRoll);
+  const clipEnd = fileDuration > 0 ? Math.min(fileDuration, endTime + postRoll) : endTime + postRoll;
+  const clipDuration = clipEnd - clipStart;
+
+  // Prepare output path
+  const clipDir = join(tmpdir(), `vellum-clips-${randomUUID()}`);
+  await mkdir(clipDir, { recursive: true });
+
+  const clipFilename = `clip-${formatTimestamp(startTime).replace(/:/g, '')}-${formatTimestamp(endTime).replace(/:/g, '')}.${outputFormat}`;
+  const clipPath = join(clipDir, clipFilename);
+
+  try {
+    context.onOutput?.(`Extracting clip ${formatTimestamp(clipStart)} – ${formatTimestamp(clipEnd)} from ${asset.title}...\n`);
+
+    // Use ffmpeg to extract the segment
+    const ffmpegArgs = [
+      'ffmpeg', '-y',
+      '-ss', String(clipStart),
+      '-i', asset.filePath,
+      '-t', String(clipDuration),
+      '-c', 'copy',
+      '-avoid_negative_ts', 'make_zero',
+      clipPath,
+    ];
+
+    const result = await spawnWithTimeout(ffmpegArgs, FFMPEG_TIMEOUT_MS);
+
+    if (result.exitCode !== 0) {
+      return {
+        content: `ffmpeg clip extraction failed: ${result.stderr.slice(0, 500)}`,
+        isError: true,
+      };
+    }
+
+    // Verify the output file exists and has content
+    const clipStat = await stat(clipPath);
+    if (clipStat.size === 0) {
+      return { content: 'Clip extraction produced an empty file.', isError: true };
+    }
+
+    context.onOutput?.(`Clip extracted (${(clipStat.size / 1024 / 1024).toFixed(1)} MB). Registering as attachment...\n`);
+
+    // Read clip file and register as attachment
+    const clipData = await readFile(clipPath);
+    const clipBase64 = clipData.toString('base64');
+    const mimeType = MIME_BY_FORMAT[outputFormat] ?? 'video/mp4';
+
+    const attachment = uploadAttachment(clipFilename, mimeType, clipBase64);
+
+    context.onOutput?.(`Clip registered as attachment ${attachment.id}.\n`);
+
+    return {
+      content: JSON.stringify({
+        message: `Clip extracted successfully`,
+        attachmentId: attachment.id,
+        filename: clipFilename,
+        mimeType,
+        sizeBytes: attachment.sizeBytes,
+        clipStart,
+        clipEnd,
+        clipDuration,
+        requestedRange: {
+          startTime,
+          endTime,
+          preRoll,
+          postRoll,
+        },
+        assetId,
+      }, null, 2),
+      isError: false,
+    };
+  } catch (err) {
+    return {
+      content: `Clip generation failed: ${(err as Error).message}`,
+      isError: true,
+    };
+  } finally {
+    // Clean up temp file
+    try { await unlink(clipPath); } catch { /* ignore */ }
+  }
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -1,0 +1,231 @@
+/**
+ * Natural language query tool for media events.
+ *
+ * Accepts a free-text query and optional asset_id, parses the query into
+ * structured filters via simple keyword matching, then delegates to the
+ * generic retrieval service. Domain-specific keyword mappings live here;
+ * the retrieval layer remains fully generic.
+ */
+
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { retrieveEvents, type RetrievalFilters } from '../services/retrieval-service.js';
+
+// ---------------------------------------------------------------------------
+// NL query parsing
+// ---------------------------------------------------------------------------
+
+/** Maps domain-specific keywords to canonical event type labels. */
+const EVENT_TYPE_KEYWORDS: Record<string, string> = {
+  // Basketball
+  turnover: 'turnover',
+  turnovers: 'turnover',
+  steal: 'turnover',
+  steals: 'turnover',
+  // Soccer / football
+  goal: 'goal',
+  goals: 'goal',
+  score: 'goal',
+  scores: 'goal',
+  // Generic
+  highlight: 'highlight',
+  highlights: 'highlight',
+  scene_change: 'scene_change',
+  'scene change': 'scene_change',
+  'scene changes': 'scene_change',
+  foul: 'foul',
+  fouls: 'foul',
+  shot: 'shot',
+  shots: 'shot',
+  rebound: 'rebound',
+  rebounds: 'rebound',
+  assist: 'assist',
+  assists: 'assist',
+  block: 'block',
+  blocks: 'block',
+  transition: 'transition',
+  transitions: 'transition',
+  fast_break: 'fast_break',
+  'fast break': 'fast_break',
+  'fast breaks': 'fast_break',
+};
+
+/**
+ * Extract a numeric limit from phrases like "top 5", "first 3", "last 10".
+ * Returns undefined if no limit phrase is found.
+ */
+function parseLimit(query: string): number | undefined {
+  const match = query.match(/(?:top|first|last|show|find|get)\s+(\d+)/i);
+  if (match) return parseInt(match[1], 10);
+  // Also match trailing "N events/moments"
+  const trailingMatch = query.match(/(\d+)\s+(?:events?|moments?|plays?|clips?)/i);
+  if (trailingMatch) return parseInt(trailingMatch[1], 10);
+  return undefined;
+}
+
+/**
+ * Extract a confidence threshold from the query.
+ */
+function parseConfidence(query: string): number | undefined {
+  const lower = query.toLowerCase();
+  if (lower.includes('high confidence') || lower.includes('very confident') || lower.includes('most confident')) {
+    return 0.8;
+  }
+  if (lower.includes('confident') || lower.includes('medium confidence')) {
+    return 0.5;
+  }
+  // Explicit threshold: "confidence > 0.7" or "confidence above 0.7"
+  const explicitMatch = lower.match(/confidence\s*(?:>|above|over|>=)\s*([\d.]+)/);
+  if (explicitMatch) return parseFloat(explicitMatch[1]);
+  return undefined;
+}
+
+/**
+ * Extract a time range from the query (returns seconds).
+ * Supports phrases like "first half", "second half", "first N minutes",
+ * "last N minutes", "between M and N minutes".
+ */
+function parseTimeRange(query: string): { startTimeMin?: number; startTimeMax?: number } {
+  const lower = query.toLowerCase();
+
+  // "first half" / "second half" — these are relative and require knowing
+  // total duration, which we don't have. Use reasonable game defaults:
+  // assume ~48 min game → 2880s, half = 1440s
+  if (lower.includes('first half')) {
+    return { startTimeMin: 0, startTimeMax: 1440 };
+  }
+  if (lower.includes('second half')) {
+    return { startTimeMin: 1440 };
+  }
+
+  // "first N minutes"
+  const firstNMin = lower.match(/first\s+(\d+)\s*min/);
+  if (firstNMin) {
+    return { startTimeMin: 0, startTimeMax: parseInt(firstNMin[1], 10) * 60 };
+  }
+
+  // "last N minutes"
+  // Without knowing total duration we can't compute this precisely,
+  // so we skip it and let the retrieval return all results.
+
+  // "between M and N minutes"
+  const betweenMatch = lower.match(/between\s+(\d+)\s*(?:and|to|-)\s*(\d+)\s*min/);
+  if (betweenMatch) {
+    return {
+      startTimeMin: parseInt(betweenMatch[1], 10) * 60,
+      startTimeMax: parseInt(betweenMatch[2], 10) * 60,
+    };
+  }
+
+  return {};
+}
+
+/**
+ * Extract the event type from the query by matching known keywords.
+ */
+function parseEventType(query: string): string | undefined {
+  const lower = query.toLowerCase();
+
+  // Check multi-word keywords first (longer matches win)
+  const multiWordKeys = Object.keys(EVENT_TYPE_KEYWORDS)
+    .filter((k) => k.includes(' ') || k.includes('_'))
+    .sort((a, b) => b.length - a.length);
+
+  for (const key of multiWordKeys) {
+    if (lower.includes(key)) return EVENT_TYPE_KEYWORDS[key];
+  }
+
+  // Check single-word keywords
+  const words = lower.replace(/[^\w\s]/g, '').split(/\s+/);
+  for (const word of words) {
+    if (EVENT_TYPE_KEYWORDS[word]) return EVENT_TYPE_KEYWORDS[word];
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse a natural language query into structured retrieval filters.
+ */
+function parseQuery(query: string, assetId?: string): RetrievalFilters {
+  const eventType = parseEventType(query);
+  const limit = parseLimit(query);
+  const minConfidence = parseConfidence(query);
+  const timeRange = parseTimeRange(query);
+
+  return {
+    assetId,
+    eventType,
+    minConfidence,
+    limit: limit ?? 10,
+    sortBy: 'confidence',
+    ...timeRange,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tool entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const query = input.query as string | undefined;
+  if (!query) {
+    return { content: 'query is required.', isError: true };
+  }
+
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required to scope the query to a specific media asset.', isError: true };
+  }
+
+  const filters = parseQuery(query, assetId);
+  const result = retrieveEvents(filters);
+
+  if (result.totalReturned === 0) {
+    const parts = ['No matching events found'];
+    if (filters.eventType) parts.push(`for event type "${filters.eventType}"`);
+    if (filters.minConfidence) parts.push(`with confidence >= ${filters.minConfidence}`);
+    parts.push(`in asset ${assetId}.`);
+    return { content: parts.join(' '), isError: false };
+  }
+
+  const eventSummaries = result.events.map((e, i) => ({
+    rank: i + 1,
+    id: e.id,
+    eventType: e.eventType,
+    timeRange: `${formatTimestamp(e.startTime)} – ${formatTimestamp(e.endTime)}`,
+    startTime: e.startTime,
+    endTime: e.endTime,
+    confidence: Math.round(e.confidence * 100) / 100,
+    reasons: e.reasons,
+    metadata: e.metadata,
+  }));
+
+  return {
+    content: JSON.stringify({
+      query,
+      parsedFilters: {
+        eventType: filters.eventType ?? null,
+        minConfidence: filters.minConfidence ?? null,
+        limit: filters.limit,
+        startTimeMin: filters.startTimeMin ?? null,
+        startTimeMax: filters.startTimeMax ?? null,
+      },
+      totalResults: result.totalReturned,
+      events: eventSummaries,
+    }, null, 2),
+    isError: false,
+  };
+}


### PR DESCRIPTION
Part of #6985: Vision-First Basketball Film Assistant MVP

## Changes
- Created services/retrieval-service.ts (generic event retrieval with configurable filters and ranking)
- Created tools/query-media-events.ts (NL query parsing into structured filters, formatted response with confidence/reasons)
- Created tools/generate-clip.ts (ffmpeg clip extraction with pre/post-roll, attachment registration)
- Updated TOOLS.json with query_media_events and generate_clip definitions
- Query interpretation supports domain-specific mappings; retrieval and clips are fully generic

Closes #6992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
