### PR TITLE
revert: remove auto-detect relation keywords from entity search

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -207,7 +207,6 @@ describe('AssistantConfigSchema', () => {
       neighborScoreMultiplier: 0.7,
       maxDepth: 3,
       depthDecay: true,
-      autoTypeDetection: true,
     });
   });
 

--- a/assistant/src/__tests__/entity-search.test.ts
+++ b/assistant/src/__tests__/entity-search.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
 
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
-import { findNeighborEntities, findMatchedEntities, getEntityLinkedItemCandidates, collectTypedNeighbors, intersectReachable, detectRelationTypes } from '../memory/search/entity.js';
+import { findNeighborEntities, findMatchedEntities, getEntityLinkedItemCandidates, collectTypedNeighbors, intersectReachable } from '../memory/search/entity.js';
 import { memoryItems, memoryItemEntities } from '../memory/schema.js';
 import { Database } from 'bun:sqlite';
 
@@ -612,38 +612,4 @@ describe('entity search', () => {
     });
   });
 
-  // ── detectRelationTypes ──────────────────────────────────────────────
-
-  describe('detectRelationTypes', () => {
-    test('detects "uses" keyword', () => {
-      const result = detectRelationTypes('what tools does the project use?');
-      expect(result).toContain('uses');
-    });
-
-    test('detects "works on" keyword', () => {
-      const result = detectRelationTypes('who works on this project?');
-      expect(result).toContain('works_on');
-    });
-
-    test('detects "depends on" keyword', () => {
-      const result = detectRelationTypes('what does this package depends on?');
-      expect(result).toContain('depends_on');
-    });
-
-    test('detects multiple relation types', () => {
-      const result = detectRelationTypes('who uses and works on this?');
-      expect(result).toContain('uses');
-      expect(result).toContain('works_on');
-    });
-
-    test('returns undefined for no keyword matches', () => {
-      const result = detectRelationTypes('tell me about the weather');
-      expect(result).toBeUndefined();
-    });
-
-    test('case insensitive matching', () => {
-      const result = detectRelationTypes('What TOOLS does Alice USE?');
-      expect(result).toContain('uses');
-    });
-  });
 });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -111,7 +111,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         neighborScoreMultiplier: 0.7,
         maxDepth: 3,
         depthDecay: true,
-        autoTypeDetection: true,
       },
     },
     conflicts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -536,9 +536,6 @@ export const MemoryEntityConfigSchema = z.object({
     depthDecay: z
       .boolean({ error: 'memory.entity.relationRetrieval.depthDecay must be a boolean' })
       .default(true),
-    autoTypeDetection: z
-      .boolean({ error: 'memory.entity.relationRetrieval.autoTypeDetection must be a boolean' })
-      .default(true),
   }).default({
     enabled: true,
     maxSeedEntities: 8,
@@ -547,7 +544,6 @@ export const MemoryEntityConfigSchema = z.object({
     neighborScoreMultiplier: 0.7,
     maxDepth: 3,
     depthDecay: true,
-    autoTypeDetection: true,
   }),
 });
 
@@ -697,7 +693,6 @@ export const MemoryConfigSchema = z.object({
       neighborScoreMultiplier: 0.7,
       maxDepth: 3,
       depthDecay: true,
-      autoTypeDetection: true,
     },
   }),
   conflicts: MemoryConflictsConfigSchema.default({
@@ -1237,7 +1232,6 @@ export const AssistantConfigSchema = z.object({
         neighborScoreMultiplier: 0.7,
         maxDepth: 3,
         depthDecay: true,
-        autoTypeDetection: true,
       },
     },
     conflicts: {

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm';
 import type { MemoryEntityConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
 import { getDb } from '../db.js';
-import type { EntityRelationType, EntityType } from '../entity-extractor.js';
+import type { EntityType } from '../entity-extractor.js';
 import {
   memoryEntities,
   memoryEntityRelations,
@@ -14,43 +14,6 @@ import type { Candidate, CandidateSource, CandidateType, EntitySearchResult, Mat
 import { computeRecencyScore } from './ranking.js';
 
 const log = getLogger('memory-retriever');
-
-const RELATION_KEYWORDS: Record<string, EntityRelationType[]> = {
-  'use': ['uses'],
-  'uses': ['uses'],
-  'using': ['uses'],
-  'work on': ['works_on'],
-  'works on': ['works_on'],
-  'working on': ['works_on'],
-  'depends on': ['depends_on'],
-  'dependency': ['depends_on'],
-  'dependencies': ['depends_on'],
-  'member of': ['member_of'],
-  'belongs to': ['member_of'],
-  'owns': ['owns'],
-  'owned by': ['owns'],
-  'located in': ['located_in'],
-  'reports to': ['reports_to'],
-  'collaborates with': ['collaborates_with'],
-  'collaborating with': ['collaborates_with'],
-};
-
-/**
- * Detect relation type hints from query text.
- * Returns matching EntityRelationType[] if keywords found, undefined otherwise.
- */
-export function detectRelationTypes(query: string): EntityRelationType[] | undefined {
-  const lower = query.toLowerCase();
-  const detected = new Set<EntityRelationType>();
-
-  for (const [keyword, types] of Object.entries(RELATION_KEYWORDS)) {
-    if (lower.includes(keyword)) {
-      for (const t of types) detected.add(t);
-    }
-  }
-
-  return detected.size > 0 ? [...detected] : undefined;
-}
 
 /**
  * Entity-based retrieval: match seed entities from query text, fetch directly
@@ -91,11 +54,6 @@ export function entitySearch(
 
   const relationSeedEntityCount = seedEntityIds.length;
 
-  // Auto-detect relation type hints from query text
-  const detectedRelationTypes = entityConfig.relationRetrieval.autoTypeDetection
-    ? detectRelationTypes(query)
-    : undefined;
-
   const {
     neighborEntityIds,
     traversedEdgeCount: relationTraversedEdgeCount,
@@ -104,7 +62,6 @@ export function entitySearch(
     maxEdges: relationConfig.maxEdges,
     maxNeighborEntities: relationConfig.maxNeighborEntities,
     maxDepth: relationConfig.maxDepth,
-    relationTypes: detectedRelationTypes,
   });
   const relationNeighborEntityCount = neighborEntityIds.length;
   const directItemIds = new Set(directCandidates.map((candidate) => candidate.id));


### PR DESCRIPTION
## Summary

Remove the `detectRelationTypes` keyword matching and `autoTypeDetection` config added in #7117. The substring-based approach is too prone to false positives and restricts entity graph recall when it fires incorrectly. The explicit `knowledge_graph_query` tool (PR #7111) already provides typed traversal for queries that need it.

## What was removed
- `RELATION_KEYWORDS` map and `detectRelationTypes()` function from `entity.ts`
- Auto-detection integration in `entitySearch()`
- `autoTypeDetection` config option from schema and defaults
- 6 tests for keyword detection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
