### PR TITLE
feat: iOS Connect UX updates for centralized config (#7097)

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -68,30 +68,46 @@ struct DaemonConnectionSection: View {
 
     var body: some View {
         Form {
-            // Show gateway connection status when connected via HTTP transport
-            if isHTTPTransport, clientProvider.isConnected {
-                Section {
-                    HStack {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                        Text("Connected via gateway")
-                            .font(VFont.body)
-                    }
-                    if let url = gatewayURL {
+            // Connection status section — always visible
+            Section {
+                if let url = gatewayURL {
+                    if clientProvider.isConnected {
+                        // Connected state
                         HStack {
-                            Text("Gateway URL")
-                                .foregroundColor(VColor.textSecondary)
-                            Spacer()
-                            Text(url)
-                                .font(.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(VColor.success)
+                            Text("Connected")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                        }
+                    } else {
+                        // Disconnected state — gateway configured but not connected
+                        HStack {
+                            Image(systemName: "exclamationmark.circle.fill")
+                                .foregroundColor(VColor.error)
+                            Text("Disconnected")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
                         }
                     }
-                } header: {
-                    Text("Connection")
+                    HStack {
+                        Text("Gateway")
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        Text(url)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                } else {
+                    // Not configured state
+                    Text("Scan a QR code or enter your Mac's gateway URL to connect.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
                 }
+            } header: {
+                Text("Connection")
             }
 
             Section {

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -10,12 +10,14 @@ struct QRPairingSheet: View {
     @State private var phase: PairingPhase = .scanning
     @State private var scannedPayload: DaemonQRPayload?
     @State private var errorMessage: String?
+    @State private var showGatewayChangedAlert = false
 
     enum PairingPhase {
         case scanning
         case confirming
         case connecting
         case connected
+        case alreadyConnected
         case error
     }
 
@@ -31,6 +33,8 @@ struct QRPairingSheet: View {
                     connectingView
                 case .connected:
                     connectedView
+                case .alreadyConnected:
+                    alreadyConnectedView
                 case .error:
                     errorView
                 }
@@ -41,6 +45,18 @@ struct QRPairingSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
+            }
+            .alert("Gateway Settings Changed", isPresented: $showGatewayChangedAlert) {
+                Button("Update") {
+                    connectToMac()
+                }
+                Button("Cancel", role: .cancel) {
+                    // Keep existing values, return to scanning
+                    scannedPayload = nil
+                    phase = .scanning
+                }
+            } message: {
+                Text("Your Mac's gateway settings have changed. Update connection?")
             }
         }
     }
@@ -148,6 +164,35 @@ struct QRPairingSheet: View {
         }
     }
 
+    // MARK: - Already Connected
+
+    private var alreadyConnectedView: some View {
+        VStack(spacing: VSpacing.xl) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 64))
+                .foregroundColor(VColor.success)
+
+            Text("Already Connected")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Already connected to this Mac.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+
+            Button("Done") {
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.bottom, VSpacing.xxl)
+        }
+    }
+
     // MARK: - Error
 
     private var errorView: some View {
@@ -222,12 +267,30 @@ struct QRPairingSheet: View {
             return
         }
 
-        scannedPayload = DaemonQRPayload(
+        let payload = DaemonQRPayload(
             gatewayURL: gatewayURL,
             bearerToken: bearerToken,
             hostId: hostId
         )
-        phase = .confirming
+        scannedPayload = payload
+
+        // Compare with stored values to detect first-time vs re-scan vs same config
+        let storedGatewayURL = UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL) ?? ""
+        let storedBearerToken = APIKeyManager.shared.getAPIKey(provider: "runtime-bearer-token") ?? ""
+
+        let hasStoredConfig = !storedGatewayURL.isEmpty && !storedBearerToken.isEmpty
+        let valuesMatch = storedGatewayURL == payload.gatewayURL && storedBearerToken == payload.bearerToken
+
+        if !hasStoredConfig {
+            // First-time scan — save directly, proceed to confirm then connect
+            phase = .confirming
+        } else if valuesMatch {
+            // Same config — show brief "already connected" confirmation
+            phase = .alreadyConnected
+        } else {
+            // Re-scan with different values — prompt before overwriting
+            showGatewayChangedAlert = true
+        }
     }
 
     private func connectToMac() {


### PR DESCRIPTION
## Summary
Update iOS Connect settings to display centralized gateway config clearly and detect when gateway settings change on re-scan.

## Implementation
- Updated ConnectionSettingsSection with clearer state display (not configured / connected / disconnected)
- Added gateway-updated detection in QRPairingSheet: compares scanned values with stored ones, prompts before overwriting
- First-time scan saves directly; re-scan with different values shows update prompt; same values shows 'Already connected'

## Files Changed
- clients/ios/Views/Settings/ConnectionSettingsSection.swift — Updated display and states
- clients/ios/Views/Settings/QRPairingSheet.swift — Added gateway-updated detection

Part of #7093
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
