### PR TITLE
fix: add missing VellumAssistantShared import to SettingsChannelsTab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// Channels settings tab — Telegram and SMS (Twilio) channel configuration.
 /// Displays a compact, status-first layout optimized for viewing and light


### PR DESCRIPTION
## Summary
- Add missing `import VellumAssistantShared` to `SettingsChannelsTab.swift` — required for design system types (VColor, VFont, VSpacing, VRadius, VButton)

## Original prompt
Fix build error from missing import in SettingsChannelsTab.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
