### PR TITLE
M5: Tracking profile UX + capability tiers

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -24,11 +24,24 @@ Extract keyframes from a video asset at regular intervals using ffmpeg. Frames a
 
 Analyze extracted keyframes using Claude VLM (vision language model). Produces structured JSON output with scene descriptions, subjects, actions, and context. Supports resumability by skipping already-analyzed frames.
 
+### select_tracking_profile
+
+Configure which event capabilities are enabled for a media asset. Capabilities are organized into tiers:
+- **Ready**: Production-quality detection, included by default.
+- **Beta**: Functional but may have accuracy gaps. Results include a confidence disclaimer.
+- **Experimental**: Early-stage detection, expect noise. Results include a confidence disclaimer.
+
+Call without capabilities to see available options; call with a capabilities array to set the profile.
+
 ## Services
 
 ### Timeline Generation
 
 The timeline service (services/timeline-service.ts) aggregates vision analysis outputs into coherent timeline segments. Call `generateTimeline(assetId)` after keyframe analysis is complete to produce a structured timeline.
+
+### Capability Registry
+
+The capability registry (services/capability-registry.ts) maintains an extensible, domain-agnostic catalog of available tracking capabilities with tier classification. Basketball capabilities are registered as one example domain. Other domains (surveillance, lecture recording, etc.) can register their own capabilities by calling `registerCapability()`.
 
 ## Usage Notes
 
@@ -40,3 +53,6 @@ The timeline service (services/timeline-service.ts) aggregates vision analysis o
 - Keyframe extraction requires ffmpeg. Vision analysis requires the ANTHROPIC_API_KEY environment variable.
 - The `analyze_keyframes` tool is marked as medium risk because it makes external API calls to Claude VLM, which incur costs.
 - All schema tables, services, and tool interfaces are media-generic. Domain-specific interpretation belongs in VLM prompt templates.
+- The `select_tracking_profile` tool controls which event types are returned by `query_media_events`. Without a profile, only ready-tier capabilities are included.
+- To enable beta or experimental capabilities for an asset: `select_tracking_profile({ asset_id: "...", capabilities: ["turnovers", "field_goals", "rebounds_per_player"] })`.
+- The capability registry is extensible: call `registerCapability()` from `services/capability-registry.ts` to add capabilities for any domain.

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -168,6 +168,29 @@
       "execution_target": "host"
     },
     {
+      "name": "select_tracking_profile",
+      "description": "Select and persist a tracking profile for a media asset. When called without capabilities, returns available capabilities organized by tier (ready, beta, experimental). When called with capabilities, validates them against the registry and stores the profile. The capability tier system is generic and extensible across domains.",
+      "category": "media",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "description": "ID of the media asset to configure tracking for"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional array of capability names to enable (e.g., ['turnovers', 'field_goals']). If omitted, returns the available capabilities for selection."
+          }
+        },
+        "required": ["asset_id"]
+      },
+      "executor": "tools/select-tracking-profile.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "generate_clip",
       "description": "Extract a video clip from a media asset using ffmpeg. Applies configurable pre/post-roll padding (clamped to file boundaries), outputs the clip as a temporary file, and registers it as an attachment for in-chat delivery.",
       "category": "media",

--- a/assistant/src/config/bundled-skills/media-processing/services/capability-registry.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/capability-registry.ts
@@ -1,0 +1,137 @@
+/**
+ * Generic capability registry with tier-based classification.
+ *
+ * The registry is domain-agnostic: any domain (sports, surveillance, lecture
+ * recording, etc.) can register its own capabilities. Basketball-specific
+ * capabilities are registered as one example via `registerDefaults()`.
+ */
+
+import type { CapabilityTier } from '../../../../memory/media-store.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Capability {
+  /** Unique name used as the key in tracking profiles (e.g. 'turnovers'). */
+  name: string;
+  /** Human-readable description of what this capability detects/tracks. */
+  description: string;
+  /** Maturity tier governing confidence disclaimers and default inclusion. */
+  tier: CapabilityTier;
+  /** Domain this capability belongs to (e.g. 'basketball', 'surveillance'). */
+  domain: string;
+  /** Granularity level (e.g. 'team', 'per-player'). */
+  granularity?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Registry (singleton in-memory Map)
+// ---------------------------------------------------------------------------
+
+const registry = new Map<string, Capability>();
+
+/**
+ * Register a capability. Overwrites any existing capability with the same name.
+ */
+export function registerCapability(cap: Capability): void {
+  registry.set(cap.name, cap);
+}
+
+/**
+ * Get all registered capabilities, optionally filtered by domain.
+ */
+export function getCapabilities(domain?: string): Capability[] {
+  const all = Array.from(registry.values());
+  if (!domain) return all;
+  return all.filter((c) => c.domain === domain);
+}
+
+/**
+ * Get capabilities filtered by tier.
+ */
+export function getCapabilitiesByTier(tier: CapabilityTier): Capability[] {
+  return Array.from(registry.values()).filter((c) => c.tier === tier);
+}
+
+/**
+ * Look up a single capability by name.
+ */
+export function getCapabilityByName(name: string): Capability | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Get all unique domain names in the registry.
+ */
+export function getRegisteredDomains(): string[] {
+  const domains = new Set<string>();
+  for (const cap of registry.values()) {
+    domains.add(cap.domain);
+  }
+  return Array.from(domains);
+}
+
+// ---------------------------------------------------------------------------
+// Default registrations — basketball as one example domain
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the default basketball capabilities as an example domain.
+ * Other domains should call `registerCapability()` with their own entries.
+ */
+export function registerDefaults(): void {
+  // Ready tier: production-quality detection
+  registerCapability({
+    name: 'turnovers',
+    description: 'Team-level turnover detection',
+    tier: 'ready',
+    domain: 'basketball',
+    granularity: 'team',
+  });
+
+  // Beta tier: functional but may have accuracy gaps
+  registerCapability({
+    name: 'field_goals',
+    description: 'Team-level field goal detection',
+    tier: 'beta',
+    domain: 'basketball',
+    granularity: 'team',
+  });
+
+  registerCapability({
+    name: 'rebounds',
+    description: 'Team-level rebound detection',
+    tier: 'beta',
+    domain: 'basketball',
+    granularity: 'team',
+  });
+
+  registerCapability({
+    name: 'turnovers_per_player',
+    description: 'Per-player turnover attribution',
+    tier: 'beta',
+    domain: 'basketball',
+    granularity: 'per-player',
+  });
+
+  // Experimental tier: early-stage, expect noise
+  registerCapability({
+    name: 'field_goals_per_player',
+    description: 'Per-player field goal attribution',
+    tier: 'experimental',
+    domain: 'basketball',
+    granularity: 'per-player',
+  });
+
+  registerCapability({
+    name: 'rebounds_per_player',
+    description: 'Per-player rebound attribution',
+    tier: 'experimental',
+    domain: 'basketball',
+    granularity: 'per-player',
+  });
+}
+
+// Auto-register defaults on first import
+registerDefaults();

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -9,6 +9,8 @@
 
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { retrieveEvents, type RetrievalFilters } from '../services/retrieval-service.js';
+import { getTrackingProfile, type CapabilityTier } from '../../../../memory/media-store.js';
+import { getCapabilitiesByTier, getCapabilityByName } from '../services/capability-registry.js';
 
 // ---------------------------------------------------------------------------
 // NL query parsing
@@ -193,25 +195,84 @@ export async function run(
   const filters = parseQuery(query, assetId);
   const result = retrieveEvents(filters);
 
-  if (result.totalReturned === 0) {
+  // Determine which capabilities are allowed based on the tracking profile
+  const profile = getTrackingProfile(assetId);
+
+  let allowedEventTypes: Set<string> | null = null;
+  const tierForEventType = new Map<string, CapabilityTier>();
+
+  if (profile) {
+    // Use the explicit profile: only enabled capabilities pass
+    allowedEventTypes = new Set<string>();
+    for (const [capName, entry] of Object.entries(profile.capabilities)) {
+      if (entry.enabled) {
+        allowedEventTypes.add(capName);
+        tierForEventType.set(capName, entry.tier);
+      }
+    }
+  } else {
+    // No profile: default to 'ready' tier capabilities only
+    const readyCaps = getCapabilitiesByTier('ready');
+    if (readyCaps.length > 0) {
+      allowedEventTypes = new Set(readyCaps.map((c) => c.name));
+      for (const cap of readyCaps) {
+        tierForEventType.set(cap.name, 'ready');
+      }
+    }
+    // If no capabilities are registered at all, allow everything (pass null)
+  }
+
+  // Filter events by allowed capabilities
+  let filteredEvents = result.events;
+  if (allowedEventTypes !== null) {
+    filteredEvents = filteredEvents.filter((e) => allowedEventTypes!.has(e.eventType));
+  }
+
+  if (filteredEvents.length === 0) {
     const parts = ['No matching events found'];
     if (filters.eventType) parts.push(`for event type "${filters.eventType}"`);
     if (filters.minConfidence) parts.push(`with confidence >= ${filters.minConfidence}`);
+    if (!profile) parts.push('(defaulting to ready-tier capabilities only)');
     parts.push(`in asset ${assetId}.`);
     return { content: parts.join(' '), isError: false };
   }
 
-  const eventSummaries = result.events.map((e, i) => ({
-    rank: i + 1,
-    id: e.id,
-    eventType: e.eventType,
-    timeRange: `${formatTimestamp(e.startTime)} – ${formatTimestamp(e.endTime)}`,
-    startTime: e.startTime,
-    endTime: e.endTime,
-    confidence: Math.round(e.confidence * 100) / 100,
-    reasons: e.reasons,
-    metadata: e.metadata,
-  }));
+  const tierLabels: Record<string, string> = {
+    ready: '[Ready]',
+    beta: '[Beta]',
+    experimental: '[Experimental]',
+  };
+
+  const tierDisclaimers: Record<string, string> = {
+    beta: 'Beta results may have accuracy gaps.',
+    experimental: 'Experimental results are early-stage; expect noise.',
+  };
+
+  const eventSummaries = filteredEvents.map((e, i) => {
+    const tier = tierForEventType.get(e.eventType) ?? getCapabilityByName(e.eventType)?.tier;
+    const tierLabel = tier ? tierLabels[tier] ?? `[${tier}]` : '[Ready]';
+    const disclaimer = tier ? tierDisclaimers[tier] : undefined;
+
+    return {
+      rank: i + 1,
+      id: e.id,
+      eventType: e.eventType,
+      tierLabel,
+      ...(disclaimer ? { confidenceDisclaimer: disclaimer } : {}),
+      timeRange: `${formatTimestamp(e.startTime)} – ${formatTimestamp(e.endTime)}`,
+      startTime: e.startTime,
+      endTime: e.endTime,
+      confidence: Math.round(e.confidence * 100) / 100,
+      reasons: e.reasons,
+      metadata: e.metadata,
+    };
+  });
+
+  // Collect disclaimers for any non-ready tiers present in results
+  const activeTiers = new Set(eventSummaries.map((e) => e.tierLabel));
+  const disclaimers: string[] = [];
+  if (activeTiers.has('[Beta]')) disclaimers.push(tierDisclaimers.beta);
+  if (activeTiers.has('[Experimental]')) disclaimers.push(tierDisclaimers.experimental);
 
   return {
     content: JSON.stringify({
@@ -223,7 +284,9 @@ export async function run(
         startTimeMin: filters.startTimeMin ?? null,
         startTimeMax: filters.startTimeMax ?? null,
       },
-      totalResults: result.totalReturned,
+      trackingProfile: profile ? 'custom' : 'default (ready tier only)',
+      ...(disclaimers.length > 0 ? { disclaimers } : {}),
+      totalResults: eventSummaries.length,
       events: eventSummaries,
     }, null, 2),
     isError: false,

--- a/assistant/src/config/bundled-skills/media-processing/tools/select-tracking-profile.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/select-tracking-profile.ts
@@ -1,0 +1,142 @@
+/**
+ * Select and persist a tracking profile for a media asset.
+ *
+ * When called without capabilities, returns the available capabilities
+ * organized by tier so the user can choose. When called with capabilities,
+ * validates them against the registry and stores the profile.
+ */
+
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getMediaAssetById, setTrackingProfile, getTrackingProfile, type CapabilityProfile } from '../../../../memory/media-store.js';
+import {
+  getCapabilities,
+  getCapabilityByName,
+  getRegisteredDomains,
+  type Capability,
+} from '../services/capability-registry.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function groupByTier(caps: Capability[]): Record<string, Capability[]> {
+  const groups: Record<string, Capability[]> = { ready: [], beta: [], experimental: [] };
+  for (const cap of caps) {
+    if (!groups[cap.tier]) groups[cap.tier] = [];
+    groups[cap.tier].push(cap);
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Tool entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    return { content: `No media asset found with id "${assetId}".`, isError: true };
+  }
+
+  const requestedCapabilities = input.capabilities as string[] | undefined;
+
+  // If no capabilities provided, return available options for the user to choose
+  if (!requestedCapabilities || requestedCapabilities.length === 0) {
+    const allCaps = getCapabilities();
+    const domains = getRegisteredDomains();
+    const byTier = groupByTier(allCaps);
+
+    const currentProfile = getTrackingProfile(assetId);
+
+    return {
+      content: JSON.stringify({
+        message: 'No capabilities specified. Here are the available capabilities organized by tier. Call again with a capabilities array to enable specific ones.',
+        domains,
+        availableCapabilities: {
+          ready: byTier.ready.map((c) => ({
+            name: c.name,
+            description: c.description,
+            domain: c.domain,
+            granularity: c.granularity ?? null,
+          })),
+          beta: byTier.beta.map((c) => ({
+            name: c.name,
+            description: c.description,
+            domain: c.domain,
+            granularity: c.granularity ?? null,
+            note: 'Beta: functional but may have accuracy gaps',
+          })),
+          experimental: byTier.experimental.map((c) => ({
+            name: c.name,
+            description: c.description,
+            domain: c.domain,
+            granularity: c.granularity ?? null,
+            note: 'Experimental: early-stage, expect noise in results',
+          })),
+        },
+        currentProfile: currentProfile ? currentProfile.capabilities : null,
+      }, null, 2),
+      isError: false,
+    };
+  }
+
+  // Validate requested capabilities exist in the registry
+  const capabilities: CapabilityProfile = {};
+  const unknownCaps: string[] = [];
+
+  for (const capName of requestedCapabilities) {
+    const registered = getCapabilityByName(capName);
+    if (!registered) {
+      unknownCaps.push(capName);
+      continue;
+    }
+    capabilities[capName] = { enabled: true, tier: registered.tier };
+  }
+
+  if (unknownCaps.length > 0) {
+    const allCaps = getCapabilities();
+    return {
+      content: JSON.stringify({
+        error: `Unknown capabilities: ${unknownCaps.join(', ')}`,
+        availableCapabilities: allCaps.map((c) => c.name),
+      }, null, 2),
+      isError: true,
+    };
+  }
+
+  // Store the profile
+  const profile = setTrackingProfile(assetId, capabilities);
+
+  // Build response with tier labels
+  const profileSummary: Record<string, { enabled: boolean; tier: string; tierLabel: string }> = {};
+  for (const [name, entry] of Object.entries(profile.capabilities)) {
+    const tierLabels: Record<string, string> = {
+      ready: '[Ready]',
+      beta: '[Beta]',
+      experimental: '[Experimental]',
+    };
+    profileSummary[name] = {
+      enabled: entry.enabled,
+      tier: entry.tier,
+      tierLabel: tierLabels[entry.tier] ?? `[${entry.tier}]`,
+    };
+  }
+
+  return {
+    content: JSON.stringify({
+      message: 'Tracking profile saved.',
+      assetId: profile.assetId,
+      profileId: profile.id,
+      capabilities: profileSummary,
+    }, null, 2),
+    isError: false,
+  };
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1123,5 +1123,18 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_events_asset_type ON media_events(asset_id, event_type)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_events_confidence ON media_events(confidence DESC)`);
 
+  // ── Media Tracking Profiles ─────────────────────────────────────────
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS media_tracking_profiles (
+      id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+      capabilities TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_tracking_profiles_asset_id ON media_tracking_profiles(asset_id)`);
+
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -8,7 +8,7 @@
 import { and, eq, inArray, gte, desc, asc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, mediaTimelines, mediaEvents } from './schema.js';
+import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, mediaTimelines, mediaEvents, mediaTrackingProfiles } from './schema.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -660,6 +660,88 @@ function parseEventRow(row: typeof mediaEvents.$inferSelect): MediaEvent {
     confidence: row.confidence,
     reasons,
     metadata,
+    createdAt: row.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tracking profile types & CRUD
+// ---------------------------------------------------------------------------
+
+export type CapabilityTier = 'ready' | 'beta' | 'experimental';
+
+export interface CapabilityProfileEntry {
+  enabled: boolean;
+  tier: CapabilityTier;
+}
+
+export type CapabilityProfile = Record<string, CapabilityProfileEntry>;
+
+export interface TrackingProfile {
+  id: string;
+  assetId: string;
+  capabilities: CapabilityProfile;
+  createdAt: number;
+}
+
+/**
+ * Upsert a tracking profile for a media asset. If a profile already exists
+ * for the given assetId, it is replaced.
+ */
+export function setTrackingProfile(assetId: string, capabilities: CapabilityProfile): TrackingProfile {
+  const db = getDb();
+  const now = Date.now();
+
+  // Check for existing profile by assetId
+  const existing = db
+    .select()
+    .from(mediaTrackingProfiles)
+    .where(eq(mediaTrackingProfiles.assetId, assetId))
+    .get();
+
+  if (existing) {
+    db.update(mediaTrackingProfiles)
+      .set({ capabilities: JSON.stringify(capabilities), createdAt: now })
+      .where(eq(mediaTrackingProfiles.id, existing.id))
+      .run();
+    return { id: existing.id, assetId, capabilities, createdAt: now };
+  }
+
+  const id = uuid();
+  db.insert(mediaTrackingProfiles).values({
+    id,
+    assetId,
+    capabilities: JSON.stringify(capabilities),
+    createdAt: now,
+  }).run();
+
+  return { id, assetId, capabilities, createdAt: now };
+}
+
+/**
+ * Get the current tracking profile for a media asset, if one exists.
+ */
+export function getTrackingProfile(assetId: string): TrackingProfile | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(mediaTrackingProfiles)
+    .where(eq(mediaTrackingProfiles.assetId, assetId))
+    .get();
+
+  if (!row) return null;
+
+  let capabilities: CapabilityProfile = {};
+  try {
+    capabilities = JSON.parse(row.capabilities) as CapabilityProfile;
+  } catch {
+    capabilities = {};
+  }
+
+  return {
+    id: row.id,
+    assetId: row.assetId,
+    capabilities,
     createdAt: row.createdAt,
   };
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -755,3 +755,11 @@ export const mediaEvents = sqliteTable('media_events', {
   metadata: text('metadata'),                                    // JSON
   createdAt: integer('created_at').notNull(),
 });
+
+export const mediaTrackingProfiles = sqliteTable('media_tracking_profiles', {
+  id: text('id').primaryKey(),
+  assetId: text('asset_id').notNull()
+    .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+  capabilities: text('capabilities').notNull(),                  // JSON: { [capName]: { enabled, tier } }
+  createdAt: integer('created_at').notNull(),
+});


### PR DESCRIPTION
Part of #6985: Vision-First Basketball Film Assistant MVP

## Changes
- Added media_tracking_profiles schema table + DB init + index
- Extended media-store.ts with tracking profile CRUD (set/get)
- Created services/capability-registry.ts with generic tier system and domain-specific registration
- Created tools/select-tracking-profile.ts for profile selection UX
- Updated tools/query-media-events.ts to respect tracking profiles and tier filtering
- Updated TOOLS.json and SKILL.md
- Capability system is fully generic; basketball tiers are one registered domain

Closes #6993
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
