### PR TITLE
feat: add Test Connection with health checks to Connect tab (#7095)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -25,6 +25,7 @@ struct SettingsConnectTab: View {
             bearerTokenSection
             pairingSection
             statusSection
+            testConnectionSection
         }
         .onAppear {
             store.refreshIngressConfig()
@@ -284,6 +285,149 @@ struct SettingsConnectTab: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Test Connection Section
+
+    private var testConnectionSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Test Connection")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            // Test Connection button
+            HStack(spacing: VSpacing.sm) {
+                if store.isCheckingGateway {
+                    VLoadingIndicator(size: 14, color: VColor.accent)
+                    Text("Checking...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                } else {
+                    VButton(
+                        label: "Test Connection",
+                        leftIcon: "antenna.radiowaves.left.and.right",
+                        style: .secondary,
+                        isDisabled: store.isCheckingGateway
+                    ) {
+                        Task { await store.testGatewayConnection() }
+                    }
+                }
+            }
+
+            // Gateway status row
+            connectionStatusRow(
+                label: "Gateway",
+                status: gatewayStatusInfo
+            )
+
+            // Tunnel status row
+            connectionStatusRow(
+                label: "Tunnel",
+                status: tunnelStatusInfo
+            )
+
+            // Diagnostic message when gateway is up but tunnel is down
+            if store.gatewayReachable == true,
+               !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               store.ingressReachable == false {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Gateway is running but tunnel is unreachable. Check your tunnel configuration.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            }
+
+            // Last verified timestamp
+            if let lastChecked = store.gatewayLastChecked {
+                Text("Last verified: \(relativeTimeString(from: lastChecked))")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            // Helper text
+            Text("Gateway checks the local process. Tunnel checks the public URL.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Connection Status Helpers
+
+    private struct ConnectionStatusInfo {
+        let label: String
+        let color: Color
+        let icon: String
+    }
+
+    private var gatewayStatusInfo: ConnectionStatusInfo {
+        guard let reachable = store.gatewayReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+        if reachable {
+            return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
+        }
+    }
+
+    private var tunnelStatusInfo: ConnectionStatusInfo {
+        let trimmedUrl = store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // No URL configured
+        if trimmedUrl.isEmpty {
+            return ConnectionStatusInfo(label: "Not configured", color: VColor.textMuted, icon: "minus.circle.fill")
+        }
+
+        // URL is non-empty but not a valid URL
+        if URL(string: trimmedUrl) == nil {
+            return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
+        }
+
+        // Haven't tested yet
+        guard let reachable = store.ingressReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+
+        if reachable {
+            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            return ConnectionStatusInfo(label: "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
+        }
+    }
+
+    private func connectionStatusRow(label: String, status: ConnectionStatusInfo) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Text(label)
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textSecondary)
+                .frame(width: 60, alignment: .leading)
+
+            Image(systemName: status.icon)
+                .foregroundColor(status.color)
+                .font(.system(size: 12))
+
+            Text(status.label)
+                .font(VFont.body)
+                .foregroundColor(status.color)
+        }
+    }
+
+    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
+    private func relativeTimeString(from date: Date) -> String {
+        let seconds = Int(-date.timeIntervalSinceNow)
+        if seconds < 5 { return "just now" }
+        if seconds < 60 { return "\(seconds) seconds ago" }
+        let minutes = seconds / 60
+        if minutes == 1 { return "1 minute ago" }
+        if minutes < 60 { return "\(minutes) minutes ago" }
+        let hours = minutes / 60
+        if hours == 1 { return "1 hour ago" }
+        return "\(hours) hours ago"
     }
 
     // MARK: - Token Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -124,6 +124,13 @@ public final class SettingsStore: ObservableObject {
     /// Read-only gateway target derived from daemon config (GATEWAY_PORT env var, default 7830).
     @Published var localGatewayTarget: String = "http://127.0.0.1:7830"
 
+    // MARK: - Connection Health Check State
+
+    @Published var gatewayReachable: Bool?
+    @Published var ingressReachable: Bool?
+    @Published var gatewayLastChecked: Date?
+    @Published var isCheckingGateway: Bool = false
+
     // MARK: - Trust Rules Coordination
 
     /// Whether any settings surface currently has a trust rules sheet open.
@@ -1018,6 +1025,51 @@ public final class SettingsStore: ObservableObject {
             try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: ingressPublicBaseUrl, enabled: enabled))
         } catch {
             log.error("Failed to send ingress config set (enabled): \(error)")
+        }
+    }
+
+    // MARK: - Connection Health Check
+
+    /// Tests reachability of both the local gateway process and the public ingress tunnel.
+    /// Updates `gatewayReachable`, `ingressReachable`, and `gatewayLastChecked` with results.
+    func testGatewayConnection() async {
+        isCheckingGateway = true
+        defer {
+            isCheckingGateway = false
+            gatewayLastChecked = Date()
+        }
+
+        // Test local gateway
+        gatewayReachable = await Self.checkHealthEndpoint(
+            baseUrl: localGatewayTarget,
+            timeoutSeconds: 3
+        )
+
+        // Test public ingress (only if URL is non-empty)
+        let trimmedUrl = ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedUrl.isEmpty {
+            ingressReachable = nil
+        } else {
+            ingressReachable = await Self.checkHealthEndpoint(
+                baseUrl: trimmedUrl,
+                timeoutSeconds: 5
+            )
+        }
+    }
+
+    /// Performs an HTTP GET to `<baseUrl>/healthz` and returns whether a 2xx response was received.
+    private static func checkHealthEndpoint(baseUrl: String, timeoutSeconds: TimeInterval) async -> Bool {
+        guard let url = URL(string: "\(baseUrl)/healthz") else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeoutSeconds
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return (200..<300).contains(httpResponse.statusCode)
+            }
+            return false
+        } catch {
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary
Add Test Connection button to the Connect settings tab that checks both local gateway process and public tunnel reachability.

## Implementation
- Added testGatewayConnection() to SettingsStore with dual health check (local + public)
- Added published state for gateway/ingress reachability and last-checked timestamp
- Updated SettingsConnectTab with Test Connection button, dual status display, and relative timestamp
- Shows separate Gateway (local) and Tunnel (public) status with appropriate colors

## Files Changed
- clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift — Added health check method + published state
- clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift — Added Test Connection UI

Part of #7093
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
