### PR TITLE
refactor: per-integration settings reference global Connect config (#7096)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -28,10 +28,6 @@ struct SettingsPanel: View {
     @State private var showingReminders = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
-    @State private var ingressUrlText: String = ""
-    @FocusState private var isIngressUrlFocused: Bool
-    @State private var checkingGateway: Bool = false
-    @State private var gatewayHealthResult: Bool? = nil
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
     @State private var connectingIntegration: String?
     @State private var integrationError: (id: String, message: String)?
@@ -45,6 +41,8 @@ struct SettingsPanel: View {
     @State private var modelDropdownFrame: CGRect = .zero
     @State private var selectedTab: SettingsTab = .connect
     @State private var testerModel: ToolPermissionTesterModel?
+    @AppStorage("ingressUseOverride") private var ingressUseOverride: Bool = false
+    @AppStorage("ingressGatewayOverride") private var ingressGatewayOverride: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -88,7 +86,6 @@ struct SettingsPanel: View {
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
-            ingressUrlText = store.ingressPublicBaseUrl
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
             if testerModel == nil, let dc = daemonClient {
@@ -102,20 +99,6 @@ struct SettingsPanel: View {
             if let monitor = mouseDownMonitor {
                 NSEvent.removeMonitor(monitor)
                 mouseDownMonitor = nil
-            }
-        }
-        .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            // Only sync from store when the field is not focused, so
-            // background IPC responses don't overwrite in-progress edits.
-            if !isIngressUrlFocused {
-                ingressUrlText = newValue
-            }
-        }
-        .onChange(of: isIngressUrlFocused) { _, focused in
-            // Re-sync when focus leaves so any updates skipped while the
-            // user was editing are applied once they're done.
-            if !focused {
-                ingressUrlText = store.ingressPublicBaseUrl
             }
         }
         .onChange(of: showModelDropdown) { _, isOpen in
@@ -203,7 +186,8 @@ struct SettingsPanel: View {
                 store: store,
                 threadManager: threadManager,
                 onClose: onClose,
-                daemonClient: daemonClient
+                daemonClient: daemonClient,
+                onNavigateToConnect: { selectedTab = .connect }
             )
         }
     }
@@ -348,105 +332,11 @@ struct SettingsPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                // Public Ingress URL field
-                HStack(spacing: VSpacing.xs) {
-                    Text("Public Ingress URL")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
+                // Global Gateway & Token readout
+                ingressGlobalConfigCard
 
-                TextField("https://abc123.ngrok-free.app", text: $ingressUrlText)
-                    .focused($isIngressUrlFocused)
-                    .textFieldStyle(.plain)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(VSpacing.md)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                    )
-
-                VButton(label: "Save", style: .primary) {
-                    store.saveIngressPublicBaseUrl(ingressUrlText)
-                }
-
-                Divider()
-                    .background(VColor.surfaceBorder)
-
-                // Local Gateway Target (read-only)
-                HStack(spacing: VSpacing.xs) {
-                    Text("Local Gateway Target")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-
-                HStack(spacing: VSpacing.sm) {
-                    Text(store.localGatewayTarget)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .textSelection(.enabled)
-                        .padding(VSpacing.md)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(VColor.surface.opacity(0.5))
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
-                        )
-
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
-                    } label: {
-                        Image(systemName: "doc.on.doc")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 28, height: 28)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Copy gateway address")
-                    .help("Copy address")
-
-                    // Check Gateway button
-                    Button {
-                        checkGatewayHealth()
-                    } label: {
-                        if checkingGateway {
-                            ProgressView()
-                                .controlSize(.small)
-                                .frame(width: 28, height: 28)
-                        } else {
-                            Image(systemName: "antenna.radiowaves.left.and.right")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(VColor.textSecondary)
-                                .frame(width: 28, height: 28)
-                                .contentShape(Rectangle())
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(checkingGateway)
-                    .accessibilityLabel("Check gateway health")
-                    .help("Check gateway health")
-                }
-
-                if let reachable = gatewayHealthResult {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: reachable ? "checkmark.circle.fill" : "xmark.circle.fill")
-                            .font(.system(size: 12))
-                            .foregroundColor(reachable ? VColor.success : VColor.error)
-                        Text(reachable ? "Gateway is reachable" : "Gateway is not reachable")
-                            .font(VFont.caption)
-                            .foregroundColor(reachable ? VColor.success : VColor.error)
-                    }
-                    .transition(.opacity)
-                }
-
-                Text("Point your tunnel service at this local address.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+                // Override section
+                ingressOverrideSection
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
@@ -1172,41 +1062,76 @@ struct SettingsPanel: View {
         onClose()
     }
 
-    // MARK: - Gateway Health Check
+    // MARK: - Ingress Global Config Card
 
-    private func checkGatewayHealth() {
-        gatewayHealthResult = nil
-        checkingGateway = true
+    /// Card showing the resolved gateway URL for public ingress, referencing global Connect config.
+    private var ingressGlobalConfigCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Using Global Gateway & Token")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .textCase(.uppercase)
 
-        Task {
-            defer { checkingGateway = false }
-
-            guard let url = URL(string: "\(store.localGatewayTarget)/healthz") else {
-                withAnimation(VAnimation.fast) { gatewayHealthResult = false }
-                return
+            HStack(alignment: .top) {
+                Text("Gateway URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 90, alignment: .leading)
+                Text(store.resolvedIngressGatewayUrl.isEmpty ? "Not configured" : store.resolvedIngressGatewayUrl)
+                    .font(VFont.mono)
+                    .foregroundColor(store.resolvedIngressGatewayUrl.isEmpty ? VColor.textMuted : VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
             }
 
-            var request = URLRequest(url: url)
-            request.timeoutInterval = 3
-
-            let reachable: Bool
-            do {
-                let (_, response) = try await URLSession.shared.data(for: request)
-                if let httpResponse = response as? HTTPURLResponse {
-                    reachable = (200..<300).contains(httpResponse.statusCode)
-                } else {
-                    reachable = false
-                }
-            } catch {
-                reachable = false
+            Button("Manage in Connect tab") {
+                selectedTab = .connect
             }
-
-            withAnimation(VAnimation.fast) { gatewayHealthResult = reachable }
-
-            // Auto-dismiss the status message after 4 seconds
-            try? await Task.sleep(nanoseconds: 4_000_000_000)
-            withAnimation(VAnimation.fast) { gatewayHealthResult = nil }
+            .font(VFont.caption)
+            .foregroundColor(VColor.accent)
         }
+        .padding(VSpacing.md)
+        .background(VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    /// Collapsed override section for per-integration ingress gateway URL customization.
+    private var ingressOverrideSection: some View {
+        DisclosureGroup("Override") {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Toggle("Use custom gateway for ingress", isOn: $ingressUseOverride)
+                    .toggleStyle(.switch)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+
+                if ingressUseOverride {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Gateway URL Override")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        TextField("https://custom-ingress.example.com", text: $ingressGatewayOverride)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+                    }
+                }
+            }
+            .padding(.top, VSpacing.sm)
+        }
+        .font(VFont.caption)
+        .foregroundColor(VColor.textSecondary)
     }
 
     // MARK: - Permission Row

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -10,14 +10,10 @@ struct SettingsAdvancedTab: View {
     @ObservedObject var threadManager: ThreadManager
     var onClose: () -> Void
     var daemonClient: DaemonClient?
+    var onNavigateToConnect: (() -> Void)?
 
-    @State private var sessionToken: String = ""
-    @State private var tokenCopied: Bool = false
-    @State private var tokenRevealed: Bool = false
     @State private var iosPairingEnabled: Bool = false
-    @State private var showingPairingQR: Bool = false
     @State private var showingPairingWarning: Bool = false
-    @State private var showingRegenerateConfirmation: Bool = false
     @State private var showingRetireConfirmation: Bool = false
     @State private var isRetiring: Bool = false
     @State private var lockfileAssistants: [LockfileAssistant] = []
@@ -25,6 +21,10 @@ struct SettingsAdvancedTab: View {
     @State private var identity: IdentityInfo?
     @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
+    @AppStorage("iosPairingUseOverride") private var iosPairingUseOverride: Bool = false
+    @AppStorage("iosPairingGatewayOverride") private var iosPairingGatewayOverride: String = ""
+    @AppStorage("iosPairingTokenOverride") private var iosPairingTokenOverride: String = ""
+
     #if DEBUG
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
@@ -48,7 +48,6 @@ struct SettingsAdvancedTab: View {
             #endif
         }
         .onAppear {
-            refreshSessionToken()
             let flagPath = NSHomeDirectory() + "/.vellum/ios-pairing-enabled"
             iosPairingEnabled = FileManager.default.fileExists(atPath: flagPath)
             lockfileAssistants = LockfileAssistant.loadAll()
@@ -290,7 +289,6 @@ struct SettingsAdvancedTab: View {
                     .labelsHidden()
                     .onChange(of: iosPairingEnabled) { _, enabled in
                         if enabled {
-                            // Show one-time warning on first enable
                             if !UserDefaults.standard.bool(forKey: "ios_pairing_warning_shown") {
                                 showingPairingWarning = true
                             } else {
@@ -302,58 +300,10 @@ struct SettingsAdvancedTab: View {
                     }
             }
 
-            // QR Code + Token display
+            // Global Gateway & Token readout
             if iosPairingEnabled {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Show QR Code", style: .primary) {
-                            showingPairingQR = true
-                        }
-                        Spacer()
-
-                        Button(tokenCopied ? "Copied!" : "Copy Token") {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(sessionToken, forType: .string)
-                            tokenCopied = true
-                            Task {
-                                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                tokenCopied = false
-                            }
-                        }
-                        .disabled(sessionToken.isEmpty)
-                    }
-
-                    if !sessionToken.isEmpty {
-                        HStack(spacing: VSpacing.xs) {
-                            Text("Token:")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                            Text(tokenRevealed ? sessionToken : String(sessionToken.prefix(16)) + "...")
-                                .font(VFont.mono)
-                                .foregroundColor(VColor.textSecondary)
-                                .textSelection(.enabled)
-                            Button(action: { tokenRevealed.toggle() }) {
-                                Image(systemName: tokenRevealed ? "eye.slash" : "eye")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel(tokenRevealed ? "Hide token" : "Reveal token")
-                        }
-                    }
-
-                    if !store.ingressEnabled || store.ingressPublicBaseUrl.isEmpty {
-                        Text("Enable ingress and set a public URL in Settings to pair with iOS.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-
-                    Button("Regenerate Token") {
-                        showingRegenerateConfirmation = true
-                    }
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.accent)
-                }
+                iosGlobalConfigCard
+                iosOverrideSection
             }
         }
         .padding(VSpacing.lg)
@@ -369,20 +319,106 @@ struct SettingsAdvancedTab: View {
         } message: {
             Text("Your assistant will be reachable on your local network. Only devices with the session token can connect. TLS encryption is always enabled.")
         }
-        .alert("Regenerate Session Token", isPresented: $showingRegenerateConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Regenerate", role: .destructive) {
-                regenerateSessionToken()
+    }
+
+    /// Card showing the resolved gateway URL and masked bearer token for iOS pairing.
+    private var iosGlobalConfigCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Using Global Gateway & Token")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .textCase(.uppercase)
+
+            HStack(alignment: .top) {
+                Text("Gateway URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 90, alignment: .leading)
+                Text(store.resolvedIosGatewayUrl.isEmpty ? "Not configured" : store.resolvedIosGatewayUrl)
+                    .font(VFont.mono)
+                    .foregroundColor(store.resolvedIosGatewayUrl.isEmpty ? VColor.textMuted : VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
             }
-        } message: {
-            Text("This will replace the current token and restart the daemon. Any paired iOS devices will need to re-scan the QR code.")
+
+            HStack(alignment: .top) {
+                Text("Bearer Token")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 90, alignment: .leading)
+                Text(store.resolvedIosBearerToken.isEmpty
+                     ? "Not configured"
+                     : String(repeating: "\u{2022}", count: 8))
+                    .font(VFont.mono)
+                    .foregroundColor(store.resolvedIosBearerToken.isEmpty ? VColor.textMuted : VColor.textPrimary)
+                Spacer()
+            }
+
+            Button("Manage in Connect tab") {
+                onNavigateToConnect?()
+            }
+            .font(VFont.caption)
+            .foregroundColor(VColor.accent)
         }
-        .sheet(isPresented: $showingPairingQR) {
-            PairingQRCodeSheet(
-                ingressEnabled: store.ingressEnabled,
-                ingressPublicBaseUrl: store.ingressPublicBaseUrl
-            )
+        .padding(VSpacing.md)
+        .background(VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    /// Collapsed override section for per-integration iOS gateway/token customization.
+    private var iosOverrideSection: some View {
+        DisclosureGroup("Override") {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Toggle("Use custom gateway for iOS", isOn: $iosPairingUseOverride)
+                    .toggleStyle(.switch)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+
+                if iosPairingUseOverride {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Gateway URL Override")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        TextField("https://custom-gateway.example.com", text: $iosPairingGatewayOverride)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Token Override")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        SecureField("Custom bearer token", text: $iosPairingTokenOverride)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                            )
+                    }
+                }
+            }
+            .padding(.top, VSpacing.sm)
         }
+        .font(VFont.caption)
+        .foregroundColor(VColor.textSecondary)
     }
 
     private func setIOSPairingEnabled(_ enabled: Bool) {
@@ -391,44 +427,6 @@ struct SettingsAdvancedTab: View {
             FileManager.default.createFile(atPath: flagPath, contents: nil)
         } else {
             try? FileManager.default.removeItem(atPath: flagPath)
-        }
-    }
-
-    private func refreshSessionToken() {
-        let tokenPath = NSHomeDirectory() + "/.vellum/session-token"
-        if let existing = try? String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
-           existing.count >= 32 {
-            sessionToken = existing
-        } else {
-            // Generate a token so pairing works immediately — the daemon
-            // will reuse this file on its next (re)start.
-            var bytes = [UInt8](repeating: 0, count: 32)
-            guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { return }
-            let newToken = bytes.map { String(format: "%02x", $0) }.joined()
-            let dir = (tokenPath as NSString).deletingLastPathComponent
-            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-            FileManager.default.createFile(atPath: tokenPath, contents: Data(newToken.utf8), attributes: [.posixPermissions: 0o600])
-            sessionToken = newToken
-        }
-    }
-
-
-    private func regenerateSessionToken() {
-        let tokenPath = NSHomeDirectory() + "/.vellum/session-token"
-        // Generate new random bytes before deleting the old file so a
-        // SecRandomCopyBytes failure doesn't leave us with no token at all.
-        var bytes = [UInt8](repeating: 0, count: 32)
-        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { return }
-        let newToken = bytes.map { String(format: "%02x", $0) }.joined()
-        try? FileManager.default.removeItem(atPath: tokenPath)
-        FileManager.default.createFile(atPath: tokenPath, contents: Data(newToken.utf8), attributes: [.posixPermissions: 0o600])
-        sessionToken = newToken
-        // Kill the daemon so the health monitor restarts it with the new token.
-        // The daemon only reads the token at startup, so a restart is required.
-        let pidPath = NSHomeDirectory() + "/.vellum/vellum.pid"
-        if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
-           let pid = Int32(pidStr) {
-            kill(pid, SIGTERM)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1073,6 +1073,38 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - Override Resolution
+
+    /// Resolved gateway URL for iOS pairing — uses per-integration override if enabled, else global.
+    var resolvedIosGatewayUrl: String {
+        UserDefaults.standard.bool(forKey: "iosPairingUseOverride")
+            ? (nonEmpty(UserDefaults.standard.string(forKey: "iosPairingGatewayOverride")) ?? ingressPublicBaseUrl)
+            : ingressPublicBaseUrl
+    }
+
+    /// Resolved bearer token for iOS pairing — uses per-integration override if enabled, else global.
+    var resolvedIosBearerToken: String {
+        if UserDefaults.standard.bool(forKey: "iosPairingUseOverride") {
+            if let override = nonEmpty(UserDefaults.standard.string(forKey: "iosPairingTokenOverride")) {
+                return override
+            }
+        }
+        return readHttpToken() ?? ""
+    }
+
+    /// Resolved gateway URL for public ingress — uses per-integration override if enabled, else global.
+    var resolvedIngressGatewayUrl: String {
+        UserDefaults.standard.bool(forKey: "ingressUseOverride")
+            ? (nonEmpty(UserDefaults.standard.string(forKey: "ingressGatewayOverride")) ?? ingressPublicBaseUrl)
+            : ingressPublicBaseUrl
+    }
+
+    /// Returns the string if it is non-nil and non-empty after trimming, otherwise nil.
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+
     // MARK: - Model Actions
 
     func setModel(_ model: String) {

--- a/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsStoreOverrideResolutionTests: XCTestCase {
+
+    // Each test manipulates UserDefaults keys that the override resolution
+    // reads. Clean up after each test to avoid cross-contamination.
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "iosPairingUseOverride")
+        UserDefaults.standard.removeObject(forKey: "iosPairingGatewayOverride")
+        UserDefaults.standard.removeObject(forKey: "iosPairingTokenOverride")
+        UserDefaults.standard.removeObject(forKey: "ingressUseOverride")
+        UserDefaults.standard.removeObject(forKey: "ingressGatewayOverride")
+        super.tearDown()
+    }
+
+    // MARK: - iOS Gateway URL
+
+    func testIosGatewayReturnsGlobalWhenOverrideOff() {
+        UserDefaults.standard.set(false, forKey: "iosPairingUseOverride")
+        UserDefaults.standard.set("https://custom.example.com", forKey: "iosPairingGatewayOverride")
+
+        let store = SettingsStore()
+        // Simulate global URL being set via IPC response
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
+    }
+
+    func testIosGatewayReturnsOverrideWhenOverrideOn() {
+        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+        UserDefaults.standard.set("https://custom.example.com", forKey: "iosPairingGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://custom.example.com")
+    }
+
+    func testIosGatewayFallsBackToGlobalWhenOverrideOnButEmpty() {
+        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+        UserDefaults.standard.set("", forKey: "iosPairingGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
+    }
+
+    func testIosGatewayFallsBackToGlobalWhenOverrideOnAndWhitespaceOnly() {
+        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+        UserDefaults.standard.set("   ", forKey: "iosPairingGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
+    }
+
+    // MARK: - Ingress Gateway URL
+
+    func testIngressGatewayReturnsGlobalWhenOverrideOff() {
+        UserDefaults.standard.set(false, forKey: "ingressUseOverride")
+        UserDefaults.standard.set("https://custom-ingress.example.com", forKey: "ingressGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://global.example.com")
+    }
+
+    func testIngressGatewayReturnsOverrideWhenOverrideOn() {
+        UserDefaults.standard.set(true, forKey: "ingressUseOverride")
+        UserDefaults.standard.set("https://custom-ingress.example.com", forKey: "ingressGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://custom-ingress.example.com")
+    }
+
+    func testIngressGatewayFallsBackToGlobalWhenOverrideOnButEmpty() {
+        UserDefaults.standard.set(true, forKey: "ingressUseOverride")
+        UserDefaults.standard.set("", forKey: "ingressGatewayOverride")
+
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://global.example.com")
+    }
+}


### PR DESCRIPTION
## Summary
Refactor Advanced tab (iOS Pairing) and Integrations tab (Public Ingress) to reference the centralized Connect config, with optional per-integration overrides.

## Implementation
- Advanced tab iOS Pairing: removed inline QR/token UI, replaced with 'Using Global Gateway & Token' card + Manage link + collapsed Override section
- Integrations tab Public Ingress: removed inline URL input, replaced with global reference card + Override section
- Added override resolution to SettingsStore (resolvedIosGatewayUrl, resolvedIosBearerToken, resolvedIngressGatewayUrl)
- Added unit test for global vs override resolution
- Each integration retains its own enable/disable toggle independently

## Files Changed
- clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift -- Refactored iOS pairing section
- clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift -- Refactored ingress section
- clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift -- Added override resolution
- clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift -- Added override resolution tests

Part of #7093
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
