### PR TITLE
Remove hard dependency on bunx for browser Chromium install

### DIFF
--- a/assistant/src/__tests__/browser-runtime-check.test.ts
+++ b/assistant/src/__tests__/browser-runtime-check.test.ts
@@ -41,7 +41,7 @@ describe('browser runtime check', () => {
     expect(status.chromiumInstalled).toBe(false);
     expect(status.chromiumPath).toBeNull();
     expect(status.error).toContain('Chromium not found');
-    expect(status.error).toContain('bunx playwright install chromium');
+    expect(status.error).toContain('bun x playwright install chromium');
   });
 
   test('handles executablePath throwing an error', async () => {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -273,7 +273,7 @@ class BrowserManager {
         const status = await checkBrowserRuntime();
         if (status.playwrightAvailable && !status.chromiumInstalled) {
           log.info('Chromium not installed, installing via playwright...');
-          const proc = Bun.spawn(['bunx', 'playwright', 'install', 'chromium'], {
+          const proc = Bun.spawn([process.execPath, 'x', 'playwright', 'install', 'chromium'], {
             stdout: 'pipe',
             stderr: 'pipe',
           });
@@ -293,7 +293,7 @@ class BrowserManager {
           } else {
             const stderr = await new Response(proc.stderr).text();
             const msg = stderr.trim() || `exited with code ${exitCode}`;
-            throw new Error(`Failed to install Chromium: ${msg}`);
+            throw new Error(`Failed to install Chromium via "${process.execPath} x playwright install chromium": ${msg}`);
           }
         }
       }

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -30,7 +30,7 @@ export async function checkBrowserRuntime(): Promise<BrowserRuntimeStatus> {
       playwrightAvailable: true,
       chromiumInstalled: installed,
       chromiumPath: installed ? execPath : null,
-      error: installed ? null : `Chromium not found at ${execPath}. Run: bunx playwright install chromium`,
+      error: installed ? null : `Chromium not found at ${execPath}. Run: bun x playwright install chromium`,
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- replace browser Chromium auto-install invocation from `bunx playwright install chromium` to `bun x playwright install chromium` via `process.execPath`
- improve install failure message to show the exact attempted command
- update browser runtime-check guidance string and test expectation to `bun x ...`

## Validation
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/browser-runtime-check.test.ts`
- Result: 3 passed, 0 failed

## Why
This removes a brittle runtime dependency on a standalone `bunx` binary in pod/container environments where Bun exists but `bunx` may be missing from PATH.
