### PR TITLE
Fix PR #7110 feedback: ingest-media job type, streaming hash, unique index

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -1,9 +1,10 @@
 import { basename, extname } from 'node:path';
-import { access, readFile } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   registerMediaAsset,
-  computeFileHash,
   getMediaAssetByHash,
   createProcessingStage,
   updateMediaAssetStatus,
@@ -117,10 +118,15 @@ export async function run(
     return { content: `Could not classify media type for MIME: ${mimeType}`, isError: true };
   }
 
-  // Compute content hash for dedup
-  context.onOutput?.('Reading file and computing content hash...\n');
-  const fileData = await readFile(filePath);
-  const fileHash = computeFileHash(fileData);
+  // Compute content hash for dedup using streaming to avoid loading entire file into memory
+  context.onOutput?.('Computing content hash (streaming)...\n');
+  const fileHash = await new Promise<string>((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', reject);
+  });
 
   // Check for existing asset with same hash
   const existingAsset = getMediaAssetByHash(fileHash);
@@ -172,7 +178,7 @@ export async function run(
   updateMediaAssetStatus(asset.id, 'processing');
 
   // Enqueue a processing job via the existing jobs framework
-  enqueueMemoryJob('embed_segment' as any, {
+  enqueueMemoryJob('media_processing', {
     mediaAssetId: asset.id,
     stage: 'ingest',
     filePath,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1033,7 +1033,7 @@ export function initializeDb(): void {
     )
   `);
 
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_assets_file_hash ON media_assets(file_hash)`);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_media_assets_file_hash ON media_assets(file_hash)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_assets_status ON media_assets(status)`);
 
   database.run(/*sql*/ `

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -20,7 +20,8 @@ export type MemoryJobType =
   | 'build_conversation_summary'
   | 'backfill'
   | 'rebuild_index'
-  | 'delete_qdrant_vectors';
+  | 'delete_qdrant_vectors'
+  | 'media_processing';
 
 const EMBED_JOB_TYPES: MemoryJobType[] = ['embed_segment', 'embed_item', 'embed_summary'];
 


### PR DESCRIPTION
Addresses review feedback on #7110:

1. Changed job enqueue from embed_segment (wrong type, silent no-op) to media_processing with proper payload
2. Switched file hashing from readFile (OOM risk for large videos) to streaming hash via createReadStream
3. Made file_hash index unique to prevent race condition duplicates

Ref: #7110
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
