### PR TITLE
Fix PR #7113 feedback: keyframe storage, dedup, batch validation, confidence

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/timeline-service.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/timeline-service.ts
@@ -117,7 +117,10 @@ export function generateTimeline(
       if (shouldMergeIntoSegment(currentSegment, vo)) {
         // Extend the current segment
         currentSegment.endTime = kf.timestamp;
-        currentSegment.confidence = (currentSegment.confidence + (vo.confidence ?? 0.5)) / 2;
+        const newConfidence = vo.confidence ?? 0.5;
+        currentSegment.confidence =
+          (currentSegment.confidence * currentSegment.frameCount + newConfidence) / (currentSegment.frameCount + 1);
+        currentSegment.frameCount++;
         mergeSubjects(currentSegment.attributes, vo.output);
         mergeActions(currentSegment.attributes, vo.output);
       } else {
@@ -167,6 +170,7 @@ interface PendingSegment {
   segmentType: string;
   attributes: Record<string, unknown>;
   confidence: number;
+  frameCount: number;
 }
 
 function createSegmentFromOutput(
@@ -188,6 +192,7 @@ function createSegmentFromOutput(
       context: (vo.output.context as string) ?? '',
     },
     confidence: vo.confidence ?? 0.5,
+    frameCount: 1,
   };
 }
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -36,6 +36,10 @@ export async function run(
   const analysisType = (input.analysis_type as string) || 'scene_description';
   const batchSize = (input.batch_size as number) || 10;
 
+  if (batchSize <= 0) {
+    return { content: 'batch_size must be greater than 0.', isError: true };
+  }
+
   const asset = getMediaAssetById(assetId);
   if (!asset) {
     return { content: `Media asset not found: ${assetId}`, isError: true };

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -1,11 +1,10 @@
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
 import { mkdir, readdir } from 'node:fs/promises';
-import { randomUUID } from 'node:crypto';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   getMediaAssetById,
   insertKeyframesBatch,
+  deleteKeyframesForAsset,
   createProcessingStage,
   updateProcessingStage,
   getProcessingStagesForAsset,
@@ -63,8 +62,8 @@ export async function run(
 
   updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
 
-  // Create output directory for frames
-  const outputDir = join(tmpdir(), `vellum-keyframes-${randomUUID()}`);
+  // Store keyframes in a durable directory alongside the source file
+  const outputDir = join(dirname(asset.filePath), 'keyframes', assetId);
   await mkdir(outputDir, { recursive: true });
 
   try {
@@ -110,6 +109,9 @@ export async function run(
       filePath: join(outputDir, file),
       metadata: { frameIndex: index, intervalSeconds },
     }));
+
+    // Clear existing keyframes to prevent duplicates on re-extraction
+    deleteKeyframesForAsset(assetId);
 
     // Batch insert
     const keyframes = insertKeyframesBatch(keyframeRows);

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -292,6 +292,11 @@ export function getKeyframesForAsset(assetId: string): MediaKeyframe[] {
   return rows.map(parseKeyframeRow);
 }
 
+export function deleteKeyframesForAsset(assetId: string): void {
+  const db = getDb();
+  db.delete(mediaKeyframes).where(eq(mediaKeyframes.assetId, assetId)).run();
+}
+
 export function getKeyframeById(id: string): MediaKeyframe | null {
   const db = getDb();
   const row = db.select().from(mediaKeyframes).where(eq(mediaKeyframes.id, id)).get();


### PR DESCRIPTION
Addresses review feedback on #7113:

1. Added batch_size > 0 validation in analyze-keyframes.ts
2. Moved keyframe storage from tmpdir to durable path alongside source file
3. Clear existing keyframes before re-extraction to prevent duplicates
4. Fixed timeline-service.ts confidence averaging to use true mean with frameCount tracking

Ref: #7113
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
