### PR TITLE
Fix PR #7124 feedback: capability names alignment and query filter ordering

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -182,7 +182,7 @@
           "capabilities": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Optional array of capability names to enable (e.g., ['turnovers', 'field_goals']). If omitted, returns the available capabilities for selection."
+            "description": "Optional array of capability names to enable (e.g., ['turnover', 'field_goal']). If omitted, returns the available capabilities for selection."
           }
         },
         "required": ["asset_id"]

--- a/assistant/src/config/bundled-skills/media-processing/services/capability-registry.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/capability-registry.ts
@@ -13,7 +13,7 @@ import type { CapabilityTier } from '../../../../memory/media-store.js';
 // ---------------------------------------------------------------------------
 
 export interface Capability {
-  /** Unique name used as the key in tracking profiles (e.g. 'turnovers'). */
+  /** Unique name used as the key in tracking profiles (e.g. 'turnover'). */
   name: string;
   /** Human-readable description of what this capability detects/tracks. */
   description: string;
@@ -83,7 +83,7 @@ export function getRegisteredDomains(): string[] {
 export function registerDefaults(): void {
   // Ready tier: production-quality detection
   registerCapability({
-    name: 'turnovers',
+    name: 'turnover',
     description: 'Team-level turnover detection',
     tier: 'ready',
     domain: 'basketball',
@@ -92,7 +92,7 @@ export function registerDefaults(): void {
 
   // Beta tier: functional but may have accuracy gaps
   registerCapability({
-    name: 'field_goals',
+    name: 'field_goal',
     description: 'Team-level field goal detection',
     tier: 'beta',
     domain: 'basketball',
@@ -100,7 +100,7 @@ export function registerDefaults(): void {
   });
 
   registerCapability({
-    name: 'rebounds',
+    name: 'rebound',
     description: 'Team-level rebound detection',
     tier: 'beta',
     domain: 'basketball',
@@ -108,7 +108,7 @@ export function registerDefaults(): void {
   });
 
   registerCapability({
-    name: 'turnovers_per_player',
+    name: 'turnover_per_player',
     description: 'Per-player turnover attribution',
     tier: 'beta',
     domain: 'basketball',
@@ -117,7 +117,7 @@ export function registerDefaults(): void {
 
   // Experimental tier: early-stage, expect noise
   registerCapability({
-    name: 'field_goals_per_player',
+    name: 'field_goal_per_player',
     description: 'Per-player field goal attribution',
     tier: 'experimental',
     domain: 'basketball',
@@ -125,7 +125,7 @@ export function registerDefaults(): void {
   });
 
   registerCapability({
-    name: 'rebounds_per_player',
+    name: 'rebound_per_player',
     description: 'Per-player rebound attribution',
     tier: 'experimental',
     domain: 'basketball',

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -193,7 +193,10 @@ export async function run(
   }
 
   const filters = parseQuery(query, assetId);
-  const result = retrieveEvents(filters);
+
+  // Retrieve without limit so we can apply capability filtering first, then limit
+  const userLimit = filters.limit;
+  const result = retrieveEvents({ ...filters, limit: undefined });
 
   // Determine which capabilities are allowed based on the tracking profile
   const profile = getTrackingProfile(assetId);
@@ -222,10 +225,13 @@ export async function run(
     // If no capabilities are registered at all, allow everything (pass null)
   }
 
-  // Filter events by allowed capabilities
+  // Filter events by allowed capabilities, then apply the user-requested limit
   let filteredEvents = result.events;
   if (allowedEventTypes !== null) {
     filteredEvents = filteredEvents.filter((e) => allowedEventTypes!.has(e.eventType));
+  }
+  if (userLimit && filteredEvents.length > userLimit) {
+    filteredEvents = filteredEvents.slice(0, userLimit);
   }
 
   if (filteredEvents.length === 0) {


### PR DESCRIPTION
Addresses review feedback on #7124:

1. Renamed capability names in capability-registry.ts to match canonical event type labels (singular forms: turnover, rebound, field_goal)
2. Fixed query-media-events.ts to apply capability filter BEFORE the limit (retrieve without limit, filter, then slice)
3. Updated TOOLS.json capability name references

Ref: #7124
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
