### PR TITLE
fix: URL trailing slash, scheme validation, stale health state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -383,8 +383,10 @@ struct SettingsConnectTab: View {
             return ConnectionStatusInfo(label: "Not configured", color: VColor.textMuted, icon: "minus.circle.fill")
         }
 
-        // URL is non-empty but not a valid URL
-        if URL(string: trimmedUrl) == nil {
+        // URL is non-empty but not a valid absolute HTTP(S) URL
+        if let parsed = URL(string: trimmedUrl), let scheme = parsed.scheme, ["http", "https"].contains(scheme.lowercased()) {
+            // valid — fall through to reachability check below
+        } else {
             return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1009,6 +1009,9 @@ public final class SettingsStore: ObservableObject {
         let previous = ingressPublicBaseUrl
         ingressPublicBaseUrl = trimmed
         pendingIngressUrl = previous
+        // Reset stale health status so the UI doesn't show results from the old URL
+        ingressReachable = nil
+        gatewayLastChecked = nil
         do {
             try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: ingressEnabled))
         } catch {
@@ -1059,7 +1062,8 @@ public final class SettingsStore: ObservableObject {
 
     /// Performs an HTTP GET to `<baseUrl>/healthz` and returns whether a 2xx response was received.
     private static func checkHealthEndpoint(baseUrl: String, timeoutSeconds: TimeInterval) async -> Bool {
-        guard let url = URL(string: "\(baseUrl)/healthz") else { return false }
+        let normalizedBase = baseUrl.hasSuffix("/") ? String(baseUrl.dropLast()) : baseUrl
+        guard let url = URL(string: "\(normalizedBase)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = timeoutSeconds
         do {


### PR DESCRIPTION
Addresses review feedback from PR #7125:

1. Strip trailing slashes from base URL before appending /healthz to avoid //healthz path mismatch
2. Validate that tunnel URL has http:// or https:// scheme, not just URL(string:) nil check
3. Reset ingressReachable and gatewayLastChecked to nil when ingress URL changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
