### PR TITLE
fix: Connect tab status gates on ingressEnabled + PID path resolution

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -268,6 +268,15 @@ struct SettingsConnectTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                 }
+            } else if !store.ingressEnabled {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 14))
+                    Text("Gateway URL is set but ingress is disabled. Enable ingress in Advanced settings to allow pairing.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
             } else {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "checkmark.circle.fill")
@@ -450,7 +459,7 @@ struct SettingsConnectTab: View {
         bearerToken = newToken
         // Kill the daemon so the health monitor restarts it with the new token.
         // The daemon only reads the token at startup, so a restart is required.
-        let pidPath = NSHomeDirectory() + "/.vellum/vellum.pid"
+        let pidPath = resolvePidPath()
         if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
            let pid = Int32(pidStr) {
             kill(pid, SIGTERM)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -63,16 +63,26 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
 
 #endif
 
+/// Resolve the `.vellum` data directory, honoring `BASE_DATA_DIR` when set.
+public func resolveVellumDir(environment: [String: String]? = nil) -> String {
+    let env = environment ?? ProcessInfo.processInfo.environment
+    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
+        let resolved = baseDir.hasPrefix("~/") ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2)) : baseDir
+        return resolved + "/.vellum"
+    }
+    return NSHomeDirectory() + "/.vellum"
+}
+
 /// Resolve the runtime HTTP bearer token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 /// Available on all platforms since HTTP transport is used on both macOS and iOS.
 public func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
-    let env = environment ?? ProcessInfo.processInfo.environment
-    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-        let resolved = baseDir.hasPrefix("~/") ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2)) : baseDir
-        return resolved + "/.vellum/http-token"
-    }
-    return NSHomeDirectory() + "/.vellum/http-token"
+    return resolveVellumDir(environment: environment) + "/http-token"
+}
+
+/// Resolve the daemon PID file path, honoring `BASE_DATA_DIR`.
+public func resolvePidPath(environment: [String: String]? = nil) -> String {
+    return resolveVellumDir(environment: environment) + "/vellum.pid"
 }
 
 /// Read the runtime HTTP bearer token from disk.


### PR DESCRIPTION
Addresses review feedback from PR #7115:

1. PID path now resolves via `resolveVellumDir()` instead of hardcoded `~/.vellum/vellum.pid`, honoring `BASE_DATA_DIR`
2. Status section now checks both `ingressPublicBaseUrl` and `ingressEnabled`, showing a warning when ingress is disabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
