### PR TITLE
fix: use dynamic assistant scope for Twilio settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -153,7 +153,14 @@ public final class SettingsStore: ObservableObject {
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
     private var lastDaemonModel: String?
-    private let twilioAssistantScope = "self"
+    private var twilioAssistantScope: String {
+        let stored = UserDefaults.standard.string(forKey: "connectedAssistantId")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let stored, !stored.isEmpty {
+            return stored
+        }
+        return "self"
+    }
     private var twilioPhoneRefreshPending = false
     private var twilioNumbersRefreshPending = false
     private var pendingGuardianChallengeChannel: String?


### PR DESCRIPTION
Replace hard-coded twilioAssistantScope='self' with a computed property using connectedAssistantId (falling back to 'self'). This ensures Twilio settings actions honor the currently selected assistant in multi-assistant workflows, matching the existing guardian flow pattern. Part of #7138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
