### PR TITLE
Fix PR #7128 feedback: cancellation support and diagnostics accuracy

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/processing-pipeline.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/processing-pipeline.ts
@@ -119,6 +119,18 @@ export async function runPipeline(
     throw new Error(`Media asset not found: ${assetId}`);
   }
 
+  // Check if asset is already cancelled before forcing processing
+  if ((asset.status as string) === 'cancelled') {
+    return {
+      assetId,
+      completedStages: [],
+      failedStage: null,
+      failureReason: null,
+      cancelled: true,
+      resumedFrom: null,
+    };
+  }
+
   // Mark asset as processing
   updateMediaAssetStatus(assetId, 'processing');
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/media-diagnostics.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/media-diagnostics.ts
@@ -77,8 +77,11 @@ interface DiagnosticReport {
 
 function computeStageDuration(stage: ProcessingStage): number | null {
   if (stage.startedAt == null) return null;
-  const end = stage.completedAt ?? Date.now();
-  return end - stage.startedAt;
+  if (stage.completedAt != null) return stage.completedAt - stage.startedAt;
+  // Only use Date.now() as a fallback for currently running stages
+  if (stage.status === 'running') return Date.now() - stage.startedAt;
+  // For failed/pending stages without completedAt, duration is unknown
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/media-store.ts
+++ b/assistant/src/memory/media-store.ts
@@ -14,7 +14,7 @@ import { mediaAssets, processingStages, mediaKeyframes, mediaVisionOutputs, medi
 // Types
 // ---------------------------------------------------------------------------
 
-export type MediaAssetStatus = 'registered' | 'processing' | 'indexed' | 'failed';
+export type MediaAssetStatus = 'registered' | 'processing' | 'indexed' | 'failed' | 'cancelled';
 export type MediaType = 'video' | 'audio' | 'image';
 export type StageStatus = 'pending' | 'running' | 'completed' | 'failed';
 


### PR DESCRIPTION
Addresses review feedback on #7128:
1. Added 'cancelled' to MediaAssetStatus type
2. Check cancellation before setting processing status
3. computeStageDuration only uses Date.now() for running stages
Ref: #7128
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
