### PR TITLE
Fix PR #7126 feedback: scoped boundary averaging and time validation

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/recalibrate.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/recalibrate.ts
@@ -74,6 +74,12 @@ export async function run(
     feedbackByEventId.get(fb.eventId)!.push(fb);
   }
 
+  // Build a map of event ID to event type for filtering feedback by type
+  const eventTypeById = new Map<string, string>();
+  for (const ev of allEvents) {
+    eventTypeById.set(ev.id, ev.eventType);
+  }
+
   const adjustments: RecalibrationAdjustment[] = [];
   const eventUpdates: EventUpdate[] = [];
   const db = getDb();
@@ -106,7 +112,7 @@ export async function run(
     // Pattern 3: Boundary edits — compute average adjustment
     if (boundaryEdit >= 1) {
       const boundaryFeedback = allFeedback.filter(
-        (fb) => fb.feedbackType === 'boundary_edit' && feedbackByEventId.has(fb.eventId),
+        (fb) => fb.feedbackType === 'boundary_edit' && eventTypeById.get(fb.eventId) === eventType,
       );
       let startAdjTotal = 0;
       let endAdjTotal = 0;

--- a/assistant/src/config/bundled-skills/media-processing/tools/submit-feedback.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/submit-feedback.ts
@@ -106,6 +106,10 @@ function handleMissedEvent(
     return { content: 'start_time and end_time are required for "missed" feedback type.', isError: true };
   }
 
+  if (endTime <= startTime) {
+    return { content: 'end_time must be greater than start_time.', isError: true };
+  }
+
   const notes = input.notes as string | undefined;
 
   // Create the missing event with low confidence (user-reported)


### PR DESCRIPTION
Addresses review feedback on #7126:
1. recalibrate.ts: boundary feedback filtered by current eventType via eventTypeById map
2. submit-feedback.ts: validate end_time > start_time for missed events
Ref: #7126
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
