### PR TITLE
Fix PR #7133 feedback: bypass default limit in capability-filtered queries

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -196,7 +196,7 @@ export async function run(
 
   // Retrieve without limit so we can apply capability filtering first, then limit
   const userLimit = filters.limit;
-  const result = retrieveEvents({ ...filters, limit: undefined });
+  const result = retrieveEvents({ ...filters, limit: 0 });
 
   // Determine which capabilities are allowed based on the tracking profile
   const profile = getTrackingProfile(assetId);


### PR DESCRIPTION
## Summary
- Pass `limit: 0` instead of `limit: undefined` to `retrieveEvents()` so the default limit of 10 is not applied before capability filtering.

## Test plan
- [ ] Verify that queries without an explicit limit return all matching events before capability filtering
- [ ] Verify that user-specified limits (e.g. "top 5") still work correctly after capability filtering

Ref: #7133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
