### PR TITLE
Fix PR #7130 feedback: job handler, hash consistency, index migration

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -1,13 +1,12 @@
 import { basename, extname } from 'node:path';
-import { createReadStream } from 'node:fs';
 import { access } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   registerMediaAsset,
   getMediaAssetByHash,
   createProcessingStage,
   updateMediaAssetStatus,
+  computeFileHash,
   type MediaType,
 } from '../../../../memory/media-store.js';
 import { enqueueMemoryJob } from '../../../../memory/jobs-store.js';
@@ -118,15 +117,11 @@ export async function run(
     return { content: `Could not classify media type for MIME: ${mimeType}`, isError: true };
   }
 
-  // Compute content hash for dedup using streaming to avoid loading entire file into memory
-  context.onOutput?.('Computing content hash (streaming)...\n');
-  const fileHash = await new Promise<string>((resolve, reject) => {
-    const hash = createHash('sha256');
-    const stream = createReadStream(filePath);
-    stream.on('data', (chunk) => hash.update(chunk));
-    stream.on('end', () => resolve(hash.digest('hex')));
-    stream.on('error', reject);
-  });
+  // Compute content hash for dedup – uses the same Bun.hash (wyhash) as
+  // media-store.ts so that hashes are consistent across ingest and lookup.
+  context.onOutput?.('Computing content hash...\n');
+  const fileBytes = await Bun.file(filePath).arrayBuffer();
+  const fileHash = computeFileHash(new Uint8Array(fileBytes));
 
   // Check for existing asset with same hash
   const existingAsset = getMediaAssetByHash(fileHash);

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1033,6 +1033,8 @@ export function initializeDb(): void {
     )
   `);
 
+  // Drop the old non-unique index so it can be recreated as UNIQUE (migration for existing databases)
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_media_assets_file_hash`);
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_media_assets_file_hash ON media_assets(file_hash)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_media_assets_status ON media_assets(status)`);
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -229,6 +229,12 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'delete_qdrant_vectors':
       await deleteQdrantVectorsJob(job);
       return;
+    case 'media_processing':
+      // Stub: actual media processing is orchestrated by the media-processing
+      // skill tools, not the job worker.  We just acknowledge the job so it
+      // doesn't fail with "Unknown memory job type".
+      log.info({ jobId: job.id, payload: job.payload }, 'media_processing job received');
+      return;
     default:
       throw new Error(`Unknown memory job type: ${(job as { type: string }).type}`);
   }


### PR DESCRIPTION
Addresses review feedback on #7130:
1. Added media_processing case to jobs-worker.ts processJob switch
2. Use consistent hash function between ingest-media and media-store
3. DROP old non-unique index before CREATE UNIQUE INDEX for migration
Ref: #7130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
