### PR TITLE
Fix PR #7132 feedback: stale frame cleanup and safer keyframe replacement

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -1,5 +1,5 @@
 import { join, dirname } from 'node:path';
-import { mkdir, readdir } from 'node:fs/promises';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   getMediaAssetById,
@@ -64,6 +64,7 @@ export async function run(
 
   // Store keyframes in a durable directory alongside the source file
   const outputDir = join(dirname(asset.filePath), 'keyframes', assetId);
+  await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
   try {


### PR DESCRIPTION
Addresses review feedback on #7132:
1. rm -rf output directory before mkdir to clear stale frames
2. Moved deleteKeyframesForAsset after successful extraction, before insert
Ref: #7132
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
