### PR TITLE
feat: add SMS messaging provider

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -83,6 +83,21 @@ Telegram is supported as a messaging provider with limited capabilities compared
 - The bot can only message users or groups that have previously interacted with it (sent `/start` or been added to a group). Bots cannot initiate conversations with arbitrary phone numbers.
 - Future support for MTProto user-account sessions may lift some of these restrictions.
 
+### SMS (Twilio)
+SMS is supported as a messaging provider with limited capabilities. The conversation ID is the recipient's phone number in E.164 format (e.g. `+14155551234`):
+
+- **Send**: Send an SMS to a phone number (high risk — requires user approval)
+- **Auth Test**: Verify Twilio credentials and show the configured phone number
+
+**Not available** (SMS limitations):
+- List conversations — SMS is stateless; there is no API to enumerate past conversations
+- Read message history — message history is not available through the gateway
+- Search messages — no search API is available for SMS
+
+**SMS limits:**
+- Outbound SMS uses the assistant's configured Twilio phone number as the sender. The phone number must be provisioned and assigned via the twilio-setup skill.
+- SMS messages are subject to Twilio's character limits and carrier filtering. Long messages may be split into multiple segments.
+
 ### Slack-specific
 - **Add Reaction**: Add an emoji reaction to a message
 - **Leave Channel**: Leave a Slack channel

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -42,6 +42,7 @@ import { registerMessagingProvider } from '../messaging/registry.js';
 import { slackProvider as slackMessagingProvider } from '../messaging/providers/slack/adapter.js';
 import { gmailMessagingProvider } from '../messaging/providers/gmail/adapter.js';
 import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
+import { smsMessagingProvider } from '../messaging/providers/sms/adapter.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { getHookManager } from '../hooks/manager.js';
@@ -386,6 +387,7 @@ export async function runDaemon(): Promise<void> {
   registerMessagingProvider(slackMessagingProvider);
   registerMessagingProvider(gmailMessagingProvider);
   registerMessagingProvider(telegramBotMessagingProvider);
+  registerMessagingProvider(smsMessagingProvider);
 
   const scheduler = startScheduler(
     async (conversationId, message) => {

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -1,0 +1,171 @@
+/**
+ * SMS messaging provider adapter.
+ *
+ * Enables proactive outbound SMS messaging via the gateway's /deliver/sms
+ * endpoint. Similar to the Telegram provider, SMS delivery is proxied through
+ * the gateway which owns the Twilio credentials and handles the Messages API.
+ *
+ * Twilio credentials (account_sid, auth_token) and a configured phone number
+ * are required for connectivity. The phone number is resolved from the config
+ * (sms.phoneNumber), env var (TWILIO_PHONE_NUMBER), or secure key fallback.
+ *
+ * The `token` parameter in MessagingProvider methods is unused for SMS
+ * because delivery is authenticated via the gateway's bearer token, not
+ * a per-user OAuth token.
+ */
+
+import type { MessagingProvider } from '../../provider.js';
+import type {
+  Conversation,
+  Message,
+  SearchResult,
+  SendResult,
+  ConnectionInfo,
+  ListOptions,
+  HistoryOptions,
+  SearchOptions,
+  SendOptions,
+} from '../../provider-types.js';
+import { getSecureKey } from '../../../security/secure-keys.js';
+import { readHttpToken } from '../../../util/platform.js';
+import { loadConfig } from '../../../config/loader.js';
+import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
+import * as externalConversationStore from '../../../memory/external-conversation-store.js';
+import * as sms from './client.js';
+
+/** Resolve the gateway base URL, preferring GATEWAY_INTERNAL_BASE_URL if set. */
+function getGatewayUrl(): string {
+  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
+    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
+  }
+  const port = Number(process.env.GATEWAY_PORT) || 7830;
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Read the runtime HTTP bearer token used to authenticate with the gateway. */
+function getBearerToken(): string {
+  const token = readHttpToken();
+  if (!token) {
+    throw new Error('No runtime HTTP bearer token available — is the daemon running?');
+  }
+  return token;
+}
+
+/** Check whether Twilio credentials are stored. */
+function hasTwilioCredentials(): boolean {
+  return (
+    !!getSecureKey('credential:twilio:account_sid') &&
+    !!getSecureKey('credential:twilio:auth_token')
+  );
+}
+
+/**
+ * Resolve the configured SMS phone number.
+ * Priority: TWILIO_PHONE_NUMBER env > config sms.phoneNumber > secure key fallback.
+ */
+function getPhoneNumber(): string | undefined {
+  const fromEnv = process.env.TWILIO_PHONE_NUMBER;
+  if (fromEnv) return fromEnv;
+
+  try {
+    const config = loadConfig();
+    if (config.sms?.phoneNumber) return config.sms.phoneNumber;
+  } catch {
+    // Config may not be available yet during early startup
+  }
+
+  return getSecureKey('credential:twilio:phone_number') || undefined;
+}
+
+export const smsMessagingProvider: MessagingProvider = {
+  id: 'sms',
+  displayName: 'SMS',
+  credentialService: 'twilio',
+  capabilities: new Set(['send']),
+
+  /**
+   * SMS is connected when Twilio credentials are stored AND a phone number
+   * is configured. Without a phone number the gateway cannot determine
+   * the `from` for outbound messages.
+   */
+  isConnected(): boolean {
+    return hasTwilioCredentials() && !!getPhoneNumber();
+  },
+
+  async testConnection(_token: string): Promise<ConnectionInfo> {
+    if (!hasTwilioCredentials()) {
+      return {
+        connected: false,
+        user: 'unknown',
+        platform: 'sms',
+        metadata: { error: 'No Twilio credentials found. Run the twilio-setup skill.' },
+      };
+    }
+
+    const phoneNumber = getPhoneNumber();
+    if (!phoneNumber) {
+      return {
+        connected: false,
+        user: 'unknown',
+        platform: 'sms',
+        metadata: { error: 'No phone number configured. Run the twilio-setup skill to assign a number.' },
+      };
+    }
+
+    const accountSid = getSecureKey('credential:twilio:account_sid')!;
+
+    return {
+      connected: true,
+      user: phoneNumber,
+      platform: 'sms',
+      metadata: {
+        accountSid: accountSid.slice(0, 6) + '...',
+        phoneNumber,
+      },
+    };
+  },
+
+  async sendMessage(_token: string, conversationId: string, text: string, _options?: SendOptions): Promise<SendResult> {
+    const gatewayUrl = getGatewayUrl();
+    const bearerToken = getBearerToken();
+
+    await sms.sendMessage(gatewayUrl, bearerToken, conversationId, text);
+
+    // Upsert external conversation binding so the conversation key mapping
+    // exists for the next inbound SMS from this number.
+    try {
+      const sourceChannel = 'sms';
+      const conversationKey = `${sourceChannel}:${conversationId}`;
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      externalConversationStore.upsertOutboundBinding({
+        conversationId: internalId,
+        sourceChannel,
+        externalChatId: conversationId,
+      });
+    } catch {
+      // Best-effort — don't fail the send if binding upsert fails
+    }
+
+    return {
+      id: `sms-${Date.now()}`,
+      timestamp: Date.now(),
+      conversationId,
+    };
+  },
+
+  // SMS does not support listing conversations. The assistant can only
+  // send to known phone numbers (conversation IDs).
+  async listConversations(_token: string, _options?: ListOptions): Promise<Conversation[]> {
+    return [];
+  },
+
+  // SMS does not provide message history retrieval via the gateway.
+  async getHistory(_token: string, _conversationId: string, _options?: HistoryOptions): Promise<Message[]> {
+    return [];
+  },
+
+  // SMS does not support message search.
+  async search(_token: string, _query: string, _options?: SearchOptions): Promise<SearchResult> {
+    return { total: 0, messages: [], hasMore: false };
+  },
+};

--- a/assistant/src/messaging/providers/sms/client.ts
+++ b/assistant/src/messaging/providers/sms/client.ts
@@ -1,0 +1,62 @@
+/**
+ * Low-level SMS operations.
+ *
+ * Outbound message delivery routes through the gateway's /deliver/sms
+ * endpoint, which handles Twilio credential management and the Messages API.
+ * The gateway resolves the `from` number using the optional assistantId or
+ * its default Twilio phone number configuration.
+ */
+
+const DELIVERY_TIMEOUT_MS = 30_000;
+
+export class SmsApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SmsApiError';
+  }
+}
+
+/** Payload accepted by the gateway's /deliver/sms endpoint. */
+interface DeliverPayload {
+  to: string;
+  text: string;
+  assistantId?: string;
+}
+
+/**
+ * Send an SMS message via the gateway's /deliver/sms endpoint.
+ */
+export async function sendMessage(
+  gatewayUrl: string,
+  bearerToken: string,
+  to: string,
+  text: string,
+  assistantId?: string,
+): Promise<void> {
+  const payload: DeliverPayload = { to, text };
+  if (assistantId) {
+    payload.assistantId = assistantId;
+  }
+
+  const url = `${gatewayUrl}/deliver/sms`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '<unreadable>');
+    throw new SmsApiError(
+      resp.status,
+      `Gateway /deliver/sms failed (${resp.status}): ${body}`,
+    );
+  }
+}

--- a/assistant/src/messaging/providers/sms/types.ts
+++ b/assistant/src/messaging/providers/sms/types.ts
@@ -1,0 +1,7 @@
+/** Twilio SMS types used by the messaging provider. */
+
+export interface TwilioAccountInfo {
+  accountSid: string;
+  friendlyName: string;
+  phoneNumber: string;
+}


### PR DESCRIPTION
Add SMS/Twilio as a first-class messaging provider in the unified messaging runtime, enabling messaging_send with platform='sms'. Mirrors the Telegram provider pattern with adapter, client, and types. Registers the provider in daemon lifecycle and updates messaging skill docs. Part of #7138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
