### PR TITLE
feat: SMS routing rejection notices and attachment-only fallback

### DIFF
--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -90,6 +90,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       chatId?: string;
       text?: string;
       assistantId?: string;
+      attachments?: unknown[];
     };
     try {
       body = (await req.json()) as typeof body;
@@ -107,7 +108,16 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "to is required" }, { status: 400 });
     }
 
-    if (!text || typeof text !== "string") {
+    // When text is missing but attachments are present, the assistant produced
+    // a media-only reply that SMS cannot deliver. Use a graceful fallback
+    // instead of rejecting outright so the user gets visible feedback.
+    const hasAttachments = Array.isArray(body.attachments) && body.attachments.length > 0;
+    const effectiveText =
+      (!text || (typeof text === "string" && text.trim().length === 0)) && hasAttachments
+        ? "I have a media attachment to share, but SMS currently supports text only."
+        : text;
+
+    if (!effectiveText || typeof effectiveText !== "string") {
       return Response.json({ error: "text is required" }, { status: 400 });
     }
 
@@ -126,14 +136,14 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
         config.twilioAuthToken,
         from,
         to,
-        text,
+        effectiveText,
       );
     } catch (err) {
       tlog.error({ err, to }, "Failed to send SMS via Twilio");
       return Response.json({ error: "SMS delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ to, textLength: text.length }, "SMS delivered");
+    tlog.info({ to, textLength: effectiveText.length }, "SMS delivered");
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -11,6 +11,47 @@ import type { GatewayInboundEventV1 } from "../../types.js";
 
 const log = getLogger("twilio-sms-webhook");
 
+// Rate limiter for routing rejection notices — at most one reply per phone
+// number within the cooldown window to avoid spamming the user.
+const REJECTION_NOTICE_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_REJECTION_CACHE_SIZE = 10_000;
+const SWEEP_INTERVAL = 100; // sweep every N calls
+const rejectionNoticeTimestamps = new Map<string, number>();
+let rejectionCallCount = 0;
+
+function sweepRejectionCache(now: number): void {
+  for (const [key, ts] of rejectionNoticeTimestamps) {
+    if (now - ts >= REJECTION_NOTICE_COOLDOWN_MS) {
+      rejectionNoticeTimestamps.delete(key);
+    }
+  }
+
+  if (rejectionNoticeTimestamps.size > MAX_REJECTION_CACHE_SIZE) {
+    const sorted = [...rejectionNoticeTimestamps.entries()].sort((a, b) => a[1] - b[1]);
+    const toRemove = sorted.length - MAX_REJECTION_CACHE_SIZE;
+    for (let i = 0; i < toRemove; i++) {
+      rejectionNoticeTimestamps.delete(sorted[i][0]);
+    }
+  }
+}
+
+function shouldSendRejectionNotice(phoneNumber: string): boolean {
+  const now = Date.now();
+
+  rejectionCallCount++;
+  if (rejectionCallCount >= SWEEP_INTERVAL) {
+    rejectionCallCount = 0;
+    sweepRejectionCache(now);
+  }
+
+  const lastSent = rejectionNoticeTimestamps.get(phoneNumber);
+  if (lastSent !== undefined && now - lastSent < REJECTION_NOTICE_COOLDOWN_MS) {
+    return false;
+  }
+  rejectionNoticeTimestamps.set(phoneNumber, now);
+  return true;
+}
+
 export const SMS_CHANNEL_TRANSPORT_HINTS = [
   "chat-first-medium",
   "channel-safe-onboarding",
@@ -169,6 +210,15 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         { from: params.From, reason: routing.reason },
         "Routing rejected inbound SMS",
       );
+      if (shouldSendRejectionNotice(params.From)) {
+        sendSmsReply(
+          config,
+          params.From,
+          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+        ).catch((err) => {
+          tlog.error({ err, to: params.From }, "Failed to send routing rejection notice");
+        });
+      }
       dedupCache.mark(messageSid);
       return Response.json({ ok: true });
     }
@@ -186,6 +236,15 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           { from: params.From, reason: result.rejectionReason },
           "Routing rejected inbound SMS",
         );
+        if (shouldSendRejectionNotice(params.From)) {
+          sendSmsReply(
+            config,
+            params.From,
+            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+          ).catch((err) => {
+            tlog.error({ err, to: params.From }, "Failed to send routing rejection notice");
+          });
+        }
         dedupCache.mark(messageSid);
         return Response.json({ ok: true });
       }


### PR DESCRIPTION
Send visible SMS notices on general routing rejection (parity with Telegram) instead of silently dropping. Add graceful fallback text for attachment-only assistant replies on SMS to prevent delivery failures. Part of #7138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
