### PR TITLE
fix: restore health state on ingress URL save rollback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1010,6 +1010,8 @@ public final class SettingsStore: ObservableObject {
         ingressPublicBaseUrl = trimmed
         pendingIngressUrl = previous
         // Reset stale health status so the UI doesn't show results from the old URL
+        let previousReachable = ingressReachable
+        let previousLastChecked = gatewayLastChecked
         ingressReachable = nil
         gatewayLastChecked = nil
         do {
@@ -1018,6 +1020,8 @@ public final class SettingsStore: ObservableObject {
             // IPC send failed — roll back the optimistic update
             ingressPublicBaseUrl = previous
             pendingIngressUrl = nil
+            ingressReachable = previousReachable
+            gatewayLastChecked = previousLastChecked
         }
     }
 


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #7135:

Saves `ingressReachable` and `gatewayLastChecked` before clearing them, then restores them in the catch block when IPC send fails and the URL is rolled back. This prevents showing stale "Unknown" health status when the URL reverts to the previous working value.

## Implementation
In `saveIngressPublicBaseUrl`, the health state values (`ingressReachable` and `gatewayLastChecked`) are now captured into local variables before being cleared to nil. If the `daemonClient?.send()` call throws, the catch block restores these values alongside the existing `ingressPublicBaseUrl` and `pendingIngressUrl` rollback.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift` — 4 lines added to save/restore health state on IPC failure rollback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
