### PR TITLE
docs: align skills and docs with SMS provider capabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2446,19 +2446,27 @@ graph TB
     subgraph "Provider Adapters"
         SLACK_ADAPTER["Slack Adapter<br/>messaging/providers/slack/"]
         GMAIL_ADAPTER["Gmail Adapter<br/>messaging/providers/gmail/"]
+        TELEGRAM_ADAPTER["Telegram Adapter<br/>messaging/providers/telegram/"]
+        SMS_ADAPTER["SMS Adapter (Twilio)<br/>messaging/providers/sms/"]
     end
 
     subgraph "External APIs"
         SLACK_API["Slack Web API"]
         GMAIL_API["Gmail REST API"]
+        TELEGRAM_API["Telegram Bot API"]
+        TWILIO_API["Twilio REST API"]
     end
 
     SHARED --> REGISTRY
     REGISTRY --> PROVIDER_IF
     SLACK_ADAPTER -.->|implements| PROVIDER_IF
     GMAIL_ADAPTER -.->|implements| PROVIDER_IF
+    TELEGRAM_ADAPTER -.->|implements| PROVIDER_IF
+    SMS_ADAPTER -.->|implements| PROVIDER_IF
     SLACK_ADAPTER --> SLACK_API
     GMAIL_ADAPTER --> GMAIL_API
+    TELEGRAM_ADAPTER --> TELEGRAM_API
+    SMS_ADAPTER --> TWILIO_API
     AUTH_TEST --> SHARED
     LIST --> SHARED
     SEARCH --> SHARED

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ If a proxied command receives a 401 or 403 despite having the correct credential
 
 Vellum integrates with third-party services via OAuth2. Each integration is exposed as a bundled skill with its own set of tools.
 
-### Messaging (Gmail, Slack, Telegram)
+### Messaging (Gmail, Slack, Telegram, SMS/Twilio)
 
-The unified messaging layer provides platform-agnostic tools (`messaging_send`, `messaging_read`, `messaging_search`, etc.) that delegate to provider adapters. Gmail and Slack each implement the `MessagingProvider` interface. Telegram is also supported as a messaging provider, though with limited capabilities compared to Slack and Gmail: bots can send messages to known chat IDs but cannot list conversations, retrieve message history, or search messages (Bot API limitations). Bots can only message users or groups that have previously interacted with the bot. Platform-specific tools (e.g. `gmail_archive`, `slack_add_reaction`) extend beyond the generic interface where needed.
+The unified messaging layer provides platform-agnostic tools (`messaging_send`, `messaging_read`, `messaging_search`, etc.) that delegate to provider adapters. Gmail and Slack each implement the `MessagingProvider` interface. Telegram is also supported as a messaging provider, though with limited capabilities compared to Slack and Gmail: bots can send messages to known chat IDs but cannot list conversations, retrieve message history, or search messages (Bot API limitations). Bots can only message users or groups that have previously interacted with the bot. SMS is supported via Twilio as a send-only provider — it can send outbound SMS messages but does not support listing conversations, reading history, or searching (SMS is stateless). **Note:** SMS only — MMS (media messages) is not currently supported. Platform-specific tools (e.g. `gmail_archive`, `slack_add_reaction`) extend beyond the generic interface where needed.
 
-Connect Gmail and Slack via the Settings UI or `integration_connect` IPC message. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions.
+Connect Gmail and Slack via the Settings UI or `integration_connect` IPC message. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions. SMS uses Twilio credentials (Account SID + Auth Token) — see the `twilio-setup` skill for setup instructions.
 
 ### Twitter (X)
 

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -18,6 +18,15 @@ This skill manages the full Twilio lifecycle:
 
 All operations go through the `twilio_config` IPC handler on the daemon, which validates inputs, stores credentials securely, and manages phone number state.
 
+### Multi-Assistant Setups
+
+In a multi-assistant environment (multiple assistants sharing the same daemon), every `twilio_config` IPC message should include an `assistantId` field to scope the configuration to the correct assistant instance. If `assistantId` is omitted, the daemon uses the default assistant. Include `assistantId` whenever:
+- Multiple assistants share the same Twilio account but use different phone numbers
+- You want to ensure configuration changes only affect a specific assistant
+- The user has explicitly selected or referenced a particular assistant
+
+All IPC examples below include the optional `assistantId` field. Omit it in single-assistant setups.
+
 ## Step 1: Check Current Configuration
 
 First, check whether Twilio is already configured by sending the `twilio_config` IPC message with `action: "get"`:
@@ -25,7 +34,8 @@ First, check whether Twilio is already configured by sending the `twilio_config`
 ```json
 {
   "type": "twilio_config",
-  "action": "get"
+  "action": "get",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -56,7 +66,8 @@ After both credentials are collected, retrieve them from secure storage and pass
   "type": "twilio_config",
   "action": "set_credentials",
   "accountSid": "<value from credential_store for twilio/account_sid>",
-  "authToken": "<value from credential_store for twilio/auth_token>"
+  "authToken": "<value from credential_store for twilio/auth_token>",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -75,7 +86,8 @@ If the user wants to buy a new number through Twilio, send:
   "type": "twilio_config",
   "action": "provision_number",
   "areaCode": "415",
-  "country": "US"
+  "country": "US",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -100,7 +112,8 @@ If the user already has a Twilio phone number, first list available numbers:
 ```json
 {
   "type": "twilio_config",
-  "action": "list_numbers"
+  "action": "list_numbers",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -112,7 +125,8 @@ Then assign the chosen number:
 {
   "type": "twilio_config",
   "action": "assign_number",
-  "phoneNumber": "+14155551234"
+  "phoneNumber": "+14155551234",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -132,7 +146,8 @@ Then assign it through the IPC:
 {
   "type": "twilio_config",
   "action": "assign_number",
-  "phoneNumber": "+14155551234"
+  "phoneNumber": "+14155551234",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -181,7 +196,8 @@ Now link the user's phone number as the trusted SMS guardian for this assistant.
 {
   "type": "guardian_verification",
   "action": "create_challenge",
-  "channel": "sms"
+  "channel": "sms",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -195,7 +211,8 @@ Now link the user's phone number as the trusted SMS guardian for this assistant.
 {
   "type": "guardian_verification",
   "action": "status",
-  "channel": "sms"
+  "channel": "sms",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -228,7 +245,8 @@ If the user wants to disconnect Twilio, send:
 ```json
 {
   "type": "twilio_config",
-  "action": "clear_credentials"
+  "action": "clear_credentials",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 


### PR DESCRIPTION
Update twilio-setup skill IPC examples to include assistantId for multi-assistant workflows. Update README integrations section to include SMS/Twilio. Update ARCHITECTURE.md messaging provider diagrams to include SMS and Telegram adapters. Part of #7138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
