### PR TITLE
Fix PR #7120 feedback: parseLimit regex and temp dir cleanup

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -8,7 +8,7 @@
 
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
-import { mkdir, unlink, stat } from 'node:fs/promises';
+import { mkdir, unlink, stat, rmdir } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
@@ -188,7 +188,8 @@ export async function run(
       isError: true,
     };
   } finally {
-    // Clean up temp file
+    // Clean up temp file and directory
     try { await unlink(clipPath); } catch { /* ignore */ }
+    try { await rmdir(clipDir); } catch { /* ignore */ }
   }
 }

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -56,7 +56,7 @@ const EVENT_TYPE_KEYWORDS: Record<string, string> = {
  * Returns undefined if no limit phrase is found.
  */
 function parseLimit(query: string): number | undefined {
-  const match = query.match(/(?:top|first|last|show|find|get)\s+(\d+)/i);
+  const match = query.match(/(?:top|first|last|show|find|get)\s+(\d+)(?!\s*min)/i);
   if (match) return parseInt(match[1], 10);
   // Also match trailing "N events/moments"
   const trailingMatch = query.match(/(\d+)\s+(?:events?|moments?|plays?|clips?)/i);


### PR DESCRIPTION
Addresses review feedback on #7120:
1. Added negative lookahead to parseLimit regex to avoid matching 'first N minutes'
2. Added rmdir cleanup for temp clip directories in generate-clip.ts
Ref: #7120
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
