### PR TITLE
fix: fetchInterfaceFile tilde expansion via resolveHttpTokenPath

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1151,14 +1151,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         } else if let port = httpPort {
             baseURL = "http://localhost:\(port)"
             // Read local bearer token from disk
-            let tokenBase: String
-            if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !baseDir.isEmpty {
-                tokenBase = baseDir
-            } else {
-                tokenBase = NSHomeDirectory()
-            }
-            let tokenPath = tokenBase + "/.vellum/http-token"
+            let tokenPath = resolveHttpTokenPath()
             do {
                 bearerToken = try String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
             } catch {


### PR DESCRIPTION
Addresses review feedback from PR #7152:

fetchInterfaceFile was manually constructing the token path from BASE_DATA_DIR without tilde expansion. Replaced with resolveHttpTokenPath() which properly expands ~ and ~/ via resolveVellumDir.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
