### PR TITLE
fix: fall back to System Settings when screen recording prompt is a no-op

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -1,4 +1,5 @@
 import ApplicationServices
+import AppKit
 
 enum PermissionStatus {
     case granted
@@ -18,6 +19,18 @@ enum PermissionManager {
     }
 
     static func requestScreenRecordingAccess() {
+        // CGRequestScreenCaptureAccess() only shows the OS prompt once per app
+        // install. On subsequent calls it's a no-op. Fall back to opening
+        // System Settings directly if permission is still denied after the call.
         CGRequestScreenCaptureAccess()
+        if !CGPreflightScreenCaptureAccess() {
+            openScreenRecordingSettings()
+        }
+    }
+
+    static func openScreenRecordingSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+            NSWorkspace.shared.open(url)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `CGRequestScreenCaptureAccess()` only shows the OS permission prompt once per app install — subsequent calls silently do nothing
- Now falls back to opening System Settings > Privacy > Screen Recording directly via `x-apple.systempreferences:` URL scheme when permission is still denied after the API call
- Adds `import AppKit` for `NSWorkspace` access

## Test plan
- [ ] Grant screen recording, then revoke it in System Settings
- [ ] Click screen recording permission in app settings — should open System Settings directly
- [ ] First-time launch still shows native OS prompt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
