### PR TITLE
fix: ingress toggle disabled checks global URL only (not override)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -320,7 +320,7 @@ struct SettingsPanel: View {
                     ))
                     .toggleStyle(.switch)
                     .labelsHidden()
-                    .disabled(store.ingressPublicBaseUrl.isEmpty && store.resolvedIngressGatewayUrl.isEmpty && !store.ingressEnabled)
+                    .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
                 }
 
                 HStack(alignment: .top, spacing: VSpacing.sm) {


### PR DESCRIPTION
Addresses review feedback from PR #7154:

Reverted the ingress toggle disabled condition to only check ingressPublicBaseUrl.isEmpty, removing the resolvedIngressGatewayUrl check. The daemon only knows about the global URL — allowing the toggle when only an override is set sends an empty URL to the daemon, breaking webhook/OAuth flows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
