### PR TITLE
fix: enforce scope, reject unresolved seeds, fix fallback in graph-query tool

### DIFF
--- a/assistant/src/config/bundled-skills/knowledge-graph/tools/graph-query.ts
+++ b/assistant/src/config/bundled-skills/knowledge-graph/tools/graph-query.ts
@@ -57,6 +57,22 @@ export async function run(
     };
   }
 
+  // For intersection queries, all seeds must resolve — dropping any seed silently
+  // changes semantics from "reachable from ALL seeds" to "reachable from resolved seeds"
+  if (params.query_type === 'intersection' && seedEntityIds.length < params.seeds.length) {
+    const unresolvedSeeds = params.seeds.filter(
+      name => !resolvedSeeds.some(s => s.name === name),
+    );
+    return {
+      content: JSON.stringify({
+        error: 'Some seed entities could not be resolved. Intersection requires all seeds to match.',
+        unresolved_seeds: unresolvedSeeds,
+        resolved_seeds: resolvedSeeds,
+      }),
+      isError: true,
+    };
+  }
+
   let resultEntityIds: string[];
 
   switch (params.query_type) {
@@ -142,12 +158,13 @@ export async function run(
       if (includeItems) {
         const candidates = getEntityLinkedItemCandidates([row.id], {
           source: 'entity_direct',
+          scopeIds: _context.memoryScopeId ? [_context.memoryScopeId] : undefined,
         });
         entity.items = candidates.slice(0, 5).map(c => {
           const parts = c.text.split(': ');
           return {
             subject: parts[0] ?? '',
-            statement: parts.slice(1).join(': ') ?? c.text,
+            statement: parts.slice(1).join(': ') || c.text,
           };
         });
       }


### PR DESCRIPTION
Addresses Codex and Devin feedback on PR #7111: (1) passes memoryScopeId to getEntityLinkedItemCandidates, (2) fails intersection queries when any seed is unresolved, (3) fixes ?? to || for empty string fallback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
