### PR TITLE
fix: add SMS adapter to credential security allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -197,6 +197,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'calls/elevenlabs-config.ts',      // ElevenLabs credential lookup
       'cli/config-commands.ts',          // CLI config management
       'messaging/providers/telegram-bot/adapter.ts', // Telegram bot token lookup for connectivity check
+      'messaging/providers/sms/adapter.ts', // Twilio credential lookup for SMS connectivity check
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Address Codex review feedback on PR #7150: add the SMS adapter to the credential-security-invariants test allowlist so the getSecureKey import doesn't violate the invariant. Part of #7138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
