### PR TITLE
fix: avoid double-prompt on first screen recording request

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -18,12 +18,22 @@ enum PermissionManager {
         return CGPreflightScreenCaptureAccess() ? .granted : .denied
     }
 
+    private static let hasRequestedScreenRecordingFlag = "hasRequestedScreenRecording"
+
     static func requestScreenRecordingAccess() {
-        // CGRequestScreenCaptureAccess() only shows the OS prompt once per app
-        // install. On subsequent calls it's a no-op. Fall back to opening
-        // System Settings directly if permission is still denied after the call.
+        let hasRequestedBefore = UserDefaults.standard.bool(forKey: hasRequestedScreenRecordingFlag)
+
+        // CGRequestScreenCaptureAccess() only shows the native OS prompt on
+        // its very first invocation per app install; subsequent calls are
+        // no-ops. The API is non-blocking, so CGPreflightScreenCaptureAccess()
+        // returns false immediately — before the user has a chance to respond
+        // to the prompt. On the first call we therefore trust the native prompt
+        // and skip the System Settings fallback to avoid showing both at once.
         CGRequestScreenCaptureAccess()
-        if !CGPreflightScreenCaptureAccess() {
+
+        if !hasRequestedBefore {
+            UserDefaults.standard.set(true, forKey: hasRequestedScreenRecordingFlag)
+        } else if !CGPreflightScreenCaptureAccess() {
             openScreenRecordingSettings()
         }
     }


### PR DESCRIPTION
On first call to requestScreenRecordingAccess(), CGRequestScreenCaptureAccess() shows the native OS permission dialog. Since the user hasn't responded yet, CGPreflightScreenCaptureAccess() returns false immediately after, causing System Settings to also open. Fix: track via UserDefaults whether the API has been called before. On first call, trust the native prompt. On subsequent calls, fall back to System Settings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
