### PR TITLE
fix: add public access modifiers to LockfilePaths

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,3 @@
+The user said: $ARGUMENTS
+
+Repeat exactly what the user said above back to them. If it doesn't exist prompt the user for it in a cli form

--- a/assistant/src/config/bundled-skills/messaging/icon.svg
+++ b/assistant/src/config/bundled-skills/messaging/icon.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="12" height="10" fill="#4A90E2"/>
+  <rect x="2" y="2" width="12" height="2" fill="#2E5C8A"/>
+  <rect x="3" y="4" width="10" height="1" fill="#E8F0F8"/>
+  <rect x="3" y="5" width="10" height="1" fill="#E8F0F8"/>
+  <rect x="3" y="6" width="10" height="1" fill="#E8F0F8"/>
+  <rect x="3" y="7" width="10" height="1" fill="#E8F0F8"/>
+  <rect x="3" y="8" width="7" height="1" fill="#E8F0F8"/>
+  <rect x="4" y="12" width="2" height="2" fill="#FF6B6B"/>
+  <rect x="7" y="12" width="2" height="2" fill="#4ECDC4"/>
+  <rect x="10" y="12" width="2" height="2" fill="#FFE66D"/>
+</svg>

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum LockfilePaths {
+public enum LockfilePaths {
     private static var baseDir: URL {
         if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
             return URL(fileURLWithPath: baseDir)
@@ -8,20 +8,20 @@ enum LockfilePaths {
         return FileManager.default.homeDirectoryForCurrentUser
     }
 
-    static var primary: URL {
+    public static var primary: URL {
         baseDir.appendingPathComponent(".vellum.lock.json")
     }
 
-    static var legacy: URL {
+    public static var legacy: URL {
         baseDir.appendingPathComponent(".vellum.lockfile.json")
     }
 
-    static var primaryPath: String { primary.path }
+    public static var primaryPath: String { primary.path }
 
     /// Read and parse the lockfile, trying the primary path first,
     /// then falling back to the legacy path.
     /// Returns nil if neither file exists or both are malformed.
-    static func read() -> [String: Any]? {
+    public static func read() -> [String: Any]? {
         for url in [primary, legacy] {
             guard let data = try? Data(contentsOf: url),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {


### PR DESCRIPTION
LockfilePaths enum and its members were internal (default Swift access), making them invisible to VellumAssistantLib which imports VellumAssistantShared across module boundaries. Added public to the enum and all non-private members.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
