### PR TITLE
fix: clear Twilio account SID after credential save

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -483,6 +483,7 @@ struct SettingsConnectTab: View {
                         accountSid: twilioAccountSidText,
                         authToken: twilioAuthTokenText
                     )
+                    twilioAccountSidText = ""
                     twilioAuthTokenText = ""
                     twilioSetupExpanded = false
                 }


### PR DESCRIPTION
Address Devin review feedback on PR #7164: clear twilioAccountSidText alongside twilioAuthTokenText after saving credentials, matching the Cancel button behavior and Telegram save flow pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
