### PR TITLE
fix: reset Twilio number picker state on credential clear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -366,6 +366,8 @@ struct SettingsConnectTab: View {
                     action: .init(label: "Clear", style: .danger, disabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                         twilioSetupExpanded = false
+                        twilioNumberPickerExpanded = false
+                        store.twilioNumbers = []
                     }
                 )
             } else if twilioSetupExpanded {


### PR DESCRIPTION
Address Codex review feedback on PR #7108: reset number picker state (cached numbers, picker visibility, selection) when clearing Twilio credentials to avoid stale data from a previous account.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
