### PR TITLE
fix: skip Telegram message delete for no-op markup errors

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -185,7 +185,23 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         chat_id: chatId,
         message_id: parsedMessageId,
       };
+      const isNoOpMarkupError = (err: unknown): boolean => {
+        const msg = err instanceof Error ? err.message : String(err);
+        return msg.includes("message is not modified");
+      };
+
       const deleteApprovalPrompt = (primaryErr: unknown, fallbackErr: unknown): void => {
+        // "message is not modified" means the inline keyboard was already
+        // removed (e.g. duplicate/stale callback clicks). The prompt is still
+        // valid — skip the delete so we don't remove audit-worthy messages.
+        if (isNoOpMarkupError(primaryErr) || isNoOpMarkupError(fallbackErr)) {
+          tlog.info(
+            { chatId, messageId: parsedMessageId, phase },
+            "Inline keyboard already cleared (no-op edit); skipping message delete",
+          );
+          return;
+        }
+
         callTelegramApi(config, "deleteMessage", basePayload).catch((deleteErr) => {
           tlog.error(
             { primaryErr, fallbackErr, deleteErr, chatId, messageId: parsedMessageId, phase },
@@ -197,7 +213,8 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       // Bot API behavior differs across wrappers/clients for "remove markup".
       // Try the explicit null form first, then fall back to an empty inline
       // keyboard payload if needed. If both fail, delete the prompt message
-      // so users are not left with stale actionable buttons.
+      // so users are not left with stale actionable buttons — unless the error
+      // indicates the markup was already removed (no-op).
       callTelegramApi(config, "editMessageReplyMarkup", {
         ...basePayload,
         reply_markup: null,


### PR DESCRIPTION
Address Codex review feedback on PR #7119: gate the hard-delete fallback on actual markup-clearing failures, skipping the delete when the error is just 'message is not modified' (buttons already removed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
