### PR TITLE
feat: prefer in-chat configuration collection over Settings page

### DIFF
--- a/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
+++ b/assistant/src/__tests__/twitter-cli-error-shaping.test.ts
@@ -100,7 +100,7 @@ describe('CLI error shaping', () => {
 
   test('routed non-session error with suggestAlternative emits structured JSON', () => {
     const err = Object.assign(
-      new Error('OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy.'),
+      new Error('OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy.'),
       {
         pathUsed: 'oauth' as const,
         suggestAlternative: 'browser' as const,
@@ -110,7 +110,7 @@ describe('CLI error shaping', () => {
 
     expect(payload).toEqual({
       ok: false,
-      error: 'OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy.',
+      error: 'OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy.',
       pathUsed: 'oauth',
       suggestAlternative: 'browser',
     });

--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -414,7 +414,7 @@ async function executeWebSearch(
 
   if (!apiKey) {
     return {
-      content: 'Error: No web search API key configured. Set PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure a key in settings.',
+      content: 'Error: No web search API key configured. Provide a PERPLEXITY_API_KEY or BRAVE_API_KEY here in the chat using the secure credential prompt, or set it from the Settings page.',
       isError: true,
     };
   }

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -17,7 +17,7 @@ OAuth uses the official X API v2. It is the most reliable connection method and 
 
 - Supports: **post** and **reply**
 - Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) always use the browser path directly, regardless of the strategy setting.
-- Setup: The user connects OAuth credentials through the Settings UI or the `twitter_auth_start` IPC flow.
+- Setup: Collect the OAuth Client ID (and optional Client Secret) from the user in chat using `credential_store` with `action: "prompt"`, then initiate the `twitter_auth_start` IPC flow. See the **First-Use Decision Flow** for the full sequence.
 - Set the strategy: `vellum x strategy set oauth`
 
 ### Browser session (no developer credentials needed)
@@ -45,14 +45,30 @@ When the user triggers a Twitter operation and no strategy has been configured y
    Look at `oauthConnected`, `browserSessionActive`, `preferredStrategy`, and `strategyConfigured` in the response. If `strategyConfigured` is `false`, the user has not yet chosen a strategy and should be guided through setup.
 
 2. **Present both options with trade-offs:**
-   - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up through Settings UI.
+   - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up right here in the chat.
    - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh`.
 
 3. **Ask the user which they prefer.** Do not choose for them.
 
 4. **Execute setup for the chosen path:**
-   - If OAuth: Guide the user to the Settings UI to connect their X developer credentials, or initiate the `twitter_auth_start` IPC flow.
+   - If OAuth: Collect the credentials in-chat using the secure credential prompt, then connect. Follow the **OAuth Setup Sequence** below.
    - If browser: Run `vellum x refresh` to capture session cookies from Chrome.
+
+### OAuth Setup Sequence
+
+When the user chooses OAuth, collect their X developer credentials conversationally using the secure UI:
+
+1. **Collect the Client ID securely:**
+   Call `credential_store` with `action: "prompt"`, `service: "integration:twitter"`, `field: "oauth_client_id"`, `label: "X (Twitter) OAuth Client ID"`, `description: "Enter the Client ID from your X Developer App"`, and `placeholder: "your-client-id"`.
+
+2. **Collect the Client Secret (if applicable):**
+   Ask the user if their X app uses a confidential client (has a Client Secret). If yes, call `credential_store` with `action: "prompt"`, `service: "integration:twitter"`, `field: "oauth_client_secret"`, `label: "X (Twitter) OAuth Client Secret"`, `description: "Enter the Client Secret from your X Developer App (leave blank if using a public client)"`, and `placeholder: "your-client-secret"`.
+
+3. **Initiate the OAuth flow:**
+   Send the `twitter_auth_start` IPC message. This opens the X authorization page in the user's browser. Wait for the flow to complete.
+
+4. **Confirm success:**
+   Tell the user: "Great, your X account is connected! You can always update these credentials from the Settings page."
 
 5. **Set the preferred strategy:**
    ```bash

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -114,6 +114,7 @@ export function buildSystemPrompt(): string {
   if (!isOnboardingComplete()) {
     parts.push(buildStarterTaskPlaybookSection());
   }
+  parts.push(buildInChatConfigurationSection());
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildChannelAwarenessSection());
@@ -288,6 +289,23 @@ export function buildStarterTaskPlaybookSection(): string {
     '- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.',
     '- Keep responses concise and action-oriented. Avoid lengthy explanations of what you\'re about to do.',
     '- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.',
+  ].join('\n');
+}
+
+function buildInChatConfigurationSection(): string {
+  return [
+    '## In-Chat Configuration',
+    '',
+    'When the user needs to configure a value (API keys, OAuth credentials, webhook URLs, or any setting that can be changed from the Settings page), **always collect it conversationally in the chat first** rather than directing them to the Settings page.',
+    '',
+    '**How to collect credentials and secrets:**',
+    '- Use `credential_store` with `action: "prompt"` to present a secure input field. The value never appears in the conversation.',
+    '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser.',
+    '- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate IPC or config tool to persist the value.',
+    '',
+    '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',
+    '',
+    '**Never tell the user to go to Settings to enter a value.** The Settings page is for reviewing and updating existing configuration, not for initial setup. Always prefer the in-chat flow for first-time configuration.',
   ].join('\n');
 }
 

--- a/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/google-oauth-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user create Google Cloud OAuth credentials so the Gmail and
 
 ## Prerequisites
 
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
+Before starting, check that `ingress.publicBaseUrl` is configured (`INGRESS_PUBLIC_BASE_URL` env var or workspace config). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 
@@ -139,7 +139,7 @@ Use `browser_click` on "+ Create Credentials" at the top, then select "OAuth cli
 Take a `browser_snapshot` and fill in:
 1. **Application type:** Select "Web application" from the dropdown
 2. **Name:** "Vellum Assistant"
-3. **Authorized redirect URIs:** Click "Add URI" and enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable.
+3. **Authorized redirect URIs:** Click "Add URI" and enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config or the `INGRESS_PUBLIC_BASE_URL` environment variable.
 
 Use `browser_click` on the "Create" button.
 
@@ -194,6 +194,6 @@ Summarize what was accomplished:
 - **Consent screen already configured with different settings:** Don't overwrite; skip to credential creation and tell the user you're using their existing configuration.
 - **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. GCP UI may have changed; adapt your selectors. Tell the user what you're looking for if you get stuck.
 - **User declines an approval gate:** Don't push back aggressively. Explain briefly why the step matters, offer to try again, or offer to cancel the whole setup gracefully. Never proceed without approval.
-- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry the connect step. The client ID is already stored, so they can also connect later from Settings.
+- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry the connect step right here in the chat. The client ID is already stored, so reconnecting only requires re-running the authorization flow. They can also manage credentials from the Settings page.
 - **"This app isn't verified" warning:** Guide the user through clicking "Advanced" → "Go to Vellum Assistant (unsafe)". Reassure them this is expected for personal-use OAuth apps.
 - **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance rather than guessing.

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user create a Slack App and OAuth credentials so the Messag
 
 ## Prerequisites
 
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
+Before starting, check that `ingress.publicBaseUrl` is configured (`INGRESS_PUBLIC_BASE_URL` env var or workspace config). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 
@@ -89,7 +89,7 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-The redirect URL must point to the gateway's OAuth callback endpoint. Determine the URL by reading the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable. The callback path is `/webhooks/oauth/callback`.
+The redirect URL must point to the gateway's OAuth callback endpoint. Determine the URL by reading the `ingress.publicBaseUrl` value from the assistant's workspace config or the `INGRESS_PUBLIC_BASE_URL` environment variable. The callback path is `/webhooks/oauth/callback`.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
@@ -98,7 +98,7 @@ In the "Redirect URLs" section:
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. Make sure your tunnel is running and `ingress.publicBaseUrl` is set in Settings so the callback can reach the gateway."
+Tell the user: "Redirect URL configured. Make sure your tunnel is running and `ingress.publicBaseUrl` is set so the callback can reach the gateway. You can always check or update this from the Settings page."
 
 ## Step 5: Extract Client ID and Client Secret
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -406,7 +406,7 @@ export async function handleShareToSlack(
       ctx.send(socket, {
         type: 'share_to_slack_response',
         success: false,
-        error: 'No Slack webhook URL configured. Set one in Settings.',
+        error: 'No Slack webhook URL configured. Provide one here in the chat, or set it from the Settings page.',
       });
       return;
     }

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -6,7 +6,7 @@
  * The canonical public base URL is resolved through a two-level chain:
  *
  *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via the
- *      Settings UI or `config set ingress.publicBaseUrl`. This is the
+ *      the in-chat config flow, the Settings UI, or `config set ingress.publicBaseUrl`. This is the
  *      primary source of truth. When the assistant spawns or restarts
  *      the gateway, this value is forwarded as the `INGRESS_PUBLIC_BASE_URL`
  *      environment variable so both processes agree on the same URL.
@@ -51,7 +51,7 @@ function normalizeUrl(url: string): string {
 export function getPublicBaseUrl(config: IngressConfig): string {
   if (config.ingress?.enabled === false) {
     throw new Error(
-      'Public ingress is disabled. Enable it in Settings to use public-facing webhooks.',
+      'Public ingress is disabled. Ask the assistant to enable it, or update it from the Settings page.',
     );
   }
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -141,7 +141,7 @@ function buildGuardianDenyContext(
     return `Permission denied: the action "${toolName}" requires guardian approval, but your identity could not be verified on ${sourceChannel}. Do not retry yet. Explain this clearly, ask the user to message from a verifiable direct account/chat, and then retry after identity is available.`;
   }
 
-  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first. The guardian/admin should open the Channels section in Settings and click "Verify Guardian", or ask the assistant to set up guardian verification. The setup flow will provide a verification token to send as /guardian_verify <token> in the ${sourceChannel} chat.`;
+  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first. Offer to set up guardian verification right here in the chat — the setup flow will provide a verification token to send as /guardian_verify <token> in the ${sourceChannel} chat. The guardian can also manage this later from the Settings page.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -630,7 +630,7 @@ class CredentialStoreTool implements Tool {
                 const dmChannel = await conversationsOpen(botToken, installingUserId);
                 const welcomeMsg =
                   `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
-                  `Manage the assistant experience for this workspace in the workspace settings page.`;
+                  `You can manage the assistant experience for this workspace by chatting with the assistant or from the Settings page.`;
                 await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
               }
             } catch (err) {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -268,7 +268,7 @@ class WebSearchTool implements Tool {
         apiKey = fallbackKey;
       } else {
         return {
-          content: 'Error: No web search API key configured. Set PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure a key in settings.',
+          content: 'Error: No web search API key configured. Provide a PERPLEXITY_API_KEY or BRAVE_API_KEY here in the chat using the secure credential prompt, or set it from the Settings page.',
           isError: true,
         };
       }

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -41,7 +41,7 @@ export async function routedPostTweet(
   if (strategy === 'oauth') {
     // User explicitly wants OAuth
     if (!oauthIsAvailable()) {
-      throw Object.assign(new Error('OAuth is not configured. Set up OAuth credentials in Settings, or switch to browser strategy: `vellum x strategy set browser`.'), {
+      throw Object.assign(new Error('OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `vellum x strategy set browser`.'), {
         pathUsed: 'oauth' as const,
         suggestAlternative: 'browser' as const,
       });


### PR DESCRIPTION
## Summary
- Added an **In-Chat Configuration** section to the system prompt that instructs the assistant to always collect credentials and config values conversationally using `credential_store` prompts, never directing users to the Settings page for initial setup
- Updated the **Twitter/X skill** with a complete OAuth Setup Sequence that collects Client ID and Client Secret via secure prompts in-chat before initiating the auth flow
- Updated error messages and instructions across 12 files (Twitter router, channel routes, Slack/Google OAuth skills, public ingress, web search, config handler, credential vault) to prefer in-chat collection and reference Settings only as a place to review/update existing config

## Original prompt
I've attached a screenshot of me configuring twitter conversationally with my assistant. You'll notice that it prompted me to go to the settings page to enter my oauth config values. The desired behavior is for the assistant to bias towards collecting them in the chat using a secure ui, not asking me to go to the settings page. After I provide details from the chat, it might (for applicable config values) say something like "Great, saved them! You can always update these values from the Settings page." This goes for any value that's configurable in the settings page. Help me find all places where we should steer the assistant in this way (maybe system prompt, maybe skills, etc.) and fix them to match the desired behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
