### PR TITLE
ci: run gateway checks on push to main

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -1,7 +1,12 @@
-name: PR Gateway Checks
+name: CI Gateway Checks
 
 on:
   pull_request:
+    paths:
+      - 'gateway/**'
+      - '.github/workflows/ci-gateway.yml'
+  push:
+    branches: [main]
     paths:
       - 'gateway/**'
       - '.github/workflows/ci-gateway.yml'


### PR DESCRIPTION
## Summary
- Add `push` trigger (branches: main) to `ci-gateway.yml` so lint/typecheck/test also run on merges to main
- Rename workflow from "PR Gateway Checks" to "CI Gateway Checks"

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
