### PR TITLE
ci: run macOS build check on push to main

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,7 +1,14 @@
-name: PR macOS Build Check
+name: CI macOS Build Check
 
 on:
   pull_request:
+    paths:
+      - 'clients/macos/**'
+      - 'clients/shared/**'
+      - 'cli/**'
+      - '.github/workflows/ci-macos.yml'
+  push:
+    branches: [main]
     paths:
       - 'clients/macos/**'
       - 'clients/shared/**'


### PR DESCRIPTION
## Summary
- Add `push` trigger (branches: main) to `ci-macos.yml` so the macOS build check also runs on merges to main
- Rename workflow from "PR macOS Build Check" to "CI macOS Build Check"

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
