### PR TITLE
ci: run iOS build check on push to main

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -1,7 +1,14 @@
-name: PR iOS Build Check
+name: CI iOS Build Check
 
 on:
   pull_request:
+    paths:
+      - 'clients/ios/**'
+      - 'clients/shared/**'
+      - 'clients/Package.swift'
+      - '.github/workflows/ci-ios.yml'
+  push:
+    branches: [main]
     paths:
       - 'clients/ios/**'
       - 'clients/shared/**'


### PR DESCRIPTION
## Summary
- Add `push` trigger (branches: main) to `ci-ios.yml` so the iOS build check also runs on merges to main
- Rename workflow from "PR iOS Build Check" to "CI iOS Build Check"

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
