### PR TITLE
ci: run gateway image build on push to main

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -1,7 +1,12 @@
-name: PR Gateway Image Build
+name: CI Gateway Image Build
 
 on:
   pull_request:
+    paths:
+      - 'gateway/**'
+      - '.github/workflows/ci-gateway-image.yml'
+  push:
+    branches: [main]
     paths:
       - 'gateway/**'
       - '.github/workflows/ci-gateway-image.yml'
@@ -24,7 +29,7 @@ jobs:
           context: gateway
           push: false
           load: true
-          tags: vellum-gateway:pr-${{ github.event.pull_request.number }}
+          tags: vellum-gateway:ci-${{ github.event.pull_request.number || github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -35,7 +40,7 @@ jobs:
             -e TELEGRAM_WEBHOOK_SECRET=test \
             -e ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821 \
             -p 19830:7830 \
-            vellum-gateway:pr-${{ github.event.pull_request.number }}
+            vellum-gateway:ci-${{ github.event.pull_request.number || github.sha }}
           sleep 3
           STATUS=$(curl -sf http://localhost:19830/healthz | jq -r '.status' || echo "failed")
           docker stop gateway-smoke || true


### PR DESCRIPTION
## Summary
- Add `push` trigger (branches: main) to `ci-gateway-image.yml` so the Docker image build + smoke check runs on merges to main
- Use `github.event.pull_request.number || github.sha` for the Docker tag so it works for both PR and push events
- Rename workflow from "PR Gateway Image Build" to "CI Gateway Image Build"

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
