### PR TITLE
M2: Swift-side context capture at activation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -1,0 +1,103 @@
+import ApplicationServices
+import AppKit
+import os
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "DictationContext")
+
+/// Context captured at Fn-hold activation time, describing the user's current app state.
+/// This is the Swift-side struct — it will be mapped to IPC types in M3.
+struct DictationContext {
+    let bundleIdentifier: String
+    let appName: String
+    let windowTitle: String
+    let selectedText: String?
+    let cursorInTextField: Bool
+}
+
+/// Captures the user's current context (frontmost app, window, selection, text field status)
+/// at voice dictation activation time using Accessibility APIs.
+struct DictationContextCapture {
+
+    /// Text-input roles that indicate the cursor is in a text field.
+    private static let textFieldRoles: Set<String> = [
+        "AXTextArea", "AXTextField", "AXTextView", "AXComboBox", "AXSearchField"
+    ]
+
+    /// Capture the current context synchronously. Returns sensible defaults when
+    /// Accessibility permissions are unavailable or the frontmost app can't be queried.
+    static func capture() -> DictationContext {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            log.warning("No frontmost application — returning empty context")
+            return DictationContext(
+                bundleIdentifier: "",
+                appName: "",
+                windowTitle: "",
+                selectedText: nil,
+                cursorInTextField: false
+            )
+        }
+
+        let bundleIdentifier = frontApp.bundleIdentifier ?? ""
+        let appName = frontApp.localizedName ?? "Unknown"
+        let pid = frontApp.processIdentifier
+
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // Window title via focused window
+        let windowTitle = axWindowTitle(appElement: appElement)
+
+        // Selected text and text-field check via focused UI element
+        let (selectedText, cursorInTextField) = axFocusedElementInfo(appElement: appElement)
+
+        log.info("Captured context: app=\(appName, privacy: .public), window=\"\(windowTitle, privacy: .public)\", selected=\(selectedText != nil), inTextField=\(cursorInTextField)")
+
+        return DictationContext(
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            windowTitle: windowTitle,
+            selectedText: selectedText,
+            cursorInTextField: cursorInTextField
+        )
+    }
+
+    // MARK: - AX Helpers
+
+    /// Get the title of the focused window for the given app element.
+    private static func axWindowTitle(appElement: AXUIElement) -> String {
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue) == .success,
+              let windowRef = windowValue else {
+            log.debug("Could not get focused window — AX permission may be missing")
+            return ""
+        }
+        let window = windowRef as! AXUIElement
+        return axStringAttribute(window, kAXTitleAttribute as CFString) ?? ""
+    }
+
+    /// Get selected text and whether the focused element is a text field.
+    private static func axFocusedElementInfo(appElement: AXUIElement) -> (selectedText: String?, cursorInTextField: Bool) {
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedValue) == .success,
+              let focusedRef = focusedValue else {
+            log.debug("Could not get focused UI element")
+            return (nil, false)
+        }
+        let focused = focusedRef as! AXUIElement
+
+        // Selected text
+        let selectedText = axStringAttribute(focused, kAXSelectedTextAttribute as CFString)
+
+        // Role check for text field
+        let role = axStringAttribute(focused, kAXRoleAttribute as CFString) ?? ""
+        let cursorInTextField = textFieldRoles.contains(role)
+
+        return (selectedText, cursorInTextField)
+    }
+
+    /// Read a string attribute from an AX element, returning nil on failure.
+    private static func axStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+}


### PR DESCRIPTION
Add DictationContextCapture.swift that captures frontmost app info, window title, selected text, and text field status via Accessibility APIs at voice activation time. Uses existing AX patterns from AccessibilityTree.swift. Part of #7180.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
