### PR TITLE
M4: Daemon dictation handler and dictation skill

### DIFF
--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -1,0 +1,121 @@
+import * as net from 'node:net';
+import { getConfig } from '../../config/loader.js';
+import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import type { DictationRequest } from '../ipc-protocol.js';
+import { log, defineHandlers, type HandlerContext } from './shared.js';
+
+// Action verbs that signal the user wants a full agent session rather than inline text
+const ACTION_VERBS = ['slack', 'email', 'send', 'create', 'open', 'search', 'find'];
+
+type DictationMode = 'dictation' | 'command' | 'action';
+
+function detectMode(msg: DictationRequest): DictationMode {
+  // Command mode: selected text present — treat transcription as a transformation instruction
+  if (msg.context.selectedText && msg.context.selectedText.trim().length > 0) {
+    return 'command';
+  }
+
+  // Action mode: transcription starts with an action verb
+  const firstWord = msg.transcription.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+  if (ACTION_VERBS.includes(firstWord)) {
+    return 'action';
+  }
+
+  // Dictation mode: cursor is in a text field with no selection — clean up for typing
+  if (msg.context.cursorInTextField) {
+    return 'dictation';
+  }
+
+  // Default to action when not in a text field and no selection
+  return 'action';
+}
+
+function buildDictationPrompt(msg: DictationRequest): string {
+  return [
+    'You are a dictation assistant. Clean up the following speech transcription for direct insertion into a text field.',
+    'Rules:',
+    '- Fix grammar, punctuation, and capitalization',
+    '- Remove filler words (um, uh, like, you know)',
+    "- Maintain the speaker's intent and meaning",
+    '- Do NOT add explanations or commentary',
+    '- Return ONLY the cleaned text, nothing else',
+    '- Adapt tone based on the app context provided',
+    '',
+    `App context: ${msg.context.appName} (${msg.context.bundleIdentifier})`,
+    `Window: ${msg.context.windowTitle}`,
+  ].join('\n');
+}
+
+function buildCommandPrompt(msg: DictationRequest): string {
+  return [
+    'You are a text transformation assistant. The user has selected text and given a voice command to transform it.',
+    'Apply the instruction to the selected text.',
+    '- Return ONLY the transformed text, nothing else',
+    '- Do NOT add explanations or commentary',
+    '',
+    'Selected text:',
+    msg.context.selectedText ?? '',
+    '',
+    `Instruction: ${msg.transcription}`,
+  ].join('\n');
+}
+
+export async function handleDictationRequest(
+  msg: DictationRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const mode = detectMode(msg);
+  log.info({ mode, transcriptionLength: msg.transcription.length }, 'Dictation request received');
+
+  // Action mode: return immediately — the client will route to a full agent session
+  if (mode === 'action') {
+    ctx.send(socket, {
+      type: 'dictation_response',
+      text: msg.transcription,
+      mode: 'action',
+      actionPlan: `User wants to: ${msg.transcription}`,
+    });
+    return;
+  }
+
+  // Dictation / command mode: make a single-turn LLM call for text cleanup or transformation
+  const systemPrompt = mode === 'dictation'
+    ? buildDictationPrompt(msg)
+    : buildCommandPrompt(msg);
+
+  const userText = mode === 'dictation'
+    ? msg.transcription
+    : msg.transcription; // command prompt already embeds the selected text and instruction
+
+  try {
+    const config = getConfig();
+    if (!listProviders().includes(config.provider)) {
+      log.warn({ provider: config.provider }, 'Dictation: no provider available, returning raw transcription');
+      ctx.send(socket, { type: 'dictation_response', text: msg.transcription, mode });
+      return;
+    }
+
+    const provider = getFailoverProvider(config.provider, config.providerOrder);
+    const response = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: userText }] }],
+      [], // no tools
+      systemPrompt,
+      { config: { max_tokens: 1024 } },
+    );
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const cleanedText = textBlock && 'text' in textBlock ? textBlock.text.trim() : msg.transcription;
+
+    ctx.send(socket, { type: 'dictation_response', text: cleanedText, mode });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Dictation LLM call failed, returning raw transcription');
+    ctx.send(socket, { type: 'dictation_response', text: msg.transcription, mode });
+    ctx.send(socket, { type: 'error', message: `Dictation cleanup failed: ${message}` });
+  }
+}
+
+export const dictationHandlers = defineHandlers({
+  dictation_request: handleDictationRequest,
+});

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -22,6 +22,7 @@ import { signingHandlers } from './signing.js';
 import { twitterAuthHandlers } from './twitter-auth.js';
 import { workspaceFileHandlers } from './workspace-files.js';
 import { identityHandlers } from './identity.js';
+import { dictationHandlers } from './dictation.js';
 
 // Re-export types and utilities for backwards compatibility
 export type {
@@ -107,6 +108,7 @@ const handlers = {
   ...twitterAuthHandlers,
   ...workspaceFileHandlers,
   ...identityHandlers,
+  ...dictationHandlers,
   ...inlineHandlers,
 } satisfies DispatchMap;
 


### PR DESCRIPTION
Add dictation_request handler that processes voice transcriptions with mode detection (dictation/command/action). For dictation and command modes, makes a single-turn LLM call with specialized prompts for text cleanup or transformation. For action mode, returns the transcription for client-side routing to a full agent session. Part of #7180.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
