### PR TITLE
feat: add Home Base chat panel via VSplitView (#7173)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -218,30 +218,82 @@ extension MainWindowView {
             }
         case .panel(let panelType):
             if panelType == .directory {
-                HomeBaseContainerView(
-                    daemonClient: daemonClient,
-                    onBack: { windowState.dismissOverlay() },
-                    onOpenApp: { surfaceMsg in
-                        windowState.activeDynamicSurface = surfaceMsg
-                        windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
-                        if let surface = windowState.activeDynamicParsedSurface,
-                           case .dynamicPage(let dpData) = surface.data,
-                           let appId = dpData.appId {
-                            windowState.selection = .app(appId)
-                        } else {
-                            windowState.selection = .app(surfaceMsg.surfaceId)
+                if isAppChatOpen {
+                    // VSplitView: ChatView (left) + Home Base (right)
+                    let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
+                    let effectiveWidth = Binding<Double>(
+                        get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
+                        set: { appPanelWidth = $0 }
+                    )
+                    VSplitView(
+                        panelWidth: effectiveWidth,
+                        showPanel: true,
+                        main: {
+                            chatView
+                        },
+                        panel: {
+                            HomeBaseContainerView(
+                                daemonClient: daemonClient,
+                                onBack: { windowState.dismissOverlay() },
+                                onOpenApp: { surfaceMsg in
+                                    windowState.activeDynamicSurface = surfaceMsg
+                                    windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                                    if let surface = windowState.activeDynamicParsedSurface,
+                                       case .dynamicPage(let dpData) = surface.data,
+                                       let appId = dpData.appId {
+                                        windowState.selection = .app(appId)
+                                    } else {
+                                        windowState.selection = .app(surfaceMsg.surfaceId)
+                                    }
+                                },
+                                onRecordAppOpen: { id, name, icon, appType in
+                                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                                },
+                                onPinApp: { id, name, icon, appType in
+                                    appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                                    appListManager.pinApp(id: id)
+                                }
+                            )
+                            .background(adaptiveColor(light: Moss._100, dark: Moss._900))
+                            .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.xl, bottomLeadingRadius: VRadius.xl))
                         }
-                    },
-                    onRecordAppOpen: { id, name, icon, appType in
-                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
-                    },
-                    onPinApp: { id, name, icon, appType in
-                        appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
-                        appListManager.pinApp(id: id)
+                    )
+                    .onAppear {
+                        // Ensure an active thread exists for the chat panel
+                        if threadManager.activeViewModel == nil {
+                            if let firstThread = threadManager.visibleThreads.first {
+                                threadManager.selectThread(id: firstThread.id)
+                            } else {
+                                threadManager.createThread()
+                            }
+                        }
                     }
-                )
-                .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                } else {
+                    HomeBaseContainerView(
+                        daemonClient: daemonClient,
+                        onBack: { windowState.dismissOverlay() },
+                        onOpenApp: { surfaceMsg in
+                            windowState.activeDynamicSurface = surfaceMsg
+                            windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
+                            if let surface = windowState.activeDynamicParsedSurface,
+                               case .dynamicPage(let dpData) = surface.data,
+                               let appId = dpData.appId {
+                                windowState.selection = .app(appId)
+                            } else {
+                                windowState.selection = .app(surfaceMsg.surfaceId)
+                            }
+                        },
+                        onRecordAppOpen: { id, name, icon, appType in
+                            appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                        },
+                        onPinApp: { id, name, icon, appType in
+                            appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
+                            appListManager.pinApp(id: id)
+                        }
+                    )
+                    .overlay(alignment: .topTrailing) { panelDismissButton }
+                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                }
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(


### PR DESCRIPTION
## Summary
- Update chatContentView to render VSplitView for .panel(.directory) when isAppChatOpen is true
- Chat renders as main (left), HomeBaseContainerView as panel (right)
- Apply same visual treatment as .appEditing: Moss background + rounded corners
- Use appPanelWidth for resizable width via drag divider
- Thread resolution ensures active thread when entering Home Base chat mode

Part of #7171

## Key files
- MODIFIED: PanelCoordinator.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
