### PR TITLE
feat: sync Edit/Done with isAppChatOpen + sticky behavior (#7176)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -337,6 +337,25 @@ struct MainWindowView: View {
                     }
                 }
 
+                // Sticky behavior: if isAppChatOpen is true and we just navigated to .app,
+                // auto-transition to .appEditing so the chat dock stays open.
+                // Guard: only auto-transition from .app (not .appEditing) to avoid infinite loops.
+                if case .app(let appId) = newSelection, isAppChatOpen {
+                    let threadId = threadManager.activeThreadId
+                        ?? threadManager.visibleThreads.first?.id
+                    if let threadId {
+                        threadManager.selectThread(id: threadId)
+                        windowState.setAppEditing(appId: appId, threadId: threadId)
+                    } else {
+                        // No threads exist — create one, then transition
+                        threadManager.createThread()
+                        if let newThreadId = threadManager.activeThreadId {
+                            windowState.setAppEditing(appId: appId, threadId: newThreadId)
+                        }
+                    }
+                    return
+                }
+
                 // Sync surface and chat dock state when selection changes
                 let expanded = windowState.isDynamicExpanded
                 let docked = windowState.isChatDockOpen

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -429,9 +429,11 @@ extension MainWindowView {
                 onToggleChatDock: {
                     if case .appEditing(let appId, _) = windowState.selection {
                         // Toggle off: go back to full-screen app view
+                        isAppChatOpen = false
                         windowState.selection = .app(appId)
                     } else if case .app(let appId) = windowState.selection {
                         // Toggle on: find most recent thread and enter editing mode
+                        isAppChatOpen = true
                         let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
                         if let threadId {
                             threadManager.selectThread(id: threadId)


### PR DESCRIPTION
## Summary
- Sync isAppChatOpen with Edit/Done Editing button transitions in dynamicWorkspaceView
- Add sticky behavior: when isAppChatOpen is true and navigating to .app, auto-transition to .appEditing
- Guard against infinite loops (only auto-transition from .app, not .appEditing)
- Thread resolution reuses existing patterns

Part of #7171

## Key files
- MODIFIED: PanelCoordinator.swift
- MODIFIED: MainWindowView.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
