### PR TITLE
M7: Action mode — intent detection and assistant routing

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -633,6 +633,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self.handleEscalationToComputerUse(routed: routed)
         }
 
+        // Forward dictation responses from the daemon to VoiceInputManager
+        daemonClient.onDictationResponse = { [weak self] msg in
+            self?.voiceInput?.onDictationResponse?(msg)
+        }
+
         daemonClient.onDocumentEditorShow = { [weak self] msg in
             self?.mainWindow?.handleDocumentEditorShow(msg)
         }
@@ -1042,6 +1047,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // Priority 2: Route to active TextResponseWindow conversation
             if let textSession = self?.currentTextSession, textSession.state == .ready {
                 self?.textResponseWindow?.updatePartialTranscription(text)
+            }
+        }
+        voiceInput?.daemonClient = daemonClient
+        voiceInput?.onActionModeTriggered = { [weak self] text in
+            guard let self else { return }
+            log.info("Action mode triggered from voice dictation — submitting task")
+            let screenBounds = CGDisplayBounds(CGMainDisplayID())
+            do {
+                try self.daemonClient.send(TaskSubmitMessage(
+                    task: text,
+                    screenWidth: Int(screenBounds.width),
+                    screenHeight: Int(screenBounds.height),
+                    attachments: nil,
+                    source: "voice_action"
+                ))
+            } catch {
+                log.error("Failed to send task_submit for voice action: \(error)")
             }
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -28,6 +28,10 @@ final class VoiceInputManager {
     /// Called when the daemon returns a dictation response (cleaned-up text + action plan).
     var onDictationResponse: ((IPCDictationResponse) -> Void)?
 
+    /// Called when the daemon classifies dictation as an action (e.g. "Slack Alex about the standup").
+    /// The callback receives the original transcription text for routing to a full agent session.
+    var onActionModeTriggered: ((String) -> Void)?
+
     /// Context captured at activation time, describing the frontmost app state.
     private var currentDictationContext: DictationContext?
 
@@ -344,14 +348,15 @@ final class VoiceInputManager {
         }
     }
 
-    /// Handle the daemon's dictation response — insert cleaned text or dismiss for action mode.
+    /// Handle the daemon's dictation response — insert cleaned text or route action mode to a task.
     func handleDictationResponse(text: String, mode: String) {
         if mode == "dictation" || mode == "command" {
             DictationTextInserter.insertText(text)
             overlayWindow.showDoneAndDismiss()
         } else if mode == "action" {
-            // Action mode handled elsewhere (M7)
             overlayWindow.dismiss()
+            log.info("Action mode detected — routing transcription to task submission: \(text, privacy: .public)")
+            onActionModeTriggered?(text)
         }
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -216,6 +216,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `task_routed` message (e.g. escalation from text_qa to CU).
     public var onTaskRouted: ((TaskRoutedMessage) -> Void)?
 
+    /// Called when the daemon sends a `dictation_response` message.
+    public var onDictationResponse: ((DictationResponseMessage) -> Void)?
+
     /// Called when a reminder fires.
     public var onReminderFired: ((ReminderFiredMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -75,6 +75,8 @@ extension DaemonClient {
             onSecretRequest?(msg)
         case .taskRouted(let msg):
             onTaskRouted?(msg)
+        case .dictationResponse(let msg):
+            onDictationResponse?(msg)
         case .reminderFired(let msg):
             onReminderFired?(msg)
         case .scheduleComplete(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -795,6 +795,9 @@ public typealias MemoryStatusMessage = IPCMemoryStatus
 /// Daemon response after classifying and routing a task_submit.
 public typealias TaskRoutedMessage = IPCTaskRouted
 
+/// Daemon response to a dictation_request with cleaned text and mode classification.
+public typealias DictationResponseMessage = IPCDictationResponse
+
 /// Result from a ride shotgun observation session.
 public typealias RideShotgunResultMessage = IPCRideShotgunResult
 
@@ -2038,6 +2041,7 @@ public enum ServerMessage: Decodable, Sendable {
     case historyResponse(HistoryResponseMessage)
     case memoryStatus(MemoryStatusMessage)
     case taskRouted(TaskRoutedMessage)
+    case dictationResponse(DictationResponseMessage)
     case error(ErrorMessage)
     case rideShotgunResult(RideShotgunResultMessage)
     case uiSurfaceShow(UiSurfaceShowMessage)
@@ -2193,6 +2197,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "task_routed":
             let message = try TaskRoutedMessage(from: decoder)
             self = .taskRouted(message)
+        case "dictation_response":
+            let message = try DictationResponseMessage(from: decoder)
+            self = .dictationResponse(message)
         case "error":
             let message = try ErrorMessage(from: decoder)
             self = .error(message)


### PR DESCRIPTION
When dictation_response has mode 'action', route the transcription to the daemon via task_submit for full agent execution. Adds onActionModeTriggered callback to VoiceInputManager and wires it in AppDelegate. Part of #7180.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
