### PR TITLE
Fix type errors in submit-feedback.ts

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/submit-feedback.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/submit-feedback.ts
@@ -62,9 +62,9 @@ export async function run(
     feedbackType: feedbackType as FeedbackType,
     originalStartTime: event.startTime,
     originalEndTime: event.endTime,
-    correctedStartTime: correctedStartTime ?? null,
-    correctedEndTime: correctedEndTime ?? null,
-    notes: notes ?? null,
+    correctedStartTime: correctedStartTime ?? undefined,
+    correctedEndTime: correctedEndTime ?? undefined,
+    notes: notes ?? undefined,
   });
 
   return {
@@ -128,11 +128,11 @@ function handleMissedEvent(
     assetId,
     eventId: newEvent.id,
     feedbackType,
-    originalStartTime: null,
-    originalEndTime: null,
+    originalStartTime: undefined,
+    originalEndTime: undefined,
     correctedStartTime: startTime,
     correctedEndTime: endTime,
-    notes: notes ?? null,
+    notes: notes ?? undefined,
   });
 
   return {


### PR DESCRIPTION
Fixes 6 TypeScript errors where `null` was passed for optional fields that expect `undefined`. Changed `?? null` to `?? undefined` in both the regular feedback and missed-event paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
