### PR TITLE
M6: Command mode — selected text transformation

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -342,7 +342,11 @@ final class VoiceInputManager {
                     cursorInTextField: context.cursorInTextField
                 )
             )
-            overlayWindow.show(state: .processing)
+            if context.selectedText != nil {
+                overlayWindow.show(state: .transforming(text))
+            } else {
+                overlayWindow.show(state: .processing)
+            }
             try? daemonClient?.send(request)
             log.info("Sent dictation_request to daemon for app=\(context.appName, privacy: .public)")
         }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 enum DictationState {
     case recording
     case processing
+    case transforming(String)
     case done
     case error(String)
 }
@@ -36,6 +37,9 @@ struct DictationOverlayView: View {
                 .frame(width: 8, height: 8)
         case .processing:
             VLoadingIndicator()
+        case .transforming:
+            Image(systemName: "wand.and.stars")
+                .foregroundStyle(VColor.accent)
         case .done:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(VColor.success)
@@ -56,6 +60,12 @@ struct DictationOverlayView: View {
             Text("Processing...")
                 .font(VFont.caption)
                 .foregroundStyle(VColor.textSecondary)
+        case .transforming(let instruction):
+            Text("Transforming: \(instruction)")
+                .font(VFont.caption)
+                .foregroundStyle(VColor.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
         case .done:
             Text("Done")
                 .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -9,12 +9,20 @@ final class DictationOverlayWindow {
     private var panel: NSPanel?
     private var state: DictationState = .recording
 
+    private func panelWidth(for state: DictationState) -> CGFloat {
+        switch state {
+        case .transforming: return 280
+        default: return 160
+        }
+    }
+
     func show(state: DictationState) {
         self.state = state
+        let width = panelWidth(for: state)
 
         if panel == nil {
             let hostingView = NSHostingView(rootView: DictationOverlayView(state: state))
-            hostingView.frame = NSRect(x: 0, y: 0, width: 160, height: 40)
+            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 40)
 
             let panel = NSPanel(
                 contentRect: hostingView.frame,
@@ -33,7 +41,7 @@ final class DictationOverlayWindow {
             // Position near top-center of screen
             if let screen = NSScreen.main {
                 let screenFrame = screen.visibleFrame
-                let x = screenFrame.midX - 80
+                let x = screenFrame.midX - width / 2
                 let y = screenFrame.maxY - 60
                 panel.setFrameOrigin(NSPoint(x: x, y: y))
             }
@@ -41,7 +49,16 @@ final class DictationOverlayWindow {
             self.panel = panel
         } else {
             let hostingView = NSHostingView(rootView: DictationOverlayView(state: state))
+            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 40)
             panel?.contentView = hostingView
+
+            // Re-center when width changes (e.g. switching to/from transforming state)
+            if let screen = NSScreen.main, let panel = panel {
+                let screenFrame = screen.visibleFrame
+                let x = screenFrame.midX - width / 2
+                panel.setFrameOrigin(NSPoint(x: x, y: panel.frame.origin.y))
+                panel.setContentSize(NSSize(width: width, height: 40))
+            }
         }
 
         panel?.orderFront(nil)


### PR DESCRIPTION
Add .transforming(instruction) state to DictationOverlayView showing the voice instruction during text transformation. Updates VoiceInputManager to detect command mode (selected text present) and show the appropriate overlay state. Part of #7180.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
