### PR TITLE
Add CI checks to release workflow with Slack summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -707,6 +707,7 @@ jobs:
     if: always() && !cancelled()
     needs: [bump-and-tag, publish-npm, publish-meta, build-macos, release, update-platform, ci-assistant, ci-cli, ci-gateway]
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Build Slack payload
         run: |
@@ -736,9 +737,9 @@ jobs:
           # Build CI status icons
           ci_icon() { if [ "$1" = "success" ]; then printf '✅'; else printf '❌'; fi; }
 
-          A=$(ci_icon "${{ needs.ci-assistant.result }}")
-          C=$(ci_icon "${{ needs.ci-cli.result }}")
-          G=$(ci_icon "${{ needs.ci-gateway.result }}")
+          A=$(ci_icon "${{ needs.ci-assistant.outcome }}")
+          C=$(ci_icon "${{ needs.ci-cli.outcome }}")
+          G=$(ci_icon "${{ needs.ci-gateway.outcome }}")
           D=$(ci_icon "${{ needs.build-macos.result }}")
 
           BODY="*CI Checks:*  ${A} assistant    ${C} cli    ${G} gateway    ${D} desktop\n\n*Version:* \`${{ inputs.version }}\`\n*Triggered by:* ${{ github.actor }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -627,40 +627,143 @@ jobs:
           sleep 10
           gh pr merge "$PR_URL" --auto --squash
 
-  notify-failure:
-    if: >-
-      !cancelled() &&
-      (needs.bump-and-tag.result == 'failure' ||
-       needs.publish-npm.result == 'failure' ||
-       needs.publish-meta.result == 'failure' ||
-       needs.build-macos.result == 'failure' ||
-       needs.release.result == 'failure' ||
-       needs.update-platform.result == 'failure')
-    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, release, update-platform]
+  ci-assistant:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: assistant
+
+      - name: Lint
+        run: bun run lint
+        working-directory: assistant
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+        working-directory: assistant
+
+      - name: Test
+        run: bun run test
+        working-directory: assistant
+        env:
+          EXCLUDE_EXPERIMENTAL: 'true'
+
+  ci-cli:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: cli
+
+      - name: Lint
+        run: bun run lint
+        working-directory: cli
+
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: cli
+
+  ci-gateway:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: gateway
+
+      - name: Lint
+        run: bun run lint
+        working-directory: gateway
+
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: gateway
+
+      - name: Test
+        run: bun run test
+        working-directory: gateway
+
+  notify:
+    if: always() && !cancelled()
+    needs: [bump-and-tag, publish-npm, publish-meta, build-macos, release, update-platform, ci-assistant, ci-cli, ci-gateway]
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack of release failure
+      - name: Build Slack payload
+        run: |
+          # Determine release status from core jobs
+          RELEASE_FAILED="false"
+          for result in \
+            "${{ needs.bump-and-tag.result }}" \
+            "${{ needs.publish-npm.result }}" \
+            "${{ needs.publish-meta.result }}" \
+            "${{ needs.build-macos.result }}" \
+            "${{ needs.release.result }}" \
+            "${{ needs.update-platform.result }}"; do
+            if [ "$result" = "failure" ]; then
+              RELEASE_FAILED="true"
+              break
+            fi
+          done
+
+          if [ "$RELEASE_FAILED" = "true" ]; then
+            HEADER="❌ Release v${{ inputs.version }} Failed"
+            STYLE="danger"
+          else
+            HEADER="✅ Release v${{ inputs.version }} Succeeded"
+            STYLE=""
+          fi
+
+          # Build CI status icons
+          ci_icon() { if [ "$1" = "success" ]; then printf '✅'; else printf '❌'; fi; }
+
+          A=$(ci_icon "${{ needs.ci-assistant.result }}")
+          C=$(ci_icon "${{ needs.ci-cli.result }}")
+          G=$(ci_icon "${{ needs.ci-gateway.result }}")
+          D=$(ci_icon "${{ needs.build-macos.result }}")
+
+          BODY="*CI Checks:*  ${A} assistant    ${C} cli    ${G} gateway    ${D} desktop\n\n*Version:* \`${{ inputs.version }}\`\n*Triggered by:* ${{ github.actor }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Build JSON payload with jq
+          BUTTON=$(jq -n --arg style "$STYLE" --arg url "$RUN_URL" '{
+            type: "button",
+            text: { type: "plain_text", text: "View Run" },
+            url: $url
+          } + (if $style != "" then { style: $style } else {} end)')
+
+          jq -n --arg header "$HEADER" --arg body "$BODY" --argjson button "$BUTTON" '{
+            unfurl_links: false,
+            unfurl_media: false,
+            blocks: [
+              { type: "header", text: { type: "plain_text", text: $header } },
+              { type: "section", text: { type: "mrkdwn", text: $body } },
+              { type: "actions", elements: [$button] }
+            ]
+          }' > /tmp/slack-payload.json
+
+      - name: Notify Slack
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            unfurl_links: false
-            unfurl_media: false
-            blocks:
-              - type: header
-                text:
-                  type: plain_text
-                  text: "\u274c Release v${{ inputs.version }} Failed"
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "*Workflow:* Unified Release\n*Version:* `${{ inputs.version }}`\n*Triggered by:* ${{ github.actor }}"
-              - type: actions
-                elements:
-                  - type: button
-                    text:
-                      type: plain_text
-                      text: "View Run"
-                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    style: danger
+          payload-file-path: /tmp/slack-payload.json


### PR DESCRIPTION
## Summary
- Add non-blocking `ci-assistant`, `ci-cli`, and `ci-gateway` jobs that run lint/typecheck/test in parallel with the release pipeline (`continue-on-error: true`)
- Replace `notify-failure` with a unified `notify` job that sends a single Slack message covering both release status and per-package CI check results (✅/❌ for assistant, cli, gateway, desktop)
- CI jobs use bun 1.3.8 with `--frozen-lockfile` and have no `needs` dependencies so they don't block the release

## Test plan
- [ ] Trigger a release workflow run and verify CI jobs appear in the workflow graph running in parallel
- [ ] Confirm CI job failures don't block the release pipeline
- [ ] Verify Slack notification includes both release status and CI check icons
- [ ] Verify the `notify` job runs regardless of individual job outcomes (success, failure, skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
