### PR TITLE
fix: create thread when none exist in onToggleChatDock

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -490,6 +490,12 @@ extension MainWindowView {
                         if let threadId {
                             threadManager.selectThread(id: threadId)
                             windowState.setAppEditing(appId: appId, threadId: threadId)
+                        } else {
+                            // No threads exist — create one, then transition
+                            threadManager.createThread()
+                            if let newThreadId = threadManager.activeThreadId {
+                                windowState.setAppEditing(appId: appId, threadId: newThreadId)
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
## Summary
- Add thread creation fallback in onToggleChatDock toggle-on path
- When no threads exist, create one before transitioning to .appEditing
- Matches the pattern already used by sticky behavior in MainWindowView
- Fixes bug where isAppChatOpen was set to true without actually opening the dock

Addresses feedback on #7203. Part of #7171.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
