### PR TITLE
fix: align TaskInputView max attachment count with shared limit

### DIFF
--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -4,7 +4,7 @@ import AppKit
 import UniformTypeIdentifiers
 
 struct TaskInputView: View {
-    private static let maxAttachmentCount = 10
+    private static let maxAttachmentCount = 5
     private static let maxTotalAttachmentBytes = 50 * 1024 * 1024
     let onSubmit: (TaskSubmission) -> Void
     @ObservedObject var daemonClient: DaemonClient


### PR DESCRIPTION
## Summary
- `TaskInputView.maxAttachmentCount` was `10` while the shared `ChatViewModel.maxAttachments` is `5`
- Aligned to `5` so both new-thread and in-chat attachment flows enforce the same cap

## Test plan
- [ ] Open new thread popover, try attaching 6+ files — verify error appears at 5
- [ ] In an existing chat thread, try attaching 6+ files — verify same limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
