### PR TITLE
Fix: DictationContextCapture AX timeout and self-app filtering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -38,10 +38,28 @@ struct DictationContextCapture {
         }
 
         let bundleIdentifier = frontApp.bundleIdentifier ?? ""
+
+        // Skip capturing our own app's context during voice activation
+        // (Bundle.main.bundleIdentifier is nil in SPM builds, so use hardcoded ID)
+        if bundleIdentifier == "com.vellum.vellum-assistant" {
+            log.info("Frontmost app is self — returning default context")
+            return DictationContext(
+                bundleIdentifier: bundleIdentifier,
+                appName: frontApp.localizedName ?? "vellum-assistant",
+                windowTitle: "",
+                selectedText: nil,
+                cursorInTextField: false
+            )
+        }
+
         let appName = frontApp.localizedName ?? "Unknown"
         let pid = frontApp.processIdentifier
 
         let appElement = AXUIElementCreateApplication(pid)
+
+        // Prevent indefinite blocking if the target app is hung (matches
+        // AccessibilityTree.swift and AmbientAXCapture.swift patterns)
+        AXUIElementSetMessagingTimeout(appElement, 5.0)
 
         // Window title via focused window
         let windowTitle = axWindowTitle(appElement: appElement)


### PR DESCRIPTION
Address review feedback from #7195: add 5s AXUIElementSetMessagingTimeout before AX queries (matching AccessibilityTree.swift and AmbientAXCapture.swift patterns), and filter out self-app to avoid capturing vellum-assistant's own context during voice activation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
