### PR TITLE
Fix: preserve selected text when command mode LLM call fails

### DIFF
--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -129,7 +129,8 @@ export async function handleDictationRequest(
     const config = getConfig();
     if (!listProviders().includes(config.provider)) {
       log.warn({ provider: config.provider }, 'Dictation: no provider available, returning raw transcription');
-      ctx.send(socket, { type: 'dictation_response', text: msg.transcription, mode });
+      const fallbackText = mode === 'command' ? (msg.context.selectedText ?? msg.transcription) : msg.transcription;
+      ctx.send(socket, { type: 'dictation_response', text: fallbackText, mode });
       return;
     }
 
@@ -142,13 +143,15 @@ export async function handleDictationRequest(
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');
-    const cleanedText = textBlock && 'text' in textBlock ? textBlock.text.trim() : msg.transcription;
+    const inlineFallback = mode === 'command' ? (msg.context.selectedText ?? msg.transcription) : msg.transcription;
+    const cleanedText = textBlock && 'text' in textBlock ? textBlock.text.trim() : inlineFallback;
 
     ctx.send(socket, { type: 'dictation_response', text: cleanedText, mode });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Dictation LLM call failed, returning raw transcription');
-    ctx.send(socket, { type: 'dictation_response', text: msg.transcription, mode });
+    const fallbackText = mode === 'command' ? (msg.context.selectedText ?? msg.transcription) : msg.transcription;
+    ctx.send(socket, { type: 'dictation_response', text: fallbackText, mode });
     ctx.send(socket, { type: 'error', message: `Dictation cleanup failed: ${message}` });
   }
 }


### PR DESCRIPTION
Address review feedback from #7197: when the LLM provider is unavailable or errors in command mode, return the original selected text instead of the spoken instruction to avoid destructively replacing the user's selection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
