### PR TITLE
Fix: clear stale DictationContext on recording setup failures

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -214,12 +214,14 @@ final class VoiceInputManager {
     private func beginRecording() {
         guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
             log.error("Speech recognizer not available")
+            currentDictationContext = nil
             return
         }
 
         // Don't start if a previous recognition task is still processing
         if recognitionTask != nil {
             log.warning("Previous recognition task still active, skipping")
+            currentDictationContext = nil
             return
         }
 
@@ -228,11 +230,13 @@ final class VoiceInputManager {
         if micStatus == .notDetermined {
             AVCaptureDevice.requestAccess(for: .audio) { _ in }
             log.info("Requested microphone authorization — try again after approving")
+            currentDictationContext = nil
             return
         }
         if micStatus == .denied || micStatus == .restricted {
             log.warning("Microphone access denied — opening System Settings")
             openPrivacySettings(for: "Privacy_Microphone")
+            currentDictationContext = nil
             return
         }
 
@@ -240,11 +244,13 @@ final class VoiceInputManager {
         if authStatus == .notDetermined {
             SFSpeechRecognizer.requestAuthorization { _ in }
             log.info("Requested speech recognition authorization — try again after approving")
+            currentDictationContext = nil
             return
         }
         if authStatus == .denied || authStatus == .restricted {
             log.warning("Speech recognition denied — opening System Settings")
             openPrivacySettings(for: "Privacy_SpeechRecognition")
+            currentDictationContext = nil
             return
         }
 
@@ -266,6 +272,7 @@ final class VoiceInputManager {
             log.error("No audio input channels available")
             isRecording = false
             onRecordingStateChanged?(false)
+            currentDictationContext = nil
             return
         }
 
@@ -311,6 +318,7 @@ final class VoiceInputManager {
             onRecordingStateChanged?(false)
             recognitionRequest = nil
             recognitionTask = nil
+            currentDictationContext = nil
         }
     }
 


### PR DESCRIPTION
Address review feedback (P2) from #7198: clear currentDictationContext in beginRecording() early-return paths so stale context from an earlier aborted activation cannot leak into a subsequent recording.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
