### PR TITLE
Fix: sanitize window title in dictation prompts

### DIFF
--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -7,6 +7,25 @@ import { log, defineHandlers, type HandlerContext } from './shared.js';
 // Action verbs that signal the user wants a full agent session rather than inline text
 const ACTION_VERBS = ['slack', 'email', 'send', 'create', 'open', 'search', 'find'];
 
+const MAX_WINDOW_TITLE_LENGTH = 100;
+
+/** Sanitize window title to mitigate prompt injection from attacker-controlled titles (e.g. browser tabs, Slack conversations). */
+function sanitizeWindowTitle(title: string | undefined): string {
+  if (!title) return '';
+  return title.slice(0, MAX_WINDOW_TITLE_LENGTH);
+}
+
+/** Build a delimited app metadata block so the LLM treats it as contextual data, not instructions. */
+function buildAppMetadataBlock(msg: DictationRequest): string {
+  const windowTitle = sanitizeWindowTitle(msg.context.windowTitle);
+  return [
+    '<app_metadata>',
+    `App: ${msg.context.appName} (${msg.context.bundleIdentifier})`,
+    `Window: ${windowTitle}`,
+    '</app_metadata>',
+  ].join('\n');
+}
+
 type DictationMode = 'dictation' | 'command' | 'action';
 
 function detectMode(msg: DictationRequest): DictationMode {
@@ -57,8 +76,7 @@ function buildDictationPrompt(msg: DictationRequest): string {
     '- Maintain the user\'s natural voice — don\'t over-formalize casual speech',
     '- The user\'s writing patterns and preferences may be available from memory context — follow those when present',
     '',
-    `App context: ${msg.context.appName} (${msg.context.bundleIdentifier})`,
-    `Window: ${msg.context.windowTitle}`,
+    buildAppMetadataBlock(msg),
   ].join('\n');
 }
 
@@ -87,8 +105,7 @@ function buildCommandPrompt(msg: DictationRequest): string {
     '- Maintain the user\'s natural voice — don\'t over-formalize casual speech',
     '- The user\'s writing patterns and preferences may be available from memory context — follow those when present',
     '',
-    `App context: ${msg.context.appName} (${msg.context.bundleIdentifier})`,
-    `Window: ${msg.context.windowTitle}`,
+    buildAppMetadataBlock(msg),
     '',
     'Selected text:',
     msg.context.selectedText ?? '',


### PR DESCRIPTION
Address review feedback from #7199: truncate window titles to 100 chars and wrap app context in delimited metadata blocks to reduce prompt injection risk from attacker-controlled window titles (browser tabs, Slack conversations).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
