### PR TITLE
Fix: dictation overlay lifecycle and clipboard preservation

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -38,6 +38,10 @@ final class VoiceInputManager {
     /// Floating overlay showing dictation state (recording/processing/done).
     private let overlayWindow = DictationOverlayWindow()
 
+    /// True after a dictation request has been sent to the daemon and we're awaiting a response.
+    /// Used by `stopRecording()` to decide whether the overlay should stay visible.
+    private var awaitingDaemonResponse = false
+
     private var isRecording = false
     private var globalMonitor: Any?
     private var localMonitor: Any?
@@ -355,13 +359,24 @@ final class VoiceInputManager {
             } else {
                 overlayWindow.show(state: .processing)
             }
-            try? daemonClient?.send(request)
-            log.info("Sent dictation_request to daemon for app=\(context.appName, privacy: .public)")
+            do {
+                guard let client = daemonClient else {
+                    throw NSError(domain: "VoiceInput", code: 1, userInfo: [NSLocalizedDescriptionKey: "Daemon client unavailable"])
+                }
+                try client.send(request)
+                awaitingDaemonResponse = true
+                log.info("Sent dictation_request to daemon for app=\(context.appName, privacy: .public)")
+            } catch {
+                log.error("Failed to send dictation_request: \(error.localizedDescription)")
+                overlayWindow.dismiss()
+                onTranscription?(text)
+            }
         }
     }
 
     /// Handle the daemon's dictation response — insert cleaned text or route action mode to a task.
     func handleDictationResponse(text: String, mode: String) {
+        awaitingDaemonResponse = false
         if mode == "dictation" || mode == "command" {
             DictationTextInserter.insertText(text)
             overlayWindow.showDoneAndDismiss()
@@ -380,6 +395,9 @@ final class VoiceInputManager {
         currentDictationContext = nil
         // Overlay stays visible if we're transitioning to processing state (dictation sent
         // to daemon). Otherwise dismiss it — recording stopped without producing a result.
+        if !awaitingDaemonResponse {
+            overlayWindow.dismiss()
+        }
         log.info("Voice recording stopped")
 
         if audioEngine.isRunning {

--- a/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
@@ -9,7 +9,10 @@ final class DictationTextInserter {
     /// Uses clipboard-paste (Cmd+V) with save/restore of previous clipboard contents.
     static func insertText(_ text: String) {
         let pasteboard = NSPasteboard.general
-        let previousContents = pasteboard.string(forType: .string)
+
+        // Save ALL pasteboard items with all their types so we can restore non-string
+        // content (images, files, rich text) after pasting.
+        let savedItems = savePasteboardItems(pasteboard)
 
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
@@ -19,6 +22,7 @@ final class DictationTextInserter {
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: true),  // 9 = V key
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: false) else {
             log.error("Failed to create keyboard events for paste")
+            restorePasteboardItems(savedItems, to: pasteboard)
             return
         }
         keyDown.flags = .maskCommand
@@ -28,15 +32,44 @@ final class DictationTextInserter {
         keyUp.post(tap: .cghidEventTap)
 
         // Restore clipboard after delay
-        let saved = previousContents
+        let itemsToRestore = savedItems
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            let pb = NSPasteboard.general
-            pb.clearContents()
-            if let saved = saved {
-                pb.setString(saved, forType: .string)
-            }
+            restorePasteboardItems(itemsToRestore, to: NSPasteboard.general)
         }
 
         log.info("Inserted dictation text (\(text.count) chars)")
+    }
+
+    // MARK: - Clipboard Save/Restore
+
+    /// Snapshot of a single pasteboard item: each type mapped to its raw data.
+    private struct SavedPasteboardItem {
+        let typeToData: [(NSPasteboard.PasteboardType, Data)]
+    }
+
+    /// Save all items and all their types from the pasteboard.
+    private static func savePasteboardItems(_ pasteboard: NSPasteboard) -> [SavedPasteboardItem] {
+        guard let items = pasteboard.pasteboardItems else { return [] }
+        return items.map { item in
+            let pairs: [(NSPasteboard.PasteboardType, Data)] = item.types.compactMap { type in
+                guard let data = item.data(forType: type) else { return nil }
+                return (type, data)
+            }
+            return SavedPasteboardItem(typeToData: pairs)
+        }
+    }
+
+    /// Restore previously saved items to the pasteboard.
+    private static func restorePasteboardItems(_ savedItems: [SavedPasteboardItem], to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        guard !savedItems.isEmpty else { return }
+        let newItems: [NSPasteboardItem] = savedItems.map { saved in
+            let item = NSPasteboardItem()
+            for (type, data) in saved.typeToData {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        pasteboard.writeObjects(newItems)
     }
 }


### PR DESCRIPTION
Address review feedback from #7200: (1) handle dictation send failures by dismissing overlay and falling back to conversation mode, (2) dismiss recording overlay in stopRecording() when not transitioning to processing state, (3) preserve all clipboard item types (not just strings) during text insertion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
