### PR TITLE
Fix: check selectedText non-empty for command mode overlay

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -354,7 +354,7 @@ final class VoiceInputManager {
                     cursorInTextField: context.cursorInTextField
                 )
             )
-            if context.selectedText != nil {
+            if let selected = context.selectedText, !selected.isEmpty {
                 overlayWindow.show(state: .transforming(text))
             } else {
                 overlayWindow.show(state: .processing)


### PR DESCRIPTION
Address review feedback from #7206: change selectedText != nil to also check !selected.isEmpty, since macOS AX API returns empty string (not nil) when cursor is in text field with no selection. Prevents incorrectly showing transforming overlay during normal dictation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
