### PR TITLE
fix: show attachment error banner on new thread empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -13,6 +13,7 @@ struct ChatEmptyStateView: View {
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    let errorText: String?
     let onSend: () -> Void
     let onStop: () -> Void
     let onAcceptSuggestion: () -> Void
@@ -20,6 +21,7 @@ struct ChatEmptyStateView: View {
     let onRemoveAttachment: (String) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
+    let onDismissError: () -> Void
     @Binding var editorContentHeight: CGFloat
     @Binding var isComposerExpanded: Bool
 
@@ -73,24 +75,42 @@ struct ChatEmptyStateView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.bottom, VSpacing.xl)
 
-            ComposerView(
-                inputText: $inputText,
-                hasAPIKey: hasAPIKey,
-                isSending: isSending,
-                isRecording: isRecording,
-                suggestion: suggestion,
-                pendingAttachments: pendingAttachments,
-                onSend: onSend,
-                onStop: onStop,
-                onAcceptSuggestion: onAcceptSuggestion,
-                onAttach: onAttach,
-                onRemoveAttachment: onRemoveAttachment,
-                onPaste: onPaste,
-                onMicrophoneToggle: onMicrophoneToggle,
-                placeholderText: placeholder,
-                editorContentHeight: $editorContentHeight,
-                isComposerExpanded: $isComposerExpanded
-            )
+            VStack(spacing: 0) {
+                if let errorText {
+                    ChatErrorBanner(
+                        text: errorText,
+                        isSecretBlockError: false,
+                        onSendAnyway: {},
+                        isRetryableError: false,
+                        onRetryError: {},
+                        isConnectionError: false,
+                        onOpenDoctor: {},
+                        onDismissError: onDismissError
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous))
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.xs)
+                }
+
+                ComposerView(
+                    inputText: $inputText,
+                    hasAPIKey: hasAPIKey,
+                    isSending: isSending,
+                    isRecording: isRecording,
+                    suggestion: suggestion,
+                    pendingAttachments: pendingAttachments,
+                    onSend: onSend,
+                    onStop: onStop,
+                    onAcceptSuggestion: onAcceptSuggestion,
+                    onAttach: onAttach,
+                    onRemoveAttachment: onRemoveAttachment,
+                    onPaste: onPaste,
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    placeholderText: placeholder,
+                    editorContentHeight: $editorContentHeight,
+                    isComposerExpanded: $isComposerExpanded
+                )
+            }
             .frame(maxWidth: 500)
             .opacity(visible ? 1 : 0)
             .offset(y: visible ? 0 : 10)
@@ -122,6 +142,7 @@ struct ChatTemporaryChatEmptyStateView: View {
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    let errorText: String?
     let onSend: () -> Void
     let onStop: () -> Void
     let onAcceptSuggestion: () -> Void
@@ -129,6 +150,7 @@ struct ChatTemporaryChatEmptyStateView: View {
     let onRemoveAttachment: (String) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
+    let onDismissError: () -> Void
     @Binding var editorContentHeight: CGFloat
     @Binding var isComposerExpanded: Bool
 
@@ -155,24 +177,42 @@ struct ChatTemporaryChatEmptyStateView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.bottom, VSpacing.xxl)
 
-            ComposerView(
-                inputText: $inputText,
-                hasAPIKey: hasAPIKey,
-                isSending: isSending,
-                isRecording: isRecording,
-                suggestion: suggestion,
-                pendingAttachments: pendingAttachments,
-                onSend: onSend,
-                onStop: onStop,
-                onAcceptSuggestion: onAcceptSuggestion,
-                onAttach: onAttach,
-                onRemoveAttachment: onRemoveAttachment,
-                onPaste: onPaste,
-                onMicrophoneToggle: onMicrophoneToggle,
-                placeholderText: "Ask anything...",
-                editorContentHeight: $editorContentHeight,
-                isComposerExpanded: $isComposerExpanded
-            )
+            VStack(spacing: 0) {
+                if let errorText {
+                    ChatErrorBanner(
+                        text: errorText,
+                        isSecretBlockError: false,
+                        onSendAnyway: {},
+                        isRetryableError: false,
+                        onRetryError: {},
+                        isConnectionError: false,
+                        onOpenDoctor: {},
+                        onDismissError: onDismissError
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous))
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.xs)
+                }
+
+                ComposerView(
+                    inputText: $inputText,
+                    hasAPIKey: hasAPIKey,
+                    isSending: isSending,
+                    isRecording: isRecording,
+                    suggestion: suggestion,
+                    pendingAttachments: pendingAttachments,
+                    onSend: onSend,
+                    onStop: onStop,
+                    onAcceptSuggestion: onAcceptSuggestion,
+                    onAttach: onAttach,
+                    onRemoveAttachment: onRemoveAttachment,
+                    onPaste: onPaste,
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    placeholderText: "Ask anything...",
+                    editorContentHeight: $editorContentHeight,
+                    isComposerExpanded: $isComposerExpanded
+                )
+            }
 
             Spacer()
             Spacer()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -105,6 +105,7 @@ struct ChatView: View {
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
+                            errorText: errorText,
                             onSend: onSend,
                             onStop: onStop,
                             onAcceptSuggestion: onAcceptSuggestion,
@@ -112,6 +113,7 @@ struct ChatView: View {
                             onRemoveAttachment: onRemoveAttachment,
                             onPaste: onPaste,
                             onMicrophoneToggle: onMicrophoneToggle,
+                            onDismissError: onDismissError,
                             editorContentHeight: $editorContentHeight,
                             isComposerExpanded: $isComposerExpanded
                         )
@@ -123,6 +125,7 @@ struct ChatView: View {
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
+                            errorText: errorText,
                             onSend: onSend,
                             onStop: onStop,
                             onAcceptSuggestion: onAcceptSuggestion,
@@ -130,6 +133,7 @@ struct ChatView: View {
                             onRemoveAttachment: onRemoveAttachment,
                             onPaste: onPaste,
                             onMicrophoneToggle: onMicrophoneToggle,
+                            onDismissError: onDismissError,
                             editorContentHeight: $editorContentHeight,
                             isComposerExpanded: $isComposerExpanded
                         )


### PR DESCRIPTION
## Summary
- `ChatEmptyStateView` and `ChatTemporaryChatEmptyStateView` didn't receive `errorText`, so attachment limit errors (e.g. dropping >5 files) were silently swallowed on new thread pages
- Pass `errorText` and `onDismissError` through to both empty state views and render `ChatErrorBanner` above the composer

## Test plan
- [ ] Open a new thread (empty state), drag-and-drop >5 files — verify red error banner appears above the composer
- [ ] Click the X on the error banner to dismiss it
- [ ] Verify the error banner also works on temporary chat empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
