### PR TITLE
Fix: overlay dismiss and resource cleanup in beginRecording failures

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -277,6 +277,8 @@ final class VoiceInputManager {
             isRecording = false
             onRecordingStateChanged?(false)
             currentDictationContext = nil
+            recognitionRequest = nil
+            overlayWindow.dismiss()
             return
         }
 
@@ -323,6 +325,8 @@ final class VoiceInputManager {
             recognitionRequest = nil
             recognitionTask = nil
             currentDictationContext = nil
+            audioEngine.inputNode.removeTap(onBus: 0)
+            overlayWindow.dismiss()
         }
     }
 


### PR DESCRIPTION
Address review feedback from #7212: dismiss the dictation overlay and clean up recognitionRequest/audio tap in beginRecording() early-return paths (channelCount==0, audioEngine.start failure) to prevent stuck overlays and crashes from duplicate audio taps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
