### PR TITLE
Fix: escape angle brackets in sanitizeWindowTitle

### DIFF
--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -12,7 +12,9 @@ const MAX_WINDOW_TITLE_LENGTH = 100;
 /** Sanitize window title to mitigate prompt injection from attacker-controlled titles (e.g. browser tabs, Slack conversations). */
 function sanitizeWindowTitle(title: string | undefined): string {
   if (!title) return '';
-  return title.slice(0, MAX_WINDOW_TITLE_LENGTH);
+  return title
+    .replace(/[<>]/g, '') // strip angle brackets to prevent tag injection
+    .slice(0, MAX_WINDOW_TITLE_LENGTH);
 }
 
 /** Build a delimited app metadata block so the LLM treats it as contextual data, not instructions. */


### PR DESCRIPTION
Address review feedback from #7213: strip/escape < and > characters in window titles to prevent attacker-controlled titles from breaking out of the app_metadata delimiter block via injected closing tags.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
