### PR TITLE
Fix: route voice action task_submit through proper session flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1053,18 +1053,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         voiceInput?.onActionModeTriggered = { [weak self] text in
             guard let self else { return }
             log.info("Action mode triggered from voice dictation — submitting task")
-            let screenBounds = CGDisplayBounds(CGMainDisplayID())
-            do {
-                try self.daemonClient.send(TaskSubmitMessage(
-                    task: text,
-                    screenWidth: Int(screenBounds.width),
-                    screenHeight: Int(screenBounds.height),
-                    attachments: nil,
-                    source: "voice_action"
-                ))
-            } catch {
-                log.error("Failed to send task_submit for voice action: \(error)")
-            }
+            self.startSession(task: text, source: "voice_action")
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
             // Check if main window is actively in the foreground (not just existing behind other apps)


### PR DESCRIPTION
## Summary
- Route action-mode voice dictation through the existing `startSession(task:source:)` flow instead of sending raw `TaskSubmitMessage` directly
- This ensures `task_routed` responses for computer_use sessions properly start a client-side `ComputerUseSession`
- Addresses review feedback from #7204

## Test plan
- [ ] Trigger voice action mode and verify the task routes through session startup
- [ ] Confirm computer_use sessions start correctly from voice action submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
