### PR TITLE
fix: clear stale twilioPhoneNumber on credential clear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -368,6 +368,7 @@ struct SettingsConnectTab: View {
                         twilioSetupExpanded = false
                         twilioNumberPickerExpanded = false
                         store.twilioNumbers = []
+                        store.twilioPhoneNumber = nil
                     }
                 )
             } else if twilioSetupExpanded {


### PR DESCRIPTION
Address Devin review feedback on PR #7175: also clear store.twilioPhoneNumber when clearing Twilio credentials to prevent stale phone number from a previous account being displayed after reconfiguring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
