### PR TITLE
Fix: reset awaitingDaemonResponse to prevent permanently stuck overlay

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -98,6 +98,7 @@ final class VoiceInputManager {
             localKeyDownMonitor = nil
         }
         stopRecording()
+        overlayWindow.dismiss()
     }
 
     /// Directly toggle recording on/off — used by UI mic buttons that bypass the Fn-key hold flow.
@@ -402,6 +403,7 @@ final class VoiceInputManager {
         if !awaitingDaemonResponse {
             overlayWindow.dismiss()
         }
+        awaitingDaemonResponse = false  // reset for next recording
         log.info("Voice recording stopped")
 
         if audioEngine.isRunning {


### PR DESCRIPTION
Address review feedback from #7214: reset awaitingDaemonResponse = false after the overlay dismiss check in stopRecording() so the flag doesn't persist across recordings if the daemon never responds. Also dismiss overlay unconditionally in stop() teardown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
