### PR TITLE
ci: cancel in-progress assistant checks on PR update or merge

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -2,6 +2,7 @@ name: CI Assistant Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'assistant/**'
       - 'clients/shared/IPC/**'
@@ -15,8 +16,13 @@ on:
       - '.githooks/**'
       - '.github/workflows/ci-assistant.yml'
 
+concurrency:
+  group: ci-assistant-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   checks:
+    if: github.event.action != 'closed'
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- Add `concurrency` group keyed on PR number with `cancel-in-progress: true` to cancel stale runs when a PR is updated
- Add `closed` to PR event types so merging/closing a PR cancels any in-flight CI run
- Add `if: github.event.action != 'closed'` so the "closed" event triggers cancellation but doesn't run the actual job

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
