### PR TITLE
ci: cancel in-progress gateway image build on PR update or merge

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -2,6 +2,7 @@ name: CI Gateway Image Build
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'gateway/**'
       - '.github/workflows/ci-gateway-image.yml'
@@ -11,8 +12,13 @@ on:
       - 'gateway/**'
       - '.github/workflows/ci-gateway-image.yml'
 
+concurrency:
+  group: ci-gateway-image-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    if: github.event.action != 'closed'
     name: Build Docker Image
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Add `concurrency` group keyed on PR number with `cancel-in-progress: true` to cancel stale runs when a PR is updated
- Add `closed` to PR event types so merging/closing a PR cancels any in-flight CI run
- Add `if: github.event.action != 'closed'` so the "closed" event triggers cancellation but doesn't run the actual job

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
