### PR TITLE
ci: cancel in-progress iOS build on PR update or merge

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -2,6 +2,7 @@ name: CI iOS Build Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'clients/ios/**'
       - 'clients/shared/**'
@@ -15,8 +16,13 @@ on:
       - 'clients/Package.swift'
       - '.github/workflows/ci-ios.yml'
 
+concurrency:
+  group: ci-ios-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-check:
+    if: github.event.action != 'closed'
     name: iOS Build
     runs-on: macos-14
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- Add `concurrency` group keyed on PR number with `cancel-in-progress: true` to cancel stale runs when a PR is updated
- Add `closed` to PR event types so merging/closing a PR cancels any in-flight CI run
- Add `if: github.event.action != 'closed'` so the "closed" event triggers cancellation but doesn't run the actual job

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
