### PR TITLE
Fix: cancel recognitionTask before nilling in audioEngine failure path

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -323,7 +323,9 @@ final class VoiceInputManager {
             log.error("Audio engine failed to start: \(error.localizedDescription)")
             isRecording = false
             onRecordingStateChanged?(false)
+            recognitionRequest?.endAudio()
             recognitionRequest = nil
+            recognitionTask?.cancel()
             recognitionTask = nil
             currentDictationContext = nil
             audioEngine.inputNode.removeTap(onBus: 0)


### PR DESCRIPTION
Address review feedback from #7217: call recognitionTask?.cancel() and recognitionRequest?.endAudio() before nilling them in the audioEngine.start() catch block, matching the cleanup pattern in stopRecording(). Prevents leaked recognition tasks and potential crashes from stale state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
