### PR TITLE
fix: correct in-chat config guidance for web search and OAuth

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -300,7 +300,7 @@ function buildInChatConfigurationSection(): string {
     '',
     '**How to collect credentials and secrets:**',
     '- Use `credential_store` with `action: "prompt"` to present a secure input field. The value never appears in the conversation.',
-    '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser.',
+    '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser. Note: some services (e.g. Twitter/X) define their own auth flow via dedicated skills rather than `oauth2_connect` — check the service\'s skill documentation for the specific auth action.',
     '- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate IPC or config tool to persist the value.',
     '',
     '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -5,7 +5,7 @@
  *
  * The canonical public base URL is resolved through a two-level chain:
  *
- *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via the
+ *   1. **User Settings** (`config.ingress.publicBaseUrl`) — set via
  *      the in-chat config flow, the Settings UI, or `config set ingress.publicBaseUrl`. This is the
  *      primary source of truth. When the assistant spawns or restarts
  *      the gateway, this value is forwarded as the `INGRESS_PUBLIC_BASE_URL`

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -268,7 +268,7 @@ class WebSearchTool implements Tool {
         apiKey = fallbackKey;
       } else {
         return {
-          content: 'Error: No web search API key configured. Provide a PERPLEXITY_API_KEY or BRAVE_API_KEY here in the chat using the secure credential prompt, or set it from the Settings page.',
+          content: 'Error: No web search API key configured. Set a PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure it from the Settings page under API Keys.',
           isError: true,
         };
       }


### PR DESCRIPTION
Address review feedback on PR #7179: fix web-search error message to accurately describe key configuration, scope OAuth guidance in system prompt to avoid conflicts with service-specific auth flows (e.g. Twitter), and fix 'the the' typo in public-ingress-urls comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
