### PR TITLE
ci: cancel in-progress macOS DMG build on PR update or merge

### DIFF
--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -2,12 +2,16 @@ name: PR macOS DMG Build
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, closed]
     paths:
       - 'clients/macos/**'
       - 'clients/shared/**'
       - 'cli/**'
       - '.github/workflows/ci-macos-dmg.yml'
+
+concurrency:
+  group: ci-macos-dmg-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build-dmg:


### PR DESCRIPTION
## Summary
- Add `concurrency` group keyed on PR number with `cancel-in-progress: true` to cancel stale runs when a PR is updated
- Add `closed` to PR event types so merging/closing a PR cancels any in-flight DMG build
- Existing job `if` already filters to `labeled`/`synchronize` only, so `closed` events naturally skip the job while triggering cancellation

## Original prompt
in separate PRs add triggers to all of these to run on merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
