### PR TITLE
Fix analyze-keyframes to use daemon's Anthropic API key

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import Anthropic from '@anthropic-ai/sdk';
+import { getConfig } from '../../../../config/defaults.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   getMediaAssetById,
@@ -82,14 +83,15 @@ export async function run(
 
   updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const config = getConfig();
+  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     updateProcessingStage(stage.id, {
       status: 'failed',
-      lastError: 'ANTHROPIC_API_KEY not set',
+      lastError: 'Anthropic API key not configured',
     });
     return {
-      content: 'ANTHROPIC_API_KEY environment variable is not set. Required for vision analysis.',
+      content: 'No Anthropic API key available. Configure it in settings or set ANTHROPIC_API_KEY.',
       isError: true,
     };
   }


### PR DESCRIPTION
The analyze-keyframes tool was checking process.env.ANTHROPIC_API_KEY directly instead of using getConfig().apiKeys.anthropic (which is how the daemon manages its API key). This caused the tool to fail even though the API key was available.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
