### PR TITLE
fix: guardian copy UX regex and DictationOverlay build error

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -668,10 +668,10 @@ struct SettingsConnectTab: View {
 
     /// Extracts the `/guardian_verify <hex>` command from a raw instruction string.
     private func extractGuardianCommand(from instruction: String) -> String? {
-        guard let range = instruction.range(of: #"/guardian_verify\s+[0-9a-fA-F]+"#, options: .regularExpression) else {
+        guard let range = instruction.range(of: #"`?/guardian_verify\s+[0-9a-fA-F]+`?"#, options: .regularExpression) else {
             return nil
         }
-        return String(instruction[range])
+        return String(instruction[range]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
@@ -25,7 +25,7 @@ struct DictationOverlayView: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
-        .vShadow(.md)
+        .vShadow(VShadow.md)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Fix `extractGuardianCommand` regex to handle backtick-wrapped commands (`` `/guardian_verify <hex>` ``) and strip backticks from the extracted command
- Fix `DictationOverlayView` build error: `.vShadow(.md)` → `.vShadow(VShadow.md)` since `md` is a static on `VShadow`, not on `VShadow.Definition`

## Original prompt
Guardian copy UX wasn't rendering because (1) the build failed due to the DictationOverlay shadow error, so the old binary was launched, and (2) the regex didn't match the backtick-wrapped command format in the instruction text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
