### PR TITLE
fix: chat toggle UX polish and voice dictation build fixes

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -3,6 +3,7 @@ import AppKit
 import Speech
 import AVFoundation
 import os
+import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "VoiceInput")
 
@@ -351,9 +352,8 @@ final class VoiceInputManager {
                 return
             }
             let request = IPCDictationRequest(
-                type: "dictation_request",
                 transcription: text,
-                context: IPCDictationContext(
+                context: .create(
                     bundleIdentifier: context.bundleIdentifier,
                     appName: context.appName,
                     windowTitle: context.windowTitle,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ChatBubbleToggle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ChatBubbleToggle.swift
@@ -9,7 +9,7 @@ struct ChatBubbleToggle: View {
     var body: some View {
         VIconButton(
             label: isActive ? "Hide chat" : "Show chat",
-            icon: "bubble.left.and.text.bubble.right",
+            icon: "bubble.left",
             isActive: isActive,
             iconOnly: true,
             tooltip: tooltip,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -24,7 +24,7 @@ struct MainWindowView: View {
     @State private var showAllThreads: Bool = false
     @State private var showAllApps: Bool = false
     @State private var showControlCenterDrawer: Bool = false
-    @AppStorage("isAppChatOpen") private var isAppChatOpen: Bool = false
+    @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
     @State private var jitPermissionManager = JITPermissionManager()
     /// Stores the thread ID the user was on before entering temporary chat,
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
@@ -503,7 +503,6 @@ struct MainWindowView: View {
                                 sidebarExpanded.toggle()
                             }
                         }
-                        Spacer()
                         if isChatBubbleVisible {
                             ChatBubbleToggle(
                                 isActive: isChatBubbleActive,
@@ -511,7 +510,8 @@ struct MainWindowView: View {
                                 onToggle: { toggleChatBubble() }
                             )
                         }
-                        if windowState.isShowingChat {
+                        Spacer()
+                        if windowState.isShowingChat || isChatBubbleActive {
                             // Copy Thread button — only visible when there's content to copy
                             if threadManager.activeViewModel?.messages.contains(where: {
                                 !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -798,6 +798,18 @@ public typealias TaskRoutedMessage = IPCTaskRouted
 /// Daemon response to a dictation_request with cleaned text and mode classification.
 public typealias DictationResponseMessage = IPCDictationResponse
 
+extension IPCDictationContext {
+    public static func create(bundleIdentifier: String, appName: String, windowTitle: String, selectedText: String?, cursorInTextField: Bool) -> IPCDictationContext {
+        IPCDictationContext(bundleIdentifier: bundleIdentifier, appName: appName, windowTitle: windowTitle, selectedText: selectedText, cursorInTextField: cursorInTextField)
+    }
+}
+
+extension IPCDictationRequest {
+    public init(transcription: String, context: IPCDictationContext) {
+        self.init(type: "dictation_request", transcription: transcription, context: context)
+    }
+}
+
 /// Result from a ride shotgun observation session.
 public typealias RideShotgunResultMessage = IPCRideShotgunResult
 


### PR DESCRIPTION
## Summary
- Polishes the chat bubble toggle: moves it next to the sidebar toggle for spatial consistency (chat opens from the left), uses a compact single-bubble SF Symbol to match other toolbar controls, and ensures chat-specific controls (Copy Thread, Voice Mode, Temp Chat) appear when the chat bubble is active.
- Fixes build errors from the voice-dictation blitz: adds missing import, creates public factory methods for IPCDictationContext/Request to work across module boundaries, and updates call sites.

## Files Changed
- **ChatBubbleToggle.swift** — icon changed to `bubble.left`
- **MainWindowView.swift** — toggle moved before Spacer, `isAppChatOpen` access level, chat controls condition
- **IPCMessages.swift** — public extensions for `IPCDictationContext.create()` and `IPCDictationRequest.init(transcription:context:)`
- **VoiceInputManager.swift** — added `import VellumAssistantShared`, updated dictation init calls

## Test Plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Chat bubble toggle appears next to sidebar toggle (left side of toolbar)
- [ ] Chat bubble toggle is same size as other toolbar icons
- [ ] Chat controls (Copy Thread, Voice Mode, Temp Chat) appear when chat bubble is active
- [ ] Voice dictation works without build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
