### PR TITLE
fix: show chat bubble toggle on all views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -229,12 +229,7 @@ struct MainWindowView: View {
 
     /// Whether the chat bubble toggle should be visible for the current selection.
     private var isChatBubbleVisible: Bool {
-        switch windowState.selection {
-        case .app, .appEditing, .panel(.directory):
-            return true
-        default:
-            return false
-        }
+        true
     }
 
     /// Whether the chat bubble toggle is active (chat is open).


### PR DESCRIPTION
## Summary
- Makes the chat bubble toggle always visible in the toolbar, regardless of the current view selection
- Previously it was restricted to `.app`, `.appEditing`, and `.panel(.directory)` — no reason to hide it elsewhere

## Test Plan
- [ ] Chat bubble toggle visible on thread view
- [ ] Chat bubble toggle visible on settings panel
- [ ] Chat bubble toggle visible on all other panels
- [ ] Toggle still functions correctly from all views

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
