### PR TITLE
fix: hide chat bubble toggle in full-screen chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -228,8 +228,9 @@ struct MainWindowView: View {
     }
 
     /// Whether the chat bubble toggle should be visible for the current selection.
+    /// Hidden when already in a full-screen chat thread (.thread / .none).
     private var isChatBubbleVisible: Bool {
-        true
+        !windowState.isShowingChat
     }
 
     /// Whether the chat bubble toggle is active (chat is open).


### PR DESCRIPTION
## Summary
- Hides the chat bubble toggle when already viewing a full-screen chat thread (`.thread` / `.none` selection)
- The toggle is redundant in that context — there's no side panel to open/close

## Test Plan
- [ ] Chat toggle hidden when viewing a chat thread
- [ ] Chat toggle visible on Home Base, app views, settings, and all other panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
