### PR TITLE
Fix search bar container styling (addresses #7236 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -185,7 +185,7 @@ struct AgentPanelContent: View {
                     .foregroundColor(VColor.textMuted)
 
                 TextField("Filter skills...", text: $skillSearchQuery)
-                    .textFieldStyle(VInputStyle())
+                    .textFieldStyle(.plain)
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)
 
@@ -198,6 +198,9 @@ struct AgentPanelContent: View {
                     .buttonStyle(.plain)
                 }
             }
+            .padding(VSpacing.md)
+            .background(VColor.inputBackground)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
             // Sort picker
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -54,7 +54,7 @@ struct AppDirectoryView: View {
                                 .foregroundColor(VColor.textMuted)
 
                             TextField("Search apps...", text: $searchText)
-                                .textFieldStyle(VInputStyle())
+                                .textFieldStyle(.plain)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textPrimary)
 
@@ -67,6 +67,11 @@ struct AppDirectoryView: View {
                                 .buttonStyle(.plain)
                             }
                         }
+                        .padding(.horizontal, VSpacing.sm)
+                        .frame(height: 26)
+                        .background(VColor.inputBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(RoundedRectangle(cornerRadius: VRadius.sm).stroke(VColor.surfaceBorder, lineWidth: 1))
                         .frame(maxWidth: 220)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -106,7 +106,7 @@ struct GeneratedPanel: View {
                         .foregroundColor(VColor.textMuted)
 
                     TextField("Filter pages...", text: $searchText)
-                        .textFieldStyle(VInputStyle())
+                        .textFieldStyle(.plain)
                         .font(VFont.mono)
                         .foregroundColor(VColor.textPrimary)
 
@@ -119,6 +119,9 @@ struct GeneratedPanel: View {
                         .buttonStyle(.plain)
                     }
                 }
+                .padding(VSpacing.md)
+                .background(VColor.inputBackground)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
             }


### PR DESCRIPTION
Restore container-level styling on search bar HStacks in AppDirectoryView, AgentPanel, and GeneratedPanel. These HStacks group icon+TextField+clear button and need container styling rather than per-TextField VInputStyle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
