### PR TITLE
Add missing border overlay to search bar containers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -201,6 +201,10 @@ struct AgentPanelContent: View {
             .padding(VSpacing.md)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
 
             // Sort picker
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -122,6 +122,10 @@ struct GeneratedPanel: View {
                 .padding(VSpacing.md)
                 .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
             }


### PR DESCRIPTION
Adds the missing .overlay(RoundedRectangle(...).stroke(VColor.surfaceBorder, lineWidth: 1)) to AgentPanel and GeneratedPanel search bar HStack containers to match AppDirectoryView's pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
