### PR TITLE
Ensure bunx is available in assistant runtime image

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy bun binary from builder instead of re-installing
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
+RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 
 # Create non-root user that also has sudo access so it can like install stuff
 RUN groupadd --system --gid 1001 assistant && \


### PR DESCRIPTION
## Summary
- add a `bunx` symlink in the assistant runtime image after copying `bun`
- keep scope minimal to `assistant/Dockerfile` only

## Why
Some runtime paths invoke `bunx`. The runtime image currently only copies `bun`, so `bunx` may be missing even when Bun is installed.

## Change
- `assistant/Dockerfile`: `RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx`
