### PR TITLE
Fix input styling: migrate all inputs to VInputStyle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -185,7 +185,7 @@ struct AgentPanelContent: View {
                     .foregroundColor(VColor.textMuted)
 
                 TextField("Filter skills...", text: $skillSearchQuery)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)
 
@@ -198,9 +198,6 @@ struct AgentPanelContent: View {
                     .buttonStyle(.plain)
                 }
             }
-            .padding(VSpacing.md)
-            .background(VColor.backgroundSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
             // Sort picker
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -185,7 +185,7 @@ struct AgentPanelContent: View {
                     .foregroundColor(VColor.textMuted)
 
                 TextField("Filter skills...", text: $skillSearchQuery)
-                    .textFieldStyle(VInputStyle())
+                    .textFieldStyle(.plain)
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)
 
@@ -198,6 +198,9 @@ struct AgentPanelContent: View {
                     .buttonStyle(.plain)
                 }
             }
+            .padding(VSpacing.md)
+            .background(VColor.inputBackground)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
             // Sort picker
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -201,6 +201,10 @@ struct AgentPanelContent: View {
             .padding(VSpacing.md)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
 
             // Sort picker
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -54,7 +54,7 @@ struct AppDirectoryView: View {
                                 .foregroundColor(VColor.textMuted)
 
                             TextField("Search apps...", text: $searchText)
-                                .textFieldStyle(.plain)
+                                .textFieldStyle(VInputStyle())
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textPrimary)
 
@@ -67,14 +67,6 @@ struct AppDirectoryView: View {
                                 .buttonStyle(.plain)
                             }
                         }
-                        .padding(.horizontal, VSpacing.sm)
-                        .frame(height: 26)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .stroke(VColor.surfaceBorder, lineWidth: 1)
-                        )
                         .frame(maxWidth: 220)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -54,7 +54,7 @@ struct AppDirectoryView: View {
                                 .foregroundColor(VColor.textMuted)
 
                             TextField("Search apps...", text: $searchText)
-                                .textFieldStyle(VInputStyle())
+                                .textFieldStyle(.plain)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textPrimary)
 
@@ -67,6 +67,11 @@ struct AppDirectoryView: View {
                                 .buttonStyle(.plain)
                             }
                         }
+                        .padding(.horizontal, VSpacing.sm)
+                        .frame(height: 26)
+                        .background(VColor.inputBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(RoundedRectangle(cornerRadius: VRadius.sm).stroke(VColor.surfaceBorder, lineWidth: 1))
                         .frame(maxWidth: 220)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -106,7 +106,7 @@ struct GeneratedPanel: View {
                         .foregroundColor(VColor.textMuted)
 
                     TextField("Filter pages...", text: $searchText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.mono)
                         .foregroundColor(VColor.textPrimary)
 
@@ -119,9 +119,6 @@ struct GeneratedPanel: View {
                         .buttonStyle(.plain)
                     }
                 }
-                .padding(VSpacing.md)
-                .background(Moss._700)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -106,7 +106,7 @@ struct GeneratedPanel: View {
                         .foregroundColor(VColor.textMuted)
 
                     TextField("Filter pages...", text: $searchText)
-                        .textFieldStyle(VInputStyle())
+                        .textFieldStyle(.plain)
                         .font(VFont.mono)
                         .foregroundColor(VColor.textPrimary)
 
@@ -119,6 +119,9 @@ struct GeneratedPanel: View {
                         .buttonStyle(.plain)
                     }
                 }
+                .padding(VSpacing.md)
+                .background(VColor.inputBackground)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -122,6 +122,10 @@ struct GeneratedPanel: View {
                 .padding(VSpacing.md)
                 .background(VColor.inputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -246,16 +246,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("This is your private generated key", text: $apiKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at console.anthropic.com")
                         .font(VFont.caption)
@@ -360,16 +353,9 @@ struct SettingsPanel: View {
 
                 TextField("https://abc123.ngrok-free.app", text: $ingressUrlText)
                     .focused($isIngressUrlFocused)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
-                    .padding(VSpacing.md)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                    )
 
                 VButton(label: "Save", style: .primary) {
                     store.saveIngressPublicBaseUrl(ingressUrlText)
@@ -485,16 +471,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Perplexity API key", text: $perplexityKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at perplexity.ai/settings/api")
                         .font(VFont.caption)
@@ -540,16 +519,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Brave Search API key", text: $braveKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at brave.com/search/api")
                         .font(VFont.caption)
@@ -613,16 +585,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Gemini API key", text: $imageGenKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at aistudio.google.com/apikey")
                         .font(VFont.caption)
@@ -668,16 +633,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your OpenAI API key", text: $openaiKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Used for Voice Mode (Whisper transcription). Get your key at platform.openai.com/api-keys")
                         .font(VFont.caption)
@@ -723,16 +681,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Used for Voice Mode (text-to-speech). Get your key at elevenlabs.io/app/settings/api-keys")
                         .font(VFont.caption)
@@ -810,28 +761,14 @@ struct SettingsPanel: View {
                     // Client credentials entry (when not yet configured)
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         TextField("OAuth Client ID", text: $twitterClientId)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
 
                         SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
 
                         HStack {
                             Text("Create an app at developer.x.com")
@@ -956,16 +893,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Telegram bot token", text: $telegramBotTokenText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your bot token from @BotFather on Telegram")
                         .font(VFont.caption)
@@ -1036,28 +966,14 @@ struct SettingsPanel: View {
                     }
 
                     TextField("Account SID", text: $twilioAccountSidText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     SecureField("Auth Token", text: $twilioAuthTokenText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     if store.twilioSaveInProgress {
                         HStack(spacing: VSpacing.sm) {
@@ -1097,16 +1013,9 @@ struct SettingsPanel: View {
 
                 HStack(spacing: VSpacing.sm) {
                     TextField("Assign existing (+1555...)", text: $twilioPhoneNumberText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     VButton(label: "Assign", style: .secondary) {
                         store.assignTwilioNumber(phoneNumber: twilioPhoneNumberText)
@@ -1120,29 +1029,15 @@ struct SettingsPanel: View {
 
                 HStack(spacing: VSpacing.sm) {
                     TextField("Area code (optional)", text: $twilioAreaCodeText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     TextField("Country", text: $twilioCountryText)
-                        .textFieldStyle(.plain)
+                        .textFieldStyle(VInputStyle())
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
                         .frame(width: 90)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     VButton(label: "Provision", style: .secondary) {
                         store.provisionTwilioNumber(

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -174,16 +174,10 @@ struct APIKeyStepView: View {
                     }
             } else {
                 SecureField("sk-ant-\u{2026}", text: $apiKey)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(.system(size: 16, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, VSpacing.lg)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
                     .focused($keyFieldFocused)
                     .onSubmit {
                         saveAndContinue()

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -97,15 +97,9 @@ struct CloudCredentialsStepView: View {
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(VColor.textSecondary)
                 TextField("arn:aws:iam::123456789012:role/VellumAssistantRole", text: $state.awsRoleArn)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.md)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
                     .focused($arnFieldFocused)
                     .onSubmit {
                         saveAndContinue()
@@ -125,15 +119,9 @@ struct CloudCredentialsStepView: View {
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(VColor.textSecondary)
                 TextField("192.168.1.100 or my-mac-mini.local", text: $state.sshHost)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.md)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
                     .focused($sshHostFieldFocused)
             }
 
@@ -142,15 +130,9 @@ struct CloudCredentialsStepView: View {
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(VColor.textSecondary)
                 TextField("admin", text: $state.sshUser)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.md)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
             }
 
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -190,15 +172,9 @@ struct CloudCredentialsStepView: View {
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(VColor.textSecondary)
                 TextField("my-gcp-project-id", text: $state.gcpProjectId)
-                    .textFieldStyle(.plain)
+                    .textFieldStyle(VInputStyle())
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.md)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
                     .focused($projectIdFieldFocused)
             }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
@@ -22,20 +22,10 @@ struct NamingStepView: View {
             .opacity(showInput ? 1 : 0)
 
             TextField("Name your agent\u{2026}", text: $state.assistantName)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(VColor.textPrimary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-                .padding(.vertical, VSpacing.lg)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(VColor.surface.opacity(0.5))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
-                )
                 .frame(maxWidth: 260)
                 .focused($nameFieldFocused)
                 .opacity(showInput ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -43,16 +43,9 @@ struct ToolPermissionTesterView: View {
             // Working directory
             fieldLabel("Working Directory")
             TextField("Leave empty for daemon default", text: $model.workingDir)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.sm)
-                .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             // Toggles
             HStack(spacing: VSpacing.lg) {
@@ -136,29 +129,15 @@ struct ToolPermissionTesterView: View {
         switch field.fieldType {
         case .string:
             TextField("", text: fieldValueBinding(for: field.id))
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.sm)
-                .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
         case .number, .integer:
             TextField("", text: fieldValueBinding(for: field.id))
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.sm)
-                .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
         case .boolean:
             Toggle("", isOn: fieldBoolBinding(for: field.id))
@@ -193,12 +172,12 @@ struct ToolPermissionTesterView: View {
                 .foregroundColor(VColor.textPrimary)
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: 60, maxHeight: 120)
-                .padding(VSpacing.sm)
+                .padding(VSpacing.md)
                 .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
         }
     }
@@ -341,16 +320,9 @@ struct ToolPermissionTesterView: View {
         if model.availableToolNames.isEmpty {
             // Fallback to text field while loading or if fetch failed
             TextField("e.g. host_bash, host_file_write", text: $model.toolName)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.mono)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.sm)
-                .background(VColor.inputBackground)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
         } else {
             Picker("", selection: $model.toolName) {
                 Text("Select a tool\u{2026}")

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -246,10 +246,12 @@ private struct TrustRuleFormView: View {
                 }
 
                 TextField("Pattern", text: $pattern, prompt: Text("e.g., git *"))
+                    .textFieldStyle(VInputStyle())
 
                 Toggle("Everywhere", isOn: $isEverywhere)
                 if !isEverywhere {
                     TextField("Scope", text: $scope, prompt: Text("e.g., /Users/me/project"))
+                        .textFieldStyle(VInputStyle())
                 }
 
                 Picker("Decision", selection: $decision) {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -190,7 +190,7 @@ struct SecretPromptView: View {
 
                 // Secure input
                 SecureField(placeholder, text: $secretValue)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(VInputStyle())
                     .font(VFont.mono)
 
                 // Safety explainer


### PR DESCRIPTION
## Summary
Migrates all unstyled TextField, SecureField, and TextEditor inputs across the macOS app to use the design system's `VInputStyle`, ensuring consistent input styling with proper padding, background, border radius, and border overlay.

## Changes
- **SettingsPanel.swift**: Replaced 15 instances of `.textFieldStyle(.plain)` + manual styling with `.textFieldStyle(VInputStyle())`, removing ~120 lines of redundant code
- **ToolPermissionTesterView.swift**: Updated 4 TextFields to VInputStyle, kept TextEditor with VColor.inputBackground
- **NamingStepView.swift**: Updated 1 TextField, removed manual background/overlay styling
- **CloudCredentialsStepView.swift**: Updated 4 TextFields (AWS ARN, SSH Host, SSH Username, GCP Project ID)
- **APIKeyStepView.swift**: Updated 1 SecureField
- **TrustRulesView.swift**: Updated 2 TextFields
- **SecretPromptManager.swift**: Changed 1 SecureField from `.roundedBorder` to VInputStyle
- **AppDirectoryView.swift, AgentPanel.swift, GeneratedPanel.swift**: Search bar HStacks use container-level styling (padding + background + clipShape + border overlay) with `.textFieldStyle(.plain)` on the inner TextField

## Milestone PRs (merged into feature branch)
- #7233: Replace .textFieldStyle(.plain) with VInputStyle in SettingsPanel
- #7236: Replace unstyled inputs with VInputStyle across remaining macOS files
- #7245: Restore search bar container styling for grouped icon+input+button HStacks
- #7246: Add missing border overlay to AgentPanel and GeneratedPanel search bars

## Project issue
Closes #7030

## Test plan
- [ ] Verify SettingsPanel inputs (API keys, public ingress URL, OAuth fields) have consistent styling
- [ ] Verify onboarding inputs (name, cloud credentials, API key) match design system
- [ ] Verify search bars in App Directory, Agent, and Generated panels have border overlays
- [ ] Verify ToolPermissionTester inputs are styled consistently
- [ ] Verify TrustRules and SecretPrompt inputs are styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
