### PR TITLE
fix: deselect threads for all panels, prevent ghost Settings window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -110,6 +110,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
 
+        // Remove stale SwiftUI Settings window frame to prevent a ghost
+        // window from being restored on launch (the Settings scene now
+        // renders EmptyView — we handle settings in the main window panel).
+        UserDefaults.standard.removeObject(forKey: "NSWindow Frame com_apple_SwiftUI_Settings_window")
+
         if let envPath = FeatureFlagManager.findRepoEnvFile() {
             FeatureFlagManager.shared.loadFromFile(at: envPath)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -771,9 +771,8 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected: Bool = {
-            // Top-level nav panels deselect all threads
-            if case .panel(let panel) = windowState.selection,
-               panel == .directory || panel == .identity {
+            // Any panel selection deselects all threads
+            if case .panel = windowState.selection {
                 return false
             }
             if thread.id == windowState.persistentThreadId { return true }


### PR DESCRIPTION
## Summary
- **Thread highlighting**: Threads in the sidebar now deselect for ALL panel selections (Skills, Settings, Debug, etc.), not just Directory and Identity. Previously, selecting Skills would leave a thread visually highlighted.
- **Ghost window**: Clears the stale SwiftUI Settings window frame from UserDefaults on launch. After the Settings consolidation (moving settings into the main window panel), macOS was restoring the old standalone Settings window from saved state, causing two windows to appear on launch.

## Test Plan
- [ ] Select Skills in sidebar — no thread should be highlighted
- [ ] Select Settings in sidebar — no thread should be highlighted
- [ ] Build and launch — only one window should appear
- [ ] Cmd+, opens settings panel in main window, not a separate window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
