### PR TITLE
fix: make chat bubble toggle work on all panel views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -218,8 +218,8 @@ struct MainWindowView: View {
             windowState.selection = .app(appId)
             isAppChatOpen = false
 
-        case .panel(.directory):
-            // Toggle: flip isAppChatOpen
+        case .panel:
+            // Toggle: flip isAppChatOpen for any panel view
             isAppChatOpen.toggle()
 
         default:
@@ -238,7 +238,7 @@ struct MainWindowView: View {
         switch windowState.selection {
         case .appEditing:
             return true
-        case .panel(.directory):
+        case .panel:
             return isAppChatOpen
         default:
             return false

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -318,6 +318,33 @@ extension MainWindowView {
                         nativePanelView(.voiceMode)
                     }
                 )
+            } else if isAppChatOpen {
+                // Split view: chat (left) + panel (right)
+                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
+                let effectiveWidth = Binding<Double>(
+                    get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
+                    set: { appPanelWidth = $0 }
+                )
+                VSplitView(
+                    panelWidth: effectiveWidth,
+                    showPanel: true,
+                    main: {
+                        chatView
+                    },
+                    panel: {
+                        fullWindowPanel(panelType)
+                            .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.xl, bottomLeadingRadius: VRadius.xl))
+                    }
+                )
+                .onAppear {
+                    if threadManager.activeViewModel == nil {
+                        if let firstThread = threadManager.visibleThreads.first {
+                            threadManager.selectThread(id: firstThread.id)
+                        } else {
+                            threadManager.createThread()
+                        }
+                    }
+                }
             } else {
                 // Full-window panels: settings, debug, doctor, identity
                 fullWindowPanel(panelType)


### PR DESCRIPTION
## Summary
- The chat bubble toggle now works on **all** panel views (Settings, Skills, Identity, Debug, etc.), not just Home Base
- When toggled on from any panel, shows a VSplitView with chat on the left and the panel content on the right
- Both `toggleChatBubble()` and `isChatBubbleActive` now use `.panel` (matching any panel) instead of `.panel(.directory)` only

## Files Changed
- **MainWindowView.swift** — `toggleChatBubble()` and `isChatBubbleActive` now handle `.panel` generically
- **PanelCoordinator.swift** — added VSplitView branch for full-window panels when `isAppChatOpen` is true

## Test Plan
- [ ] Toggle chat from Home Base — works as before
- [ ] Toggle chat from Skills — shows split view with chat + Skills panel
- [ ] Toggle chat from Settings — shows split view with chat + Settings panel
- [ ] Toggle chat from Identity — shows split view with chat + Identity panel
- [ ] Toggle off from any panel — returns to full-window panel view

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
