### PR TITLE
fix: exclude voiceMode and documentEditor from chat bubble toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -218,8 +218,9 @@ struct MainWindowView: View {
             windowState.selection = .app(appId)
             isAppChatOpen = false
 
-        case .panel:
+        case .panel(let panelType) where panelType != .voiceMode && panelType != .documentEditor:
             // Toggle: flip isAppChatOpen for any panel view
+            // (voiceMode and documentEditor have their own dedicated split layouts)
             isAppChatOpen.toggle()
 
         default:
@@ -228,9 +229,15 @@ struct MainWindowView: View {
     }
 
     /// Whether the chat bubble toggle should be visible for the current selection.
-    /// Hidden when already in a full-screen chat thread (.thread / .none).
+    /// Hidden when already in a full-screen chat thread (.thread / .none),
+    /// or on panels that have their own dedicated chat layouts.
     private var isChatBubbleVisible: Bool {
-        !windowState.isShowingChat
+        if windowState.isShowingChat { return false }
+        if case .panel(let panelType) = windowState.selection,
+           panelType == .voiceMode || panelType == .documentEditor {
+            return false
+        }
+        return true
     }
 
     /// Whether the chat bubble toggle is active (chat is open).
@@ -238,7 +245,7 @@ struct MainWindowView: View {
         switch windowState.selection {
         case .appEditing:
             return true
-        case .panel:
+        case .panel(let panelType) where panelType != .voiceMode && panelType != .documentEditor:
             return isAppChatOpen
         default:
             return false


### PR DESCRIPTION
## Summary
Addresses review feedback on #7251 from both Codex and Devin.

Voice mode and document editor panels have their own dedicated split view layouts that render chat independently of `isAppChatOpen`. The chat bubble toggle is now:
- **Hidden** on these panels (no misleading button)
- **Excluded** from state mutation (no silent side effects)

## Files Changed
- **MainWindowView.swift** — `toggleChatBubble()`, `isChatBubbleVisible`, and `isChatBubbleActive` now exclude `.voiceMode` and `.documentEditor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
