### PR TITLE
fix: tighten GHA secrets allowlist regex to reject fallback values

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -64,7 +64,7 @@ declare -a SAFE_LINE_PATTERNS=(
     "client[Ss]ecret:[[:space:]]*(String[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil)|client[Ss]ecret[[:space:]]*[,)])"
     "[Pp]rivate[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
     "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here|[a-zA-Z][a-zA-Z_/ '-]*[A-Z_/][a-zA-Z_/ '.-]*)>['\"]"
-    "[a-zA-Z_-]*[[:space:]]*[:=][[:space:]]*\\\$\\{\\{[[:space:]]*secrets\\."
+    "[a-zA-Z_-]*[[:space:]]*[:=][[:space:]]*\\\$\\{\\{[[:space:]]*secrets\\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\\}\\}[[:space:]]*$"
 )
 
 matches_safe_line_pattern() {
@@ -140,6 +140,7 @@ if [ "${1:-}" = "--self-test" ]; then
     UNSAFE_ANGLEBRACKET_SECRET='clientSecret: "<abcDEF1234567890>"'
     UNSAFE_PASSPHRASE_SECRET='client_secret: "<correct horse battery staple>"'
     SAFE_GHA_SECRETS_LINE='          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}'
+    UNSAFE_GHA_SECRETS_FALLBACK='          client_secret: ${{ secrets.CLIENT_SECRET || "SuperSecretFallback12345" }}'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -283,6 +284,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_GHA_SECRETS_LINE" && ! matches_safe_line_pattern "$SAFE_GHA_SECRETS_LINE"; then
         echo -e "${RED}Self-test failed:${NC} GitHub Actions \${{ secrets.* }} reference false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_GHA_SECRETS_FALLBACK" && matches_safe_line_pattern "$UNSAFE_GHA_SECRETS_FALLBACK"; then
+        echo -e "${RED}Self-test failed:${NC} GHA secrets with fallback value was incorrectly whitelisted"
         exit 1
     fi
 


### PR DESCRIPTION
Addresses Codex feedback on #7193: the GHA secrets safe-line regex was too broad and could mask lines with hardcoded secret fallbacks. Tightens the pattern to only match complete ${{ secrets.NAME }} expressions and reject lines with fallback values like || "literal".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
