### PR TITLE
fix: use NSHomeDirectory() for cross-platform iOS/macOS compatibility

### DIFF
--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -5,7 +5,7 @@ public enum LockfilePaths {
         if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
             return URL(fileURLWithPath: baseDir)
         }
-        return FileManager.default.homeDirectoryForCurrentUser
+        return URL(fileURLWithPath: NSHomeDirectory())
     }
 
     public static var primary: URL {


### PR DESCRIPTION
Fixes the CI iOS Build Check workflow that failed for #7237 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22327692557).

`FileManager.default.homeDirectoryForCurrentUser` is unavailable on iOS. Replaced with `NSHomeDirectory()` which works on all Apple platforms.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
