### PR TITLE
fix: resolve CI Assistant Checks failures on main

### DIFF
--- a/assistant/src/__tests__/daemon-lifecycle.test.ts
+++ b/assistant/src/__tests__/daemon-lifecycle.test.ts
@@ -165,7 +165,7 @@ function internals(server: DaemonServer): DaemonServerInternals {
 
 function createFakeSocket(overrides?: Partial<net.Socket>) {
   const writes: string[] = [];
-  const socket = {
+  const base: Record<string, unknown> = {
     destroyed: false,
     writable: true,
     remoteAddress: '127.0.0.1',
@@ -174,16 +174,17 @@ function createFakeSocket(overrides?: Partial<net.Socket>) {
       return true;
     },
     destroy(): void {
-      this.destroyed = true;
+      base.destroyed = true;
     },
     on(_event: string, _handler: (...args: unknown[]) => void): unknown {
-      return this;
+      return socket;
     },
     once(_event: string, _handler: (...args: unknown[]) => void): unknown {
-      return this;
+      return socket;
     },
     ...overrides,
-  } as unknown as net.Socket;
+  };
+  const socket = base as unknown as net.Socket;
   return { socket, writes };
 }
 
@@ -586,7 +587,7 @@ describe('IPC protocol', () => {
       const parser = createMessageParser();
       const messages = parser.feed('{"type":"ping"}\n');
       expect(messages).toHaveLength(1);
-      expect((messages[0] as Record<string, unknown>).type).toBe('ping');
+      expect((messages[0] as unknown as Record<string, unknown>).type).toBe('ping');
     });
 
     test('buffers partial messages until newline arrives', () => {
@@ -597,22 +598,22 @@ describe('IPC protocol', () => {
 
       const partial2 = parser.feed('"ping"}\n');
       expect(partial2).toHaveLength(1);
-      expect((partial2[0] as Record<string, unknown>).type).toBe('ping');
+      expect((partial2[0] as unknown as Record<string, unknown>).type).toBe('ping');
     });
 
     test('handles multiple messages in a single chunk', () => {
       const parser = createMessageParser();
       const messages = parser.feed('{"type":"ping"}\n{"type":"pong"}\n');
       expect(messages).toHaveLength(2);
-      expect((messages[0] as Record<string, unknown>).type).toBe('ping');
-      expect((messages[1] as Record<string, unknown>).type).toBe('pong');
+      expect((messages[0] as unknown as Record<string, unknown>).type).toBe('ping');
+      expect((messages[1] as unknown as Record<string, unknown>).type).toBe('pong');
     });
 
     test('skips malformed JSON lines gracefully', () => {
       const parser = createMessageParser();
       const messages = parser.feed('not json\n{"type":"valid"}\n');
       expect(messages).toHaveLength(1);
-      expect((messages[0] as Record<string, unknown>).type).toBe('valid');
+      expect((messages[0] as unknown as Record<string, unknown>).type).toBe('valid');
     });
 
     test('throws when line exceeds maxLineSize', () => {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -564,6 +564,17 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   tool_names_list: {
     type: 'tool_names_list',
   },
+  dictation_request: {
+    type: 'dictation_request',
+    transcription: 'Hello world',
+    context: {
+      bundleIdentifier: 'com.example.app',
+      appName: 'Example App',
+      windowTitle: 'Main Window',
+      selectedText: 'some selected text',
+      cursorInTextField: true,
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1607,6 +1618,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   tool_names_list_response: {
     type: 'tool_names_list_response',
     names: ['bash', 'file_read', 'file_write'],
+  },
+  dictation_response: {
+    type: 'dictation_response',
+    text: 'Hello world',
+    mode: 'dictation',
+    actionPlan: undefined,
   },
 };
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../../../../config/defaults.js';
+import { getConfig } from '../../../../config/loader.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import {
   getMediaAssetById,


### PR DESCRIPTION
Fixes the CI Assistant Checks workflow that has been failing on main since #7229. Latest failure: #7247 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22328230124).

## Summary

Three type-check errors fixed:

1. **`analyze-keyframes.ts`**: `getConfig` was imported from `config/defaults.js` which doesn't export it — changed to `config/loader.js` where it's actually exported.
2. **`ipc-snapshot.test.ts`**: Missing `dictation_request` (client) and `dictation_response` (server) entries in the snapshot test `Record` types, which must exhaustively cover all message types.
3. **`daemon-lifecycle.test.ts`**: `as Record<string, unknown>` casts on `ClientMessage | ServerMessage` values failed because `SubagentDetailResponse` has no index signature — fixed by casting through `unknown` first. Also fixed `this.destroyed` property access in an object literal by using a named reference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
