### PR TITLE
docs: align /deliver/sms OpenAPI schema and README with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ The unified messaging layer provides platform-agnostic tools (`messaging_send`, 
 
 Connect Gmail and Slack via the Settings UI or `integration_connect` IPC message. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions. SMS uses Twilio credentials (Account SID + Auth Token) — see the `twilio-setup` skill for setup instructions.
 
+#### Per-assistant phone number mapping (SMS)
+
+In multi-assistant setups, each assistant can have its own dedicated Twilio phone number. Inbound SMS is routed to the correct assistant based on which number received the message, and outbound SMS is sent from the assistant's mapped number.
+
+Configure via `sms.assistantPhoneNumbers` in the gateway config file (`~/.vellum/workspace/config.json`):
+
+```json
+{
+  "sms": {
+    "assistantPhoneNumbers": {
+      "assistant-id-1": "+15551234567",
+      "assistant-id-2": "+15559876543"
+    }
+  }
+}
+```
+
+The `TWILIO_PHONE_NUMBER` environment variable (or `sms.phoneNumber` in the config file) serves as the global fallback when no per-assistant mapping matches. If an `assistantId` is provided in a `/deliver/sms` request and has a mapped phone number, that number is used as the sender; otherwise, the global `TWILIO_PHONE_NUMBER` is used.
+
 ### Twitter (X)
 
 Twitter integration supports two operation paths: **OAuth** (X API v2) and **Browser** (CDP). A strategy router selects which path is used for each operation.

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -759,12 +759,13 @@ export function buildSchema(): Record<string, unknown> {
         },
         SmsDeliverRequest: {
           type: "object",
-          required: ["text"],
-          description: "Request to deliver an SMS message via Twilio. Provide either `to` or `chatId` (alias) as the recipient phone number.",
+          description: "Request to deliver an SMS message via Twilio. Provide either `to` or `chatId` (alias) as the recipient phone number. `text` is optional when `attachments` are present — a fallback text message is sent instead.",
           properties: {
             to: { type: "string", description: "Recipient phone number in E.164 format" },
             chatId: { type: "string", description: "Alias for `to` — recipient phone number in E.164 format. Used by the runtime channel callback payload." },
             text: { type: "string", description: "Text content to send", minLength: 1 },
+            assistantId: { type: "string", description: "Optional assistant ID for per-assistant phone number resolution in multi-assistant setups" },
+            attachments: { type: "array", items: { type: "object" }, description: "Media attachments. When text is empty but attachments are present, a fallback text message is sent instead." },
           },
           anyOf: [
             { required: ["to"] },


### PR DESCRIPTION
Fixes #7240. Updates the SmsDeliverRequest OpenAPI schema to reflect the actual implementation: text is now optional (fallback when attachments present), and assistantId/attachments fields are documented. Also updates README to document per-assistant phone number mapping.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
