### PR TITLE
fix: show avatar on every assistant message

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -190,7 +190,7 @@ struct ChatBubble: View {
                     }
                 }
                 .overlay(alignment: .topLeading) {
-                    if !isUser && isLatestAssistantMessage {
+                    if !isUser {
                         Image(nsImage: appearance.chatAvatarImage)
                             .interpolation(.none)
                             .resizable()


### PR DESCRIPTION
## Summary
- Previously only the latest assistant message displayed the avatar icon, making earlier messages look disconnected
- Now all assistant messages show the 28pt circular avatar for visual consistency across the conversation

## Test plan
- [ ] Open a conversation with multiple assistant messages
- [ ] Verify every assistant message shows the avatar, not just the latest one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
