### PR TITLE
test: add SMS coverage for routing rejection and attachment-only fallback

### DIFF
--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -336,6 +336,41 @@ describe("/deliver/sms", () => {
     expect(sentParams.get("From")).toBe("+15551234567");
   });
 
+  it("attachment-only request (no text) uses fallback text", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({ url: urlStr, init: init ?? {} });
+      return new Response(JSON.stringify({ sid: "SM-sent" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const handler = createSmsDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
+    );
+    const req = makeRequest({
+      to: "+15559876543",
+      attachments: [{ url: "https://example.com/image.png" }],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify the Twilio Messages API was called
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("AC-test-sid/Messages.json");
+
+    // Verify the Body parameter contains the fallback text
+    const sentBody = fetchCalls[0].init.body as string;
+    const sentParams = new URLSearchParams(sentBody);
+    expect(sentParams.get("Body")).toBe(
+      "I have a media attachment to share, but SMS currently supports text only.",
+    );
+  });
+
   it("returns 503 when no From number is available", async () => {
     const handler = createSmsDeliverHandler(
       makeConfig({

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -643,6 +643,73 @@ describe("twilio-sms-webhook", () => {
     expect(typedOptions.routingOverride!.routeSource).toBe("default");
   });
 
+  it("regular inbound SMS with routing rejection sends rejection notice", async () => {
+    const rejectConfig: GatewayConfig = {
+      ...baseConfig,
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    };
+    const handler = createTwilioSmsWebhookHandler(rejectConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    // Use a unique From number to avoid the module-level rejection notice
+    // rate limiter (shouldSendRejectionNotice) cooldown from other tests.
+    const params = {
+      Body: "Hello",
+      From: "+15553001001",
+      To: "+15559876543",
+      MessageSid: "SM-regular-reject",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Rejection notice SMS should have been sent
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(to).toBe("+15553001001");
+    expect(typeof text).toBe("string");
+    expect((text as string).toLowerCase()).toContain("could not be routed");
+
+    // handleInbound should NOT have been called
+    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("runtime rejection (handleInbound rejected) sends rejection notice", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: false, rejected: true, rejectionReason: "test" }),
+    );
+
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    // Use a unique From number to avoid the module-level rejection notice
+    // rate limiter (shouldSendRejectionNotice) cooldown from other tests.
+    const params = {
+      Body: "Hello runtime reject",
+      From: "+15553002002",
+      To: "+15559876543",
+      MessageSid: "SM-runtime-reject",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // handleInbound should have been called
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    // Rejection notice SMS should have been sent
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+    const [, to, text] = sendSmsReplyMock.mock.calls[0] as unknown[];
+    expect(to).toBe("+15553002002");
+    expect(typeof text).toBe("string");
+    expect((text as string).toLowerCase()).toContain("could not be routed");
+  });
+
   it("MMS detected via MediaContentType0 when NumMedia is absent", async () => {
     const handler = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";


### PR DESCRIPTION
Fixes #7241. Adds tests for: (1) regular inbound SMS routing rejection notice, (2) runtime rejection notice from handleInbound, (3) attachment-only SMS delivery with fallback text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
