### PR TITLE
fix: pass assistantId to getPhoneNumber in testConnection

### DIFF
--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -135,7 +135,7 @@ export const smsMessagingProvider: MessagingProvider = {
       };
     }
 
-    const phoneNumber = getPhoneNumber();
+    const phoneNumber = getPhoneNumber(getAssistantId());
     if (!phoneNumber) {
       return {
         connected: false,


### PR DESCRIPTION
Follow-up to #7257. Fixes testConnection() to pass assistantId to getPhoneNumber(), matching the isConnected() behavior. Without this, testConnection reports disconnected in multi-assistant setups where only assistant-scoped phone numbers are configured.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
