### PR TITLE
fix: add text-or-attachments constraint to SmsDeliverRequest schema

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -767,9 +767,9 @@ export function buildSchema(): Record<string, unknown> {
             assistantId: { type: "string", description: "Optional assistant ID for per-assistant phone number resolution in multi-assistant setups" },
             attachments: { type: "array", items: { type: "object" }, description: "Media attachments. When text is empty but attachments are present, a fallback text message is sent instead." },
           },
-          anyOf: [
-            { required: ["to"] },
-            { required: ["chatId"] },
+          allOf: [
+            { anyOf: [{ required: ["to"] }, { required: ["chatId"] }] },
+            { anyOf: [{ required: ["text"] }, { required: ["attachments"] }] },
           ],
         },
         TelegramUpdate: {


### PR DESCRIPTION
Follow-up to #7259. Adds anyOf constraint requiring at least text or attachments in SmsDeliverRequest, matching TelegramDeliverRequest pattern and the actual implementation behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
