### PR TITLE
fix: add minItems constraint to SmsDeliverRequest attachments schema

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -765,7 +765,7 @@ export function buildSchema(): Record<string, unknown> {
             chatId: { type: "string", description: "Alias for `to` — recipient phone number in E.164 format. Used by the runtime channel callback payload." },
             text: { type: "string", description: "Text content to send", minLength: 1 },
             assistantId: { type: "string", description: "Optional assistant ID for per-assistant phone number resolution in multi-assistant setups" },
-            attachments: { type: "array", items: { type: "object" }, description: "Media attachments. When text is empty but attachments are present, a fallback text message is sent instead." },
+            attachments: { type: "array", items: { type: "object" }, minItems: 1, description: "Media attachments. When text is empty but attachments are present, a fallback text message is sent instead." },
           },
           allOf: [
             { anyOf: [{ required: ["to"] }, { required: ["chatId"] }] },


### PR DESCRIPTION
Adds minItems: 1 to the attachments array in SmsDeliverRequest so the OpenAPI schema rejects empty attachment arrays that would fail at runtime.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
