### PR TITLE
fix: resolve CI Gateway Checks failure from #7265

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -35,10 +35,7 @@ mock.module("node:child_process", () => {
 
 import {
   readTelegramCredentials,
-  readCredential,
   readKeychainCredential,
-  getMetadataPath,
-  getRootDir,
 } from "../credential-reader.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the CI Gateway Checks workflow failure from merged PR #7265 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22328618927).

Removed unused imports (`spyOn`, `readCredential`, `getMetadataPath`, `getRootDir`) from `gateway/src/__tests__/credential-reader.test.ts` that were causing lint errors.