### PR TITLE
docs: audit and update READMEs across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The platform has three main components:
 
 - **Assistant runtime** (`assistant/`): Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
 - **Native clients** (`clients/`): Swift Package with macOS and iOS apps sharing ~45-50% of code via `VellumAssistantShared`. The macOS app is a menu bar assistant with computer-use (accessibility + CGEvent). The iOS app is a chat client supporting standalone mode (direct Anthropic API) and connected-to-Mac mode (TCP proxy through the daemon).
-- **Gateway** (`gateway/`): Standalone Bun + TypeScript service that owns Telegram integration end-to-end. Receives Telegram webhooks, routes to the correct assistant via static settings, forwards to the assistant runtime, and sends replies back to Telegram. Optionally acts as an authenticated reverse proxy for the assistant runtime API (client → gateway → runtime).
+- **Gateway** (`gateway/`): Standalone Bun + TypeScript service that serves as the public ingress boundary for all external webhooks and callbacks. Owns Telegram integration end-to-end (receives webhooks, routes to assistants, delivers replies). Routes Twilio voice and SMS webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime API (client → gateway → runtime).
 
 ## Repository Structure
 

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -41,17 +41,21 @@ All UI and feature code lives in `Features/`, organized by domain:
 
 | Module | Purpose |
 |--------|---------|
+| `Ambient/` | Background screen monitoring UI |
+| `Avatar/` | Avatar customization |
+| `BrowserPiP/` | Browser picture-in-picture |
 | `Chat/` | ChatView, ChatViewModel (multi-turn messaging), ChatMessage model |
-| `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ThreadManager, 6 side panels |
+| `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ThreadManager, side panels |
+| `MainWindow/Panels/` | Side panels including DebugPanel (real-time trace viewer with metrics + timeline) |
+| `MenuBar/` | NSStatusItem and popover lifecycle |
 | `Onboarding/` | Multi-step first-launch flow (OnboardingFlowView → OnboardingState) |
 | `Session/` | Session overlay UI for computer-use task execution |
-| `Settings/` | API key entry, hotkey config, permission status, tool permission tester |
-| `Ambient/` | Background screen monitoring UI |
-| `Voice/` | Voice input UI (VoiceTranscriptionWindow) |
-| `MenuBar/` | NSStatusItem and popover lifecycle |
+| `Settings/` | Tabbed settings panels (Appearance, Advanced, Connect, Trust, Skills, etc.) |
+| `Sharing/` | Content sharing and export |
 | `Surfaces/` | Daemon surface rendering (HTML/JSON overlays) |
 | `TaskInput/` | Quick task input popover |
-| `MainWindow/Panels/` | Side panels including DebugPanel (real-time trace viewer with metrics + timeline) |
+| `Tasks/` | Task management UI |
+| `Voice/` | Voice input UI (VoiceTranscriptionWindow) |
 
 **Main window layout** (`MainWindowView`):
 ```

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -266,9 +266,9 @@ The package is split into a library target (`VellumAssistantLib`) and a thin exe
 1. **Select the library scheme.** At the very top center of the Xcode window, there's a dropdown button that shows the current scheme (it probably says `vellum-assistant > My Mac`). Click it and switch to **`VellumAssistantLib`**. Previews only work on the library target — the executable target will show an error about `ENABLE_DEBUG_DYLIB`.
 
 2. **Open a SwiftUI file.** In the left sidebar (file navigator), expand `vellum-assistant` and navigate to any SwiftUI view, for example:
-   - `Features/Settings/SettingsView.swift`
    - `Features/Onboarding/OnboardingFlowView.swift`
-   - `UI/SessionOverlayView.swift`
+   - `Features/Session/SessionOverlayView.swift`
+   - `Features/Settings/SettingsAppearanceTab.swift`
 
 3. **Show the Canvas.** Go to the menu bar: **Editor → Canvas** (or press `⌥⌘↩` / Option+Command+Return). A preview panel appears on the right side of the editor.
 
@@ -286,11 +286,11 @@ To add a preview, put this at the bottom of the file (outside any struct):
 }
 ```
 
-For example, `SettingsView` requires an argument:
+For example, views with dependencies need them passed in:
 
 ```swift
 #Preview {
-    SettingsView(ambientAgent: AmbientAgent())
+    OnboardingFlowView()
 }
 ```
 
@@ -314,21 +314,13 @@ ComputerUse/          Core perception + action pipeline
   ActionExecutor      CGEvent mouse/keyboard injection
   ActionVerifier      Safety checks (sensitive data, loops, limits)
   ChromeAccessibilityHelper  Auto-restart Chrome with --force-renderer-accessibility
+  RecipeExecutor      Recipe-based onboarding (computer-use driven setup)
   ScreenCapture       ScreenCaptureKit screenshot capture
   Session             Main orchestration loop
 Inference/            AI action selection
   AnthropicClient     Shared HTTP client with retry logic (used by KnowledgeCron)
   ToolDefinitions     Tool schemas for function calling
-IPC/                  Daemon communication
-  DaemonClient        Unix domain socket IPC client (auto-reconnect, ping/pong,
-                      blob probe for zero-copy transport)
-  IpcBlobStore        Local blob file writer for zero-copy IPC payloads
-  Generated/
-    IPCContractGenerated  Auto-generated Codable DTOs from the TS IPC contract
-  IPCMessages         Typealiases to generated types, convenience inits,
-                      ServerMessage routing enum, and a few hand-maintained
-                      types that require Swift-specific logic (SessionErrorCode
-                      enum, polymorphic surface data, typed ClaWHub wrappers)
+Services/             Singleton service containers
 Ambient/              Background screen-watching agent
   AmbientAgent        Periodic capture → OCR → analyze via daemon IPC
   AmbientAnalyzer     Type definitions (AmbientDecision, AmbientAnalysisResult)
@@ -336,16 +328,21 @@ Ambient/              Background screen-watching agent
   KnowledgeCron       Triggers periodic insight analysis
   InsightStore        Higher-level insights derived from observations
   ScreenOCR           Vision framework OCR
-Features/Chat/        Main window chat interface
-  ChatMessage         Message model (role, text, streaming state)
-  ChatView            Presentational view (bubbles, composer, thinking, error banner)
-  ChatViewModel       Session bootstrap, streaming, cancel via daemon IPC
-Features/MainWindow/Panels/
-  DebugPanel          Real-time trace viewer (metrics strip + timeline)
-  TraceTimelineView   Events grouped by requestId with status indicators
-  TraceRowView        Individual trace event display
-UI/                   SwiftUI views + overlay windows
+Features/
+  Ambient/            Background screen monitoring UI
+  Avatar/             Avatar customization
+  BrowserPiP/         Browser picture-in-picture
+  Chat/               Chat interface (ChatView, ChatViewModel, ChatMessage)
+  MainWindow/         Main window shell, ThreadTabBar, PanelCoordinator, side panels
+  MenuBar/            NSStatusItem and popover lifecycle
   Onboarding/         First-launch setup flow (permissions, naming, Fn key)
+  Session/            Session overlay UI for computer-use task execution
+  Settings/           Tabbed settings panels (Appearance, Advanced, Connect, Trust, etc.)
+  Sharing/            Content sharing and export
+  Surfaces/           Daemon surface rendering (HTML/JSON overlays)
+  TaskInput/          Quick task input popover
+  Tasks/              Task management UI
+  Voice/              Voice input UI (VoiceTranscriptionWindow)
 Logging/
   TraceStore          In-memory trace event store (per-session, dedup, retention cap)
   Session recording   JSON logs to ~/Library/App Support/

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -290,7 +290,13 @@ For example, views with dependencies need them passed in:
 
 ```swift
 #Preview {
-    OnboardingFlowView()
+    OnboardingFlowView(
+        state: OnboardingState(),
+        daemonClient: DaemonClient(),
+        authManager: AuthManager(),
+        onComplete: {},
+        onOpenSettings: {}
+    )
 }
 ```
 


### PR DESCRIPTION
## Summary

Audited all 14 README/documentation files across the project. Fixed stale information in 3 files:

- **Root README.md** — Updated gateway description to reflect its expanded role as the public ingress boundary (Telegram + Twilio voice/SMS + OAuth callbacks), not just Telegram
- **clients/macos/README.md** — Fixed stale Xcode preview paths (deleted `SettingsView.swift`, non-existent `UI/` directory), rewrote architecture tree to match current directory structure (added 5 missing Feature modules, `Services/`, `RecipeExecutor`; removed stale `IPC/` section now in shared package)
- **clients/macos/CLAUDE.md** — Updated Feature Modules table with 5 missing modules and current Settings description

## Test plan

- [ ] Verify all referenced file paths exist in the codebase
- [ ] Confirm architecture trees match actual directory layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
