### PR TITLE
M3: Wire media-processing handler into jobs-worker

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -29,6 +29,7 @@ import { checkContradictionsJob, cleanupStaleSupersededItemsJob } from './job-ha
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from './job-handlers/summarization.js';
 import { backfillJob, backfillEntityRelationsJob } from './job-handlers/backfill.js';
 import { rebuildIndexJob, deleteQdrantVectorsJob } from './job-handlers/index-maintenance.js';
+import { mediaProcessingJob } from './job-handlers/media-processing.js';
 
 // Re-export public utilities consumed by tests and other modules
 export { currentWeekWindow } from './job-utils.js';
@@ -230,10 +231,7 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
       await deleteQdrantVectorsJob(job);
       return;
     case 'media_processing':
-      // Stub: actual media processing is orchestrated by the media-processing
-      // skill tools, not the job worker.  We just acknowledge the job so it
-      // doesn't fail with "Unknown memory job type".
-      log.info({ jobId: job.id, payload: job.payload }, 'media_processing job received');
+      await mediaProcessingJob(job);
       return;
     default:
       throw new Error(`Unknown memory job type: ${(job as { type: string }).type}`);


### PR DESCRIPTION
Part of #7266. Replaces the media_processing stub in jobs-worker.ts with a call to the new mediaProcessingJob handler, completing the end-to-end pipeline wiring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
