### PR TITLE
fix: replace deprecated kIOMasterPortDefault with kIOMainPortDefault

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -201,7 +201,7 @@ struct PairingQRCodeSheet: View {
     /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
     private static func getPlatformUUID() -> String? {
         let service = IOServiceGetMatchingService(
-            kIOMasterPortDefault,
+            kIOMainPortDefault,
             IOServiceMatching("IOPlatformExpertDevice")
         )
         guard service != 0 else { return nil }


### PR DESCRIPTION
## Summary
- Replace deprecated `kIOMasterPortDefault` with `kIOMainPortDefault` in PairingQRCodeSheet.swift to silence macOS 12+ deprecation warning

## Original prompt
fix deprecated kIOMasterPortDefault warning in PairingQRCodeSheet.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)