### PR TITLE
fix: suppress NSParagraphStyle Sendable warning in MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -170,7 +170,7 @@ struct MarkdownSegmentView: View {
 
                     // Build paragraph style with hanging indent so wrapped lines
                     // align with the text column rather than the bullet/number.
-                    let paraStyle = NSMutableParagraphStyle()
+                    nonisolated(unsafe) let paraStyle = NSMutableParagraphStyle()
                     paraStyle.firstLineHeadIndent = leftMargin
                     paraStyle.headIndent = textColumn
                     paraStyle.tabStops = [NSTextTab(textAlignment: .left, location: textColumn)]


### PR DESCRIPTION
## Summary
- Mark `paraStyle` as `nonisolated(unsafe)` to suppress the unavailable `NSParagraphStyle` Sendable conformance warning when assigning to `AttributedString.paragraphStyle`

## Original prompt
fix this: [#DeprecatedDeclaration] — conformance of 'NSParagraphStyle' to 'Sendable' is unavailable in macOS, triggered at MarkdownSegmentView.swift lines 181 and 186 when assigning paragraph style to AttributedString.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
