### PR TITLE
feat: propagate target app through IPC + frontmost-app runtime guard

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -105,6 +105,7 @@ export async function handleTaskSubmit(
         type: 'task_routed',
         sessionId,
         interactionType: 'computer_use',
+        ...(targetApp ? { targetAppName: targetApp.appName, targetAppBundleId: targetApp.bundleId } : {}),
         ...(isQa ? {
           qaMode: true,
           reportToSessionId: msg.conversationId,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -260,6 +260,7 @@ export function wireEscalationHandler(
       task,
       escalatedFrom: sourceSessionId,
       reportToSessionId: sourceSessionId,
+      ...(targetApp ? { targetAppName: targetApp.appName, targetAppBundleId: targetApp.bundleId } : {}),
       ...(isQa ? {
         qaMode: true,
         retentionDays: config.qaRecording.defaultRetentionDays,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1567,6 +1567,10 @@ export interface TaskRouted {
   captureScope?: 'window' | 'display';
   /** Whether to include audio in QA recording (from daemon config). */
   includeAudio?: boolean;
+  /** Target app name for frontmost-app guard (from target-app-hints). */
+  targetAppName?: string;
+  /** Target app bundle ID for frontmost-app guard (from target-app-hints). */
+  targetAppBundleId?: string;
 }
 
 export interface RideShotgunResult {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -107,7 +107,9 @@ extension AppDelegate {
                 qaMode: routed.qaMode ?? false,
                 retentionDays: routed.retentionDays.flatMap { Int($0) } ?? 7,
                 captureScope: routed.captureScope ?? "display",
-                includeAudio: routed.includeAudio ?? false
+                includeAudio: routed.includeAudio ?? false,
+                targetAppName: routed.targetAppName,
+                targetAppBundleId: routed.targetAppBundleId
             )
             // Don't bind relatedViewModel for escalated sessions — the active view model
             // may be unrelated if the user switched threads. Tool calls for escalated
@@ -256,7 +258,9 @@ extension AppDelegate {
                     qaMode: routed.qaMode ?? false,
                     retentionDays: routed.retentionDays.flatMap { Int($0) } ?? 7,
                     captureScope: routed.captureScope ?? "display",
-                    includeAudio: routed.includeAudio ?? false
+                    includeAudio: routed.includeAudio ?? false,
+                    targetAppName: routed.targetAppName,
+                    targetAppBundleId: routed.targetAppBundleId
                 )
                 // Don't bind relatedViewModel — sessions started via startSession() don't
                 // originate from a chat thread, so there's no ChatViewModel to extract

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -55,6 +55,11 @@ final class ComputerUseSession: ObservableObject {
     /// Whether to include audio in QA recording (from daemon config, default false).
     let includeAudio: Bool
 
+    /// Target app name for frontmost-app guard — nil means no constraint.
+    let targetAppName: String?
+    /// Target app bundle ID for frontmost-app guard — nil means no constraint.
+    let targetAppBundleId: String?
+
     /// Weak reference to the chat view model for extracting tool calls for notifications.
     weak var relatedViewModel: ChatViewModel?
 
@@ -102,7 +107,9 @@ final class ComputerUseSession: ObservableObject {
         qaMode: Bool = false,
         retentionDays: Int = 7,
         captureScope: String = "display",
-        includeAudio: Bool = false
+        includeAudio: Bool = false,
+        targetAppName: String? = nil,
+        targetAppBundleId: String? = nil
     ) {
         self.id = sessionId ?? UUID().uuidString
         self.task = task
@@ -123,6 +130,8 @@ final class ComputerUseSession: ObservableObject {
         self.retentionDays = retentionDays
         self.captureScope = captureScope
         self.includeAudio = includeAudio
+        self.targetAppName = targetAppName
+        self.targetAppBundleId = targetAppBundleId
         self.verifier = ActionVerifier(maxSteps: maxSteps)
         self.logger = SessionLogger(task: task, attachments: attachments)
     }
@@ -465,6 +474,23 @@ final class ComputerUseSession: ObservableObject {
             return
         }
 
+        // FRONTMOST-APP GUARD — block destructive actions when the wrong app is in front.
+        // Non-destructive actions (screenshot, open_app, wait, runAppleScript) are allowed
+        // regardless of which app is focused.
+        if let guardError = await checkFrontmostAppGuard(for: agentAction) {
+            log.error("Frontmost guard BLOCKED action \(agentAction.type.rawValue): \(guardError)")
+            let obs = await buildObservation(executionResult: nil, executionError: guardError)
+            if let obs {
+                do {
+                    try daemonClient.send(obs)
+                } catch {
+                    log.error("Failed to send frontmost-guard blocked observation: \(error)")
+                }
+            }
+            state = .thinking(step: action.stepNumber + 1, maxSteps: maxSteps)
+            return
+        }
+
         // EXECUTE
         var executionResult: String? = nil
         var executionError: String? = nil
@@ -508,6 +534,49 @@ final class ComputerUseSession: ObservableObject {
         }
 
         state = .thinking(step: action.stepNumber + 1, maxSteps: maxSteps)
+    }
+
+    // MARK: - Frontmost App Guard
+
+    /// Returns an error message if the frontmost app doesn't match the target and
+    /// activation retry failed; returns nil if the action should proceed normally.
+    private func checkFrontmostAppGuard(for action: AgentAction) async -> String? {
+        let destructiveTypes: Set<ActionType> = [.click, .doubleClick, .rightClick, .type, .key, .scroll, .drag]
+        guard destructiveTypes.contains(action.type) else { return nil }
+
+        // When we have a bundle ID, match on that (most reliable)
+        if let targetBundleId = targetAppBundleId {
+            let frontmost = NSWorkspace.shared.frontmostApplication
+            let frontmostBundleId = frontmost?.bundleIdentifier
+            let frontmostName = frontmost?.localizedName ?? "unknown"
+
+            guard frontmostBundleId != targetBundleId else { return nil }
+
+            log.warning("Frontmost guard: frontmost=\(frontmostName) (\(frontmostBundleId ?? "nil")), target=\(self.targetAppName ?? "nil") (\(targetBundleId)). Attempting activation retry.")
+
+            // Attempt to activate the target app once
+            if let targetRunning = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == targetBundleId }) {
+                targetRunning.activate()
+                try? await Task.sleep(nanoseconds: 300_000_000) // 300ms for focus to settle
+                if NSWorkspace.shared.frontmostApplication?.bundleIdentifier == targetBundleId {
+                    log.info("Frontmost guard: activation retry succeeded for \(self.targetAppName ?? targetBundleId)")
+                    return nil
+                }
+            }
+
+            return "Action blocked: frontmost app is '\(frontmostName)' but target is '\(self.targetAppName ?? targetBundleId)'. Please switch to the target app first."
+        }
+
+        // Fall back to name-based matching when no bundle ID is available
+        if let targetName = targetAppName {
+            let frontmostName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
+            guard frontmostName != targetName else { return nil }
+
+            log.warning("Frontmost guard (name): frontmost=\(frontmostName), target=\(targetName). No bundle ID for activation retry.")
+            return "Action blocked: frontmost app is '\(frontmostName)' but target is '\(targetName)'. Please switch to the target app first."
+        }
+
+        return nil
     }
 
     // MARK: - Observation Builder

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -480,6 +480,10 @@ public struct IPCCuSessionCreate: Codable, Sendable {
     public let reportToSessionId: String?
     /// Marks this CU run as a QA/test workflow.
     public let qaMode: Bool?
+    /// Optional target app name constraint for disambiguation.
+    public let targetAppName: String?
+    /// Optional target app bundle identifier for disambiguation.
+    public let targetAppBundleId: String?
 }
 
 public struct IPCCuSessionFinalized: Codable, Sendable {
@@ -1756,6 +1760,10 @@ public struct IPCTaskRouted: Codable, Sendable {
     public let captureScope: String?
     /// Whether to include audio in QA recording (from daemon config).
     public let includeAudio: Bool?
+    /// Target app name for frontmost-app guard (from target-app-hints).
+    public let targetAppName: String?
+    /// Target app bundle ID for frontmost-app guard (from target-app-hints).
+    public let targetAppBundleId: String?
 }
 
 /// Server push — broadcast when a task run creates a conversation, so the client can show it as a chat thread.


### PR DESCRIPTION
## Summary
- Add targetAppName and targetAppBundleId to TaskRouted IPC contract
- Populate target app fields in both direct CU and escalation routing paths
- Update Swift IPC types and ComputerUseSession to consume target app
- Add frontmost-app runtime guard: before click/type/key/scroll/drag, verify frontmost app matches target; activate-once retry on mismatch; block with clear error if still mismatched

## Files changed
- `assistant/src/daemon/ipc-contract.ts` — TaskRouted fields
- `assistant/src/daemon/handlers/misc.ts` — direct CU routing
- `assistant/src/daemon/handlers/shared.ts` — escalation routing
- `clients/shared/IPC/Generated/IPCContractGenerated.swift` — auto-generated Swift IPC types
- `clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift` — consume target app
- `clients/macos/vellum-assistant/ComputerUse/Session.swift` — store target, frontmost guard

## Test plan
- [ ] Integration: escalation preserves target app
- [ ] Integration: frontmost guard prevents typing into Codex/Vellum when mismatched
- [ ] Manual: CU session with Codex in foreground — guard activates target and retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
