### PR TITLE
Fix: Throw on pipeline failure in media-processing job handler

### DIFF
--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -81,4 +81,11 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
     },
     'Media processing pipeline finished',
   );
+
+  if (result.failedStage) {
+    throw new Error(`Media processing failed at stage ${result.failedStage}: ${result.failureReason}`);
+  }
+  if (result.cancelled) {
+    throw new Error(`Media processing cancelled for asset ${mediaAssetId}`);
+  }
 }


### PR DESCRIPTION
Addresses feedback from #7273 and #7275. The handler now throws when runPipeline reports a failed stage or cancellation, so the job worker can properly retry or fail the job instead of silently marking it as completed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
