### PR TITLE
Fix: Gate media processing pipeline to video assets only

### DIFF
--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -41,6 +41,14 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
     return;
   }
 
+  if (asset.mediaType !== 'video') {
+    log.info(
+      { assetId: mediaAssetId, mediaType: asset.mediaType },
+      'Skipping media processing pipeline — only video assets are supported',
+    );
+    return;
+  }
+
   // Build detection config, allowing optional eventType override from payload
   const eventType = asString(job.payload.eventType);
   const detectionConfig: DetectionConfig = eventType


### PR DESCRIPTION
Addresses feedback from #7275. Adds an early return for non-video assets (audio, image) since the processing pipeline (keyframe extraction) only supports video. Prevents non-video assets from failing with an unhelpful error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
