### PR TITLE
Fix: Thread abort signal into analyzeKeyframesForAsset

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -30,6 +30,7 @@ export async function analyzeKeyframesForAsset(
   analysisType?: string,
   batchSize?: number,
   onProgress?: (msg: string) => void,
+  signal?: AbortSignal,
 ): Promise<void> {
   const type = analysisType ?? 'scene_description';
   const batch = batchSize ?? 10;
@@ -82,13 +83,17 @@ export async function analyzeKeyframesForAsset(
   const client = new Anthropic({ apiKey });
   let analyzedCount = analyzedKeyframeIds.size;
   const totalKeyframes = keyframes.length;
-  let errorCount = 0;
 
   onProgress?.(`Analyzing ${pendingKeyframes.length} keyframes (${analyzedKeyframeIds.size} already done)...\n`);
 
   try {
     // Process in batches
     for (let i = 0; i < pendingKeyframes.length; i += batch) {
+      if (signal?.aborted) {
+        onProgress?.('Aborted.\n');
+        break;
+      }
+
       const currentBatch = pendingKeyframes.slice(i, i + batch);
       const batchResults: Array<{
         assetId: string;
@@ -99,6 +104,11 @@ export async function analyzeKeyframesForAsset(
       }> = [];
 
       for (const keyframe of currentBatch) {
+        if (signal?.aborted) {
+          onProgress?.('Aborted.\n');
+          break;
+        }
+
         try {
           const result = await analyzeKeyframe(client, keyframe);
           batchResults.push({
@@ -110,7 +120,6 @@ export async function analyzeKeyframesForAsset(
           });
           analyzedCount++;
         } catch (err) {
-          errorCount++;
           onProgress?.(`  Warning: failed to analyze frame at ${keyframe.timestamp}s: ${(err as Error).message}\n`);
         }
       }
@@ -176,7 +185,7 @@ export async function run(
       };
     }
 
-    await analyzeKeyframesForAsset(assetId, analysisType, batchSize, context.onOutput);
+    await analyzeKeyframesForAsset(assetId, analysisType, batchSize, context.onOutput, context.signal);
 
     // Gather final stats
     const allKeyframes = getKeyframesForAsset(assetId);


### PR DESCRIPTION
Addresses feedback from #7270. Adds optional AbortSignal parameter to analyzeKeyframesForAsset and restores cooperative cancellation checks between batches and frames. Also cleans up unused imports/variables.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
