### PR TITLE
Replace unstyled inputs with VInputStyle in Connect and Advanced tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -385,16 +385,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         TextField("https://custom-gateway.example.com", text: $iosPairingGatewayOverride)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -402,16 +395,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         SecureField("Custom bearer token", text: $iosPairingTokenOverride)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -95,16 +95,9 @@ struct SettingsConnectTab: View {
 
             TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
                 .focused($isGatewayUrlFocused)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             VButton(label: "Save", style: .primary) {
                 store.saveIngressPublicBaseUrl(gatewayUrlText)
@@ -317,16 +310,9 @@ struct SettingsConnectTab: View {
             }
 
             SecureField("Telegram bot token", text: $telegramBotTokenText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             Text("Get your bot token from @BotFather on Telegram")
                 .font(VFont.caption)
@@ -457,28 +443,14 @@ struct SettingsConnectTab: View {
             }
 
             TextField("Account SID", text: $twilioAccountSidText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             SecureField("Auth Token", text: $twilioAuthTokenText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             if store.twilioSaveInProgress {
                 HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
Replaces .textFieldStyle(.plain) + manual padding/background/clipShape/overlay with .textFieldStyle(VInputStyle()) on 6 inputs across SettingsConnectTab.swift (gateway URL, Telegram bot token, Twilio SID, Twilio auth token) and SettingsAdvancedTab.swift (iOS pairing gateway override, iOS pairing token override).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
