### PR TITLE
Migrate All TextFields to VInputStyle Design System Component

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -385,16 +385,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         TextField("https://custom-gateway.example.com", text: $iosPairingGatewayOverride)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -402,16 +395,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         SecureField("Custom bearer token", text: $iosPairingTokenOverride)
-                            .textFieldStyle(.plain)
+                            .textFieldStyle(VInputStyle())
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -95,16 +95,9 @@ struct SettingsConnectTab: View {
 
             TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
                 .focused($isGatewayUrlFocused)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             VButton(label: "Save", style: .primary) {
                 store.saveIngressPublicBaseUrl(gatewayUrlText)
@@ -317,16 +310,9 @@ struct SettingsConnectTab: View {
             }
 
             SecureField("Telegram bot token", text: $telegramBotTokenText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             Text("Get your bot token from @BotFather on Telegram")
                 .font(VFont.caption)
@@ -457,28 +443,14 @@ struct SettingsConnectTab: View {
             }
 
             TextField("Account SID", text: $twilioAccountSidText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             SecureField("Auth Token", text: $twilioAuthTokenText)
-                .textFieldStyle(.plain)
+                .textFieldStyle(VInputStyle())
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             if store.twilioSaveInProgress {
                 HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
Ensures all TextField and SecureField inputs across the app use the `VInputStyle` design system component instead of manual styling with `.textFieldStyle(.plain)`.

## Changes
- Replaced 6 unstyled TextField/SecureField inputs with `VInputStyle()` in SettingsConnectTab and SettingsAdvancedTab

## Milestone PRs (merged into feature branch)
- #7287: Replace unstyled inputs in SettingsConnectTab and SettingsAdvancedTab

## Project issue
Closes #7277

## Test plan
- [ ] Verify all text inputs in Settings → Connect tab have consistent styling (background, border, rounded corners)
- [ ] Verify all text inputs in Settings → Advanced tab have consistent styling
- [ ] Verify search bars in Agent, Generated, and App Directory panels still render correctly (should be unchanged)
- [ ] Build and run the app — confirm no regressions

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
