### PR TITLE
fix: preserve pending prompt on retro-approve send failure

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -48,10 +48,10 @@ final class ComputerUseSession: ObservableObject {
                     log.info("Retro-resolving pending prompt \(pending.requestId) (tool=\(pending.toolName), risk=\(normalizedRisk))")
                     do {
                         try daemonClient.send(ConfirmationResponseMessage(requestId: pending.requestId, decision: "allow"))
+                        pendingToolPermissionPrompt = nil
                     } catch {
-                        log.error("Failed to retro-resolve pending prompt: \(error)")
+                        log.error("Failed to retro-resolve pending prompt: \(error) — keeping prompt visible for manual approval")
                     }
-                    pendingToolPermissionPrompt = nil
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Only clear `pendingToolPermissionPrompt` after successful daemon send in the `autoApproveTools` `didSet` observer
- On failure, keep prompt visible so user can manually approve instead of silently dropping it

Addresses feedback on #7288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
