### PR TITLE
fix: handle legacy denied screen recording on first request

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -33,6 +33,12 @@ enum PermissionManager {
 
         if !hasRequestedBefore {
             UserDefaults.standard.set(true, forKey: hasRequestedScreenRecordingFlag)
+            // For legacy installs that denied screen recording before this flag
+            // existed: CGRequestScreenCaptureAccess() was a no-op, so check if
+            // permission is still denied and fall back to System Settings.
+            if CGPreflightScreenCaptureAccess() == false {
+                openScreenRecordingSettings()
+            }
         } else if !CGPreflightScreenCaptureAccess() {
             openScreenRecordingSettings()
         }


### PR DESCRIPTION
## Summary
- After calling `CGRequestScreenCaptureAccess()`, check if permission is still denied
- If denied (legacy install that previously denied), fall back to opening System Settings
- Preserves the double-prompt fix for fresh installs

Addresses feedback on #7167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
