### PR TITLE
fix: use 2-column grid for chat image attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -838,12 +838,16 @@ struct ChatBubble: View {
     }
 
     private func attachmentImageGrid(_ images: [(ChatAttachment, NSImage)]) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
+        let columns = images.count == 1
+            ? [GridItem(.flexible())]
+            : [GridItem(.flexible(), spacing: VSpacing.sm), GridItem(.flexible(), spacing: VSpacing.sm)]
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: VSpacing.sm) {
             ForEach(images, id: \.0.id) { attachment, nsImage in
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: 280)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxHeight: 180)
+                    .clipped()
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     .onTapGesture {
                         openImageInPreview(attachment)


### PR DESCRIPTION
## Summary
- Replace `HStack` with `LazyVGrid` (2 columns) in `attachmentImageGrid` so multiple image attachments display as a compact thumbnail grid instead of being crammed side-by-side
- Single images use 1 column (full bubble width); 2+ images use a 2-column grid with `aspectRatio(.fill)` and `maxHeight: 180` for uniform thumbnails

## Test plan
- [ ] Send a message with 1 image attachment — should display at full bubble width
- [ ] Send a message with 2+ image attachments — should display in a 2-column grid with compact thumbnails
- [ ] Tap a thumbnail to verify preview still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
