### PR TITLE
fix: frontmost guard consecutive-block termination + CuSessionCreate wrapper

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -107,6 +107,7 @@ final class ComputerUseSession: ObservableObject {
     private var previousFlatElements: [AXElement]?
     private var consecutiveUnchangedSteps = 0
     private var currentStepNumber = 0
+    private var consecutiveFrontmostBlocks = 0
 
     /// Adaptive delay configuration
     private let adaptiveDelayEnabled: Bool
@@ -172,6 +173,7 @@ final class ComputerUseSession: ObservableObject {
         previousFlatElements = nil
         consecutiveUnchangedSteps = 0
         currentStepNumber = 0
+        consecutiveFrontmostBlocks = 0
         state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...", reasoning: "")
 
         log.info("Session starting — task: \(self.task, privacy: .public)")
@@ -245,7 +247,9 @@ final class ComputerUseSession: ObservableObject {
                     attachments: ipcAttachments,
                     interactionType: interactionTypeString,
                     reportToSessionId: reportToSessionId,
-                    qaMode: qaMode ? true : nil
+                    qaMode: qaMode ? true : nil,
+                    targetAppName: targetAppName,
+                    targetAppBundleId: targetAppBundleId
                 ))
             } catch {
                 log.error("Failed to send session create message: \(error)")
@@ -504,7 +508,14 @@ final class ComputerUseSession: ObservableObject {
         // Non-destructive actions (screenshot, open_app, wait, runAppleScript) are allowed
         // regardless of which app is focused.
         if let guardError = await checkFrontmostAppGuard(for: agentAction) {
-            log.error("Frontmost guard BLOCKED action \(agentAction.type.rawValue): \(guardError)")
+            consecutiveFrontmostBlocks += 1
+            log.error("Frontmost guard BLOCKED action \(agentAction.type.rawValue) (\(self.consecutiveFrontmostBlocks) consecutive): \(guardError)")
+            if consecutiveFrontmostBlocks >= 3 {
+                isCancelled = true
+                state = .failed(reason: "Target app could not be activated after repeated attempts.")
+                logger.finishSession(result: "failed: frontmost guard — too many blocks")
+                return
+            }
             let obs = await buildObservation(executionResult: nil, executionError: guardError)
             if let obs {
                 do {
@@ -516,6 +527,7 @@ final class ComputerUseSession: ObservableObject {
             state = .thinking(step: action.stepNumber + 1, maxSteps: maxSteps)
             return
         }
+        consecutiveFrontmostBlocks = 0
 
         // EXECUTE
         var executionResult: String? = nil

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -148,8 +148,8 @@ extension IPCUserMessageAttachment {
 public typealias CuSessionCreateMessage = IPCCuSessionCreate
 
 extension IPCCuSessionCreate {
-    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?, reportToSessionId: String? = nil, qaMode: Bool? = nil) {
-        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType, reportToSessionId: reportToSessionId, qaMode: qaMode)
+    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?, reportToSessionId: String? = nil, qaMode: Bool? = nil, targetAppName: String? = nil, targetAppBundleId: String? = nil) {
+        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType, reportToSessionId: reportToSessionId, qaMode: qaMode, targetAppName: targetAppName, targetAppBundleId: targetAppBundleId)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add consecutive-block counter to frontmost-app guard so sessions fail fast when target app can't be activated (3 consecutive blocks -> session terminates with a clear failure message)
- Fix CuSessionCreate convenience init to forward new `targetAppName` and `targetAppBundleId` fields to the generated struct's memberwise init
- Forward `targetAppName` and `targetAppBundleId` from the session create call site to the daemon

Addresses feedback on #7282.

## Test plan
- [ ] Verify session terminates after 3 consecutive frontmost-guard blocks instead of burning through all remaining steps
- [ ] Verify the `consecutiveFrontmostBlocks` counter resets when an action passes the guard
- [ ] Verify `CuSessionCreateMessage` compiles with and without the new optional parameters
- [ ] Verify target app fields are forwarded to the daemon in the session create message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
