### PR TITLE
chore: regenerate Swift IPC bindings

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2384,6 +2384,12 @@ public struct IPCRideShotgunProgress: Codable, Sendable {
     public let type: String
     public let watchId: String
     public let message: String
+
+    public init(type: String, watchId: String, message: String) {
+        self.type = type
+        self.watchId = watchId
+        self.message = message
+    }
 }
 
 public struct IPCRideShotgunResult: Codable, Sendable {


### PR DESCRIPTION
CI Assistant Checks was failing on main because the generated Swift IPC file was out of date. This regenerates it to fix CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
