### PR TITLE
fix: preserve full image display for single attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -845,8 +845,8 @@ struct ChatBubble: View {
             ForEach(images, id: \.0.id) { attachment, nsImage in
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(maxHeight: 180)
+                    .aspectRatio(contentMode: images.count == 1 ? .fit : .fill)
+                    .frame(maxHeight: images.count == 1 ? 320 : 180)
                     .clipped()
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                     .onTapGesture {


### PR DESCRIPTION
## Summary
- Use `.fit` content mode for single image attachments so they display fully without cropping
- Keep `.fill` + compact `maxHeight: 180` only for multi-image grid thumbnails
- Single images get `maxHeight: 320` for generous display space

## Original prompt
Addresses feedback from PR #7299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
