### PR TITLE
fix: use manifest metadata for skill tools in Permission Simulator

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -4,8 +4,8 @@ import { initializeProviders } from '../../providers/registry.js';
 import { addRule, removeRule, updateRule, getAllRules, acceptStarterBundle } from '../../permissions/trust-store.js';
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } from '../../permissions/checker.js';
 import { isSideEffectTool } from '../../tools/executor.js';
-import { resolveExecutionTarget } from '../../tools/execution-target.js';
-import { getAllTools } from '../../tools/registry.js';
+import { resolveExecutionTarget, type ManifestOverride } from '../../tools/execution-target.js';
+import { getAllTools, getTool } from '../../tools/registry.js';
 import { loadSkillCatalog } from '../../config/skills.js';
 import { parseToolManifestFile } from '../../skills/tool-manifest.js';
 import { join } from 'node:path';
@@ -1566,6 +1566,32 @@ export function handleEnvVarsRequest(socket: net.Socket, ctx: HandlerContext): v
   ctx.send(socket, { type: 'env_vars_response', vars });
 }
 
+/**
+ * Look up manifest metadata for a tool that isn't in the live registry.
+ * Searches all installed skills' TOOLS.json manifests for a matching tool name.
+ */
+function resolveManifestOverride(toolName: string): ManifestOverride | undefined {
+  if (getTool(toolName)) return undefined;
+  try {
+    const catalog = loadSkillCatalog();
+    for (const skill of catalog) {
+      if (!skill.toolManifest?.present || !skill.toolManifest.valid) continue;
+      try {
+        const manifest = parseToolManifestFile(join(skill.directoryPath, 'TOOLS.json'));
+        const entry = manifest.tools.find((t) => t.name === toolName);
+        if (entry) {
+          return { risk: entry.risk, execution_target: entry.execution_target };
+        }
+      } catch {
+        // Skip unparseable manifests
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+  return undefined;
+}
+
 export async function handleToolPermissionSimulate(
   msg: ToolPermissionSimulateRequest,
   socket: net.Socket,
@@ -1591,13 +1617,15 @@ export async function handleToolPermissionSimulate(
 
     const workingDir = msg.workingDir ?? process.cwd();
 
-    // Resolve execution target using manifest metadata or prefix heuristics.
-    // resolveExecutionTarget handles unregistered tools via prefix fallback.
-    const executionTarget = resolveExecutionTarget(msg.toolName);
+    // For unregistered skill tools, resolve manifest metadata so the simulation
+    // uses accurate risk/execution_target values instead of falling back to defaults.
+    const manifestOverride = resolveManifestOverride(msg.toolName);
+
+    const executionTarget = resolveExecutionTarget(msg.toolName, manifestOverride);
     const policyContext = { executionTarget };
 
-    const riskLevel = await classifyRisk(msg.toolName, msg.input, workingDir);
-    const result = await check(msg.toolName, msg.input, workingDir, policyContext);
+    const riskLevel = await classifyRisk(msg.toolName, msg.input, workingDir, undefined, manifestOverride);
+    const result = await check(msg.toolName, msg.input, workingDir, policyContext, manifestOverride);
 
     // Private-thread override: promote allow → prompt for side-effect tools
     if (

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -12,6 +12,7 @@ import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/net
 import { normalizeFilePath, isSkillSourcePath } from '../skills/path-classifier.js';
 import { isWorkspaceScopedInvocation } from './workspace-policy.js';
 import { buildShellCommandCandidates, buildShellAllowlistOptions, type ParsedCommand } from './shell-identity.js';
+import type { ManifestOverride } from '../tools/execution-target.js';
 
 // Ensures the legacy mode deprecation warning fires at most once per process.
 let _legacyDeprecationWarned = false;
@@ -244,7 +245,7 @@ async function buildCommandCandidates(toolName: string, input: Record<string, un
   return [...new Set(candidates)];
 }
 
-export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string, preParsed?: ParsedCommand): Promise<RiskLevel> {
+export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string, preParsed?: ParsedCommand, manifestOverride?: ManifestOverride): Promise<RiskLevel> {
   if (toolName === 'file_read') return RiskLevel.Low;
   if (toolName === 'file_write' || toolName === 'file_edit') {
     const filePath = getStringField(input, 'path', 'file_path');
@@ -342,6 +343,13 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   const tool = getTool(toolName);
   if (tool) return tool.defaultRiskLevel;
 
+  // Use manifest metadata for unregistered skill tools so the Permission
+  // Simulator shows accurate risk levels instead of defaulting to Medium.
+  if (manifestOverride) {
+    const riskMap: Record<string, RiskLevel> = { low: RiskLevel.Low, medium: RiskLevel.Medium, high: RiskLevel.High };
+    return riskMap[manifestOverride.risk] ?? RiskLevel.Medium;
+  }
+
   // Unknown tool → Medium
   return RiskLevel.Medium;
 }
@@ -351,6 +359,7 @@ export async function check(
   input: Record<string, unknown>,
   workingDir: string,
   policyContext?: PolicyContext,
+  manifestOverride?: ManifestOverride,
 ): Promise<PermissionCheckResult> {
   // For shell tools, parse once and share the result to avoid duplicate tree-sitter work.
   let shellParsed: ParsedCommand | undefined;
@@ -361,7 +370,7 @@ export async function check(
     }
   }
 
-  const risk = await classifyRisk(toolName, input, workingDir, shellParsed);
+  const risk = await classifyRisk(toolName, input, workingDir, shellParsed, manifestOverride);
 
   // Build command string candidates for rule matching
   const commandCandidates = await buildCommandCandidates(toolName, input, workingDir, shellParsed);
@@ -406,9 +415,14 @@ export async function check(
   // Third-party skill-origin tools default to prompting when no trust rule
   // matches, regardless of risk level. Bundled skill tools are first-party
   // and trusted, so they fall through to the normal risk-based policy.
+  // When manifestOverride is present, the tool comes from a skill manifest
+  // but isn't registered — treat it as a third-party skill tool.
   if (!matchedRule) {
     const tool = getTool(toolName);
     if (tool?.origin === 'skill' && !tool.ownerSkillBundled) {
+      return { decision: 'prompt', reason: 'Skill tool: requires approval by default' };
+    }
+    if (!tool && manifestOverride) {
       return { decision: 'prompt', reason: 'Skill tool: requires approval by default' };
     }
   }

--- a/assistant/src/tools/execution-target.ts
+++ b/assistant/src/tools/execution-target.ts
@@ -1,7 +1,12 @@
 import type { ExecutionTarget } from './types.js';
 import { getTool } from './registry.js';
 
-export function resolveExecutionTarget(toolName: string): ExecutionTarget {
+export interface ManifestOverride {
+  risk: 'low' | 'medium' | 'high';
+  execution_target: 'host' | 'sandbox';
+}
+
+export function resolveExecutionTarget(toolName: string, manifestOverride?: ManifestOverride): ExecutionTarget {
   const tool = getTool(toolName);
   // Manifest-declared execution target is authoritative — check it first so
   // skill tools with host_/computer_use_ prefixes aren't mis-classified.
@@ -12,6 +17,11 @@ export function resolveExecutionTarget(toolName: string): ExecutionTarget {
   // client (host), not inside the sandbox.
   if (tool?.executionMode === 'proxy') {
     return 'host';
+  }
+  // Use manifest metadata for unregistered skill tools so the Permission
+  // Simulator shows accurate execution targets instead of defaulting to sandbox.
+  if (!tool && manifestOverride) {
+    return manifestOverride.execution_target;
   }
   // Prefix heuristics for core tools that don't declare an explicit target.
   if (toolName.startsWith('host_') || toolName.startsWith('computer_use_')) {


### PR DESCRIPTION
Codex flagged in PR #7283 that adding manifest-only tool names makes the Permission Simulator inaccurate — simulation logic falls back to medium risk and sandbox target for unregistered tools. This fix threads manifest metadata (risk level, execution target) through to the simulation path so skill tools are evaluated accurately. Addresses feedback from #7283.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
