### PR TITLE
fix: add ride_shotgun_progress to IPC snapshot test

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -835,6 +835,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: 'sess-routed-001',
     interactionType: 'computer_use',
   },
+  ride_shotgun_progress: {
+    type: 'ride_shotgun_progress',
+    watchId: 'watch-shotgun-001',
+    message: 'Observing user activity...',
+  },
   ride_shotgun_result: {
     type: 'ride_shotgun_result',
     sessionId: 'sess-shotgun-001',


### PR DESCRIPTION
CI Assistant Checks was failing on main because the IPC snapshot test was missing a sample entry for the new ride_shotgun_progress server message type. This adds the missing entry to fix the TypeScript compilation error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
