### PR TITLE
fix: tighten iOS ATS and add local network permission (#7294)

### DIFF
--- a/clients/ios/Resources/Info.plist
+++ b/clients/ios/Resources/Info.plist
@@ -33,6 +33,8 @@
     <string>Vellum Assistant uses the camera to scan QR codes for pairing with your Mac.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Select photos to attach to your message</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Vellum Assistant connects to the Vellum daemon on your local network to send and receive messages.</string>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>
@@ -47,8 +49,34 @@
     </array>
     <key>NSAppTransportSecurity</key>
     <dict>
-        <key>NSAllowsArbitraryLoads</key>
+        <!-- Allow HTTP on the local network only -->
+        <key>NSAllowsLocalNetworking</key>
         <true/>
+
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+            <key>127.0.0.1</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+            <key>vellum.local</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Replace global NSAllowsArbitraryLoads with targeted ATS exceptions for localhost, 127.0.0.1, and vellum.local. Add NSLocalNetworkUsageDescription for local network access permission.

Part of #7293.

## Changes
- Remove `NSAllowsArbitraryLoads: true` from iOS Info.plist
- Add `NSAllowsLocalNetworking: true` for local network HTTP
- Add exception domains: localhost, 127.0.0.1, vellum.local (with subdomains)
- Add `NSLocalNetworkUsageDescription` usage string

## Files Changed
- `clients/ios/Resources/Info.plist`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
