### PR TITLE
fix: tighten macOS ATS in build-generated Info.plist (#7295)

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -383,8 +383,34 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>AppIcon</string>
     <key>NSAppTransportSecurity</key>
     <dict>
-        <key>NSAllowsArbitraryLoads</key>
+        <!-- Allow HTTP on the local network only -->
+        <key>NSAllowsLocalNetworking</key>
         <true/>
+
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+            <key>127.0.0.1</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+            <key>vellum.local</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
     <key>CFBundleURLTypes</key>
     <array>


### PR DESCRIPTION
## Summary
Replace global NSAllowsArbitraryLoads with targeted ATS exceptions for localhost, 127.0.0.1, and vellum.local in the macOS build script Info.plist template.

Part of #7293.

## Changes
- Remove `NSAllowsArbitraryLoads: true` from build.sh Info.plist template
- Add `NSAllowsLocalNetworking: true` for local network HTTP
- Add exception domains: localhost, 127.0.0.1, vellum.local (with subdomains)

## Files Changed
- `clients/macos/build.sh`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
