### PR TITLE
fix: guard NSScreen.main in ActionPreviewWindow (#7296)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/ActionPreviewWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ActionPreviewWindow.swift
@@ -6,10 +6,11 @@ final class ActionPreviewWindow {
 
     /// Show a colored dot at the given screen position, then fade it out.
     func flash(at point: CGPoint, color: NSColor = .systemBlue, duration: TimeInterval = 0.3) {
+        guard let screen = NSScreen.main else { return }
         let size: CGFloat = 24
         let frame = NSRect(
             x: point.x - size / 2,
-            y: NSScreen.main!.frame.height - point.y - size / 2, // Flip to screen coords
+            y: screen.frame.height - point.y - size / 2, // Flip to screen coords
             width: size,
             height: size
         )


### PR DESCRIPTION
## Summary
Replace force-unwrap of NSScreen.main with a guard that silently returns when no screen is available. Prevents a crash in headless contexts (CI, remote sessions, no display).

Part of #7293.

## Changes
- Replace `NSScreen.main!` with `guard let screen = NSScreen.main else { return }`
- Use `screen.frame.height` instead of force-unwrapped access

## Files Changed
- `clients/macos/vellum-assistant/Features/Session/ActionPreviewWindow.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
