### PR TITLE
fix: resolve Twilio account SID and phone number from credential store

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -56,6 +56,16 @@ PY
      bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:auth_token") ?? "")'
      cd ..
    )"
+   TWILIO_ACCOUNT_SID="$(
+     cd assistant
+     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:account_sid") ?? "")'
+     cd ..
+   )"
+   TWILIO_PHONE_NUMBER="$(
+     cd assistant
+     bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:phone_number") ?? "")'
+     cd ..
+   )"
 
    # Mirror CLI startGateway() behavior: only auto-enable default routing
    # when exactly one assistant is present in ~/.vellum.lock.json.
@@ -108,6 +118,12 @@ PY
    if [ -z "$TWILIO_AUTH_TOKEN" ]; then
      echo "WARNING: TWILIO_AUTH_TOKEN is empty (Twilio webhooks will be rejected)."
    fi
+   if [ -z "$TWILIO_ACCOUNT_SID" ]; then
+     echo "WARNING: TWILIO_ACCOUNT_SID is empty (SMS delivery will fail)."
+   fi
+   if [ -z "$TWILIO_PHONE_NUMBER" ]; then
+     echo "WARNING: TWILIO_PHONE_NUMBER is empty (SMS delivery will fail)."
+   fi
    if [ "${GATEWAY_UNMAPPED_POLICY:-}" = "default" ]; then
      if [ -n "${GATEWAY_DEFAULT_ASSISTANT_ID:-}" ]; then
        echo "Gateway routing: default -> ${GATEWAY_DEFAULT_ASSISTANT_ID}"
@@ -128,6 +144,8 @@ PY
      GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false \
      INGRESS_PUBLIC_BASE_URL="$INGRESS_PUBLIC_BASE_URL" \
      TWILIO_AUTH_TOKEN="$TWILIO_AUTH_TOKEN" \
+     TWILIO_ACCOUNT_SID="$TWILIO_ACCOUNT_SID" \
+     TWILIO_PHONE_NUMBER="$TWILIO_PHONE_NUMBER" \
      ${GATEWAY_UNMAPPED_POLICY:+GATEWAY_UNMAPPED_POLICY="$GATEWAY_UNMAPPED_POLICY"} \
      ${GATEWAY_DEFAULT_ASSISTANT_ID:+GATEWAY_DEFAULT_ASSISTANT_ID="$GATEWAY_DEFAULT_ASSISTANT_ID"} \
      bun run dev:proxy \

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { getLogger, type LogFileConfig } from "./logger.js";
+import { getRootDir, readKeychainCredential, readCredential, readTwilioCredentials } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -247,9 +248,31 @@ export function loadConfig(): GatewayConfig {
     );
   }
 
-  const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || undefined;
-  const twilioAccountSid = process.env.TWILIO_ACCOUNT_SID || undefined;
-  const twilioPhoneNumber = process.env.TWILIO_PHONE_NUMBER || undefined;
+  // Twilio credentials: env var > credential store (keychain / encrypted file)
+  const twilioCreds = readTwilioCredentials();
+  const twilioAuthToken = process.env.TWILIO_AUTH_TOKEN || twilioCreds?.authToken || undefined;
+  const twilioAccountSid = process.env.TWILIO_ACCOUNT_SID || twilioCreds?.accountSid || undefined;
+
+  // Phone number: env var > config file sms.phoneNumber > credential store
+  let twilioPhoneNumber: string | undefined = process.env.TWILIO_PHONE_NUMBER || undefined;
+  if (!twilioPhoneNumber) {
+    try {
+      const cfgPath = join(getRootDir(), "workspace", "config.json");
+      const raw = readFileSync(cfgPath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data?.sms?.phoneNumber && typeof data.sms.phoneNumber === "string") {
+        twilioPhoneNumber = data.sms.phoneNumber;
+      }
+    } catch {
+      // config file may not exist yet
+    }
+  }
+  if (!twilioPhoneNumber) {
+    twilioPhoneNumber =
+      readKeychainCredential("credential:twilio:phone_number")
+      || readCredential("credential:twilio:phone_number")
+      || undefined;
+  }
 
   const smsDeliverAuthBypassRaw = process.env.GATEWAY_SMS_DELIVER_AUTH_BYPASS;
   if (


### PR DESCRIPTION
## Summary
- **gateway/src/config.ts**: `loadConfig()` now resolves `twilioAccountSid` and `twilioAuthToken` from the credential store (via `readTwilioCredentials()`) when env vars are absent, and resolves `twilioPhoneNumber` from the config file (`sms.phoneNumber`) and credential store as additional fallbacks.
- **.claude/commands/update.md**: The `/update` command now resolves `TWILIO_ACCOUNT_SID` and `TWILIO_PHONE_NUMBER` from the secure key store and passes them as env vars to the gateway process, with warnings when empty.

## Original prompt
**Bug:** Gateway doesn't receive `TWILIO_ACCOUNT_SID` or `TWILIO_PHONE_NUMBER` env vars at startup, so outbound SMS silently fails with 503.

**Validation:** After the fix, restart the gateway with `/update` and confirm `hasTwilioAccountSid: true` and `hasTwilioPhoneNumber: true` appear in `~/.vellum/gateway-dev.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
