### PR TITLE
fix: replace AX force-casts with safe casts (#7297)

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
@@ -71,15 +71,15 @@ enum AmbientAXCapture {
             log.debug("No focused window for \(appName, privacy: .public)")
             return nil
         }
-        let windowElement = windowRef as! AXUIElement
+        guard let windowElement = windowRef as? AXUIElement else { return nil }
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
 
         // Get focused element
         var focusedRef: CFTypeRef?
         var focusedElement: (role: String, label: String?)?
         if AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
-           let focused = focusedRef {
-            let fe = focused as! AXUIElement
+           let focused = focusedRef,
+           let fe = focused as? AXUIElement {
             let role = getStringAttribute(fe, kAXRoleAttribute as CFString) ?? "unknown"
             let label = getStringAttribute(fe, kAXTitleAttribute as CFString)
                 ?? getStringAttribute(fe, kAXDescriptionAttribute as CFString)

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -140,7 +140,7 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             }
             return nil
         }
-        let windowElement = windowRef as! AXUIElement
+        guard let windowElement = windowRef as? AXUIElement else { return nil }
 
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
 
@@ -207,7 +207,7 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             log.debug("enumerateAppByPID: no focused window for \(appName, privacy: .public) (pid \(pid)): AXError \(result.rawValue)")
             return nil
         }
-        let windowElement = windowRef as! AXUIElement
+        guard let windowElement = windowRef as? AXUIElement else { return nil }
 
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
         let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
@@ -424,12 +424,11 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
         var point = CGPoint.zero
         var size = CGSize.zero
 
-        // Extract values from AXValue refs (force cast is safe here since we validated success above)
-        if let posRef = positionValue {
-            AXValueGetValue(posRef as! AXValue, .cgPoint, &point)
+        if let posRef = positionValue, let posVal = posRef as? AXValue {
+            AXValueGetValue(posVal, .cgPoint, &point)
         }
-        if let sizeRef = sizeValue {
-            AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        if let sizeRef = sizeValue, let sizeVal = sizeRef as? AXValue {
+            AXValueGetValue(sizeVal, .cgSize, &size)
         }
 
         return CGRect(origin: point, size: size)

--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -88,7 +88,7 @@ struct DictationContextCapture {
             log.debug("Could not get focused window — AX permission may be missing")
             return ""
         }
-        let window = windowRef as! AXUIElement
+        guard let window = windowRef as? AXUIElement else { return "" }
         return axStringAttribute(window, kAXTitleAttribute as CFString) ?? ""
     }
 
@@ -100,7 +100,7 @@ struct DictationContextCapture {
             log.debug("Could not get focused UI element")
             return (nil, false)
         }
-        let focused = focusedRef as! AXUIElement
+        guard let focused = focusedRef as? AXUIElement else { return (nil, false) }
 
         // Selected text
         let selectedText = axStringAttribute(focused, kAXSelectedTextAttribute as CFString)


### PR DESCRIPTION
## Summary
Replace force-casts (as!) with safe casts (as?) in the AX capture pipeline. Prevents crashes when Accessibility APIs return unexpected types or permissions change mid-session.

Part of #7293.

## Changes
- Replace `as! AXUIElement` with `guard let ... as? AXUIElement` in all 3 files
- Replace `as! AXValue` with safe cast in AccessibilityTree.swift
- Use appropriate fallbacks (continue/return nil) for each context

## Files Changed
- `clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift`
- `clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift`
- `clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
