### PR TITLE
Fix: Mark non-video assets as indexed before skipping pipeline

### DIFF
--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '../../util/logger.js';
 import { asString } from '../job-utils.js';
-import { getMediaAssetById } from '../media-store.js';
+import { getMediaAssetById, updateMediaAssetStatus } from '../media-store.js';
 import type { MemoryJob } from '../jobs-store.js';
 import {
   runPipeline,
@@ -46,6 +46,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
       { assetId: mediaAssetId, mediaType: asset.mediaType },
       'Skipping media processing pipeline — only video assets are supported',
     );
+    updateMediaAssetStatus(mediaAssetId, 'indexed');
     return;
   }
 


### PR DESCRIPTION
Addresses feedback from #7285. Non-video assets (audio, image) were left stuck in processing status when the handler returned early. Now sets status to indexed before returning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
