### PR TITLE
fix: escape error message in document editor innerHTML

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -421,12 +421,13 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
       // Focus editor
       setTimeout(() => window.editor.focus(), 100);
     } catch (e) {
+      var msg = e.message.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       document.getElementById('editor').innerHTML =
         '<div style="padding: 32px; color: var(--v-text-secondary); font-size: 14px;">' +
         '<strong>Editor failed to load</strong><br><br>' +
         'The document editor could not be initialized. This may be due to a network issue preventing ' +
         'external assets from loading.<br><br>' +
-        '<em>' + e.message + '</em></div>';
+        '<em>' + msg + '</em></div>';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
Escape `e.message` before injecting into innerHTML in the document editor catch block to prevent HTML injection from error messages containing angle brackets.

Addresses feedback on #7311.

## Changes
- Add HTML entity escaping for `e.message` (`&`, `<`, `>`)
- Use escaped string in innerHTML instead of raw error message

## Files Changed
- `clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
