### PR TITLE
Fix: dictation not inserting text on Fn-release

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -202,7 +202,13 @@ final class VoiceInputManager {
             holdTask?.cancel()
             holdTask = nil
             if isRecording {
-                stopRecording()
+                if currentMode == .dictation {
+                    // In dictation mode, don't cancel the recognition — let it finish
+                    // processing and deliver the final transcription via the callback.
+                    stopRecordingForDictation()
+                } else {
+                    stopRecording()
+                }
             }
         }
     }
@@ -392,6 +398,26 @@ final class VoiceInputManager {
             log.info("Action mode detected — routing transcription to task submission: \(text, privacy: .public)")
             onActionModeTriggered?(text)
         }
+    }
+
+    /// Stop recording for dictation mode: stop audio input and signal end-of-audio
+    /// so the recognizer delivers a final transcription via the callback.
+    /// Does NOT cancel the recognition task or set isRecording=false — the callback
+    /// handles cleanup after receiving the isFinal result.
+    private func stopRecordingForDictation() {
+        guard isRecording else { return }
+        log.info("Stopping dictation recording — waiting for final transcription")
+
+        onRecordingStateChanged?(false)
+
+        if audioEngine.isRunning {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+
+        // Signal end of audio — the recognizer will process remaining audio
+        // and fire the callback with isFinal = true.
+        recognitionRequest?.endAudio()
     }
 
     private func stopRecording() {


### PR DESCRIPTION
stopRecording() was cancelling the SFSpeechRecognitionTask and setting isRecording=false before the recognizer could produce a final transcription. This meant the Fn-hold → speak → Fn-release flow never delivered text to the dictation handler.

Add stopRecordingForDictation() that stops the audio engine and calls endAudio() without cancelling the recognition task, allowing it to deliver the isFinal result through the callback. The existing stopRecording() is still used for conversation mode where immediate cancellation is desired.

Part of #7180.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
