### PR TITLE
fix: handle non-Error throw values in document editor catch block

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -421,7 +421,7 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
       // Focus editor
       setTimeout(() => window.editor.focus(), 100);
     } catch (e) {
-      var msg = e.message.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      var msg = String(e && e.message ? e.message : e).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       document.getElementById('editor').innerHTML =
         '<div style="padding: 32px; color: var(--v-text-secondary); font-size: 14px;">' +
         '<strong>Editor failed to load</strong><br><br>' +


### PR DESCRIPTION
## Summary
Use `String(e && e.message ? e.message : e)` to safely coerce any thrown value before HTML-escaping. JavaScript catch can receive non-Error values (strings, numbers, plain objects) where `e.message` is undefined, which would throw a secondary exception and prevent the fallback UI from rendering.

Addresses Codex feedback on #7319.

## Files Changed
- `clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
