### PR TITLE
Fix VInputStyle native white background by converting to ViewModifier

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -385,16 +385,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         TextField("https://custom-gateway.example.com", text: $iosPairingGatewayOverride)
-                            .textFieldStyle(.plain)
+                            .vInputStyle()
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -402,16 +395,9 @@ struct SettingsAdvancedTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         SecureField("Custom bearer token", text: $iosPairingTokenOverride)
-                            .textFieldStyle(.plain)
+                            .vInputStyle()
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -72,7 +72,7 @@ struct SettingsAppearanceTab: View {
 
                     HStack(spacing: VSpacing.sm) {
                         TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                            .textFieldStyle(VInputStyle())
+                            .vInputStyle()
 
                         VButton(label: "Add", style: .primary) {
                             let domain = newAllowlistDomain

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -95,16 +95,9 @@ struct SettingsConnectTab: View {
 
             TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
                 .focused($isGatewayUrlFocused)
-                .textFieldStyle(.plain)
+                .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             VButton(label: "Save", style: .primary) {
                 store.saveIngressPublicBaseUrl(gatewayUrlText)
@@ -317,16 +310,9 @@ struct SettingsConnectTab: View {
             }
 
             SecureField("Telegram bot token", text: $telegramBotTokenText)
-                .textFieldStyle(.plain)
+                .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             Text("Get your bot token from @BotFather on Telegram")
                 .font(VFont.caption)
@@ -457,28 +443,14 @@ struct SettingsConnectTab: View {
             }
 
             TextField("Account SID", text: $twilioAccountSidText)
-                .textFieldStyle(.plain)
+                .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             SecureField("Auth Token", text: $twilioAuthTokenText)
-                .textFieldStyle(.plain)
+                .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
 
             if store.twilioSaveInProgress {
                 HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -265,7 +265,7 @@ struct SkillsSettingsView: View {
                     // Browse section (placeholder)
                     Section("Browse") {
                         TextField("Search skills...", text: $searchText)
-                            .textFieldStyle(VInputStyle())
+                            .vInputStyle()
 
                         HStack {
                             Image(systemName: "sparkles")

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
-/// A TextFieldStyle that matches the design system input background.
-/// Use on raw TextField / SecureField instances: `.textFieldStyle(VInputStyle())`
-public struct VInputStyle: TextFieldStyle {
+/// A ViewModifier that applies the design system input styling.
+/// Strips the native macOS text field background and applies VColor.inputBackground.
+/// Use on raw TextField / SecureField instances: `.vInputStyle()`
+public struct VInputStyleModifier: ViewModifier {
     public init() {}
 
-    public func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
+    public func body(content: Content) -> some View {
+        content
+            .textFieldStyle(.plain)
             .padding(VSpacing.md)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
@@ -14,6 +16,12 @@ public struct VInputStyle: TextFieldStyle {
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .stroke(VColor.surfaceBorder, lineWidth: 1)
             )
+    }
+}
+
+extension View {
+    public func vInputStyle() -> some View {
+        modifier(VInputStyleModifier())
     }
 }
 


### PR DESCRIPTION
## Summary
- Convert `VInputStyle` from `TextFieldStyle` to `VInputStyleModifier` (`ViewModifier`) that applies `.textFieldStyle(.plain)` first, stripping the native macOS white text field background before applying design system styling
- Migrate remaining manually-styled inputs in Connect tab (gateway URL, Telegram token, Twilio SID/token) and Advanced tab (iOS pairing overrides) to use `.vInputStyle()`
- Update 2 remaining `VInputStyle()` call sites in Appearance and Skills tabs

## Original prompt
Fix VInputStyle native white background by converting to ViewModifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
