### PR TITLE
fix: use CFGetTypeID for AX CoreFoundation type checks

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
@@ -71,7 +71,8 @@ enum AmbientAXCapture {
             log.debug("No focused window for \(appName, privacy: .public)")
             return nil
         }
-        guard let windowElement = windowRef as? AXUIElement else { return nil }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        let windowElement = windowRef as! AXUIElement
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
 
         // Get focused element
@@ -79,7 +80,8 @@ enum AmbientAXCapture {
         var focusedElement: (role: String, label: String?)?
         if AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
            let focused = focusedRef,
-           let fe = focused as? AXUIElement {
+           CFGetTypeID(focused) == AXUIElementGetTypeID() {
+            let fe = focused as! AXUIElement
             let role = getStringAttribute(fe, kAXRoleAttribute as CFString) ?? "unknown"
             let label = getStringAttribute(fe, kAXTitleAttribute as CFString)
                 ?? getStringAttribute(fe, kAXDescriptionAttribute as CFString)

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -140,7 +140,8 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             }
             return nil
         }
-        guard let windowElement = windowRef as? AXUIElement else { return nil }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        let windowElement = windowRef as! AXUIElement
 
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
 
@@ -207,7 +208,8 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             log.debug("enumerateAppByPID: no focused window for \(appName, privacy: .public) (pid \(pid)): AXError \(result.rawValue)")
             return nil
         }
-        guard let windowElement = windowRef as? AXUIElement else { return nil }
+        guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
+        let windowElement = windowRef as! AXUIElement
 
         let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
         let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
@@ -424,11 +426,11 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
         var point = CGPoint.zero
         var size = CGSize.zero
 
-        if let posRef = positionValue, let posVal = posRef as? AXValue {
-            AXValueGetValue(posVal, .cgPoint, &point)
+        if let posRef = positionValue, CFGetTypeID(posRef) == AXValueGetTypeID() {
+            AXValueGetValue(posRef as! AXValue, .cgPoint, &point)
         }
-        if let sizeRef = sizeValue, let sizeVal = sizeRef as? AXValue {
-            AXValueGetValue(sizeVal, .cgSize, &size)
+        if let sizeRef = sizeValue, CFGetTypeID(sizeRef) == AXValueGetTypeID() {
+            AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
         }
 
         return CGRect(origin: point, size: size)

--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -88,7 +88,8 @@ struct DictationContextCapture {
             log.debug("Could not get focused window — AX permission may be missing")
             return ""
         }
-        guard let window = windowRef as? AXUIElement else { return "" }
+        guard CFGetTypeID(windowRef as CFTypeRef) == AXUIElementGetTypeID() else { return "" }
+        let window = windowRef as! AXUIElement
         return axStringAttribute(window, kAXTitleAttribute as CFString) ?? ""
     }
 
@@ -100,7 +101,8 @@ struct DictationContextCapture {
             log.debug("Could not get focused UI element")
             return (nil, false)
         }
-        guard let focused = focusedRef as? AXUIElement else { return (nil, false) }
+        guard CFGetTypeID(focusedRef as CFTypeRef) == AXUIElementGetTypeID() else { return (nil, false) }
+        let focused = focusedRef as! AXUIElement
 
         // Selected text
         let selectedText = axStringAttribute(focused, kAXSelectedTextAttribute as CFString)


### PR DESCRIPTION
## Summary

Fixes CI failures on main caused by PR #7310 (AX force-cast hardening). The `as? AXUIElement` and `as? AXValue` conditional downcasts always succeed on CoreFoundation types, which the compiler treats as an error in release builds.

## Implementation

Replaced all 8 `as?` conditional downcasts with `CFGetTypeID()` comparisons — the correct way to validate CoreFoundation types at runtime. After the type ID check confirms the type, the subsequent `as!` is guaranteed safe.

**Pattern:**
```swift
// Before (compiler error — conditional downcast always succeeds):
guard let windowElement = windowRef as? AXUIElement else { return nil }

// After (actual runtime type validation):
guard CFGetTypeID(windowRef) == AXUIElementGetTypeID() else { return nil }
let windowElement = windowRef as! AXUIElement
```

## Files Changed

- `AmbientAXCapture.swift` — 2 AXUIElement casts
- `AccessibilityTree.swift` — 2 AXUIElement + 2 AXValue casts  
- `DictationContextCapture.swift` — 2 AXUIElement casts

## Testing

- `swift build` succeeds locally with no CF downcast warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
