### PR TITLE
Fix remaining SMS parity gaps (guardian context + assistant scoping)

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1295,6 +1295,31 @@ describe('IPC handler channel-aware guardian status', () => {
     expect(resp!.assistantId).toBe('self');
   });
 
+  test('status action returns guardian username/displayName from binding metadata', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'user-43',
+      guardianDeliveryChatId: 'chat-43',
+      metadataJson: JSON.stringify({ username: 'guardian_handle', displayName: 'Guardian Name' }),
+    });
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'telegram',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.guardianUsername).toBe('guardian_handle');
+    expect(resp!.guardianDisplayName).toBe('Guardian Name');
+  });
+
   test('status action defaults channel to telegram when omitted (backward compat)', () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {

--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { MessagingProvider } from '../messaging/provider.js';
+import type { SendOptions } from '../messaging/provider-types.js';
+
+const sendMessageMock = mock(async (..._args: unknown[]) => ({
+  id: 'msg-1',
+  timestamp: 123,
+  conversationId: 'conv-1',
+}));
+
+const provider: MessagingProvider = {
+  id: 'sms',
+  displayName: 'SMS',
+  credentialService: 'twilio',
+  capabilities: new Set(['send']),
+  testConnection: async () => ({ connected: true, user: 'x', platform: 'sms' }),
+  listConversations: async () => [],
+  getHistory: async () => [],
+  search: async () => ({ total: 0, messages: [], hasMore: false }),
+  sendMessage: (token: string, conversationId: string, text: string, options?: SendOptions) =>
+    sendMessageMock(token, conversationId, text, options),
+};
+
+mock.module('../config/bundled-skills/messaging/tools/shared.js', () => ({
+  resolveProvider: () => provider,
+  withProviderToken: async (_provider: MessagingProvider, fn: (token: string) => Promise<unknown>) => fn('provider-token'),
+  ok: (content: string) => ({ content, isError: false }),
+  err: (content: string) => ({ content, isError: true }),
+}));
+
+import { run } from '../config/bundled-skills/messaging/tools/messaging-send.js';
+
+describe('messaging-send tool', () => {
+  beforeEach(() => {
+    sendMessageMock.mockClear();
+  });
+
+  test('passes assistantId from tool context to provider send options', async () => {
+    const result = await run(
+      {
+        platform: 'sms',
+        conversation_id: '+15550004444',
+        text: 'test message',
+      },
+      {
+        workingDir: '/tmp',
+        sessionId: 'sess-1',
+        conversationId: 'conv-1',
+        assistantId: 'ast-alpha',
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      'provider-token',
+      '+15550004444',
+      'test message',
+      {
+        subject: undefined,
+        inReplyTo: undefined,
+        assistantId: 'ast-alpha',
+      },
+    );
+  });
+});

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -68,6 +68,8 @@ function makeSessionEmittingViaClient(...messages: ServerMessage[]): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -90,6 +92,8 @@ function makeSessionEmittingViaAgentLoop(...messages: ServerMessage[]): Session 
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       for (const msg of messages) {

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -26,6 +26,12 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    secretDetection: { enabled: false },
+  }),
+}));
+
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { createRun, getRun, setRunConfirmation } from '../memory/runs-store.js';
@@ -43,6 +49,8 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -64,6 +72,8 @@ function makeSessionWithEvent(message: ServerMessage): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent(message);
@@ -228,6 +238,8 @@ describe('startRun channel capability resolution', () => {
       setChannelCapabilities: (caps: ChannelCapabilities | null) => {
         if (caps) capturedCapabilities = caps;
       },
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -262,6 +274,8 @@ describe('startRun channel capability resolution', () => {
       setChannelCapabilities: (caps: ChannelCapabilities | null) => {
         if (caps) capturedCapabilities = caps;
       },
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -292,6 +306,8 @@ describe('startRun channel capability resolution', () => {
       setChannelCapabilities: (caps: ChannelCapabilities | null) => {
         if (caps) capturedCapabilities = caps;
       },
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -335,6 +351,8 @@ describe('strictSideEffects re-derivation across runs', () => {
       persistUserMessage: () => undefined as unknown as string,
       memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
       setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -369,6 +387,8 @@ describe('strictSideEffects re-derivation across runs', () => {
       persistUserMessage: () => undefined as unknown as string,
       memoryPolicy: { scopeId: 'private-scope', includeDefaultFallback: true, strictSideEffects: true },
       setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -404,6 +424,8 @@ describe('strictSideEffects re-derivation across runs', () => {
       persistUserMessage: () => undefined as unknown as string,
       memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: true },
       setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -3,12 +3,14 @@ import type { Message } from '../providers/types.js';
 import {
   applyRuntimeInjections,
   injectChannelCapabilityContext,
+  injectGuardianContext,
   injectTemporalContext,
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
+  stripGuardianContext,
   stripTemporalContext,
 } from '../daemon/session-runtime-assembly.js';
-import type { ChannelCapabilities } from '../daemon/session-runtime-assembly.js';
+import type { ChannelCapabilities, GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import { buildChannelAwarenessSection } from '../config/system-prompt.js';
 
 // ---------------------------------------------------------------------------
@@ -277,6 +279,12 @@ describe('buildChannelAwarenessSection', () => {
     const section = buildChannelAwarenessSection();
     expect(section).toContain('computer-control permissions on non-dashboard');
   });
+
+  test('includes guardian context contract for channel actors', () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).toContain('<guardian_context>');
+    expect(section).toContain('Never infer guardian status');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -472,5 +480,81 @@ describe('applyRuntimeInjections with temporalContext', () => {
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// guardian_context
+// ---------------------------------------------------------------------------
+
+describe('injectGuardianContext', () => {
+  const baseUserMessage: Message = {
+    role: 'user',
+    content: [{ type: 'text', text: 'Can you text me updates?' }],
+  };
+
+  test('prepends guardian_context block to user message', () => {
+    const ctx: GuardianRuntimeContext = {
+      sourceChannel: 'sms',
+      actorRole: 'guardian',
+      guardianExternalUserId: 'guardian-user-1',
+      guardianChatId: '+15550001111',
+      requesterIdentifier: '+15550001111',
+      requesterExternalUserId: 'guardian-user-1',
+      requesterChatId: '+15550001111',
+    };
+
+    const result = injectGuardianContext(baseUserMessage, ctx);
+    expect(result.content.length).toBe(2);
+    const injected = result.content[0];
+    expect(injected.type).toBe('text');
+    const text = (injected as { type: 'text'; text: string }).text;
+    expect(text).toContain('<guardian_context>');
+    expect(text).toContain('actor_role: guardian');
+    expect(text).toContain('source_channel: sms');
+    expect(text).toContain('</guardian_context>');
+  });
+});
+
+describe('stripGuardianContext', () => {
+  test('strips guardian_context blocks from user messages', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<guardian_context>\nactor_role: guardian\n</guardian_context>' },
+          { type: 'text', text: 'Hello' },
+        ],
+      },
+    ];
+    const result = stripGuardianContext(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(1);
+    expect((result[0].content[0] as { type: 'text'; text: string }).text).toBe('Hello');
+  });
+});
+
+describe('applyRuntimeInjections with guardianContext', () => {
+  const baseMessages: Message[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Help me send this over SMS.' }],
+    },
+  ];
+
+  test('injects guardian context when provided', () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      guardianContext: {
+        sourceChannel: 'sms',
+        actorRole: 'non-guardian',
+        guardianExternalUserId: 'guardian-1',
+        requesterExternalUserId: 'requester-1',
+        requesterIdentifier: '+15550002222',
+        requesterChatId: '+15550002222',
+      },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(2);
+    expect((result[0].content[0] as { type: 'text'; text: string }).text).toContain('<guardian_context>');
   });
 });

--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const sendSmsMock = mock(async (..._args: unknown[]) => {});
+const getOrCreateConversationMock = mock((_key: string) => ({ conversationId: 'conv-1' }));
+const upsertOutboundBindingMock = mock((_input: Record<string, unknown>) => {});
+
+let secureKeys: Record<string, string | undefined> = {
+  'credential:twilio:account_sid': 'AC1234567890',
+  'credential:twilio:auth_token': 'auth-token',
+};
+
+let configState: {
+  sms?: {
+    phoneNumber?: string;
+    assistantPhoneNumbers?: Record<string, string>;
+  };
+} = {
+  sms: {},
+};
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => secureKeys[key],
+}));
+
+mock.module('../util/platform.js', () => ({
+  readHttpToken: () => 'runtime-token',
+}));
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => configState,
+}));
+
+mock.module('../memory/conversation-key-store.js', () => ({
+  getOrCreateConversation: (key: string) => getOrCreateConversationMock(key),
+}));
+
+mock.module('../memory/external-conversation-store.js', () => ({
+  upsertOutboundBinding: (input: Record<string, unknown>) => upsertOutboundBindingMock(input),
+}));
+
+mock.module('../messaging/providers/sms/client.js', () => ({
+  sendMessage: (
+    gatewayUrl: string,
+    bearerToken: string,
+    to: string,
+    text: string,
+    assistantId?: string,
+  ) => sendSmsMock(gatewayUrl, bearerToken, to, text, assistantId),
+}));
+
+import { smsMessagingProvider } from '../messaging/providers/sms/adapter.js';
+
+describe('smsMessagingProvider', () => {
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    getOrCreateConversationMock.mockClear();
+    upsertOutboundBindingMock.mockClear();
+    secureKeys = {
+      'credential:twilio:account_sid': 'AC1234567890',
+      'credential:twilio:auth_token': 'auth-token',
+    };
+    configState = { sms: {} };
+    delete process.env.TWILIO_PHONE_NUMBER;
+    delete process.env.GATEWAY_INTERNAL_BASE_URL;
+    delete process.env.GATEWAY_PORT;
+  });
+
+  test('isConnected is true when assistant-scoped numbers exist', () => {
+    configState = {
+      sms: {
+        assistantPhoneNumbers: { 'ast-alpha': '+15550001111' },
+      },
+    };
+
+    expect(smsMessagingProvider.isConnected?.()).toBe(true);
+  });
+
+  test('sendMessage forwards explicit assistant scope and avoids outbound binding writes for non-self', async () => {
+    await smsMessagingProvider.sendMessage('', '+15550002222', 'hi', {
+      assistantId: 'ast-alpha',
+    });
+
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:7830',
+      'runtime-token',
+      '+15550002222',
+      'hi',
+      'ast-alpha',
+    );
+    expect(getOrCreateConversationMock).toHaveBeenCalledWith('asst:ast-alpha:sms:+15550002222');
+    expect(upsertOutboundBindingMock).not.toHaveBeenCalled();
+  });
+
+  test('sendMessage uses canonical self key and writes outbound binding for self scope', async () => {
+    await smsMessagingProvider.sendMessage('', '+15550003333', 'hello', {
+      assistantId: 'self',
+    });
+
+    expect(getOrCreateConversationMock).toHaveBeenCalledWith('sms:+15550003333');
+    expect(upsertOutboundBindingMock).toHaveBeenCalledWith({
+      conversationId: 'conv-1',
+      sourceChannel: 'sms',
+      externalChatId: '+15550003333',
+    });
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -1,7 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
 
-export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
   const text = input.text as string;
@@ -21,6 +21,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       const result = await provider.sendMessage(token, conversationId, text, {
         subject,
         inReplyTo,
+        assistantId: context.assistantId,
       });
 
       return ok(`Message sent (ID: ${result.id}).`);

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -395,6 +395,12 @@ export function buildChannelAwarenessSection(): string {
     '- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.',
     '- Do not ask for computer-control permissions on non-dashboard channels.',
     '- When you do request a permission, be transparent about what it enables and why you need it.',
+    '',
+    '### Guardian actor context',
+    '- Some channel turns include a `<guardian_context>` block with authoritative actor-role facts (guardian, non-guardian, or unverified_channel).',
+    '- Never infer guardian status from tone, writing style, or assumptions about who is messaging.',
+    '- Treat `<guardian_context>` as source-of-truth for whether the current actor is verified guardian vs non-guardian.',
+    '- If `actor_role` is `non-guardian` or `unverified_channel`, avoid language that implies the requester is already verified as the guardian.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -12,6 +12,7 @@ import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secu
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { postToSlackWebhook } from '../../slack/slack-webhook.js';
 import { getApp } from '../../memory/app-store.js';
+import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { readHttpToken } from '../../util/platform.js';
 import type {
   ModelSetRequest,
@@ -1518,11 +1519,40 @@ export function handleGuardianVerification(
       });
     } else if (msg.action === 'status') {
       const binding = getGuardianBinding(assistantId, channel);
+      let guardianUsername: string | undefined;
+      let guardianDisplayName: string | undefined;
+      if (binding?.metadataJson) {
+        try {
+          const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
+          if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+            guardianUsername = parsed.username.trim();
+          }
+          if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+            guardianDisplayName = parsed.displayName.trim();
+          }
+        } catch {
+          // ignore malformed metadata
+        }
+      }
+      if (binding?.guardianDeliveryChatId && (!guardianUsername || !guardianDisplayName)) {
+        const ext = externalConversationStore.getBindingByChannelChat(
+          channel,
+          binding.guardianDeliveryChatId,
+        );
+        if (!guardianUsername && ext?.username) {
+          guardianUsername = ext.username;
+        }
+        if (!guardianDisplayName && ext?.displayName) {
+          guardianDisplayName = ext.displayName;
+        }
+      }
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
         bound: binding !== null,
         guardianExternalUserId: binding?.guardianExternalUserId,
+        guardianUsername,
+        guardianDisplayName,
         channel,
         assistantId,
         guardianDeliveryChatId: binding?.guardianDeliveryChatId,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -114,6 +114,8 @@ export async function handleUserMessage(
     }
 
     rlog.info('Processing user message');
+    session.setAssistantId('self');
+    session.setGuardianContext(null);
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -9,6 +9,7 @@ import type { ClientMessage, CuSessionCreate, ServerMessage, SessionTransportMet
 import type { SecretPromptResult } from '../../permissions/secret-prompter.js';
 import { getConfig } from '../../config/loader.js';
 import type { DebouncerMap } from '../../util/debounce.js';
+import type { GuardianRuntimeContext } from '../session-runtime-assembly.js';
 
 const log = getLogger('handlers');
 
@@ -99,6 +100,8 @@ export interface SessionCreateOptions {
   systemPromptOverride?: string;
   maxResponseTokens?: number;
   transport?: SessionTransportMetadata;
+  assistantId?: string;
+  guardianContext?: GuardianRuntimeContext;
   memoryScopeId?: string;
   isPrivateThread?: boolean;
   strictPrivateSideEffects?: boolean;

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -605,6 +605,10 @@ export interface GuardianVerificationResponse {
   assistantId?: string;
   /** The delivery chat ID for the guardian (e.g. Telegram chat ID). Present when action is 'status' and bound is true. */
   guardianDeliveryChatId?: string;
+  /** Optional channel username/handle for the bound guardian (for UI display). */
+  guardianUsername?: string;
+  /** Optional display name for the bound guardian (for UI display). */
+  guardianDisplayName?: string;
   error?: string;
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -666,6 +666,8 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    session.setAssistantId(options?.assistantId ?? 'self');
+    session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     const attachments = attachmentIds
@@ -720,6 +722,8 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    session.setAssistantId(options?.assistantId ?? 'self');
+    session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
 
     const attachments = attachmentIds

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -34,7 +34,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import { buildTemporalContext } from './date-context.js';
-import type { ActiveSurfaceContext, ChannelCapabilities } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
   drainDirectiveDisplayBuffer,
@@ -95,6 +95,7 @@ export interface AgentLoopSessionContext {
   workspaceTopLevelContext: string | null;
   workspaceTopLevelDirty: boolean;
   channelCapabilities?: ChannelCapabilities;
+  guardianContext?: GuardianRuntimeContext;
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
@@ -296,6 +297,7 @@ export async function runAgentLoopImpl(
       activeSurface,
       workspaceTopLevelContext: ctx.workspaceTopLevelContext,
       channelCapabilities: ctx.channelCapabilities ?? null,
+      guardianContext: ctx.guardianContext ?? null,
       temporalContext,
     });
 
@@ -617,6 +619,7 @@ export async function runAgentLoopImpl(
           activeSurface,
           workspaceTopLevelContext: ctx.workspaceTopLevelContext,
           channelCapabilities: ctx.channelCapabilities ?? null,
+          guardianContext: ctx.guardianContext ?? null,
           temporalContext,
         });
         preRepairMessages = runMessages;
@@ -649,6 +652,7 @@ export async function runAgentLoopImpl(
             activeSurface,
             workspaceTopLevelContext: ctx.workspaceTopLevelContext,
             channelCapabilities: ctx.channelCapabilities ?? null,
+            guardianContext: ctx.guardianContext ?? null,
             temporalContext,
           });
           preRepairMessages = runMessages;

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -25,6 +25,18 @@ export interface ChannelCapabilities {
   supportsVoiceInput: boolean;
 }
 
+/** Guardian identity/trust context for external chat channels. */
+export interface GuardianRuntimeContext {
+  sourceChannel: string;
+  actorRole: 'guardian' | 'non-guardian' | 'unverified_channel';
+  guardianChatId?: string;
+  guardianExternalUserId?: string;
+  requesterIdentifier?: string;
+  requesterExternalUserId?: string;
+  requesterChatId?: string;
+  denialReason?: 'no_binding' | 'no_identity';
+}
+
 /** Derive channel capabilities from a raw source channel identifier. */
 export function resolveChannelCapabilities(sourceChannel?: string | null): ChannelCapabilities {
   const channel = sourceChannel ?? 'dashboard';
@@ -264,6 +276,32 @@ export function injectChannelCapabilityContext(message: Message, caps: ChannelCa
   };
 }
 
+/**
+ * Prepend guardian trust/identity facts to the last user message so the
+ * model can reason about guardian status from deterministic runtime facts.
+ */
+export function injectGuardianContext(message: Message, ctx: GuardianRuntimeContext): Message {
+  const lines: string[] = ['<guardian_context>'];
+  lines.push(`source_channel: ${ctx.sourceChannel}`);
+  lines.push(`actor_role: ${ctx.actorRole}`);
+  lines.push(`guardian_external_user_id: ${ctx.guardianExternalUserId ?? 'unknown'}`);
+  lines.push(`guardian_chat_id: ${ctx.guardianChatId ?? 'unknown'}`);
+  lines.push(`requester_identifier: ${ctx.requesterIdentifier ?? 'unknown'}`);
+  lines.push(`requester_external_user_id: ${ctx.requesterExternalUserId ?? 'unknown'}`);
+  lines.push(`requester_chat_id: ${ctx.requesterChatId ?? 'unknown'}`);
+  lines.push(`denial_reason: ${ctx.denialReason ?? 'none'}`);
+  lines.push('</guardian_context>');
+
+  const block = lines.join('\n');
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Prefix-based stripping primitive
 // ---------------------------------------------------------------------------
@@ -296,6 +334,11 @@ export function stripUserTextBlocksByPrefix(messages: Message[], prefixes: strin
 /** Strip `<channel_capabilities>` blocks injected by `injectChannelCapabilityContext`. */
 export function stripChannelCapabilityContext(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ['<channel_capabilities>']);
+}
+
+/** Strip `<guardian_context>` blocks injected by `injectGuardianContext`. */
+export function stripGuardianContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ['<guardian_context>']);
 }
 
 /**
@@ -358,6 +401,7 @@ export function stripActiveSurfaceContext(messages: Message[]): Message[] {
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   '<channel_capabilities>',
+  '<guardian_context>',
   '<workspace_top_level>',
   TEMPORAL_INJECTED_PREFIX,
   '<active_workspace>',
@@ -398,6 +442,7 @@ export function applyRuntimeInjections(
     activeSurface?: ActiveSurfaceContext | null;
     workspaceTopLevelContext?: string | null;
     channelCapabilities?: ChannelCapabilities | null;
+    guardianContext?: GuardianRuntimeContext | null;
     temporalContext?: string | null;
   },
 ): Message[] {
@@ -429,6 +474,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCapabilityContext(userTail, options.channelCapabilities),
+      ];
+    }
+  }
+
+  if (options.guardianContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectGuardianContext(userTail, options.guardianContext),
       ];
     }
   }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -41,6 +41,7 @@ import { projectSkillTools, type SkillProjectionCache } from './session-skill-to
  */
 export interface ToolSetupContext extends SurfaceSessionContext {
   readonly conversationId: string;
+  assistantId?: string;
   currentRequestId?: string;
   workingDir: string;
   sandboxOverride?: boolean;
@@ -186,6 +187,7 @@ export function createToolExecutor(
       workingDir: ctx.workingDir,
       sessionId: ctx.conversationId,
       conversationId: ctx.conversationId,
+      assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
       onOutput,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -38,7 +38,7 @@ import { getHookManager } from '../hooks/manager.js';
 import { ConflictGate } from './session-conflict-gate.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import type { ChannelCapabilities } from './session-runtime-assembly.js';
+import type { ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { AssistantAttachmentDraft } from './assistant-attachments.js';
 import {
   handleSurfaceAction as handleSurfaceActionImpl,
@@ -127,6 +127,8 @@ export class Session {
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
+  /** @internal */ guardianContext?: GuardianRuntimeContext;
+  /** @internal */ assistantId?: string;
   /** @internal */ pendingSurfaceActions = new Map<string, { surfaceType: SurfaceType }>();
   /** @internal */ lastSurfaceAction = new Map<string, { actionId: string; data?: Record<string, unknown> }>();
   /** @internal */ surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
@@ -325,6 +327,14 @@ export class Session {
 
   setChannelCapabilities(caps: ChannelCapabilities | null): void {
     this.channelCapabilities = caps ?? undefined;
+  }
+
+  setGuardianContext(ctx: GuardianRuntimeContext | null): void {
+    this.guardianContext = ctx ?? undefined;
+  }
+
+  setAssistantId(assistantId: string | null): void {
+    this.assistantId = assistantId ?? undefined;
   }
 
   persistUserMessage(

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -142,6 +142,7 @@ export function createBinding(params: {
   guardianExternalUserId: string;
   guardianDeliveryChatId: string;
   verifiedVia?: string;
+  metadataJson?: string | null;
 }): GuardianBinding {
   const db = getDb();
   const now = Date.now();
@@ -156,7 +157,7 @@ export function createBinding(params: {
     status: 'active' as const,
     verifiedAt: now,
     verifiedVia: params.verifiedVia ?? 'challenge',
-    metadataJson: null,
+    metadataJson: params.metadataJson ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -77,4 +77,6 @@ export interface SendOptions {
   subject?: string;
   /** For email: in-reply-to message ID */
   inReplyTo?: string;
+  /** Optional assistant scope for multi-assistant channels. */
+  assistantId?: string;
 }

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -27,7 +27,7 @@ import type {
   SendOptions,
 } from '../../provider-types.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
-import { readHttpToken, readLockfile } from '../../../util/platform.js';
+import { readHttpToken } from '../../../util/platform.js';
 import { loadConfig } from '../../../config/loader.js';
 import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
@@ -60,28 +60,6 @@ function hasTwilioCredentials(): boolean {
 }
 
 /**
- * Read the current assistantId from the lockfile.
- * Returns the most recently hatched assistant's ID, or undefined if unavailable.
- */
-function getAssistantId(): string | undefined {
-  try {
-    const lockData = readLockfile();
-    const assistants = lockData?.assistants as Array<Record<string, unknown>> | undefined;
-    if (assistants && assistants.length > 0) {
-      const sorted = [...assistants].sort((a, b) => {
-        const dateA = new Date(a.hatchedAt as string || 0).getTime();
-        const dateB = new Date(b.hatchedAt as string || 0).getTime();
-        return dateB - dateA;
-      });
-      return sorted[0].assistantId as string | undefined;
-    }
-  } catch {
-    // ignore — lockfile may not exist
-  }
-  return undefined;
-}
-
-/**
  * Resolve the configured SMS phone number.
  * Priority: assistant-scoped phone number > TWILIO_PHONE_NUMBER env > config sms.phoneNumber > secure key fallback.
  */
@@ -110,6 +88,15 @@ function getPhoneNumber(assistantId?: string): string | undefined {
   return getSecureKey('credential:twilio:phone_number') || undefined;
 }
 
+function hasAnyAssistantPhoneNumber(): boolean {
+  try {
+    const config = loadConfig();
+    return Object.keys(config.sms?.assistantPhoneNumbers ?? {}).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export const smsMessagingProvider: MessagingProvider = {
   id: 'sms',
   displayName: 'SMS',
@@ -122,7 +109,7 @@ export const smsMessagingProvider: MessagingProvider = {
    * the `from` for outbound messages.
    */
   isConnected(): boolean {
-    return hasTwilioCredentials() && !!getPhoneNumber(getAssistantId());
+    return hasTwilioCredentials() && (!!getPhoneNumber() || hasAnyAssistantPhoneNumber());
   },
 
   async testConnection(_token: string): Promise<ConnectionInfo> {
@@ -135,8 +122,8 @@ export const smsMessagingProvider: MessagingProvider = {
       };
     }
 
-    const phoneNumber = getPhoneNumber(getAssistantId());
-    if (!phoneNumber) {
+    const phoneNumber = getPhoneNumber();
+    if (!phoneNumber && !hasAnyAssistantPhoneNumber()) {
       return {
         connected: false,
         user: 'unknown',
@@ -149,19 +136,20 @@ export const smsMessagingProvider: MessagingProvider = {
 
     return {
       connected: true,
-      user: phoneNumber,
+      user: phoneNumber ?? 'assistant-scoped numbers configured',
       platform: 'sms',
       metadata: {
         accountSid: accountSid.slice(0, 6) + '...',
-        phoneNumber,
+        ...(phoneNumber ? { phoneNumber } : {}),
+        hasAssistantScopedPhoneNumbers: hasAnyAssistantPhoneNumber(),
       },
     };
   },
 
-  async sendMessage(_token: string, conversationId: string, text: string, _options?: SendOptions): Promise<SendResult> {
+  async sendMessage(_token: string, conversationId: string, text: string, options?: SendOptions): Promise<SendResult> {
     const gatewayUrl = getGatewayUrl();
     const bearerToken = getBearerToken();
-    const assistantId = getAssistantId();
+    const assistantId = options?.assistantId;
 
     await sms.sendMessage(gatewayUrl, bearerToken, conversationId, text, assistantId);
 
@@ -169,13 +157,20 @@ export const smsMessagingProvider: MessagingProvider = {
     // exists for the next inbound SMS from this number.
     try {
       const sourceChannel = 'sms';
-      const conversationKey = `${sourceChannel}:${conversationId}`;
+      const conversationKey = assistantId && assistantId !== 'self'
+        ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
+        : `${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } = getOrCreateConversation(conversationKey);
-      externalConversationStore.upsertOutboundBinding({
-        conversationId: internalId,
-        sourceChannel,
-        externalChatId: conversationId,
-      });
+      // external_conversation_bindings is assistant-agnostic (unique by
+      // sourceChannel + externalChatId). Restrict proactive writes to self so
+      // multi-assistant sends cannot clobber each other's binding metadata.
+      if (!assistantId || assistantId === 'self') {
+        externalConversationStore.upsertOutboundBinding({
+          conversationId: internalId,
+          sourceChannel,
+          externalChatId: conversationId,
+        });
+      }
     } catch {
       // Best-effort — don't fail the send if binding upsert fails
     }

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -129,6 +129,8 @@ export function validateAndConsumeChallenge(
   secret: string,
   actorExternalUserId: string,
   actorChatId: string,
+  actorUsername?: string,
+  actorDisplayName?: string,
 ): ValidateChallengeResult {
   // ── Rate-limit check ──
   const existing = getRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
@@ -166,6 +168,14 @@ export function validateAndConsumeChallenge(
   // Revoke any existing active binding before creating a new one
   storeRevokeBinding(assistantId, channel);
 
+  const metadata: Record<string, string> = {};
+  if (actorUsername && actorUsername.trim().length > 0) {
+    metadata.username = actorUsername.trim();
+  }
+  if (actorDisplayName && actorDisplayName.trim().length > 0) {
+    metadata.displayName = actorDisplayName.trim();
+  }
+
   // Create the new guardian binding
   const binding = createBinding({
     assistantId,
@@ -173,6 +183,7 @@ export function validateAndConsumeChallenge(
     guardianExternalUserId: actorExternalUserId,
     guardianDeliveryChatId: actorChatId,
     verifiedVia: 'challenge',
+    metadataJson: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null,
   });
 
   return { success: true, bindingId: binding.id };

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -74,6 +74,7 @@ import { RelayConnection, activeRelayConnections } from '../calls/relay-server.j
 import type { RelayWebSocketData } from '../calls/relay-server.js';
 import { handleSubscribeAssistantEvents } from './routes/events-routes.js';
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 
 // Re-export shared types so existing consumers don't need to update imports
 export type {
@@ -106,6 +107,37 @@ function getGatewayBaseUrl(): string {
 
 /** Global hard cap on request body size (50 MB). Bun rejects larger payloads before they reach handlers. */
 const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
+
+function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  const actorRole = raw.actorRole;
+  if (
+    actorRole !== 'guardian'
+    && actorRole !== 'non-guardian'
+    && actorRole !== 'unverified_channel'
+  ) {
+    return undefined;
+  }
+  const sourceChannel = typeof raw.sourceChannel === 'string' && raw.sourceChannel.trim().length > 0
+    ? raw.sourceChannel
+    : undefined;
+  if (!sourceChannel) return undefined;
+  const denialReason =
+    raw.denialReason === 'no_binding' || raw.denialReason === 'no_identity'
+      ? raw.denialReason
+      : undefined;
+  return {
+    sourceChannel,
+    actorRole,
+    guardianChatId: typeof raw.guardianChatId === 'string' ? raw.guardianChatId : undefined,
+    guardianExternalUserId: typeof raw.guardianExternalUserId === 'string' ? raw.guardianExternalUserId : undefined,
+    requesterIdentifier: typeof raw.requesterIdentifier === 'string' ? raw.requesterIdentifier : undefined,
+    requesterExternalUserId: typeof raw.requesterExternalUserId === 'string' ? raw.requesterExternalUserId : undefined,
+    requesterChatId: typeof raw.requesterChatId === 'string' ? raw.requesterChatId : undefined,
+    denialReason,
+  };
+}
 
 interface DiskSpaceInfo {
   path: string;
@@ -907,6 +939,10 @@ export class RuntimeHttpServer {
       const attachmentIds = Array.isArray(payload.attachmentIds) ? payload.attachmentIds as string[] : undefined;
       const sourceChannel = payload.sourceChannel as string;
       const sourceMetadata = payload.sourceMetadata as Record<string, unknown> | undefined;
+      const assistantId = typeof payload.assistantId === 'string'
+        ? payload.assistantId
+        : undefined;
+      const guardianContext = parseGuardianRuntimeContext(payload.guardianCtx);
 
       const metadataHintsRaw = sourceMetadata?.hints;
       const metadataHints = Array.isArray(metadataHintsRaw)
@@ -927,6 +963,8 @@ export class RuntimeHttpServer {
               hints: metadataHints.length > 0 ? metadataHints : undefined,
               uxBrief: metadataUxBrief,
             },
+            assistantId,
+            guardianContext,
           },
         );
         channelDeliveryStore.linkMessage(event.id, userMessageId);
@@ -939,9 +977,6 @@ export class RuntimeHttpServer {
         if (replyCallbackUrl) {
           const externalChatId = typeof payload.externalChatId === 'string'
             ? payload.externalChatId
-            : undefined;
-          const assistantId = typeof payload.assistantId === 'string'
-            ? payload.assistantId
             : undefined;
           if (externalChatId) {
             await this.deliverReplyViaCallback(

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -2,6 +2,7 @@
  * Shared types for the runtime HTTP server and its route handlers.
  */
 import type { RunOrchestrator } from './run-orchestrator.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 
 export interface RuntimeMessageSessionOptions {
   transport?: {
@@ -9,6 +10,8 @@ export interface RuntimeMessageSessionOptions {
     hints?: string[];
     uxBrief?: string;
   };
+  assistantId?: string;
+  guardianContext?: GuardianRuntimeContext;
 }
 
 export type MessageProcessor = (

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -44,6 +44,7 @@ import type {
   MessageProcessor,
   RuntimeAttachmentMetadata,
 } from '../http-types.js';
+import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
 
 const log = getLogger('runtime-http');
 
@@ -108,6 +109,19 @@ export interface GuardianContext {
   requesterChatId?: string;
   /** Sub-reason when actorRole is 'unverified_channel'. */
   denialReason?: DenialReason;
+}
+
+function toGuardianRuntimeContext(sourceChannel: string, ctx: GuardianContext): GuardianRuntimeContext {
+  return {
+    sourceChannel,
+    actorRole: ctx.actorRole,
+    guardianChatId: ctx.guardianChatId,
+    guardianExternalUserId: ctx.guardianExternalUserId,
+    requesterIdentifier: ctx.requesterIdentifier,
+    requesterExternalUserId: ctx.requesterExternalUserId,
+    requesterChatId: ctx.requesterChatId,
+    denialReason: ctx.denialReason,
+  };
 }
 
 /** Guardian approval request expiry (30 minutes). */
@@ -396,6 +410,8 @@ export async function handleChannelInbound(
         token,
         body.senderExternalUserId,
         externalChatId,
+        body.senderUsername,
+        body.senderName,
       );
 
       const replyText = verifyResult.success
@@ -427,15 +443,25 @@ export async function handleChannelInbound(
   // side-effect controls and their approvals route to the guardian's chat.
   //
   // Guardian actor-role resolution always runs.
-  let guardianCtx: GuardianContext = { actorRole: 'guardian' };
+  let guardianCtx: GuardianContext;
   if (body.senderExternalUserId) {
+    const requesterLabel = body.senderUsername
+      ? `@${body.senderUsername}`
+      : body.senderExternalUserId;
     const senderIsGuardian = isGuardian(assistantId, sourceChannel, body.senderExternalUserId);
-    if (!senderIsGuardian) {
+    if (senderIsGuardian) {
+      const binding = getGuardianBinding(assistantId, sourceChannel);
+      guardianCtx = {
+        actorRole: 'guardian',
+        guardianChatId: binding?.guardianDeliveryChatId ?? externalChatId,
+        guardianExternalUserId: binding?.guardianExternalUserId ?? body.senderExternalUserId,
+        requesterIdentifier: requesterLabel,
+        requesterExternalUserId: body.senderExternalUserId,
+        requesterChatId: externalChatId,
+      };
+    } else {
       const binding = getGuardianBinding(assistantId, sourceChannel);
       if (binding) {
-        const requesterLabel = body.senderUsername
-          ? `@${body.senderUsername}`
-          : body.senderExternalUserId;
         guardianCtx = {
           actorRole: 'non-guardian',
           guardianChatId: binding.guardianDeliveryChatId,
@@ -450,6 +476,7 @@ export async function handleChannelInbound(
         guardianCtx = {
           actorRole: 'unverified_channel',
           denialReason: 'no_binding',
+          requesterIdentifier: requesterLabel,
           requesterExternalUserId: body.senderExternalUserId,
           requesterChatId: externalChatId,
         };
@@ -462,6 +489,7 @@ export async function handleChannelInbound(
     guardianCtx = {
       actorRole: 'unverified_channel',
       denialReason: 'no_identity',
+      requesterIdentifier: body.senderUsername ? `@${body.senderUsername}` : undefined,
       requesterExternalUserId: undefined,
       requesterChatId: externalChatId,
     };
@@ -524,6 +552,7 @@ export async function handleChannelInbound(
       senderName: body.senderName,
       senderExternalUserId: body.senderExternalUserId,
       senderUsername: body.senderUsername,
+      guardianCtx,
       replyCallbackUrl,
       assistantId,
     });
@@ -576,6 +605,7 @@ export async function handleChannelInbound(
         attachmentIds: hasAttachments ? attachmentIds : undefined,
         sourceChannel,
         externalChatId,
+        guardianCtx,
         metadataHints,
         metadataUxBrief,
         replyCallbackUrl,
@@ -600,6 +630,7 @@ interface BackgroundProcessingParams {
   attachmentIds?: string[];
   sourceChannel: string;
   externalChatId: string;
+  guardianCtx: GuardianContext;
   metadataHints: string[];
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
@@ -616,6 +647,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     attachmentIds,
     sourceChannel,
     externalChatId,
+    guardianCtx,
     metadataHints,
     metadataUxBrief,
     replyCallbackUrl,
@@ -635,6 +667,8 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
             hints: metadataHints.length > 0 ? metadataHints : undefined,
             uxBrief: metadataUxBrief,
           },
+          assistantId,
+          guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
         },
         sourceChannel,
       );
@@ -744,6 +778,8 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
           sourceChannel,
           hints: metadataHints.length > 0 ? metadataHints : undefined,
           uxBrief: metadataUxBrief,
+          assistantId,
+          guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
         },
       );
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -18,6 +18,7 @@ import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import { resolveChannelCapabilities } from '../daemon/session-runtime-assembly.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import type { UserDecision } from '../permissions/types.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';
@@ -81,6 +82,10 @@ export interface RunStartOptions {
    * Forwarded to the session so the agent loop can tailor its response.
    */
   uxBrief?: string;
+  /** Assistant scope for multi-assistant channels. */
+  assistantId?: string;
+  /** Guardian trust/identity context for the inbound actor. */
+  guardianContext?: GuardianRuntimeContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +150,8 @@ export class RunOrchestrator {
       ...session.memoryPolicy,
       strictSideEffects,
     };
+    session.setAssistantId(options?.assistantId ?? 'self');
+    session.setGuardianContext(options?.guardianContext ?? null);
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)
@@ -225,6 +232,8 @@ export class RunOrchestrator {
       // Reset channel capabilities so a subsequent IPC/desktop session on the
       // same conversation is not incorrectly treated as an HTTP-API client.
       session.setChannelCapabilities(null);
+      session.setGuardianContext(null);
+      session.setAssistantId('self');
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.
       // Set hasNoClient=true here since the run is done and no HTTP caller

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -41,8 +41,8 @@ function formatBytes(bytes: number): string {
 /**
  * Load an attachment row (including base64 data) by its primary key.
  *
- * Not scoped by assistantId because ToolContext doesn't carry it.
- * Cross-thread isolation is enforced by the visibility check in execute().
+ * Not scoped by assistantId because attachment access is enforced by
+ * conversation visibility checks in execute().
  */
 function loadAttachmentById(
   attachmentId: string,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -87,6 +87,8 @@ export interface ToolContext {
   workingDir: string;
   sessionId: string;
   conversationId: string;
+  /** Logical assistant scope for multi-assistant routing. */
+  assistantId?: string;
   /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
   /** Per-message request ID for log correlation across session/connection boundaries. */

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -614,15 +614,47 @@ struct SettingsConnectTab: View {
 
     private var guardianLabel: some View {
         HStack(spacing: VSpacing.xs) {
-            Text("Guardian")
+            Text("Verification")
             Image(systemName: "info.circle")
                 .font(.system(size: 10))
                 .foregroundColor(VColor.textMuted)
-                .help("Guardian verifies your identity so only you can interact with your assistant on this channel.")
+                .help("Guardian verification links your account identity for this channel.")
         }
         .font(VFont.caption)
         .foregroundColor(VColor.textSecondary)
         .frame(width: 90, alignment: .leading)
+    }
+
+    private func guardianPrimaryIdentity(channel: String, identity: String?) -> String? {
+        if channel == "telegram" {
+            if let username = store.telegramGuardianUsername?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !username.isEmpty {
+                return username.hasPrefix("@") ? username : "@\(username)"
+            }
+            if let displayName = store.telegramGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !displayName.isEmpty {
+                return displayName
+            }
+        } else if channel == "sms" {
+            if let displayName = store.smsGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !displayName.isEmpty {
+                return displayName
+            }
+        }
+        return identity
+    }
+
+    private func guardianSecondaryIdentity(primary: String?, identity: String?) -> String? {
+        guard let identity = identity?.trimmingCharacters(in: .whitespacesAndNewlines), !identity.isEmpty else {
+            return nil
+        }
+        if let primary {
+            let normalizedPrimary = primary.trimmingCharacters(in: .whitespacesAndNewlines)
+            if normalizedPrimary.caseInsensitiveCompare(identity) == .orderedSame {
+                return nil
+            }
+        }
+        return "ID: \(identity)"
     }
 
     @ViewBuilder
@@ -632,6 +664,8 @@ struct SettingsConnectTab: View {
         let inProgress: Bool = channel == "telegram" ? store.telegramGuardianVerificationInProgress : store.smsGuardianVerificationInProgress
         let instruction: String? = channel == "telegram" ? store.telegramGuardianInstruction : store.smsGuardianInstruction
         let error: String? = channel == "telegram" ? store.telegramGuardianError : store.smsGuardianError
+        let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
+        let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             if verified {
@@ -640,10 +674,18 @@ struct SettingsConnectTab: View {
                     Image(systemName: "checkmark.shield.fill")
                         .foregroundColor(VColor.success)
                         .font(.system(size: 12))
-                    Text(identity.map { "Verified: \($0)" } ?? "Verified")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(primaryIdentity ?? "Verified")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(1)
+                        if let secondaryIdentity {
+                            Text(secondaryIdentity)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                        }
+                    }
                     Spacer()
                     VButton(label: "Revoke", style: .danger) {
                         store.revokeChannelGuardian(channel: channel)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -104,6 +104,8 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Channel Guardian State (Telegram)
 
     @Published var telegramGuardianIdentity: String?
+    @Published var telegramGuardianUsername: String?
+    @Published var telegramGuardianDisplayName: String?
     @Published var telegramGuardianVerified: Bool = false
     @Published var telegramGuardianVerificationInProgress: Bool = false
     @Published var telegramGuardianInstruction: String?
@@ -112,6 +114,8 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Channel Guardian State (SMS)
 
     @Published var smsGuardianIdentity: String?
+    @Published var smsGuardianUsername: String?
+    @Published var smsGuardianDisplayName: String?
     @Published var smsGuardianVerified: Bool = false
     @Published var smsGuardianVerificationInProgress: Bool = false
     @Published var smsGuardianInstruction: String?
@@ -177,6 +181,14 @@ public final class SettingsStore: ObservableObject {
             return stored
         }
         return "self"
+    }
+
+    private static func reflectedString(_ value: Any, key: String) -> String? {
+        for child in Mirror(reflecting: value).children {
+            guard child.label == key else { continue }
+            return child.value as? String
+        }
+        return nil
     }
 
     init(
@@ -371,6 +383,8 @@ public final class SettingsStore: ObservableObject {
                 self.telegramGuardianVerificationInProgress = false
                 if response.success {
                     self.telegramGuardianIdentity = response.guardianExternalUserId
+                    self.telegramGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.telegramGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
                     self.telegramGuardianVerified = isVerified
                     if isVerified {
@@ -386,6 +400,8 @@ public final class SettingsStore: ObservableObject {
                 self.smsGuardianVerificationInProgress = false
                 if response.success {
                     self.smsGuardianIdentity = response.guardianExternalUserId
+                    self.smsGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.smsGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
                     self.smsGuardianVerified = isVerified
                     if isVerified {


### PR DESCRIPTION
## Summary
- thread guardian actor facts into runtime prompt injection via a deterministic `<guardian_context>` block and explicit channel-awareness prompt rules
- propagate assistant scope through tool execution (`ToolContext.assistantId`) and use it in `messaging_send` + SMS provider delivery path
- remove SMS lockfile assistant heuristic, use explicit assistant scope for sends, and prevent non-self outbound binding clobber on assistant-agnostic `external_conversation_bindings`
- enrich guardian verification status with optional username/display metadata and improve macOS Settings guardian presentation (verification labeling + primary identity with de-emphasized ID)
- add focused tests for guardian context injection, SMS provider scoping behavior, messaging send assistant scoping, and guardian metadata status responses

## Validation
- `bun test src/__tests__/session-runtime-assembly.test.ts src/__tests__/sms-messaging-provider.test.ts src/__tests__/messaging-send-tool.test.ts src/__tests__/channel-guardian.test.ts src/__tests__/run-orchestrator.test.ts src/__tests__/run-orchestrator-assistant-events.test.ts`
- `bun test src/__tests__/channel-approval-routes.test.ts`

## Notes
- Full `bunx tsc --noEmit` is currently blocked by an unrelated pre-existing snapshot typing issue in `src/__tests__/ipc-snapshot.test.ts` (missing `ride_shotgun_progress` key in that snapshot map).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
