### PR TITLE
fix: replace AX force-cast with CFGetTypeID check in WatchSession

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -174,7 +174,8 @@ public final class WatchSession: ObservableObject {
         guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
         let appRef = AXUIElementCreateApplication(app.processIdentifier)
         var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &value) == .success else {
+        guard AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &value) == .success,
+              let value = value, CFGetTypeID(value) == AXUIElementGetTypeID() else {
             return nil
         }
         let window = value as! AXUIElement


### PR DESCRIPTION
Replaces the remaining as! AXUIElement force-cast with CFGetTypeID runtime type validation. Uses the same pattern established in PR #7323 for other AX files. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
