### PR TITLE
fix: require HTTPS for non-local iOS gateway connections

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -194,6 +194,17 @@ struct DaemonConnectionSection: View {
             return
         }
 
+        // Require HTTPS for non-local connections (ATS policy)
+        if url.scheme == "http" {
+            let host = url.host ?? ""
+            let isLocal = host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".local")
+            if !isLocal {
+                alertMessage = "HTTPS is required for non-local connections."
+                showingAlert = true
+                return
+            }
+        }
+
         let trimmedAuth = manualAuthValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedAuth.isEmpty else {
             alertMessage = "Please enter a bearer token."


### PR DESCRIPTION
Enforces HTTPS for non-local hosts in the iOS manual connect flow. HTTP is still allowed for localhost, 127.0.0.1, and *.local (matching ATS exception domains). Shows a validation error when users attempt non-local HTTP. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
