### PR TITLE
fix: guard Application Support directory lookup in DebugStateWriter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -17,7 +17,8 @@ final class DebugStateWriter {
     private let encoder: JSONEncoder
 
     init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
         let dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.fileURL = dir.appendingPathComponent("debug-state.json")


### PR DESCRIPTION
Replaces .first! with a safe fallback to the temporary directory when Application Support is unavailable. Prevents crashes in edge-case environments. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
