### PR TITLE
fix: regenerate IPC bindings after SMS parity changes

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1542,9 +1542,13 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let assistantId: String?
     /// The delivery chat ID for the guardian (e.g. Telegram chat ID). Present when action is 'status' and bound is true.
     public let guardianDeliveryChatId: String?
+    /// Optional channel username/handle for the bound guardian (for UI display).
+    public let guardianUsername: String?
+    /// Optional display name for the bound guardian (for UI display).
+    public let guardianDisplayName: String?
     public let error: String?
 
-    public init(type: String, success: Bool, secret: String?, instruction: String?, bound: Bool?, guardianExternalUserId: String?, channel: String?, assistantId: String?, guardianDeliveryChatId: String?, error: String?) {
+    public init(type: String, success: Bool, secret: String?, instruction: String?, bound: Bool?, guardianExternalUserId: String?, channel: String?, assistantId: String?, guardianDeliveryChatId: String?, guardianUsername: String?, guardianDisplayName: String?, error: String?) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1554,6 +1558,8 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.channel = channel
         self.assistantId = assistantId
         self.guardianDeliveryChatId = guardianDeliveryChatId
+        self.guardianUsername = guardianUsername
+        self.guardianDisplayName = guardianDisplayName
         self.error = error
     }
 }


### PR DESCRIPTION
## Summary
Regenerates `IPCContractGenerated.swift` to match IPC contract changes from PR #7324. Fixes CI `check:ipc-generated` failure.

## Changes
- Added `guardianUsername` and `guardianDisplayName` optional fields to `IPCGuardianVerificationResponse` in the generated Swift bindings

## Test plan
- [ ] CI `check:ipc-generated` passes
- [ ] CI `ipc:inventory` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
