### PR TITLE
fix: use ResourceBundle for editor asset lookup instead of Bundle.main

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -199,7 +199,7 @@ struct DocumentEditorView: NSViewRepresentable {
 private func loadEditorAsset(_ filename: String) -> String {
     let name = (filename as NSString).deletingPathExtension
     let ext = (filename as NSString).pathExtension
-    guard let url = Bundle.main.url(forResource: name, withExtension: ext, subdirectory: "editor"),
+    guard let url = ResourceBundle.bundle.url(forResource: name, withExtension: ext, subdirectory: "editor"),
           let contents = try? String(contentsOf: url, encoding: .utf8) else {
         log.error("Failed to load bundled editor asset: \(filename)")
         return ""


### PR DESCRIPTION
Fixes critical bug from PR #7336: SPM .copy() resources are in the library resource bundle, not Bundle.main. Uses ResourceBundle.bundle matching the pattern used by RecipeExecutor and DynamicPageSurfaceView. Without this fix, the editor would fail to load in production builds. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
