### PR TITLE
fix: expand local host detection for iOS HTTP validation

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -181,6 +181,39 @@ struct DaemonConnectionSection: View {
         }
     }
 
+    // MARK: - Local Host Detection
+
+    /// Checks whether a host string refers to a local or private-network address.
+    /// Used to allow plain HTTP for LAN/loopback endpoints while requiring HTTPS
+    /// for public hosts (ATS policy). Comparison is case-insensitive.
+    static func isLocalHost(_ rawHost: String) -> Bool {
+        let host = rawHost.lowercased()
+
+        // Loopback & mDNS
+        if host == "localhost" || host == "::1" || host.hasSuffix(".local") {
+            return true
+        }
+
+        // IPv6 link-local (fe80::…)
+        if host.hasPrefix("fe80:") {
+            return true
+        }
+
+        let octets = host.split(separator: ".").compactMap { UInt8($0) }
+        if octets.count == 4 {
+            // 127.0.0.0/8 — full loopback range
+            if octets[0] == 127 { return true }
+            // 10.0.0.0/8 — private
+            if octets[0] == 10 { return true }
+            // 172.16.0.0/12 — private (172.16.x.x through 172.31.x.x)
+            if octets[0] == 172 && (16...31).contains(octets[1]) { return true }
+            // 192.168.0.0/16 — private
+            if octets[0] == 192 && octets[1] == 168 { return true }
+        }
+
+        return false
+    }
+
     // MARK: - Manual Connection
 
     private func connectManually() {
@@ -196,9 +229,7 @@ struct DaemonConnectionSection: View {
 
         // Require HTTPS for non-local connections (ATS policy)
         if url.scheme == "http" {
-            let host = url.host ?? ""
-            let isLocal = host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".local")
-            if !isLocal {
+            if !Self.isLocalHost(url.host ?? "") {
                 alertMessage = "HTTPS is required for non-local connections."
                 showingAlert = true
                 return


### PR DESCRIPTION
Addresses review feedback on PR #7334: (1) lowercases host for case-insensitive comparison, (2) adds private IP range detection (10.x, 172.16-31.x, 192.168.x, ::1, fe80::, 127.x) so LAN addresses are treated as local. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
