### PR TITLE
fix: require exact 4-part IPv4 in local host detection

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -199,8 +199,9 @@ struct DaemonConnectionSection: View {
             return true
         }
 
-        let octets = host.split(separator: ".").compactMap { UInt8($0) }
-        if octets.count == 4 {
+        let parts = host.split(separator: ".")
+        let octets = parts.compactMap { UInt8($0) }
+        if parts.count == 4 && octets.count == 4 {
             // 127.0.0.0/8 — full loopback range
             if octets[0] == 127 { return true }
             // 10.0.0.0/8 — private


### PR DESCRIPTION
Addresses review feedback on PR #7339: adds parts.count == 4 check before compactMap to prevent crafted hostnames like 10.0.0.1.evil.com from bypassing HTTPS enforcement. Part of #7325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
