### PR TITLE
M1: macOS-Parity Prompt Composition Foundation

### DIFF
--- a/assistant/src/__tests__/approval-message-composer.test.ts
+++ b/assistant/src/__tests__/approval-message-composer.test.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  composeApprovalMessage,
+  getFallbackMessage,
+} from '../runtime/approval-message-composer.js';
+import type {
+  ApprovalMessageScenario,
+  ApprovalMessageContext,
+} from '../runtime/approval-message-composer.js';
+
+// ---------------------------------------------------------------------------
+// Every scenario must produce a non-empty string
+// ---------------------------------------------------------------------------
+
+const ALL_SCENARIOS: ApprovalMessageScenario[] = [
+  'standard_prompt',
+  'guardian_prompt',
+  'reminder_prompt',
+  'guardian_delivery_failed',
+  'guardian_request_forwarded',
+  'guardian_disambiguation',
+  'guardian_identity_mismatch',
+  'request_pending_guardian',
+  'guardian_decision_outcome',
+  'guardian_expired_requester',
+  'guardian_expired_guardian',
+  'guardian_verify_success',
+  'guardian_verify_failed',
+  'guardian_verify_challenge_setup',
+  'guardian_verify_status_bound',
+  'guardian_verify_status_unbound',
+  'guardian_deny_no_identity',
+  'guardian_deny_no_binding',
+];
+
+describe('approval-message-composer', () => {
+  // -----------------------------------------------------------------------
+  // Fallback messages — every scenario produces non-empty output
+  // -----------------------------------------------------------------------
+
+  describe('getFallbackMessage', () => {
+    for (const scenario of ALL_SCENARIOS) {
+      test(`scenario "${scenario}" produces a non-empty string`, () => {
+        const msg = getFallbackMessage({ scenario });
+        expect(typeof msg).toBe('string');
+        expect(msg.trim().length).toBeGreaterThan(0);
+      });
+    }
+
+    test('standard_prompt includes toolName when provided', () => {
+      const msg = getFallbackMessage({
+        scenario: 'standard_prompt',
+        toolName: 'execute_shell',
+      });
+      expect(msg).toContain('execute_shell');
+    });
+
+    test('guardian_prompt includes requester identifier and toolName', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_prompt',
+        toolName: 'write_file',
+        requesterIdentifier: 'alice',
+      });
+      expect(msg).toContain('alice');
+      expect(msg).toContain('write_file');
+    });
+
+    test('guardian_disambiguation includes pendingCount', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_disambiguation',
+        pendingCount: 3,
+      });
+      expect(msg).toContain('3');
+    });
+
+    test('guardian_decision_outcome includes decision and toolName', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_decision_outcome',
+        decision: 'approved',
+        toolName: 'read_file',
+      });
+      expect(msg).toContain('approved');
+      expect(msg).toContain('read_file');
+    });
+
+    test('guardian_expired_requester includes toolName', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_expired_requester',
+        toolName: 'deploy',
+      });
+      expect(msg).toContain('deploy');
+      expect(msg).toContain('expired');
+    });
+
+    test('guardian_expired_guardian includes requester and toolName', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_expired_guardian',
+        requesterIdentifier: 'bob',
+        toolName: 'delete_file',
+      });
+      expect(msg).toContain('bob');
+      expect(msg).toContain('delete_file');
+    });
+
+    test('guardian_verify_failed includes failureReason', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_verify_failed',
+        failureReason: 'Code did not match.',
+      });
+      expect(msg).toContain('Code did not match.');
+    });
+
+    test('guardian_verify_challenge_setup includes verifyCommand and ttlSeconds', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_verify_challenge_setup',
+        verifyCommand: '/verify abc123',
+        ttlSeconds: 30,
+      });
+      expect(msg).toContain('/verify abc123');
+      expect(msg).toContain('30');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // composeApprovalMessage — layered source selection
+  // -----------------------------------------------------------------------
+
+  describe('composeApprovalMessage', () => {
+    test('returns assistantPreface when provided (primary source)', () => {
+      const preface = 'The assistant already said something helpful.';
+      const msg = composeApprovalMessage({
+        scenario: 'standard_prompt',
+        toolName: 'execute_shell',
+        assistantPreface: preface,
+      });
+      expect(msg).toBe(preface);
+    });
+
+    test('ignores empty assistantPreface and falls back to template', () => {
+      const msg = composeApprovalMessage({
+        scenario: 'standard_prompt',
+        toolName: 'execute_shell',
+        assistantPreface: '',
+      });
+      expect(msg).toContain('execute_shell');
+      expect(msg).not.toBe('');
+    });
+
+    test('ignores whitespace-only assistantPreface', () => {
+      const msg = composeApprovalMessage({
+        scenario: 'standard_prompt',
+        toolName: 'execute_shell',
+        assistantPreface: '   ',
+      });
+      expect(msg).toContain('execute_shell');
+    });
+
+    test('falls back to deterministic template when no assistantPreface', () => {
+      const msg = composeApprovalMessage({
+        scenario: 'guardian_prompt',
+        toolName: 'write_file',
+        requesterIdentifier: 'charlie',
+      });
+      expect(msg).toContain('charlie');
+      expect(msg).toContain('write_file');
+    });
+
+    test('fallback matches getFallbackMessage output', () => {
+      const ctx: ApprovalMessageContext = {
+        scenario: 'reminder_prompt',
+      };
+      expect(composeApprovalMessage(ctx)).toBe(getFallbackMessage(ctx));
+    });
+  });
+});

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -41,6 +41,7 @@ import {
   buildApprovalUIMetadata,
   handleChannelDecision,
   buildReminderPrompt,
+  buildGuardianApprovalPrompt,
   channelSupportsRichApprovalUI,
 } from '../runtime/channel-approvals.js';
 import type { ApprovalDecisionResult, ChannelApprovalPrompt } from '../runtime/channel-approval-types.js';
@@ -547,7 +548,53 @@ describe('buildReminderPrompt', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 5. channelSupportsRichApprovalUI
+// 5. buildGuardianApprovalPrompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildGuardianApprovalPrompt', () => {
+  test('prompt includes requester identifier and tool name', () => {
+    const runInfo: PendingRunInfo = {
+      runId: 'run-g1',
+      requestId: 'req-g1',
+      toolName: 'deploy',
+      input: {},
+      riskLevel: 'high',
+    };
+    const prompt = buildGuardianApprovalPrompt(runInfo, 'alice');
+    expect(prompt.promptText).toContain('alice');
+    expect(prompt.promptText).toContain('deploy');
+  });
+
+  test('excludes approve_always action', () => {
+    const runInfo: PendingRunInfo = {
+      runId: 'run-g2',
+      requestId: 'req-g2',
+      toolName: 'shell',
+      input: {},
+      riskLevel: 'medium',
+    };
+    const prompt = buildGuardianApprovalPrompt(runInfo, 'bob');
+    expect(prompt.actions.map((a) => a.id)).not.toContain('approve_always');
+    expect(prompt.actions.map((a) => a.id)).toContain('approve_once');
+    expect(prompt.actions.map((a) => a.id)).toContain('reject');
+  });
+
+  test('plainTextFallback contains parser-compatible keywords', () => {
+    const runInfo: PendingRunInfo = {
+      runId: 'run-g3',
+      requestId: 'req-g3',
+      toolName: 'write_file',
+      input: {},
+      riskLevel: 'high',
+    };
+    const prompt = buildGuardianApprovalPrompt(runInfo, 'charlie');
+    expect(prompt.plainTextFallback).toContain('yes');
+    expect(prompt.plainTextFallback).toContain('no');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. channelSupportsRichApprovalUI
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('channelSupportsRichApprovalUI', () => {

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -1,0 +1,141 @@
+/**
+ * Layered approval message composition system.
+ *
+ * Generates approval prompt text through a priority chain:
+ *   1. Assistant preface (macOS parity — reuse existing assistant text)
+ *   2. Deterministic fallback templates (natural, scenario-specific messages)
+ *
+ * A provider-backed generation layer can be inserted between 1 and 2 later.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ApprovalMessageScenario =
+  | 'standard_prompt'
+  | 'guardian_prompt'
+  | 'reminder_prompt'
+  | 'guardian_delivery_failed'
+  | 'guardian_request_forwarded'
+  | 'guardian_disambiguation'
+  | 'guardian_identity_mismatch'
+  | 'request_pending_guardian'
+  | 'guardian_decision_outcome'
+  | 'guardian_expired_requester'
+  | 'guardian_expired_guardian'
+  | 'guardian_verify_success'
+  | 'guardian_verify_failed'
+  | 'guardian_verify_challenge_setup'
+  | 'guardian_verify_status_bound'
+  | 'guardian_verify_status_unbound'
+  | 'guardian_deny_no_identity'
+  | 'guardian_deny_no_binding';
+
+export interface ApprovalMessageContext {
+  scenario: ApprovalMessageScenario;
+  channel?: string;
+  toolName?: string;
+  requesterIdentifier?: string;
+  guardianIdentifier?: string;
+  pendingCount?: number;
+  decision?: 'approved' | 'denied';
+  richUi?: boolean;
+  /** Pre-existing assistant text to reuse (macOS parity). */
+  assistantPreface?: string;
+  verifyCommand?: string;
+  ttlSeconds?: number;
+  failureReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose an approval message using layered source selection:
+ *   1. If an assistant preface is provided and non-empty, return it directly.
+ *   2. Otherwise fall back to a deterministic scenario-specific template.
+ */
+export function composeApprovalMessage(context: ApprovalMessageContext): string {
+  if (context.assistantPreface && context.assistantPreface.trim().length > 0) {
+    return context.assistantPreface;
+  }
+
+  return getFallbackMessage(context);
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fallback templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a scenario-specific deterministic fallback message.
+ *
+ * Each template is slightly more conversational than the old hard-coded
+ * strings while preserving all required semantic content (tool name,
+ * who must approve, next action, etc.).
+ */
+export function getFallbackMessage(context: ApprovalMessageContext): string {
+  switch (context.scenario) {
+    case 'standard_prompt':
+      return `I'd like to use the tool "${context.toolName ?? 'unknown'}". Would you like to allow this?`;
+
+    case 'guardian_prompt':
+      return `${context.requesterIdentifier ?? 'A user'} is requesting to use "${context.toolName ?? 'unknown'}". Please approve or deny this request.`;
+
+    case 'reminder_prompt':
+      return "I'm still waiting for your decision on the pending approval request.";
+
+    case 'guardian_delivery_failed':
+      return "I wasn't able to reach the guardian to request approval. The request has been denied for safety.";
+
+    case 'guardian_request_forwarded':
+      return "Your request has been forwarded to the guardian for approval. I'll let you know once they decide.";
+
+    case 'guardian_disambiguation':
+      return `There are ${context.pendingCount ?? 'multiple'} pending approval requests. Please use the approval buttons to specify which request you're responding to.`;
+
+    case 'guardian_identity_mismatch':
+      return 'This approval request can only be handled by the designated guardian.';
+
+    case 'request_pending_guardian':
+      return 'Your request is pending guardian approval. Please wait for the guardian to respond.';
+
+    case 'guardian_decision_outcome':
+      return `The guardian has ${context.decision ?? 'decided on'} your request to use "${context.toolName ?? 'unknown'}".`;
+
+    case 'guardian_expired_requester':
+      return `The approval request for "${context.toolName ?? 'unknown'}" has expired without a guardian response. The request has been denied.`;
+
+    case 'guardian_expired_guardian':
+      return `The approval request from ${context.requesterIdentifier ?? 'the requester'} for "${context.toolName ?? 'unknown'}" has expired.`;
+
+    case 'guardian_verify_success':
+      return 'Guardian verification successful! You are now set as the guardian for this channel.';
+
+    case 'guardian_verify_failed':
+      return `Verification failed. ${context.failureReason ?? 'Please try again.'}`;
+
+    case 'guardian_verify_challenge_setup':
+      return `To complete guardian verification, send ${context.verifyCommand ?? 'the verification command'} within ${context.ttlSeconds ?? 60} seconds.`;
+
+    case 'guardian_verify_status_bound':
+      return 'A guardian is currently active for this channel.';
+
+    case 'guardian_verify_status_unbound':
+      return 'No guardian is currently configured for this channel.';
+
+    case 'guardian_deny_no_identity':
+      return 'This action requires approval, but your identity could not be verified. The request has been denied for safety.';
+
+    case 'guardian_deny_no_binding':
+      return 'This action requires guardian approval, but no guardian has been configured for this channel. The request has been denied for safety.';
+
+    default: {
+      // Exhaustive check — TypeScript will flag if a scenario is missing.
+      const _exhaustive: never = context.scenario;
+      return `Approval required. ${String(_exhaustive)}`;
+    }
+  }
+}

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -21,6 +21,7 @@ import type {
   ApprovalUIMetadata,
   ApprovalDecisionResult,
 } from './channel-approval-types.js';
+import { composeApprovalMessage } from './approval-message-composer.js';
 
 // ---------------------------------------------------------------------------
 // 1. Detect pending confirmations and build prompt
@@ -47,13 +48,17 @@ export function getChannelApprovalPrompt(
  * Internal helper: turn a PendingRunInfo into a ChannelApprovalPrompt.
  */
 function buildPromptFromRunInfo(info: PendingRunInfo): ChannelApprovalPrompt {
-  const promptText = `The assistant wants to use the tool "${info.toolName}". Do you want to allow this?`;
+  const promptText = composeApprovalMessage({
+    scenario: 'standard_prompt',
+    toolName: info.toolName,
+  });
 
   // Hide "approve always" when persistent trust rules are disallowed for this invocation.
   const actions = info.persistentDecisionsAllowed === false
     ? DEFAULT_APPROVAL_ACTIONS.filter((a) => a.id !== 'approve_always')
     : [...DEFAULT_APPROVAL_ACTIONS];
 
+  // Plain-text fallback must remain parser-compatible (contains "yes"/"always"/"no" keywords).
   const plainTextFallback = info.persistentDecisionsAllowed === false
     ? `${promptText}\n\nReply "yes" to approve or "no" to reject.`
     : `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
@@ -166,8 +171,11 @@ export function buildGuardianApprovalPrompt(
   info: PendingRunInfo,
   requesterIdentifier: string,
 ): ChannelApprovalPrompt {
-  const promptText =
-    `User ${requesterIdentifier} is requesting to run "${info.toolName}". Approve or deny?`;
+  const promptText = composeApprovalMessage({
+    scenario: 'guardian_prompt',
+    toolName: info.toolName,
+    requesterIdentifier,
+  });
 
   // Guardian approvals are always one-time decisions — "approve always"
   // doesn't make sense when the guardian is approving on behalf of someone else.
@@ -211,7 +219,7 @@ export function channelSupportsRichApprovalUI(channel: string): boolean {
 export function buildReminderPrompt(
   pendingPrompt: ChannelApprovalPrompt,
 ): ChannelApprovalPrompt {
-  const reminderPrefix = "I'm still waiting for your decision on the previous request.";
+  const reminderPrefix = composeApprovalMessage({ scenario: 'reminder_prompt' });
   return {
     promptText: `${reminderPrefix}\n\n${pendingPrompt.promptText}`,
     actions: pendingPrompt.actions,


### PR DESCRIPTION
Part of #7314. Adds approval-message-composer.ts with layered source selection (assistant preface → deterministic fallback) and wires it into channel-approvals.ts. Replaces hard-coded approval prompt strings with composer calls while keeping action computation, UI metadata, and plain-text fallback deterministic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
