### PR TITLE
M2: Route-Level Approval/Guardian Notices to Generative + Single-Message UX

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1635,7 +1635,9 @@ describe('SMS guardian verify intercept', () => {
     const replyArgs = deliverSpy.mock.calls[0];
     const replyPayload = replyArgs[1] as { chatId: string; text: string };
     expect(replyPayload.chatId).toBe('sms-chat-verify');
-    expect(replyPayload.text).toContain('Guardian verified successfully');
+    expect(typeof replyPayload.text).toBe('string');
+    expect(replyPayload.text.toLowerCase()).toContain('guardian');
+    expect(replyPayload.text.toLowerCase()).toContain('verif');
 
     deliverSpy.mockRestore();
   });
@@ -1668,7 +1670,9 @@ describe('SMS guardian verify intercept', () => {
     expect(deliverSpy).toHaveBeenCalled();
     const replyArgs = deliverSpy.mock.calls[0];
     const replyPayload = replyArgs[1] as { chatId: string; text: string };
-    expect(replyPayload.text).toContain('Verification failed');
+    expect(typeof replyPayload.text).toBe('string');
+    expect(replyPayload.text.toLowerCase()).toContain('verif');
+    expect(replyPayload.text.toLowerCase()).toContain('failed');
 
     deliverSpy.mockRestore();
   });
@@ -1944,11 +1948,11 @@ describe('fail-closed guardian gate — unverified channel', () => {
 
     // The deny decision should carry guardian setup context for assistant reply generation.
     expect(typeof decisionArgs[2]).toBe('string');
-    expect((decisionArgs[2] as string)).toContain('no guardian is configured');
+    expect((decisionArgs[2] as string).toLowerCase()).toContain('no guardian');
 
     // The runtime should not send a second deterministic denial notice.
     const deterministicNoticeCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('no guardian'),
     );
     expect(deterministicNoticeCalls.length).toBe(0);
 
@@ -2045,11 +2049,11 @@ describe('fail-closed guardian gate — unverified channel', () => {
     const lastDecision = submitCalls[submitCalls.length - 1];
     expect(lastDecision[1]).toBe('deny');
     expect(typeof lastDecision[2]).toBe('string');
-    expect((lastDecision[2] as string)).toContain('no guardian is configured');
+    expect((lastDecision[2] as string).toLowerCase()).toContain('no guardian');
 
     // Interception should not emit a separate deterministic denial notice.
     const denialCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('no guardian has been set up'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('no guardian'),
     );
     expect(denialCalls.length).toBe(0);
 
@@ -2092,9 +2096,9 @@ describe('guardian-with-binding path regression', () => {
     const approvalArgs = approvalSpy.mock.calls[0];
     expect(approvalArgs[1]).toBe('guardian-chat-1');
 
-    // Requester should have been notified the request was sent to the guardian
+    // Requester should have been notified the request was forwarded to the guardian
     const notifyCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('has been sent to the guardian for approval'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('guardian'),
     );
     expect(notifyCalls.length).toBeGreaterThanOrEqual(1);
 
@@ -2223,14 +2227,14 @@ describe('guardian delivery failure → denial', () => {
 
     // Requester should have been notified that delivery failed
     const failureCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('could not be sent to the guardian for approval'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('denied'),
     );
     expect(failureCalls.length).toBeGreaterThanOrEqual(1);
 
-    // The "has been sent to the guardian for approval" success notice should
-    // NOT have been delivered (since delivery failed).
+    // The guardian_request_forwarded success notice should NOT have been
+    // delivered (since delivery failed).
     const successCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('has been sent to the guardian for approval'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('forwarded'),
     );
     expect(successCalls.length).toBe(0);
 
@@ -2487,7 +2491,7 @@ describe('ambiguous plain-text decision with multiple pending requests', () => {
 
     // A disambiguation message should have been sent to the guardian
     const disambigCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('pending approval requests'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('pending'),
     );
     expect(disambigCalls.length).toBeGreaterThanOrEqual(1);
 
@@ -3178,12 +3182,12 @@ describe('guardian enforcement behavior', () => {
     const lastDecision = submitCalls[submitCalls.length - 1];
     expect(lastDecision[1]).toBe('deny');
     expect(typeof lastDecision[2]).toBe('string');
-    expect((lastDecision[2] as string)).toContain('identity could not be verified');
+    expect((lastDecision[2] as string).toLowerCase()).toContain('identity');
 
     // No separate deterministic denial notice should be emitted here.
     const denialCalls = deliverSpy.mock.calls.filter(
       (call) => typeof call[1] === 'object'
-        && ((call[1] as { text?: string }).text ?? '').includes('identity could not be determined'),
+        && ((call[1] as { text?: string }).text ?? '').toLowerCase().includes('identity'),
     );
     expect(denialCalls.length).toBe(0);
 
@@ -3217,11 +3221,11 @@ describe('guardian enforcement behavior', () => {
     const lastDecision = submitCalls[submitCalls.length - 1];
     expect(lastDecision[1]).toBe('deny');
     expect(typeof lastDecision[2]).toBe('string');
-    expect((lastDecision[2] as string)).toContain('identity could not be verified');
+    expect((lastDecision[2] as string).toLowerCase()).toContain('identity');
 
     const denialCalls = deliverSpy.mock.calls.filter(
       (call) => typeof call[1] === 'object'
-        && ((call[1] as { text?: string }).text ?? '').includes('identity could not be determined'),
+        && ((call[1] as { text?: string }).text ?? '').toLowerCase().includes('identity'),
     );
     expect(denialCalls.length).toBe(0);
     expect(approvalSpy).not.toHaveBeenCalled();

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -45,6 +45,7 @@ import type {
   RuntimeAttachmentMetadata,
 } from '../http-types.js';
 import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
+import { composeApprovalMessage } from '../approval-message-composer.js';
 
 const log = getLogger('runtime-http');
 
@@ -152,10 +153,10 @@ function buildGuardianDenyContext(
   sourceChannel: string,
 ): string {
   if (denialReason === 'no_identity') {
-    return `Permission denied: the action "${toolName}" requires guardian approval, but your identity could not be verified on ${sourceChannel}. Do not retry yet. Explain this clearly, ask the user to message from a verifiable direct account/chat, and then retry after identity is available.`;
+    return `Permission denied: ${composeApprovalMessage({ scenario: 'guardian_deny_no_identity', toolName, channel: sourceChannel })} Do not retry yet. Ask the user to message from a verifiable direct account/chat, and then retry after identity is available.`;
   }
 
-  return `Permission denied: the action "${toolName}" requires guardian approval, but no guardian is configured for this ${sourceChannel} channel. Do not retry yet. Explain that a guardian must be set up first. Offer to set up guardian verification right here in the chat — the setup flow will provide a verification token to send as /guardian_verify <token> in the ${sourceChannel} chat. The guardian can also manage this later from the Settings page.`;
+  return `Permission denied: ${composeApprovalMessage({ scenario: 'guardian_deny_no_binding', toolName, channel: sourceChannel })} Do not retry yet. Offer to set up guardian verification. The setup flow will provide a verification token to send as /guardian_verify <token>.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -870,7 +871,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               try {
                 await deliverChannelReply(replyCallbackUrl, {
                   chatId: guardianCtx.requesterChatId ?? externalChatId,
-                  text: `Your request to run "${pending[0].toolName}" could not be sent to the guardian for approval. The action has been denied.`,
+                  text: composeApprovalMessage({ scenario: 'guardian_delivery_failed', toolName: pending[0].toolName }),
                   assistantId,
                 }, bearerToken);
               } catch (notifyErr) {
@@ -883,7 +884,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
               try {
                 await deliverChannelReply(replyCallbackUrl, {
                   chatId: guardianCtx.requesterChatId ?? externalChatId,
-                  text: `Your request to run "${pending[0].toolName}" has been sent to the guardian for approval.`,
+                  text: composeApprovalMessage({ scenario: 'guardian_request_forwarded', toolName: pending[0].toolName }),
                   assistantId,
                 }, bearerToken);
               } catch (err) {
@@ -1110,7 +1111,7 @@ async function handleApprovalInterception(
         try {
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
-            text: `You have ${allPending.length} pending approval requests. Please use the approval buttons to respond to a specific request.`,
+            text: composeApprovalMessage({ scenario: 'guardian_disambiguation', pendingCount: allPending.length }),
             assistantId,
           }, bearerToken);
         } catch (err) {
@@ -1143,7 +1144,7 @@ async function handleApprovalInterception(
         try {
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
-            text: 'Only the verified guardian can approve or deny this request.',
+            text: composeApprovalMessage({ scenario: 'guardian_identity_mismatch' }),
             assistantId,
           }, bearerToken);
         } catch (err) {
@@ -1177,10 +1178,11 @@ async function handleApprovalInterception(
 
         if (result.applied) {
           // Notify the requester's chat about the outcome with the tool name
-          const toolLabel = guardianApproval.toolName;
-          const outcomeText = decision.action === 'reject'
-            ? `Your request to run "${toolLabel}" was denied by the guardian.`
-            : `Your request to run "${toolLabel}" was approved by the guardian.`;
+          const outcomeText = composeApprovalMessage({
+            scenario: 'guardian_decision_outcome',
+            decision: decision.action === 'reject' ? 'denied' : 'approved',
+            toolName: guardianApproval.toolName,
+          });
           try {
             await deliverChannelReply(replyCallbackUrl, {
               chatId: guardianApproval.requesterChatId,
@@ -1286,7 +1288,7 @@ async function handleApprovalInterception(
         try {
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
-            text: 'Your request is pending guardian approval. Only the verified guardian can approve or deny this request.',
+            text: composeApprovalMessage({ scenario: 'request_pending_guardian' }),
             assistantId,
           }, bearerToken);
         } catch (err) {
@@ -1313,7 +1315,7 @@ async function handleApprovalInterception(
         try {
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
-            text: 'Your guardian approval request has expired and the action has been denied. Please try again.',
+            text: composeApprovalMessage({ scenario: 'guardian_expired_requester', toolName: pending[0].toolName }),
             assistantId,
           }, bearerToken);
         } catch (err) {


### PR DESCRIPTION
Part of #7314. Migrates all hard-coded approval/guardian notice strings in channel-routes.ts to use the approval-message-composer. Replaces exact string assertions in route tests with semantic content checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
