### PR TITLE
M4: Cleanup Legacy TCP/TLS Copy and Toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -279,7 +279,7 @@ struct SettingsAdvancedTab: View {
                     Text("Enable iOS Pairing")
                         .font(VFont.bodyMedium)
                         .foregroundColor(VColor.textPrimary)
-                    Text("Allow iPhone connections over your local network (TLS encrypted).")
+                    Text("Allow your iPhone to connect via the gateway (bearer-token authenticated).")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
@@ -317,7 +317,7 @@ struct SettingsAdvancedTab: View {
                 setIOSPairingEnabled(true)
             }
         } message: {
-            Text("Your assistant will be reachable on your local network. Only devices with the session token can connect. TLS encryption is always enabled.")
+            Text("Your iPhone will connect through the gateway. Only devices with a valid session token can reach your assistant.")
         }
     }
 


### PR DESCRIPTION
## Summary
Update settings copy to reflect the current gateway-based iOS pairing model. Remove references to TLS encryption and direct TCP connections that no longer apply.

## Implementation
- Replace "TLS encrypted" descriptions with accurate gateway/bearer-token language
- Update warning and info text in SettingsAdvancedTab.swift
- No behavior changes — copy/UX only

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
