### PR TITLE
M5: Validation + Documentation

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -223,6 +223,15 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 
 Requires Accessibility, Screen Recording, and Microphone permissions (System Settings > Privacy & Security). `PermissionManager` handles checking/prompting. API key stored in Keychain via `APIKeyManager`.
 
+## Developer Local Pairing
+
+Developer-only feature for pairing an iOS device over the local network (LAN) for debugging purposes.
+
+- **What it is:** Allows a macOS instance to expose a local HTTP gateway that an iOS device on the same network can connect to, bypassing the cloud relay.
+- **How to enable:** Settings > Connect > Developer Local Pairing toggle. This is a developer-only feature gated behind the developer settings toggle.
+- **How it works:** The macOS app generates a QR code containing the local HTTP gateway URL. The iOS app scans the QR code and connects directly over LAN if the developer local pairing toggle is enabled on the iOS side.
+- **Security:** HTTP is permitted only for local/private addresses (loopback, mDNS `.local`, link-local, RFC 1918 ranges). Bearer token authentication is still required for all requests. Address validation uses `LocalAddressValidator.isLocalAddress()` in `clients/shared/Utilities/LocalAddressValidator.swift`.
+
 ## Data Storage
 
 - Session logs: `~/Library/Application Support/vellum-assistant/logs/session-*.json`

--- a/clients/shared/Tests/LocalAddressValidatorTests.swift
+++ b/clients/shared/Tests/LocalAddressValidatorTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class LocalAddressValidatorTests: XCTestCase {
+
+    // MARK: - Positive cases (should return true)
+
+    func testLocalhost() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("localhost"))
+    }
+
+    func testLocalhostUppercase() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("LOCALHOST"))
+    }
+
+    func testLocalhostMixedCase() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("LocalHost"))
+    }
+
+    func testLoopback127_0_0_1() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("127.0.0.1"))
+    }
+
+    func testLoopback127_255_255_255() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("127.255.255.255"))
+    }
+
+    func testPrivate192_168_1_1() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("192.168.1.1"))
+    }
+
+    func testPrivate10_0_0_1() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("10.0.0.1"))
+    }
+
+    func testPrivate10_255_255_255() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("10.255.255.255"))
+    }
+
+    func testPrivate172_16_0_1() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("172.16.0.1"))
+    }
+
+    func testPrivate172_31_255_255() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("172.31.255.255"))
+    }
+
+    func testIPv6Loopback() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("::1"))
+    }
+
+    func testIPv6LinkLocal() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("fe80::1"))
+    }
+
+    func testMDNSLocal() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("myhost.local"))
+    }
+
+    // MARK: - Negative cases (should return false)
+
+    func testPublicDomain() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("google.com"))
+    }
+
+    func testPublicIP() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("8.8.8.8"))
+    }
+
+    func testPrivate172OutOfRange_172_32() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("172.32.0.1"))
+    }
+
+    func testPrivate172OutOfRange_172_15() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("172.15.0.1"))
+    }
+
+    func testCraftedHostnameBypass() {
+        // 10.0.0.1.evil.com has more than 4 dot-separated parts,
+        // so it must NOT be treated as a private IPv4 address.
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("10.0.0.1.evil.com"))
+    }
+
+    func testNonPrivate192_169() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("192.169.1.1"))
+    }
+
+    func testNonPrivate11_0_0_1() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("11.0.0.1"))
+    }
+
+    func testEmptyString() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress(""))
+    }
+
+    func testURLNotHost() {
+        // A full URL (with scheme) is not a valid host string
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("https://localhost"))
+    }
+}

--- a/clients/shared/Utilities/LocalAddressValidator.swift
+++ b/clients/shared/Utilities/LocalAddressValidator.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Validates whether a host string refers to a local or private-network address.
+/// Used to allow plain HTTP for LAN/loopback endpoints while requiring HTTPS
+/// for public hosts (ATS policy). Shared across iOS and macOS targets.
+public enum LocalAddressValidator {
+
+    /// Returns `true` if the given host is a loopback, mDNS (.local), IPv6 link-local,
+    /// or RFC 1918 private address. Comparison is case-insensitive.
+    ///
+    /// This validates the raw part count before checking IPv4 octets, preventing
+    /// bypass via crafted hostnames like `10.0.0.1.evil.com`.
+    public static func isLocalAddress(_ rawHost: String) -> Bool {
+        let host = rawHost.lowercased()
+
+        // Empty host is never local
+        if host.isEmpty { return false }
+
+        // Loopback & mDNS
+        if host == "localhost" || host == "::1" || host.hasSuffix(".local") {
+            return true
+        }
+
+        // IPv6 link-local (fe80::...)
+        if host.hasPrefix("fe80:") {
+            return true
+        }
+
+        // IPv4: split on "." and require exactly 4 parts before parsing octets.
+        // This prevents bypass via hostnames like "10.0.0.1.evil.com" where
+        // compactMap alone would yield 4 valid octets from 6 dot-separated parts.
+        let parts = host.split(separator: ".")
+        if parts.count == 4 {
+            let octets = parts.compactMap { UInt8($0) }
+            if octets.count == 4 {
+                // 127.0.0.0/8 -- full loopback range
+                if octets[0] == 127 { return true }
+                // 10.0.0.0/8 -- private
+                if octets[0] == 10 { return true }
+                // 172.16.0.0/12 -- private (172.16.x.x through 172.31.x.x)
+                if octets[0] == 172 && (16...31).contains(octets[1]) { return true }
+                // 192.168.0.0/16 -- private
+                if octets[0] == 192 && octets[1] == 168 { return true }
+            }
+        }
+
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
Add a shared local address validation helper with comprehensive unit tests and documentation for the Developer Local Pairing feature.

## Implementation
- Create shared `isLocalAddress` helper validating loopback, mDNS, link-local, and RFC 1918 private ranges
- Add unit tests covering positive cases (localhost, private IPs, IPv6) and negative cases (public IPs, crafted hostnames)
- Add Developer Local Pairing documentation to macOS CLAUDE.md

## Key Technical Choices
- Placed in shared code so both iOS and macOS can use the same validation
- Validates parts.count == 4 before checking IPv4 octets (prevents 10.0.0.1.evil.com bypass)
- Case-insensitive host comparison

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
