### PR TITLE
M1: macOS Developer Local Pairing Override UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LANIPHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LANIPHelper.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Discovers the Mac's LAN IPv4 address by enumerating network interfaces.
+/// Returns the first non-loopback, up, IPv4 address on an en* interface (Wi-Fi or Ethernet),
+/// or nil if no suitable address is found.
+enum LANIPHelper {
+    static func currentLANAddress() -> String? {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else {
+            return nil
+        }
+        defer { freeifaddrs(ifaddr) }
+
+        var result: String?
+        var current: UnsafeMutablePointer<ifaddrs>? = firstAddr
+
+        while let addr = current {
+            let flags = Int32(addr.pointee.ifa_flags)
+            let isUp = (flags & IFF_UP) != 0
+            let isLoopback = (flags & IFF_LOOPBACK) != 0
+
+            // Only consider interfaces that are up and not loopback
+            if isUp, !isLoopback,
+               let sa = addr.pointee.ifa_addr,
+               sa.pointee.sa_family == UInt8(AF_INET) {
+
+                let name = String(cString: addr.pointee.ifa_name)
+                // Filter to en* interfaces (en0 = Wi-Fi, en1 = Ethernet, etc.)
+                if name.hasPrefix("en") {
+                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(sa, socklen_t(sa.pointee.sa_len),
+                                   &hostname, socklen_t(hostname.count),
+                                   nil, 0, NI_NUMERICHOST) == 0 {
+                        result = String(cString: hostname)
+                        break
+                    }
+                }
+            }
+            current = addr.pointee.ifa_next
+        }
+
+        return result
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -34,6 +34,11 @@ struct SettingsConnectTab: View {
     // Guardian copy state (tracks which channel's command was just copied)
     @State private var guardianCommandCopiedChannel: String?
 
+    // Developer local pairing state
+    @AppStorage("iosPairingUseOverride") private var iosPairingUseOverride: Bool = false
+    @AppStorage("iosPairingGatewayOverride") private var iosPairingGatewayOverride: String = ""
+    @State private var lanUrlCopied: Bool = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             gatewaySection
@@ -43,6 +48,7 @@ struct SettingsConnectTab: View {
             pairingSection
             statusSection
             testConnectionSection
+            developerLocalPairingSection
         }
         .onAppear {
             store.refreshIngressConfig()
@@ -942,6 +948,124 @@ struct SettingsConnectTab: View {
             Text("Gateway checks the local process. Tunnel checks the public URL.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Developer Local Pairing Section
+
+    private var suggestedLanUrl: String? {
+        guard let ip = LANIPHelper.currentLANAddress() else { return nil }
+        return "http://\(ip):7830"
+    }
+
+    private var developerLocalPairingSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Developer Local Pairing (LAN-only)")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            // Enable toggle
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Enable developer local pairing")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                    Text("Override the iOS pairing gateway URL for LAN development.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                Toggle("", isOn: $iosPairingUseOverride)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+            }
+
+            if iosPairingUseOverride {
+                // Warning banner
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 14))
+                    Text("Debug only. Uses unencrypted HTTP over your local network. Do not use in production.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(VColor.warning.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+                // Suggested LAN URL with copy button
+                if let lanUrl = suggestedLanUrl {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Suggested URL")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+
+                        HStack(spacing: VSpacing.sm) {
+                            Text(lanUrl)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                                .textSelection(.enabled)
+                                .padding(VSpacing.md)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(VColor.surface.opacity(0.5))
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: VRadius.md)
+                                        .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                                )
+
+                            Button {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(lanUrl, forType: .string)
+                                lanUrlCopied = true
+                                Task {
+                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                    lanUrlCopied = false
+                                }
+                            } label: {
+                                Image(systemName: lanUrlCopied ? "checkmark" : "doc.on.doc")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(lanUrlCopied ? VColor.success : VColor.textSecondary)
+                                    .frame(width: 28, height: 28)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Copy suggested LAN URL")
+                            .help("Copy URL")
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(VColor.textMuted)
+                            .font(.system(size: 12))
+                        Text("No LAN address detected. Connect to a Wi-Fi or Ethernet network.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                }
+
+                // Editable override URL
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Override URL")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    TextField("http://192.168.1.x:7830", text: $iosPairingGatewayOverride)
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                }
+
+                // Reset / disable button
+                VButton(label: "Disable & Reset", style: .danger) {
+                    iosPairingGatewayOverride = ""
+                    iosPairingUseOverride = false
+                }
+            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
Add a Developer Local iOS Pairing (LAN-only) section to the macOS Settings → Connect tab, giving developers an explicit opt-in for LAN pairing without touching production defaults.

## Implementation
- Add a new section at the bottom of SettingsConnectTab with toggle, LAN IP suggestion, editable override URL, and warning text
- Create a LAN IP helper using getifaddrs() to detect the Mac's local network address
- Wire up to existing AppStorage keys (iosPairingUseOverride, iosPairingGatewayOverride)
- Include a reset/disable button

## Key Technical Choices
- Uses getifaddrs() for reliable LAN IP detection (filters en0/en1, IPv4, non-loopback)
- Reuses existing AppStorage keys from SettingsAdvancedTab rather than creating new ones
- Placed in Connect tab (where pairing config lives) rather than Advanced tab

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
