### PR TITLE
M2: QR Payload Uses Local Override (LAN-only)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -14,13 +14,23 @@ struct PairingQRCodeSheet: View {
     let gatewayUrl: String
     let resolvedBearerToken: String
 
+    /// Whether the developer local pairing override is active.
+    let isLocalOverride: Bool
+
     @State private var hostId: String = ""
     @State private var isTokenRevealed: Bool = false
     @State private var copiedField: String? = nil
 
-    /// Whether the ingress configuration is sufficient for pairing.
+    /// Whether the configuration is sufficient for pairing.
     private var canGenerateQR: Bool {
-        ingressEnabled && !gatewayUrl.isEmpty && !resolvedBearerToken.isEmpty
+        let hasRequiredFields = !gatewayUrl.isEmpty && !resolvedBearerToken.isEmpty
+        if isLocalOverride {
+            // For developer local pairing, ingress is not required
+            // but the URL must be a local/private address
+            guard let url = URL(string: gatewayUrl), let host = url.host else { return false }
+            return hasRequiredFields && LocalAddressValidator.isLocalAddress(host)
+        }
+        return ingressEnabled && hasRequiredFields
     }
 
     var body: some View {
@@ -47,7 +57,12 @@ struct PairingQRCodeSheet: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 32))
                         .foregroundColor(VColor.error)
-                    if !ingressEnabled || gatewayUrl.isEmpty {
+                    if isLocalOverride {
+                        Text("The override URL must be a local/private network address for developer pairing.")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    } else if !ingressEnabled || gatewayUrl.isEmpty {
                         Text("Enable ingress and set a public URL in Settings to pair with iOS")
                             .font(VFont.body)
                             .foregroundColor(VColor.error)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -79,7 +79,8 @@ struct SettingsConnectTab: View {
             PairingQRCodeSheet(
                 ingressEnabled: store.ingressEnabled,
                 gatewayUrl: store.resolvedIosGatewayUrl,
-                resolvedBearerToken: store.resolvedIosBearerToken
+                resolvedBearerToken: store.resolvedIosBearerToken,
+                isLocalOverride: UserDefaults.standard.bool(forKey: "iosPairingUseOverride")
             )
         }
     }


### PR DESCRIPTION
## Summary
Allow the QR pairing sheet to generate QR codes when the developer local pairing override is active, even if ingress is not enabled. Validates that the override URL is a local/private address.

## Implementation
- Add `isLocalOverride` property to PairingQRCodeSheet
- Update `canGenerateQR` to skip the ingress requirement when override is active, but validate the URL is local via `LocalAddressValidator.isLocalAddress()`
- Show a clear error message when override URL is not a local address
- Update call site in SettingsConnectTab to pass the override flag

## Key Technical Choices
- Uses the shared `LocalAddressValidator.isLocalAddress()` for consistent validation
- Preserves existing behavior when override is not active (ingress still required)
- Security: rejects non-local URLs when override is active (prevents accidental exposure over public internet)

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
