### PR TITLE
M3: Verification Copy Migration to Generative Composer

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -416,8 +416,8 @@ export async function handleChannelInbound(
       );
 
       const replyText = verifyResult.success
-        ? 'Guardian verified successfully. Your identity is now linked to this bot.'
-        : 'Verification failed. Please try again later.';
+        ? composeApprovalMessage({ scenario: 'guardian_verify_success' })
+        : verifyResult.reason;
 
       try {
         await deliverChannelReply(replyCallbackUrl, {


### PR DESCRIPTION
## Summary
- Replace hard-coded `/guardian_verify` success/failure reply strings in `channel-routes.ts` with `composeApprovalMessage()` calls
- Success path uses `guardian_verify_success` scenario
- Failure path uses the already-composed `reason` from `ValidateChallengeResult`
- Sweep expiry notices were already migrated in M2

Part of #7314

## Test plan
- [x] `channel-approval-routes.test.ts` passes (78/78)
- [x] `channel-guardian.test.ts` passes (69/69)
- [x] `approval-message-composer.test.ts` passes (37/37)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
