### PR TITLE
M4: Hardening + Documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3688,6 +3688,7 @@ Runtime detects needs_confirmation
 
 | Module | Purpose |
 |--------|---------|
+| `assistant/src/runtime/approval-message-composer.ts` | Centralized approval message composition: layered source selection (assistant preface → deterministic fallback) for all approval/guardian/verification user-facing copy |
 | `assistant/src/runtime/channel-approvals.ts` | Orchestration: detect pending confirmations, build prompts (including guardian-aware prompts), apply decisions, build reminders, plain-text fallback selection |
 | `assistant/src/runtime/channel-approval-parser.ts` | Plain-text decision parser (phrase matching) |
 | `assistant/src/runtime/channel-approval-types.ts` | Shared types: actions, prompts, UI metadata, decisions |
@@ -3698,6 +3699,15 @@ Runtime detects needs_confirmation
 | `assistant/src/runtime/gateway-client.ts` | `deliverApprovalPrompt()` — sends approval payload to gateway |
 | `gateway/src/telegram/send.ts` | `buildInlineKeyboard()` — renders approval actions as Telegram inline buttons |
 | `gateway/src/telegram/normalize.ts` | `callback_query` normalization into `GatewayInboundEventV1` (DM-only, drops callbacks without data) |
+
+### Approval Message Composer
+
+The `approval-message-composer.ts` module provides a centralized system for generating approval lifecycle messages across channels. It uses a layered source selection:
+
+1. **Assistant preface** — reuses existing assistant text (macOS parity)
+2. **Deterministic fallback** — scenario-specific templates with required semantic content
+
+All approval/guardian/verification user-facing copy routes through this composer. Deterministic behavior (action IDs, callback payloads, plain-text parsing) remains separate and unchanged. A guard test (`approval-hardcoded-copy-guard.test.ts`) scans the route/service files for banned hard-coded copy literals to prevent regressions.
 
 ### Channel Guardian Security
 

--- a/assistant/src/__tests__/approval-hardcoded-copy-guard.test.ts
+++ b/assistant/src/__tests__/approval-hardcoded-copy-guard.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Guard test: ensures no production hard-coded approval lifecycle copy creeps
+ * back into route/service files outside of the composer module.
+ *
+ * The composer file (`approval-message-composer.ts`) is intentionally excluded
+ * since that is where deterministic fallback copy legitimately lives.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, test, expect } from 'bun:test';
+
+const SCANNED_FILES = [
+  'runtime/channel-approvals.ts',
+  'runtime/routes/channel-routes.ts',
+  'runtime/channel-guardian-service.ts',
+];
+
+const BANNED_PATTERNS: { pattern: RegExp; description: string }[] = [
+  { pattern: /The assistant wants to use/i, description: 'old standard prompt' },
+  { pattern: /Do you want to allow this/i, description: 'old approval question' },
+  { pattern: /['"`]I'm still waiting/i, description: 'old reminder prefix (string literal)' },
+  { pattern: /['"`].*is requesting to run/i, description: 'old guardian prompt (string literal)' },
+  { pattern: /['"`]Sent to guardian/i, description: 'old forwarding notice (string literal)' },
+  { pattern: /['"`]Guardian verified successfully/i, description: 'old verify success (string literal)' },
+  { pattern: /['"`]Verification failed/i, description: 'old verify failure (string literal)' },
+  { pattern: /['"`]Your request has been sent/i, description: 'old request forwarded notice (string literal)' },
+  { pattern: /['"`]No guardian is configured/i, description: 'old no-binding notice (string literal)' },
+];
+
+describe('approval hardcoded copy guard', () => {
+  for (const file of SCANNED_FILES) {
+    test(`${file} does not contain banned approval copy literals`, () => {
+      const content = readFileSync(join(__dirname, '..', file), 'utf-8');
+      for (const { pattern, description } of BANNED_PATTERNS) {
+        const match = content.match(pattern);
+        expect(match).toBeNull();
+      }
+    });
+  }
+});

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -416,8 +416,8 @@ export async function handleChannelInbound(
       );
 
       const replyText = verifyResult.success
-        ? 'Guardian verified successfully. Your identity is now linked to this bot.'
-        : 'Verification failed. Please try again later.';
+        ? composeApprovalMessage({ scenario: 'guardian_verify_success' })
+        : composeApprovalMessage({ scenario: 'guardian_verify_failed', failureReason: 'Please try again later.' });
 
       try {
         await deliverChannelReply(replyCallbackUrl, {


### PR DESCRIPTION
Part of #7314. Adds a guard test that scans approval/guardian/verification modules for banned hard-coded copy literals, preventing regressions. Updates ARCHITECTURE.md with the approval message composer documentation. Also migrates the last remaining hard-coded verification copy in channel-routes.ts to use the composer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
