### PR TITLE
M3: iOS Gated Acceptance of Local Gateway

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -56,6 +56,8 @@ struct DaemonConnectionSection: View {
     @State private var manualAuthValue: String = ""
     @State private var isConnecting = false
 
+    @AppStorage("devLocalPairingEnabled") private var devLocalPairingEnabled: Bool = false
+
     /// The currently configured gateway URL, shown as read-only status.
     private var gatewayURL: String? {
         UserDefaults.standard.string(forKey: UserDefaultsKeys.gatewayBaseURL).flatMap { $0.isEmpty ? nil : $0 }
@@ -166,6 +168,19 @@ struct DaemonConnectionSection: View {
                 Text("Manual Setup")
             } footer: {
                 Text("Enter the gateway URL and bearer token shown in your Mac's Settings.")
+            }
+
+            // Developer options
+            Section {
+                Toggle("Developer Local Pairing", isOn: $devLocalPairingEnabled)
+                    .font(VFont.body)
+                if devLocalPairingEnabled {
+                    Text("Debug only. Allows connecting to local HTTP gateways scanned via QR code.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            } header: {
+                Text("Developer")
             }
 
         }

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -11,6 +11,7 @@ struct QRPairingSheet: View {
     @State private var scannedPayload: DaemonQRPayload?
     @State private var errorMessage: String?
     @State private var showGatewayChangedAlert = false
+    @AppStorage("devLocalPairingEnabled") private var devLocalPairingEnabled: Bool = false
 
     enum PairingPhase {
         case scanning
@@ -275,6 +276,23 @@ struct QRPairingSheet: View {
             errorMessage = "QR code is missing required fields. Please regenerate the QR code on your Mac."
             phase = .error
             return
+        }
+
+        // Validate HTTP scheme — require HTTPS for non-local, or devLocalPairingEnabled for local HTTP
+        if let url = URL(string: gatewayURL), url.scheme == "http" {
+            if let host = url.host {
+                let isLocal = DaemonConnectionSection.isLocalHost(host)
+                if !isLocal {
+                    errorMessage = "HTTPS is required for non-local connections."
+                    phase = .error
+                    return
+                }
+                if !devLocalPairingEnabled {
+                    errorMessage = "Enable Developer Local Pairing in connection settings to use local HTTP gateways."
+                    phase = .error
+                    return
+                }
+            }
         }
 
         let payload = DaemonQRPayload(


### PR DESCRIPTION
## Summary
Add a Developer Local Pairing toggle in iOS connection settings that gates acceptance of local HTTP gateway URLs during QR pairing. Default behavior is unchanged — HTTPS is required unless the developer toggle is explicitly enabled.

## Implementation
- Add `devLocalPairingEnabled` AppStorage toggle to ConnectionSettingsSection with warning text
- Add scheme validation in QRPairingSheet.handleScannedCode():
  - HTTPS URLs always accepted (no change)
  - HTTP + non-local host → rejected
  - HTTP + local host + toggle off → rejected with guidance
  - HTTP + local host + toggle on → accepted
- Uses existing isLocalHost() / LocalAddressValidator for address validation

## Key Technical Choices
- Separate toggle from the macOS override — iOS has its own explicit opt-in
- Validation happens at QR scan time, not connection time, for clear user feedback
- Error messages guide users to enable the toggle when needed

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
