### PR TITLE
Fix: add IPv4 link-local range to local address validator

### DIFF
--- a/clients/shared/Tests/LocalAddressValidatorTests.swift
+++ b/clients/shared/Tests/LocalAddressValidatorTests.swift
@@ -57,6 +57,14 @@ final class LocalAddressValidatorTests: XCTestCase {
         XCTAssertTrue(LocalAddressValidator.isLocalAddress("myhost.local"))
     }
 
+    func testLinkLocal169_254_1_1() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("169.254.1.1"))
+    }
+
+    func testLinkLocal169_254_255_255() {
+        XCTAssertTrue(LocalAddressValidator.isLocalAddress("169.254.255.255"))
+    }
+
     // MARK: - Negative cases (should return false)
 
     func testPublicDomain() {
@@ -87,6 +95,14 @@ final class LocalAddressValidatorTests: XCTestCase {
 
     func testNonPrivate11_0_0_1() {
         XCTAssertFalse(LocalAddressValidator.isLocalAddress("11.0.0.1"))
+    }
+
+    func testNonLinkLocal169_253() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("169.253.1.1"))
+    }
+
+    func testNonLinkLocal169_255() {
+        XCTAssertFalse(LocalAddressValidator.isLocalAddress("169.255.1.1"))
     }
 
     func testEmptyString() {

--- a/clients/shared/Utilities/LocalAddressValidator.swift
+++ b/clients/shared/Utilities/LocalAddressValidator.swift
@@ -6,7 +6,7 @@ import Foundation
 public enum LocalAddressValidator {
 
     /// Returns `true` if the given host is a loopback, mDNS (.local), IPv6 link-local,
-    /// or RFC 1918 private address. Comparison is case-insensitive.
+    /// IPv4 link-local (169.254.0.0/16), or RFC 1918 private address. Comparison is case-insensitive.
     ///
     /// This validates the raw part count before checking IPv4 octets, preventing
     /// bypass via crafted hostnames like `10.0.0.1.evil.com`.
@@ -41,6 +41,8 @@ public enum LocalAddressValidator {
                 if octets[0] == 172 && (16...31).contains(octets[1]) { return true }
                 // 192.168.0.0/16 -- private
                 if octets[0] == 192 && octets[1] == 168 { return true }
+                // 169.254.0.0/16 -- IPv4 link-local (APIPA)
+                if octets[0] == 169 && octets[1] == 254 { return true }
             }
         }
 


### PR DESCRIPTION
## Summary
Add IPv4 link-local (169.254.0.0/16, APIPA) to the local address validator, addressing feedback on #7352.

## Changes
- Add `169.254.x.x` range check to `LocalAddressValidator.isLocalAddress()`
- Add test cases for link-local addresses (positive and negative)

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
