### PR TITLE
Fix: specific error messages for local override QR failures

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -57,7 +57,17 @@ struct PairingQRCodeSheet: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 32))
                         .foregroundColor(VColor.error)
-                    if isLocalOverride {
+                    if isLocalOverride && gatewayUrl.isEmpty {
+                        Text("Set an override URL in Developer Local Pairing settings.")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    } else if isLocalOverride && resolvedBearerToken.isEmpty {
+                        Text("Bearer token not found. Restart the daemon to generate it.")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    } else if isLocalOverride {
                         Text("The override URL must be a local/private network address for developer pairing.")
                             .font(VFont.body)
                             .foregroundColor(VColor.error)


### PR DESCRIPTION
## Summary
Address feedback on #7356: show specific, actionable error messages for each failure mode when the local override is active (empty URL, missing token, non-local URL) instead of a generic "must be local" message.

## Changes
- Split the single `isLocalOverride` error message into three specific messages covering empty URL, missing token, and non-local URL cases

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
