### PR TITLE
Fix: derive port from gateway target and clear token on reset

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -37,6 +37,7 @@ struct SettingsConnectTab: View {
     // Developer local pairing state
     @AppStorage("iosPairingUseOverride") private var iosPairingUseOverride: Bool = false
     @AppStorage("iosPairingGatewayOverride") private var iosPairingGatewayOverride: String = ""
+    @AppStorage("iosPairingTokenOverride") private var iosPairingTokenOverride: String = ""
     @State private var lanUrlCopied: Bool = false
 
     var body: some View {
@@ -958,7 +959,8 @@ struct SettingsConnectTab: View {
 
     private var suggestedLanUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(ip):7830"
+        let port = URL(string: store.localGatewayTarget)?.port ?? 7830
+        return "http://\(ip):\(port)"
     }
 
     private var developerLocalPairingSection: some View {
@@ -1064,6 +1066,7 @@ struct SettingsConnectTab: View {
                 // Reset / disable button
                 VButton(label: "Disable & Reset", style: .danger) {
                     iosPairingGatewayOverride = ""
+                    iosPairingTokenOverride = ""
                     iosPairingUseOverride = false
                 }
             }


### PR DESCRIPTION
## Summary
Address feedback on #7354: (1) derive the suggested LAN URL port from the active gateway target instead of hardcoding 7830, and (2) clear the token override when resetting developer local pairing.

## Changes
- Update `suggestedLanUrl` to extract port from `store.localGatewayTarget`
- Add `iosPairingTokenOverride = ""` to the reset button action

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
