### PR TITLE
fix: include tool name in guardian_request_forwarded template

### DIFF
--- a/assistant/src/__tests__/approval-message-composer.test.ts
+++ b/assistant/src/__tests__/approval-message-composer.test.ts
@@ -65,6 +65,14 @@ describe('approval-message-composer', () => {
       expect(msg).toContain('write_file');
     });
 
+    test('guardian_request_forwarded includes toolName', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_request_forwarded',
+        toolName: 'execute_shell',
+      });
+      expect(msg).toContain('execute_shell');
+    });
+
     test('guardian_disambiguation includes pendingCount', () => {
       const msg = getFallbackMessage({
         scenario: 'guardian_disambiguation',

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -91,7 +91,7 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       return "I wasn't able to reach the guardian to request approval. The request has been denied for safety.";
 
     case 'guardian_request_forwarded':
-      return "Your request has been forwarded to the guardian for approval. I'll let you know once they decide.";
+      return `Your request to use "${context.toolName ?? 'unknown'}" has been forwarded to the guardian for approval. I'll let you know once they decide.`;
 
     case 'guardian_disambiguation':
       return `There are ${context.pendingCount ?? 'multiple'} pending approval requests. Please use the approval buttons to specify which request you're responding to.`;


### PR DESCRIPTION
## Summary
- Update `guardian_request_forwarded` fallback template to interpolate `toolName`
- Add test asserting toolName is included in the forwarded message

Addresses review feedback from #7350.

## Original prompt
Address Codex feedback: include tool name in guardian_request_forwarded message template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
