### PR TITLE
fix: lint error in hardcoded-copy guard test

### DIFF
--- a/assistant/src/__tests__/approval-hardcoded-copy-guard.test.ts
+++ b/assistant/src/__tests__/approval-hardcoded-copy-guard.test.ts
@@ -32,7 +32,7 @@ describe('approval hardcoded copy guard', () => {
   for (const file of SCANNED_FILES) {
     test(`${file} does not contain banned approval copy literals`, () => {
       const content = readFileSync(join(__dirname, '..', file), 'utf-8');
-      for (const { pattern, description } of BANNED_PATTERNS) {
+      for (const { pattern, description: _description } of BANNED_PATTERNS) {
         const match = content.match(pattern);
         expect(match).toBeNull();
       }


### PR DESCRIPTION
## Summary
- Fix unused variable lint error in `approval-hardcoded-copy-guard.test.ts`
- Prefixed or removed the unused `description` variable at line 35

Fixes CI failure from #7358 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22331546673)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
