### PR TITLE
Fix: harden HTTP scheme validation in iOS QR pairing

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -279,19 +279,22 @@ struct QRPairingSheet: View {
         }
 
         // Validate HTTP scheme — require HTTPS for non-local, or devLocalPairingEnabled for local HTTP
-        if let url = URL(string: gatewayURL), url.scheme == "http" {
-            if let host = url.host {
-                let isLocal = DaemonConnectionSection.isLocalHost(host)
-                if !isLocal {
-                    errorMessage = "HTTPS is required for non-local connections."
-                    phase = .error
-                    return
-                }
-                if !devLocalPairingEnabled {
-                    errorMessage = "Enable Developer Local Pairing in connection settings to use local HTTP gateways."
-                    phase = .error
-                    return
-                }
+        if let url = URL(string: gatewayURL), url.scheme?.lowercased() == "http" {
+            guard let host = url.host, !host.isEmpty else {
+                errorMessage = "Invalid HTTP URL — no host found."
+                phase = .error
+                return
+            }
+            let isLocal = DaemonConnectionSection.isLocalHost(host)
+            if !isLocal {
+                errorMessage = "HTTPS is required for non-local connections."
+                phase = .error
+                return
+            }
+            if !devLocalPairingEnabled {
+                errorMessage = "Enable Developer Local Pairing in connection settings to use local HTTP gateways."
+                phase = .error
+                return
             }
         }
 


### PR DESCRIPTION
## Summary
Address feedback on #7359: (1) use case-insensitive scheme comparison to catch `HTTP://` URLs, and (2) reject malformed HTTP URLs with nil/empty host instead of silently accepting them.

## Changes
- `url.scheme == "http"` → `url.scheme?.lowercased() == "http"` (case-insensitive)
- `if let host` → `guard let host, !host.isEmpty else { error }` (reject nil host)

Part of #7344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
