### PR TITLE
fix: unify guardian verification failure messages to prevent oracle leakage

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -138,7 +138,7 @@ export function validateAndConsumeChallenge(
       success: false,
       reason: composeApprovalMessage({
         scenario: 'guardian_verify_failed',
-        failureReason: 'Too many attempts. Please try again later.',
+        failureReason: 'The verification code is invalid or has expired.',
       }),
     };
   }


### PR DESCRIPTION
## Summary
- Unified all three verification failure paths to use the same generic failure reason
- Prevents response oracle that could leak whether an actor is rate-limited vs code is wrong
- Preserves anti-oracle intent documented in the code comment

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/7353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
