### PR TITLE
fix: include tool name in guardian forwarded/failed fallback templates

### DIFF
--- a/assistant/src/__tests__/approval-message-composer.test.ts
+++ b/assistant/src/__tests__/approval-message-composer.test.ts
@@ -65,6 +65,14 @@ describe('approval-message-composer', () => {
       expect(msg).toContain('write_file');
     });
 
+    test('guardian_delivery_failed includes toolName when provided', () => {
+      const msg = getFallbackMessage({
+        scenario: 'guardian_delivery_failed',
+        toolName: 'execute_shell',
+      });
+      expect(msg).toContain('execute_shell');
+    });
+
     test('guardian_request_forwarded includes toolName', () => {
       const msg = getFallbackMessage({
         scenario: 'guardian_request_forwarded',

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -88,7 +88,9 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       return "I'm still waiting for your decision on the pending approval request.";
 
     case 'guardian_delivery_failed':
-      return "I wasn't able to reach the guardian to request approval. The request has been denied for safety.";
+      return context.toolName
+        ? `Your request to run "${context.toolName}" could not be sent to the guardian for approval. The request has been denied for safety.`
+        : "I wasn't able to reach the guardian to request approval. The request has been denied for safety.";
 
     case 'guardian_request_forwarded':
       return `Your request to use "${context.toolName ?? 'unknown'}" has been forwarded to the guardian for approval. I'll let you know once they decide.`;


### PR DESCRIPTION
## Summary
- Updated guardian_delivery_failed fallback template to include the tool name when available
- Added test coverage for guardian_delivery_failed with toolName
- Addresses Codex review feedback on #7350

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/7350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
