### PR TITLE
fix: remove redundant CPU avatar icon from subagent thread bar

### DIFF
--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -98,14 +98,6 @@ public struct SubagentThreadView: View {
 
     private var threadBar: some View {
         HStack(spacing: VSpacing.sm) {
-            // Subagent avatar circle
-            Image(systemName: "cpu")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(statusColor)
-                .frame(width: 22, height: 22)
-                .background(statusColor.opacity(0.12))
-                .clipShape(Circle())
-
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
                 .font(VFont.captionMedium)


### PR DESCRIPTION
## Summary
- Remove the CPU icon avatar circle from the subagent thread bar — it was unnecessary visual clutter next to the label

## Test plan
- [ ] Verify subagent thread bars render cleanly with just the label and status indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
