### PR TITLE
Fix Fn dictation crash by keeping action mode in inline insertion path

### DIFF
--- a/assistant/src/__tests__/dictation-mode-detection.test.ts
+++ b/assistant/src/__tests__/dictation-mode-detection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import type { DictationRequest } from '../daemon/ipc-protocol.js';
+import { detectDictationMode } from '../daemon/handlers/dictation.js';
+
+type DictationRequestOverrides = Omit<Partial<DictationRequest>, 'context'> & {
+  context?: Partial<DictationRequest['context']>;
+};
+
+function makeRequest(overrides: DictationRequestOverrides = {}): DictationRequest {
+  const base: DictationRequest = {
+    type: 'dictation_request',
+    transcription: 'hello there',
+    context: {
+      bundleIdentifier: 'com.google.Chrome',
+      appName: 'Google Chrome',
+      windowTitle: 'Inbox - Gmail',
+      selectedText: undefined,
+      cursorInTextField: false,
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    context: {
+      ...base.context,
+      ...(overrides.context ?? {}),
+    },
+  };
+}
+
+describe('detectDictationMode', () => {
+  test('uses command mode when selected text exists', () => {
+    const mode = detectDictationMode(makeRequest({
+      transcription: 'make this friendlier',
+      context: { selectedText: 'Please send me the files.', cursorInTextField: true },
+    }));
+    expect(mode).toBe('command');
+  });
+
+  test('uses action mode for action-verb utterances', () => {
+    const mode = detectDictationMode(makeRequest({
+      transcription: 'send Alex a follow up',
+      context: { selectedText: undefined, cursorInTextField: false },
+    }));
+    expect(mode).toBe('action');
+  });
+
+  test('uses dictation mode when cursor is in a text field', () => {
+    const mode = detectDictationMode(makeRequest({
+      transcription: 'quick update on status',
+      context: { cursorInTextField: true },
+    }));
+    expect(mode).toBe('dictation');
+  });
+
+  test('defaults to dictation when context is ambiguous', () => {
+    const mode = detectDictationMode(makeRequest({
+      transcription: 'just checking in about tomorrow',
+      context: { selectedText: undefined, cursorInTextField: false },
+    }));
+    expect(mode).toBe('dictation');
+  });
+});

--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -30,7 +30,7 @@ function buildAppMetadataBlock(msg: DictationRequest): string {
 
 type DictationMode = 'dictation' | 'command' | 'action';
 
-function detectMode(msg: DictationRequest): DictationMode {
+export function detectDictationMode(msg: DictationRequest): DictationMode {
   // Command mode: selected text present — treat transcription as a transformation instruction
   if (msg.context.selectedText && msg.context.selectedText.trim().length > 0) {
     return 'command';
@@ -47,8 +47,10 @@ function detectMode(msg: DictationRequest): DictationMode {
     return 'dictation';
   }
 
-  // Default to action when not in a text field and no selection
-  return 'action';
+  // AX focus-role detection in browser editors (for example Gmail compose)
+  // is occasionally incomplete. If we default to action here, normal dictation
+  // gets misrouted into a new chat task. Treat ambiguous context as dictation.
+  return 'dictation';
 }
 
 function buildDictationPrompt(msg: DictationRequest): string {
@@ -121,7 +123,7 @@ export async function handleDictationRequest(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const mode = detectMode(msg);
+  const mode = detectDictationMode(msg);
   log.info({ mode, transcriptionLength: msg.transcription.length }, 'Dictation request received');
 
   // Action mode: return immediately — the client will route to a full agent session

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -390,14 +390,13 @@ final class VoiceInputManager {
     /// Handle the daemon's dictation response — insert cleaned text or route action mode to a task.
     func handleDictationResponse(text: String, mode: String) {
         awaitingDaemonResponse = false
-        if mode == "dictation" || mode == "command" || mode == "action" {
+        if mode == "dictation" || mode == "command" {
             DictationTextInserter.insertText(text)
             overlayWindow.showDoneAndDismiss()
-            if mode == "action" {
-                // Fn dictation should always end in inline insertion. Treat action-classified
-                // responses as dictation so users don't get redirected into a chat session.
-                log.info("Dictation response mode=action coerced to inline insertion")
-            }
+        } else if mode == "action" {
+            overlayWindow.dismiss()
+            log.info("Action mode detected — routing transcription to task submission: \(text, privacy: .public)")
+            onActionModeTriggered?(text)
         }
     }
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -390,13 +390,14 @@ final class VoiceInputManager {
     /// Handle the daemon's dictation response — insert cleaned text or route action mode to a task.
     func handleDictationResponse(text: String, mode: String) {
         awaitingDaemonResponse = false
-        if mode == "dictation" || mode == "command" {
+        if mode == "dictation" || mode == "command" || mode == "action" {
             DictationTextInserter.insertText(text)
             overlayWindow.showDoneAndDismiss()
-        } else if mode == "action" {
-            overlayWindow.dismiss()
-            log.info("Action mode detected — routing transcription to task submission: \(text, privacy: .public)")
-            onActionModeTriggered?(text)
+            if mode == "action" {
+                // Fn dictation should always end in inline insertion. Treat action-classified
+                // responses as dictation so users don't get redirected into a chat session.
+                log.info("Dictation response mode=action coerced to inline insertion")
+            }
         }
     }
 


### PR DESCRIPTION
The purpose of this PR is to fix a crash where Fn dictation misrouted action-classified responses into a chat session instead of inserting text inline.

## Changes Made
- Change default dictation mode from `action` to `dictation` when context is ambiguous (e.g., browser editors where AX focus-role detection is incomplete)
- Keep all dictation response modes (`dictation`, `command`, `action`) in the inline text insertion path on the Swift side, preventing redirection into a chat session
- Export `detectDictationMode` and add unit tests for mode detection logic

## Testing
- Added `dictation-mode-detection.test.ts` covering all four mode detection scenarios (command, action, dictation, ambiguous default)

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
