### PR TITLE
fix: remove preview text and icon from subagent thread indicator

### DIFF
--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -121,15 +121,6 @@ public struct SubagentThreadView: View {
                 animatedDots
             }
 
-            // Preview of latest reply
-            if let preview = lastReplyPreview {
-                Text(preview)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-
             Spacer(minLength: VSpacing.xs)
 
             // Reply count (like Slack's "3 replies")


### PR DESCRIPTION
## Summary
- Remove the cpu icon circle from the subagent thread indicator bar
- Remove the preview text showing the last reply content
- Simplifies the indicator to just show label, status icon, and reply count

## Test plan
- [ ] Verify subagent thread indicator renders without icon or preview text
- [ ] Verify label, status badge, reply count, and chevron still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
