### PR TITLE
fix: update anti-oracle test for unified failure messages

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -985,21 +985,33 @@ describe('guardian service rate limiting', () => {
   test('rate-limit uses generic failure message (no oracle leakage)', () => {
     createVerificationChallenge('asst-1', 'telegram');
 
-    // Trigger rate limit
-    for (let i = 0; i < 5; i++) {
+    // Capture a normal invalid-code failure response
+    const normalFailure = validateAndConsumeChallenge(
+      'asst-1', 'telegram', 'wrong-first', 'user-42', 'chat-42',
+    );
+    expect(normalFailure.success).toBe(false);
+    const normalReason = (normalFailure as { reason: string }).reason;
+
+    // Trigger rate limit (4 more attempts to reach 5 total)
+    for (let i = 0; i < 4; i++) {
       validateAndConsumeChallenge(
         'asst-1', 'telegram', `wrong-${i}`, 'user-42', 'chat-42',
       );
     }
 
-    const result = validateAndConsumeChallenge(
+    // The rate-limited response should be indistinguishable from normal failure
+    const rateLimitedResult = validateAndConsumeChallenge(
       'asst-1', 'telegram', 'anything', 'user-42', 'chat-42',
     );
-    expect(result.success).toBe(false);
-    // Must NOT reveal "invalid", "expired", or "rate limit" specifically
-    expect((result as { reason: string }).reason).not.toContain('Invalid');
-    expect((result as { reason: string }).reason).not.toContain('expired');
-    expect((result as { reason: string }).reason).not.toContain('rate limit');
+    expect(rateLimitedResult.success).toBe(false);
+    const rateLimitedReason = (rateLimitedResult as { reason: string }).reason;
+
+    // Anti-oracle: both responses must be identical
+    expect(rateLimitedReason).toBe(normalReason);
+
+    // Neither should reveal rate-limiting info
+    expect(rateLimitedReason).not.toContain('rate limit');
+    expect(normalReason).not.toContain('rate limit');
   });
 
   test('rate limit does not affect different actors', () => {


### PR DESCRIPTION
## Summary
- Update anti-oracle test to compare rate-limited vs normal failure responses for equality
- Replaces brittle substring-exclusion assertions with direct equality check
- Proves the anti-oracle property: rate-limited responses are indistinguishable from normal failures

Addresses review feedback from #7366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
