### PR TITLE
fix: QA auto-approve from session start + recorder salvage + toast UX

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -10,7 +10,9 @@ extension AppDelegate {
 
     /// Return a user-facing explanation when CU ended without a successful completion/response.
     /// This avoids the "silent disappear" feeling when the overlay auto-closes.
-    private func computerUseEndMessage(for state: SessionState) -> String? {
+    private func computerUseEndMessage(for session: ComputerUseSession) -> String? {
+        let state = session.state
+
         func completionLooksUnsuccessful(_ text: String) -> Bool {
             let lower = text.lowercased()
             let signals = [
@@ -26,32 +28,37 @@ extension AppDelegate {
             return signals.contains { lower.contains($0) }
         }
 
-        func compact(_ text: String) -> String {
-            let singleLine = text.replacingOccurrences(of: "\n", with: " ")
-            if singleLine.count <= 220 { return singleLine }
-            return String(singleLine.prefix(220)) + "..."
-        }
-
-        switch state {
+        let baseMessage: String? = switch state {
         case .completed(let summary, _):
             if completionLooksUnsuccessful(summary) {
-                return "Computer control finished with warnings: \(compact(summary))"
+                "Computer control finished with warnings: \(summary.replacingOccurrences(of: "\n", with: " "))"
+            } else {
+                nil
             }
-            return nil
         case .responded(let answer, _):
             if completionLooksUnsuccessful(answer) {
-                return "Computer control finished with warnings: \(compact(answer))"
+                "Computer control finished with warnings: \(answer.replacingOccurrences(of: "\n", with: " "))"
+            } else {
+                nil
             }
-            return nil
         case .failed(let reason):
-            return "Computer control stopped: \(reason)"
+            "Computer control stopped: \(reason)"
         case .cancelled:
-            return "Computer control was cancelled."
+            "Computer control was cancelled."
         case .awaitingConfirmation(let reason):
-            return "Computer control stopped while waiting for confirmation: \(reason)"
+            "Computer control stopped while waiting for confirmation: \(reason)"
         case .running, .thinking, .paused, .idle:
-            return "Computer control ended unexpectedly before finishing the task."
+            "Computer control ended unexpectedly before finishing the task."
         }
+
+        if let recordingWarning = session.qaRecordingWarningMessage {
+            if let baseMessage {
+                return "\(baseMessage) Recording warning: \(recordingWarning)"
+            }
+            return "Computer control finished with warnings: \(recordingWarning)"
+        }
+
+        return baseMessage
     }
 
     // MARK: - Accessibility Permission
@@ -131,7 +138,7 @@ extension AppDelegate {
             self.showMainWindow()
 
             await session.run()
-            let endMessage = self.computerUseEndMessage(for: session.state)
+            let endMessage = self.computerUseEndMessage(for: session)
             try? await Task.sleep(nanoseconds: 10_000_000_000)
             overlay.close()
             self.overlayWindow = nil
@@ -278,7 +285,7 @@ extension AppDelegate {
                     self.showMainWindow()
                 }
                 await session.run()
-                let endMessage = self.computerUseEndMessage(for: session.state)
+                let endMessage = self.computerUseEndMessage(for: session)
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
                 overlay.close()
                 self.overlayWindow = nil

--- a/clients/macos/vellum-assistant/ComputerUse/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenRecorder.swift
@@ -77,6 +77,8 @@ protocol ScreenRecording {
 @MainActor
 final class ScreenRecorder: NSObject, ScreenRecording {
     private(set) var isRecording = false
+    /// The file URL of the last recording attempt, available even after failure for salvage.
+    private(set) var lastRecordingFileURL: URL?
 
     private var stream: SCStream?
     private var assetWriter: AVAssetWriter?
@@ -185,6 +187,7 @@ final class ScreenRecorder: NSObject, ScreenRecording {
         let fileName = "qa-recording-\(timestamp).mp4"
         let fileURL = recordingsDir.appendingPathComponent(fileName)
         recordingFileURL = fileURL
+        lastRecordingFileURL = fileURL
 
         // Set up AVAssetWriter
         let writer: AVAssetWriter
@@ -297,8 +300,12 @@ final class ScreenRecorder: NSObject, ScreenRecording {
         await capturedWriter.finishWriting()
 
         if capturedWriter.status == .failed {
-            let errorMsg = capturedWriter.error?.localizedDescription ?? "Unknown error"
-            log.error("Asset writer failed: \(errorMsg)")
+            let writerError = capturedWriter.error
+            let nsError = writerError as? NSError
+            let errorMsg = writerError?.localizedDescription ?? "Unknown error"
+            let domain = nsError?.domain ?? "unknown"
+            let code = nsError?.code ?? -1
+            log.error("Asset writer failed: \(errorMsg) (domain=\(domain), code=\(code))")
             throw ScreenRecorderError.assetWriterFailed(errorMsg)
         }
 

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -32,7 +32,7 @@ final class ComputerUseSession: ObservableObject {
     @Published var autoApproveTools = false {
         didSet {
             guard autoApproveTools != oldValue else { return }
-            log.info("Auto-approve tools toggled: \(autoApproveTools)")
+            log.info("Auto-approve tools toggled: \(self.autoApproveTools)")
 
             // Notify daemon so it can skip prompt creation proactively
             do {
@@ -108,6 +108,7 @@ final class ComputerUseSession: ObservableObject {
     private var consecutiveUnchangedSteps = 0
     private var currentStepNumber = 0
     private var consecutiveFrontmostBlocks = 0
+    private(set) var qaRecordingWarningMessage: String?
 
     /// Adaptive delay configuration
     private let adaptiveDelayEnabled: Bool
@@ -168,6 +169,7 @@ final class ComputerUseSession: ObservableObject {
         isCancelled = false
         isPaused = false
         pendingToolPermissionPrompt = nil
+        qaRecordingWarningMessage = nil
         previousAXTreeText = nil
         previousElements = nil
         previousFlatElements = nil
@@ -175,6 +177,12 @@ final class ComputerUseSession: ObservableObject {
         currentStepNumber = 0
         consecutiveFrontmostBlocks = 0
         state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...", reasoning: "")
+
+        // QA sessions auto-approve low/medium tools from the start.
+        // Set here (not in init) so the didSet fires and notifies the daemon.
+        if qaMode && !autoApproveTools {
+            autoApproveTools = true
+        }
 
         log.info("Session starting — task: \(self.task, privacy: .public)")
 
@@ -217,6 +225,7 @@ final class ComputerUseSession: ObservableObject {
                 log.info("QA mode: screen recording started for session \(self.id) (scope: \(self.captureScope))")
             } catch {
                 log.error("QA mode: failed to start screen recording: \(error.localizedDescription)")
+                qaRecordingWarningMessage = "Unable to start recording. \(error.localizedDescription)"
                 // Non-fatal — continue the session without recording
             }
         }
@@ -1191,6 +1200,29 @@ final class ComputerUseSession: ObservableObject {
                 log.info("QA recording finalized: \(result.fileURL.lastPathComponent) (\(result.sizeBytes) bytes, \(result.durationMs)ms)")
             } catch {
                 log.error("QA mode: failed to stop screen recording: \(error.localizedDescription)")
+                if qaRecordingWarningMessage == nil {
+                    qaRecordingWarningMessage = "Unable to finalize recording. \(error.localizedDescription)"
+                }
+                // Salvage: if the partial file exists on disk, track it for cleanup
+                if let salvageURL = (recorder as? ScreenRecorder)?.lastRecordingFileURL,
+                   FileManager.default.fileExists(atPath: salvageURL.path) {
+                    let attrs = try? FileManager.default.attributesOfItem(atPath: salvageURL.path)
+                    let sizeBytes = (attrs?[.size] as? Int) ?? 0
+                    let expiresAtEpoch = Int(Date().addingTimeInterval(Double(retentionDays) * 24 * 3600).timeIntervalSince1970 * 1000)
+                    log.info("QA mode: salvaging partial recording at \(salvageURL.lastPathComponent) (\(sizeBytes) bytes)")
+                    recordingData = IPCCuSessionFinalizedRecording(
+                        localPath: salvageURL.path,
+                        mimeType: "video/mp4",
+                        sizeBytes: sizeBytes,
+                        durationMs: 0,
+                        width: 0,
+                        height: 0,
+                        captureScope: captureScope,
+                        includeAudio: includeAudio,
+                        targetBundleId: nil,
+                        expiresAt: expiresAtEpoch
+                    )
+                }
             }
         }
 

--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -39,13 +39,16 @@ public struct VToast: View {
     }
 
     public var body: some View {
-        HStack(spacing: VSpacing.md) {
+        HStack(alignment: .top, spacing: VSpacing.md) {
             Image(systemName: iconName)
                 .foregroundColor(iconColor)
             Text(message)
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
-                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .layoutPriority(1)
 
             Spacer(minLength: 0)
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -163,11 +163,7 @@ extension IPCCuSessionFinalized {
     }
 }
 
-extension IPCCuSessionFinalizedRecording {
-    public init(localPath: String, mimeType: String, sizeBytes: Int, durationMs: Int, width: Int, height: Int, captureScope: String, includeAudio: Bool, targetBundleId: String?, expiresAt: Int) {
-        self.init(localPath: localPath, mimeType: mimeType, sizeBytes: sizeBytes, durationMs: durationMs, width: width, height: height, captureScope: captureScope, includeAudio: includeAudio, targetBundleId: targetBundleId, expiresAt: expiresAt)
-    }
-}
+// IPCCuSessionFinalizedRecording uses the generated memberwise init directly.
 
 /// Sent after each perceive step with AX tree, screenshot, and execution results.
 /// Backed by generated `IPCCuObservation`.


### PR DESCRIPTION
## Summary
- QA sessions auto-enable `autoApproveTools` in `run()` so didSet fires and notifies daemon before any tool calls
- ScreenRecorder exposes `lastRecordingFileURL` for partial file salvage on failure
- Session.swift salvages partial recording files when stopRecording fails, with concrete error domain/code logging
- VToast supports multiline text with no truncation
- AppDelegate+Sessions passes full session to `computerUseEndMessage` for recording warning display
- Removed infinite-recursion IPCCuSessionFinalizedRecording convenience init

## Test plan
- [x] Build succeeds
- [x] QA sessions auto-approve tools from start (verified in previous testing)
- [x] Partial recording salvage tested with recorder failure scenario

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
