### PR TITLE
fix: assert lockout active before anti-oracle comparison

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -999,6 +999,11 @@ describe('guardian service rate limiting', () => {
       );
     }
 
+    // Verify lockout is actually active before making the rate-limited call
+    const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
+    expect(rl).not.toBeNull();
+    expect(rl!.lockedUntil).not.toBeNull();
+
     // The rate-limited response should be indistinguishable from normal failure
     const rateLimitedResult = validateAndConsumeChallenge(
       'asst-1', 'telegram', 'anything', 'user-42', 'chat-42',


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback on PR #7377
- Adds assertion that user is actually locked out before comparing rate-limited vs normal failure responses
- Prevents false-positive passing if lockout logic regresses

## Original prompt
Address Codex review feedback on PR #7377: assert lockout is active before comparing rate-limited response to normal failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
