### PR TITLE
fix: assert lockout is active in anti-oracle rate-limit test

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -999,10 +999,11 @@ describe('guardian service rate limiting', () => {
       );
     }
 
-    // Verify lockout is actually active before making the rate-limited call
+    // Verify lockout is actually active before testing the rate-limited response
     const rl = getRateLimit('asst-1', 'telegram', 'user-42', 'chat-42');
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
+    expect(rl!.lockedUntil!).toBeGreaterThan(Date.now());
 
     // The rate-limited response should be indistinguishable from normal failure
     const rateLimitedResult = validateAndConsumeChallenge(


### PR DESCRIPTION
## Summary
- Added assertion that lockout is actually active before comparing rate-limited response to normal failure
- Ensures the test can't silently pass if the lockout gate is skipped
- Addresses Codex review feedback on #7377

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/7377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
