### PR TITLE
fix: harden /update with gateway health checks and startup summary

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -153,22 +153,65 @@ PY
    cd ..
    ```
 
-7. Build and launch the macOS app from source with gateway pinned to local `gateway/`:
+7. Poll gateway health with retries (fail fast before building the macOS app):
+   ```bash
+   # Poll gateway health with retries
+   GATEWAY_HEALTHY=false
+   for i in 1 2 3 4 5 6 7 8 9 10; do
+     sleep 1
+     if curl -sS --max-time 2 http://127.0.0.1:7830/healthz >/dev/null 2>&1; then
+       GATEWAY_HEALTHY=true
+       break
+     fi
+   done
+
+   if [ "$GATEWAY_HEALTHY" != "true" ]; then
+     echo ""
+     echo "ERROR: Gateway failed to start or is not healthy after 10 seconds."
+     echo "Recent gateway logs:"
+     cat "${HOME}/.vellum/gateway-dev.log" 2>/dev/null || echo "(no log file found)"
+     echo ""
+     echo "Troubleshooting:"
+     echo "  1. Check if port 7830 is in use: lsof -i :7830"
+     echo "  2. Review full gateway log: cat ~/.vellum/gateway-dev.log"
+     echo "  3. Try restarting: pkill -f 'gateway/src/index' && /update"
+     echo ""
+     echo "Stopping — please fix the issue before continuing."
+     exit 1
+   fi
+
+   GATEWAY_PIDS=$(pgrep -f "gateway/src/index" 2>/dev/null | wc -l | tr -d ' ')
+   if [ "$GATEWAY_PIDS" -gt 1 ]; then
+     echo "WARNING: Multiple gateway processes detected ($GATEWAY_PIDS). Kill extras with: pkill -f 'gateway/src/index'"
+   fi
+   ```
+
+8. Build and launch the macOS app from source with gateway pinned to local `gateway/`:
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
-8. Verify health:
+9. Print startup summary:
    ```bash
-   curl -sS http://127.0.0.1:7821/healthz
-   curl -sS http://127.0.0.1:7830/healthz
+   echo ""
+   echo "=== Startup Summary ==="
+   DAEMON_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7821/healthz 2>&1 || echo "UNHEALTHY")
+   GATEWAY_STATUS=$(curl -sS --max-time 2 http://127.0.0.1:7830/healthz 2>&1 || echo "UNHEALTHY")
+   echo "  Daemon:   $DAEMON_STATUS"
+   echo "  Gateway:  $GATEWAY_STATUS"
+   echo "  Ingress:  ${INGRESS_PUBLIC_BASE_URL:-<not set>}"
+   echo "  Twilio SID:   $([ -n "$TWILIO_ACCOUNT_SID" ] && echo 'present' || echo 'MISSING')"
+   echo "  Twilio Token: $([ -n "$TWILIO_AUTH_TOKEN" ] && echo 'present' || echo 'MISSING')"
+   echo "  Twilio Phone: $([ -n "$TWILIO_PHONE_NUMBER" ] && echo "$TWILIO_PHONE_NUMBER" || echo 'MISSING')"
+   echo "  Gateway routing: ${GATEWAY_UNMAPPED_POLICY:-reject} ${GATEWAY_DEFAULT_ASSISTANT_ID:+(default: $GATEWAY_DEFAULT_ASSISTANT_ID)}"
+   echo "  Gateway log: ~/.vellum/gateway-dev.log"
+   echo "======================="
+   echo ""
    ```
 
 Report:
 
 1. What was pulled (new commits).
-2. Daemon health and gateway health results.
-3. Whether ingress and Twilio auth env were non-empty at startup.
-4. Gateway routing env values used (`GATEWAY_UNMAPPED_POLICY`, `GATEWAY_DEFAULT_ASSISTANT_ID`).
-5. The gateway log path: `~/.vellum/gateway-dev.log`.
+2. The startup summary block output (daemon health, gateway health, env presence, routing config).
+3. The gateway log path: `~/.vellum/gateway-dev.log`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. The PR body includes the full plan content for traceability. |
 
-| `/update` | Pull latest from main, restart the backend daemon, and rebuild/launch the macOS app. |
+| `/update` | Pull latest from main, restart the backend daemon, verify gateway health (fail fast on startup failure), rebuild/launch the macOS app, and print a startup summary. |
 
 
 ## Track merged PRs

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, then launch app pinned to local `gateway/`. |
+| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure), then launch app pinned to local `gateway/`. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
 
 
 ### Review


### PR DESCRIPTION
Part of #7368. Adds gateway health polling with retries after launch, validates single gateway process, and replaces simple curl checks with a comprehensive startup summary block showing daemon/gateway health, Twilio env presence, ingress config, and routing policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
