### PR TITLE
feat: generic channel readiness primitive with IPC surface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -451,6 +451,8 @@ All three paths are best-effort: webhook sync failures do not prevent the primar
 
 **Limitations (v1)**: Text-only — MMS payloads are explicitly rejected with a user-facing notice rather than silently dropped.
 
+**Channel Readiness**: The `channel_readiness` IPC contract (`ChannelReadinessService` in `src/runtime/channel-readiness-service.ts`) provides a unified readiness subsystem for all channels. Each channel registers a `ChannelProbe` that runs synchronous local checks (credential presence, phone number, ingress config) and optional async remote checks (API reachability) with a 5-minute TTL cache. Built-in probes: SMS (Twilio credentials, phone number, ingress) and Telegram (bot token, webhook secret, ingress). The `get` action returns cached snapshots; `refresh` invalidates the cache first. Unknown channels return `unsupported_channel`.
+
 ---
 
 ## macOS App — Service and State Ownership

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -251,6 +251,34 @@ Guardian bindings, verification challenges, and approval requests are all scoped
 
 The channel guardian service generates verification challenge instructions with channel-appropriate wording. The `channelLabel()` function maps `sourceChannel` values to human-readable labels (e.g., `"telegram"` -> `"Telegram"`, `"sms"` -> `"SMS"`), so challenge prompts reference the correct channel name.
 
+## Channel Readiness
+
+The `channel_readiness` IPC contract provides a unified way to check whether a channel (SMS, Telegram, etc.) is fully configured and operational. It runs local checks (credential presence, phone number assignment, ingress config) synchronously and optional remote checks (API reachability) asynchronously with a 5-minute TTL cache.
+
+### `channel_readiness` IPC Contract
+
+| Action | Description |
+|--------|-------------|
+| `get` | Returns readiness snapshots for the specified channel (or all channels if omitted). Local checks always run; remote checks run only when `includeRemote=true` and cache is stale. |
+| `refresh` | Invalidates the cache for the specified channel (or all channels), then returns fresh snapshots. |
+
+Request fields: `action` (required), `channel` (optional filter), `assistantId` (optional), `includeRemote` (optional boolean).
+
+Response type: `channel_readiness_response` with `success`, optional `snapshots` array (each with `channel`, `ready`, `checkedAt`, `stale`, `reasons`, `localChecks`, optional `remoteChecks`), and optional `error`.
+
+### Built-in Channel Probes
+
+- **SMS**: Checks Twilio credentials, phone number assignment, and public ingress URL.
+- **Telegram**: Checks bot token, webhook secret, and public ingress URL.
+
+### Key modules
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/channel-readiness-types.ts` | Shared types: `ChannelId`, `ReadinessCheckResult`, `ChannelReadinessSnapshot`, `ChannelProbe` |
+| `src/runtime/channel-readiness-service.ts` | Service class with probe registration, cached readiness evaluation, and built-in SMS/Telegram probes |
+| `src/daemon/handlers/config.ts` | `handleChannelReadiness` — IPC handler for `channel_readiness` messages |
+
 ## Database
 
 SQLite via Drizzle ORM, stored at `~/.vellum/workspace/data/db/assistant.db`. Key tables include conversations, messages, tool invocations, attachments, memory segments (with FTS5), memory items, entities, reminders, and recurrence schedules (cron + RRULE).

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -601,6 +601,15 @@ exports[`IPC message snapshots ClientMessage types twilio_config serializes to e
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types channel_readiness serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "channel": "sms",
+  "includeRemote": true,
+  "type": "channel_readiness",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types guardian_verification serializes to expected JSON 1`] = `
 {
   "action": "create_challenge",
@@ -905,6 +914,20 @@ exports[`IPC message snapshots ClientMessage types tool_permission_simulate seri
 exports[`IPC message snapshots ClientMessage types tool_names_list serializes to expected JSON 1`] = `
 {
   "type": "tool_names_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types dictation_request serializes to expected JSON 1`] = `
+{
+  "context": {
+    "appName": "Example App",
+    "bundleIdentifier": "com.example.app",
+    "cursorInTextField": true,
+    "selectedText": "some selected text",
+    "windowTitle": "Main Window",
+  },
+  "transcription": "Hello world",
+  "type": "dictation_request",
 }
 `;
 
@@ -1320,6 +1343,14 @@ exports[`IPC message snapshots ServerMessage types task_routed serializes to exp
   "interactionType": "computer_use",
   "sessionId": "sess-routed-001",
   "type": "task_routed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ride_shotgun_progress serializes to expected JSON 1`] = `
+{
+  "message": "Observing user activity...",
+  "type": "ride_shotgun_progress",
+  "watchId": "watch-shotgun-001",
 }
 `;
 
@@ -1936,6 +1967,44 @@ exports[`IPC message snapshots ServerMessage types twilio_config_response serial
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types channel_readiness_response serializes to expected JSON 1`] = `
+{
+  "snapshots": [
+    {
+      "channel": "sms",
+      "checkedAt": 1700000000000,
+      "localChecks": [
+        {
+          "message": "Twilio credentials are not configured",
+          "name": "twilio_credentials",
+          "passed": false,
+        },
+        {
+          "message": "Phone number is assigned",
+          "name": "phone_number",
+          "passed": true,
+        },
+        {
+          "message": "Public ingress URL is configured",
+          "name": "ingress",
+          "passed": true,
+        },
+      ],
+      "ready": false,
+      "reasons": [
+        {
+          "code": "twilio_credentials",
+          "text": "Twilio credentials are not configured",
+        },
+      ],
+      "stale": false,
+    },
+  ],
+  "success": true,
+  "type": "channel_readiness_response",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types guardian_verification_response serializes to expected JSON 1`] = `
 {
   "instruction": "Send this code to the Telegram bot",
@@ -2497,5 +2566,13 @@ exports[`IPC message snapshots ServerMessage types tool_names_list_response seri
     "file_write",
   ],
   "type": "tool_names_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types dictation_response serializes to expected JSON 1`] = `
+{
+  "mode": "dictation",
+  "text": "Hello world",
+  "type": "dictation_response",
 }
 `;

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { ChannelReadinessService, REMOTE_TTL_MS } from '../runtime/channel-readiness-service.js';
+import type { ChannelProbe, ReadinessCheckResult } from '../runtime/channel-readiness-types.js';
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+function makeProbe(
+  channel: string,
+  localResults: ReadinessCheckResult[],
+  remoteResults?: ReadinessCheckResult[],
+): ChannelProbe & { localCallCount: number; remoteCallCount: number } {
+  const probe = {
+    channel,
+    localCallCount: 0,
+    remoteCallCount: 0,
+    runLocalChecks(): ReadinessCheckResult[] {
+      probe.localCallCount++;
+      return localResults;
+    },
+    ...(remoteResults !== undefined
+      ? {
+          async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
+            probe.remoteCallCount++;
+            return remoteResults;
+          },
+        }
+      : {}),
+  };
+  return probe;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ChannelReadinessService', () => {
+  let service: ChannelReadinessService;
+
+  beforeEach(() => {
+    service = new ChannelReadinessService();
+  });
+
+  test('local checks run on every call (no caching of local results)', async () => {
+    const probe = makeProbe('sms', [
+      { name: 'creds', passed: true, message: 'ok' },
+    ]);
+    service.registerProbe(probe);
+
+    await service.getReadiness('sms');
+    await service.getReadiness('sms');
+
+    expect(probe.localCallCount).toBe(2);
+  });
+
+  test('cache miss runs local checks and returns snapshot', async () => {
+    const probe = makeProbe('sms', [
+      { name: 'creds', passed: true, message: 'ok' },
+      { name: 'phone', passed: false, message: 'missing' },
+    ]);
+    service.registerProbe(probe);
+
+    const [snapshot] = await service.getReadiness('sms');
+
+    expect(probe.localCallCount).toBe(1);
+    expect(snapshot.channel).toBe('sms');
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.localChecks).toHaveLength(2);
+    expect(snapshot.reasons).toEqual([
+      { code: 'phone', text: 'missing' },
+    ]);
+  });
+
+  test('includeRemote=true runs remote checks on cache miss', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    const [snapshot] = await service.getReadiness('sms', true);
+
+    expect(probe.remoteCallCount).toBe(1);
+    expect(snapshot.remoteChecks).toHaveLength(1);
+    expect(snapshot.remoteChecks![0].passed).toBe(true);
+  });
+
+  test('cached remote checks reused within TTL', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    // First call populates cache
+    await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+
+    // Second call within TTL should reuse cache
+    const [snapshot] = await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+    expect(snapshot.remoteChecks).toHaveLength(1);
+  });
+
+  test('stale cache triggers remote check re-run', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    // First call
+    await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+
+    // Manually age the cached snapshot beyond TTL
+    const cached = (service as unknown as { snapshots: Map<string, { checkedAt: number }> }).snapshots.get('sms')!;
+    cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
+
+    // Second call should re-run remote checks
+    await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(2);
+  });
+
+  test('invalidateChannel clears cache for specific channel', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+
+    service.invalidateChannel('sms');
+
+    // After invalidation, remote checks should run again
+    await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(2);
+  });
+
+  test('invalidateAll clears all cached snapshots', async () => {
+    const smsProbe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api', passed: true, message: 'ok' }],
+    );
+    const telegramProbe = makeProbe(
+      'telegram',
+      [{ name: 'token', passed: true, message: 'ok' }],
+      [{ name: 'webhook', passed: true, message: 'ok' }],
+    );
+    service.registerProbe(smsProbe);
+    service.registerProbe(telegramProbe);
+
+    await service.getReadiness(undefined, true);
+    expect(smsProbe.remoteCallCount).toBe(1);
+    expect(telegramProbe.remoteCallCount).toBe(1);
+
+    service.invalidateAll();
+
+    await service.getReadiness(undefined, true);
+    expect(smsProbe.remoteCallCount).toBe(2);
+    expect(telegramProbe.remoteCallCount).toBe(2);
+  });
+
+  test('unknown channel returns unsupported_channel reason', async () => {
+    const [snapshot] = await service.getReadiness('carrier_pigeon');
+
+    expect(snapshot.channel).toBe('carrier_pigeon');
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.reasons).toEqual([
+      { code: 'unsupported_channel', text: 'Channel carrier_pigeon is not supported' },
+    ]);
+    expect(snapshot.localChecks).toHaveLength(0);
+  });
+
+  test('all checks passing yields ready=true', async () => {
+    const probe = makeProbe('test', [
+      { name: 'a', passed: true, message: 'ok' },
+      { name: 'b', passed: true, message: 'ok' },
+    ]);
+    service.registerProbe(probe);
+
+    const [snapshot] = await service.getReadiness('test');
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.reasons).toHaveLength(0);
+  });
+
+  test('getReadiness with no channel returns all registered channels', async () => {
+    service.registerProbe(makeProbe('sms', [{ name: 'a', passed: true, message: 'ok' }]));
+    service.registerProbe(makeProbe('telegram', [{ name: 'b', passed: true, message: 'ok' }]));
+
+    const snapshots = await service.getReadiness();
+
+    expect(snapshots).toHaveLength(2);
+    const channels = snapshots.map((s) => s.channel).sort();
+    expect(channels).toEqual(['sms', 'telegram']);
+  });
+
+  test('failed remote check makes channel not ready', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: false, message: 'API unreachable' }],
+    );
+    service.registerProbe(probe);
+
+    const [snapshot] = await service.getReadiness('sms', true);
+
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.reasons).toEqual([
+      { code: 'api_check', text: 'API unreachable' },
+    ]);
+  });
+});

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -382,6 +382,12 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'twilio_config',
     action: 'get',
   },
+  channel_readiness: {
+    type: 'channel_readiness',
+    action: 'get',
+    channel: 'sms',
+    includeRemote: true,
+  },
   guardian_verification: {
     type: 'guardian_verification',
     action: 'create_challenge',
@@ -1243,6 +1249,24 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     hasCredentials: true,
     phoneNumber: '+15551234567',
+  },
+  channel_readiness_response: {
+    type: 'channel_readiness_response',
+    success: true,
+    snapshots: [
+      {
+        channel: 'sms',
+        ready: false,
+        checkedAt: 1700000000000,
+        stale: false,
+        reasons: [{ code: 'twilio_credentials', text: 'Twilio credentials are not configured' }],
+        localChecks: [
+          { name: 'twilio_credentials', passed: false, message: 'Twilio credentials are not configured' },
+          { name: 'phone_number', passed: true, message: 'Phone number is assigned' },
+          { name: 'ingress', passed: true, message: 'Public ingress URL is configured' },
+        ],
+      },
+    ],
   },
   guardian_verification_response: {
     type: 'guardian_verification_response',

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -33,6 +33,7 @@ import type {
   TwitterIntegrationConfigRequest,
   TelegramConfigRequest,
   TwilioConfigRequest,
+  ChannelReadinessRequest,
   GuardianVerificationRequest,
   ToolPermissionSimulateRequest,
 } from '../ipc-protocol.js';
@@ -50,6 +51,7 @@ import {
   type IngressConfig,
 } from '../../inbound/public-ingress-urls.js';
 import { createVerificationChallenge, getGuardianBinding, revokeBinding as revokeGuardianBinding } from '../../runtime/channel-guardian-service.js';
+import { createReadinessService, type ChannelReadinessService } from '../../runtime/channel-readiness-service.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
 import { MODEL_TO_PROVIDER } from '../session-slash.js';
 
@@ -1588,6 +1590,57 @@ export function handleGuardianVerification(
   }
 }
 
+// Lazy singleton — created on first use so module-load stays lightweight.
+let _readinessService: ChannelReadinessService | undefined;
+function getReadinessService(): ChannelReadinessService {
+  if (!_readinessService) {
+    _readinessService = createReadinessService();
+  }
+  return _readinessService;
+}
+
+export async function handleChannelReadiness(
+  msg: ChannelReadinessRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const service = getReadinessService();
+
+    if (msg.action === 'refresh') {
+      if (msg.channel) {
+        service.invalidateChannel(msg.channel);
+      } else {
+        service.invalidateAll();
+      }
+    }
+
+    const snapshots = await service.getReadiness(msg.channel, msg.includeRemote);
+
+    ctx.send(socket, {
+      type: 'channel_readiness_response',
+      success: true,
+      snapshots: snapshots.map((s) => ({
+        channel: s.channel,
+        ready: s.ready,
+        checkedAt: s.checkedAt,
+        stale: s.stale,
+        reasons: s.reasons,
+        localChecks: s.localChecks,
+        remoteChecks: s.remoteChecks,
+      })),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to handle channel readiness');
+    ctx.send(socket, {
+      type: 'channel_readiness_response',
+      success: false,
+      error: message,
+    });
+  }
+}
+
 export function handleEnvVarsRequest(socket: net.Socket, ctx: HandlerContext): void {
   const vars: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -1770,6 +1823,7 @@ export const configHandlers = defineHandlers({
   twitter_integration_config: handleTwitterIntegrationConfig,
   telegram_config: handleTelegramConfig,
   twilio_config: handleTwilioConfig,
+  channel_readiness: handleChannelReadiness,
   guardian_verification: handleGuardianVerification,
   env_vars_request: (_msg, socket, ctx) => handleEnvVarsRequest(socket, ctx),
   tool_permission_simulate: handleToolPermissionSimulate,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -583,6 +583,29 @@ export interface TwilioConfigResponse {
   warning?: string;
 }
 
+export interface ChannelReadinessRequest {
+  type: 'channel_readiness';
+  action: 'get' | 'refresh';
+  channel?: string;
+  assistantId?: string;
+  includeRemote?: boolean;
+}
+
+export interface ChannelReadinessResponse {
+  type: 'channel_readiness_response';
+  success: boolean;
+  snapshots?: Array<{
+    channel: string;
+    ready: boolean;
+    checkedAt: number;
+    stale: boolean;
+    reasons: Array<{ code: string; text: string }>;
+    localChecks: Array<{ name: string; passed: boolean; message: string }>;
+    remoteChecks?: Array<{ name: string; passed: boolean; message: string }>;
+  }>;
+  error?: string;
+}
+
 export interface GuardianVerificationRequest {
   type: 'guardian_verification';
   action: 'create_challenge' | 'status' | 'revoke';
@@ -1102,6 +1125,7 @@ export type ClientMessage =
   | TwitterIntegrationConfigRequest
   | TelegramConfigRequest
   | TwilioConfigRequest
+  | ChannelReadinessRequest
   | GuardianVerificationRequest
   | TwitterAuthStartRequest
   | TwitterAuthStatusRequest
@@ -2485,6 +2509,7 @@ export type ServerMessage =
   | TwitterIntegrationConfigResponse
   | TelegramConfigResponse
   | TwilioConfigResponse
+  | ChannelReadinessResponse
   | GuardianVerificationResponse
   | TwitterAuthResult
   | TwitterAuthStatusResponse

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,0 +1,225 @@
+import type {
+  ChannelId,
+  ChannelProbe,
+  ChannelReadinessSnapshot,
+  ReadinessCheckResult,
+} from './channel-readiness-types.js';
+import { hasTwilioCredentials } from '../calls/twilio-rest.js';
+import { getSecureKey } from '../security/secure-keys.js';
+import { loadRawConfig } from '../config/loader.js';
+
+/** Remote check results are cached for 5 minutes before being considered stale. */
+export const REMOTE_TTL_MS = 5 * 60 * 1000;
+
+// ── SMS Probe ───────────────────────────────────────────────────────────────
+
+function hasIngressConfigured(): boolean {
+  try {
+    const raw = loadRawConfig();
+    const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+    const publicBaseUrl = (ingress.publicBaseUrl as string) ?? '';
+    const enabled = (ingress.enabled as boolean | undefined) ?? (publicBaseUrl ? true : false);
+    return enabled && publicBaseUrl.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+const smsProbe: ChannelProbe = {
+  channel: 'sms',
+  runLocalChecks(): ReadinessCheckResult[] {
+    const results: ReadinessCheckResult[] = [];
+
+    const hasCreds = hasTwilioCredentials();
+    results.push({
+      name: 'twilio_credentials',
+      passed: hasCreds,
+      message: hasCreds
+        ? 'Twilio credentials are configured'
+        : 'Twilio Account SID and Auth Token are not configured',
+    });
+
+    const hasPhone = !!getSecureKey('credential:twilio:phone_number');
+    results.push({
+      name: 'phone_number',
+      passed: hasPhone,
+      message: hasPhone
+        ? 'Phone number is assigned'
+        : 'No phone number assigned',
+    });
+
+    const hasIngress = hasIngressConfigured();
+    results.push({
+      name: 'ingress',
+      passed: hasIngress,
+      message: hasIngress
+        ? 'Public ingress URL is configured'
+        : 'Public ingress URL is not configured or disabled',
+    });
+
+    return results;
+  },
+  // Placeholder for remote checks (will be extended in PR3 with Twilio API calls)
+  async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
+    return [];
+  },
+};
+
+// ── Telegram Probe ──────────────────────────────────────────────────────────
+
+const telegramProbe: ChannelProbe = {
+  channel: 'telegram',
+  runLocalChecks(): ReadinessCheckResult[] {
+    const results: ReadinessCheckResult[] = [];
+
+    const hasBotToken = !!getSecureKey('credential:telegram:bot_token');
+    results.push({
+      name: 'bot_token',
+      passed: hasBotToken,
+      message: hasBotToken
+        ? 'Telegram bot token is configured'
+        : 'Telegram bot token is not configured',
+    });
+
+    const hasWebhookSecret = !!getSecureKey('credential:telegram:webhook_secret');
+    results.push({
+      name: 'webhook_secret',
+      passed: hasWebhookSecret,
+      message: hasWebhookSecret
+        ? 'Telegram webhook secret is configured'
+        : 'Telegram webhook secret is not configured',
+    });
+
+    const hasIngress = hasIngressConfigured();
+    results.push({
+      name: 'ingress',
+      passed: hasIngress,
+      message: hasIngress
+        ? 'Public ingress URL is configured'
+        : 'Public ingress URL is not configured or disabled',
+    });
+
+    return results;
+  },
+  // Telegram has no remote checks currently
+};
+
+// ── Service ─────────────────────────────────────────────────────────────────
+
+export class ChannelReadinessService {
+  private probes = new Map<ChannelId, ChannelProbe>();
+  private snapshots = new Map<ChannelId, ChannelReadinessSnapshot>();
+
+  registerProbe(probe: ChannelProbe): void {
+    this.probes.set(probe.channel, probe);
+  }
+
+  /**
+   * Get readiness snapshots for the specified channel (or all registered channels).
+   * Local checks always run inline. Remote checks run only when `includeRemote`
+   * is true and the cache is stale or missing.
+   */
+  async getReadiness(
+    channel?: ChannelId,
+    includeRemote?: boolean,
+  ): Promise<ChannelReadinessSnapshot[]> {
+    const channels = channel
+      ? [channel]
+      : Array.from(this.probes.keys());
+
+    const results: ChannelReadinessSnapshot[] = [];
+    for (const ch of channels) {
+      const probe = this.probes.get(ch);
+      if (!probe) {
+        results.push(this.unsupportedSnapshot(ch));
+        continue;
+      }
+
+      const localChecks = probe.runLocalChecks();
+      let remoteChecks: ReadinessCheckResult[] | undefined;
+      let stale = false;
+
+      const cached = this.snapshots.get(ch);
+      const now = Date.now();
+
+      if (includeRemote && probe.runRemoteChecks) {
+        const cacheExpired = !cached || (now - cached.checkedAt) >= REMOTE_TTL_MS;
+        if (cacheExpired) {
+          remoteChecks = await probe.runRemoteChecks();
+        } else {
+          // Reuse cached remote checks
+          remoteChecks = cached.remoteChecks;
+        }
+      } else if (cached?.remoteChecks) {
+        // Surface cached remote checks even when not explicitly requested,
+        // but mark stale if TTL has elapsed
+        remoteChecks = cached.remoteChecks;
+        stale = (now - cached.checkedAt) >= REMOTE_TTL_MS;
+      }
+
+      const allLocalPassed = localChecks.every((c) => c.passed);
+      const allRemotePassed = remoteChecks ? remoteChecks.every((c) => c.passed) : true;
+      const ready = allLocalPassed && allRemotePassed;
+
+      const reasons: Array<{ code: string; text: string }> = [];
+      for (const check of localChecks) {
+        if (!check.passed) {
+          reasons.push({ code: check.name, text: check.message });
+        }
+      }
+      if (remoteChecks) {
+        for (const check of remoteChecks) {
+          if (!check.passed) {
+            reasons.push({ code: check.name, text: check.message });
+          }
+        }
+      }
+
+      const snapshot: ChannelReadinessSnapshot = {
+        channel: ch,
+        ready,
+        checkedAt: now,
+        stale,
+        reasons,
+        localChecks,
+        remoteChecks,
+      };
+
+      this.snapshots.set(ch, snapshot);
+      results.push(snapshot);
+    }
+
+    return results;
+  }
+
+  /** Clear cached snapshot for a specific channel, forcing re-evaluation on next call. */
+  invalidateChannel(channel: ChannelId): void {
+    this.snapshots.delete(channel);
+  }
+
+  /** Clear all cached snapshots. */
+  invalidateAll(): void {
+    this.snapshots.clear();
+  }
+
+  private unsupportedSnapshot(channel: ChannelId): ChannelReadinessSnapshot {
+    return {
+      channel,
+      ready: false,
+      checkedAt: Date.now(),
+      stale: false,
+      reasons: [{ code: 'unsupported_channel', text: `Channel ${channel} is not supported` }],
+      localChecks: [],
+    };
+  }
+}
+
+// ── Factory ─────────────────────────────────────────────────────────────────
+
+/** Create a service instance with built-in SMS and Telegram probes registered. */
+export function createReadinessService(): ChannelReadinessService {
+  const service = new ChannelReadinessService();
+  service.registerProbe(smsProbe);
+  service.registerProbe(telegramProbe);
+  return service;
+}

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -1,0 +1,29 @@
+// Channel readiness types — reusable primitive for all channels.
+
+/** Logical channel identifier. Well-known channels have literal types; custom channels use string. */
+export type ChannelId = 'sms' | 'telegram' | string;
+
+/** Result of a single readiness check (local or remote). */
+export interface ReadinessCheckResult {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+/** Point-in-time snapshot of a channel's readiness state. */
+export interface ChannelReadinessSnapshot {
+  channel: ChannelId;
+  ready: boolean;
+  checkedAt: number;
+  stale: boolean;
+  reasons: Array<{ code: string; text: string }>;
+  localChecks: ReadinessCheckResult[];
+  remoteChecks?: ReadinessCheckResult[];
+}
+
+/** Probe interface that channels implement to provide readiness checks. */
+export interface ChannelProbe {
+  channel: ChannelId;
+  runLocalChecks(): ReadinessCheckResult[];
+  runRemoteChecks?(): Promise<ReadinessCheckResult[]>;
+}


### PR DESCRIPTION
Part of #7368. Adds a reusable channel readiness subsystem with cached probes and IPC surface for all channels. Includes SMS and Telegram probes, IPC contract, handler, unit tests, and IPC snapshot updates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
