### PR TITLE
feat: recording status indicator + expandable error text in CU overlay

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -110,7 +110,9 @@ final class ComputerUseSession: ObservableObject {
     private var consecutiveUnchangedSteps = 0
     private var currentStepNumber = 0
     private var consecutiveFrontmostBlocks = 0
-    private(set) var qaRecordingWarningMessage: String?
+    @Published private(set) var qaRecordingWarningMessage: String?
+    /// Whether screen recording is currently active (for UI indicator).
+    @Published private(set) var isRecordingActive: Bool = false
 
     /// Adaptive delay configuration
     private let adaptiveDelayEnabled: Bool
@@ -174,6 +176,7 @@ final class ComputerUseSession: ObservableObject {
         isPaused = false
         pendingToolPermissionPrompt = nil
         qaRecordingWarningMessage = nil
+        isRecordingActive = false
         previousAXTreeText = nil
         previousElements = nil
         previousFlatElements = nil
@@ -227,6 +230,7 @@ final class ComputerUseSession: ObservableObject {
                 }
                 try await recorder.startRecording(windowID: windowID, displayID: displayID, includeAudio: self.includeAudio)
                 log.info("QA mode: screen recording started for session \(self.id) (scope: \(self.captureScope))")
+                isRecordingActive = true
                 // Notify daemon that recording started successfully
                 try? daemonClient.send(CuRecordingStatusMessage(sessionId: id, status: "started"))
             } catch {
@@ -1216,10 +1220,12 @@ final class ComputerUseSession: ObservableObject {
                     targetBundleId: result.targetBundleId,
                     expiresAt: expiresAtEpoch
                 )
+                isRecordingActive = false
                 log.info("QA recording finalized: \(result.fileURL.lastPathComponent) (\(result.sizeBytes) bytes, \(result.durationMs)ms)")
                 // Notify daemon that recording stopped successfully
                 try? daemonClient.send(CuRecordingStatusMessage(sessionId: id, status: "stopped"))
             } catch {
+                isRecordingActive = false
                 log.error("QA mode: failed to stop screen recording: \(error.localizedDescription)")
                 try? daemonClient.send(CuRecordingStatusMessage(sessionId: id, status: "failed", reason: error.localizedDescription))
                 if qaRecordingWarningMessage == nil {

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
@@ -21,6 +21,9 @@ struct SessionOverlayView: View {
             candidates.append(prompt.toolName)
             candidates.append(prompt.summary)
         }
+        if let warning = session.qaRecordingWarningMessage {
+            candidates.append(warning)
+        }
         switch session.state {
         case .running(_, _, let lastAction, let reasoning):
             candidates.append(lastAction)
@@ -57,6 +60,9 @@ struct SessionOverlayView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             Divider()
+
+            // Recording status indicator (QA mode only)
+            recordingStatusView
 
             if let prompt = session.pendingToolPermissionPrompt {
                 toolPermissionPromptView(prompt)
@@ -222,19 +228,82 @@ struct SessionOverlayView: View {
             }
 
         case .failed(let reason):
-            HStack(spacing: 6) {
+            HStack(alignment: .top, spacing: 6) {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.red)
-                Text(reason)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 1)
+                ScrollView {
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .frame(maxHeight: 120)
             }
 
         case .cancelled:
             Text("Cancelled")
                 .font(.caption.bold())
                 .foregroundStyle(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private var recordingStatusView: some View {
+        if session.qaMode {
+            if let warning = session.qaRecordingWarningMessage {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Circle()
+                        .fill(VColor.error)
+                        .frame(width: 8, height: 8)
+                        .padding(.top, 3)
+                    ScrollView {
+                        Text(warning)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.error)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 60)
+                }
+                .padding(.horizontal, VSpacing.xs)
+            } else if session.isRecordingActive {
+                HStack(spacing: VSpacing.sm) {
+                    Circle()
+                        .fill(VColor.success)
+                        .frame(width: 8, height: 8)
+                    Text("Recording")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
+                .padding(.horizontal, VSpacing.xs)
+            } else if session.requiresRecording {
+                HStack(spacing: VSpacing.sm) {
+                    Circle()
+                        .fill(VColor.warning)
+                        .frame(width: 8, height: 8)
+                    Text("Recording required \u{2014} waiting...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+                .padding(.horizontal, VSpacing.xs)
+            } else {
+                switch session.state {
+                case .idle, .running(step: 0, _, _, _):
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text("Recording starting...")
+                            .font(VFont.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, VSpacing.xs)
+                default:
+                    EmptyView()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a **recording status badge** to the CU session overlay when `qaMode` is true, showing real-time recording state:
  - Green dot + "Recording" — recording is active
  - Red dot + scrollable error text — recording failed (with full error message)
  - Yellow dot + "Recording required — waiting..." — waiting for required recording to start
  - Spinner + "Recording starting..." — during initialization
- Makes **failed-state error text scrollable** (up to 120px) with text selection enabled, preventing silent truncation of long error messages
- Includes recording warning text in overlay width calculation so the panel auto-sizes appropriately

## Changes
- `clients/macos/vellum-assistant/ComputerUse/Session.swift` — Add `@Published isRecordingActive` property and make `qaRecordingWarningMessage` `@Published` so the overlay can observe recording state transitions
- `clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift` — Add `recordingStatusView` component with status-dependent indicators, wrap failed-state text in `ScrollView`

## Test plan
- [ ] Start a QA-mode CU session and verify green "Recording" badge appears in overlay
- [ ] Simulate recording failure (e.g., revoke screen recording permission) and verify red error badge appears with full error text
- [ ] Verify long error messages are scrollable and selectable in both the recording status area and the failed state area
- [ ] Verify overlay auto-sizes width when recording warning text is long
- [ ] Verify no recording status badge appears for non-QA sessions
- [ ] Build succeeds: `cd clients/macos && ./build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
