### PR TITLE
feat: truthful SMS send semantics and skill-driven SMS doctor

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -208,8 +208,10 @@ The daemon handles `twilio_config` messages with the following actions:
 | `provision_number` | Purchases a new phone number via the Twilio API. Accepts optional `areaCode` and `country` (ISO 3166-1 alpha-2, default `US`). Auto-assigns the number to the assistant (persists to config and secure storage) and configures Twilio webhooks (voice, status callback, SMS) when a public ingress URL is available. |
 | `assign_number` | Assigns an existing Twilio phone number (E.164 format) to the assistant and auto-configures webhooks when ingress is available |
 | `list_numbers` | Lists all incoming phone numbers on the Twilio account with their capabilities (voice, SMS) |
+| `sms_send_test` | Sends a test SMS to the specified `phoneNumber` with the given `text`, polls Twilio for delivery status (up to 3 retries at 2-second intervals), and returns the result in `testResult`. Stores the last result in memory for use by `sms_doctor`. |
+| `sms_doctor` | Runs a comprehensive SMS health diagnostic. Checks channel readiness, compliance/toll-free verification status, and the last `sms_send_test` result. Returns structured diagnostics in `diagnostics` with an overall `status` ("healthy", "degraded", or "unhealthy") and actionable `items`. |
 
-Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, optional `error`, and optional `warning` (for non-fatal webhook sync failures).
+Response type: `twilio_config_response` with `success`, `hasCredentials`, optional `phoneNumber`, optional `numbers` array, optional `error`, optional `warning` (for non-fatal webhook sync failures), optional `testResult` (for `sms_send_test`), and optional `diagnostics` (for `sms_doctor`).
 
 ### Ingress Webhook Reconciliation
 

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1960,9 +1960,27 @@ exports[`IPC message snapshots ServerMessage types telegram_config_response seri
 
 exports[`IPC message snapshots ServerMessage types twilio_config_response serializes to expected JSON 1`] = `
 {
+  "diagnostics": {
+    "actionItems": [],
+    "compliance": {
+      "remediation": "Your number is verified and ready for SMS",
+      "status": "approved",
+    },
+    "overallStatus": "healthy",
+    "readiness": {
+      "issues": [],
+      "ready": true,
+    },
+  },
   "hasCredentials": true,
   "phoneNumber": "+15551234567",
   "success": true,
+  "testResult": {
+    "finalStatus": "delivered",
+    "initialStatus": "queued",
+    "messageSid": "SM1234567890abcdef1234567890abcdef",
+    "to": "+15559876543",
+  },
   "type": "twilio_config_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1249,6 +1249,18 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     hasCredentials: true,
     phoneNumber: '+15551234567',
+    testResult: {
+      messageSid: 'SM1234567890abcdef1234567890abcdef',
+      to: '+15559876543',
+      initialStatus: 'queued',
+      finalStatus: 'delivered',
+    },
+    diagnostics: {
+      readiness: { ready: true, issues: [] },
+      compliance: { status: 'approved', remediation: 'Your number is verified and ready for SMS' },
+      overallStatus: 'healthy',
+      actionItems: [],
+    },
   },
   channel_readiness_response: {
     type: 'channel_readiness_response',

--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-const sendSmsMock = mock(async (..._args: unknown[]) => {});
+const sendSmsMock = mock(async (..._args: unknown[]) => ({ messageSid: 'SM-mock-sid', status: 'queued' }));
 const getOrCreateConversationMock = mock((_key: string) => ({ conversationId: 'conv-1' }));
 const upsertOutboundBindingMock = mock((_input: Record<string, unknown>) => {});
 
@@ -89,6 +89,25 @@ describe('smsMessagingProvider', () => {
     );
     expect(getOrCreateConversationMock).toHaveBeenCalledWith('asst:ast-alpha:sms:+15550002222');
     expect(upsertOutboundBindingMock).not.toHaveBeenCalled();
+  });
+
+  test('sendMessage uses messageSid from gateway response as result ID', async () => {
+    sendSmsMock.mockImplementation(async () => ({ messageSid: 'SM-test-12345', status: 'queued' }));
+    const result = await smsMessagingProvider.sendMessage('', '+15550009999', 'sid test', {
+      assistantId: 'self',
+    });
+    expect(result.id).toBe('SM-test-12345');
+  });
+
+  test('sendMessage falls back to timestamp-based ID when messageSid is absent', async () => {
+    sendSmsMock.mockImplementation(async () => ({}));
+    const before = Date.now();
+    const result = await smsMessagingProvider.sendMessage('', '+15550009999', 'no sid', {
+      assistantId: 'self',
+    });
+    expect(result.id).toMatch(/^sms-\d+$/);
+    const ts = parseInt(result.id.replace('sms-', ''), 10);
+    expect(ts).toBeGreaterThanOrEqual(before);
   });
 
   test('sendMessage uses canonical self key and writes outbound binding for self scope', async () => {

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -155,6 +155,38 @@ export async function provisionPhoneNumber(
   };
 }
 
+/** Fetch the current status of a Twilio message by SID. */
+export async function fetchMessageStatus(
+  accountSid: string,
+  authToken: string,
+  messageSid: string,
+): Promise<{ status: string; errorCode?: string; errorMessage?: string }> {
+  const res = await fetch(
+    `${twilioBaseUrl(accountSid)}/Messages/${encodeURIComponent(messageSid)}.json`,
+    {
+      method: 'GET',
+      headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Twilio API error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    status?: string;
+    error_code?: number | null;
+    error_message?: string | null;
+  };
+
+  return {
+    status: data.status ?? 'unknown',
+    errorCode: data.error_code != null ? String(data.error_code) : undefined,
+    errorMessage: data.error_message ?? undefined,
+  };
+}
+
 export interface WebhookUrls {
   voiceUrl: string;
   statusCallbackUrl: string;

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -24,6 +24,10 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
         assistantId: context.assistantId,
       });
 
+      // SMS acceptance is not the same as handset delivery — surface truthful wording.
+      if (provider.id === 'sms') {
+        return ok(`SMS accepted by Twilio (ID: ${result.id}). Note: "accepted" means Twilio received it for delivery — it has not yet been confirmed as delivered to the handset.`);
+      }
       return ok(`Message sent (ID: ${result.id}).`);
     });
   } catch (e) {

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -43,6 +43,7 @@ import {
   searchAvailableNumbers,
   provisionPhoneNumber,
   updatePhoneNumberWebhooks,
+  fetchMessageStatus,
 } from '../../calls/twilio-rest.js';
 import {
   getTwilioVoiceWebhookUrl,
@@ -1181,6 +1182,30 @@ export async function handleTelegramConfig(
   }
 }
 
+// In-memory store for the last sms_send_test result, used by sms_doctor.
+let _lastTestResult: {
+  messageSid: string;
+  to: string;
+  initialStatus: string;
+  finalStatus: string;
+  errorCode?: string;
+  errorMessage?: string;
+} | undefined;
+
+/** Map common Twilio error codes to human-readable remediation advice. */
+function mapTwilioErrorRemediation(errorCode: string): string | undefined {
+  const map: Record<string, string> = {
+    '30003': 'Unreachable destination handset',
+    '30004': 'Message blocked by carrier or Twilio',
+    '30005': 'Unknown destination handset',
+    '30006': 'Landline or unreachable carrier',
+    '30007': 'Message filtered by carrier',
+    '30008': 'Unknown error',
+    '21610': 'Recipient has opted out (replied STOP)',
+  };
+  return map[errorCode];
+}
+
 export async function handleTwilioConfig(
   msg: TwilioConfigRequest,
   socket: net.Socket,
@@ -1480,6 +1505,225 @@ export async function handleTwilioConfig(
         success: true,
         hasCredentials: true,
         numbers,
+      });
+    } else if (msg.action === 'sms_send_test') {
+      // Send a test SMS and do a brief status poll to observe Twilio-side reality.
+      if (!hasTwilioCredentials()) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: false,
+          error: 'Twilio credentials not configured. Set credentials first.',
+        });
+        return;
+      }
+
+      const targetPhone = msg.phoneNumber;
+      if (!targetPhone) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: true,
+          error: 'phoneNumber is required for sms_send_test action',
+        });
+        return;
+      }
+
+      const testText = msg.text ?? 'Test SMS from your Vellum assistant';
+      const accountSid = getSecureKey('credential:twilio:account_sid')!;
+      const authToken = getSecureKey('credential:twilio:auth_token')!;
+
+      // Send via the gateway /deliver/sms endpoint
+      const gatewayBase = computeGatewayTarget();
+      const token = readHttpToken();
+      if (!token) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: true,
+          error: 'No runtime HTTP bearer token available — is the daemon running?',
+        });
+        return;
+      }
+
+      let messageSid: string;
+      let initialStatus: string;
+      try {
+        const deliverResp = await fetch(`${gatewayBase}/deliver/sms`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ to: targetPhone, text: testText }),
+          signal: AbortSignal.timeout(15_000),
+        });
+
+        if (!deliverResp.ok) {
+          const body = await deliverResp.text().catch(() => '<unreadable>');
+          ctx.send(socket, {
+            type: 'twilio_config_response',
+            success: false,
+            hasCredentials: true,
+            error: `Gateway /deliver/sms failed (${deliverResp.status}): ${body}`,
+          });
+          return;
+        }
+
+        const deliverData = (await deliverResp.json()) as {
+          ok?: boolean;
+          messageSid?: string;
+          status?: string;
+        };
+        messageSid = deliverData.messageSid ?? '';
+        initialStatus = deliverData.status ?? 'unknown';
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: true,
+          error: `Failed to send test SMS: ${errMsg}`,
+        });
+        return;
+      }
+
+      // Brief status poll (2-3 attempts, 2 seconds apart)
+      let finalStatus = initialStatus;
+      let errorCode: string | undefined;
+      let errorMessage: string | undefined;
+
+      if (messageSid) {
+        const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+        for (let i = 0; i < 3; i++) {
+          await sleep(2_000);
+          try {
+            const poll = await fetchMessageStatus(accountSid, authToken, messageSid);
+            finalStatus = poll.status;
+            errorCode = poll.errorCode;
+            errorMessage = poll.errorMessage;
+            // Terminal statuses — no need to keep polling
+            if (['delivered', 'undelivered', 'failed'].includes(finalStatus)) break;
+          } catch {
+            // Non-fatal — keep the last known status
+            break;
+          }
+        }
+      }
+
+      // Store the last test result in memory for sms_doctor
+      _lastTestResult = {
+        messageSid,
+        to: targetPhone,
+        initialStatus,
+        finalStatus,
+        errorCode,
+        errorMessage,
+      };
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: true,
+        testResult: _lastTestResult,
+      });
+    } else if (msg.action === 'sms_doctor') {
+      // Aggregated diagnostics: readiness + compliance + last test send
+      const actionItems: string[] = [];
+
+      // 1. Channel readiness check (local + remote)
+      const readinessService = getReadinessService();
+      const smsSnapshots = await readinessService.getReadiness('sms', true);
+      const smsSnap = smsSnapshots[0];
+      const readinessIssues: string[] = smsSnap
+        ? smsSnap.reasons.map((r) => r.text)
+        : ['SMS channel probe not registered'];
+      const readinessReady = smsSnap?.ready ?? false;
+      if (!readinessReady) {
+        actionItems.push(...readinessIssues.map((issue) => `Fix readiness: ${issue}`));
+      }
+
+      // 2. Compliance / toll-free verification status
+      let complianceStatus = 'unknown';
+      let complianceDetail: string | undefined;
+      let complianceRemediation: string | undefined;
+
+      // Attempt to read toll-free verification status from remote checks
+      if (smsSnap?.remoteChecks) {
+        for (const rc of smsSnap.remoteChecks) {
+          if (rc.name === 'toll_free_verification') {
+            complianceStatus = rc.passed ? 'approved' : 'not_approved';
+            complianceDetail = rc.message;
+          }
+        }
+      }
+
+      // Map remediation advice based on verification status keywords
+      if (complianceDetail) {
+        if (complianceDetail.includes('TWILIO_APPROVED')) {
+          complianceStatus = 'approved';
+          complianceRemediation = 'Your number is verified and ready for SMS';
+        } else if (complianceDetail.includes('PENDING_REVIEW') || complianceDetail.includes('IN_REVIEW')) {
+          complianceStatus = 'pending';
+          complianceRemediation = 'Verification is pending. Twilio review typically takes 1-5 business days.';
+          actionItems.push('Wait for Twilio toll-free verification review');
+        } else if (complianceDetail.includes('TWILIO_REJECTED') && complianceDetail.includes('editAllowed=true')) {
+          complianceStatus = 'rejected_editable';
+          complianceRemediation = 'Verification was rejected. You can edit and resubmit.';
+          actionItems.push('Edit and resubmit toll-free verification');
+        } else if (complianceDetail.includes('TWILIO_REJECTED')) {
+          complianceStatus = 'rejected';
+          complianceRemediation = 'Verification was rejected and the edit window has expired. Delete and resubmit (this resets queue priority).';
+          actionItems.push('Delete and resubmit toll-free verification');
+        }
+
+        // Political use case warning
+        if (complianceDetail.includes('POLLING_AND_VOTING')) {
+          actionItems.push('Political use case detected: Campaign Verify token may be required');
+        }
+      }
+
+      // 3. Last test send result
+      let lastSend: { status: string; errorCode?: string; remediation?: string } | undefined;
+      if (_lastTestResult) {
+        const errorRemediation = _lastTestResult.errorCode
+          ? mapTwilioErrorRemediation(_lastTestResult.errorCode)
+          : undefined;
+        lastSend = {
+          status: _lastTestResult.finalStatus,
+          errorCode: _lastTestResult.errorCode,
+          remediation: errorRemediation,
+        };
+        if (errorRemediation) {
+          actionItems.push(`Resolve send error ${_lastTestResult.errorCode}: ${errorRemediation}`);
+        }
+      }
+
+      // Determine overall status
+      let overallStatus: 'healthy' | 'degraded' | 'broken' = 'healthy';
+      if (!readinessReady) {
+        overallStatus = 'broken';
+      } else if (lastSend?.errorCode || complianceStatus === 'pending') {
+        overallStatus = 'degraded';
+      } else if (complianceStatus.startsWith('rejected')) {
+        overallStatus = 'broken';
+      }
+
+      ctx.send(socket, {
+        type: 'twilio_config_response',
+        success: true,
+        hasCredentials: hasTwilioCredentials(),
+        diagnostics: {
+          readiness: { ready: readinessReady, issues: readinessIssues },
+          compliance: {
+            status: complianceStatus,
+            detail: complianceDetail,
+            remediation: complianceRemediation,
+          },
+          lastSend,
+          overallStatus,
+          actionItems,
+        },
       });
     } else {
       ctx.send(socket, {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -563,13 +563,14 @@ export interface TelegramConfigResponse {
 
 export interface TwilioConfigRequest {
   type: 'twilio_config';
-  action: 'get' | 'set_credentials' | 'clear_credentials' | 'provision_number' | 'assign_number' | 'list_numbers';
+  action: 'get' | 'set_credentials' | 'clear_credentials' | 'provision_number' | 'assign_number' | 'list_numbers' | 'sms_send_test' | 'sms_doctor';
   accountSid?: string;        // Only for action: 'set_credentials'
   authToken?: string;         // Only for action: 'set_credentials'
-  phoneNumber?: string;       // Only for action: 'assign_number'
+  phoneNumber?: string;       // Only for action: 'assign_number' or 'sms_send_test'
   areaCode?: string;          // Only for action: 'provision_number'
   country?: string;           // Only for action: 'provision_number' (ISO 3166-1 alpha-2, default 'US')
   assistantId?: string;       // Scope number assignment/lookup to a specific assistant
+  text?: string;              // Only for action: 'sms_send_test' (default: "Test SMS from your Vellum assistant")
 }
 
 export interface TwilioConfigResponse {
@@ -581,6 +582,23 @@ export interface TwilioConfigResponse {
   error?: string;
   /** Non-fatal warning message (e.g. webhook sync failure that did not prevent the primary operation). */
   warning?: string;
+  /** Present when action is 'sms_send_test'. */
+  testResult?: {
+    messageSid: string;
+    to: string;
+    initialStatus: string;
+    finalStatus: string;
+    errorCode?: string;
+    errorMessage?: string;
+  };
+  /** Present when action is 'sms_doctor'. */
+  diagnostics?: {
+    readiness: { ready: boolean; issues: string[] };
+    compliance: { status: string; detail?: string; remediation?: string };
+    lastSend?: { status: string; errorCode?: string; remediation?: string };
+    overallStatus: 'healthy' | 'degraded' | 'broken';
+    actionItems: string[];
+  };
 }
 
 export interface ChannelReadinessRequest {

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -151,7 +151,7 @@ export const smsMessagingProvider: MessagingProvider = {
     const bearerToken = getBearerToken();
     const assistantId = options?.assistantId;
 
-    await sms.sendMessage(gatewayUrl, bearerToken, conversationId, text, assistantId);
+    const sendResult = await sms.sendMessage(gatewayUrl, bearerToken, conversationId, text, assistantId);
 
     // Upsert external conversation binding so the conversation key mapping
     // exists for the next inbound SMS from this number.
@@ -175,8 +175,12 @@ export const smsMessagingProvider: MessagingProvider = {
       // Best-effort — don't fail the send if binding upsert fails
     }
 
+    // Use the Twilio message SID as the send result ID when available,
+    // falling back to a timestamp-based ID for older gateway versions.
+    const id = sendResult.messageSid || `sms-${Date.now()}`;
+
     return {
-      id: `sms-${Date.now()}`,
+      id,
       timestamp: Date.now(),
       conversationId,
     };

--- a/assistant/src/messaging/providers/sms/client.ts
+++ b/assistant/src/messaging/providers/sms/client.ts
@@ -26,8 +26,20 @@ interface DeliverPayload {
   assistantId?: string;
 }
 
+/** Result returned by sendMessage with Twilio acceptance details. */
+export interface SmsSendResult {
+  messageSid?: string;
+  status?: string;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+}
+
 /**
  * Send an SMS message via the gateway's /deliver/sms endpoint.
+ *
+ * Returns Twilio acceptance details propagated from the gateway.
+ * "Accepted" means Twilio received it for delivery -- it has NOT yet
+ * been confirmed as delivered to the handset.
  */
 export async function sendMessage(
   gatewayUrl: string,
@@ -35,7 +47,7 @@ export async function sendMessage(
   to: string,
   text: string,
   assistantId?: string,
-): Promise<void> {
+): Promise<SmsSendResult> {
   const payload: DeliverPayload = { to, text };
   if (assistantId) {
     payload.assistantId = assistantId;
@@ -58,5 +70,24 @@ export async function sendMessage(
       resp.status,
       `Gateway /deliver/sms failed (${resp.status}): ${body}`,
     );
+  }
+
+  try {
+    const data = (await resp.json()) as {
+      ok?: boolean;
+      messageSid?: string;
+      status?: string;
+      errorCode?: string | null;
+      errorMessage?: string | null;
+    };
+    return {
+      messageSid: data.messageSid,
+      status: data.status,
+      errorCode: data.errorCode,
+      errorMessage: data.errorMessage,
+    };
+  } catch {
+    // Older gateway versions may not return JSON with Twilio details
+    return {};
   }
 }

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -64,9 +64,9 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-function mockTwilioApi() {
+function mockTwilioApi(overrides?: Record<string, unknown>) {
   globalThis.fetch = mock(async () => {
-    return new Response(JSON.stringify({ sid: "SM-sent" }), {
+    return new Response(JSON.stringify({ sid: "SM-sent", status: "queued", error_code: null, error_message: null, ...overrides }), {
       status: 201,
       headers: { "content-type": "application/json" },
     });
@@ -369,6 +369,38 @@ describe("/deliver/sms", () => {
     expect(sentParams.get("Body")).toBe(
       "I have a media attachment to share, but SMS currently supports text only.",
     );
+  });
+
+  it("returns enriched Twilio acceptance details in response", async () => {
+    mockTwilioApi({ sid: "SM-enrich-test", status: "queued", error_code: null, error_message: null });
+    const handler = createSmsDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
+    );
+    const req = makeRequest({ to: "+15559876543", text: "enriched" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.messageSid).toBe("SM-enrich-test");
+    expect(body.status).toBe("queued");
+    expect(body.errorCode).toBeNull();
+    expect(body.errorMessage).toBeNull();
+  });
+
+  it("returns Twilio error details in response when error_code is present", async () => {
+    mockTwilioApi({ sid: "SM-err-test", status: "failed", error_code: 30003, error_message: "Unreachable" });
+    const handler = createSmsDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
+    );
+    const req = makeRequest({ to: "+15559876543", text: "fail test" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.messageSid).toBe("SM-err-test");
+    expect(body.status).toBe("failed");
+    expect(body.errorCode).toBe("30003");
+    expect(body.errorMessage).toBe("Unreachable");
   });
 
   it("returns 503 when no From number is available", async () => {

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -4,8 +4,19 @@ import { getLogger } from "../../logger.js";
 
 const log = getLogger("sms-deliver");
 
+/** Parsed subset of the Twilio Messages API response. */
+export interface TwilioSmsResult {
+  sid: string;
+  status: string;
+  errorCode: string | null;
+  errorMessage: string | null;
+}
+
 /**
  * Send an SMS message via the Twilio Messages API.
+ *
+ * Returns the Twilio acceptance details so callers can distinguish
+ * "accepted for delivery" from "confirmed delivered to handset".
  */
 async function sendTwilioSms(
   accountSid: string,
@@ -13,7 +24,7 @@ async function sendTwilioSms(
   from: string,
   to: string,
   body: string,
-): Promise<void> {
+): Promise<TwilioSmsResult> {
   const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
   const params = new URLSearchParams({ From: from, To: to, Body: body });
   const authHeader =
@@ -29,9 +40,30 @@ async function sendTwilioSms(
   });
 
   if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Twilio Messages API error ${response.status}: ${text}`);
+    // Try to parse structured error details from the Twilio error body
+    let errorText: string;
+    try {
+      const errBody = await response.json() as Record<string, unknown>;
+      errorText = `Twilio Messages API error ${response.status}: code=${errBody.code ?? "unknown"} message=${errBody.message ?? "unknown"}`;
+    } catch {
+      errorText = `Twilio Messages API error ${response.status}: ${await response.text().catch(() => "<unreadable>")}`;
+    }
+    throw new Error(errorText);
   }
+
+  const data = (await response.json()) as {
+    sid?: string;
+    status?: string;
+    error_code?: number | null;
+    error_message?: string | null;
+  };
+
+  return {
+    sid: data.sid ?? "",
+    status: data.status ?? "unknown",
+    errorCode: data.error_code != null ? String(data.error_code) : null,
+    errorMessage: data.error_message ?? null,
+  };
 }
 
 function resolveFromNumber(
@@ -130,8 +162,9 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       );
     }
 
+    let result: TwilioSmsResult;
     try {
-      await sendTwilioSms(
+      result = await sendTwilioSms(
         config.twilioAccountSid,
         config.twilioAuthToken,
         from,
@@ -143,7 +176,13 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "SMS delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ to, textLength: effectiveText.length }, "SMS delivered");
-    return Response.json({ ok: true });
+    tlog.info({ to, textLength: effectiveText.length, messageSid: result.sid, status: result.status }, "SMS accepted by Twilio");
+    return Response.json({
+      ok: true,
+      messageSid: result.sid,
+      status: result.status,
+      errorCode: result.errorCode ?? null,
+      errorMessage: result.errorMessage ?? null,
+    });
   };
 }


### PR DESCRIPTION
Part of #7368. Makes SMS send results truthful (accepted vs delivered), adds sms_send_test and sms_doctor IPC actions, enriches gateway response with Twilio message SID and status, and updates messaging-send tool wording for SMS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
