### PR TITLE
M1: Define a Single Source of Truth for Pairing Settings

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -56,7 +56,7 @@ struct DaemonConnectionSection: View {
     @State private var manualAuthValue: String = ""
     @State private var isConnecting = false
 
-    @AppStorage("devLocalPairingEnabled") private var devLocalPairingEnabled: Bool = false
+    @AppStorage(PairingConfiguration.devLocalPairingKey) private var devLocalPairingEnabled: Bool = false
 
     /// The currently configured gateway URL, shown as read-only status.
     private var gatewayURL: String? {

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -11,7 +11,7 @@ struct QRPairingSheet: View {
     @State private var scannedPayload: DaemonQRPayload?
     @State private var errorMessage: String?
     @State private var showGatewayChangedAlert = false
-    @AppStorage("devLocalPairingEnabled") private var devLocalPairingEnabled: Bool = false
+    @AppStorage(PairingConfiguration.devLocalPairingKey) private var devLocalPairingEnabled: Bool = false
 
     enum PairingPhase {
         case scanning

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -21,9 +21,9 @@ struct SettingsAdvancedTab: View {
     @State private var identity: IdentityInfo?
     @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
-    @AppStorage("iosPairingUseOverride") private var iosPairingUseOverride: Bool = false
-    @AppStorage("iosPairingGatewayOverride") private var iosPairingGatewayOverride: String = ""
-    @AppStorage("iosPairingTokenOverride") private var iosPairingTokenOverride: String = ""
+    @AppStorage(PairingConfiguration.overrideEnabledKey) private var iosPairingUseOverride: Bool = false
+    @AppStorage(PairingConfiguration.gatewayOverrideKey) private var iosPairingGatewayOverride: String = ""
+    @AppStorage(PairingConfiguration.tokenOverrideKey) private var iosPairingTokenOverride: String = ""
 
     #if DEBUG
     @State private var showingEnvVars = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -35,9 +35,9 @@ struct SettingsConnectTab: View {
     @State private var guardianCommandCopiedChannel: String?
 
     // Developer local pairing state
-    @AppStorage("iosPairingUseOverride") private var iosPairingUseOverride: Bool = false
-    @AppStorage("iosPairingGatewayOverride") private var iosPairingGatewayOverride: String = ""
-    @AppStorage("iosPairingTokenOverride") private var iosPairingTokenOverride: String = ""
+    @AppStorage(PairingConfiguration.overrideEnabledKey) private var iosPairingUseOverride: Bool = false
+    @AppStorage(PairingConfiguration.gatewayOverrideKey) private var iosPairingGatewayOverride: String = ""
+    @AppStorage(PairingConfiguration.tokenOverrideKey) private var iosPairingTokenOverride: String = ""
     @State private var lanUrlCopied: Bool = false
 
     var body: some View {
@@ -81,7 +81,7 @@ struct SettingsConnectTab: View {
                 ingressEnabled: store.ingressEnabled,
                 gatewayUrl: store.resolvedIosGatewayUrl,
                 resolvedBearerToken: store.resolvedIosBearerToken,
-                isLocalOverride: UserDefaults.standard.bool(forKey: "iosPairingUseOverride")
+                isLocalOverride: PairingConfiguration.isOverrideEnabled
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1123,19 +1123,12 @@ public final class SettingsStore: ObservableObject {
 
     /// Resolved gateway URL for iOS pairing — uses per-integration override if enabled, else global.
     var resolvedIosGatewayUrl: String {
-        UserDefaults.standard.bool(forKey: "iosPairingUseOverride")
-            ? (nonEmpty(UserDefaults.standard.string(forKey: "iosPairingGatewayOverride")) ?? ingressPublicBaseUrl)
-            : ingressPublicBaseUrl
+        PairingConfiguration.resolvedGatewayURL(fallback: ingressPublicBaseUrl)
     }
 
     /// Resolved bearer token for iOS pairing — uses per-integration override if enabled, else global.
     var resolvedIosBearerToken: String {
-        if UserDefaults.standard.bool(forKey: "iosPairingUseOverride") {
-            if let override = nonEmpty(UserDefaults.standard.string(forKey: "iosPairingTokenOverride")) {
-                return override
-            }
-        }
-        return readHttpToken() ?? ""
+        PairingConfiguration.resolvedBearerToken(fallback: readHttpToken() ?? "")
     }
 
     /// Resolved gateway URL for public ingress — uses per-integration override if enabled, else global.

--- a/clients/shared/Settings/PairingConfiguration.swift
+++ b/clients/shared/Settings/PairingConfiguration.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Central resolver for pairing configuration.
+/// Reads from UserDefaults and provides resolved values.
+/// Placed in the shared target so both iOS and macOS can use it.
+public enum PairingConfiguration {
+    // MARK: - Keys
+
+    public static let overrideEnabledKey = "iosPairingUseOverride"
+    public static let gatewayOverrideKey = "iosPairingGatewayOverride"
+    public static let tokenOverrideKey = "iosPairingTokenOverride"
+    public static let devLocalPairingKey = "devLocalPairingEnabled"
+
+    // MARK: - Override State
+
+    public static var isOverrideEnabled: Bool {
+        UserDefaults.standard.bool(forKey: overrideEnabledKey)
+    }
+
+    public static var devLocalPairingEnabled: Bool {
+        UserDefaults.standard.bool(forKey: devLocalPairingKey)
+    }
+
+    // MARK: - Resolution
+
+    /// Resolve the gateway URL: override if enabled, else fallback.
+    public static func resolvedGatewayURL(fallback: String) -> String {
+        if isOverrideEnabled {
+            if let override = nonEmpty(UserDefaults.standard.string(forKey: gatewayOverrideKey)) {
+                return override
+            }
+        }
+        return fallback
+    }
+
+    /// Resolve the bearer token: override if enabled, else fallback.
+    public static func resolvedBearerToken(fallback: String) -> String {
+        if isOverrideEnabled {
+            if let override = nonEmpty(UserDefaults.standard.string(forKey: tokenOverrideKey)) {
+                return override
+            }
+        }
+        return fallback
+    }
+
+    /// Reset all override settings.
+    public static func resetOverrides() {
+        UserDefaults.standard.set(false, forKey: overrideEnabledKey)
+        UserDefaults.standard.set("", forKey: gatewayOverrideKey)
+        UserDefaults.standard.set("", forKey: tokenOverrideKey)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let v = value?.trimmingCharacters(in: .whitespacesAndNewlines), !v.isEmpty else { return nil }
+        return v
+    }
+}


### PR DESCRIPTION
## Summary
Create a central `PairingConfiguration` enum in shared code that serves as the single source of truth for pairing-related keys and resolution logic. Refactor SettingsStore and all consumers to use it.

## Implementation
- New `PairingConfiguration` enum in `clients/shared/Settings/PairingConfiguration.swift`
- Centralizes key constants, override resolution, and reset logic
- Refactors SettingsStore computed properties to delegate to PairingConfiguration
- Updates all @AppStorage references across macOS and iOS to use centralized key constants
- No UI changes — purely a data model refactor

## Key Technical Choices
- Enum (not class/struct) since it's stateless — just resolves from UserDefaults
- Placed in shared target so both iOS and macOS can use it
- Preserves all existing behavior — same override precedence and fallback logic

Part of #7390
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
