### PR TITLE
Fix outbound call opening flow and suppress spoken control markers

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -291,6 +291,30 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('strips USER_ANSWERED and USER_INSTRUCTION markers from spoken output', async () => {
+    mockStreamFn.mockImplementation(() =>
+      createMockStream([
+        'Thanks for waiting. ',
+        '[USER_ANSWERED: The guardian said 3 PM works.] ',
+        '[USER_INSTRUCTION: Keep this short.] ',
+        'I can confirm 3 PM works.',
+      ]),
+    );
+    const { relay, orchestrator } = setupOrchestrator();
+
+    await orchestrator.handleCallerUtterance('Any update?');
+
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('Thanks for waiting.');
+    expect(allText).toContain('I can confirm 3 PM works.');
+    expect(allText).not.toContain('[USER_ANSWERED:');
+    expect(allText).not.toContain('[USER_INSTRUCTION:');
+    expect(allText).not.toContain('USER_ANSWERED');
+    expect(allText).not.toContain('USER_INSTRUCTION');
+
+    orchestrator.destroy();
+  });
+
   // ── END_CALL pattern ──────────────────────────────────────────────
 
   test('END_CALL pattern: detects marker, calls endSession, updates status to completed', async () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -87,7 +87,7 @@ import {
   updateCallSession,
   getCallEvents,
 } from '../calls/call-store.js';
-import { resolveRelayUrl, handleStatusCallback, handleVoiceWebhook } from '../calls/twilio-routes.js';
+import { resolveRelayUrl, buildWelcomeGreeting, handleStatusCallback, handleVoiceWebhook } from '../calls/twilio-routes.js';
 import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from '../calls/call-state.js';
 
 initializeDb();
@@ -119,14 +119,14 @@ function resetTables() {
   ensuredConvIds = new Set();
 }
 
-function createTestSession(convId: string, callSid: string) {
+function createTestSession(convId: string, callSid: string, task = 'test task') {
   ensureConversation(convId);
   const session = createCallSession({
     conversationId: convId,
     provider: 'twilio',
     fromNumber: '+15550001111',
     toNumber: '+15559998888',
-    task: 'test task',
+    task,
   });
   updateCallSession(session.id, { providerCallSid: callSid });
   return session;
@@ -416,6 +416,24 @@ describe('twilio webhook routes', () => {
     });
   });
 
+  describe('buildWelcomeGreeting', () => {
+    test('builds a contextual opener from task text', () => {
+      const greeting = buildWelcomeGreeting('check store hours for tomorrow');
+      expect(greeting).toBe('Hello, I am calling about check store hours for tomorrow. Is now a good time to talk?');
+    });
+
+    test('ignores appended Context block when building opener', () => {
+      const greeting = buildWelcomeGreeting('check store hours\n\nContext: Caller asked by email');
+      expect(greeting).toBe('Hello, I am calling about check store hours. Is now a good time to talk?');
+      expect(greeting).not.toContain('Context:');
+    });
+
+    test('uses configured greeting override when provided', () => {
+      const greeting = buildWelcomeGreeting('check store hours', 'Custom hello');
+      expect(greeting).toBe('Custom hello');
+    });
+  });
+
   // ── TwiML relay URL generation ──────────────────────────────────────
   // Call handleVoiceWebhook directly since direct routes are blocked.
 
@@ -445,6 +463,24 @@ describe('twilio webhook routes', () => {
       expect(res.status).toBe(200);
       const twiml = await res.text();
       expect(twiml).toContain('wss://gateway.example.com/v1/calls/relay');
+    });
+
+    test('TwiML welcome greeting is task-aware by default', async () => {
+      const session = createTestSession(
+        'conv-twiml-3',
+        'CA_twiml_3',
+        'confirm appointment time\n\nContext: Prior email thread',
+      );
+      const req = makeVoiceRequest(session.id, { CallSid: 'CA_twiml_3' });
+
+      const res = await handleVoiceWebhook(req);
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain(
+        'welcomeGreeting="Hello, I am calling about confirm appointment time. Is now a good time to talk?"',
+      );
+      expect(twiml).not.toContain('Hello, how can I help you today?');
     });
   });
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -26,8 +26,20 @@ const log = getLogger('call-orchestrator');
 
 type OrchestratorState = 'idle' | 'processing' | 'waiting_on_user' | 'speaking';
 
-const ASK_USER_REGEX = /\[ASK_USER:\s*(.+?)\]/;
+const ASK_USER_CAPTURE_REGEX = /\[ASK_USER:\s*(.+?)\]/;
+const ASK_USER_MARKER_REGEX = /\[ASK_USER:\s*.+?\]/g;
+const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
+const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
+const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
 const END_CALL_MARKER = '[END_CALL]';
+
+function stripInternalSpeechMarkers(text: string): string {
+  return text
+    .replace(ASK_USER_MARKER_REGEX, '')
+    .replace(USER_ANSWERED_MARKER_REGEX, '')
+    .replace(USER_INSTRUCTION_MARKER_REGEX, '')
+    .replace(END_CALL_MARKER_REGEX, '');
+}
 
 export class CallOrchestrator {
   private callSessionId: string;
@@ -314,8 +326,12 @@ export class CallOrchestrator {
           const afterBracket = ttsBuffer;
           const couldBeControl =
             '[ASK_USER:'.startsWith(afterBracket) ||
+            '[USER_ANSWERED:'.startsWith(afterBracket) ||
+            '[USER_INSTRUCTION:'.startsWith(afterBracket) ||
             '[END_CALL]'.startsWith(afterBracket) ||
             afterBracket.startsWith('[ASK_USER:') ||
+            afterBracket.startsWith('[USER_ANSWERED:') ||
+            afterBracket.startsWith('[USER_INSTRUCTION:') ||
             afterBracket === '[END_CALL' ||
             afterBracket.startsWith('[END_CALL]');
 
@@ -339,13 +355,8 @@ export class CallOrchestrator {
         if (!this.isCurrentRun(runVersion)) return;
         ttsBuffer += text;
 
-        // If the buffer contains a complete control marker, strip it
-        if (ASK_USER_REGEX.test(ttsBuffer)) {
-          ttsBuffer = ttsBuffer.replace(ASK_USER_REGEX, '');
-        }
-        if (ttsBuffer.includes(END_CALL_MARKER)) {
-          ttsBuffer = ttsBuffer.replace(END_CALL_MARKER, '');
-        }
+        // Remove complete control markers before text reaches TTS.
+        ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
 
         flushSafeText(false);
       });
@@ -354,7 +365,7 @@ export class CallOrchestrator {
       if (!this.isCurrentRun(runVersion)) return;
 
       // Final sweep: strip any remaining control markers from the buffer
-      ttsBuffer = ttsBuffer.replace(ASK_USER_REGEX, '').replace(END_CALL_MARKER, '');
+      ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
       if (ttsBuffer.length > 0) {
         this.relay.sendTextToken(ttsBuffer, false);
       }
@@ -371,7 +382,7 @@ export class CallOrchestrator {
       // Record the assistant response
       this.conversationHistory.push({ role: 'assistant', content: responseText });
       recordCallEvent(this.callSessionId, 'assistant_spoke', { text: responseText });
-      const spokenText = responseText.replace(ASK_USER_REGEX, '').replace(END_CALL_MARKER, '').trim();
+      const spokenText = stripInternalSpeechMarkers(responseText).trim();
       if (spokenText.length > 0) {
         const session = getCallSession(this.callSessionId);
         if (session) {
@@ -380,7 +391,7 @@ export class CallOrchestrator {
       }
 
       // Check for ASK_USER pattern
-      const askMatch = responseText.match(ASK_USER_REGEX);
+      const askMatch = responseText.match(ASK_USER_CAPTURE_REGEX);
       if (askMatch) {
         const questionText = askMatch[1];
         createPendingQuestion(this.callSessionId, questionText);

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -29,6 +29,10 @@ import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality
 
 const log = getLogger('twilio-routes');
 
+const CONTEXT_BLOCK_SPLIT_REGEX = /\n\s*\nContext:\s*/i;
+const MAX_TASK_SUMMARY_CHARS = 120;
+const DEFAULT_WELCOME_GREETING = 'Hello, this is an assistant calling. Is now a good time to talk?';
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function escapeXml(str: string): string {
@@ -61,6 +65,40 @@ export function generateTwiML(
     />
   </Connect>
 </Response>`;
+}
+
+function summarizeTaskForGreeting(task: string | null): string | null {
+  if (!task) return null;
+  const primaryTask = task.split(CONTEXT_BLOCK_SPLIT_REGEX)[0]?.trim() ?? '';
+  if (!primaryTask) return null;
+
+  const compact = primaryTask.replace(/\s+/g, ' ').trim().replace(/[.!?]+$/, '');
+  if (!compact) return null;
+  if (compact.length <= MAX_TASK_SUMMARY_CHARS) return compact;
+  return `${compact.slice(0, MAX_TASK_SUMMARY_CHARS - 3).trimEnd()}...`;
+}
+
+function formatTaskAsCallPurpose(taskSummary: string): string {
+  const lower = taskSummary.toLowerCase();
+  if (
+    lower.startsWith('about ') ||
+    lower.startsWith('to ') ||
+    lower.startsWith('for ') ||
+    lower.startsWith('regarding ')
+  ) {
+    return taskSummary;
+  }
+  return `about ${taskSummary}`;
+}
+
+export function buildWelcomeGreeting(task: string | null, configuredGreeting?: string): string {
+  const override = configuredGreeting?.trim();
+  if (override) return override;
+
+  const taskSummary = summarizeTaskForGreeting(task);
+  if (!taskSummary) return DEFAULT_WELCOME_GREETING;
+
+  return `Hello, I am calling ${formatTaskAsCallPurpose(taskSummary)}. Is now a good time to talk?`;
 }
 
 /**
@@ -183,7 +221,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     // Fallback to legacy resolution when ingress is not configured
     relayUrl = resolveRelayUrl(twilioConfig.wssBaseUrl, twilioConfig.webhookBaseUrl);
   }
-  const welcomeGreeting = process.env.CALL_WELCOME_GREETING ?? 'Hello, how can I help you today?';
+  const welcomeGreeting = buildWelcomeGreeting(session.task, process.env.CALL_WELCOME_GREETING);
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 


### PR DESCRIPTION
## Summary
- make Twilio ConversationRelay welcome greeting contextual to the outbound call task instead of using a generic inbound-style opener
- preserve `CALL_WELCOME_GREETING` as an explicit override
- strip internal control markers (`[ASK_USER: ...]`, `[USER_ANSWERED: ...]`, `[USER_INSTRUCTION: ...]`, `[END_CALL]`) from spoken streaming output and transcript text
- add regression tests for task-aware greeting generation and marker suppression

## Validation
- `bun test src/__tests__/call-orchestrator.test.ts src/__tests__/twilio-routes.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` *(fails due to pre-existing unrelated unused import in `src/__tests__/channel-readiness-service.test.ts`)*