### PR TITLE
M3: iOS — Match the macOS Story & Gate Dev Mode

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -128,8 +128,10 @@ struct DaemonConnectionSection: View {
                     }
                     .padding(.vertical, 12)
                 }
+            } header: {
+                Text("Pair with Mac")
             } footer: {
-                Text("Open Vellum on your Mac, then go to Settings > Show QR Code.")
+                Text("Open Vellum on your Mac, go to Settings \u{2192} Connect, and tap Show QR Code.")
             }
 
             // Manual setup section
@@ -172,15 +174,31 @@ struct DaemonConnectionSection: View {
 
             // Developer options
             Section {
-                Toggle("Developer Local Pairing", isOn: $devLocalPairingEnabled)
-                    .font(VFont.body)
-                if devLocalPairingEnabled {
-                    Text("Debug only. Allows connecting to local HTTP gateways scanned via QR code.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.warning)
+                DisclosureGroup("Developer Options") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Toggle("Allow Local HTTP Connections", isOn: $devLocalPairingEnabled)
+                            .font(VFont.body)
+
+                        Text("When enabled, QR pairing accepts local HTTP gateway URLs for LAN debugging. Keep disabled unless you're developing locally.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+
+                        if devLocalPairingEnabled {
+                            HStack(spacing: 6) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundColor(VColor.warning)
+                                    .font(.system(size: 12))
+                                Text("Local HTTP connections are unencrypted. Only use on trusted networks.")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.warning)
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(VColor.warning.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+                    }
                 }
-            } header: {
-                Text("Developer")
             }
 
         }

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -89,7 +89,7 @@ struct QRPairingSheet: View {
             .cornerRadius(VRadius.md)
             .padding(.horizontal, VSpacing.lg)
 
-            Text("Open Vellum on your Mac > Settings > Show QR Code. Ingress must be enabled on the Mac for pairing.")
+            Text("Open Vellum on your Mac, go to Settings \u{2192} Connect, and tap Show QR Code. Ingress must be enabled on the Mac for pairing.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .multilineTextAlignment(.center)
@@ -256,7 +256,7 @@ struct QRPairingSheet: View {
         }
 
         guard json["type"] as? String == "vellum-daemon" else {
-            errorMessage = "This QR code is not from Vellum. Open Vellum on your Mac and scan the QR code from Settings."
+            errorMessage = "This QR code is not from Vellum. Open Vellum on your Mac and scan the QR code from Settings \u{2192} Connect."
             phase = .error
             return
         }


### PR DESCRIPTION
## Summary
Restructures the iOS connection settings to match the macOS pairing UX model with clear section hierarchy and developer options gating.

## Implementation
- Added "Pair with Mac" header to the QR scanning section (mirrors macOS "QR Pairing")
- Updated QR section footer to reference "Settings → Connect" for consistency
- Wrapped Developer toggle in a collapsible "Developer Options" DisclosureGroup
- Added descriptive help text explaining what the developer toggle does
- Added warning banner when developer local pairing is enabled (matches macOS style)
- Updated QRPairingSheet help text for consistency

## Key Technical Choices
- Used DisclosureGroup for developer options to keep them discoverable but not prominent
- Warning banner matches macOS's visual style (amber background, triangle icon)
- Copy aligned with macOS: "Pair with Mac" ↔ "Pair with iOS", "Developer Options" ↔ "Developer Local Pairing"

Closes #7393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
