### PR TITLE
fix: remove unresolvable includes from sms-setup skill

### DIFF
--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -52,8 +52,7 @@
       "id": "sms-setup",
       "name": "SMS Setup",
       "description": "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification",
-      "emoji": "\ud83d\udce8",
-      "includes": ["twilio-setup"]
+      "emoji": "\ud83d\udce8"
     }
   ]
 }

--- a/assistant/src/config/vellum-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/sms-setup/SKILL.md
@@ -2,7 +2,6 @@
 name: "SMS Setup"
 description: "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification"
 user-invocable: true
-includes: ["twilio-setup"]
 metadata: {"vellum": {"emoji": "\ud83d\udce8"}}
 ---
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -52,8 +52,7 @@
       "id": "sms-setup",
       "name": "SMS Setup",
       "description": "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification",
-      "emoji": "\ud83d\udce8",
-      "includes": ["twilio-setup"]
+      "emoji": "\ud83d\udce8"
     }
   ]
 }

--- a/skills/sms-setup/SKILL.md
+++ b/skills/sms-setup/SKILL.md
@@ -2,7 +2,6 @@
 name: "SMS Setup"
 description: "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification"
 user-invocable: true
-includes: ["twilio-setup"]
 metadata: {"vellum": {"emoji": "\ud83d\udce8"}}
 ---
 


### PR DESCRIPTION
## Summary
- Remove `includes: ["twilio-setup"]` from sms-setup SKILL.md frontmatter and catalog.json entries
- twilio-setup is a catalog skill (not bundled), so skill_load fails if it hasn't been independently installed
- The skill body already instructs the model to load twilio-setup manually in Step 2

Addresses feedback from PR #7389.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
