### PR TITLE
fix: channel readiness TTL cache reset, includeRemote miss, and phone number fallback

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -200,6 +200,45 @@ describe('ChannelReadinessService', () => {
     expect(channels).toEqual(['sms', 'telegram']);
   });
 
+  test('cached remote checks preserve original checkedAt (TTL not reset on reuse)', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    // First call populates cache with freshly fetched remote checks
+    const [first] = await service.getReadiness('sms', true);
+    const originalCheckedAt = first.checkedAt;
+    expect(probe.remoteCallCount).toBe(1);
+
+    // Second call within TTL reuses cache — checkedAt must stay at the original value
+    const [second] = await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+    expect(second.checkedAt).toBe(originalCheckedAt);
+  });
+
+  test('includeRemote runs remote checks when cache exists without remote data', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: true, message: 'remote ok' }],
+    );
+    service.registerProbe(probe);
+
+    // First call without includeRemote — cache has no remote data
+    await service.getReadiness('sms', false);
+    expect(probe.remoteCallCount).toBe(0);
+
+    // Second call with includeRemote — should run remote checks even though
+    // the cached snapshot exists (because it has no remoteChecks)
+    const [snapshot] = await service.getReadiness('sms', true);
+    expect(probe.remoteCallCount).toBe(1);
+    expect(snapshot.remoteChecks).toHaveLength(1);
+    expect(snapshot.remoteChecks![0].passed).toBe(true);
+  });
+
   test('failed remote check makes channel not ready', async () => {
     const probe = makeProbe(
       'sms',

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -43,7 +43,17 @@ const smsProbe: ChannelProbe = {
         : 'Twilio Account SID and Auth Token are not configured',
     });
 
-    const hasPhone = !!getSecureKey('credential:twilio:phone_number');
+    let hasPhone = !!process.env.TWILIO_PHONE_NUMBER;
+    if (!hasPhone) {
+      try {
+        const raw = loadRawConfig();
+        const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+        hasPhone = !!(smsConfig.phoneNumber as string);
+      } catch { /* ignore */ }
+    }
+    if (!hasPhone) {
+      hasPhone = !!getSecureKey('credential:twilio:phone_number');
+    }
     results.push({
       name: 'phone_number',
       passed: hasPhone,
@@ -189,15 +199,17 @@ export class ChannelReadinessService {
 
       const localChecks = probe.runLocalChecks();
       let remoteChecks: ReadinessCheckResult[] | undefined;
+      let remoteChecksFreshlyFetched = false;
       let stale = false;
 
       const cached = this.snapshots.get(ch);
       const now = Date.now();
 
       if (includeRemote && probe.runRemoteChecks) {
-        const cacheExpired = !cached || (now - cached.checkedAt) >= REMOTE_TTL_MS;
+        const cacheExpired = !cached || !cached.remoteChecks || (now - cached.checkedAt) >= REMOTE_TTL_MS;
         if (cacheExpired) {
           remoteChecks = await probe.runRemoteChecks();
+          remoteChecksFreshlyFetched = true;
         } else {
           // Reuse cached remote checks
           remoteChecks = cached.remoteChecks;
@@ -230,7 +242,7 @@ export class ChannelReadinessService {
       const snapshot: ChannelReadinessSnapshot = {
         channel: ch,
         ready,
-        checkedAt: now,
+        checkedAt: (remoteChecks && cached && !remoteChecksFreshlyFetched) ? cached.checkedAt : now,
         stale,
         reasons,
         localChecks,


### PR DESCRIPTION
## Summary
- Fix TTL cache reset: preserve cached checkedAt when remote checks are reused, preventing indefinite staleness
- Fix includeRemote cache miss: run remote checks when cached snapshot has no remote data
- Fix phone number readiness check to use full resolution chain (env var, config, secure key)

Addresses feedback from PR #7386.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
