### PR TITLE
M4: QR Pairing — Make the Flow Self-Explanatory

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -120,6 +120,22 @@ struct QRPairingSheet: View {
                 .background(VColor.surface)
                 .cornerRadius(VRadius.md)
                 .padding(.horizontal, VSpacing.xl)
+
+                if payload.mode == "local" {
+                    HStack(spacing: 6) {
+                        Image(systemName: "laptopcomputer.and.iphone")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 14))
+                        Text("Local network connection (developer mode)")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.warning)
+                    }
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.warning.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .padding(.horizontal, VSpacing.xl)
+                }
             }
 
             Spacer()
@@ -298,10 +314,13 @@ struct QRPairingSheet: View {
             }
         }
 
+        let mode = json["m"] as? String
+
         let payload = DaemonQRPayload(
             gatewayURL: gatewayURL,
             bearerToken: bearerToken,
-            hostId: hostId
+            hostId: hostId,
+            mode: mode
         )
         scannedPayload = payload
 
@@ -429,5 +448,6 @@ struct DaemonQRPayload {
     let gatewayURL: String
     let bearerToken: String
     let hostId: String
+    let mode: String?  // "gateway", "local", or nil (legacy)
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -73,7 +73,7 @@ struct PairingQRCodeSheet: View {
                             .foregroundColor(VColor.error)
                             .multilineTextAlignment(.center)
                     } else if !ingressEnabled || gatewayUrl.isEmpty {
-                        Text("Enable ingress and set a public URL in Settings to pair with iOS")
+                        Text("Set up a gateway URL in the Connect tab to enable pairing.")
                             .font(VFont.body)
                             .foregroundColor(VColor.error)
                             .multilineTextAlignment(.center)
@@ -87,7 +87,39 @@ struct PairingQRCodeSheet: View {
                 .frame(width: 220, height: 220)
             }
 
-            Text("Scan this QR code with the Vellum iOS app to connect.")
+            // State indicator
+            if canGenerateQR {
+                if isLocalOverride {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "laptopcomputer.and.iphone")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 14))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Developer mode — local network")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.warning)
+                            Text(gatewayUrl)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text("Ready to pair with iOS")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.success)
+                    }
+                }
+            }
+
+            Text(isLocalOverride && canGenerateQR
+                 ? "Scan this QR code with the Vellum iOS app. Developer Local Pairing must be enabled on the iPhone."
+                 : "Scan this QR code with the Vellum iOS app to connect.")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
@@ -203,6 +235,7 @@ struct PairingQRCodeSheet: View {
             "id": hostId,
             "g": gatewayUrl,
             "bt": resolvedBearerToken,
+            "m": isLocalOverride ? "local" : "gateway",
         ]
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),


### PR DESCRIPTION
## Summary
Adds clear state indicators to the QR pairing sheet and annotates QR payloads with a mode field so users understand what's happening at each step.

## Implementation

### macOS (PairingQRCodeSheet.swift)
- Added state indicator below QR code: "Ready to pair with iOS" (green) or "Developer mode — local network" (amber with URL)
- Context-sensitive help text based on pairing mode
- Improved error message: "Set up a gateway URL..." instead of "Enable ingress..."
- Added `"m"` field to QR payload: `"gateway"` or `"local"`

### iOS (QRPairingSheet.swift)
- Parse optional `"m"` (mode) field from QR payload — backward-compatible with older payloads
- Show "Local network connection (developer mode)" banner in confirming view when mode is "local"
- Updated DaemonQRPayload struct with optional mode field

## Key Technical Choices
- Mode field is additive (optional) — no version bump needed, older iOS apps ignore it gracefully
- State indicator placement between QR image and help text for immediate visibility
- Used existing VColor.warning/VColor.success tokens for consistency

Closes #7394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
