### PR TITLE
fix: rewrite DictationOverlayWindow in pure AppKit to eliminate constraint crash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayView.swift
@@ -1,79 +1,7 @@
-import SwiftUI
-import VellumAssistantShared
-
 enum DictationState {
     case recording
     case processing
     case transforming(String)
     case done
     case error(String)
-}
-
-struct DictationOverlayView: View {
-    let state: DictationState
-
-    var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            stateIcon
-            stateText
-        }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.md)
-        .background(VColor.surface)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-        .vShadow(VShadow.md)
-    }
-
-    @ViewBuilder
-    private var stateIcon: some View {
-        switch state {
-        case .recording:
-            Circle()
-                .fill(Color.red)
-                .frame(width: 8, height: 8)
-        case .processing:
-            VLoadingIndicator()
-        case .transforming:
-            Image(systemName: "wand.and.stars")
-                .foregroundStyle(VColor.accent)
-        case .done:
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(VColor.success)
-        case .error:
-            Image(systemName: "exclamation.triangle.fill")
-                .foregroundStyle(VColor.error)
-        }
-    }
-
-    @ViewBuilder
-    private var stateText: some View {
-        switch state {
-        case .recording:
-            Text("Recording...")
-                .font(VFont.caption)
-                .foregroundStyle(VColor.textSecondary)
-        case .processing:
-            Text("Processing...")
-                .font(VFont.caption)
-                .foregroundStyle(VColor.textSecondary)
-        case .transforming(let instruction):
-            Text("Transforming: \(instruction)")
-                .font(VFont.caption)
-                .foregroundStyle(VColor.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-        case .done:
-            Text("Done")
-                .font(VFont.caption)
-                .foregroundStyle(VColor.success)
-        case .error(let message):
-            Text(message)
-                .font(VFont.caption)
-                .foregroundStyle(VColor.error)
-        }
-    }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -1,5 +1,4 @@
 import AppKit
-import SwiftUI
 import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "DictationOverlay")
@@ -7,7 +6,9 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Di
 @MainActor
 final class DictationOverlayWindow {
     private var panel: NSPanel?
-    private var currentState: DictationState = .recording
+    private var iconView: NSView?
+    private var label: NSTextField?
+    private var spinner: NSProgressIndicator?
 
     private func panelWidth(for state: DictationState) -> CGFloat {
         switch state {
@@ -17,18 +18,11 @@ final class DictationOverlayWindow {
     }
 
     func show(state: DictationState) {
-        currentState = state
         let width = panelWidth(for: state)
 
         if let panel = panel {
-            // Update content in-place by replacing the hosting view's root view
-            if let hostingView = panel.contentView as? NSHostingView<DictationOverlayView> {
-                hostingView.rootView = DictationOverlayView(state: state)
-            } else {
-                panel.contentView = NSHostingView(rootView: DictationOverlayView(state: state))
-            }
+            updateContent(state: state)
 
-            // Re-center if width changed
             if let screen = NSScreen.main {
                 let screenFrame = screen.visibleFrame
                 let x = screenFrame.midX - width / 2
@@ -38,11 +32,10 @@ final class DictationOverlayWindow {
 
             panel.orderFront(nil)
         } else {
-            let hostingView = NSHostingView(rootView: DictationOverlayView(state: state))
-            hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 40)
+            let contentView = buildContentView(state: state)
 
             let newPanel = NSPanel(
-                contentRect: hostingView.frame,
+                contentRect: NSRect(x: 0, y: 0, width: width, height: 40),
                 styleMask: [.borderless, .nonactivatingPanel],
                 backing: .buffered,
                 defer: false
@@ -51,11 +44,10 @@ final class DictationOverlayWindow {
             newPanel.level = .floating
             newPanel.backgroundColor = .clear
             newPanel.isOpaque = false
-            newPanel.hasShadow = false
-            newPanel.contentView = hostingView
+            newPanel.hasShadow = true
+            newPanel.contentView = contentView
             newPanel.isMovableByWindowBackground = false
 
-            // Position near top-center of screen
             if let screen = NSScreen.main {
                 let screenFrame = screen.visibleFrame
                 let x = screenFrame.midX - width / 2
@@ -71,8 +63,12 @@ final class DictationOverlayWindow {
     }
 
     func dismiss() {
+        spinner?.stopAnimation(nil)
         panel?.orderOut(nil)
         panel = nil
+        iconView = nil
+        label = nil
+        spinner = nil
     }
 
     func showDoneAndDismiss() {
@@ -80,5 +76,142 @@ final class DictationOverlayWindow {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.dismiss()
         }
+    }
+
+    // MARK: - AppKit Content
+
+    private func buildContentView(state: DictationState) -> NSView {
+        let container = OverlayBackgroundView()
+        container.wantsLayer = true
+
+        let icon = makeIcon(for: state)
+        let text = makeLabel(for: state)
+
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        text.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(icon)
+        container.addSubview(text)
+
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+
+            text.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 8),
+            text.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+            text.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        self.iconView = icon
+        self.label = text
+
+        return container
+    }
+
+    private func updateContent(state: DictationState) {
+        // Replace icon
+        if let oldIcon = iconView, let container = oldIcon.superview {
+            let newIcon = makeIcon(for: state)
+            newIcon.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(newIcon)
+            NSLayoutConstraint.activate([
+                newIcon.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+                newIcon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            ])
+            if let lbl = label {
+                lbl.leadingAnchor.constraint(equalTo: newIcon.trailingAnchor, constant: 8).isActive = true
+            }
+            spinner?.stopAnimation(nil)
+            oldIcon.removeFromSuperview()
+            self.iconView = newIcon
+        }
+
+        // Update label
+        let (text, color) = labelContent(for: state)
+        label?.stringValue = text
+        label?.textColor = color
+    }
+
+    private func makeIcon(for state: DictationState) -> NSView {
+        switch state {
+        case .recording:
+            let dot = NSView(frame: NSRect(x: 0, y: 0, width: 8, height: 8))
+            dot.wantsLayer = true
+            dot.layer?.backgroundColor = NSColor.systemRed.cgColor
+            dot.layer?.cornerRadius = 4
+            dot.widthAnchor.constraint(equalToConstant: 8).isActive = true
+            dot.heightAnchor.constraint(equalToConstant: 8).isActive = true
+            return dot
+
+        case .processing:
+            let s = NSProgressIndicator()
+            s.style = .spinning
+            s.controlSize = .small
+            s.isIndeterminate = true
+            s.startAnimation(nil)
+            s.widthAnchor.constraint(equalToConstant: 16).isActive = true
+            s.heightAnchor.constraint(equalToConstant: 16).isActive = true
+            self.spinner = s
+            return s
+
+        case .transforming:
+            return makeSymbolView("wand.and.stars", color: .systemPurple)
+
+        case .done:
+            return makeSymbolView("checkmark.circle.fill", color: .systemGreen)
+
+        case .error:
+            return makeSymbolView("exclamationmark.triangle.fill", color: .systemRed)
+        }
+    }
+
+    private func makeSymbolView(_ name: String, color: NSColor) -> NSView {
+        let imageView = NSImageView()
+        if let img = NSImage(systemSymbolName: name, accessibilityDescription: nil) {
+            imageView.image = img
+            imageView.contentTintColor = color
+        }
+        imageView.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        return imageView
+    }
+
+    private func labelContent(for state: DictationState) -> (String, NSColor) {
+        switch state {
+        case .recording:
+            return ("Recording...", .secondaryLabelColor)
+        case .processing:
+            return ("Processing...", .secondaryLabelColor)
+        case .transforming(let instruction):
+            let truncated = instruction.count > 30 ? String(instruction.prefix(30)) + "..." : instruction
+            return ("Transforming: \(truncated)", .secondaryLabelColor)
+        case .done:
+            return ("Done", .systemGreen)
+        case .error(let message):
+            return (message, .systemRed)
+        }
+    }
+
+    private func makeLabel(for state: DictationState) -> NSTextField {
+        let (text, color) = labelContent(for: state)
+        let field = NSTextField(labelWithString: text)
+        field.font = NSFont.systemFont(ofSize: 11)
+        field.textColor = color
+        field.lineBreakMode = .byTruncatingTail
+        field.maximumNumberOfLines = 1
+        self.label = field
+        return field
+    }
+}
+
+/// Rounded, semi-transparent background matching the app's dark surface style.
+private class OverlayBackgroundView: NSView {
+    override var wantsUpdateLayer: Bool { true }
+
+    override func updateLayer() {
+        layer?.backgroundColor = NSColor(white: 0.15, alpha: 0.95).cgColor
+        layer?.cornerRadius = 12
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor(white: 0.25, alpha: 1.0).cgColor
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -109,8 +109,9 @@ final class DictationOverlayWindow {
     }
 
     private func updateContent(state: DictationState) {
-        // Replace icon
+        // Replace icon — stop old spinner before makeIcon overwrites self.spinner
         if let oldIcon = iconView, let container = oldIcon.superview {
+            let oldSpinner = spinner
             let newIcon = makeIcon(for: state)
             newIcon.translatesAutoresizingMaskIntoConstraints = false
             container.addSubview(newIcon)
@@ -121,7 +122,7 @@ final class DictationOverlayWindow {
             if let lbl = label {
                 lbl.leadingAnchor.constraint(equalTo: newIcon.trailingAnchor, constant: 8).isActive = true
             }
-            spinner?.stopAnimation(nil)
+            oldSpinner?.stopAnimation(nil)
             oldIcon.removeFromSuperview()
             self.iconView = newIcon
         }


### PR DESCRIPTION
## Summary
- Rewrites the dictation overlay from SwiftUI (`NSHostingView`) to pure AppKit (`NSView`, `NSTextField`, `NSImageView`, `NSProgressIndicator`)
- Eliminates the `_postWindowNeedsUpdateConstraints` re-entrant constraint crash that occurred every time dictation text was injected on macOS 26
- The crash was caused by `NSHostingView.updateConstraints` triggering a view graph update that re-entrantly called `setNeedsUpdateConstraints` during the display cycle — a known SwiftUI/AppKit issue with hosting views in floating panels

## Test plan
- [ ] Hold Fn to dictate in a text field — text should be inserted without crash
- [ ] Verify overlay shows recording → processing → done states
- [ ] Test dictation with selected text (command/transform mode)
- [ ] Verify overlay dismisses after "Done" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
