### PR TITLE
fix: restore IPC snapshots and add phone number fallback to remote readiness checks

### DIFF
--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -80,10 +80,13 @@ const smsProbe: ChannelProbe = {
     const authToken = getSecureKey('credential:twilio:auth_token');
     if (!accountSid || !authToken) return [];
 
-    // Resolve the assigned phone number
+    // Resolve the assigned phone number using fallback chain
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const phoneNumber = (smsConfig.phoneNumber as string) ?? '';
+    const phoneNumber = (smsConfig.phoneNumber as string)
+      || getSecureKey('credential:twilio:phone_number')
+      || process.env.TWILIO_PHONE_NUMBER
+      || '';
     if (!phoneNumber) return [];
 
     // Only toll-free numbers need verification checks


### PR DESCRIPTION
## Summary
- Restore IPC snapshot file by running snapshot tests (was deleted in PR #7397)
- Add phone number fallback chain to runRemoteChecks (env var, secure key, config)

Addresses feedback from PR #7397.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
