### PR TITLE
fix: avoid double prompt on fresh screen recording request

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -22,24 +22,29 @@ enum PermissionManager {
 
     static func requestScreenRecordingAccess() {
         let hasRequestedBefore = UserDefaults.standard.bool(forKey: hasRequestedScreenRecordingFlag)
+        let preflightBeforeRequest = CGPreflightScreenCaptureAccess()
 
         // CGRequestScreenCaptureAccess() only shows the native OS prompt on
         // its very first invocation per app install; subsequent calls are
         // no-ops. The API is non-blocking, so CGPreflightScreenCaptureAccess()
         // returns false immediately — before the user has a chance to respond
-        // to the prompt. On the first call we therefore trust the native prompt
-        // and skip the System Settings fallback to avoid showing both at once.
+        // to the prompt.
         CGRequestScreenCaptureAccess()
 
         if !hasRequestedBefore {
             UserDefaults.standard.set(true, forKey: hasRequestedScreenRecordingFlag)
-            // For legacy installs that denied screen recording before this flag
-            // existed: CGRequestScreenCaptureAccess() was a no-op, so check if
-            // permission is still denied and fall back to System Settings.
-            if CGPreflightScreenCaptureAccess() == false {
-                openScreenRecordingSettings()
-            }
-        } else if !CGPreflightScreenCaptureAccess() {
+            // On first request we cannot distinguish between a fresh install
+            // (where the native prompt just appeared) and a legacy denied
+            // install (where CGRequestScreenCaptureAccess() was a no-op).
+            // In both cases CGPreflightScreenCaptureAccess() returns false.
+            // To avoid opening System Settings alongside the native prompt
+            // (double-prompt), we only open Settings when we know the user
+            // had already been prompted before — i.e. hasRequestedBefore was
+            // true. Legacy denied users will get the Settings fallback on
+            // their next interaction.
+        } else if !preflightBeforeRequest {
+            // Permission was already denied before this request — the native
+            // prompt won't appear, so open System Settings as a fallback.
             openScreenRecordingSettings()
         }
     }


### PR DESCRIPTION
Fixes the issue from PR #7291 feedback where fresh installs would see both the native macOS prompt AND System Settings opening simultaneously.

The root cause was that after calling CGRequestScreenCaptureAccess(), the code checked CGPreflightScreenCaptureAccess() to detect legacy denied installs but could not distinguish them from fresh installs (both return false). The fix captures the preflight state before the request call and only opens System Settings as a fallback when hasRequestedBefore is true, ensuring fresh installs only see the native OS prompt. Legacy denied users will get the Settings fallback on their next interaction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
