### PR TITLE
feat: soft-delete with archive for local assistant retirement

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -22,6 +22,7 @@ import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { startLocalDaemon, startGateway, stopLocalProcesses } from "../lib/local";
 import { isProcessAlive } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
+import { validateAssistantName } from "../lib/retire-archive";
 import { exec } from "../lib/step-runner";
 
 export type { PollResult, WatchHatchingResult } from "../lib/gcp";
@@ -167,6 +168,12 @@ function parseArgs(): HatchArgs {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
         console.error("Error: --name requires a value");
+        process.exit(1);
+      }
+      try {
+        validateAssistantName(next);
+      } catch {
+        console.error(`Error: --name contains invalid characters (path separators or traversal segments are not allowed)`);
         process.exit(1);
       }
       name = next;

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync, unlinkSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { saveAssistantEntry } from "../lib/assistant-config";
+import type { AssistantEntry } from "../lib/assistant-config";
+import { startLocalDaemon, startGateway } from "../lib/local";
+import { getArchivePath, getMetadataPath } from "../lib/retire-archive";
+import { exec } from "../lib/step-runner";
+
+export async function recover(): Promise<void> {
+  const name = process.argv[3];
+  if (!name) {
+    console.error("Usage: vellum-cli recover <name>");
+    process.exit(1);
+  }
+
+  const archivePath = getArchivePath(name);
+  const metadataPath = getMetadataPath(name);
+
+  // 1. Verify archive exists
+  if (!existsSync(archivePath) || !existsSync(metadataPath)) {
+    console.error(`No retired archive found for '${name}'.`);
+    process.exit(1);
+  }
+
+  // 2. Check ~/.vellum doesn't already exist
+  const vellumDir = join(homedir(), ".vellum");
+  if (existsSync(vellumDir)) {
+    console.error(
+      "Error: ~/.vellum already exists. Retire the current assistant first."
+    );
+    process.exit(1);
+  }
+
+  // 3. Extract archive
+  await exec("tar", ["xzf", archivePath, "-C", homedir()]);
+
+  // 4. Restore lockfile entry
+  const entry: AssistantEntry = JSON.parse(readFileSync(metadataPath, "utf-8"));
+  saveAssistantEntry(entry);
+
+  // 5. Clean up archive
+  unlinkSync(archivePath);
+  unlinkSync(metadataPath);
+
+  // 6. Start daemon + gateway (same as wake)
+  await startLocalDaemon();
+  if (!process.env.VELLUM_DESKTOP_APP) {
+    await startGateway();
+  }
+
+  console.log(`✅ Recovered assistant '${name}'.`);
+}

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -1,13 +1,14 @@
 import { spawn } from "child_process";
-import { rmSync } from "fs";
+import { rmSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { basename, dirname, join } from "path";
 
 import { findAssistantByName, removeAssistantEntry } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import { retireInstance as retireAwsInstance } from "../lib/aws";
 import { retireInstance as retireGcpInstance } from "../lib/gcp";
 import { stopProcessByPidFile } from "../lib/process";
+import { getArchivePath, getMetadataPath } from "../lib/retire-archive";
 import { exec } from "../lib/step-runner";
 
 function resolveCloud(entry: AssistantEntry): string {
@@ -32,7 +33,7 @@ function extractHostFromUrl(url: string): string {
   }
 }
 
-async function retireLocal(): Promise<void> {
+async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local daemon...\n");
 
   const vellumDir = join(homedir(), ".vellum");
@@ -59,6 +60,18 @@ async function retireLocal(): Promise<void> {
         child.on("error", () => resolve());
       });
     } catch {}
+  }
+
+  // Archive ~/.vellum before deleting
+  try {
+    const archivePath = getArchivePath(name);
+    const metadataPath = getMetadataPath(name);
+    await exec("tar", ["czf", archivePath, "-C", dirname(vellumDir), basename(vellumDir)]);
+    writeFileSync(metadataPath, JSON.stringify(entry, null, 2) + "\n");
+    console.log(`📦 Archived to ${archivePath}`);
+  } catch (err) {
+    console.warn(`⚠️  Failed to archive: ${err instanceof Error ? err.message : err}`);
+    console.warn("Proceeding with permanent deletion.");
   }
 
   rmSync(vellumDir, { recursive: true, force: true });
@@ -142,7 +155,7 @@ export async function retire(): Promise<void> {
     }
     await retireAwsInstance(name, region, source);
   } else if (cloud === "local") {
-    await retireLocal();
+    await retireLocal(name, entry);
   } else if (cloud === "custom") {
     await retireCustom(entry);
   } else {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { client } from "./commands/client";
 import { email } from "./commands/email";
 import { hatch } from "./commands/hatch";
 import { ps } from "./commands/ps";
+import { recover } from "./commands/recover";
 import { retire } from "./commands/retire";
 import { sleep } from "./commands/sleep";
 import { ssh } from "./commands/ssh";
@@ -19,6 +20,7 @@ const commands = {
   email,
   hatch,
   ps,
+  recover,
   retire,
   sleep,
   ssh,
@@ -65,6 +67,7 @@ async function main() {
     console.log("  email    Email operations (status, create inbox)");
     console.log("  hatch    Create a new assistant instance");
     console.log("  ps       List assistants (or processes for a specific assistant)");
+    console.log("  recover  Restore a previously retired local assistant");
     console.log("  retire   Delete an assistant instance");
     console.log("  sleep    Stop the daemon process");
     console.log("  ssh      SSH into a remote assistant instance");

--- a/cli/src/lib/retire-archive.ts
+++ b/cli/src/lib/retire-archive.ts
@@ -1,0 +1,19 @@
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export function getRetiredDir(): string {
+  const xdgData =
+    process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
+  const dir = join(xdgData, "vellum", "retired");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function getArchivePath(assistantId: string): string {
+  return join(getRetiredDir(), `${assistantId}.tar.gz`);
+}
+
+export function getMetadataPath(assistantId: string): string {
+  return join(getRetiredDir(), `${assistantId}.json`);
+}

--- a/cli/src/lib/retire-archive.ts
+++ b/cli/src/lib/retire-archive.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { basename, join, resolve } from "path";
 
 export function getRetiredDir(): string {
   const xdgData =
@@ -10,10 +10,30 @@ export function getRetiredDir(): string {
   return dir;
 }
 
+function safeName(assistantId: string): string {
+  // Reject path separators and traversal segments
+  if (
+    assistantId.includes("/") ||
+    assistantId.includes("\\") ||
+    assistantId === ".." ||
+    assistantId === "." ||
+    assistantId === ""
+  ) {
+    throw new Error(`Invalid assistant name: '${assistantId}'`);
+  }
+  // Canonicalize and verify the result stays inside the retired directory
+  const retiredDir = getRetiredDir();
+  const candidate = resolve(retiredDir, basename(assistantId));
+  if (!candidate.startsWith(retiredDir + "/")) {
+    throw new Error(`Invalid assistant name: '${assistantId}'`);
+  }
+  return basename(assistantId);
+}
+
 export function getArchivePath(assistantId: string): string {
-  return join(getRetiredDir(), `${assistantId}.tar.gz`);
+  return join(getRetiredDir(), `${safeName(assistantId)}.tar.gz`);
 }
 
 export function getMetadataPath(assistantId: string): string {
-  return join(getRetiredDir(), `${assistantId}.json`);
+  return join(getRetiredDir(), `${safeName(assistantId)}.json`);
 }

--- a/cli/src/lib/retire-archive.ts
+++ b/cli/src/lib/retire-archive.ts
@@ -10,17 +10,21 @@ export function getRetiredDir(): string {
   return dir;
 }
 
-function safeName(assistantId: string): string {
-  // Reject path separators and traversal segments
+/** Throws if the name contains path separators or traversal segments. */
+export function validateAssistantName(name: string): void {
   if (
-    assistantId.includes("/") ||
-    assistantId.includes("\\") ||
-    assistantId === ".." ||
-    assistantId === "." ||
-    assistantId === ""
+    !name ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name === ".." ||
+    name === "."
   ) {
-    throw new Error(`Invalid assistant name: '${assistantId}'`);
+    throw new Error(`Invalid assistant name: '${name}'`);
   }
+}
+
+function safeName(assistantId: string): string {
+  validateAssistantName(assistantId);
   // Canonicalize and verify the result stays inside the retired directory
   const retiredDir = getRetiredDir();
   const candidate = resolve(retiredDir, basename(assistantId));


### PR DESCRIPTION
## Summary
- Archives `~/.vellum` to `$XDG_DATA_HOME/vellum/retired/` (tar.gz + JSON metadata) before deleting on `retire`, with graceful fallback to destructive deletion if archiving fails
- Adds `vellum-cli recover <name>` command that restores a retired local assistant from its archive, re-registers the lockfile entry, and starts daemon + gateway
- Scoped to local assistants only

## Test plan
- [ ] `vellum-cli hatch local` — hatch an assistant
- [ ] `vellum-cli retire <name>` — verify archive appears at `~/.local/share/vellum/retired/<name>.tar.gz` and `.json`
- [ ] `vellum-cli recover <name>` — verify `~/.vellum` is restored, lockfile entry is back, daemon starts
- [ ] `vellum-cli recover <name>` with no archive — verify clean error message
- [ ] `vellum-cli recover <name>` with `~/.vellum` existing — verify clean error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
