### PR TITLE
M5: Cleanup & Copy Alignment

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -100,7 +100,7 @@ struct ContentView: View {
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("Unable to reach your Mac's gateway. This could mean your Mac is offline, the tunnel is down, or ingress is disabled.")
+            Text("Unable to reach your Mac's gateway. This could mean your Mac is offline, the tunnel is down, or the gateway is not active.")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -188,7 +188,7 @@ struct DaemonConnectionSection: View {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .foregroundColor(VColor.warning)
                                     .font(.system(size: 12))
-                                Text("Local HTTP connections are unencrypted. Only use on trusted networks.")
+                                Text("Debug only. Uses unencrypted HTTP over your local network. Do not use in production.")
                                     .font(VFont.caption)
                                     .foregroundColor(VColor.warning)
                             }

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -89,7 +89,7 @@ struct QRPairingSheet: View {
             .cornerRadius(VRadius.md)
             .padding(.horizontal, VSpacing.lg)
 
-            Text("Open Vellum on your Mac, go to Settings \u{2192} Connect, and tap Show QR Code. Ingress must be enabled on the Mac for pairing.")
+            Text("Open Vellum on your Mac, go to Settings \u{2192} Connect, and tap Show QR Code. The gateway must be configured on the Mac for pairing.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .multilineTextAlignment(.center)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1060,7 +1060,7 @@ struct SettingsPanel: View {
 
     // MARK: - Ingress Global Config Card
 
-    /// Card showing the resolved gateway URL for public ingress, referencing global Connect config.
+    /// Card showing the resolved gateway URL, referencing global Connect config.
     private var ingressGlobalConfigCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Using Global Gateway & Token")
@@ -1096,11 +1096,11 @@ struct SettingsPanel: View {
         )
     }
 
-    /// Collapsed override section for per-integration ingress gateway URL customization.
+    /// Collapsed override section for per-integration gateway URL customization.
     private var ingressOverrideSection: some View {
         DisclosureGroup("Override") {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Toggle("Use custom gateway for ingress", isOn: $ingressUseOverride)
+                Toggle("Use custom gateway URL", isOn: $ingressUseOverride)
                     .toggleStyle(.switch)
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
@@ -1110,7 +1110,7 @@ struct SettingsPanel: View {
                         Text("Gateway URL Override")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
-                        TextField("https://custom-ingress.example.com", text: $ingressGatewayOverride)
+                        TextField("https://custom-gateway.example.com", text: $ingressGatewayOverride)
                             .textFieldStyle(.plain)
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Displays a QR code containing the v2 connection payload for iOS pairing.
-/// Payload format: `{"type":"vellum-daemon","v":2,"id":"<mac-hash>","g":"<ingress-url>","bt":"<bearer-token>"}`
+/// Payload format: `{"type":"vellum-daemon","v":2,"id":"<mac-hash>","g":"<gateway-url>","bt":"<bearer-token>"}`
 ///
 /// Below the QR code, shows the gateway URL and bearer token for manual entry on iOS.
 @MainActor
@@ -25,7 +25,7 @@ struct PairingQRCodeSheet: View {
     private var canGenerateQR: Bool {
         let hasRequiredFields = !gatewayUrl.isEmpty && !resolvedBearerToken.isEmpty
         if isLocalOverride {
-            // For developer local pairing, ingress is not required
+            // For developer local pairing, the gateway is not required
             // but the URL must be a local/private address
             guard let url = URL(string: gatewayUrl), let host = url.host else { return false }
             return hasRequiredFields && LocalAddressValidator.isLocalAddress(host)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -946,7 +946,7 @@ struct SettingsConnectTab: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(VColor.warning)
                         .font(.system(size: 14))
-                    Text("Gateway URL is set but ingress is disabled. Enable ingress in Advanced settings to allow pairing.")
+                    Text("Gateway URL is set but the gateway is not active. Check your tunnel or gateway configuration.")
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1075,7 +1075,7 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Connection Health Check
 
-    /// Tests reachability of both the local gateway process and the public ingress tunnel.
+    /// Tests reachability of both the local gateway process and the public tunnel.
     /// Updates `gatewayReachable`, `ingressReachable`, and `gatewayLastChecked` with results.
     func testGatewayConnection() async {
         isCheckingGateway = true
@@ -1090,7 +1090,7 @@ public final class SettingsStore: ObservableObject {
             timeoutSeconds: 3
         )
 
-        // Test public ingress (only if URL is non-empty)
+        // Test public tunnel (only if URL is non-empty)
         let trimmedUrl = ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedUrl.isEmpty {
             ingressReachable = nil
@@ -1131,7 +1131,7 @@ public final class SettingsStore: ObservableObject {
         PairingConfiguration.resolvedBearerToken(fallback: readHttpToken() ?? "")
     }
 
-    /// Resolved gateway URL for public ingress — uses per-integration override if enabled, else global.
+    /// Resolved gateway URL — uses per-integration override if enabled, else global.
     var resolvedIngressGatewayUrl: String {
         UserDefaults.standard.bool(forKey: "ingressUseOverride")
             ? (nonEmpty(UserDefaults.standard.string(forKey: "ingressGatewayOverride")) ?? ingressPublicBaseUrl)


### PR DESCRIPTION
## Summary
Sweeps user-facing copy across both macOS and iOS platforms for consistency, replacing legacy "ingress" terminology with "gateway" and removing remaining TLS/TCP references from the UI.

## Implementation
- Replaced user-facing "ingress" with "gateway" in status messages and help text
- Updated status section copy to reflect consolidated settings layout
- Verified developer flow labels are consistent across platforms
- Removed or updated any remaining user-facing TLS/TCP text
- Cross-platform copy alignment for QR help text, status labels, and warnings

## Key Technical Choices
- Only user-facing strings changed — code identifiers (ingressEnabled, etc.) kept for backward compatibility
- Copy changes are terminology-only — no functional behavior changes

Closes #7395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
