### PR TITLE
fix: sms_doctor array handling, test-send routing, and Twilio error body parsing

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1895,9 +1895,18 @@ export async function handleTwilioConfig(
 
       const raw = loadRawConfig();
       const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-      const from = (smsSection.phoneNumber as string | undefined)
-        || getSecureKey('credential:twilio:phone_number')
-        || '';
+      let from = '';
+      // When assistantId is provided, check assistant-scoped phone mapping first
+      if (msg.assistantId) {
+        const mapping = (smsSection.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
+        from = mapping[msg.assistantId] ?? '';
+      }
+      // Fall back to global phone number
+      if (!from) {
+        from = (smsSection.phoneNumber as string | undefined)
+          || getSecureKey('credential:twilio:phone_number')
+          || '';
+      }
       if (!from) {
         ctx.send(socket, {
           type: 'twilio_config_response',
@@ -1923,7 +1932,7 @@ export async function handleTwilioConfig(
           'Content-Type': 'application/json',
           ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
         },
-        body: JSON.stringify({ to, text }),
+        body: JSON.stringify({ to, text, ...(msg.assistantId ? { assistantId: msg.assistantId } : {}) }),
         signal: AbortSignal.timeout(30_000),
       });
 
@@ -1995,10 +2004,15 @@ export async function handleTwilioConfig(
       const readinessIssues: string[] = [];
       try {
         const readinessService = getReadinessService();
-        const snapshot = await readinessService.getReadiness('sms', { includeRemote: false });
-        readinessReady = snapshot.ready;
-        for (const r of snapshot.reasons) {
-          readinessIssues.push(r.text);
+        const snapshots = await readinessService.getReadiness('sms', false);
+        const snapshot = snapshots[0];
+        if (snapshot) {
+          readinessReady = snapshot.ready;
+          for (const r of snapshot.reasons) {
+            readinessIssues.push(r.text);
+          }
+        } else {
+          readinessIssues.push('No readiness snapshot returned for SMS channel');
         }
       } catch (err) {
         readinessIssues.push(`Readiness check failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -40,13 +40,14 @@ async function sendTwilioSms(
   });
 
   if (!response.ok) {
-    // Try to parse structured error details from the Twilio error body
+    // Read body as text first to avoid double-consumption (response body is a one-shot stream)
     let errorText: string;
+    const rawBody = await response.text().catch(() => "<unreadable>");
     try {
-      const errBody = await response.json() as Record<string, unknown>;
+      const errBody = JSON.parse(rawBody) as Record<string, unknown>;
       errorText = `Twilio Messages API error ${response.status}: code=${errBody.code ?? "unknown"} message=${errBody.message ?? "unknown"}`;
     } catch {
-      errorText = `Twilio Messages API error ${response.status}: ${await response.text().catch(() => "<unreadable>")}`;
+      errorText = `Twilio Messages API error ${response.status}: ${rawBody}`;
     }
     throw new Error(errorText);
   }


### PR DESCRIPTION
## Summary
- Fix sms_doctor: destructure array from getReadiness() instead of treating as single object
- Fix sms_send_test: check assistant-scoped phone number mappings when assistantId is provided
- Fix sms_send_test: pass assistantId through to gateway request body
- Fix gateway SMS error path: read body as text first to avoid double-consumption

Addresses feedback from PR #7400.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
