### PR TITLE
fix: preserve caller-provided Twilio env vars in update command

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -51,21 +51,21 @@ except Exception:
     print("")
 PY
    )"
-   TWILIO_AUTH_TOKEN="$(
+   TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN:-$(
      cd assistant
      bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:auth_token") ?? "")'
      cd ..
-   )"
-   TWILIO_ACCOUNT_SID="$(
+   )}"
+   TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID:-$(
      cd assistant
      bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:account_sid") ?? "")'
      cd ..
-   )"
-   TWILIO_PHONE_NUMBER="$(
+   )}"
+   TWILIO_PHONE_NUMBER="${TWILIO_PHONE_NUMBER:-$(
      cd assistant
      bun -e 'import { getSecureKey } from "./src/security/secure-keys.js"; process.stdout.write(getSecureKey("credential:twilio:phone_number") ?? "")'
      cd ..
-   )"
+   )}"
 
    # Mirror CLI startGateway() behavior: only auto-enable default routing
    # when exactly one assistant is present in ~/.vellum.lock.json.


### PR DESCRIPTION
Addresses review feedback on #7309. Uses conditional assignment (${VAR:-$(lookup)}) for TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_PHONE_NUMBER so that existing env vars are not overwritten by empty secure-store lookups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
