### PR TITLE
fix: invalidate backend challenge token on guardian cancel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -919,6 +919,12 @@ public final class SettingsStore: ObservableObject {
         default:
             break
         }
+        // Invalidate the pending challenge token on the backend so it can't be used after cancellation
+        do {
+            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
+        } catch {
+            log.error("Failed to revoke \(channel) guardian challenge on cancel: \(error)")
+        }
     }
 
     func revokeChannelGuardian(channel: String) {


### PR DESCRIPTION
Addresses review feedback on #7227. When the user cancels a guardian verification challenge, sends a revoke action to the backend to invalidate the pending challenge token, preventing stale tokens from being used after cancellation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
