### PR TITLE
fix: preserve guardian context on replay and pass assistantId in messaging-reply

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-reply.ts
@@ -1,7 +1,7 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
 
-export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
   const threadId = input.thread_id as string;
@@ -22,6 +22,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     return withProviderToken(provider, async (token) => {
       const result = await provider.sendMessage(token, conversationId, text, {
         threadId,
+        assistantId: context.assistantId,
       });
 
       return ok(`Reply sent (ID: ${result.id}).`);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -553,7 +553,7 @@ export async function handleChannelInbound(
       senderName: body.senderName,
       senderExternalUserId: body.senderExternalUserId,
       senderUsername: body.senderUsername,
-      guardianCtx,
+      guardianCtx: toGuardianRuntimeContext(sourceChannel, guardianCtx),
       replyCallbackUrl,
       assistantId,
     });


### PR DESCRIPTION
Addresses review feedback on #7324. Two fixes: (1) Store full GuardianRuntimeContext (with sourceChannel) in delivery payload so replayed events retain guardian context. (2) Forward context.assistantId in messaging-reply.ts to maintain multi-assistant SMS isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
