### PR TITLE
fix: move Twilio phone number clear to success path of config response

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -72,6 +72,12 @@ struct SettingsConnectTab: View {
                 gatewayUrlText = store.ingressPublicBaseUrl
             }
         }
+        .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
+            if !hasCredentials {
+                twilioSetupExpanded = false
+                twilioNumberPickerExpanded = false
+            }
+        }
         .alert("Regenerate Bearer Token", isPresented: $showingRegenerateConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Regenerate", role: .destructive) {
@@ -382,10 +388,6 @@ struct SettingsConnectTab: View {
                     value: "Configured",
                     action: .init(label: "Clear", style: .danger, disabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
-                        twilioSetupExpanded = false
-                        twilioNumberPickerExpanded = false
-                        store.twilioNumbers = []
-                        store.twilioPhoneNumber = nil
                     }
                 )
             } else if twilioSetupExpanded {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -351,13 +351,19 @@ public final class SettingsStore: ObservableObject {
             self.twilioListInProgress = false
             if response.success {
                 self.twilioHasCredentials = response.hasCredentials
-                if self.twilioPhoneRefreshPending || response.phoneNumber != nil {
+                if !response.hasCredentials {
+                    // Credentials were confirmed removed — clear derived state
+                    self.twilioPhoneNumber = nil
+                    self.twilioNumbers = []
+                } else if self.twilioPhoneRefreshPending || response.phoneNumber != nil {
                     self.twilioPhoneNumber = response.phoneNumber
                 }
-                if self.twilioNumbersRefreshPending {
-                    self.twilioNumbers = response.numbers ?? []
-                } else if let numbers = response.numbers {
-                    self.twilioNumbers = numbers
+                if response.hasCredentials {
+                    if self.twilioNumbersRefreshPending {
+                        self.twilioNumbers = response.numbers ?? []
+                    } else if let numbers = response.numbers {
+                        self.twilioNumbers = numbers
+                    }
                 }
                 self.twilioWarning = response.warning
                 self.twilioError = nil


### PR DESCRIPTION
Addresses review feedback on #7220. Moves optimistic UI updates (twilioPhoneNumber = nil, twilioNumbers = [], etc.) from the button action into the onTwilioConfigResponse success handler, so they only apply after the backend confirms credentials were cleared.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
