### PR TITLE
fix: persist assistantId on CallSession for webhook path

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -221,6 +221,7 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
       callerIdentityMode: identityResult.mode,
       callerIdentitySource: identityResult.source,
+      assistantId,
     });
     sessionId = session.id;
 

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -22,6 +22,7 @@ function parseCallSession(row: typeof callSessions.$inferSelect): CallSession {
     status: row.status as CallSession['status'],
     callerIdentityMode: row.callerIdentityMode,
     callerIdentitySource: row.callerIdentitySource,
+    assistantId: row.assistantId,
     startedAt: row.startedAt,
     endedAt: row.endedAt,
     lastError: row.lastError,
@@ -62,6 +63,7 @@ export function createCallSession(opts: {
   task?: string;
   callerIdentityMode?: string;
   callerIdentitySource?: string;
+  assistantId?: string;
 }): CallSession {
   const db = getDb();
   const now = Date.now();
@@ -76,6 +78,7 @@ export function createCallSession(opts: {
     status: 'initiated' as const,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
+    assistantId: opts.assistantId ?? null,
     startedAt: null,
     endedAt: null,
     lastError: null,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -213,7 +213,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     });
   }
 
-  const twilioConfig = getTwilioConfig();
+  const twilioConfig = getTwilioConfig(session.assistantId ?? undefined);
   let relayUrl: string;
   try {
     relayUrl = getTwilioRelayUrl(loadConfig());

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -13,6 +13,7 @@ export interface CallSession {
   status: CallStatus;
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
+  assistantId: string | null;
   startedAt: number | null;
   endedAt: number | null;
   lastError: string | null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -782,6 +782,9 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_mode TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN caller_identity_source TEXT`); } catch { /* already exists */ }
 
+  // Persist assistantId so the webhook path can resolve assistant-scoped Twilio numbers
+  try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN assistant_id TEXT`); } catch { /* already exists */ }
+
   // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid).
   // On upgraded databases that pre-date this constraint, duplicate rows may exist; deduplicate
   // them first to avoid a UNIQUE constraint failure that would prevent startup.

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -551,6 +551,7 @@ export const callSessions = sqliteTable('call_sessions', {
   status: text('status').notNull().default('initiated'),
   callerIdentityMode: text('caller_identity_mode'),
   callerIdentitySource: text('caller_identity_source'),
+  assistantId: text('assistant_id'),
   startedAt: integer('started_at'),
   endedAt: integer('ended_at'),
   lastError: text('last_error'),


### PR DESCRIPTION
Addresses review feedback on #7355. Adds assistantId to CallSession, persists it during startCall, and uses it in handleVoiceWebhook to pass assistant scope to getTwilioConfig. This ensures assistant-scoped-only setups work for both call creation and webhook handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
