### PR TITLE
fix: set QA latch on user_message path

### DIFF
--- a/assistant/src/__tests__/qa-latch-user-message.test.ts
+++ b/assistant/src/__tests__/qa-latch-user-message.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { detectQaIntent, detectQaOptOut } from '../daemon/qa-intent.js';
+import {
+  setQaLatch,
+  clearQaLatch,
+  isQaLatchActive,
+  qaLatchByConversation,
+} from '../daemon/handlers/shared.js';
+
+/**
+ * Tests that the QA latch is correctly set/cleared based on user message
+ * content, mirroring the logic added to handleUserMessage in sessions.ts.
+ *
+ * We test the detection + latch functions directly rather than going through
+ * the full IPC handler, since the handler simply calls these functions on
+ * the message content. This avoids the heavy Session/AgentLoop mock setup
+ * while still verifying the integration contract.
+ */
+describe('QA latch via user_message path', () => {
+  const sessionId = 'test-session-1';
+
+  beforeEach(() => {
+    // Clear all latch state between tests
+    qaLatchByConversation.clear();
+  });
+
+  test('user message with QA intent sets the QA latch', () => {
+    const content = 'help me test Slack typing';
+    expect(detectQaIntent(content)).toBe(true);
+    expect(detectQaOptOut(content)).toBe(false);
+
+    // Simulate what handleUserMessage does:
+    if (detectQaOptOut(content)) {
+      clearQaLatch(sessionId);
+    } else if (detectQaIntent(content)) {
+      setQaLatch(sessionId);
+    }
+
+    expect(isQaLatchActive(sessionId)).toBe(true);
+  });
+
+  test('user message with opt-out clears the QA latch', () => {
+    // Pre-set the latch
+    setQaLatch(sessionId);
+    expect(isQaLatchActive(sessionId)).toBe(true);
+
+    const content = 'stop qa mode';
+    expect(detectQaOptOut(content)).toBe(true);
+
+    // Simulate what handleUserMessage does:
+    if (detectQaOptOut(content)) {
+      clearQaLatch(sessionId);
+    } else if (detectQaIntent(content)) {
+      setQaLatch(sessionId);
+    }
+
+    expect(isQaLatchActive(sessionId)).toBe(false);
+  });
+
+  test('user message without QA intent does not change the latch', () => {
+    expect(isQaLatchActive(sessionId)).toBe(false);
+
+    const content = 'Can you check my email?';
+    expect(detectQaIntent(content)).toBe(false);
+    expect(detectQaOptOut(content)).toBe(false);
+
+    // Simulate what handleUserMessage does:
+    if (detectQaOptOut(content)) {
+      clearQaLatch(sessionId);
+    } else if (detectQaIntent(content)) {
+      setQaLatch(sessionId);
+    }
+
+    // Latch should remain unset
+    expect(isQaLatchActive(sessionId)).toBe(false);
+  });
+
+  test('opt-out takes priority over QA intent in the same message', () => {
+    // The current implementation checks opt-out first, so a message that
+    // somehow matches both patterns should clear rather than set.
+    setQaLatch(sessionId);
+
+    // "stop testing" matches both detectQaOptOut (/\bstop\s+testing\b/)
+    // and could theoretically trigger QA patterns. The handler checks
+    // opt-out first, so the latch should be cleared.
+    const content = 'stop testing';
+    const isOptOut = detectQaOptOut(content);
+    const isQa = detectQaIntent(content);
+
+    // Simulate what handleUserMessage does (opt-out checked first):
+    if (isOptOut) {
+      clearQaLatch(sessionId);
+    } else if (isQa) {
+      setQaLatch(sessionId);
+    }
+
+    expect(isQaLatchActive(sessionId)).toBe(false);
+  });
+
+  test('latch persists across multiple non-QA messages', () => {
+    // Set latch with QA intent
+    setQaLatch(sessionId);
+    expect(isQaLatchActive(sessionId)).toBe(true);
+
+    // Subsequent non-QA messages should not affect the latch
+    const normalMessages = [
+      'What is the weather today?',
+      'Send a message to the team',
+      'Open the settings page',
+    ];
+
+    for (const content of normalMessages) {
+      if (detectQaOptOut(content)) {
+        clearQaLatch(sessionId);
+      } else if (detectQaIntent(content)) {
+        setQaLatch(sessionId);
+      }
+    }
+
+    // Latch should still be active
+    expect(isQaLatchActive(sessionId)).toBe(true);
+  });
+
+  test('empty message content does not affect the latch', () => {
+    setQaLatch(sessionId);
+    expect(isQaLatchActive(sessionId)).toBe(true);
+
+    const content = '';
+    // In handleUserMessage, empty content skips QA detection entirely
+    if (content) {
+      if (detectQaOptOut(content)) {
+        clearQaLatch(sessionId);
+      } else if (detectQaIntent(content)) {
+        setQaLatch(sessionId);
+      }
+    }
+
+    expect(isQaLatchActive(sessionId)).toBe(true);
+  });
+});

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -31,12 +31,15 @@ import {
   renderHistoryContent,
   mergeToolResults,
   pendingStandaloneSecrets,
+  setQaLatch,
+  clearQaLatch,
   type HandlerContext,
   defineHandlers,
   type HistoryToolCall,
   type HistorySurface,
   type ParsedHistoryMessage,
 } from './shared.js';
+import { detectQaIntent, detectQaOptOut } from '../qa-intent.js';
 import { truncate } from '../../util/truncate.js';
 
 export async function handleUserMessage(
@@ -54,6 +57,17 @@ export async function handleUserMessage(
     // here would replace those dimensions with the daemon's defaults.
     if (!session.hasEscalationHandler()) {
       wireEscalationHandler(session, socket, ctx);
+    }
+
+    // Detect QA intent / opt-out in the user message so the latch is active
+    // before any subsequent CU escalation within this conversation.
+    const messageContent = msg.content ?? '';
+    if (messageContent) {
+      if (detectQaOptOut(messageContent)) {
+        clearQaLatch(msg.sessionId);
+      } else if (detectQaIntent(messageContent)) {
+        setQaLatch(msg.sessionId);
+      }
     }
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);


### PR DESCRIPTION
## Summary
- Adds `detectQaIntent` / `detectQaOptOut` checks to `handleUserMessage` in `sessions.ts` so the QA latch is set/cleared when users send regular chat messages (not just `task_submit`)
- Previously, typing "help me test Slack typing" as a `user_message` would not activate QA mode for subsequent CU escalations
- Adds test coverage for QA latch behavior via the user_message path

## Test plan
- [x] `bun test src/__tests__/qa-latch-user-message.test.ts` — 6 tests pass
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing errors in unrelated files only)
- [ ] Manual: send a QA-intent message via chat (e.g. "help me test Slack typing"), verify latch is active when agent escalates to CU
- [ ] Manual: send "stop qa mode" to verify latch clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
