### PR TITLE
Fix: iOS developer options visibility and stale error text

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -57,6 +57,7 @@ struct DaemonConnectionSection: View {
     @State private var isConnecting = false
 
     @AppStorage(PairingConfiguration.devLocalPairingKey) private var devLocalPairingEnabled: Bool = false
+    @State private var devOptionsExpanded: Bool = false
 
     /// The currently configured gateway URL, shown as read-only status.
     private var gatewayURL: String? {
@@ -174,7 +175,7 @@ struct DaemonConnectionSection: View {
 
             // Developer options
             Section {
-                DisclosureGroup("Developer Options") {
+                DisclosureGroup("Developer Options", isExpanded: $devOptionsExpanded) {
                     VStack(alignment: .leading, spacing: 8) {
                         Toggle("Allow Local HTTP Connections", isOn: $devLocalPairingEnabled)
                             .font(VFont.body)
@@ -199,6 +200,21 @@ struct DaemonConnectionSection: View {
                         }
                     }
                 }
+
+                // Show a brief warning when dev mode is on but section is collapsed
+                if devLocalPairingEnabled && !devOptionsExpanded {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 12))
+                        Text("Local HTTP connections enabled")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.warning)
+                    }
+                }
+            }
+            .onAppear {
+                devOptionsExpanded = devLocalPairingEnabled
             }
 
         }

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -308,7 +308,7 @@ struct QRPairingSheet: View {
                 return
             }
             if !devLocalPairingEnabled {
-                errorMessage = "Enable Developer Local Pairing in connection settings to use local HTTP gateways."
+                errorMessage = "Enable 'Allow Local HTTP Connections' under Developer Options in connection settings."
                 phase = .error
                 return
             }


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #7402 (M3).

## Changes
- Auto-expand Developer Options DisclosureGroup when local HTTP toggle is enabled
- Show warning indicator outside collapsed DisclosureGroup when dev mode is active
- Update QR pairing error message to reference current toggle name ("Allow Local HTTP Connections" under "Developer Options")

Fixes feedback from #7402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
