### PR TITLE
Fix: Distinct QR pairing error messages for URL vs gateway state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -72,8 +72,13 @@ struct PairingQRCodeSheet: View {
                             .font(VFont.body)
                             .foregroundColor(VColor.error)
                             .multilineTextAlignment(.center)
-                    } else if !ingressEnabled || gatewayUrl.isEmpty {
+                    } else if gatewayUrl.isEmpty {
                         Text("Set up a gateway URL in the Connect tab to enable pairing.")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.error)
+                            .multilineTextAlignment(.center)
+                    } else if !ingressEnabled {
+                        Text("Gateway is configured but not active. Check your tunnel or gateway configuration.")
                             .font(VFont.body)
                             .foregroundColor(VColor.error)
                             .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #7407 (M4).

## Changes
- Split the combined `!ingressEnabled || gatewayUrl.isEmpty` error into two distinct messages:
  - Empty URL: "Set up a gateway URL in the Connect tab to enable pairing."
  - URL set but gateway inactive: "Gateway is configured but not active. Check your tunnel or gateway configuration."
- Users now get actionable guidance specific to their actual issue

Fixes feedback from #7407

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
