### PR TITLE
Fix: Restore token override UI in Developer Local Pairing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1158,6 +1158,17 @@ struct SettingsConnectTab: View {
                         .foregroundColor(VColor.textPrimary)
                 }
 
+                // Token Override
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Token Override (optional)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    SecureField("Custom bearer token", text: $iosPairingTokenOverride)
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                }
+
                 // Reset / disable button
                 VButton(label: "Disable & Reset", style: .danger) {
                     iosPairingGatewayOverride = ""


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #7403 (M2).

## Changes
- Added bearer token override field (SecureField) to the Developer Local Pairing section
- Field appears when the override toggle is enabled, alongside the existing gateway URL override
- Labeled "Token Override (optional)" since most LAN pairing uses the default token

Fixes feedback from #7403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
