### PR TITLE
fix: resolve CI failures from channel readiness changes

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2159,6 +2159,7 @@ public enum ServerMessage: Decodable, Sendable {
     case workspaceFilesListResponse(WorkspaceFilesListResponseMessage)
     case workspaceFileReadResponse(WorkspaceFileReadResponseMessage)
     case identityGetResponse(IdentityGetResponseMessage)
+    case channelReadinessResponse(IPCChannelReadinessResponse)
     case pong
     case unknown(String)
 
@@ -2522,6 +2523,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "identity_get_response":
             let message = try IdentityGetResponseMessage(from: decoder)
             self = .identityGetResponse(message)
+        case "channel_readiness_response":
+            let message = try IPCChannelReadinessResponse(from: decoder)
+            self = .channelReadinessResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
Fixes CI failures on main introduced by the channel readiness feature (#7386) and subsequent fix PRs (#7404, #7405, #7406). See failed run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22332771129
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
