### PR TITLE
fix: prevent Vellum from stealing focus during external-app QA

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -61,6 +61,17 @@ extension AppDelegate {
         return baseMessage
     }
 
+    // MARK: - External App Target Detection
+
+    /// Returns `true` when the CU session targets an external app (not Vellum
+    /// itself). When `bundleId` is nil the session has no target constraint and
+    /// is treated as "self" (backward compatibility).
+    private func isExternalAppTarget(bundleId: String?) -> Bool {
+        guard let bundleId, !bundleId.isEmpty else { return false }
+        let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+        return bundleId != selfBundleId
+    }
+
     // MARK: - Accessibility Permission
 
     /// Poll for accessibility permission after prompting, giving the user time to grant it in System Settings.
@@ -135,8 +146,13 @@ extension AppDelegate {
             self.textResponseWindow = nil
 
             // Keep the main app visible during escalated CU so permission prompts
-            // and status are always visible to the user.
-            self.showMainWindow()
+            // and status are always visible to the user — but only when the
+            // target app IS Vellum itself (or unspecified). For external-app QA
+            // sessions (e.g., targeting Slack, Chrome), activating Vellum's main
+            // window would steal focus from the app under test.
+            if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId) {
+                self.showMainWindow()
+            }
 
             await session.run()
             let endMessage = self.computerUseEndMessage(for: session)
@@ -283,8 +299,13 @@ extension AppDelegate {
                     || effectiveTask.localizedCaseInsensitiveContains("test")
                     || effectiveTask.localizedCaseInsensitiveContains("verify")
                 if routed.qaMode == true || looksLikeQaTask {
-                    // QA/test CU sessions should keep the main app open.
-                    self.showMainWindow()
+                    // QA/test CU sessions should keep the main app open —
+                    // but only when the target app is Vellum itself (or
+                    // unspecified). For external-app QA sessions, activating
+                    // Vellum would steal focus from the app under test.
+                    if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId) {
+                        self.showMainWindow()
+                    }
                 }
                 await session.run()
                 let endMessage = self.computerUseEndMessage(for: session)

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -689,7 +689,13 @@ final class ComputerUseSession: ObservableObject {
 
         if let result = enumerator.enumerateCurrentWindow() {
             // On first step with Chrome: check if web content is visible.
+            // Skip this check when targeting an external app — showing the
+            // NSAlert would activate Vellum and steal focus from the app
+            // under test.
+            let isExternalTarget = targetAppBundleId != nil
+                && targetAppBundleId != Bundle.main.bundleIdentifier
             if !didChromeAccessibilityCheck,
+               !isExternalTarget,
                let frontApp = NSWorkspace.shared.frontmostApplication,
                ChromeAccessibilityHelper.isChromium(frontApp),
                !ChromeAccessibilityHelper.hasWebContent(elements: result.elements) {


### PR DESCRIPTION
## Summary
- Gate `showMainWindow()` calls in CU session lifecycle (both `startSession` and `handleEscalationToComputerUse`) so they only activate Vellum's main window when the target app IS Vellum itself or unspecified
- Skip the Chrome accessibility restart prompt (`NSApp.activate` + `NSAlert`) during external-app QA sessions to avoid stealing focus
- Add `isExternalAppTarget(bundleId:)` helper that checks whether the target bundle ID differs from Vellum's own bundle ID

## Test plan
- [ ] Start a QA session targeting an external app (e.g., Slack) -- verify Vellum does NOT steal focus
- [ ] Start a QA session targeting Vellum itself -- verify `showMainWindow()` still fires
- [ ] Start a QA session with no `targetAppBundleId` -- verify backward-compatible behavior (window shows)
- [ ] Escalate from text_qa to computer_use targeting an external app -- verify focus stays on target app
- [ ] Verify session overlay still appears and is visible during external-app QA
- [ ] Verify tool confirmation prompts still work via the overlay window (not main window)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
