### PR TITLE
fix: align runRemoteChecks phone number fallback order with canonical resolution

### DIFF
--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -83,9 +83,9 @@ const smsProbe: ChannelProbe = {
     // Resolve the assigned phone number using fallback chain
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const phoneNumber = (smsConfig.phoneNumber as string)
+    const phoneNumber = process.env.TWILIO_PHONE_NUMBER
+      || (smsConfig.phoneNumber as string)
       || getSecureKey('credential:twilio:phone_number')
-      || process.env.TWILIO_PHONE_NUMBER
       || '';
     if (!phoneNumber) return [];
 


### PR DESCRIPTION
## Summary
- Reorder phone number fallback chain in `runRemoteChecks` to match canonical `resolveTwilioPhoneNumber` order: env var → config → secure key
- Fixes potential false-ready status when env var override and config differ

## Original prompt
Address the feedback on PR #7410 — both Codex and Devin flagged inverted phone number fallback order in `runRemoteChecks` vs canonical `resolveTwilioPhoneNumber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
