### PR TITLE
Fix: Correct misleading comment in PairingQRCodeSheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -25,7 +25,7 @@ struct PairingQRCodeSheet: View {
     private var canGenerateQR: Bool {
         let hasRequiredFields = !gatewayUrl.isEmpty && !resolvedBearerToken.isEmpty
         if isLocalOverride {
-            // For developer local pairing, the gateway is not required
+            // For developer local pairing, the ingress-enabled flag is not required
             // but the URL must be a local/private address
             guard let url = URL(string: gatewayUrl), let host = url.host else { return false }
             return hasRequiredFields && LocalAddressValidator.isLocalAddress(host)


### PR DESCRIPTION
## Summary
Fixes misleading comment in PairingQRCodeSheet.canGenerateQR that said "the gateway is not required" when what's actually skipped is the ingressEnabled flag check. The gateway URL IS required for local pairing.

Fixes feedback from #7415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
