### PR TITLE
feat: thread app_bundle_id through open_app tool

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -250,6 +250,10 @@
             "type": "string",
             "description": "The name of the application to open (e.g. \"Slack\", \"Safari\", \"Google Chrome\", \"VS Code\")"
           },
+          "app_bundle_id": {
+            "type": "string",
+            "description": "Bundle identifier of the app (e.g. com.apple.Safari). If provided, used for precise app activation."
+          },
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you need to open or switch to this app"

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -684,6 +684,11 @@ export class ComputerUseSession {
             isError: true,
           };
         }
+
+        // Inject targetAppBundleId when the LLM didn't provide one
+        if (!input.app_bundle_id && this.targetAppBundleId) {
+          input = { ...input, app_bundle_id: this.targetAppBundleId };
+        }
       }
 
       if (toolName === 'computer_use_run_applescript') {

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -302,6 +302,10 @@ export const computerUseOpenAppTool: Tool = {
             type: 'string',
             description: 'The name of the application to open (e.g. "Slack", "Safari", "Google Chrome", "VS Code")',
           },
+          app_bundle_id: {
+            type: 'string',
+            description: 'Bundle identifier of the app (e.g. com.apple.Safari). If provided, used for precise app activation.',
+          },
           reasoning: {
             type: 'string',
             description: 'Explanation of why you need to open or switch to this app',

--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -235,7 +235,7 @@ final class ActionExecutor: ActionExecuting {
             try drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: endX, y: endY))
         case .openApp:
             guard let appName = action.appName else { throw ExecutorError.appNotFound("(no name)") }
-            try await openApp(name: appName)
+            try await openApp(name: appName, bundleId: action.appBundleId)
         case .runAppleScript:
             guard let source = action.script else { throw ExecutorError.appleScriptMissingScript }
             return try await runAppleScript(source)

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -36,6 +36,7 @@ struct AgentAction: Codable {
     var summary: String?
     var waitDuration: Int?
     var appName: String?
+    var appBundleId: String?
     var script: String?
     var reasoning: String
     var resolvedFromElementId: Int?
@@ -56,6 +57,7 @@ struct AgentAction: Codable {
         summary: String? = nil,
         waitDuration: Int? = nil,
         appName: String? = nil,
+        appBundleId: String? = nil,
         script: String? = nil,
         resolvedFromElementId: Int? = nil,
         resolvedToElementId: Int? = nil,
@@ -74,6 +76,7 @@ struct AgentAction: Codable {
         self.summary = summary
         self.waitDuration = waitDuration
         self.appName = appName
+        self.appBundleId = appBundleId
         self.script = script
         self.resolvedFromElementId = resolvedFromElementId
         self.resolvedToElementId = resolvedToElementId

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -912,6 +912,8 @@ final class ComputerUseSession: ObservableObject {
             ?? extractInt(from: msg.input, key: "wait_duration")
         let appName = msg.input["app_name"]?.value as? String
             ?? msg.input["appName"]?.value as? String
+        let appBundleId = msg.input["app_bundle_id"]?.value as? String
+            ?? msg.input["appBundleId"]?.value as? String
         let script = msg.input["script"]?.value as? String
         let elementId = extractInt(from: msg.input, key: "element_id")
             ?? extractInt(from: msg.input, key: "elementId")
@@ -934,6 +936,7 @@ final class ComputerUseSession: ObservableObject {
             summary: summary,
             waitDuration: waitDuration,
             appName: appName,
+            appBundleId: appBundleId,
             script: script,
             resolvedFromElementId: elementId,
             resolvedToElementId: toElementId,


### PR DESCRIPTION
## Summary

- Add `app_bundle_id` as an optional string parameter to the `computer_use_open_app` tool definition (both `definitions.ts` and `TOOLS.json`)
- In `computer-use-session.ts`, inject the session's `targetAppBundleId` as the default `app_bundle_id` when the LLM doesn't provide one
- Add `appBundleId: String?` field to the Swift `AgentAction` struct and wire it through the initializer
- Extract `app_bundle_id` / `appBundleId` from the IPC input dictionary in `Session.swift`'s `mapToAgentAction()`
- Pass `action.appBundleId` to the existing `openApp(name:bundleId:)` method instead of `nil`

This threads the bundleId from target-app-hints through the tool definition, IPC, and Swift action types so that `openApp` can use precise bundle identifier resolution instead of just fuzzy name matching.

## Test plan

- [ ] Verify TypeScript type-check passes (pre-existing errors only)
- [ ] Verify a CU session with a target app hint correctly populates `app_bundle_id` in the IPC action message
- [ ] Verify Swift side receives and passes `bundleId` to `openApp()`, which activates via bundle ID when available
- [ ] Verify fallback: when no `app_bundle_id` is provided, behavior is identical to before (name-based resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
