### PR TITLE
fix: resolve TS2322 type error in sms-messaging-provider test

### DIFF
--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { SmsSendResult } from '../messaging/providers/sms/client.js';
 
-const sendSmsMock = mock(async (..._args: unknown[]) => ({ messageSid: 'SM-mock-sid', status: 'queued' }));
+const sendSmsMock = mock(async (..._args: unknown[]): Promise<SmsSendResult> => ({ messageSid: 'SM-mock-sid', status: 'queued' }));
 const getOrCreateConversationMock = mock((_key: string) => ({ conversationId: 'conv-1' }));
 const upsertOutboundBindingMock = mock((_input: Record<string, unknown>) => {});
 


### PR DESCRIPTION
Fixes CI type-check failure from merged PR #7435 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22333118392).

The sendSmsMock on line 3 of sms-messaging-provider.test.ts inferred its return type as `{ messageSid: string; status: string }` (required fields) from the default mock value. However, the actual `SmsSendResult` type in `sms/client.ts` has all optional fields (`messageSid?: string; status?: string`). This caused a TS2322 error on line 103 where `mockImplementation(async () => ({}))` returns an empty object to test the fallback path.

Fix: explicitly annotate the mock's return type as `Promise<SmsSendResult>` so the empty object is a valid implementation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
