### PR TITLE
Fix SMS readiness/compliance regressions and harden /update

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -182,7 +182,17 @@ PY
 
    GATEWAY_PIDS=$(pgrep -f "gateway/src/index" 2>/dev/null | wc -l | tr -d ' ')
    if [ "$GATEWAY_PIDS" -gt 1 ]; then
-     echo "WARNING: Multiple gateway processes detected ($GATEWAY_PIDS). Kill extras with: pkill -f 'gateway/src/index'"
+     echo ""
+     echo "ERROR: Multiple gateway processes detected ($GATEWAY_PIDS)."
+     echo "PIDs:"
+     pgrep -f "gateway/src/index" || true
+     echo "Recent gateway logs:"
+     tail -n 80 "${HOME}/.vellum/gateway-dev.log" 2>/dev/null || echo "(no log file found)"
+     echo ""
+     echo "Kill extras and retry:"
+     echo "  pkill -f 'gateway/src/index' && /update"
+     echo ""
+     exit 1
    fi
    ```
 

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure), then launch app pinned to local `gateway/`. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
+| `/update` | Pull latest from `main`, restart daemon, relaunch a single source gateway with ingress + Twilio auth env plus resilient routing defaults (`GATEWAY_UNMAPPED_POLICY` / `GATEWAY_DEFAULT_ASSISTANT_ID`) injected from local config/credentials, verify gateway health (fail fast on startup failure or duplicate gateway processes), then launch app pinned to local `gateway/`. Prints a startup summary with daemon/gateway health, Twilio env presence, and routing config. |
 
 
 ### Review

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -114,7 +114,7 @@ describe('ChannelReadinessService', () => {
     expect(probe.remoteCallCount).toBe(1);
 
     // Manually age the cached snapshot beyond TTL
-    const cached = (service as unknown as { snapshots: Map<string, { checkedAt: number }> }).snapshots.get('sms')!;
+    const cached = (service as unknown as { snapshots: Map<string, { checkedAt: number }> }).snapshots.get('sms::__default__')!;
     cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
 
     // Second call should re-run remote checks
@@ -253,5 +253,48 @@ describe('ChannelReadinessService', () => {
     expect(snapshot.reasons).toEqual([
       { code: 'api_check', text: 'API unreachable' },
     ]);
+  });
+
+  test('stale cached remote failures do not affect local-only readiness', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: false, message: 'API unreachable' }],
+    );
+    service.registerProbe(probe);
+
+    // Prime remote cache with a failing check
+    await service.getReadiness('sms', true);
+
+    // Age snapshot beyond TTL so remote checks are stale
+    const cached = (service as unknown as { snapshots: Map<string, { checkedAt: number }> }).snapshots.get('sms::__default__')!;
+    cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
+
+    // Local-only call should not be blocked by stale remote failure
+    const [snapshot] = await service.getReadiness('sms', false);
+    expect(snapshot.stale).toBe(true);
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.reasons).toEqual([]);
+  });
+
+  test('remote cache is scoped per assistantId', async () => {
+    const remoteCalls: Record<string, number> = {};
+    const probe: ChannelProbe = {
+      channel: 'sms',
+      runLocalChecks: () => [{ name: 'local', passed: true, message: 'ok' }],
+      async runRemoteChecks(context) {
+        const key = context?.assistantId ?? '__default__';
+        remoteCalls[key] = (remoteCalls[key] ?? 0) + 1;
+        return [{ name: 'remote', passed: true, message: `ok-${key}` }];
+      },
+    };
+    service.registerProbe(probe);
+
+    await service.getReadiness('sms', true, 'ast-alpha');
+    await service.getReadiness('sms', true, 'ast-beta');
+    await service.getReadiness('sms', true, 'ast-alpha');
+
+    expect(remoteCalls['ast-alpha']).toBe(1);
+    expect(remoteCalls['ast-beta']).toBe(1);
   });
 });

--- a/assistant/src/__tests__/handlers-twilio-config.test.ts
+++ b/assistant/src/__tests__/handlers-twilio-config.test.ts
@@ -1595,6 +1595,49 @@ describe('Twilio config handler', () => {
     expect(capturedBody).toContain('BusinessType=SOLE_PROPRIETOR');
   });
 
+  test('sms_submit_tollfree_verification accepts current Twilio enum ACCOUNT_NOTIFICATIONS', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    let capturedBody = '';
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('Tollfree/Verifications') && init?.method === 'POST') {
+        capturedBody = init?.body?.toString() ?? '';
+        return new Response(JSON.stringify({
+          sid: 'TF_VER_NEW',
+          status: 'PENDING_REVIEW',
+        }), { status: 201 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'sms_submit_tollfree_verification',
+      verificationParams: {
+        tollfreePhoneNumberSid: 'PN123',
+        businessName: 'Test Biz',
+        businessWebsite: 'https://test.com',
+        notificationEmail: 'test@test.com',
+        useCaseCategories: ['ACCOUNT_NOTIFICATIONS'],
+        useCaseSummary: 'Account alerts',
+        productionMessageSample: 'Your account was updated',
+        optInImageUrls: ['https://test.com/optin.png'],
+        optInType: 'WEB_FORM',
+        messageVolume: '100',
+      },
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { success: boolean };
+    expect(res.success).toBe(true);
+    expect(capturedBody).toContain('UseCaseCategories=ACCOUNT_NOTIFICATIONS');
+  });
+
   test('sms_submit_tollfree_verification rejects invalid useCaseCategories', async () => {
     secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
     secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
@@ -1795,5 +1838,88 @@ describe('Twilio config handler', () => {
     const res = sent[0] as { type: string; success: boolean; error?: string };
     expect(res.success).toBe(false);
     expect(res.error).toContain('verificationSid is required');
+  });
+
+  test('sms_update_tollfree_verification blocks updates when rejected verification is not editable', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+
+    let attemptedUpdate = false;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('Tollfree/Verifications/TF_VER_001') && init?.method === 'GET') {
+        return new Response(JSON.stringify({
+          sid: 'TF_VER_001',
+          status: 'TWILIO_REJECTED',
+          edit_allowed: false,
+          edit_expiration: '2026-01-01T00:00:00Z',
+        }), { status: 200 });
+      }
+      if (urlStr.includes('Tollfree/Verifications/TF_VER_001') && init?.method === 'POST') {
+        attemptedUpdate = true;
+        return new Response(JSON.stringify({
+          sid: 'TF_VER_001',
+          status: 'IN_REVIEW',
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'sms_update_tollfree_verification',
+      verificationSid: 'TF_VER_001',
+      verificationParams: { useCaseSummary: 'Updated summary' },
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as { success: boolean; error?: string; compliance?: Record<string, unknown> };
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('cannot be updated');
+    expect(res.compliance?.editAllowed).toBe(false);
+    expect(attemptedUpdate).toBe(false);
+  });
+
+  test('sms_doctor resolves toll-free verification using phone SID lookup', async () => {
+    secureKeyStore['credential:twilio:account_sid'] = 'AC1234567890abcdef1234567890abcdef';
+    secureKeyStore['credential:twilio:auth_token'] = 'test_auth_token';
+    rawConfigStore = { sms: { phoneNumber: '+18001234567' } };
+
+    let verificationLookupUrl = '';
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes('IncomingPhoneNumbers.json') && urlStr.includes('PhoneNumber=%2B18001234567')) {
+        return new Response(JSON.stringify({
+          incoming_phone_numbers: [{ sid: 'PN123abc', phone_number: '+18001234567' }],
+        }), { status: 200 });
+      }
+      if (urlStr.includes('Tollfree/Verifications')) {
+        verificationLookupUrl = urlStr;
+        return new Response(JSON.stringify({
+          verifications: [{ sid: 'TF_VER_001', status: 'TWILIO_APPROVED' }],
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const msg: TwilioConfigRequest = {
+      type: 'twilio_config',
+      action: 'sms_doctor',
+    };
+
+    const { ctx, sent } = createTestContext();
+    await handleTwilioConfig(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      success: boolean;
+      diagnostics?: { compliance?: { status?: string } };
+    };
+    expect(res.success).toBe(true);
+    expect(verificationLookupUrl).toContain('TollfreePhoneNumberSid=PN123abc');
+    expect(res.diagnostics?.compliance?.status).toBe('TWILIO_APPROVED');
   });
 });

--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-const sendSmsMock = mock(async (..._args: unknown[]) => ({ messageSid: 'SM-mock-sid', status: 'queued' }));
+const sendSmsMock = mock(async (..._args: unknown[]): Promise<{ messageSid?: string; status?: string }> => ({
+  messageSid: 'SM-mock-sid',
+  status: 'queued',
+}));
 const getOrCreateConversationMock = mock((_key: string) => ({ conversationId: 'conv-1' }));
 const upsertOutboundBindingMock = mock((_input: Record<string, unknown>) => {});
 

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -320,6 +320,30 @@ export async function getTollFreeVerificationStatus(
   return parseTollFreeVerification(verifications[0]);
 }
 
+/** Fetch a specific toll-free verification by SID. */
+export async function getTollFreeVerificationBySid(
+  accountSid: string,
+  authToken: string,
+  verificationSid: string,
+): Promise<TollFreeVerification | null> {
+  const res = await fetch(`${TOLLFREE_VERIFICATION_BASE}/${encodeURIComponent(verificationSid)}`, {
+    method: 'GET',
+    headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+  });
+
+  if (res.status === 404) {
+    return null;
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Twilio Toll-Free Verification fetch error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+  return parseTollFreeVerification(data);
+}
+
 export interface TollFreeVerificationSubmitParams {
   tollfreePhoneNumberSid: string;
   businessName: string;

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -44,6 +44,7 @@ import {
   provisionPhoneNumber,
   updatePhoneNumberWebhooks,
   getTollFreeVerificationStatus,
+  getTollFreeVerificationBySid,
   submitTollFreeVerification,
   updateTollFreeVerification,
   deleteTollFreeVerification,
@@ -1215,6 +1216,35 @@ function mapTwilioErrorRemediation(errorCode: string | undefined): string | unde
   return map[errorCode];
 }
 
+const TWILIO_USE_CASE_ALIASES: Record<string, string> = {
+  ACCOUNT_NOTIFICATION: 'ACCOUNT_NOTIFICATIONS',
+  DELIVERY_NOTIFICATION: 'DELIVERY_NOTIFICATIONS',
+  FRAUD_ALERT: 'FRAUD_ALERT_MESSAGING',
+  POLLING_AND_VOTING: 'POLLING_AND_VOTING_NON_POLITICAL',
+};
+
+const TWILIO_VALID_USE_CASE_CATEGORIES = [
+  'TWO_FACTOR_AUTHENTICATION',
+  'ACCOUNT_NOTIFICATIONS',
+  'CUSTOMER_CARE',
+  'CHARITY_NONPROFIT',
+  'DELIVERY_NOTIFICATIONS',
+  'FRAUD_ALERT_MESSAGING',
+  'EVENTS',
+  'HIGHER_EDUCATION',
+  'K12',
+  'MARKETING',
+  'POLLING_AND_VOTING_NON_POLITICAL',
+  'POLITICAL_ELECTION_CAMPAIGNS',
+  'PUBLIC_SERVICE_ANNOUNCEMENT',
+  'SECURITY_ALERT',
+] as const;
+
+function normalizeUseCaseCategories(rawCategories: string[]): string[] {
+  const normalized = rawCategories.map((value) => TWILIO_USE_CASE_ALIASES[value] ?? value);
+  return Array.from(new Set(normalized));
+}
+
 export async function handleTwilioConfig(
   msg: TwilioConfigRequest,
   socket: net.Socket,
@@ -1648,18 +1678,16 @@ export async function handleTwilioConfig(
       }
 
       // Validate enum values
-      const validUseCaseCategories = [
-        'TWO_FACTOR_AUTHENTICATION', 'ACCOUNT_NOTIFICATION', 'CUSTOMER_CARE',
-        'DELIVERY_NOTIFICATION', 'FRAUD_ALERT', 'HIGHER_EDUCATION', 'MARKETING',
-        'POLLING_AND_VOTING', 'PUBLIC_SERVICE_ANNOUNCEMENT', 'SECURITY_ALERT',
-      ];
-      const invalidCategories = (vp.useCaseCategories ?? []).filter((c) => !validUseCaseCategories.includes(c));
+      const normalizedUseCaseCategories = normalizeUseCaseCategories(vp.useCaseCategories ?? []);
+      const invalidCategories = normalizedUseCaseCategories.filter(
+        (c) => !TWILIO_VALID_USE_CASE_CATEGORIES.includes(c as (typeof TWILIO_VALID_USE_CASE_CATEGORIES)[number]),
+      );
       if (invalidCategories.length > 0) {
         ctx.send(socket, {
           type: 'twilio_config_response',
           success: false,
           hasCredentials: true,
-          error: `Invalid useCaseCategories: ${invalidCategories.join(', ')}. Valid values: ${validUseCaseCategories.join(', ')}`,
+          error: `Invalid useCaseCategories: ${invalidCategories.join(', ')}. Valid values: ${TWILIO_VALID_USE_CASE_CATEGORIES.join(', ')}`,
         });
         return;
       }
@@ -1697,7 +1725,7 @@ export async function handleTwilioConfig(
         businessName: vp.businessName!,
         businessWebsite: vp.businessWebsite!,
         notificationEmail: vp.notificationEmail!,
-        useCaseCategories: vp.useCaseCategories!,
+        useCaseCategories: normalizedUseCaseCategories,
         useCaseSummary: vp.useCaseSummary!,
         productionMessageSample: vp.productionMessageSample!,
         optInImageUrls: vp.optInImageUrls!,
@@ -1742,6 +1770,43 @@ export async function handleTwilioConfig(
 
       const accountSid = getSecureKey('credential:twilio:account_sid')!;
       const authToken = getSecureKey('credential:twilio:auth_token')!;
+
+      const currentVerification = await getTollFreeVerificationBySid(accountSid, authToken, msg.verificationSid);
+      if (!currentVerification) {
+        ctx.send(socket, {
+          type: 'twilio_config_response',
+          success: false,
+          hasCredentials: true,
+          error: `Verification ${msg.verificationSid} was not found on this Twilio account.`,
+        });
+        return;
+      }
+
+      if (currentVerification.status === 'TWILIO_REJECTED') {
+        const expirationMillis = currentVerification.editExpiration
+          ? Date.parse(currentVerification.editExpiration)
+          : Number.NaN;
+        const editExpired = Number.isFinite(expirationMillis) && Date.now() > expirationMillis;
+        if (currentVerification.editAllowed === false || editExpired) {
+          const detail = editExpired
+            ? `edit_expiration=${currentVerification.editExpiration}`
+            : 'edit_allowed=false';
+          ctx.send(socket, {
+            type: 'twilio_config_response',
+            success: false,
+            hasCredentials: true,
+            error: `Verification ${msg.verificationSid} cannot be updated (${detail}). Delete and resubmit instead.`,
+            compliance: {
+              numberType: 'toll_free',
+              verificationSid: currentVerification.sid,
+              verificationStatus: currentVerification.status,
+              editAllowed: currentVerification.editAllowed,
+              editExpiration: currentVerification.editExpiration,
+            },
+          });
+          return;
+        }
+      }
 
       const verification = await updateTollFreeVerification(
         accountSid,
@@ -2004,7 +2069,7 @@ export async function handleTwilioConfig(
       const readinessIssues: string[] = [];
       try {
         const readinessService = getReadinessService();
-        const snapshots = await readinessService.getReadiness('sms', false);
+        const snapshots = await readinessService.getReadiness('sms', true, msg.assistantId);
         const snapshot = snapshots[0];
         if (snapshot) {
           readinessReady = snapshot.ready;
@@ -2026,7 +2091,14 @@ export async function handleTwilioConfig(
         try {
           const raw = loadRawConfig();
           const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-          const phoneNumber = (smsSection.phoneNumber as string | undefined) || getSecureKey('credential:twilio:phone_number') || '';
+          let phoneNumber = '';
+          if (msg.assistantId) {
+            const mapping = (smsSection.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
+            phoneNumber = mapping[msg.assistantId] ?? '';
+          }
+          if (!phoneNumber) {
+            phoneNumber = (smsSection.phoneNumber as string | undefined) || getSecureKey('credential:twilio:phone_number') || '';
+          }
           if (phoneNumber) {
             const accountSid = getSecureKey('credential:twilio:account_sid')!;
             const authToken = getSecureKey('credential:twilio:auth_token')!;
@@ -2036,24 +2108,37 @@ export async function handleTwilioConfig(
             );
             if (isTollFree) {
               try {
-                const verification = await getTollFreeVerificationStatus(accountSid, authToken, phoneNumber);
-                if (verification) {
-                  const status = verification.status;
-                  complianceStatus = status;
-                  complianceDetail = `Toll-free verification: ${status}`;
-                  if (status === 'TWILIO_APPROVED') {
-                    complianceRemediation = undefined;
-                  } else if (status === 'PENDING_REVIEW' || status === 'IN_REVIEW') {
-                    complianceRemediation = 'Toll-free verification is pending. Messaging may have limited throughput until approved.';
-                  } else if (status === 'TWILIO_REJECTED') {
-                    complianceRemediation = 'Toll-free verification was rejected. Check rejection reasons and resubmit.';
-                  } else {
-                    complianceRemediation = 'Submit a toll-free verification to enable full messaging throughput.';
-                  }
+                const phoneSid = await getPhoneNumberSid(accountSid, authToken, phoneNumber);
+                if (!phoneSid) {
+                  complianceStatus = 'check_failed';
+                  complianceDetail = `Assigned number ${phoneNumber} was not found on the Twilio account`;
+                  complianceRemediation = 'Reassign the number in twilio-setup or update credentials to the matching account.';
                 } else {
-                  complianceStatus = 'unverified';
-                  complianceDetail = 'Toll-free number without verification';
-                  complianceRemediation = 'Submit a toll-free verification request to avoid filtering.';
+                  const verification = await getTollFreeVerificationStatus(accountSid, authToken, phoneSid);
+                  if (verification) {
+                    const status = verification.status;
+                    complianceStatus = status;
+                    complianceDetail = `Toll-free verification: ${status}`;
+                    if (status === 'TWILIO_APPROVED') {
+                      complianceRemediation = undefined;
+                    } else if (status === 'PENDING_REVIEW' || status === 'IN_REVIEW') {
+                      complianceRemediation = 'Toll-free verification is pending. Messaging may have limited throughput until approved.';
+                    } else if (status === 'TWILIO_REJECTED') {
+                      if (verification.editAllowed) {
+                        complianceRemediation = verification.editExpiration
+                          ? `Toll-free verification was rejected but can still be edited until ${verification.editExpiration}. Update and resubmit it.`
+                          : 'Toll-free verification was rejected but can still be edited. Update and resubmit it.';
+                      } else {
+                        complianceRemediation = 'Toll-free verification was rejected and is no longer editable. Delete and resubmit it.';
+                      }
+                    } else {
+                      complianceRemediation = 'Submit a toll-free verification to enable full messaging throughput.';
+                    }
+                  } else {
+                    complianceStatus = 'unverified';
+                    complianceDetail = 'Toll-free number without verification';
+                    complianceRemediation = 'Submit a toll-free verification request to avoid filtering.';
+                  }
                 }
               } catch {
                 complianceStatus = 'check_failed';
@@ -2259,13 +2344,13 @@ export async function handleChannelReadiness(
 
     if (msg.action === 'refresh') {
       if (msg.channel) {
-        service.invalidateChannel(msg.channel);
+        service.invalidateChannel(msg.channel, msg.assistantId);
       } else {
         service.invalidateAll();
       }
     }
 
-    const snapshots = await service.getReadiness(msg.channel, msg.includeRemote);
+    const snapshots = await service.getReadiness(msg.channel, msg.includeRemote, msg.assistantId);
 
     ctx.send(socket, {
       type: 'channel_readiness_response',

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelId,
   ChannelProbe,
+  ChannelProbeContext,
   ChannelReadinessSnapshot,
   ReadinessCheckResult,
 } from './channel-readiness-types.js';
@@ -29,9 +30,54 @@ function hasIngressConfigured(): boolean {
   }
 }
 
+function getAssistantMappedPhoneNumber(
+  smsConfig: Record<string, unknown>,
+  assistantId?: string,
+): string | undefined {
+  if (!assistantId) return undefined;
+  const mapping = (smsConfig.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
+  return mapping[assistantId];
+}
+
+function hasAnyAssistantMappedPhoneNumber(smsConfig: Record<string, unknown>): boolean {
+  const mapping = (smsConfig.assistantPhoneNumbers as Record<string, string> | undefined) ?? {};
+  return Object.keys(mapping).length > 0;
+}
+
+function hasAnyAssistantMappedPhoneNumberSafe(): boolean {
+  try {
+    const raw = loadRawConfig();
+    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    return hasAnyAssistantMappedPhoneNumber(smsConfig);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve SMS from-number with canonical precedence:
+ * assistant mapping -> env override -> config sms.phoneNumber -> secure key fallback.
+ */
+function resolveSmsPhoneNumber(assistantId?: string): string {
+  try {
+    const raw = loadRawConfig();
+    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    const mapped = getAssistantMappedPhoneNumber(smsConfig, assistantId);
+    return mapped
+      || process.env.TWILIO_PHONE_NUMBER
+      || (smsConfig.phoneNumber as string)
+      || getSecureKey('credential:twilio:phone_number')
+      || '';
+  } catch {
+    return process.env.TWILIO_PHONE_NUMBER
+      || getSecureKey('credential:twilio:phone_number')
+      || '';
+  }
+}
+
 const smsProbe: ChannelProbe = {
   channel: 'sms',
-  runLocalChecks(): ReadinessCheckResult[] {
+  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[] {
     const results: ReadinessCheckResult[] = [];
 
     const hasCreds = hasTwilioCredentials();
@@ -43,23 +89,18 @@ const smsProbe: ChannelProbe = {
         : 'Twilio Account SID and Auth Token are not configured',
     });
 
-    let hasPhone = !!process.env.TWILIO_PHONE_NUMBER;
-    if (!hasPhone) {
-      try {
-        const raw = loadRawConfig();
-        const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-        hasPhone = !!(smsConfig.phoneNumber as string);
-      } catch { /* ignore */ }
-    }
-    if (!hasPhone) {
-      hasPhone = !!getSecureKey('credential:twilio:phone_number');
-    }
+    const resolvedNumber = resolveSmsPhoneNumber(context?.assistantId);
+    const hasPhone = !!resolvedNumber || (!context?.assistantId && hasAnyAssistantMappedPhoneNumberSafe());
     results.push({
       name: 'phone_number',
       passed: hasPhone,
       message: hasPhone
-        ? 'Phone number is assigned'
-        : 'No phone number assigned',
+        ? (context?.assistantId && !resolvedNumber
+          ? `Assistant ${context.assistantId} has no direct mapping, but SMS phone numbers are assigned`
+          : 'Phone number is assigned')
+        : (context?.assistantId
+          ? `No phone number assigned for assistant ${context.assistantId}`
+          : 'No phone number assigned'),
     });
 
     const hasIngress = hasIngressConfigured();
@@ -73,20 +114,14 @@ const smsProbe: ChannelProbe = {
 
     return results;
   },
-  async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
+  async runRemoteChecks(context?: ChannelProbeContext): Promise<ReadinessCheckResult[]> {
     if (!hasTwilioCredentials()) return [];
 
     const accountSid = getSecureKey('credential:twilio:account_sid');
     const authToken = getSecureKey('credential:twilio:auth_token');
     if (!accountSid || !authToken) return [];
 
-    // Resolve the assigned phone number using fallback chain
-    const raw = loadRawConfig();
-    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const phoneNumber = process.env.TWILIO_PHONE_NUMBER
-      || (smsConfig.phoneNumber as string)
-      || getSecureKey('credential:twilio:phone_number')
-      || '';
+    const phoneNumber = resolveSmsPhoneNumber(context?.assistantId);
     if (!phoneNumber) return [];
 
     // Only toll-free numbers need verification checks
@@ -173,7 +208,7 @@ const telegramProbe: ChannelProbe = {
 
 export class ChannelReadinessService {
   private probes = new Map<ChannelId, ChannelProbe>();
-  private snapshots = new Map<ChannelId, ChannelReadinessSnapshot>();
+  private snapshots = new Map<string, ChannelReadinessSnapshot>();
 
   registerProbe(probe: ChannelProbe): void {
     this.probes.set(probe.channel, probe);
@@ -187,6 +222,7 @@ export class ChannelReadinessService {
   async getReadiness(
     channel?: ChannelId,
     includeRemote?: boolean,
+    assistantId?: string,
   ): Promise<ChannelReadinessSnapshot[]> {
     const channels = channel
       ? [channel]
@@ -200,32 +236,40 @@ export class ChannelReadinessService {
         continue;
       }
 
-      const localChecks = probe.runLocalChecks();
+      const probeContext: ChannelProbeContext = { assistantId };
+      const localChecks = probe.runLocalChecks(probeContext);
       let remoteChecks: ReadinessCheckResult[] | undefined;
       let remoteChecksFreshlyFetched = false;
+      let remoteChecksAffectReadiness = false;
       let stale = false;
 
-      const cached = this.snapshots.get(ch);
+      const cacheKey = this.snapshotCacheKey(ch, assistantId);
+      const cached = this.snapshots.get(cacheKey);
       const now = Date.now();
 
       if (includeRemote && probe.runRemoteChecks) {
         const cacheExpired = !cached || !cached.remoteChecks || (now - cached.checkedAt) >= REMOTE_TTL_MS;
         if (cacheExpired) {
-          remoteChecks = await probe.runRemoteChecks();
+          remoteChecks = await probe.runRemoteChecks(probeContext);
           remoteChecksFreshlyFetched = true;
+          remoteChecksAffectReadiness = true;
         } else {
           // Reuse cached remote checks
           remoteChecks = cached.remoteChecks;
+          remoteChecksAffectReadiness = true;
         }
       } else if (cached?.remoteChecks) {
-        // Surface cached remote checks even when not explicitly requested,
-        // but mark stale if TTL has elapsed
+        // Surface cached remote checks when present. Stale checks are included
+        // for visibility but do not affect readiness until explicitly refreshed.
         remoteChecks = cached.remoteChecks;
         stale = (now - cached.checkedAt) >= REMOTE_TTL_MS;
+        remoteChecksAffectReadiness = !stale;
       }
 
       const allLocalPassed = localChecks.every((c) => c.passed);
-      const allRemotePassed = remoteChecks ? remoteChecks.every((c) => c.passed) : true;
+      const allRemotePassed = (remoteChecks && remoteChecksAffectReadiness)
+        ? remoteChecks.every((c) => c.passed)
+        : true;
       const ready = allLocalPassed && allRemotePassed;
 
       const reasons: Array<{ code: string; text: string }> = [];
@@ -234,7 +278,7 @@ export class ChannelReadinessService {
           reasons.push({ code: check.name, text: check.message });
         }
       }
-      if (remoteChecks) {
+      if (remoteChecks && remoteChecksAffectReadiness) {
         for (const check of remoteChecks) {
           if (!check.passed) {
             reasons.push({ code: check.name, text: check.message });
@@ -252,7 +296,7 @@ export class ChannelReadinessService {
         remoteChecks,
       };
 
-      this.snapshots.set(ch, snapshot);
+      this.snapshots.set(cacheKey, snapshot);
       results.push(snapshot);
     }
 
@@ -260,8 +304,17 @@ export class ChannelReadinessService {
   }
 
   /** Clear cached snapshot for a specific channel, forcing re-evaluation on next call. */
-  invalidateChannel(channel: ChannelId): void {
-    this.snapshots.delete(channel);
+  invalidateChannel(channel: ChannelId, assistantId?: string): void {
+    if (assistantId) {
+      this.snapshots.delete(this.snapshotCacheKey(channel, assistantId));
+      return;
+    }
+    const prefix = `${channel}::`;
+    for (const key of this.snapshots.keys()) {
+      if (key.startsWith(prefix)) {
+        this.snapshots.delete(key);
+      }
+    }
   }
 
   /** Clear all cached snapshots. */
@@ -278,6 +331,10 @@ export class ChannelReadinessService {
       reasons: [{ code: 'unsupported_channel', text: `Channel ${channel} is not supported` }],
       localChecks: [],
     };
+  }
+
+  private snapshotCacheKey(channel: ChannelId, assistantId?: string): string {
+    return `${channel}::${assistantId ?? '__default__'}`;
   }
 }
 

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -21,9 +21,14 @@ export interface ChannelReadinessSnapshot {
   remoteChecks?: ReadinessCheckResult[];
 }
 
+/** Optional probe context for assistant-scoped readiness checks. */
+export interface ChannelProbeContext {
+  assistantId?: string;
+}
+
 /** Probe interface that channels implement to provide readiness checks. */
 export interface ChannelProbe {
   channel: ChannelId;
-  runLocalChecks(): ReadinessCheckResult[];
-  runRemoteChecks?(): Promise<ReadinessCheckResult[]>;
+  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[];
+  runRemoteChecks?(context?: ChannelProbeContext): Promise<ReadinessCheckResult[]>;
 }


### PR DESCRIPTION
## Summary
- fix Twilio toll-free use-case enum validation to accept current categories and normalize legacy aliases
- fix `sms_doctor` to resolve toll-free verification via phone SID (not raw E.164)
- prevent stale cached remote readiness checks from poisoning local-only readiness
- scope channel readiness cache by `assistantId` and plumb assistant-scoped readiness through IPC handler
- enforce editability guardrails before `sms_update_tollfree_verification` updates rejected verifications
- make `/update` fail fast on duplicate gateway processes (not just warn)

## Tests
- `cd assistant && bun test src/__tests__/channel-readiness-service.test.ts src/__tests__/handlers-twilio-config.test.ts src/__tests__/sms-messaging-provider.test.ts src/__tests__/messaging-send-tool.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd gateway && bun test src/http/routes/sms-deliver.test.ts`
- `cd gateway && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
