### PR TITLE
M1: QR Payload v3 — Add allowLocalHttp and localLanUrl

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -121,7 +121,7 @@ struct QRPairingSheet: View {
                 .cornerRadius(VRadius.md)
                 .padding(.horizontal, VSpacing.xl)
 
-                if payload.mode == "local" {
+                if payload.allowLocalHttp {
                     HStack(spacing: 6) {
                         Image(systemName: "laptopcomputer.and.iphone")
                             .foregroundColor(VColor.warning)
@@ -294,7 +294,10 @@ struct QRPairingSheet: View {
             return
         }
 
-        // Validate HTTP scheme — require HTTPS for non-local, or devLocalPairingEnabled for local HTTP
+        let allowLocalHttp = json["allowLocalHttp"] as? Bool ?? false
+        let localLanUrl = json["localLanUrl"] as? String
+
+        // Validate HTTP scheme — require HTTPS for non-local, or allowLocalHttp/devLocalPairingEnabled for local HTTP
         if let url = URL(string: gatewayURL), url.scheme?.lowercased() == "http" {
             guard let host = url.host, !host.isEmpty else {
                 errorMessage = "Invalid HTTP URL — no host found."
@@ -307,20 +310,22 @@ struct QRPairingSheet: View {
                 phase = .error
                 return
             }
-            if !devLocalPairingEnabled {
+            // v3: QR payload carries the permission
+            // v2 fallback: check iOS developer toggle
+            if !allowLocalHttp && !devLocalPairingEnabled {
                 errorMessage = "Enable 'Allow Local HTTP Connections' under Developer Options in connection settings."
                 phase = .error
                 return
             }
         }
 
-        let mode = json["m"] as? String
-
         let payload = DaemonQRPayload(
             gatewayURL: gatewayURL,
             bearerToken: bearerToken,
             hostId: hostId,
-            mode: mode
+            mode: json["m"] as? String,
+            allowLocalHttp: allowLocalHttp,
+            localLanUrl: localLanUrl
         )
         scannedPayload = payload
 
@@ -443,11 +448,13 @@ struct QRPairingSheet: View {
     }
 }
 
-/// Parsed QR code payload from the macOS pairing QR code (v2 gateway format).
+/// Parsed QR code payload from the macOS pairing QR code (v2/v3 gateway format).
 struct DaemonQRPayload {
     let gatewayURL: String
     let bearerToken: String
     let hostId: String
-    let mode: String?  // "gateway", "local", or nil (legacy)
+    let mode: String?           // v2 compat — "gateway", "local", or nil
+    let allowLocalHttp: Bool    // v3 — whether iOS should accept local HTTP
+    let localLanUrl: String?    // v3 — LAN URL for display
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -2,8 +2,13 @@ import CryptoKit
 import SwiftUI
 import VellumAssistantShared
 
-/// Displays a QR code containing the v2 connection payload for iOS pairing.
-/// Payload format: `{"type":"vellum-daemon","v":2,"id":"<mac-hash>","g":"<gateway-url>","bt":"<bearer-token>"}`
+/// Displays a QR code containing the v3 connection payload for iOS pairing.
+///
+/// Normal gateway mode payload:
+/// `{"type":"vellum-daemon","v":3,"id":"<mac-hash>","g":"<gateway-url>","bt":"<bearer-token>"}`
+///
+/// Developer local pairing mode payload:
+/// `{"type":"vellum-daemon","v":3,"id":"<mac-hash>","g":"<lan-url>","bt":"<bearer-token>","localLanUrl":"<lan-url>","allowLocalHttp":true}`
 ///
 /// Below the QR code, shows the gateway URL and bearer token for manual entry on iOS.
 @MainActor
@@ -103,6 +108,9 @@ struct PairingQRCodeSheet: View {
                             Text("Developer mode — local network")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.warning)
+                            Text("iOS will accept local HTTP")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.warning)
                             Text(gatewayUrl)
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.textMuted)
@@ -123,7 +131,7 @@ struct PairingQRCodeSheet: View {
             }
 
             Text(isLocalOverride && canGenerateQR
-                 ? "Scan this QR code with the Vellum iOS app. Developer Local Pairing must be enabled on the iPhone."
+                 ? "Scan this QR code with the Vellum iOS app. iOS will automatically accept local HTTP from this QR code."
                  : "Scan this QR code with the Vellum iOS app to connect.")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
@@ -234,14 +242,18 @@ struct PairingQRCodeSheet: View {
     private func generateQRImage() -> NSImage? {
         guard canGenerateQR else { return nil }
 
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "type": "vellum-daemon",
-            "v": 2,
+            "v": 3,
             "id": hostId,
             "g": gatewayUrl,
             "bt": resolvedBearerToken,
-            "m": isLocalOverride ? "local" : "gateway",
         ]
+
+        if isLocalOverride {
+            payload["allowLocalHttp"] = true
+            payload["localLanUrl"] = gatewayUrl
+        }
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
               let jsonString = String(data: jsonData, encoding: .utf8) else {


### PR DESCRIPTION
## Summary
Evolves the QR pairing payload to v3 so macOS carries the local HTTP permission directly in the QR code, eliminating the need for a separate iOS developer toggle.

## Implementation

### macOS (PairingQRCodeSheet.swift)
- v3 payload: adds `allowLocalHttp` (bool) and `localLanUrl` (string) fields
- Normal mode: gateway URL in `"g"`, no local fields
- Developer mode: LAN URL in `"g"`, `allowLocalHttp: true`, `localLanUrl` for display
- Removed `"m"` mode field (replaced by `allowLocalHttp`)
- Updated state indicator text for developer mode

### iOS (QRPairingSheet.swift)
- Parses `allowLocalHttp` and `localLanUrl` from v3 payloads
- v3 behavior: accepts local HTTP when `allowLocalHttp` is true
- v2 fallback: still checks iOS `devLocalPairingEnabled` toggle
- Updated DaemonQRPayload struct with new fields
- Updated confirming view indicator to use `allowLocalHttp`

## Key Technical Choices
- Backward compatible: v2 payloads still work via iOS toggle fallback
- `allowLocalHttp` is absent (not false) in normal mode to keep payload small
- Version bump to v3 but iOS accepts both v2 and v3

Closes #7438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
