### PR TITLE
Fix call-start greeting to avoid speaking prompt text

### DIFF
--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -422,10 +422,27 @@ describe('twilio webhook routes', () => {
       expect(greeting).toBe('Hello, I am calling about check store hours for tomorrow. Is now a good time to talk?');
     });
 
+    test('strips Task prefix from task line', () => {
+      const greeting = buildWelcomeGreeting('Task: check store hours for tomorrow');
+      expect(greeting).toBe('Hello, I am calling about check store hours for tomorrow. Is now a good time to talk?');
+    });
+
     test('ignores appended Context block when building opener', () => {
       const greeting = buildWelcomeGreeting('check store hours\n\nContext: Caller asked by email');
       expect(greeting).toBe('Hello, I am calling about check store hours. Is now a good time to talk?');
       expect(greeting).not.toContain('Context:');
+    });
+
+    test('falls back to default opener for prompt-like task text', () => {
+      const greeting = buildWelcomeGreeting('You are on a live phone call on behalf of my human. IMPORTANT RULES: ...');
+      expect(greeting).toBe('Hello, this is an assistant calling. Is now a good time to talk?');
+    });
+
+    test('falls back to default opener for overly long multi-step task text', () => {
+      const greeting = buildWelcomeGreeting(
+        'Check store hours, ask about holiday closures, ask about parking validation, ask about wheelchair access, and ask to transfer to the manager.',
+      );
+      expect(greeting).toBe('Hello, this is an assistant calling. Is now a good time to talk?');
     });
 
     test('uses configured greeting override when provided', () => {
@@ -481,6 +498,25 @@ describe('twilio webhook routes', () => {
         'welcomeGreeting="Hello, I am calling about confirm appointment time. Is now a good time to talk?"',
       );
       expect(twiml).not.toContain('Hello, how can I help you today?');
+    });
+
+    test('TwiML welcome greeting does not leak prompt-like task text', async () => {
+      const session = createTestSession(
+        'conv-twiml-4',
+        'CA_twiml_4',
+        'You are on a live phone call on behalf of my human. IMPORTANT RULES: respond naturally and include [ASK_USER: ...]',
+      );
+      const req = makeVoiceRequest(session.id, { CallSid: 'CA_twiml_4' });
+
+      const res = await handleVoiceWebhook(req);
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain(
+        'welcomeGreeting="Hello, this is an assistant calling. Is now a good time to talk?"',
+      );
+      expect(twiml).not.toContain('IMPORTANT RULES');
+      expect(twiml).not.toContain('ASK_USER');
     });
   });
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -30,8 +30,25 @@ import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality
 const log = getLogger('twilio-routes');
 
 const CONTEXT_BLOCK_SPLIT_REGEX = /\n\s*\nContext:\s*/i;
-const MAX_TASK_SUMMARY_CHARS = 120;
+const MAX_TASK_SUMMARY_CHARS = 90;
+const MAX_TASK_SUMMARY_WORDS = 18;
 const DEFAULT_WELCOME_GREETING = 'Hello, this is an assistant calling. Is now a good time to talk?';
+const TASK_PREFIX_REGEX = /^task:\s*/i;
+const UNSAFE_TASK_PATTERNS: RegExp[] = [
+  /\byou are\b/i,
+  /\b(system|assistant)\s+prompt\b/i,
+  /\bimportant rules?\b/i,
+  /\brespond naturally\b/i,
+  /\bask_user\b/i,
+  /\buser_answered\b/i,
+  /\buser_instruction\b/i,
+  /\bend_call\b/i,
+  /\bcall_start\b/i,
+  /\bllm\b/i,
+  /\bclaude\b/i,
+  /\bsay\s+(this|the following|exactly)\b/i,
+];
+const UNSAFE_TASK_CHARS_REGEX = /[<>{}\[\]`]/;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -69,11 +86,23 @@ export function generateTwiML(
 
 function summarizeTaskForGreeting(task: string | null): string | null {
   if (!task) return null;
-  const primaryTask = task.split(CONTEXT_BLOCK_SPLIT_REGEX)[0]?.trim() ?? '';
+  const primaryTaskBlock = task.split(CONTEXT_BLOCK_SPLIT_REGEX)[0]?.trim() ?? '';
+  const primaryTaskLine = primaryTaskBlock
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? '';
+  const primaryTask = primaryTaskLine.replace(TASK_PREFIX_REGEX, '').trim();
   if (!primaryTask) return null;
 
   const compact = primaryTask.replace(/\s+/g, ' ').trim().replace(/[.!?]+$/, '');
   if (!compact) return null;
+
+  if (UNSAFE_TASK_CHARS_REGEX.test(compact)) return null;
+  if (UNSAFE_TASK_PATTERNS.some((pattern) => pattern.test(compact))) return null;
+
+  const wordCount = compact.split(/\s+/).length;
+  if (wordCount > MAX_TASK_SUMMARY_WORDS) return null;
+
   if (compact.length <= MAX_TASK_SUMMARY_CHARS) return compact;
   return `${compact.slice(0, MAX_TASK_SUMMARY_CHARS - 3).trimEnd()}...`;
 }


### PR DESCRIPTION
## Summary
- harden call-start welcome greeting generation to avoid reading prompt-like task text aloud
- only allow short, single-line, human-style task summaries for contextual openers
- fall back to a neutral opener when task text looks like internal prompt/instructions or is too long
- keep `CALL_WELCOME_GREETING` override behavior unchanged

## Validation
- `bun test src/__tests__/twilio-routes.test.ts`
- `bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
