### PR TITLE
refactor(ios): remove dead developer toggle and v2 mode compat (#7443)

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -11,7 +11,6 @@ struct QRPairingSheet: View {
     @State private var scannedPayload: DaemonQRPayload?
     @State private var errorMessage: String?
     @State private var showGatewayChangedAlert = false
-    @AppStorage(PairingConfiguration.devLocalPairingKey) private var devLocalPairingEnabled: Bool = false
 
     enum PairingPhase {
         case scanning
@@ -297,7 +296,7 @@ struct QRPairingSheet: View {
         let allowLocalHttp = json["allowLocalHttp"] as? Bool ?? false
         let localLanUrl = json["localLanUrl"] as? String
 
-        // Validate HTTP scheme — require HTTPS for non-local, or allowLocalHttp/devLocalPairingEnabled for local HTTP
+        // Validate HTTP scheme — require HTTPS for non-local, or allowLocalHttp for local HTTP
         if let url = URL(string: gatewayURL), url.scheme?.lowercased() == "http" {
             guard let host = url.host, !host.isEmpty else {
                 errorMessage = "Invalid HTTP URL — no host found."
@@ -310,9 +309,7 @@ struct QRPairingSheet: View {
                 phase = .error
                 return
             }
-            // v3: QR payload carries the permission
-            // v2 fallback: check iOS developer toggle
-            if !allowLocalHttp && !devLocalPairingEnabled {
+            if !allowLocalHttp {
                 errorMessage = "This QR code uses a local network connection. Enable Developer Local Pairing on your Mac and rescan."
                 phase = .error
                 return
@@ -323,7 +320,6 @@ struct QRPairingSheet: View {
             gatewayURL: gatewayURL,
             bearerToken: bearerToken,
             hostId: hostId,
-            mode: json["m"] as? String,
             allowLocalHttp: allowLocalHttp,
             localLanUrl: localLanUrl
         )
@@ -453,7 +449,6 @@ struct DaemonQRPayload {
     let gatewayURL: String
     let bearerToken: String
     let hostId: String
-    let mode: String?           // v2 compat — "gateway", "local", or nil
     let allowLocalHttp: Bool    // v3 — whether iOS should accept local HTTP
     let localLanUrl: String?    // v3 — LAN URL for display
 }

--- a/clients/shared/Settings/PairingConfiguration.swift
+++ b/clients/shared/Settings/PairingConfiguration.swift
@@ -9,6 +9,8 @@ public enum PairingConfiguration {
     public static let overrideEnabledKey = "iosPairingUseOverride"
     public static let gatewayOverrideKey = "iosPairingGatewayOverride"
     public static let tokenOverrideKey = "iosPairingTokenOverride"
+    /// Key for the developer local pairing toggle.
+    /// Used on macOS only — iOS derives this permission from the QR payload's `allowLocalHttp` field.
     public static let devLocalPairingKey = "devLocalPairingEnabled"
 
     // MARK: - Override State


### PR DESCRIPTION
## Summary
Removes dead code from the old toggle-based developer mode on iOS. The QR payload's `allowLocalHttp` field (v3) now fully controls local HTTP permission — iOS no longer needs its own toggle.

## Changes

### QRPairingSheet.swift
- Removed `@AppStorage(PairingConfiguration.devLocalPairingKey)` — no longer needed
- Simplified HTTP validation: only checks `allowLocalHttp` from payload (removed `devLocalPairingEnabled` fallback)
- Removed `mode` field from `DaemonQRPayload` struct (v2 `"m"` field no longer parsed)

### PairingConfiguration.swift
- Added comment clarifying `devLocalPairingKey` is macOS-only (iOS uses QR payload)

## Key files
- `clients/ios/Views/Settings/QRPairingSheet.swift`
- `clients/shared/Settings/PairingConfiguration.swift`

Closes #7443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
