### PR TITLE
fix: clean up legacy iOS pairing flag file (#7448 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -58,6 +58,15 @@ struct SettingsConnectTab: View {
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
+
+            // Migration: remove legacy ios-pairing-enabled flag file.
+            // The old "Enable iOS Pairing" toggle created this file to expose
+            // the daemon on 0.0.0.0. With QR-first pairing via gateway, the
+            // flag is no longer needed and leaving it active is a security concern.
+            let legacyFlagPath = NSHomeDirectory() + "/.vellum/ios-pairing-enabled"
+            if FileManager.default.fileExists(atPath: legacyFlagPath) {
+                try? FileManager.default.removeItem(atPath: legacyFlagPath)
+            }
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
             if !isGatewayUrlFocused {


### PR DESCRIPTION
## Summary
Adds a one-time migration that removes the legacy `~/.vellum/ios-pairing-enabled` flag file on macOS app launch.

## Problem
The old "Enable iOS Pairing" toggle (removed in #7448) created this flag file. The daemon reads it to decide whether to bind TCP on `0.0.0.0` (all interfaces). With the toggle removed, users who previously enabled pairing have the flag but no UI to disable it, leaving the daemon LAN-exposed.

## Fix
On app launch, check for and remove the legacy flag file. This is a safe migration — the QR-first pairing flow uses gateway HTTP, not direct TCP.

## Key files
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
