### PR TITLE
fix: move legacy pairing flag cleanup to AppDelegate (#7453 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -110,6 +110,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
 
+        // Migration: remove legacy ios-pairing-enabled flag file.
+        // The old "Enable iOS Pairing" toggle created this file to expose
+        // the daemon on 0.0.0.0. With QR-first pairing via gateway, the
+        // flag is no longer needed and leaving it active is a security concern.
+        let legacyFlagPath = NSHomeDirectory() + "/.vellum/ios-pairing-enabled"
+        if FileManager.default.fileExists(atPath: legacyFlagPath) {
+            try? FileManager.default.removeItem(atPath: legacyFlagPath)
+        }
+
         // Remove stale SwiftUI Settings window frame to prevent a ghost
         // window from being restored on launch (the Settings scene now
         // renders EmptyView — we handle settings in the main window panel).

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -58,15 +58,6 @@ struct SettingsConnectTab: View {
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
-
-            // Migration: remove legacy ios-pairing-enabled flag file.
-            // The old "Enable iOS Pairing" toggle created this file to expose
-            // the daemon on 0.0.0.0. With QR-first pairing via gateway, the
-            // flag is no longer needed and leaving it active is a security concern.
-            let legacyFlagPath = NSHomeDirectory() + "/.vellum/ios-pairing-enabled"
-            if FileManager.default.fileExists(atPath: legacyFlagPath) {
-                try? FileManager.default.removeItem(atPath: legacyFlagPath)
-            }
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
             if !isGatewayUrlFocused {


### PR DESCRIPTION
## Summary
Moves the legacy `~/.vellum/ios-pairing-enabled` flag file cleanup from `SettingsConnectTab.onAppear` to `AppDelegate.applicationDidFinishLaunching` so it runs on every app launch, not just when the user opens Settings.

## Problem
The migration in #7453 was placed in `SettingsConnectTab.onAppear`, which only runs when the user opens Settings → Connect. Users who never open Settings would still have the flag file active, leaving the daemon bound to `0.0.0.0`.

## Fix
- Added migration to `AppDelegate.applicationDidFinishLaunching` (runs unconditionally on launch)
- Removed the duplicate from `SettingsConnectTab.onAppear`

## Key files
- `clients/macos/vellum-assistant/App/AppDelegate.swift`
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
