### PR TITLE
fix: mdfind termination handler ordering and single-quote escaping

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -381,32 +381,21 @@ final class ActionExecutor: ActionExecuting {
     private func mdfindApp(name: String, timeout: UInt64 = 2_000_000_000) async -> URL? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/mdfind")
+        // Escape single quotes in the app name to prevent breaking the mdfind query
+        let sanitizedName = name.replacingOccurrences(of: "'", with: "'\\''")
         process.arguments = [
-            "kMDItemKind == 'Application' && kMDItemDisplayName == '\(name)'"
+            "kMDItemKind == 'Application' && kMDItemDisplayName == '\(sanitizedName)'"
         ]
 
         let stdout = Pipe()
         process.standardOutput = stdout
         process.standardError = Pipe() // discard stderr
 
-        do {
-            try process.run()
-        } catch {
-            log.warning("openApp mdfind failed to launch: \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
-
-        let timeoutTask = Task {
-            try await Task.sleep(nanoseconds: timeout)
-            if process.isRunning {
-                process.terminate()
-            }
-        }
-
         return await withCheckedContinuation { continuation in
+            // Register termination handler BEFORE starting the process to avoid
+            // a race where mdfind exits before the handler is set, which would
+            // cause withCheckedContinuation to never resume and hang forever.
             process.terminationHandler = { proc in
-                timeoutTask.cancel()
-
                 guard proc.terminationStatus == 0,
                       proc.terminationReason != .uncaughtSignal else {
                     continuation.resume(returning: nil)
@@ -423,6 +412,23 @@ final class ActionExecutor: ActionExecuting {
                     continuation.resume(returning: URL(fileURLWithPath: String(firstLine)))
                 } else {
                     continuation.resume(returning: nil)
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                // process.run() failed so terminationHandler won't fire — resume manually
+                log.warning("openApp mdfind failed to launch: \(error.localizedDescription, privacy: .public)")
+                continuation.resume(returning: nil)
+                return
+            }
+
+            // Timeout — terminate the subprocess if it takes too long
+            Task {
+                try? await Task.sleep(nanoseconds: timeout)
+                if process.isRunning {
+                    process.terminate()
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes two issues raised in PR #7436 review feedback:

- **Register termination handler before starting mdfind** (Codex P1): Moves `process.terminationHandler` assignment before `process.run()` to prevent a race condition where mdfind exits before the handler is set, causing `withCheckedContinuation` to never resume and hang forever. Also moves `process.run()` inside the continuation closure and adds manual `continuation.resume` on launch failure.

- **Escape single quotes in app names for mdfind queries** (Devin): Sanitizes the app name by replacing `'` with `'\''` before interpolating into the Spotlight query string, preventing query breakage for names containing single quotes.

## Test plan

- [ ] Verify `mdfindApp` resolves apps correctly for names without quotes
- [ ] Verify `mdfindApp` handles app names with single quotes (e.g. "Kate's App")
- [ ] Verify rapid mdfind termination does not hang the continuation

Addresses feedback from #7436.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
