### PR TITLE
fix: narrow target-app-hints to avoid false-positive matches

### DIFF
--- a/assistant/src/__tests__/target-app-hints.test.ts
+++ b/assistant/src/__tests__/target-app-hints.test.ts
@@ -60,8 +60,13 @@ describe('resolveComputerUseTargetAppHint', () => {
       expect(result).toEqual({ appName: 'Discord', bundleId: 'com.hnc.Discord' });
     });
 
-    test('matches "zoom"', () => {
-      const result = resolveComputerUseTargetAppHint('join the zoom meeting');
+    test('matches "open zoom"', () => {
+      const result = resolveComputerUseTargetAppHint('open zoom and join the call');
+      expect(result).toEqual({ appName: 'zoom.us', bundleId: 'us.zoom.xos' });
+    });
+
+    test('matches "zoom app"', () => {
+      const result = resolveComputerUseTargetAppHint('check the zoom app');
       expect(result).toEqual({ appName: 'zoom.us', bundleId: 'us.zoom.xos' });
     });
 
@@ -102,6 +107,11 @@ describe('resolveComputerUseTargetAppHint', () => {
       const result = resolveComputerUseTargetAppHint('use iterm2 for this');
       expect(result).toEqual({ appName: 'iTerm', bundleId: 'com.googlecode.iterm2' });
     });
+
+    test('"open terminal in iterm2" resolves to iTerm', () => {
+      const result = resolveComputerUseTargetAppHint('open terminal in iterm2');
+      expect(result).toEqual({ appName: 'iTerm', bundleId: 'com.googlecode.iterm2' });
+    });
   });
 
   // ── IDEs ───────────────────────────────────────────────────────────
@@ -121,8 +131,13 @@ describe('resolveComputerUseTargetAppHint', () => {
       expect(result).toEqual({ appName: 'Visual Studio Code', bundleId: 'com.microsoft.VSCode' });
     });
 
-    test('matches "cursor"', () => {
+    test('matches "open cursor"', () => {
       const result = resolveComputerUseTargetAppHint('open cursor and edit the file');
+      expect(result).toEqual({ appName: 'Cursor', bundleId: 'com.todesktop.230313mzl4w4u92' });
+    });
+
+    test('matches "cursor app"', () => {
+      const result = resolveComputerUseTargetAppHint('check the cursor app');
       expect(result).toEqual({ appName: 'Cursor', bundleId: 'com.todesktop.230313mzl4w4u92' });
     });
 
@@ -242,6 +257,26 @@ describe('resolveComputerUseTargetAppHint', () => {
 
     test('"terminal velocity" does NOT return Terminal', () => {
       const result = resolveComputerUseTargetAppHint('terminal velocity of the object');
+      expect(result).toBeUndefined();
+    });
+
+    test('"move cursor to the submit button" does NOT return Cursor', () => {
+      const result = resolveComputerUseTargetAppHint('move cursor to the submit button');
+      expect(result).toBeUndefined();
+    });
+
+    test('"zoom in on the chart" does NOT return Zoom', () => {
+      const result = resolveComputerUseTargetAppHint('zoom in on the chart');
+      expect(result).toBeUndefined();
+    });
+
+    test('"login terminal" does NOT return Terminal (word boundary)', () => {
+      const result = resolveComputerUseTargetAppHint('login terminal');
+      expect(result).toBeUndefined();
+    });
+
+    test('"domain mail server" does NOT return Mail (word boundary)', () => {
+      const result = resolveComputerUseTargetAppHint('domain mail server');
       expect(result).toBeUndefined();
     });
 

--- a/assistant/src/daemon/target-app-hints.ts
+++ b/assistant/src/daemon/target-app-hints.ts
@@ -19,7 +19,7 @@ function contextPattern(word: string): RegExp {
   // Deliberately excludes "the" — too many false positives
   // ("the settings in the config", "the messages carefully").
   return new RegExp(
-    `(?:(?:(?:open|launch|switch\\s+to|in|test|qa|check|use)\\s+)${word}|${word}\\s+app)\\b`,
+    `(?:(?:(?:^|\\b)(?:open|launch|switch\\s+to|in|test|qa|check|use)\\s+)${word}|\\b${word}\\s+app)\\b`,
     'i',
   );
 }
@@ -79,7 +79,7 @@ export const APP_HINTS: AppHintEntry[] = [
     bundleId: 'com.hnc.Discord',
   },
   {
-    patterns: [/\bzoom\b/],
+    patterns: [contextPattern('zoom')],
     appName: 'zoom.us',
     bundleId: 'us.zoom.xos',
   },
@@ -95,14 +95,14 @@ export const APP_HINTS: AppHintEntry[] = [
     bundleId: 'dev.warp.Warp-Stable',
   },
   {
-    patterns: [contextPattern('terminal')],
-    appName: 'Terminal',
-    bundleId: 'com.apple.Terminal',
-  },
-  {
     patterns: [/\biterm2?\b/],
     appName: 'iTerm',
     bundleId: 'com.googlecode.iterm2',
+  },
+  {
+    patterns: [contextPattern('terminal')],
+    appName: 'Terminal',
+    bundleId: 'com.apple.Terminal',
   },
   // IDEs
   {
@@ -111,7 +111,7 @@ export const APP_HINTS: AppHintEntry[] = [
     bundleId: 'com.microsoft.VSCode',
   },
   {
-    patterns: [/\bcursor\b/],
+    patterns: [contextPattern('cursor')],
     appName: 'Cursor',
     bundleId: 'com.todesktop.230313mzl4w4u92',
   },


### PR DESCRIPTION
## Summary

- Add `\b` word boundary before action verb group in `contextPattern` to prevent partial matches (e.g., "login" matching the "in" verb, "domain" matching "in")
- Switch Cursor from simple `\bcursor\b` to `contextPattern('cursor')` so UI wording like "move cursor to the submit button" no longer triggers a false match
- Switch Zoom from simple `\bzoom\b` to `contextPattern('zoom')` so "zoom in on the chart" no longer triggers a false match
- Reorder iTerm entry before Terminal entry in `APP_HINTS` array so "open terminal in iterm2" resolves to iTerm, not Terminal
- Add regression tests for all five false-positive scenarios

Addresses feedback from #7428.

## Test plan

- [x] All 58 tests pass in `target-app-hints.test.ts`
- [x] New false-positive tests: "move cursor to the submit button" -> no match
- [x] New false-positive tests: "zoom in on the chart" -> no match
- [x] New false-positive tests: "login terminal" -> no match (word boundary)
- [x] New false-positive tests: "domain mail server" -> no match (word boundary)
- [x] New test: "open terminal in iterm2" -> resolves to iTerm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
