### PR TITLE
fix: prevent double QA finalization on frontmost guard abort

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -110,6 +110,7 @@ final class ComputerUseSession: ObservableObject {
     private var consecutiveUnchangedSteps = 0
     private var currentStepNumber = 0
     private var consecutiveFrontmostBlocks = 0
+    private var didFinalizeQARecording = false
     @Published private(set) var qaRecordingWarningMessage: String?
     /// Whether screen recording is currently active (for UI indicator).
     @Published private(set) var isRecordingActive: Bool = false
@@ -183,6 +184,7 @@ final class ComputerUseSession: ObservableObject {
         consecutiveUnchangedSteps = 0
         currentStepNumber = 0
         consecutiveFrontmostBlocks = 0
+        didFinalizeQARecording = false
         state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...", reasoning: "")
 
         // QA sessions auto-approve low/medium tools from the start.
@@ -422,7 +424,8 @@ final class ComputerUseSession: ObservableObject {
         cancelSafetyNetTask = nil
 
         // Finalize QA recording and send cu_session_finalized
-        if qaMode {
+        // Guard: skip if already finalized (e.g. frontmost guard limit triggered finalization early)
+        if qaMode && !didFinalizeQARecording {
             await finalizeQARecording()
 
             // Send the abort immediately after finalization for cancelled QA sessions.
@@ -1313,6 +1316,8 @@ final class ComputerUseSession: ObservableObject {
         } catch {
             log.error("QA mode: failed to send cu_session_finalized: \(error.localizedDescription)")
         }
+
+        didFinalizeQARecording = true
     }
 
     // MARK: - Control


### PR DESCRIPTION
## Summary
- Adds `didFinalizeQARecording` guard flag to prevent duplicate `cu_session_finalized` and `cu_session_abort` messages when the frontmost guard limit triggers session termination in QA mode.
- The flag is declared as a private var, reset at the start of `run()`, set at the end of `finalizeQARecording()`, and checked in the post-loop finalization code.

Addresses feedback from #7412.

## Test plan
- [ ] Run a QA session where the frontmost guard hits its 3-consecutive-block limit
- [ ] Verify only one `cu_session_finalized` message is sent to the daemon
- [ ] Verify only one `cu_session_abort` message is sent to the daemon
- [ ] Verify normal QA session finalization (non-frontmost-guard path) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
