### PR TITLE
fix: keep Gmail distinct from Mail in APP_CANONICAL_MAP

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -366,7 +366,7 @@ export class ComputerUseSession {
     ['vellum assistant', 'vellum'],
     ['visual studio code', 'vscode'],
     ['iterm2', 'iterm'],
-    ['gmail', 'mail'],
+    ['gmail', 'gmail'],
   ]);
 
   /**


### PR DESCRIPTION
## Summary
- Changes the `APP_CANONICAL_MAP` entry for `'gmail'` from mapping to `'mail'` to mapping to `'gmail'`, so Gmail and Mail retain distinct canonical keys.
- This fixes cross-app detection in `taskExplicitlyRequestsCrossApp()` for workflows involving both Gmail and Mail (e.g., "copy from Gmail into Mail").

## Context
Addresses review feedback from #7409 where both Codex and Devin flagged that `['gmail', 'mail']` incorrectly collapses two genuinely different apps into one canonical key, preventing the cross-app escape path from activating.

## Test plan
- [ ] Verify that a task mentioning both "Gmail" and "Mail" triggers `taskExplicitlyRequestsCrossApp()` to return `true`
- [ ] Verify that existing canonical mappings (e.g., "google chrome" -> "chrome") still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)