### PR TITLE
fix: restrict bundle ID injection to target app matches only

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -685,8 +685,8 @@ export class ComputerUseSession {
           };
         }
 
-        // Inject targetAppBundleId when the LLM didn't provide one
-        if (!input.app_bundle_id && this.targetAppBundleId) {
+        // Inject targetAppBundleId only when the requested app matches the target app
+        if (!input.app_bundle_id && this.targetAppBundleId && (!requestedApp || this.isTargetAppMatch(requestedApp))) {
           input = { ...input, app_bundle_id: this.targetAppBundleId };
         }
       }


### PR DESCRIPTION
## Summary
- Only injects `targetAppBundleId` when the requested app matches the target app, preventing incorrect bundle ID injection in cross-app workflows
- Previously, the target app's bundle ID was unconditionally injected when the LLM didn't provide one, causing wrong app activation in cross-app scenarios (e.g., Safari's bundle ID being attached to a Chrome open request)

## Test plan
- [ ] Verify single-app workflow still correctly injects `targetAppBundleId` when LLM omits it
- [ ] Verify cross-app workflow (e.g., "copy from Chrome and paste into Safari") does NOT inject target app's bundle ID when opening a non-target app
- [ ] Verify that when no `app_name` is provided, the bundle ID is still injected (fallback behavior preserved)

Addresses review feedback from #7434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
