### PR TITLE
fix: pass qaMode explicitly to ComputerUseSession constructor

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -108,6 +108,8 @@ export class ComputerUseSession {
   recordingFailureReason?: string;
   /** When true, destructive actions are blocked until recording has started. */
   private readonly requiresRecording: boolean;
+  /** Whether this session is operating in QA mode. */
+  private readonly qaMode: boolean;
   /** Timer for the recording handshake timeout. */
   private recordingHandshakeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -127,6 +129,7 @@ export class ComputerUseSession {
     targetAppName?: string,
     targetAppBundleId?: string,
     requiresRecording?: boolean,
+    qaMode?: boolean,
   ) {
     this.sessionId = sessionId;
     this.task = task;
@@ -140,11 +143,12 @@ export class ComputerUseSession {
     this.targetAppName = targetAppName;
     this.targetAppBundleId = targetAppBundleId;
     this.requiresRecording = requiresRecording ?? false;
+    this.qaMode = qaMode ?? false;
 
     log.info(
       {
         sessionId,
-        qaMode: !!requiresRecording,
+        qaMode: this.qaMode,
         requiresRecording: this.requiresRecording,
         targetAppName,
         targetAppBundleId,

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -99,6 +99,7 @@ export function handleCuSessionCreate(
     msg.targetAppName,
     msg.targetAppBundleId,
     msg.requiresRecording,
+    msg.qaMode,
   );
   sessionRef.current = session;
 


### PR DESCRIPTION
## Summary
- Passes `qaMode` as a separate constructor parameter to `ComputerUseSession` instead of deriving it from `requiresRecording`
- The constructor log now accurately reflects QA mode status regardless of recording requirements
- Addresses feedback from both Codex and Devin on #7425

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit` — pre-existing errors only, no new errors from this change)
- [ ] Confirm structured logs show correct `qaMode` value when `qaMode: true` but `requiresRecording: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
