### PR TITLE
fix: external target detection fallback and name-based gating

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -64,12 +64,22 @@ extension AppDelegate {
     // MARK: - External App Target Detection
 
     /// Returns `true` when the CU session targets an external app (not Vellum
-    /// itself). When `bundleId` is nil the session has no target constraint and
-    /// is treated as "self" (backward compatibility).
-    private func isExternalAppTarget(bundleId: String?) -> Bool {
-        guard let bundleId, !bundleId.isEmpty else { return false }
-        let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
-        return bundleId != selfBundleId
+    /// itself). Uses bundle ID for precise comparison when available, falls back
+    /// to name-based check for sessions where only the app name is set.
+    /// When both are nil the session has no target constraint and is treated as
+    /// "self" (backward compatibility).
+    private func isExternalAppTarget(bundleId: String?, name: String?) -> Bool {
+        // If we have a bundleId, use precise comparison
+        if let bundleId, !bundleId.isEmpty {
+            let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+            return bundleId != selfBundleId
+        }
+        // If we only have a name, check it's not Vellum
+        if let name, !name.isEmpty {
+            let lower = name.lowercased()
+            return lower != "vellum" && lower != "vellum assistant"
+        }
+        return false
     }
 
     // MARK: - Accessibility Permission
@@ -150,7 +160,7 @@ extension AppDelegate {
             // target app IS Vellum itself (or unspecified). For external-app QA
             // sessions (e.g., targeting Slack, Chrome), activating Vellum's main
             // window would steal focus from the app under test.
-            if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId) {
+            if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId, name: routed.targetAppName) {
                 self.showMainWindow()
             }
 
@@ -303,7 +313,7 @@ extension AppDelegate {
                     // but only when the target app is Vellum itself (or
                     // unspecified). For external-app QA sessions, activating
                     // Vellum would steal focus from the app under test.
-                    if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId) {
+                    if !self.isExternalAppTarget(bundleId: routed.targetAppBundleId, name: routed.targetAppName) {
                         self.showMainWindow()
                     }
                 }

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -695,8 +695,9 @@ final class ComputerUseSession: ObservableObject {
             // Skip this check when targeting an external app — showing the
             // NSAlert would activate Vellum and steal focus from the app
             // under test.
+            let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
             let isExternalTarget = targetAppBundleId != nil
-                && targetAppBundleId != Bundle.main.bundleIdentifier
+                && targetAppBundleId != selfBundleId
             if !didChromeAccessibilityCheck,
                !isExternalTarget,
                let frontApp = NSWorkspace.shared.frontmostApplication,


### PR DESCRIPTION
## Summary
- Adds `Bundle.main.bundleIdentifier` fallback (`?? "com.vellum.vellum-assistant"`) in `Session.swift`'s inline `isExternalTarget` check so SPM builds correctly detect Vellum-targeting sessions
- Extends `isExternalAppTarget` in `AppDelegate+Sessions.swift` to accept a `name` parameter alongside `bundleId`, enabling name-based external app detection when `targetAppBundleId` is nil but `targetAppName` is set (e.g., Slack, Chrome)
- Updates both call sites to pass `routed.targetAppName`

Addresses feedback from #7431.

## Test plan
- [ ] Verify SPM debug builds no longer skip Chrome accessibility check for Vellum-targeting sessions
- [ ] Verify external-app QA sessions with only `targetAppName` set (no bundleId) correctly skip `showMainWindow()` to avoid focus stealing
- [ ] Verify sessions with neither bundleId nor name still default to "self" behavior (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
