### PR TITLE
fix: use double-quoted Spotlight query for mdfind app names

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -381,10 +381,13 @@ final class ActionExecutor: ActionExecuting {
     private func mdfindApp(name: String, timeout: UInt64 = 2_000_000_000) async -> URL? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/mdfind")
-        // Escape single quotes in the app name to prevent breaking the mdfind query
-        let sanitizedName = name.replacingOccurrences(of: "'", with: "'\\''")
+        // Use double quotes for the display-name value so we only need to escape
+        // double quotes. Process.arguments bypasses the shell, so shell-style
+        // single-quote escaping (e.g. '\'') would be passed raw to mdfind and
+        // break Spotlight query parsing.
+        let sanitizedName = name.replacingOccurrences(of: "\"", with: "\\\"")
         process.arguments = [
-            "kMDItemKind == 'Application' && kMDItemDisplayName == '\(sanitizedName)'"
+            "kMDItemKind == 'Application' && kMDItemDisplayName == \"\(sanitizedName)\""
         ]
 
         let stdout = Pipe()


### PR DESCRIPTION
Switches mdfind query value from single-quoted with shell-style escaping to double-quoted with proper escaping, since Process.arguments bypasses the shell. Addresses feedback from #7456.

## Summary

- `Process.arguments` passes arguments directly to the executable without shell interpretation, so the POSIX shell idiom `'\''` for escaping single quotes was being passed raw to `mdfind`, breaking Spotlight query parsing.
- Switched the `kMDItemDisplayName` comparison value to use double quotes with proper double-quote escaping instead.

## Test plan

- [ ] Build the macOS app with `./build.sh`
- [ ] Test app lookup with `mdfind` for apps with standard names (e.g., "Safari", "Terminal")
- [ ] Test app lookup for apps with special characters in names (e.g., names containing quotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
