### PR TITLE
fix: use defer for didFinalizeQARecording flag in all return paths

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -1203,6 +1203,8 @@ final class ComputerUseSession: ObservableObject {
 
     /// Stops the screen recorder (if active) and sends a `cu_session_finalized` message to the daemon.
     private func finalizeQARecording() async {
+        defer { didFinalizeQARecording = true }
+
         // Map SessionState to a status string
         let status: String
         let summary: String
@@ -1316,8 +1318,6 @@ final class ComputerUseSession: ObservableObject {
         } catch {
             log.error("QA mode: failed to send cu_session_finalized: \(error.localizedDescription)")
         }
-
-        didFinalizeQARecording = true
     }
 
     // MARK: - Control


### PR DESCRIPTION
## Summary

- Replaces the explicit `didFinalizeQARecording = true` assignment at the end of `finalizeQARecording()` with a `defer` block at the top of the method
- Ensures the flag is set on all return paths, including the early return when recording was required but no artifact was produced (around line 1303)
- Prevents potential duplicate calls to `finalizeQARecording()` from post-loop code

## Test plan

- [ ] Verify the macOS app builds successfully (`./build.sh`)
- [ ] Confirm that `finalizeQARecording()` sets `didFinalizeQARecording = true` even when hitting the early return path (missing recording artifact)
- [ ] Confirm normal finalization path still works correctly

Addresses feedback from #7458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
