### PR TITLE
fix: add name-based fallback to Session.swift isExternalTarget check

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -695,8 +695,16 @@ final class ComputerUseSession: ObservableObject {
             // Skip this check when targeting an external app — showing the
             // NSAlert would activate Vellum and steal focus from the app
             // under test.
-            let isExternalTarget = targetAppBundleId != nil
-                && targetAppBundleId != Bundle.main.bundleIdentifier
+            let isExternalTarget: Bool
+            if let bundleId = targetAppBundleId, !bundleId.isEmpty {
+                let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+                isExternalTarget = bundleId != selfBundleId
+            } else if let name = targetAppName, !name.isEmpty {
+                let lower = name.lowercased()
+                isExternalTarget = lower != "vellum" && lower != "vellum assistant"
+            } else {
+                isExternalTarget = false
+            }
             if !didChromeAccessibilityCheck,
                !isExternalTarget,
                let frontApp = NSWorkspace.shared.frontmostApplication,


### PR DESCRIPTION
## Summary

- Extends the `isExternalTarget` check in `Session.swift` to also consider `targetAppName` when `targetAppBundleId` is nil, matching the behavior of `isExternalAppTarget` in `AppDelegate+Sessions.swift`
- When `targetAppBundleId` is nil but `targetAppName` is set (e.g. "Chrome"), the check now correctly identifies the session as targeting an external app, preventing the Chrome accessibility NSAlert from stealing focus
- Addresses feedback from #7463

## Test plan

- [ ] Run a QA session targeting Chrome by name only (no bundle ID) — verify the Chrome accessibility restart alert does NOT appear and focus stays on Chrome
- [ ] Run a QA session targeting Vellum by name — verify the Chrome accessibility check still runs normally
- [ ] Run a QA session with both bundle ID and app name set — verify bundle ID takes precedence
- [ ] Run a QA session with neither set — verify `isExternalTarget` is `false` (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
