### PR TITLE
fix: remove unused 'mock' import in channel-readiness-service test

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
 import { ChannelReadinessService, REMOTE_TTL_MS } from '../runtime/channel-readiness-service.js';
 import type { ChannelProbe, ReadinessCheckResult } from '../runtime/channel-readiness-types.js';
 


### PR DESCRIPTION
## Summary
- Remove unused `mock` import from `bun:test` in `channel-readiness-service.test.ts` to fix CI lint failure

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22333775630

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
