### PR TITLE
Drive outbound call opener from orchestrator intelligence

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -264,6 +264,29 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('startInitialGreeting: generates model-driven opening and strips control marker from speech', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const firstUser = firstArg.messages.find((m) => m.role === 'user');
+      expect(firstUser?.content).toContain('[CALL_OPENING]');
+      return createMockStream(['Hi, I am calling about your appointment request. Is now a good time to talk?']);
+    });
+
+    const { relay, orchestrator } = setupOrchestrator('Confirm appointment');
+
+    const callCountBefore = mockStreamFn.mock.calls.length;
+    await orchestrator.startInitialGreeting();
+    await orchestrator.startInitialGreeting();
+
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('appointment request');
+    expect(allText).toContain('good time to talk');
+    expect(allText).not.toContain('[CALL_OPENING]');
+    expect(mockStreamFn.mock.calls.length - callCountBefore).toBe(1);
+
+    orchestrator.destroy();
+  });
+
   // ── ASK_USER pattern ──────────────────────────────────────────────
 
   test('ASK_USER pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -211,6 +211,41 @@ describe('relay-server', () => {
     relay.destroy();
   });
 
+  test('handleMessage: setup triggers initial assistant greeting turn', async () => {
+    ensureConversation('conv-relay-setup-greet');
+    const session = createCallSession({
+      conversationId: 'conv-relay-setup-greet',
+      provider: 'twilio',
+      fromNumber: '+15551111111',
+      toNumber: '+15552222222',
+      task: 'Confirm appointment time',
+    });
+
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello, I am calling to confirm your appointment.']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_setup_greet_123',
+      from: '+15551111111',
+      to: '+15552222222',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string; last?: boolean })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('confirm your appointment'))).toBe(true);
+    expect(textMessages.some((m) => m.last === true)).toBe(true);
+
+    const events = getCallEvents(session.id).filter((e) => e.eventType === 'assistant_spoke');
+    expect(events.length).toBeGreaterThan(0);
+
+    relay.destroy();
+  });
+
   test('handleTransportClosed: normal close marks call completed and notifies completion', () => {
     ensureConversation('conv-relay-close-normal');
     const session = createCallSession({
@@ -285,8 +320,9 @@ describe('relay-server', () => {
 
     // Verify event recorded with custom parameters
     const events = getCallEvents(session.id);
-    expect(events.length).toBe(1);
-    const payload = JSON.parse(events[0].payloadJson);
+    const connectedEvents = events.filter((e) => e.eventType === 'call_connected');
+    expect(connectedEvents.length).toBe(1);
+    const payload = JSON.parse(connectedEvents[0].payloadJson);
     expect(payload.customParameters).toEqual({ taskId: 'task-1', priority: 'high' });
 
     relay.destroy();
@@ -359,6 +395,9 @@ describe('relay-server', () => {
       to: '+15552222222',
     }));
 
+    // Let any async initial-greeting turn settle so we can compare only
+    // the effect of the partial prompt itself.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     const messagesBeforePrompt = ws.sentMessages.length;
 
     // Send a partial prompt (last=false)

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -124,4 +124,15 @@ describe('generateTwiML with voice quality profile', () => {
     expect(twiml).toContain('interruptible="true"');
     expect(twiml).toContain('dtmfDetection="true"');
   });
+
+  test('TwiML omits welcomeGreeting attribute when not provided', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, null, {
+      language: 'en-US',
+      transcriptionProvider: 'Deepgram',
+      ttsProvider: 'Google',
+      voice: 'Google.en-US-Journey-O',
+    });
+
+    expect(twiml).not.toContain('welcomeGreeting=');
+  });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -155,6 +155,7 @@ describe('twilio webhook routes', () => {
     resetTables();
     mockWssBaseUrl = 'wss://test.example.com';
     mockWebhookBaseUrl = 'https://test.example.com';
+    delete process.env.CALL_WELCOME_GREETING;
   });
 
   afterAll(() => {
@@ -417,32 +418,9 @@ describe('twilio webhook routes', () => {
   });
 
   describe('buildWelcomeGreeting', () => {
-    test('builds a contextual opener from task text', () => {
+    test('returns empty by default so orchestrator drives first opener', () => {
       const greeting = buildWelcomeGreeting('check store hours for tomorrow');
-      expect(greeting).toBe('Hello, I am calling about check store hours for tomorrow. Is now a good time to talk?');
-    });
-
-    test('strips Task prefix from task line', () => {
-      const greeting = buildWelcomeGreeting('Task: check store hours for tomorrow');
-      expect(greeting).toBe('Hello, I am calling about check store hours for tomorrow. Is now a good time to talk?');
-    });
-
-    test('ignores appended Context block when building opener', () => {
-      const greeting = buildWelcomeGreeting('check store hours\n\nContext: Caller asked by email');
-      expect(greeting).toBe('Hello, I am calling about check store hours. Is now a good time to talk?');
-      expect(greeting).not.toContain('Context:');
-    });
-
-    test('falls back to default opener for prompt-like task text', () => {
-      const greeting = buildWelcomeGreeting('You are on a live phone call on behalf of my human. IMPORTANT RULES: ...');
-      expect(greeting).toBe('Hello, this is an assistant calling. Is now a good time to talk?');
-    });
-
-    test('falls back to default opener for overly long multi-step task text', () => {
-      const greeting = buildWelcomeGreeting(
-        'Check store hours, ask about holiday closures, ask about parking validation, ask about wheelchair access, and ask to transfer to the manager.',
-      );
-      expect(greeting).toBe('Hello, this is an assistant calling. Is now a good time to talk?');
+      expect(greeting).toBe('');
     });
 
     test('uses configured greeting override when provided', () => {
@@ -482,7 +460,7 @@ describe('twilio webhook routes', () => {
       expect(twiml).toContain('wss://gateway.example.com/v1/calls/relay');
     });
 
-    test('TwiML welcome greeting is task-aware by default', async () => {
+    test('TwiML omits welcome greeting by default so call opener is model-driven', async () => {
       const session = createTestSession(
         'conv-twiml-3',
         'CA_twiml_3',
@@ -494,29 +472,19 @@ describe('twilio webhook routes', () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain(
-        'welcomeGreeting="Hello, I am calling about confirm appointment time. Is now a good time to talk?"',
-      );
-      expect(twiml).not.toContain('Hello, how can I help you today?');
+      expect(twiml).not.toContain('welcomeGreeting=');
     });
 
-    test('TwiML welcome greeting does not leak prompt-like task text', async () => {
-      const session = createTestSession(
-        'conv-twiml-4',
-        'CA_twiml_4',
-        'You are on a live phone call on behalf of my human. IMPORTANT RULES: respond naturally and include [ASK_USER: ...]',
-      );
+    test('TwiML includes explicit welcome greeting override when configured', async () => {
+      process.env.CALL_WELCOME_GREETING = 'Custom transport greeting';
+      const session = createTestSession('conv-twiml-4', 'CA_twiml_4');
       const req = makeVoiceRequest(session.id, { CallSid: 'CA_twiml_4' });
 
       const res = await handleVoiceWebhook(req);
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain(
-        'welcomeGreeting="Hello, this is an assistant calling. Is now a good time to talk?"',
-      );
-      expect(twiml).not.toContain('IMPORTANT RULES');
-      expect(twiml).not.toContain('ASK_USER');
+      expect(twiml).toContain('welcomeGreeting="Custom transport greeting"');
     });
   });
 

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -30,7 +30,9 @@ const ASK_USER_CAPTURE_REGEX = /\[ASK_USER:\s*(.+?)\]/;
 const ASK_USER_MARKER_REGEX = /\[ASK_USER:\s*.+?\]/g;
 const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
 const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
+const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
 const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
+const CALL_OPENING_MARKER = '[CALL_OPENING]';
 const END_CALL_MARKER = '[END_CALL]';
 
 function stripInternalSpeechMarkers(text: string): string {
@@ -38,6 +40,7 @@ function stripInternalSpeechMarkers(text: string): string {
     .replace(ASK_USER_MARKER_REGEX, '')
     .replace(USER_ANSWERED_MARKER_REGEX, '')
     .replace(USER_INSTRUCTION_MARKER_REGEX, '')
+    .replace(CALL_OPENING_MARKER_REGEX, '')
     .replace(END_CALL_MARKER_REGEX, '');
 }
 
@@ -56,6 +59,8 @@ export class CallOrchestrator {
   private task: string | null;
   /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
   private pendingInstructions: string[] = [];
+  /** Ensures the outbound-call opener is triggered at most once per call. */
+  private initialGreetingStarted = false;
   /** Monotonic run id used to suppress stale turn side effects after interruption. */
   private llmRunVersion = 0;
 
@@ -73,6 +78,19 @@ export class CallOrchestrator {
    */
   getState(): OrchestratorState {
     return this.state;
+  }
+
+  /**
+   * Kick off the first outbound call utterance from the assistant.
+   */
+  async startInitialGreeting(): Promise<void> {
+    if (this.initialGreetingStarted) return;
+    if (this.state !== 'idle') return;
+
+    this.initialGreetingStarted = true;
+    this.resetSilenceTimer();
+    this.conversationHistory.push({ role: 'user', content: CALL_OPENING_MARKER });
+    await this.runLlm();
   }
 
   /**
@@ -245,6 +263,7 @@ export class CallOrchestrator {
       '7. Do not make up information — ask the user if unsure.',
       '8. Keep responses short — 1-3 sentences is ideal for phone conversation.',
       '9. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
+      '10. If the latest user turn is [CALL_OPENING], produce the first outbound-call line: briefly state the reason for calling using the Task context and ask if now is a good time to talk.',
     ]
       .filter(Boolean)
       .join('\n');
@@ -328,10 +347,13 @@ export class CallOrchestrator {
             '[ASK_USER:'.startsWith(afterBracket) ||
             '[USER_ANSWERED:'.startsWith(afterBracket) ||
             '[USER_INSTRUCTION:'.startsWith(afterBracket) ||
+            '[CALL_OPENING]'.startsWith(afterBracket) ||
             '[END_CALL]'.startsWith(afterBracket) ||
             afterBracket.startsWith('[ASK_USER:') ||
             afterBracket.startsWith('[USER_ANSWERED:') ||
             afterBracket.startsWith('[USER_INSTRUCTION:') ||
+            afterBracket === '[CALL_OPENING' ||
+            afterBracket.startsWith('[CALL_OPENING]') ||
             afterBracket === '[END_CALL' ||
             afterBracket.startsWith('[END_CALL]');
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -302,6 +302,9 @@ export class RelayConnection {
     // Create and attach the LLM-driven orchestrator
     const orchestrator = new CallOrchestrator(this.callSessionId, this, session?.task ?? null);
     this.setOrchestrator(orchestrator);
+    orchestrator.startInitialGreeting().catch((err) =>
+      log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting'),
+    );
   }
 
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -29,27 +29,6 @@ import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality
 
 const log = getLogger('twilio-routes');
 
-const CONTEXT_BLOCK_SPLIT_REGEX = /\n\s*\nContext:\s*/i;
-const MAX_TASK_SUMMARY_CHARS = 90;
-const MAX_TASK_SUMMARY_WORDS = 18;
-const DEFAULT_WELCOME_GREETING = 'Hello, this is an assistant calling. Is now a good time to talk?';
-const TASK_PREFIX_REGEX = /^task:\s*/i;
-const UNSAFE_TASK_PATTERNS: RegExp[] = [
-  /\byou are\b/i,
-  /\b(system|assistant)\s+prompt\b/i,
-  /\bimportant rules?\b/i,
-  /\brespond naturally\b/i,
-  /\bask_user\b/i,
-  /\buser_answered\b/i,
-  /\buser_instruction\b/i,
-  /\bend_call\b/i,
-  /\bcall_start\b/i,
-  /\bllm\b/i,
-  /\bclaude\b/i,
-  /\bsay\s+(this|the following|exactly)\b/i,
-];
-const UNSAFE_TASK_CHARS_REGEX = /[<>{}\[\]`]/;
-
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function escapeXml(str: string): string {
@@ -64,15 +43,18 @@ function escapeXml(str: string): string {
 export function generateTwiML(
   callSessionId: string,
   relayUrl: string,
-  welcomeGreeting: string,
+  welcomeGreeting: string | null,
   profile: { language: string; transcriptionProvider: string; ttsProvider: string; voice: string },
 ): string {
+  const greetingAttr = welcomeGreeting && welcomeGreeting.trim().length > 0
+    ? `\n      welcomeGreeting="${escapeXml(welcomeGreeting.trim())}"`
+    : '';
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <ConversationRelay
       url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}"
-      welcomeGreeting="${escapeXml(welcomeGreeting)}"
+${greetingAttr}
       voice="${escapeXml(profile.voice)}"
       language="${escapeXml(profile.language)}"
       transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"
@@ -84,50 +66,14 @@ export function generateTwiML(
 </Response>`;
 }
 
-function summarizeTaskForGreeting(task: string | null): string | null {
-  if (!task) return null;
-  const primaryTaskBlock = task.split(CONTEXT_BLOCK_SPLIT_REGEX)[0]?.trim() ?? '';
-  const primaryTaskLine = primaryTaskBlock
-    .split('\n')
-    .map((line) => line.trim())
-    .find((line) => line.length > 0) ?? '';
-  const primaryTask = primaryTaskLine.replace(TASK_PREFIX_REGEX, '').trim();
-  if (!primaryTask) return null;
-
-  const compact = primaryTask.replace(/\s+/g, ' ').trim().replace(/[.!?]+$/, '');
-  if (!compact) return null;
-
-  if (UNSAFE_TASK_CHARS_REGEX.test(compact)) return null;
-  if (UNSAFE_TASK_PATTERNS.some((pattern) => pattern.test(compact))) return null;
-
-  const wordCount = compact.split(/\s+/).length;
-  if (wordCount > MAX_TASK_SUMMARY_WORDS) return null;
-
-  if (compact.length <= MAX_TASK_SUMMARY_CHARS) return compact;
-  return `${compact.slice(0, MAX_TASK_SUMMARY_CHARS - 3).trimEnd()}...`;
-}
-
-function formatTaskAsCallPurpose(taskSummary: string): string {
-  const lower = taskSummary.toLowerCase();
-  if (
-    lower.startsWith('about ') ||
-    lower.startsWith('to ') ||
-    lower.startsWith('for ') ||
-    lower.startsWith('regarding ')
-  ) {
-    return taskSummary;
-  }
-  return `about ${taskSummary}`;
-}
-
 export function buildWelcomeGreeting(task: string | null, configuredGreeting?: string): string {
+  void task;
   const override = configuredGreeting?.trim();
   if (override) return override;
-
-  const taskSummary = summarizeTaskForGreeting(task);
-  if (!taskSummary) return DEFAULT_WELCOME_GREETING;
-
-  return `Hello, I am calling ${formatTaskAsCallPurpose(taskSummary)}. Is now a good time to talk?`;
+  // The contextual first opener now comes from the call orchestrator's
+  // initial LLM turn. Keep Twilio's relay-level greeting empty by default
+  // so we don't speak a deterministic static line first.
+  return '';
 }
 
 /**


### PR DESCRIPTION
## Summary
- move outbound call opening responsibility from Twilio's static `welcomeGreeting` to the call orchestrator's initial LLM turn
- keep Twilio `welcomeGreeting` empty by default (transport-only), with explicit `CALL_WELCOME_GREETING` override still supported
- trigger an initial opener turn on relay setup using a synthetic `[CALL_OPENING]` marker and add guardrails in the system prompt for contextual opening behavior
- extend marker sanitization to strip `[CALL_OPENING]` from spoken output if echoed
- update relay and Twilio route tests to cover the new opener flow

## Validation
- `bun test src/__tests__/twilio-routes.test.ts src/__tests__/twilio-routes-twiml.test.ts src/__tests__/call-orchestrator.test.ts src/__tests__/relay-server.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` *(fails due to pre-existing unrelated unused import in `src/__tests__/channel-readiness-service.test.ts`)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
