### PR TITLE
fix: improve bash command preview titles for compound commands

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -635,7 +635,20 @@ public struct ToolCallData: Identifiable, Equatable {
     }
 
     private func interpretBashCommand(_ cmd: String) -> String {
-        let tokens = cmd.trimmingCharacters(in: .whitespaces)
+        // For compound commands (cd foo && claude ...), skip trivial prefix commands
+        // to describe the meaningful part.
+        let trivialPrefixes: Set<String> = ["cd", "pushd", "popd", "export", "source"]
+        let segments = cmd.components(separatedBy: "&&").map { $0.trimmingCharacters(in: .whitespaces) }
+        let effectiveCmd: String
+        if segments.count > 1,
+           let firstWord = segments[0].components(separatedBy: .whitespaces).first(where: { !$0.isEmpty }),
+           trivialPrefixes.contains((firstWord as NSString).lastPathComponent.lowercased()) {
+            effectiveCmd = segments.dropFirst().joined(separator: " && ").trimmingCharacters(in: .whitespaces)
+        } else {
+            effectiveCmd = cmd
+        }
+
+        let tokens = effectiveCmd.trimmingCharacters(in: .whitespaces)
             .components(separatedBy: .whitespaces)
             .filter { !$0.isEmpty }
         guard let first = tokens.first else { return "Ran a command" }
@@ -721,6 +734,16 @@ public struct ToolCallData: Identifiable, Equatable {
         case "pkill", "kill", "killall":
             return target().map { "Stopped \($0)" } ?? "Stopped a process"
         case "build.sh":            return "Built the project"
+        case "cd", "pushd", "popd":
+            return target().map { "Navigated to \($0)" } ?? "Changed directory"
+        case "claude":
+            // Extract the prompt flag value for context
+            if let pIdx = tokens.firstIndex(of: "-p"), pIdx + 1 < tokens.count {
+                let prompt = tokens[(pIdx + 1)...].joined(separator: " ")
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                return truncated(prompt, to: 60)
+            }
+            return "Ran Claude Code"
         case "echo", "printf":      return "Output text"
         case "export", "env":       return "Set environment variables"
         default:


### PR DESCRIPTION
## Summary
- Skip trivial prefix commands (`cd`, `pushd`, `export`, `source`) in compound `&&` commands so the preview shows the meaningful command instead (e.g. `cd foo && claude -p "..."` now shows the Claude prompt instead of "Ran cd")
- Add `claude` as a recognized command — extracts the `-p` prompt value for the preview title
- Add `cd`/`pushd`/`popd` as recognized commands with "Navigated to ..." descriptions for standalone use

## Original prompt
"Ran cd" isn't a good representation of what actually happened here lol. Improve the preview title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
