### PR TITLE
feat: show live tool progress during streaming responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -294,29 +294,18 @@ struct ChatBubble: View {
             }
             .frame(maxWidth: 520, alignment: .leading)
         } else if hasActuallyRunningTool && !permissionWasDenied {
-            // In progress — show running indicator or claude_code progress view
+            // In progress — show live progress view with completed + running steps
             let current = message.toolCalls.first(where: { !$0.isComplete })!
             if current.toolName == "claude_code" && !current.claudeCodeSteps.isEmpty {
                 ClaudeCodeProgressView(steps: current.claudeCodeSteps, isRunning: true)
                     .frame(maxWidth: 520, alignment: .leading)
             } else {
-                let progressive = current.buildingStatus != nil ? [] : Self.progressiveLabels(for: current.toolName)
-                RunningIndicator(
-                    label: Self.friendlyRunningLabel(current.toolName, inputSummary: current.inputSummary, buildingStatus: current.buildingStatus),
-                    progressiveLabels: progressive,
-                    labelInterval: progressive.isEmpty ? 6 : 15,
-                    onTap: nil
-                )
+                LiveToolProgressView(toolCalls: message.toolCalls, isRunning: true)
                     .frame(maxWidth: 520, alignment: .leading)
             }
         } else if toolsCompleteButStillStreaming && !permissionWasDenied {
             // All tools done but model is still working (generating next tool call)
-            RunningIndicator(
-                label: "Thinking",
-                progressiveLabels: ["Thinking", "Figuring out next steps", "Almost ready"],
-                labelInterval: 8,
-                onTap: nil
-            )
+            LiveToolProgressView(toolCalls: message.toolCalls, isRunning: true, thinkingLabel: "Thinking")
                 .frame(maxWidth: 520, alignment: .leading)
         } else if hasCompletedTools || hasPermission || (hasInProgressTools && permissionWasDenied) {
             // All done (or denied) — steps pill + permission chip on one row,

--- a/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Shows real-time progress of tool calls within a single assistant message.
+/// Completed tool calls appear with checkmarks; the currently running tool shows
+/// a pulsing indicator. Mirrors the style of `ClaudeCodeProgressView`.
+struct LiveToolProgressView: View {
+    let toolCalls: [ToolCallData]
+    let isRunning: Bool
+    /// When set, shown as the header label instead of the current tool's running label.
+    /// Used for the "all tools done but still streaming" state.
+    var thinkingLabel: String? = nil
+
+    @State private var isExpanded: Bool = true
+    @State private var userHasToggled: Bool = false
+
+    private var currentCall: ToolCallData? {
+        toolCalls.first(where: { !$0.isComplete })
+    }
+
+    private var headerLabel: String {
+        if let thinkingLabel { return thinkingLabel }
+        if isRunning, let current = currentCall {
+            return ChatBubble.friendlyRunningLabel(
+                current.toolName,
+                inputSummary: current.inputSummary,
+                buildingStatus: current.buildingStatus
+            )
+        }
+        return "Completed \(toolCalls.count) step\(toolCalls.count == 1 ? "" : "s")"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header button
+            Button(action: {
+                withAnimation(VAnimation.fast) {
+                    isExpanded.toggle()
+                    userHasToggled = true
+                }
+            }) {
+                HStack(spacing: VSpacing.sm) {
+                    if isRunning {
+                        Circle()
+                            .fill(VColor.accent)
+                            .frame(width: 8, height: 8)
+                            .modifier(LiveToolPulsingModifier())
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.success)
+                    }
+
+                    Text(headerLabel)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+
+            // Expanded step list
+            if isExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    ForEach(toolCalls) { toolCall in
+                        HStack(spacing: VSpacing.sm) {
+                            if toolCall.isComplete {
+                                Image(systemName: toolCall.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(toolCall.isError ? VColor.error : VColor.success)
+                                    .frame(width: 14)
+                            } else {
+                                Circle()
+                                    .fill(VColor.accent)
+                                    .frame(width: 6, height: 6)
+                                    .modifier(LiveToolPulsingModifier())
+                                    .frame(width: 14)
+                            }
+
+                            if toolCall.isComplete {
+                                Text(toolCall.actionDescription)
+                                    .font(VFont.captionMedium)
+                                    .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            } else {
+                                Text(ChatBubble.friendlyRunningLabel(
+                                    toolCall.toolName,
+                                    inputSummary: toolCall.inputSummary,
+                                    buildingStatus: toolCall.buildingStatus
+                                ))
+                                    .font(VFont.captionMedium)
+                                    .foregroundColor(VColor.textSecondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                    }
+                }
+                .padding(.bottom, VSpacing.xs)
+            }
+        }
+        .background(VColor.surface.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onChange(of: isRunning) { _, newValue in
+            if !newValue && !userHasToggled {
+                withAnimation(VAnimation.fast) {
+                    isExpanded = false
+                }
+            }
+        }
+    }
+}
+
+private struct LiveToolPulsingModifier: ViewModifier {
+    @State private var isPulsing = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isPulsing ? 0.4 : 1.0)
+            .animation(
+                Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear { isPulsing = true }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the generic "Running a command" indicator with a `LiveToolProgressView` that shows completed tool calls (with checkmarks) and the currently running tool (with a pulsing dot) in real time
- When the model is thinking between tool calls, the same view shows completed steps with a "Thinking" header instead of a bare "Thinking" label
- New view is collapsible, matches the style of `ClaudeCodeProgressView`

## Original prompt
Instead of just saying something like "Running a command" (Image 1), I want to be able to see the detailed view of what's happening while the response is still running instead of having to wait until afterwards (Image 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
