### PR TITLE
refactor: QR sheet manual pairing behind disclosure (#7472)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -25,6 +25,7 @@ struct PairingQRCodeSheet: View {
     @State private var hostId: String = ""
     @State private var isTokenRevealed: Bool = false
     @State private var copiedField: String? = nil
+    @State private var manualPairingExpanded: Bool = false
 
     /// Whether the configuration is sufficient for pairing.
     private var canGenerateQR: Bool {
@@ -139,89 +140,91 @@ struct PairingQRCodeSheet: View {
 
             // Manual pairing info
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Manual Pairing")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .textCase(.uppercase)
-
-                // Gateway URL row
-                HStack {
-                    Text("Gateway URL")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 90, alignment: .leading)
-                    Text(gatewayUrl.isEmpty ? "Not configured" : gatewayUrl)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Spacer()
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(gatewayUrl, forType: .string)
-                        withAnimation { copiedField = "url" }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            withAnimation { if copiedField == "url" { copiedField = nil } }
+                DisclosureGroup("Manual Pairing", isExpanded: $manualPairingExpanded) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        // Gateway URL row
+                        HStack {
+                            Text("Gateway URL")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 90, alignment: .leading)
+                            Text(gatewayUrl.isEmpty ? "Not configured" : gatewayUrl)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Button {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(gatewayUrl, forType: .string)
+                                withAnimation { copiedField = "url" }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                    withAnimation { if copiedField == "url" { copiedField = nil } }
+                                }
+                            } label: {
+                                Text(copiedField == "url" ? "Copied" : "Copy")
+                                    .font(VFont.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(gatewayUrl.isEmpty)
                         }
-                    } label: {
-                        Text(copiedField == "url" ? "Copied" : "Copy")
-                            .font(VFont.caption)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(gatewayUrl.isEmpty)
-                }
 
-                Divider()
+                        Divider()
 
-                // Bearer token row
-                HStack {
-                    Text("Bearer Token")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 90, alignment: .leading)
-                    if resolvedBearerToken.isEmpty {
-                        Text("Not available")
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                    } else if isTokenRevealed {
-                        Text(resolvedBearerToken)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    } else {
-                        Text(String(repeating: "\u{2022}", count: min(resolvedBearerToken.count, 24)))
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                    }
-                    Spacer()
-                    Button {
-                        isTokenRevealed.toggle()
-                    } label: {
-                        Image(systemName: isTokenRevealed ? "eye.slash" : "eye")
-                            .font(VFont.caption)
-                    }
-                    .buttonStyle(.borderless)
-                    .help(isTokenRevealed ? "Hide token" : "Reveal token")
-                    .disabled(resolvedBearerToken.isEmpty)
+                        // Bearer token row
+                        HStack {
+                            Text("Bearer Token")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 90, alignment: .leading)
+                            if resolvedBearerToken.isEmpty {
+                                Text("Not available")
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textPrimary)
+                            } else if isTokenRevealed {
+                                Text(resolvedBearerToken)
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textPrimary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            } else {
+                                Text(String(repeating: "\u{2022}", count: min(resolvedBearerToken.count, 24)))
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textPrimary)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            Button {
+                                isTokenRevealed.toggle()
+                            } label: {
+                                Image(systemName: isTokenRevealed ? "eye.slash" : "eye")
+                                    .font(VFont.caption)
+                            }
+                            .buttonStyle(.borderless)
+                            .help(isTokenRevealed ? "Hide token" : "Reveal token")
+                            .disabled(resolvedBearerToken.isEmpty)
 
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(resolvedBearerToken, forType: .string)
-                        withAnimation { copiedField = "token" }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            withAnimation { if copiedField == "token" { copiedField = nil } }
+                            Button {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(resolvedBearerToken, forType: .string)
+                                withAnimation { copiedField = "token" }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                    withAnimation { if copiedField == "token" { copiedField = nil } }
+                                }
+                            } label: {
+                                Text(copiedField == "token" ? "Copied" : "Copy")
+                                    .font(VFont.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(resolvedBearerToken.isEmpty)
                         }
-                    } label: {
-                        Text(copiedField == "token" ? "Copied" : "Copy")
-                            .font(VFont.caption)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(resolvedBearerToken.isEmpty)
+                    .padding(.top, VSpacing.sm)
                 }
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
             }
             .padding(VSpacing.md)
             .background(VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
Wraps the manual pairing section in PairingQRCodeSheet behind a DisclosureGroup, collapsed by default, so the QR modal feels focused on scanning rather than a second settings page.

## Changes
- Added `@State private var manualPairingExpanded: Bool = false`
- Wrapped gateway URL row + bearer token row in `DisclosureGroup("Manual Pairing")`
- Removed standalone "Manual Pairing" header (DisclosureGroup label replaces it)
- All copy/reveal functionality preserved

## Key files
- `clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift`

Closes #7472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
