### PR TITLE
feat: show all input parameters in tool permission preview

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -99,6 +99,36 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
+    /// Structured preview of ALL input parameters, formatted as key: value lines.
+    /// Used in the "More details" section so the user can see exactly what will happen.
+    public var fullInputPreview: String {
+        // For bash, the command itself is the full picture
+        switch toolName {
+        case "bash", "host_bash":
+            return (input["command"]?.value as? String) ?? ""
+        default:
+            break
+        }
+
+        let lines: [String] = input.keys.sorted().compactMap { key in
+            guard let value = input[key]?.value else { return nil }
+            let formatted: String
+            if let str = value as? String {
+                formatted = str.count > 120 ? String(str.prefix(117)) + "..." : str
+            } else if let bool = value as? Bool {
+                formatted = bool ? "true" : "false"
+            } else if let num = value as? Int {
+                formatted = "\(num)"
+            } else if let num = value as? Double {
+                formatted = "\(num)"
+            } else {
+                formatted = "\(value)"
+            }
+            return "\(key): \(formatted)"
+        }
+        return lines.joined(separator: "\n")
+    }
+
     /// Human-readable preview of the tool input (e.g. the bash command or file path).
     public var commandPreview: String {
         switch toolName {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -52,9 +52,9 @@ public struct ToolConfirmationBubble: View {
         confirmation.riskLevel.lowercased() == "high" ? "always_allow_high_risk" : "always_allow"
     }
 
-    /// The raw command/path preview for the inline display.
+    /// The full input preview for the inline display (all key-value pairs).
     private var inlinePreviewText: String? {
-        let preview = confirmation.commandPreview
+        let preview = confirmation.fullInputPreview
         return preview.isEmpty ? nil : preview
     }
 


### PR DESCRIPTION
## Summary
- Add `fullInputPreview` computed property that formats all input key-value pairs as sorted `key: value` lines
- Use `fullInputPreview` instead of `commandPreview` in the confirmation bubble's "More details" section
- Bash commands still show just the command string; all other tools show every parameter

## Original prompt
I want to see all the keys in the preview so I can know whether or not to approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
