### PR TITLE
feat: handle Telegram /start as command-intent with generative greeting

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -118,6 +118,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildToolPermissionSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildChannelAwarenessSection());
+  parts.push(buildChannelCommandIntentSection());
   parts.push(buildExternalCommsIdentitySection());
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildAccessPreferenceSection());
@@ -401,6 +402,24 @@ export function buildChannelAwarenessSection(): string {
     '- Never infer guardian status from tone, writing style, or assumptions about who is messaging.',
     '- Treat `<guardian_context>` as source-of-truth for whether the current actor is verified guardian vs non-guardian.',
     '- If `actor_role` is `non-guardian` or `unverified_channel`, avoid language that implies the requester is already verified as the guardian.',
+  ].join('\n');
+}
+
+export function buildChannelCommandIntentSection(): string {
+  return [
+    '## Channel Command Intents',
+    '',
+    'Some channel turns include a `<channel_command_context>` block indicating the user triggered a bot command (e.g. Telegram `/start`).',
+    '',
+    '### `/start` command',
+    'When `command_type` is `start`:',
+    '- Generate a warm, friendly greeting as if the user just arrived for the first time.',
+    '- Keep it brief (1-3 sentences). Do not be verbose or list capabilities.',
+    '- If the user message is `/start` verbatim, treat the entire user intent as "I just started chatting with this bot, say hello."',
+    '- If a `payload` field is present (deep link), acknowledge what the payload references if you recognise it, but still greet warmly.',
+    '- Do NOT reset the conversation, clear history, or treat this as a "new conversation" command.',
+    '- Do NOT mention `/start` or any slash commands in your response.',
+    '- Respond in the same language as the user\'s locale if available from channel context, otherwise default to English.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1123,6 +1123,7 @@ export async function handleTelegramConfig(
 
       const commands = msg.commands ?? [
         { command: 'new', description: 'Start a new conversation' },
+        { command: 'help', description: 'Show available commands' },
         { command: 'guardian_verify', description: 'Verify your guardian identity' },
       ];
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -105,6 +105,8 @@ export interface SessionCreateOptions {
   memoryScopeId?: string;
   isPrivateThread?: boolean;
   strictPrivateSideEffects?: boolean;
+  /** Channel command intent metadata (e.g. Telegram /start). */
+  commandIntent?: { type: string; payload?: string };
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -669,6 +669,7 @@ export class DaemonServer {
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
+    session.setCommandIntent(options?.commandIntent ?? null);
 
     const attachments = attachmentIds
       ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
@@ -725,6 +726,7 @@ export class DaemonServer {
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
+    session.setCommandIntent(options?.commandIntent ?? null);
 
     const attachments = attachmentIds
       ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -34,7 +34,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import { buildTemporalContext } from './date-context.js';
-import type { ActiveSurfaceContext, ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities, ChannelCommandContext, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
   drainDirectiveDisplayBuffer,
@@ -95,6 +95,7 @@ export interface AgentLoopSessionContext {
   workspaceTopLevelContext: string | null;
   workspaceTopLevelDirty: boolean;
   channelCapabilities?: ChannelCapabilities;
+  commandIntent?: { type: string; payload?: string };
   guardianContext?: GuardianRuntimeContext;
 
   readonly coreToolNames: Set<string>;
@@ -297,6 +298,7 @@ export async function runAgentLoopImpl(
       activeSurface,
       workspaceTopLevelContext: ctx.workspaceTopLevelContext,
       channelCapabilities: ctx.channelCapabilities ?? null,
+      channelCommandContext: ctx.commandIntent ?? null,
       guardianContext: ctx.guardianContext ?? null,
       temporalContext,
     });

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -276,6 +276,34 @@ export function injectChannelCapabilityContext(message: Message, caps: ChannelCa
   };
 }
 
+/** Channel command intent metadata (e.g. Telegram /start). */
+export interface ChannelCommandContext {
+  type: string;
+  payload?: string;
+}
+
+/**
+ * Prepend channel command context to the last user message so the
+ * model knows this turn was triggered by a channel command (e.g. /start).
+ */
+export function injectChannelCommandContext(message: Message, ctx: ChannelCommandContext): Message {
+  const lines: string[] = ['<channel_command_context>'];
+  lines.push(`command_type: ${ctx.type}`);
+  if (ctx.payload) {
+    lines.push(`payload: ${ctx.payload}`);
+  }
+  lines.push('</channel_command_context>');
+
+  const block = lines.join('\n');
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
 /**
  * Prepend guardian trust/identity facts to the last user message so the
  * model can reason about guardian status from deterministic runtime facts.
@@ -398,9 +426,15 @@ export function stripActiveSurfaceContext(messages: Message[]): Message[] {
 // Declarative strip pipeline
 // ---------------------------------------------------------------------------
 
+/** Strip `<channel_command_context>` blocks injected by `injectChannelCommandContext`. */
+export function stripChannelCommandContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ['<channel_command_context>']);
+}
+
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   '<channel_capabilities>',
+  '<channel_command_context>',
   '<guardian_context>',
   '<workspace_top_level>',
   TEMPORAL_INJECTED_PREFIX,
@@ -442,6 +476,7 @@ export function applyRuntimeInjections(
     activeSurface?: ActiveSurfaceContext | null;
     workspaceTopLevelContext?: string | null;
     channelCapabilities?: ChannelCapabilities | null;
+    channelCommandContext?: ChannelCommandContext | null;
     guardianContext?: GuardianRuntimeContext | null;
     temporalContext?: string | null;
   },
@@ -474,6 +509,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCapabilityContext(userTail, options.channelCapabilities),
+      ];
+    }
+  }
+
+  if (options.channelCommandContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectChannelCommandContext(userTail, options.channelCommandContext),
       ];
     }
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -129,6 +129,7 @@ export class Session {
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ guardianContext?: GuardianRuntimeContext;
   /** @internal */ assistantId?: string;
+  /** @internal */ commandIntent?: { type: string; payload?: string };
   /** @internal */ pendingSurfaceActions = new Map<string, { surfaceType: SurfaceType }>();
   /** @internal */ lastSurfaceAction = new Map<string, { actionId: string; data?: Record<string, unknown> }>();
   /** @internal */ surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
@@ -335,6 +336,10 @@ export class Session {
 
   setAssistantId(assistantId: string | null): void {
     this.assistantId = assistantId ?? undefined;
+  }
+
+  setCommandIntent(intent: { type: string; payload?: string } | null): void {
+    this.commandIntent = intent ?? undefined;
   }
 
   persistUserMessage(

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -12,6 +12,8 @@ export interface RuntimeMessageSessionOptions {
   };
   assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
+  /** Channel command intent metadata (e.g. Telegram /start). */
+  commandIntent?: { type: string; payload?: string };
 }
 
 export type MessageProcessor = (

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -495,6 +495,12 @@ export async function handleChannelInbound(
     ? sourceMetadata.uxBrief.trim()
     : undefined;
 
+  // Extract channel command intent (e.g. /start from Telegram)
+  const rawCommandIntent = sourceMetadata?.commandIntent;
+  const commandIntent = rawCommandIntent && typeof rawCommandIntent === 'object' && !Array.isArray(rawCommandIntent)
+    ? rawCommandIntent as Record<string, unknown>
+    : undefined;
+
   const replyCallbackUrl = body.replyCallbackUrl;
 
   // ── Guardian verification command intercept ──
@@ -703,6 +709,7 @@ export async function handleChannelInbound(
         assistantId,
         metadataHints,
         metadataUxBrief,
+        commandIntent,
       });
     } else {
       // Fire-and-forget: process the message and deliver the reply in the background.
@@ -718,6 +725,7 @@ export async function handleChannelInbound(
         guardianCtx,
         metadataHints,
         metadataUxBrief,
+        commandIntent,
         replyCallbackUrl,
         bearerToken,
         assistantId,
@@ -746,6 +754,7 @@ interface BackgroundProcessingParams {
   replyCallbackUrl?: string;
   bearerToken?: string;
   assistantId?: string;
+  commandIntent?: Record<string, unknown>;
 }
 
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
@@ -763,10 +772,14 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     replyCallbackUrl,
     bearerToken,
     assistantId,
+    commandIntent,
   } = params;
 
   (async () => {
     try {
+      const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
+        ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}) }
+        : undefined;
       const { messageId: userMessageId } = await processMessage(
         conversationId,
         content,
@@ -779,6 +792,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           },
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
+          ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,
       );
@@ -843,6 +857,7 @@ interface ApprovalProcessingParams {
   assistantId: string;
   metadataHints: string[];
   metadataUxBrief?: string;
+  commandIntent?: Record<string, unknown>;
 }
 
 /**
@@ -872,10 +887,15 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
     assistantId,
     metadataHints,
     metadataUxBrief,
+    commandIntent,
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
   const isUnverifiedChannel = guardianCtx.actorRole === 'unverified_channel';
+
+  const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
+    ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}) }
+    : undefined;
 
   (async () => {
     try {
@@ -890,6 +910,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
           uxBrief: metadataUxBrief,
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
+          ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
       );
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -86,6 +86,8 @@ export interface RunStartOptions {
   assistantId?: string;
   /** Guardian trust/identity context for the inbound actor. */
   guardianContext?: GuardianRuntimeContext;
+  /** Channel command intent metadata (e.g. Telegram /start). */
+  commandIntent?: { type: string; payload?: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -152,6 +154,7 @@ export class RunOrchestrator {
     };
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
+    session.setCommandIntent(options?.commandIntent ?? null);
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -27,6 +27,8 @@ export type HandleInboundOptions = {
   traceId?: string;
   /** When provided, skip resolveAssistant() and use this pre-resolved route. */
   routingOverride?: RouteResult;
+  /** Extra fields merged into sourceMetadata (e.g. commandIntent). */
+  sourceMetadata?: Record<string, unknown>;
 };
 
 function normalizeTransportHints(hints: string[] | undefined): string[] {
@@ -88,6 +90,7 @@ export async function handleInbound(
           isBot: event.sender.isBot,
           ...(transportHints.length > 0 ? { hints: transportHints } : {}),
           ...(transportUxBrief ? { uxBrief: transportUxBrief } : {}),
+          ...(options?.sourceMetadata ?? {}),
         },
         ...(options?.attachmentIds?.length ? { attachmentIds: options.attachmentIds } : {}),
         ...(options?.replyCallbackUrl ? { replyCallbackUrl: options.replyCallbackUrl } : {}),

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -27,6 +27,18 @@ export function buildTelegramTransportMetadata(): { hints: string[]; uxBrief: st
   };
 }
 
+/**
+ * Parse `/start` or `/start <payload>` from Telegram message content.
+ * Returns null if the message is not a /start command.
+ */
+export function parseTelegramStartCommand(content: string): { payload?: string } | null {
+  const trimmed = content.trim();
+  if (/^\/start$/i.test(trimmed)) return {};
+  const match = trimmed.match(/^\/start\s+(.+)$/i);
+  if (match) return { payload: match[1].trim() };
+  return null;
+}
+
 // Rate limiter for routing rejection notices — at most one reply per chat
 // within the cooldown window to avoid spamming the user.
 const REJECTION_NOTICE_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
@@ -255,6 +267,88 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       },
       "Webhook received",
     );
+
+    // Handle /start command — forward to runtime as a channel command intent
+    const startCmd = parseTelegramStartCommand(normalized.message.content);
+    if (startCmd !== null) {
+      const startRouting = resolveAssistant(
+        config,
+        normalized.message.externalChatId,
+        normalized.sender.externalUserId,
+      );
+
+      if (isRejection(startRouting)) {
+        tlog.warn(
+          { chatId: normalized.message.externalChatId, reason: startRouting.reason },
+          "Routing rejected /start command",
+        );
+        if (shouldSendRejectionNotice(normalized.message.externalChatId)) {
+          sendTelegramReply(
+            config,
+            normalized.message.externalChatId,
+            "\u26a0\ufe0f This bot is not fully set up yet. Please check the gateway configuration.",
+          ).catch((err) => {
+            tlog.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /start routing rejection notice");
+          });
+        }
+        return respond({ ok: true });
+      }
+
+      // Forward to runtime with command-intent metadata so the assistant
+      // generates a natural greeting via the normal agent loop.
+      try {
+        const result = await handleInbound(config, normalized, {
+          transportMetadata: buildTelegramTransportMetadata(),
+          replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/telegram`,
+          traceId,
+          sourceMetadata: {
+            commandIntent: {
+              type: "start",
+              ...(startCmd.payload ? { payload: startCmd.payload } : {}),
+            },
+            languageCode: normalized.sender.languageCode,
+          },
+        });
+
+        if (result.rejected) {
+          tlog.warn(
+            { chatId: normalized.message.externalChatId, reason: result.rejectionReason },
+            "Routing rejected /start forward",
+          );
+          if (shouldSendRejectionNotice(normalized.message.externalChatId)) {
+            sendTelegramReply(
+              config,
+              normalized.message.externalChatId,
+              "\u26a0\ufe0f This bot is not fully set up yet. Please check the gateway configuration.",
+            ).catch((err) => {
+              tlog.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /start rejection notice");
+            });
+          }
+        } else if (!result.forwarded) {
+          tlog.error({ updateId: payload.update_id }, "Failed to forward /start to runtime");
+          sendTelegramReply(
+            config,
+            normalized.message.externalChatId,
+            "Welcome! I'm having a brief setup hiccup. Please try again in a moment.",
+          ).catch((err) => {
+            tlog.error({ err }, "Failed to send /start fallback reply");
+          });
+        } else {
+          tlog.info({ status: "forwarded" }, "Forwarded /start to runtime");
+        }
+      } catch (err) {
+        tlog.error({ err, updateId: payload.update_id }, "Failed to process /start command");
+        sendTelegramReply(
+          config,
+          normalized.message.externalChatId,
+          "Welcome! I'm having a brief setup hiccup. Please try again in a moment.",
+        ).catch((replyErr) => {
+          tlog.error({ err: replyErr }, "Failed to send /start error fallback");
+        });
+      }
+
+      return respond({ ok: true });
+    }
 
     // Handle /new command — reset conversation before it reaches the runtime
     if (normalized.message.content.trim() === "/new") {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -159,7 +159,10 @@ function main() {
 
   function registerTelegramCommands(): void {
     callTelegramApi(config, "setMyCommands", {
-      commands: [{ command: "new", description: "Start a new conversation" }],
+      commands: [
+        { command: "new", description: "Start a new conversation" },
+        { command: "help", description: "Show available commands" },
+      ],
     }).catch((err) => {
       log.error({ err }, "Failed to register Telegram bot commands");
     });


### PR DESCRIPTION
## Summary
- Intercepts Telegram `/start` (and `/start <payload>` deep links) in the gateway webhook and forwards to the runtime as `commandIntent` metadata instead of treating it as a regular message or unknown slash command.
- Threads `commandIntent` through the full pipeline: gateway → `handleInbound` → channel-routes → `run-orchestrator`/`server` → session → agent loop, injecting a `<channel_command_context>` block on the user message so the model can generate a contextually appropriate greeting.
- Adds a system prompt section (`Channel Command Intents`) that instructs the model to produce a warm, brief greeting for `/start` without resetting the conversation.
- Adds `/help` to both gateway and daemon default Telegram bot command registrations for parity.
- Includes deterministic fallback messages in the gateway for routing rejections and forwarding failures.

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/telegram-start-bot-ux-plan-2026-02-24.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
