### PR TITLE
refactor: remove Private Thread section from settings page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -2,8 +2,8 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// Advanced settings tab — computer usage limits, private threads,
-/// archived threads, and developer tools.
+/// Advanced settings tab — computer usage limits, archived threads,
+/// and developer tools.
 @MainActor
 struct SettingsAdvancedTab: View {
     @ObservedObject var store: SettingsStore
@@ -29,7 +29,6 @@ struct SettingsAdvancedTab: View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             assistantInfoSection
             computerUsageSection
-            privateThreadSection
             archivedThreadsSection
             switchAssistantSection
             retireAssistantSection
@@ -190,34 +189,6 @@ struct SettingsAdvancedTab: View {
             }
 
             VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Private Thread
-
-    private var privateThreadSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Private Thread")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("New Private Thread")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Private threads have isolated memory — facts learned in private threads stay private and won't appear in other conversations.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                Spacer()
-                VButton(label: "New Private Thread", style: .primary) {
-                    threadManager.createPrivateThread()
-                    onClose()
-                }
-            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Remove the "Private Thread" card from the Advanced settings tab since private threads can already be created from the top nav bar

## Original prompt
Remove this from the settings page since it can be created from the top nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
