### PR TITLE
fix: pairing status uses resolved values + full-width hero (#7478 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -892,7 +892,7 @@ struct SettingsConnectTab: View {
             }
 
             // Status line
-            if !store.ingressPublicBaseUrl.isEmpty && !bearerToken.isEmpty {
+            if !store.resolvedIosGatewayUrl.isEmpty && !store.resolvedIosBearerToken.isEmpty {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(VColor.success)
@@ -901,7 +901,7 @@ struct SettingsConnectTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.success)
                 }
-            } else if store.ingressPublicBaseUrl.isEmpty {
+            } else if store.resolvedIosGatewayUrl.isEmpty {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(VColor.warning)
@@ -922,6 +922,7 @@ struct SettingsConnectTab: View {
             }
         }
         .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
     }
 


### PR DESCRIPTION
## Summary
Two fixes to the pairing section in SettingsConnectTab:

1. **Use resolved values for pairing status** — The status line now checks `store.resolvedIosGatewayUrl` and `store.resolvedIosBearerToken` instead of raw values. This correctly shows "Ready to pair" when developer local pairing overrides provide the URL/token.

2. **Full-width pairing section** — Added `.frame(maxWidth: .infinity)` so the "Pair with iOS" hero card stretches full width.

## Key files
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
