### PR TITLE
feat: add build caching to macOS CI workflows

### DIFF
--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -55,6 +55,29 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+      - name: Cache SPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: clients/.build
+          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          restore-keys: |
+            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-
+
+      - name: Cache Bun dependencies (assistant)
+        uses: actions/cache@v4
+        with:
+          path: assistant/node_modules
+          key: macos-bun-assistant-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: macos-bun-assistant-
+
+      - name: Cache Bun dependencies (cli)
+        uses: actions/cache@v4
+        with:
+          path: cli/node_modules
+          key: macos-bun-cli-${{ hashFiles('cli/bun.lock') }}
+          restore-keys: macos-bun-cli-
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -105,6 +128,7 @@ jobs:
       - name: Build release .app
         working-directory: clients/macos
         run: |
+          SKIP_CLEAN=1 \
           BUNDLE_DISPLAY_NAME="$APP_DISPLAY_NAME" \
           SIGN_IDENTITY="Developer ID Application" \
           ./build.sh release

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -59,6 +59,29 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
+      - name: Cache SPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: clients/.build
+          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          restore-keys: |
+            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-
+
+      - name: Cache Bun dependencies (assistant)
+        uses: actions/cache@v4
+        with:
+          path: assistant/node_modules
+          key: macos-bun-assistant-${{ hashFiles('assistant/bun.lock') }}
+          restore-keys: macos-bun-assistant-
+
+      - name: Cache Bun dependencies (cli)
+        uses: actions/cache@v4
+        with:
+          path: cli/node_modules
+          key: macos-bun-cli-${{ hashFiles('cli/bun.lock') }}
+          restore-keys: macos-bun-cli-
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -109,6 +132,7 @@ jobs:
       - name: Build release .app
         working-directory: clients/macos
         run: |
+          SKIP_CLEAN=1 \
           SIGN_IDENTITY="Developer ID Application" \
           ./build.sh release
           ls -la "dist/Vellum.app"

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -125,9 +125,14 @@ SWIFT_FLAGS=""
 if [ "$CMD" = "release" ]; then
     CONFIG="release"
     SWIFT_FLAGS="-c release --arch arm64 --arch x86_64"
-    # Force clean for release builds to prevent stale artifacts in production
-    echo "Release build: forcing clean to ensure no stale artifacts..."
-    rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
+    if [ "${SKIP_CLEAN:-}" = "1" ]; then
+        echo "Release build: skipping .build clean (SKIP_CLEAN=1, using cached artifacts)"
+        rm -rf "$SCRIPT_DIR/dist"
+    else
+        # Force clean for release builds to prevent stale artifacts in production
+        echo "Release build: forcing clean to ensure no stale artifacts..."
+        rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
+    fi
 fi
 
 # 1. Build with SPM


### PR DESCRIPTION
## Summary

- Cache SPM `.build/` directory across CI runs (keyed on `Package.resolved` + Swift source hash) to enable incremental Swift compilation — the release build currently takes 4.5 min from scratch every time
- Cache Bun `node_modules` for `assistant/` and `cli/` (keyed on `bun.lock`) so `bun install` is a no-op when deps haven't changed
- Add `SKIP_CLEAN` env var to `build.sh` so CI can skip wiping `.build/` while local `./build.sh release` still defaults to a clean build
- Applied to both `ci-macos.yml` and `ci-macos-dmg.yml`; left `release.yml` unchanged (production releases should always be clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
