### PR TITLE
feat: wire up ScheduledTasksView in Settings Reminders tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,6 +25,7 @@ struct SettingsPanel: View {
     @State private var elevenLabsKeyText: String = ""
     @State private var showingTrustRules = false
     @State private var showingReminders = false
+    @State private var showingScheduledTasks = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
@@ -145,6 +146,11 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingReminders) {
             if let daemonClient {
                 RemindersView(daemonClient: daemonClient)
+            }
+        }
+        .sheet(isPresented: $showingScheduledTasks) {
+            if let daemonClient {
+                ScheduledTasksView(daemonClient: daemonClient)
             }
         }
     }
@@ -912,6 +918,29 @@ struct SettingsPanel: View {
                         Spacer()
                         VButton(label: "Manage...", style: .tertiary) {
                             showingReminders = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Scheduled Tasks")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Scheduled Tasks")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View and manage recurring tasks (cron and RRULE schedules)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .tertiary) {
+                            showingScheduledTasks = true
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Added a "Scheduled Tasks" section to the Reminders tab in macOS Settings
- Wires up the existing (but unreachable) `ScheduledTasksView` as a sheet modal
- Users can now view, toggle, and delete recurring cron/RRULE schedules from the desktop app

## Original prompt
yes please add this to the Reminders section of Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
