### PR TITLE
fix: suppress NSParagraphStyle Sendable warnings in MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -1,4 +1,4 @@
-import AppKit
+@preconcurrency import AppKit
 import SwiftUI
 import VellumAssistantShared
 


### PR DESCRIPTION
## Summary
- Add `@preconcurrency` to `import AppKit` in MarkdownSegmentView.swift to suppress unavailable Sendable conformance warnings for NSParagraphStyle

## Original prompt
Fix NSParagraphStyle Sendable warnings in MarkdownSegmentView.swift (lines 181, 186)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
