### PR TITLE
fix: resolve 5 failing CI tests

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -198,6 +198,7 @@ describe('Invariant 2: no generic plaintext secret read API', () => {
       'cli/config-commands.ts',          // CLI config management
       'messaging/providers/telegram-bot/adapter.ts', // Telegram bot token lookup for connectivity check
       'messaging/providers/sms/adapter.ts', // Twilio credential lookup for SMS connectivity check
+      'runtime/channel-readiness-service.ts', // channel readiness probes for SMS/Telegram connectivity
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/runtime-runs-http.test.ts
+++ b/assistant/src/__tests__/runtime-runs-http.test.ts
@@ -60,6 +60,9 @@ function makeCompletingSession(): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -67,6 +70,7 @@ function makeCompletingSession(): Session {
       processing = false;
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -76,11 +80,15 @@ function makeFailingSession(errorMsg: string): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -91,6 +99,9 @@ function makeConfirmationSession(toolName: string): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -108,6 +119,7 @@ function makeConfirmationSession(toolName: string): Session {
       await new Promise<void>(() => {});
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -118,12 +130,16 @@ function makeHangingSession(): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
       await new Promise<void>(() => {});
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 

--- a/assistant/src/__tests__/runtime-runs.test.ts
+++ b/assistant/src/__tests__/runtime-runs.test.ts
@@ -50,6 +50,9 @@ function makeCompletingSession(): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -58,6 +61,7 @@ function makeCompletingSession(): Session {
       processing = false;
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -69,6 +73,9 @@ function makeHangingSession(): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async () => {
       processing = true;
@@ -76,6 +83,7 @@ function makeHangingSession(): Session {
       await new Promise<void>(() => {});
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -86,11 +94,15 @@ function makeFailingSession(errorMsg: string): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent({ type: 'error', message: errorMsg });
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 
@@ -102,6 +114,9 @@ function makeConfirmationSession(toolName: string): Session {
     persistUserMessage: () => undefined as unknown as string,
     memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
     setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -119,6 +134,7 @@ function makeConfirmationSession(toolName: string): Session {
       await new Promise<void>(() => {});
     },
     handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
   } as unknown as Session;
 }
 

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -17,7 +17,7 @@ export function resolveUserReference(): string {
 
   try {
     const content = readFileSync(userPath, 'utf-8');
-    const match = content.match(/Preferred name\/reference:\s*(.+)/);
+    const match = content.match(/Preferred name\/reference:[ \t]*(.*)/);
     if (match && match[1].trim()) {
       return match[1].trim();
     }

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -24,7 +24,7 @@ export class ConfigWatcher {
     protectedKeyPrefix: '__',
   });
   private suppressReload = false;
-  private lastFingerprint = '';
+  lastFingerprint = '';
   private lastRefreshTime = 0;
 
   static readonly REFRESH_INTERVAL_MS = 30_000;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -488,6 +488,20 @@ export class DaemonServer {
     }
   }
 
+  get lastConfigFingerprint(): string {
+    return this.configWatcher.lastFingerprint;
+  }
+
+  set lastConfigFingerprint(value: string) {
+    this.configWatcher.lastFingerprint = value;
+  }
+
+  refreshConfigFromSources(): boolean {
+    const changed = this.configWatcher.refreshConfigFromSources();
+    if (changed) this.evictSessionsForReload();
+    return changed;
+  }
+
   private async sendInitialSession(socket: net.Socket): Promise<void> {
     const conversation = conversationStore.getLatestConversation();
     if (!conversation) {


### PR DESCRIPTION
## Summary
- **credential-security-invariants**: `runtime/channel-readiness-service.ts` legitimately imports `getSecureKey` for SMS/Telegram connectivity probes — added to allowlist
- **user-reference**: regex `\s*(.+)` crossed newline boundaries when preferred name was empty — changed to `[ \t]*(.*)`
- **runtime-runs-http / runtime-runs**: mock Session objects were missing `setAssistantId`, `setGuardianContext`, `setCommandIntent`, and `handleSecretResponse` methods added by recent RunOrchestrator changes
- **daemon-lifecycle**: tests expected `refreshConfigFromSources()` and `lastConfigFingerprint` on DaemonServer — added delegate methods and made `ConfigWatcher.lastFingerprint` public

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22334545882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
