### PR TITLE
Fix duplicate outbound call intros after opener

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -287,6 +287,41 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
+  test('startInitialGreeting: tags only the first caller response with CALL_OPENING_ACK', async () => {
+    let callCount = 0;
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      callCount++;
+      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const lastUser = userMessages[userMessages.length - 1]?.content ?? '';
+
+      if (callCount === 1) {
+        expect(lastUser).toContain('[CALL_OPENING]');
+        return createMockStream(['Hey Noa, it\'s Credence calling about your joke request. Is now okay for a quick one?']);
+      }
+
+      if (callCount === 2) {
+        expect(lastUser).toContain('[CALL_OPENING_ACK]');
+        expect(lastUser).toContain('Yeah. Sure. What\'s up?');
+        return createMockStream(['Great, here\'s one right away. Why did the scarecrow win an award?']);
+      }
+
+      expect(lastUser).not.toContain('[CALL_OPENING_ACK]');
+      expect(lastUser).toContain('Tell me the punchline');
+      return createMockStream(['Because he was outstanding in his field.']);
+    });
+
+    const { orchestrator } = setupOrchestrator('Tell a joke immediately');
+
+    await orchestrator.startInitialGreeting();
+    await orchestrator.handleCallerUtterance('Yeah. Sure. What\'s up?');
+    await orchestrator.handleCallerUtterance('Tell me the punchline');
+
+    expect(callCount).toBe(3);
+
+    orchestrator.destroy();
+  });
+
   // ── ASK_USER pattern ──────────────────────────────────────────────
 
   test('ASK_USER pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
@@ -314,12 +349,13 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  test('strips USER_ANSWERED and USER_INSTRUCTION markers from spoken output', async () => {
+  test('strips internal context markers from spoken output', async () => {
     mockStreamFn.mockImplementation(() =>
       createMockStream([
         'Thanks for waiting. ',
         '[USER_ANSWERED: The guardian said 3 PM works.] ',
         '[USER_INSTRUCTION: Keep this short.] ',
+        '[CALL_OPENING_ACK] ',
         'I can confirm 3 PM works.',
       ]),
     );
@@ -332,8 +368,10 @@ describe('call-orchestrator', () => {
     expect(allText).toContain('I can confirm 3 PM works.');
     expect(allText).not.toContain('[USER_ANSWERED:');
     expect(allText).not.toContain('[USER_INSTRUCTION:');
+    expect(allText).not.toContain('[CALL_OPENING_ACK]');
     expect(allText).not.toContain('USER_ANSWERED');
     expect(allText).not.toContain('USER_INSTRUCTION');
+    expect(allText).not.toContain('CALL_OPENING_ACK');
 
     orchestrator.destroy();
   });
@@ -969,6 +1007,19 @@ describe('call-orchestrator', () => {
       expect(firstArg.system).toContain('refer to yourself as an assistant');
       expect(firstArg.system).toContain('Avoid the phrase "AI assistant" unless directly asked');
       return createMockStream(['Sure thing.']);
+    });
+
+    const { orchestrator } = setupOrchestrator();
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('system prompt includes opening-ack guidance to avoid duplicate introductions', async () => {
+    mockStreamFn.mockImplementation((...args: unknown[]) => {
+      const firstArg = args[0] as { system: string };
+      expect(firstArg.system).toContain('[CALL_OPENING_ACK]');
+      expect(firstArg.system).toContain('without re-introducing yourself');
+      return createMockStream(['Understood.']);
     });
 
     const { orchestrator } = setupOrchestrator();

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -31,8 +31,10 @@ const ASK_USER_MARKER_REGEX = /\[ASK_USER:\s*.+?\]/g;
 const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
 const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
+const CALL_OPENING_ACK_MARKER_REGEX = /\[CALL_OPENING_ACK\]/g;
 const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
 const CALL_OPENING_MARKER = '[CALL_OPENING]';
+const CALL_OPENING_ACK_MARKER = '[CALL_OPENING_ACK]';
 const END_CALL_MARKER = '[END_CALL]';
 
 function stripInternalSpeechMarkers(text: string): string {
@@ -41,6 +43,7 @@ function stripInternalSpeechMarkers(text: string): string {
     .replace(USER_ANSWERED_MARKER_REGEX, '')
     .replace(USER_INSTRUCTION_MARKER_REGEX, '')
     .replace(CALL_OPENING_MARKER_REGEX, '')
+    .replace(CALL_OPENING_ACK_MARKER_REGEX, '')
     .replace(END_CALL_MARKER_REGEX, '');
 }
 
@@ -61,6 +64,8 @@ export class CallOrchestrator {
   private pendingInstructions: string[] = [];
   /** Ensures the outbound-call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
+  /** Marks that the next caller turn should be treated as an opening acknowledgment. */
+  private awaitingOpeningAck = false;
   /** Monotonic run id used to suppress stale turn side effects after interruption. */
   private llmRunVersion = 0;
 
@@ -91,6 +96,10 @@ export class CallOrchestrator {
     this.resetSilenceTimer();
     this.conversationHistory.push({ role: 'user', content: CALL_OPENING_MARKER });
     await this.runLlm();
+    const lastMessage = this.conversationHistory[this.conversationHistory.length - 1];
+    if (lastMessage?.role === 'assistant') {
+      this.awaitingOpeningAck = true;
+    }
   }
 
   /**
@@ -107,6 +116,15 @@ export class CallOrchestrator {
     this.state = 'processing';
     this.resetSilenceTimer();
     const callerContent = this.formatCallerUtterance(transcript, speaker);
+    const shouldMarkOpeningAck = this.awaitingOpeningAck;
+    if (shouldMarkOpeningAck) {
+      this.awaitingOpeningAck = false;
+    }
+    const callerTurnContent = shouldMarkOpeningAck
+      ? callerContent.length > 0
+        ? `${CALL_OPENING_ACK_MARKER}\n${callerContent}`
+        : CALL_OPENING_ACK_MARKER
+      : callerContent;
 
     // Preserve strict role alternation for Anthropic. If the last message
     // is already user-role (e.g. interrupted run never appended assistant,
@@ -114,11 +132,11 @@ export class CallOrchestrator {
     // this utterance into that same user turn.
     const lastMessage = this.conversationHistory[this.conversationHistory.length - 1];
     if (lastMessage?.role === 'user') {
-      lastMessage.content = `${lastMessage.content}\n${callerContent}`;
+      lastMessage.content = `${lastMessage.content}\n${callerTurnContent}`;
     } else {
       this.conversationHistory.push({
         role: 'user',
-        content: callerContent,
+        content: callerTurnContent,
       });
     }
 
@@ -263,7 +281,9 @@ export class CallOrchestrator {
       '7. Do not make up information — ask the user if unsure.',
       '8. Keep responses short — 1-3 sentences is ideal for phone conversation.',
       '9. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
-      '10. If the latest user turn is [CALL_OPENING], produce the first outbound-call line: briefly state the reason for calling using the Task context and ask if now is a good time to talk.',
+      '10. If the latest user turn is [CALL_OPENING], generate a natural, context-specific opener: briefly introduce yourself once as an assistant, state why you are calling using the Task context, and ask a short permission/check-in question. Vary the wording; do not use a fixed template.',
+      '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.',
+      '12. Do not repeat your introduction within the same call unless the callee explicitly asks who you are.',
     ]
       .filter(Boolean)
       .join('\n');
@@ -348,12 +368,15 @@ export class CallOrchestrator {
             '[USER_ANSWERED:'.startsWith(afterBracket) ||
             '[USER_INSTRUCTION:'.startsWith(afterBracket) ||
             '[CALL_OPENING]'.startsWith(afterBracket) ||
+            '[CALL_OPENING_ACK]'.startsWith(afterBracket) ||
             '[END_CALL]'.startsWith(afterBracket) ||
             afterBracket.startsWith('[ASK_USER:') ||
             afterBracket.startsWith('[USER_ANSWERED:') ||
             afterBracket.startsWith('[USER_INSTRUCTION:') ||
             afterBracket === '[CALL_OPENING' ||
             afterBracket.startsWith('[CALL_OPENING]') ||
+            afterBracket === '[CALL_OPENING_ACK' ||
+            afterBracket.startsWith('[CALL_OPENING_ACK]') ||
             afterBracket === '[END_CALL' ||
             afterBracket.startsWith('[END_CALL]');
 


### PR DESCRIPTION
## Summary
- add a one-time `[CALL_OPENING_ACK]` internal marker on the first caller turn after the model-generated outbound opener
- update call orchestration prompt guidance so post-opening turns continue naturally without re-introducing or repeating the initial check-in
- strip `[CALL_OPENING_ACK]` from streamed TTS/transcript output and add tests for marker injection/one-time behavior

## Validation
- bun test src/__tests__/call-orchestrator.test.ts src/__tests__/relay-server.test.ts src/__tests__/twilio-routes.test.ts src/__tests__/twilio-routes-twiml.test.ts
- bunx tsc --noEmit
- bun run lint *(fails on existing unrelated issue in `src/daemon/session-agent-loop.ts`: unused `ChannelCommandContext` import)*