### PR TITLE
fix: avoid disk I/O in pairing status check (#7483 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -891,8 +891,13 @@ struct SettingsConnectTab: View {
                 showingPairingQR = true
             }
 
-            // Status line
-            if !store.resolvedIosGatewayUrl.isEmpty && !store.resolvedIosBearerToken.isEmpty {
+            // Status line — use resolvedIosGatewayUrl for gateway (no I/O) and
+            // cached bearerToken + override for token (avoids synchronous disk read).
+            let hasGateway = !store.resolvedIosGatewayUrl.isEmpty
+            let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !iosPairingTokenOverride.isEmpty)
+
+            if hasGateway && hasToken {
+                // "Ready to pair" — green checkmark
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(VColor.success)
@@ -901,7 +906,8 @@ struct SettingsConnectTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.success)
                 }
-            } else if store.resolvedIosGatewayUrl.isEmpty {
+            } else if !hasGateway {
+                // "Configure a gateway URL below" — amber warning
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(VColor.warning)
@@ -911,6 +917,7 @@ struct SettingsConnectTab: View {
                         .foregroundColor(VColor.warning)
                 }
             } else {
+                // "Bearer token required" — amber warning
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(VColor.warning)


### PR DESCRIPTION
## Summary
Replaces `store.resolvedIosBearerToken` in the pairing status line with a check against the cached `@State bearerToken` + override properties, avoiding a synchronous `readHttpToken()` disk read on every view render.

## Fix
- `hasGateway` uses `store.resolvedIosGatewayUrl` (no disk I/O — just AppStorage string logic)
- `hasToken` uses cached `bearerToken` (populated once in onAppear) OR the override properties (`iosPairingUseOverride && !iosPairingTokenOverride.isEmpty`)

## Key files
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
