### PR TITLE
refactor: reorder Connect tab sections (#7470)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -47,9 +47,9 @@ struct SettingsConnectTab: View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             pairingSection
             gatewaySection
-            channelsSection
             advancedSection
             diagnosticsSection
+            channelsSection
         }
         .onAppear {
             store.refreshIngressConfig()


### PR DESCRIPTION
## Summary
Reorders the Connect tab: Channels moved below Diagnostics per user request.

**New order:** Pairing → Gateway → Advanced → Diagnostics → Channels

## Key files
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
