### PR TITLE
fix: scroll passthrough targets correct scroll view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -780,7 +780,7 @@ private struct ScrollWheelPassthrough: NSViewRepresentable {
             let location = v.convert(event.locationInWindow, from: nil)
             guard v.bounds.width > 0, v.bounds.contains(location) else { return event }
 
-            if let scrollView = coordinator.findScrollView() {
+            if let scrollView = coordinator.findScrollView(for: event) {
                 scrollView.scrollWheel(with: event)
             }
             return event
@@ -800,16 +800,24 @@ private struct ScrollWheelPassthrough: NSViewRepresentable {
         weak var view: NSView?
         var monitor: Any?
 
-        func findScrollView() -> NSScrollView? {
+        /// Finds the deepest NSScrollView whose frame contains the event point.
+        /// This ensures we forward to the chat scroll view, not the sidebar.
+        func findScrollView(for event: NSEvent) -> NSScrollView? {
             guard let contentView = view?.window?.contentView else { return nil }
-            return Self.firstScrollView(in: contentView)
+            return Self.deepestScrollView(in: contentView, containing: event.locationInWindow)
         }
 
-        private static func firstScrollView(in view: NSView) -> NSScrollView? {
-            if let sv = view as? NSScrollView { return sv }
-            for sub in view.subviews {
-                if let sv = firstScrollView(in: sub) { return sv }
+        private static func deepestScrollView(in view: NSView, containing windowPoint: NSPoint) -> NSScrollView? {
+            let localPoint = view.convert(windowPoint, from: nil)
+            guard view.bounds.contains(localPoint) else { return nil }
+
+            for sub in view.subviews.reversed() {
+                if let sv = deepestScrollView(in: sub, containing: windowPoint) {
+                    return sv
+                }
             }
+
+            if let sv = view as? NSScrollView { return sv }
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Changed `ScrollWheelPassthrough` to find the deepest NSScrollView whose frame contains the event point, instead of naively picking the first one in the view tree
- The previous depth-first search was hitting the sidebar's thread list scroll view instead of the chat scroll view

## Original prompt
this isn't working - it's scrolling the threads on the left sidebar not the chat when I try to scroll while hovering over "Scroll to latest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
