### PR TITLE
fix: bundle skills directory alongside compiled daemon binary

### DIFF
--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -101,6 +101,7 @@ jobs:
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
           cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
           cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
+          cp -R src/config/bundled-skills ../clients/macos/daemon-bin/bundled-skills
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -105,6 +105,7 @@ jobs:
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
           cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
           cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
+          cp -R src/config/bundled-skills ../clients/macos/daemon-bin/bundled-skills
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,7 @@ jobs:
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
           cp node_modules/web-tree-sitter/web-tree-sitter.wasm ../clients/macos/daemon-bin/
           cp node_modules/tree-sitter-bash/tree-sitter-bash.wasm ../clients/macos/daemon-bin/
+          cp -R src/config/bundled-skills ../clients/macos/daemon-bin/bundled-skills
           echo "Daemon universal binary built:"
           ls -lh ../clients/macos/daemon-bin/vellum-daemon
           file ../clients/macos/daemon-bin/vellum-daemon

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -209,7 +209,22 @@ export function getSkillsDir(): string {
 }
 
 export function getBundledSkillsDir(): string {
-  return join(import.meta.dir, 'bundled-skills');
+  const dir = import.meta.dir;
+
+  // In compiled Bun binaries, import.meta.dir points into the virtual
+  // /$bunfs/ filesystem where non-JS assets don't exist.  Fall back to
+  // the macOS .app bundle Resources dir or next to the binary.
+  if (dir.startsWith('/$bunfs/')) {
+    const execDir = dirname(process.execPath);
+    // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
+    const resourcesPath = join(execDir, '..', 'Resources', 'bundled-skills');
+    if (existsSync(resourcesPath)) return resourcesPath;
+    // Next to the binary itself (non-app-bundle deployments)
+    const execDirPath = join(execDir, 'bundled-skills');
+    if (existsSync(execDirPath)) return execDirPath;
+  }
+
+  return join(dir, 'bundled-skills');
 }
 
 function getSkillsIndexPath(skillsDir: string): string {

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -191,6 +191,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     # Copy WASM assets next to daemon binary (not bundled by bun --compile)
     cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
     cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
+    # Copy bundled skills (not embedded by bun --compile)
+    rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
+    cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
     echo "Daemon binary built: $SCRIPT_DIR/daemon-bin/vellum-daemon"
 fi
 
@@ -280,6 +283,11 @@ if [ "$NEEDS_REBUILD" = true ]; then
         for wasm in "$SCRIPT_DIR/daemon-bin/"*.wasm; do
             [ -f "$wasm" ] && cp "$wasm" "$RESOURCES_DIR/"
         done
+        # Bundle skills into Resources (not embedded by bun --compile)
+        if [ -d "$SCRIPT_DIR/daemon-bin/bundled-skills" ]; then
+            rm -rf "$RESOURCES_DIR/bundled-skills"
+            cp -R "$SCRIPT_DIR/daemon-bin/bundled-skills" "$RESOURCES_DIR/bundled-skills"
+        fi
     else
         echo "No daemon binary at $DAEMON_BIN — skipping (dev mode)"
     fi


### PR DESCRIPTION
## Summary
- **Root cause**: `getBundledSkillsDir()` used `import.meta.dir` which resolves to `/$bunfs/` in compiled binaries — the `bundled-skills/` directory doesn't exist there
- **Runtime fix**: Added `/$bunfs/` detection with fallback to `Contents/Resources/bundled-skills` (same pattern as WASM file resolution in `parser.ts`)
- **Build fix**: Copy `bundled-skills/` into daemon-bin staging and app bundle Resources in `build.sh` and all 3 CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
