### PR TITLE
Fix /start command intent handling and callback acknowledgements

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -783,6 +783,7 @@ describe('Telegram config handler', () => {
     expect(setCommandsCalled).toBe(true);
     expect((setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands).toEqual([
       { command: 'new', description: 'Start a new conversation' },
+      { command: 'help', description: 'Show available commands' },
       { command: 'guardian_verify', description: 'Verify your guardian identity' },
     ]);
   });
@@ -863,7 +864,7 @@ describe('Telegram config handler', () => {
     expect(res.error).toContain('Failed to set bot commands');
   });
 
-  test('default command registration includes /new and /guardian_verify', async () => {
+  test('default command registration includes /new, /help, and /guardian_verify', async () => {
     secureKeyStore['credential:telegram:bot_token'] = 'test-bot-token';
     secureKeyStore['credential:telegram:webhook_secret'] = 'test-webhook-secret';
 
@@ -891,9 +892,10 @@ describe('Telegram config handler', () => {
     expect(res.success).toBe(true);
 
     const commands = (setCommandsBody as { commands: Array<{ command: string; description: string }> }).commands;
-    expect(commands).toHaveLength(2);
+    expect(commands).toHaveLength(3);
     expect(commands).toEqual([
       { command: 'new', description: 'Start a new conversation' },
+      { command: 'help', description: 'Show available commands' },
       { command: 'guardian_verify', description: 'Verify your guardian identity' },
     ]);
   });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -116,6 +116,7 @@ export async function handleUserMessage(
     rlog.info('Processing user message');
     session.setAssistantId('self');
     session.setGuardianContext(null);
+    session.setCommandIntent(null);
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -870,6 +870,9 @@ export async function runAgentLoopImpl(
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;
     ctx.preactivatedSkillIds = undefined;
+    // Channel command intents (e.g. Telegram /start) are single-turn metadata.
+    // Clear at turn end so they never leak into subsequent unrelated messages.
+    ctx.commandIntent = undefined;
 
     if (userMessageId) {
       consolidateAssistantMessages(ctx.conversationId, userMessageId);

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -186,6 +186,57 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
 });
 
 describe("telegram webhook handler: /new rejection", () => {
+  test("/start forwards command intent metadata and does not reset conversation", async () => {
+    const config = makeConfig({
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+    });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("/start deep-link-token", 2501);
+    const req = makeWebhookRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const runtimeCall = fetchCalls.find((c) => c.url.includes("/inbound"));
+    expect(runtimeCall).toBeDefined();
+    expect((runtimeCall!.body as any).sourceMetadata.commandIntent).toEqual({
+      type: "start",
+      payload: "deep-link-token",
+    });
+
+    const resetCall = fetchCalls.find((c) => c.url.includes("/channels/conversation"));
+    expect(resetCall).toBeUndefined();
+
+    const sendMessageCall = fetchCalls.find((c) => c.url.includes("/sendMessage"));
+    expect(sendMessageCall).toBeUndefined();
+  });
+
+  test("/start with routing rejection sends setup notice and does not forward", async () => {
+    const config = makeConfig({ unmappedPolicy: "reject" });
+    installFetchMock();
+    const handler = createTelegramWebhookHandler(config);
+
+    const payload = makeTelegramPayload("/start", 2502);
+    (payload.message as any).chat.id = 54321;
+    const req = makeWebhookRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const runtimeCall = fetchCalls.find((c) => c.url.includes("/inbound"));
+    expect(runtimeCall).toBeUndefined();
+
+    const sendMessageCall = fetchCalls.find((c) => c.url.includes("/sendMessage"));
+    expect(sendMessageCall).toBeDefined();
+    expect((sendMessageCall!.body as any).text).toContain("not fully set up");
+  });
+
   test("sends rejection notice when /new command routing is rejected", async () => {
     // No routing entries and unmappedPolicy is "reject" — routing will fail
     const config = makeConfig({ unmappedPolicy: "reject" });

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -8,8 +8,9 @@ const callTelegramApiMock = mock(
     Promise.resolve({}),
 );
 const sendTelegramReplyMock = mock(() => Promise.resolve());
-const handleInboundMock = mock(() =>
-  Promise.resolve({ forwarded: true, rejected: false }),
+const handleInboundMock = mock(
+  (_config: GatewayConfig, _normalized: unknown, _options?: unknown) =>
+    Promise.resolve({ forwarded: true, rejected: false }),
 );
 const resetConversationMock = mock(() => Promise.resolve());
 
@@ -207,6 +208,47 @@ describe("telegram-webhook callback query acknowledgment", () => {
     expect(answerCalls.length).toBe(1);
     expect(answerCalls[0][2]).toEqual({
       callback_query_id: "cbq-42",
+    });
+  });
+
+  it("acknowledges callback query when /start command is triggered via callback", async () => {
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = makeCallbackQueryBody("/start", 313);
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    const answerCalls = callTelegramApiMock.mock.calls.filter(
+      (c) => c[1] === "answerCallbackQuery",
+    );
+    expect(answerCalls.length).toBe(1);
+    expect(answerCalls[0][2]).toEqual({
+      callback_query_id: "cbq-42",
+    });
+  });
+
+  it("forwards /start as channel command-intent metadata", async () => {
+    const handler = createTelegramWebhookHandler(baseConfig);
+    const body = JSON.stringify({
+      update_id: 314,
+      message: {
+        message_id: 12,
+        text: "/start ref-123",
+        chat: { id: 42, type: "private" },
+        from: { id: 42, first_name: "Alice", language_code: "en" },
+      },
+    });
+    const res = await handler(postRequest(body));
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const options = handleInboundMock.mock.calls[0][2] as {
+      sourceMetadata?: {
+        commandIntent?: { type: string; payload?: string };
+      };
+    };
+    expect(options.sourceMetadata?.commandIntent).toEqual({
+      type: "start",
+      payload: "ref-123",
     });
   });
 

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -291,6 +291,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
             tlog.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /start routing rejection notice");
           });
         }
+        acknowledgeCallbackQuery(normalized.message.callbackQueryId, "start_command_routing_rejected");
         return respond({ ok: true });
       }
 
@@ -347,6 +348,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         });
       }
 
+      acknowledgeCallbackQuery(normalized.message.callbackQueryId, "start_command");
       return respond({ ok: true });
     }
 


### PR DESCRIPTION
## Summary
- clear channel command intent after each agent turn to prevent metadata leaking into later messages
- clear command intent on IPC user-message entry so desktop-triggered turns never inherit stale channel intent
- acknowledge Telegram callback queries for  in both forwarded and routing-rejected paths
- add  metadata/ack tests and update Telegram command-registration tests for 

## Validation
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)
[03:17:24.777] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "1001"
    updateId: 1001
[03:17:24.781] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.781] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.781] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "2001"
    updateId: 2001
[03:17:24.782] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.782] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.782] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "2501"
    updateId: 2501
[03:17:24.782] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.782] INFO (gateway/62053): Forwarded /start to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.782] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "54321"
    messageId: "2502"
    updateId: 2502
[03:17:24.783] INFO (gateway/62053): No route matched, rejecting
    module: "routing"
    chatId: "54321"
    userId: "67890"
[03:17:24.783] WARN (gateway/62053): Routing rejected /start command
    module: "telegram-webhook"
    chatId: "54321"
    reason: "No route configured for this chat"
[03:17:24.783] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "3001"
    updateId: 3001
[03:17:24.783] INFO (gateway/62053): No route matched, rejecting
    module: "routing"
    chatId: "12345"
    userId: "67890"
[03:17:24.783] WARN (gateway/62053): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "12345"
    reason: "No route configured for this chat"
[03:17:24.784] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "4001"
    updateId: 4001
[03:17:24.784] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "5001"
    updateId: 5001
[03:17:24.784] INFO (gateway/62053): No route matched, rejecting
    module: "routing"
    chatId: "12345"
    userId: "67890"
[03:17:24.784] WARN (gateway/62053): Routing rejected /new command
    module: "telegram-webhook"
    chatId: "12345"
    reason: "No route configured for this chat"
[03:17:24.784] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "9001"
    updateId: 9001
[03:17:24.785] INFO (gateway/62053): Duplicate update_id while still processing, returning 503
    module: "telegram-webhook"
    updateId: 9001
[03:17:24.785] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.785] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.785] INFO (gateway/62053): Duplicate update_id, returning cached response
    module: "telegram-webhook"
    updateId: 9001
[03:17:24.785] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "9002"
    updateId: 9002
[03:17:24.785] WARN (gateway/62053): Runtime returned server error
    module: "runtime-client"
    status: 500
    attempt: 0
    assistantId: "assistant-a"
[03:17:24.785] ERROR (gateway/62053): Failed to forward inbound event to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    err: {
      "type": "Error",
      "message": "Runtime returned 500: Internal error",
      "stack":
          Error: Runtime returned 500: Internal error
              at forwardToRuntime (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/runtime/client.ts:128:25)
              at async handleInbound (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/handlers/handle-inbound.ts:71:28)
              at async <anonymous> (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/http/routes/telegram-webhook.ts:475:28)
              at async <anonymous> (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/__tests__/telegram-webhook-handler.test.ts:414:25)
              at processTicksAndRejections (native:7:39)
    }
[03:17:24.786] ERROR (gateway/62053): Failed to forward inbound event
    module: "telegram-webhook"
    updateId: 9002
[03:17:24.786] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "9002"
    updateId: 9002
[03:17:24.786] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-2"
    duplicate: false
    hasReply: false
[03:17:24.786] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.786] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "9003"
    updateId: 9003
[03:17:24.786] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.786] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.786] INFO (gateway/62053): Duplicate update_id, returning cached response
    module: "telegram-webhook"
    updateId: 9003
[03:17:24.787] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "7001"
    updateId: 7001
[03:17:24.787] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.787] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.787] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "7002"
    updateId: 7002
[03:17:24.787] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.787] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.839] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "7003"
    updateId: 7003
[03:17:24.839] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.839] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.891] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "7004"
    updateId: 7004
[03:17:24.891] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.892] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.892] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "8001"
    updateId: 8001
[03:17:24.892] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.892] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.892] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "12345"
    messageId: "8002"
    updateId: 8002
[03:17:24.892] INFO (gateway/62053): Inbound event forwarded to runtime
    module: "handle-inbound"
    assistantId: "assistant-a"
    routeSource: "chat_id"
    eventId: "evt-1"
    duplicate: false
    hasReply: false
[03:17:24.893] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.896] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "300"
    updateId: 300
[03:17:24.896] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.896] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "301"
    updateId: 301
[03:17:24.896] WARN (gateway/62053): Routing rejected inbound Telegram message
    module: "telegram-webhook"
    chatId: "42"
    reason: "No route"
[03:17:24.897] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "304"
    updateId: 304
[03:17:24.897] ERROR (gateway/62053): Failed to forward inbound event
    module: "telegram-webhook"
    updateId: 304
[03:17:24.897] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "305"
    updateId: 305
[03:17:24.897] ERROR (gateway/62053): Failed to process inbound event
    module: "telegram-webhook"
    updateId: 305
    err: {
      "type": "Error",
      "message": "boom",
      "stack":
          Error: boom
              at <anonymous> (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/http/routes/telegram-webhook.test.ts:183:67)
              at unknown
              at <anonymous> (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/http/routes/telegram-webhook.ts:475:28)
              at async <anonymous> (/Users/noaflaherty/Repos/vellum-ai/vellum-assistant-codex-start-fixes/gateway/src/http/routes/telegram-webhook.test.ts:187:23)
              at processTicksAndRejections (native:7:39)
    }
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "302"
    updateId: 302
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "313"
    updateId: 313
[03:17:24.898] INFO (gateway/62053): Forwarded /start to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "314"
    updateId: 314
[03:17:24.898] INFO (gateway/62053): Forwarded /start to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "303"
    updateId: 303
[03:17:24.898] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "306"
    updateId: 306
[03:17:24.898] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.898] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "307"
    updateId: 307
[03:17:24.898] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.899] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "308"
    updateId: 308
[03:17:24.899] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.899] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "310"
    updateId: 310
[03:17:24.899] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.899] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "311"
    updateId: 311
[03:17:24.899] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.900] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "309"
    updateId: 309
[03:17:24.901] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.902] INFO (gateway/62053): Webhook received
    module: "telegram-webhook"
    source: "telegram"
    chatId: "42"
    messageId: "312"
    updateId: 312
[03:17:24.902] INFO (gateway/62053): Forwarded to runtime
    module: "telegram-webhook"
    status: "forwarded"
[03:17:24.903] ERROR (gateway/62053): Failed to clear inline approval buttons and delete prompt message
    module: "telegram-webhook"
    primaryErr: {}
    fallbackErr: {}
    deleteErr: {}
    chatId: "42"
    messageId: 10
    phase: "decision_applied"
- 
- 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
