### PR TITLE
feat: add Generate/Regenerate token button in pairing hero

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -897,7 +897,7 @@ struct SettingsConnectTab: View {
             let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !iosPairingTokenOverride.isEmpty)
 
             if hasGateway && hasToken {
-                // "Ready to pair" — green checkmark
+                // "Ready to pair" — green checkmark + subtle regenerate
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(VColor.success)
@@ -905,6 +905,13 @@ struct SettingsConnectTab: View {
                     Text("Ready to pair")
                         .font(VFont.body)
                         .foregroundColor(VColor.success)
+                    Spacer()
+                    Button("Regenerate Token") {
+                        showingRegenerateConfirmation = true
+                    }
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .help("Replace the current token. Paired devices will need to reconnect.")
                 }
             } else if !hasGateway {
                 // "Configure a gateway URL below" — amber warning
@@ -917,14 +924,19 @@ struct SettingsConnectTab: View {
                         .foregroundColor(VColor.warning)
                 }
             } else {
-                // "Bearer token required" — amber warning
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 14))
-                    Text("Bearer token required \u{2014} check Advanced settings")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.warning)
+                // "Bearer token required" — amber warning + Generate button
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(VColor.warning)
+                            .font(.system(size: 14))
+                        Text("Bearer token required")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.warning)
+                    }
+                    VButton(label: "Generate Token", leftIcon: "key", style: .secondary) {
+                        regenerateHttpToken()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Adds a Generate/Regenerate token button directly in the Connect tab's pairing hero section.

- **When token is missing**: Shows amber "Bearer token required" warning with a "Generate Token" button that creates a new token immediately (no confirmation needed since there's nothing to lose).
- **When token is present**: Shows green "Ready to pair" status with a subtle "Regenerate Token" link on the right. Clicking triggers the existing confirmation dialog warning that paired devices will need to reconnect.

Both actions use the existing `regenerateHttpToken()` function which generates cryptographically random bytes, writes the token file, and restarts the daemon.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Updated `pairingSection` to include token generation/regeneration controls inline with the status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
