### PR TITLE
fix: suppress scroll-to-latest bubble when near bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -715,9 +715,18 @@ private struct ScrollWheelDetector: NSViewRepresentable {
             guard view.bounds.width > 0, view.bounds.contains(locationInView) else { return event }
 
             if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
-                // Direct user scroll up (toward older content) — untether.
+                // Direct user scroll up (toward older content) — untether,
+                // but only if actually scrolled away from the bottom.
                 // Momentum events are excluded so a flick doesn't accidentally untether.
-                coordinator.onScrollUp?()
+                if let scrollView = coordinator.findEnclosingScrollView() {
+                    let clipBounds = scrollView.contentView.bounds
+                    let docHeight = scrollView.documentView?.frame.height ?? 0
+                    if docHeight - clipBounds.maxY >= 50 {
+                        coordinator.onScrollUp?()
+                    }
+                } else {
+                    coordinator.onScrollUp?()
+                }
             } else if event.scrollingDeltaY < -1 {
                 // Scrolling down (direct or momentum) — re-tether if at bottom.
                 // Scrolling down — check if the underlying NSScrollView is at the bottom


### PR DESCRIPTION
## Summary
- Added scroll-position check before untethering: the "Scroll to latest" bubble only shows if the scroll view is actually 50+ points away from the bottom
- Previously, any tiny scroll-up gesture (deltaY > 3) would immediately show the bubble, even when the user was visually at the bottom

## Original prompt
Cool that worked! "Scroll to latest" is sometimes showing up even when we're at the bottom. Can you suppress it from showing up when we're at or very close to the bottom?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
