### PR TITLE
fix: trim whitespace in override token for pairing status

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -894,7 +894,8 @@ struct SettingsConnectTab: View {
             // Status line — use resolvedIosGatewayUrl for gateway (no I/O) and
             // cached bearerToken + override for token (avoids synchronous disk read).
             let hasGateway = !store.resolvedIosGatewayUrl.isEmpty
-            let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !iosPairingTokenOverride.isEmpty)
+            let trimmedOverrideToken = iosPairingTokenOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !trimmedOverrideToken.isEmpty)
 
             if hasGateway && hasToken {
                 // "Ready to pair" — green checkmark + subtle regenerate


### PR DESCRIPTION
## Summary
Fixes a false "Ready to pair" status when the developer override token contains only whitespace.

Previously, `!iosPairingTokenOverride.isEmpty` would return `true` for whitespace-only strings, showing a green status even though `PairingConfiguration.resolvedBearerToken` trims whitespace and yields an empty token. Now trims the override token before checking emptiness, matching the resolver's behavior.

Addresses feedback from [#7496](https://github.com/vellum-ai/vellum-assistant/pull/7496).

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Trim `iosPairingTokenOverride` before emptiness check in `pairingSection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
