### PR TITLE
M1: ASK_USER → ASK_GUARDIAN marker rename

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3905,7 +3905,7 @@ sequenceDiagram
         Orch->>CallStore: recordCallEvent()
     end
 
-    alt ASK_USER pattern detected
+    alt ASK_GUARDIAN pattern detected
         Orch->>CallStore: createPendingQuestion()
         Orch->>State: fireCallQuestionNotifier()
         State->>Session: question callback
@@ -3941,7 +3941,7 @@ sequenceDiagram
 | `assistant/src/calls/twilio-routes.ts` | HTTP webhook handlers: voice webhook (returns TwiML with WS-A/WS-B guardrails), status callback, connect action |
 | `assistant/src/calls/relay-server.ts` | WebSocket handler for the Twilio ConversationRelay protocol; manages RelayConnection instances per call |
 | `assistant/src/calls/speaker-identification.ts` | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
-| `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_USER and END_CALL control markers |
+| `assistant/src/calls/call-orchestrator.ts` | LLM-driven conversation manager: receives caller utterances, streams responses via Anthropic Claude, detects ASK_GUARDIAN and END_CALL control markers |
 | `assistant/src/calls/call-state.ts` | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and orchestrator registry |
 | `assistant/src/calls/call-constants.ts` | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers |
 | `assistant/src/calls/voice-provider.ts` | Abstract VoiceProvider interface for provider-agnostic call initiation |
@@ -3989,7 +3989,7 @@ The bridge function `tryRouteCallMessage()` applies the following decision logic
 
 #### Answer path detail
 
-1. **Question emission**: When the LLM emits `[ASK_USER: question]`, the orchestrator creates a pending question in SQLite, fires the question notifier, and transitions to `waiting_on_user` state.
+1. **Question emission**: When the LLM emits `[ASK_GUARDIAN: question]`, the orchestrator creates a pending question in SQLite, fires the question notifier, and transitions to `waiting_on_user` state.
 2. **In-thread display**: The Session's registered question notifier callback persists an assistant message in the conversation thread (via `conversationStore.addMessage()`) and emits `assistant_text_delta` + `message_complete` events to connected clients.
 3. **Auto-consumption**: `tryRouteCallMessage()` is checked before the agent loop in two entrypoints:
    - **HTTP path**: `DaemonServer.processMessage()` / `persistAndProcessMessage()` in the daemon server.
@@ -4026,7 +4026,7 @@ All three tables live in `~/.vellum/workspace/data/db/assistant.db` alongside ex
 
 - **`call_events`** — Append-only event log for each call session. Event types include `call_started`, `call_connected`, `caller_spoke`, `assistant_spoke`, `user_question_asked`, `user_answered`, `call_ended`, `call_failed`. For voice prompts, `caller_spoke` payloads include speaker context (`speakerId`, `speakerLabel`, `speakerConfidence`, `speakerSource`) when available. Foreign key to `call_sessions(id)` with cascade delete. Includes a unique index on `(call_session_id, dedupe_key)` for callback idempotency.
 
-- **`call_pending_questions`** — Tracks questions the AI asks the user during a call (via the `[ASK_USER: ...]` pattern). Status lifecycle: `pending` -> `answered`/`expired`/`cancelled`. Foreign key to `call_sessions(id)` with cascade delete.
+- **`call_pending_questions`** — Tracks questions the AI asks the user during a call (via the `[ASK_GUARDIAN: ...]` pattern). Status lifecycle: `pending` -> `answered`/`expired`/`cancelled`. Foreign key to `call_sessions(id)` with cascade delete.
 
 ### Gateway Twilio Webhook Ingress
 
@@ -4086,7 +4086,7 @@ Both tools and HTTP routes delegate to the same domain functions in `call-domain
 
 The CallOrchestrator detects two special markers in the LLM's response text:
 
-- **`[ASK_USER: question]`** — The AI needs to consult the user. The orchestrator creates a pending question, notifies the session via `fireCallQuestionNotifier`, puts the caller on hold, and waits for a user answer (timeout configured via `calls.userConsultTimeoutSeconds`).
+- **`[ASK_GUARDIAN: question]`** — The AI needs to consult the guardian. The orchestrator creates a pending question, notifies the session via `fireCallQuestionNotifier`, puts the caller on hold, and waits for a guardian answer (timeout configured via `calls.userConsultTimeoutSeconds`).
 - **`[END_CALL]`** — The AI has determined the call's purpose is fulfilled. The orchestrator sends a goodbye, closes the ConversationRelay session, and marks the call as completed.
 
 Both markers are stripped from the TTS output so the callee never hears the raw control text.

--- a/assistant/src/__tests__/call-bridge.test.ts
+++ b/assistant/src/__tests__/call-bridge.test.ts
@@ -261,9 +261,9 @@ describe('call-bridge', () => {
   });
 
   test('routes answer to orchestrator when waiting and returns handled:true', async () => {
-    // Setup: trigger ASK_USER to put orchestrator in waiting_on_user state
+    // Setup: trigger ASK_GUARDIAN to put orchestrator in waiting_on_user state
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_USER: Preferred date?]']),
+      createMockStream(['Hold on. [ASK_GUARDIAN: Preferred date?]']),
     );
 
     ensureConversation('conv-bridge');
@@ -327,9 +327,9 @@ describe('call-bridge', () => {
   });
 
   test('prefers answer path over instruction path when pending question exists', async () => {
-    // Setup: trigger ASK_USER to put orchestrator in waiting_on_user state
+    // Setup: trigger ASK_GUARDIAN to put orchestrator in waiting_on_user state
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_USER: Budget range?]']),
+      createMockStream(['Hold on. [ASK_GUARDIAN: Budget range?]']),
     );
 
     ensureConversation('conv-prefer-answer');

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -287,11 +287,11 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  // ── ASK_USER pattern ──────────────────────────────────────────────
+  // ── ASK_GUARDIAN pattern ──────────────────────────────────────────
 
-  test('ASK_USER pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
+  test('ASK_GUARDIAN pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['Let me check on that. ', '[ASK_USER: What date works best?]']),
+      createMockStream(['Let me check on that. ', '[ASK_GUARDIAN: What date works best?]']),
     );
     const { session, relay, orchestrator } = setupOrchestrator('Book appointment');
 
@@ -307,9 +307,9 @@ describe('call-orchestrator', () => {
     const updatedSession = getCallSession(session.id);
     expect(updatedSession!.status).toBe('waiting_on_user');
 
-    // The ASK_USER marker text should NOT appear in the relay tokens
+    // The ASK_GUARDIAN marker text should NOT appear in the relay tokens
     const allText = relay.sentTokens.map((t) => t.token).join('');
-    expect(allText).not.toContain('[ASK_USER:');
+    expect(allText).not.toContain('[ASK_GUARDIAN:');
 
     orchestrator.destroy();
   });
@@ -366,9 +366,9 @@ describe('call-orchestrator', () => {
   // ── handleUserAnswer ──────────────────────────────────────────────
 
   test('handleUserAnswer: returns true immediately and fires LLM asynchronously', async () => {
-    // First utterance triggers ASK_USER
+    // First utterance triggers ASK_GUARDIAN
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_USER: Preferred time?]']),
+      createMockStream(['Hold on. [ASK_GUARDIAN: Preferred time?]']),
     );
     const { relay, orchestrator } = setupOrchestrator();
 
@@ -402,7 +402,7 @@ describe('call-orchestrator', () => {
   test('mid-call question flow: unavailable time → ask user → user confirms → resumed call', async () => {
     // Step 1: Caller says "7:30" but it's unavailable. The LLM asks the user.
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['I\'m sorry, 7:30 is not available. ', '[ASK_USER: Is 8:00 okay instead?]']),
+      createMockStream(['I\'m sorry, 7:30 is not available. ', '[ASK_GUARDIAN: Is 8:00 okay instead?]']),
     );
 
     const { session, relay, orchestrator } = setupOrchestrator('Schedule a haircut');
@@ -892,9 +892,9 @@ describe('call-orchestrator', () => {
   });
 
   test('handleUserInstruction: does not trigger LLM when orchestrator is not idle', async () => {
-    // First, trigger ASK_USER so orchestrator enters waiting_on_user
+    // First, trigger ASK_GUARDIAN so orchestrator enters waiting_on_user
     mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_USER: What time?]']),
+      createMockStream(['Hold on. [ASK_GUARDIAN: What time?]']),
     );
 
     const { session, orchestrator } = setupOrchestrator();

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -26,8 +26,8 @@ const log = getLogger('call-orchestrator');
 
 type OrchestratorState = 'idle' | 'processing' | 'waiting_on_user' | 'speaking';
 
-const ASK_USER_CAPTURE_REGEX = /\[ASK_USER:\s*(.+?)\]/;
-const ASK_USER_MARKER_REGEX = /\[ASK_USER:\s*.+?\]/g;
+const ASK_GUARDIAN_CAPTURE_REGEX = /\[ASK_GUARDIAN:\s*(.+?)\]/;
+const ASK_GUARDIAN_MARKER_REGEX = /\[ASK_GUARDIAN:\s*.+?\]/g;
 const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
 const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
@@ -37,7 +37,7 @@ const END_CALL_MARKER = '[END_CALL]';
 
 function stripInternalSpeechMarkers(text: string): string {
   return text
-    .replace(ASK_USER_MARKER_REGEX, '')
+    .replace(ASK_GUARDIAN_MARKER_REGEX, '')
     .replace(USER_ANSWERED_MARKER_REGEX, '')
     .replace(USER_INSTRUCTION_MARKER_REGEX, '')
     .replace(CALL_OPENING_MARKER_REGEX, '')
@@ -256,7 +256,7 @@ export class CallOrchestrator {
       '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',
       disclosureRule,
       '2. Be concise — phone conversations should be brief and natural.',
-      '3. If the callee asks something you don\'t know, include [ASK_USER: your question here] in your response along with a hold message like "Let me check on that for you."',
+      '3. If the callee asks something you don\'t know, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
       '4. If the callee provides information preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
       '5. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
       '6. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
@@ -312,7 +312,7 @@ export class CallOrchestrator {
         { signal: runSignal },
       );
 
-      // Buffer incoming tokens so we can strip control markers ([ASK_USER:...], [END_CALL])
+      // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
       // could be the start of a control marker.
       let ttsBuffer = '';
@@ -339,17 +339,17 @@ export class CallOrchestrator {
           // The check must be bidirectional:
           //  - When the buffer is shorter than the prefix (e.g. "[ASK"), the
           //    buffer is a prefix of the control tag → hold it.
-          //  - When the buffer is longer than the prefix (e.g. "[ASK_USER: what"),
+          //  - When the buffer is longer than the prefix (e.g. "[ASK_GUARDIAN: what"),
           //    the buffer starts with the control tag prefix → hold it (the
           //    variable-length payload hasn't been closed yet).
           const afterBracket = ttsBuffer;
           const couldBeControl =
-            '[ASK_USER:'.startsWith(afterBracket) ||
+            '[ASK_GUARDIAN:'.startsWith(afterBracket) ||
             '[USER_ANSWERED:'.startsWith(afterBracket) ||
             '[USER_INSTRUCTION:'.startsWith(afterBracket) ||
             '[CALL_OPENING]'.startsWith(afterBracket) ||
             '[END_CALL]'.startsWith(afterBracket) ||
-            afterBracket.startsWith('[ASK_USER:') ||
+            afterBracket.startsWith('[ASK_GUARDIAN:') ||
             afterBracket.startsWith('[USER_ANSWERED:') ||
             afterBracket.startsWith('[USER_INSTRUCTION:') ||
             afterBracket === '[CALL_OPENING' ||
@@ -412,8 +412,8 @@ export class CallOrchestrator {
         }
       }
 
-      // Check for ASK_USER pattern
-      const askMatch = responseText.match(ASK_USER_CAPTURE_REGEX);
+      // Check for ASK_GUARDIAN pattern
+      const askMatch = responseText.match(ASK_GUARDIAN_CAPTURE_REGEX);
       if (askMatch) {
         const questionText = askMatch[1];
         createPendingQuestion(this.callSessionId, questionText);


### PR DESCRIPTION
Part of #7488. Mechanical rename of the consultation marker from ASK_USER to ASK_GUARDIAN across call-orchestrator, tests, skill docs, and architecture docs. Zero behavioral change — just semantics to reflect that during a call, the AI is asking the guardian (user/owner), not the callee.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
