### PR TITLE
fix: add SQLite busy_timeout to prevent SQLITE_BUSY errors

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -132,13 +132,27 @@ export function addMessage(conversationId: string, role: string, content: string
     ...(metadata ? { metadata: JSON.stringify(metadata) } : {}),
   };
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
-  db.transaction((tx) => {
-    tx.insert(messages).values(message).run();
-    tx.update(conversations)
-      .set({ updatedAt: now })
-      .where(eq(conversations.id, conversationId))
-      .run();
-  });
+  // Retry on SQLITE_BUSY in case busy_timeout is exhausted under heavy contention.
+  const MAX_RETRIES = 3;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      db.transaction((tx) => {
+        tx.insert(messages).values(message).run();
+        tx.update(conversations)
+          .set({ updatedAt: now })
+          .where(eq(conversations.id, conversationId))
+          .run();
+      });
+      break;
+    } catch (err) {
+      if (attempt < MAX_RETRIES && (err as { code?: string }).code === 'SQLITE_BUSY') {
+        log.warn({ attempt, conversationId }, 'addMessage: SQLITE_BUSY, retrying');
+        Bun.sleepSync(50 * (attempt + 1));
+        continue;
+      }
+      throw err;
+    }
+  }
 
   try {
     const config = getConfig();

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -12,6 +12,7 @@ export function getDb() {
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec('PRAGMA journal_mode=WAL');
+    sqlite.exec('PRAGMA busy_timeout=5000');
     sqlite.exec('PRAGMA foreign_keys = ON');
     db = drizzle(sqlite, { schema });
   }


### PR DESCRIPTION
## Summary
- Add `PRAGMA busy_timeout=5000` to the SQLite connection so concurrent writers wait up to 5 seconds instead of immediately failing with SQLITE_BUSY
- Add retry logic (3 retries with backoff) around the `addMessage` transaction as defense-in-depth

## Original prompt
prevent this error: database is locked (SQLITE_BUSY) in conversation-store.ts addMessage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
