### PR TITLE
fix: hide Regenerate Token in override mode, add .buttonStyle(.plain)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -897,8 +897,11 @@ struct SettingsConnectTab: View {
             let trimmedOverrideToken = iosPairingTokenOverride.trimmingCharacters(in: .whitespacesAndNewlines)
             let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !trimmedOverrideToken.isEmpty)
 
+            // Token is from daemon file (not from developer override)
+            let tokenFromDaemon = !bearerToken.isEmpty && !iosPairingUseOverride
+
             if hasGateway && hasToken {
-                // "Ready to pair" — green checkmark + subtle regenerate
+                // "Ready to pair" — green checkmark + subtle regenerate (daemon token only)
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(VColor.success)
@@ -906,13 +909,16 @@ struct SettingsConnectTab: View {
                     Text("Ready to pair")
                         .font(VFont.body)
                         .foregroundColor(VColor.success)
-                    Spacer()
-                    Button("Regenerate Token") {
-                        showingRegenerateConfirmation = true
+                    if tokenFromDaemon {
+                        Spacer()
+                        Button("Regenerate Token") {
+                            showingRegenerateConfirmation = true
+                        }
+                        .buttonStyle(.plain)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .help("Replace the current token. Paired devices will need to reconnect.")
                     }
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .help("Replace the current token. Paired devices will need to reconnect.")
                 }
             } else if !hasGateway {
                 // "Configure a gateway URL below" — amber warning


### PR DESCRIPTION
## Summary
Addresses two pieces of reviewer feedback on [#7504](https://github.com/vellum-ai/vellum-assistant/pull/7504):

1. **Hide Regenerate Token in override mode** (Codex P2): When developer override provides the pairing token, clicking "Regenerate Token" only rewrites the daemon token file — a no-op for pairing since the override token is what's actually used. Now only shows the button when the token comes from the daemon file (`!bearerToken.isEmpty && !iosPairingUseOverride`).

2. **Add `.buttonStyle(.plain)`** (Devin): Without it, macOS renders the button with a default bezel/border instead of the intended subtle text link appearance.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Gate Regenerate Token button on non-override mode, add `.buttonStyle(.plain)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
