### PR TITLE
fix: include job IDs in schedule tool output

### DIFF
--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -66,6 +66,7 @@ export async function executeScheduleCreate(
     return {
       content: [
         `Schedule created successfully.`,
+        `  ID: ${job.id}`,
         `  Name: ${job.name}`,
         `  Syntax: ${job.syntax}`,
         `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ''}`,

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -27,6 +27,7 @@ export async function executeScheduleList(
     const runs = getScheduleRuns(jobId, 5);
     const lines = [
       `Schedule: ${job.name}`,
+      `  ID: ${job.id}`,
       `  Syntax: ${job.syntax}`,
       `  Expression: ${job.expression}`,
       `  Schedule: ${describeSchedule(job)}${job.timezone ? ` (${job.timezone})` : ''}`,
@@ -62,7 +63,7 @@ export async function executeScheduleList(
   for (const job of jobs) {
     const status = job.enabled ? 'enabled' : 'disabled';
     const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
-    lines.push(`  - [${status}] ${job.name} ([${job.syntax}] ${describeSchedule(job)}) — next: ${next}`);
+    lines.push(`  - [${status}] ${job.name} (id: ${job.id}) ([${job.syntax}] ${describeSchedule(job)}) — next: ${next}`);
   }
 
   return { content: lines.join('\n'), isError: false };


### PR DESCRIPTION
## Summary
- Add job ID to `schedule_list` output (both list mode and detail mode)
- Add job ID to `schedule_create` response so the model can immediately use it with update/delete

## Original prompt
my assistant is complaining that the schedule_list tool isn't returning the ids needed to use the other tools. please fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
