### PR TITLE
fix: escape backslashes in mdfind Spotlight query sanitization

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -381,11 +381,12 @@ final class ActionExecutor: ActionExecuting {
     private func mdfindApp(name: String, timeout: UInt64 = 2_000_000_000) async -> URL? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/mdfind")
-        // Use double quotes for the display-name value so we only need to escape
-        // double quotes. Process.arguments bypasses the shell, so shell-style
+        // Use double quotes for the display-name value. Escape backslashes first
+        // (Spotlight treats \ as an escape character inside double-quoted strings),
+        // then double quotes. Process.arguments bypasses the shell, so shell-style
         // single-quote escaping (e.g. '\'') would be passed raw to mdfind and
         // break Spotlight query parsing.
-        let sanitizedName = name.replacingOccurrences(of: "\"", with: "\\\"")
+        let sanitizedName = name.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
         process.arguments = [
             "kMDItemKind == 'Application' && kMDItemDisplayName == \"\(sanitizedName)\""
         ]


### PR DESCRIPTION
## Summary
- Escape backslashes before double quotes in `mdfindApp` sanitization to prevent malformed Spotlight queries when app names contain backslashes
- Addresses review feedback from PR #7464: the sanitization only escaped double quotes but Spotlight's query parser treats `\` as an escape character inside double-quoted strings

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Verify `mdfindApp` correctly handles app names with backslashes (e.g. hypothetical edge case)
- [ ] Verify `mdfindApp` still correctly handles app names with double quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
