### PR TITLE
M2: Voice channel identity + per-call conversation

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -26,6 +26,8 @@ import { getSecureKey } from '../security/secure-keys.js';
 import type { CallSession } from './types.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../config/schema.js';
 import type { AssistantConfig } from '../config/types.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import { upsertBinding } from '../memory/external-conversation-store.js';
 
 const log = getLogger('call-domain');
 
@@ -222,10 +224,32 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       callerIdentityMode: identityResult.mode,
       callerIdentitySource: identityResult.source,
       assistantId,
+      initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
 
-    log.info({ callSessionId: session.id, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
+    // Create a dedicated voice conversation for this call so that voice
+    // transcripts live in their own thread, separate from the chat that
+    // triggered the call.
+    const voiceConvKey = assistantId
+      ? `asst:${assistantId}:voice:call:${session.id}`
+      : `voice:call:${session.id}`;
+    const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey);
+
+    upsertBinding({
+      conversationId: voiceConversationId,
+      sourceChannel: 'voice',
+      externalChatId: session.id,
+    });
+
+    // Point the call session at the new voice conversation; the original
+    // chat is preserved in initiatedFromConversationId.
+    updateCallSession(session.id, {
+      conversationId: voiceConversationId,
+    });
+    session.conversationId = voiceConversationId;
+
+    log.info({ callSessionId: session.id, voiceConversationId, initiatedFrom: conversationId, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
 
     const { callSid } = await provider.initiateCall({
       from: fromNumber,

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -23,6 +23,7 @@ function parseCallSession(row: typeof callSessions.$inferSelect): CallSession {
     callerIdentityMode: row.callerIdentityMode,
     callerIdentitySource: row.callerIdentitySource,
     assistantId: row.assistantId,
+    initiatedFromConversationId: row.initiatedFromConversationId,
     startedAt: row.startedAt,
     endedAt: row.endedAt,
     lastError: row.lastError,
@@ -64,6 +65,7 @@ export function createCallSession(opts: {
   callerIdentityMode?: string;
   callerIdentitySource?: string;
   assistantId?: string;
+  initiatedFromConversationId?: string;
 }): CallSession {
   const db = getDb();
   const now = Date.now();
@@ -79,6 +81,7 @@ export function createCallSession(opts: {
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
     assistantId: opts.assistantId ?? null,
+    initiatedFromConversationId: opts.initiatedFromConversationId ?? null,
     startedAt: null,
     endedAt: null,
     lastError: null,
@@ -126,7 +129,7 @@ export function getActiveCallSessionForConversation(conversationId: string): Cal
 
 export function updateCallSession(
   id: string,
-  updates: Partial<Pick<CallSession, 'status' | 'providerCallSid' | 'startedAt' | 'endedAt' | 'lastError'>>,
+  updates: Partial<Pick<CallSession, 'status' | 'providerCallSid' | 'startedAt' | 'endedAt' | 'lastError' | 'conversationId' | 'initiatedFromConversationId'>>,
 ): void {
   const db = getDb();
 

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -14,6 +14,7 @@ export interface CallSession {
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
   assistantId: string | null;
+  initiatedFromConversationId?: string | null;
   startedAt: number | null;
   endedAt: number | null;
   lastError: string | null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -12,6 +12,7 @@ import {
   migrateLlmUsageEventsDropAssistantId,
   migrateExtConvBindingsChannelChatUnique,
   migrateCallSessionsProviderSidDedup,
+  migrateCallSessionsAddInitiatedFrom,
   migrateMemoryFtsBackfill,
 } from './schema-migration.js';
 
@@ -784,6 +785,9 @@ export function initializeDb(): void {
 
   // Persist assistantId so the webhook path can resolve assistant-scoped Twilio numbers
   try { database.run(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN assistant_id TEXT`); } catch { /* already exists */ }
+
+  // Track which conversation initiated the call (the chat where call_start was invoked)
+  migrateCallSessionsAddInitiatedFrom(database);
 
   // Unique constraint: at most one non-null provider_call_sid per (provider, provider_call_sid).
   // On upgraded databases that pre-date this constraint, duplicate rows may exist; deduplicate

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -982,3 +982,21 @@ export function migrateCallSessionsProviderSidDedup(database: Db): void {
     throw e;
   }
 }
+
+/**
+ * Add the `initiated_from_conversation_id` column to `call_sessions` so
+ * voice calls can track which conversation triggered them while pointing
+ * the session's `conversation_id` to a dedicated per-call voice conversation.
+ *
+ * Uses ALTER TABLE ... ADD COLUMN which is a no-op if the column already
+ * exists (caught via try/catch, matching the existing migration pattern in
+ * db-init.ts for similar additive columns).
+ */
+export function migrateCallSessionsAddInitiatedFrom(database: Db): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  try {
+    raw.exec(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN initiated_from_conversation_id TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -552,6 +552,7 @@ export const callSessions = sqliteTable('call_sessions', {
   callerIdentityMode: text('caller_identity_mode'),
   callerIdentitySource: text('caller_identity_source'),
   assistantId: text('assistant_id'),
+  initiatedFromConversationId: text('initiated_from_conversation_id'),
   startedAt: integer('started_at'),
   endedAt: integer('ended_at'),
   lastError: text('last_error'),

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -165,6 +165,47 @@ const smsProbe: ChannelProbe = {
   },
 };
 
+// ── Voice Probe ─────────────────────────────────────────────────────────────
+
+const voiceProbe: ChannelProbe = {
+  channel: 'voice',
+  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[] {
+    const results: ReadinessCheckResult[] = [];
+
+    const hasCreds = hasTwilioCredentials();
+    results.push({
+      name: 'twilio_credentials',
+      passed: hasCreds,
+      message: hasCreds
+        ? 'Twilio credentials are configured'
+        : 'Twilio Account SID and Auth Token are not configured',
+    });
+
+    const phoneNumber = process.env.TWILIO_PHONE_NUMBER
+      || getSecureKey('credential:twilio:phone_number')
+      || '';
+    const hasPhone = !!phoneNumber;
+    results.push({
+      name: 'phone_number',
+      passed: hasPhone,
+      message: hasPhone
+        ? 'Phone number is assigned for voice calls'
+        : 'No phone number assigned for voice calls',
+    });
+
+    const hasIngress = hasIngressConfigured();
+    results.push({
+      name: 'ingress',
+      passed: hasIngress,
+      message: hasIngress
+        ? 'Public ingress URL is configured'
+        : 'Public ingress URL is not configured or disabled',
+    });
+
+    return results;
+  },
+};
+
 // ── Telegram Probe ──────────────────────────────────────────────────────────
 
 const telegramProbe: ChannelProbe = {
@@ -340,10 +381,11 @@ export class ChannelReadinessService {
 
 // ── Factory ─────────────────────────────────────────────────────────────────
 
-/** Create a service instance with built-in SMS and Telegram probes registered. */
+/** Create a service instance with built-in SMS, Voice, and Telegram probes registered. */
 export function createReadinessService(): ChannelReadinessService {
   const service = new ChannelReadinessService();
   service.registerProbe(smsProbe);
+  service.registerProbe(voiceProbe);
   service.registerProbe(telegramProbe);
   return service;
 }

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -1,7 +1,7 @@
 // Channel readiness types — reusable primitive for all channels.
 
 /** Logical channel identifier. Well-known channels have literal types; custom channels use string. */
-export type ChannelId = 'sms' | 'telegram' | string;
+export type ChannelId = 'sms' | 'telegram' | 'voice' | string;
 
 /** Result of a single readiness check (local or remote). */
 export interface ReadinessCheckResult {


### PR DESCRIPTION
Part of #7488. Adds voice as a first-class channel in the readiness system, creates per-call voice conversations bound as sourceChannel=voice, and stores the initiating conversation separately in a new initiatedFromConversationId column on call_sessions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
