### PR TITLE
fix: use dynamic repo path in SMS setup skill IPC example

### DIFF
--- a/assistant/src/config/vellum-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/sms-setup/SKILL.md
@@ -206,7 +206,7 @@ Common issues:
 The skill references IPC messages (`channel_readiness`, `twilio_config`) that are sent via Unix socket to the daemon. The assistant does not have an HTTP endpoint for IPC. Use the following pattern to send IPC messages:
 
 ```bash
-cd /Users/noaflaherty/Repos/vellum-ai/vellum-assistant/assistant && bun -e '
+cd "$(git rev-parse --show-toplevel)/assistant" && bun -e '
 import { sendOneMessage } from "./src/cli/ipc-client.js";
 const res = await sendOneMessage({ type: "twilio_config", action: "get" });
 console.log(JSON.stringify(res, null, 2));


### PR DESCRIPTION
Addresses review feedback on #7452. Replaces hardcoded developer-specific absolute path in sms-setup SKILL.md with a dynamic path resolution so the IPC example works from any checkout location.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
