### PR TITLE
fix: sms_doctor local-only readiness + normalize useCaseCategories in update path

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -1809,11 +1809,16 @@ export async function handleTwilioConfig(
         }
       }
 
+      const updateParams = { ...(msg.verificationParams ?? {}) };
+      if (updateParams.useCaseCategories) {
+        updateParams.useCaseCategories = normalizeUseCaseCategories(updateParams.useCaseCategories);
+      }
+
       const verification = await updateTollFreeVerification(
         accountSid,
         authToken,
         msg.verificationSid,
-        msg.verificationParams ?? {},
+        updateParams,
       );
 
       ctx.send(socket, {
@@ -2070,7 +2075,7 @@ export async function handleTwilioConfig(
       const readinessIssues: string[] = [];
       try {
         const readinessService = getReadinessService();
-        const snapshots = await readinessService.getReadiness('sms', true, msg.assistantId);
+        const snapshots = await readinessService.getReadiness('sms', false, msg.assistantId);
         const snapshot = snapshots[0];
         if (snapshot) {
           readinessReady = snapshot.ready;


### PR DESCRIPTION
Addresses review feedback on #7445. (1) Reverts sms_doctor readiness check to local-only to avoid false 'broken' status for toll-free numbers in PENDING_REVIEW/IN_REVIEW. (2) Adds normalizeUseCaseCategories to the sms_update_tollfree_verification handler so legacy aliases are mapped correctly, matching the submit path behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
