### PR TITLE
fix: escape backslashes in mdfind Spotlight query sanitization

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -385,7 +385,7 @@ final class ActionExecutor: ActionExecuting {
         // double quotes. Process.arguments bypasses the shell, so shell-style
         // single-quote escaping (e.g. '\'') would be passed raw to mdfind and
         // break Spotlight query parsing.
-        let sanitizedName = name.replacingOccurrences(of: "\"", with: "\\\"")
+        let sanitizedName = name.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
         process.arguments = [
             "kMDItemKind == 'Application' && kMDItemDisplayName == \"\(sanitizedName)\""
         ]


### PR DESCRIPTION
## Summary
- Escape backslashes before double quotes in `mdfindApp` query sanitization to prevent malformed Spotlight queries when app names contain backslashes.

## Context
Addresses review feedback from PR #7464. The previous sanitization only escaped double quotes, but backslashes also need escaping first to avoid producing unintended escape sequences in the Spotlight query string.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Verify `mdfindApp` correctly handles app names containing backslashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
