### PR TITLE
fix: strip CALL_OPENING marker on barge-in and skip LLM opener when static greeting configured

### DIFF
--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -111,6 +111,18 @@ export class CallOrchestrator {
     if (interruptedInFlight) {
       this.abortController.abort();
       this.abortController = new AbortController();
+
+      // Strip the one-shot [CALL_OPENING] marker from conversation history
+      // so it doesn't leak into subsequent LLM requests after barge-in.
+      // Without this, the consecutive-user merge path below would append
+      // the caller's transcript to the synthetic "[CALL_OPENING]" message,
+      // causing the model to re-run opener behavior instead of responding
+      // directly to the caller.
+      for (const entry of this.conversationHistory) {
+        if (entry.content.includes(CALL_OPENING_MARKER)) {
+          entry.content = entry.content.replace(CALL_OPENING_MARKER_REGEX, '').trim();
+        }
+      }
     }
 
     this.state = 'processing';

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -302,9 +302,17 @@ export class RelayConnection {
     // Create and attach the LLM-driven orchestrator
     const orchestrator = new CallOrchestrator(this.callSessionId, this, session?.task ?? null);
     this.setOrchestrator(orchestrator);
-    orchestrator.startInitialGreeting().catch((err) =>
-      log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting'),
-    );
+
+    // Skip the LLM-driven opener when a static welcome greeting is already
+    // configured via CALL_WELCOME_GREETING — Twilio's ConversationRelay will
+    // speak it at the transport level, so firing the orchestrator opener too
+    // would cause a double greeting.
+    const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
+    if (!hasStaticGreeting) {
+      orchestrator.startInitialGreeting().catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting'),
+      );
+    }
   }
 
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {


### PR DESCRIPTION
Addresses review feedback on #7468. (1) Strips the [CALL_OPENING] marker from conversation history when a barge-in occurs during the initial greeting, preventing the model from re-running opener behavior. (2) Skips orchestrator.startInitialGreeting() when CALL_WELCOME_GREETING env var is set, avoiding double greeting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
