### PR TITLE
fix: show Regenerate Token when override only sets URL

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -897,8 +897,10 @@ struct SettingsConnectTab: View {
             let trimmedOverrideToken = iosPairingTokenOverride.trimmingCharacters(in: .whitespacesAndNewlines)
             let hasToken = !bearerToken.isEmpty || (iosPairingUseOverride && !trimmedOverrideToken.isEmpty)
 
-            // Token is from daemon file (not from developer override)
-            let tokenFromDaemon = !bearerToken.isEmpty && !iosPairingUseOverride
+            // Token is from daemon file — true unless override mode is active WITH a
+            // custom token. When override only sets the URL (token override empty), the
+            // resolver falls back to the daemon token, so regeneration is still useful.
+            let tokenFromDaemon = !bearerToken.isEmpty && !(iosPairingUseOverride && !trimmedOverrideToken.isEmpty)
 
             if hasGateway && hasToken {
                 // "Ready to pair" — green checkmark + subtle regenerate (daemon token only)


### PR DESCRIPTION
## Summary
Fixes the `tokenFromDaemon` condition so the Regenerate Token button appears when developer override mode only overrides the gateway URL (leaving the token override empty).

When override is on but the token override is empty, `PairingConfiguration.resolvedBearerToken` falls back to the daemon token — so regenerating it IS meaningful for pairing. The previous condition (`!iosPairingUseOverride`) incorrectly hid the button in this case.

**New condition:** `!(iosPairingUseOverride && !trimmedOverrideToken.isEmpty)` — only hides the button when override mode is active AND has a custom token set.

Addresses feedback from [#7509](https://github.com/vellum-ai/vellum-assistant/pull/7509).

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Refined `tokenFromDaemon` condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
