### PR TITLE
fix: preserve locale in /start command intent and clear commandIntent in cleanup

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -106,7 +106,7 @@ export interface SessionCreateOptions {
   isPrivateThread?: boolean;
   strictPrivateSideEffects?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
-  commandIntent?: { type: string; payload?: string };
+  commandIntent?: { type: string; payload?: string; languageCode?: string };
 }
 
 /**

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -95,7 +95,7 @@ export interface AgentLoopSessionContext {
   workspaceTopLevelContext: string | null;
   workspaceTopLevelDirty: boolean;
   channelCapabilities?: ChannelCapabilities;
-  commandIntent?: { type: string; payload?: string };
+  commandIntent?: { type: string; payload?: string; languageCode?: string };
   guardianContext?: GuardianRuntimeContext;
 
   readonly coreToolNames: Set<string>;

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -280,6 +280,7 @@ export function injectChannelCapabilityContext(message: Message, caps: ChannelCa
 export interface ChannelCommandContext {
   type: string;
   payload?: string;
+  languageCode?: string;
 }
 
 /**
@@ -291,6 +292,9 @@ export function injectChannelCommandContext(message: Message, ctx: ChannelComman
   lines.push(`command_type: ${ctx.type}`);
   if (ctx.payload) {
     lines.push(`payload: ${ctx.payload}`);
+  }
+  if (ctx.languageCode) {
+    lines.push(`language_code: ${ctx.languageCode}`);
   }
   lines.push('</channel_command_context>');
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -129,7 +129,7 @@ export class Session {
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ guardianContext?: GuardianRuntimeContext;
   /** @internal */ assistantId?: string;
-  /** @internal */ commandIntent?: { type: string; payload?: string };
+  /** @internal */ commandIntent?: { type: string; payload?: string; languageCode?: string };
   /** @internal */ pendingSurfaceActions = new Map<string, { surfaceType: SurfaceType }>();
   /** @internal */ lastSurfaceAction = new Map<string, { actionId: string; data?: Record<string, unknown> }>();
   /** @internal */ surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
@@ -338,7 +338,7 @@ export class Session {
     this.assistantId = assistantId ?? undefined;
   }
 
-  setCommandIntent(intent: { type: string; payload?: string } | null): void {
+  setCommandIntent(intent: { type: string; payload?: string; languageCode?: string } | null): void {
     this.commandIntent = intent ?? undefined;
   }
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -13,7 +13,7 @@ export interface RuntimeMessageSessionOptions {
   assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
   /** Channel command intent metadata (e.g. Telegram /start). */
-  commandIntent?: { type: string; payload?: string };
+  commandIntent?: { type: string; payload?: string; languageCode?: string };
 }
 
 export type MessageProcessor = (

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -501,6 +501,11 @@ export async function handleChannelInbound(
     ? rawCommandIntent as Record<string, unknown>
     : undefined;
 
+  // Preserve locale from sourceMetadata so the model can greet in the user's language
+  const sourceLanguageCode = typeof sourceMetadata?.languageCode === 'string' && sourceMetadata.languageCode.trim().length > 0
+    ? sourceMetadata.languageCode.trim()
+    : undefined;
+
   const replyCallbackUrl = body.replyCallbackUrl;
 
   // ── Guardian verification command intercept ──
@@ -710,6 +715,7 @@ export async function handleChannelInbound(
         metadataHints,
         metadataUxBrief,
         commandIntent,
+        sourceLanguageCode,
       });
     } else {
       // Fire-and-forget: process the message and deliver the reply in the background.
@@ -726,6 +732,7 @@ export async function handleChannelInbound(
         metadataHints,
         metadataUxBrief,
         commandIntent,
+        sourceLanguageCode,
         replyCallbackUrl,
         bearerToken,
         assistantId,
@@ -755,6 +762,7 @@ interface BackgroundProcessingParams {
   bearerToken?: string;
   assistantId?: string;
   commandIntent?: Record<string, unknown>;
+  sourceLanguageCode?: string;
 }
 
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
@@ -773,12 +781,13 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     bearerToken,
     assistantId,
     commandIntent,
+    sourceLanguageCode,
   } = params;
 
   (async () => {
     try {
       const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
-        ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}) }
+        ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}), ...(sourceLanguageCode ? { languageCode: sourceLanguageCode } : {}) }
         : undefined;
       const { messageId: userMessageId } = await processMessage(
         conversationId,
@@ -858,6 +867,7 @@ interface ApprovalProcessingParams {
   metadataHints: string[];
   metadataUxBrief?: string;
   commandIntent?: Record<string, unknown>;
+  sourceLanguageCode?: string;
 }
 
 /**
@@ -888,13 +898,14 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
     metadataHints,
     metadataUxBrief,
     commandIntent,
+    sourceLanguageCode,
   } = params;
 
   const isNonGuardian = guardianCtx.actorRole === 'non-guardian';
   const isUnverifiedChannel = guardianCtx.actorRole === 'unverified_channel';
 
   const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
-    ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}) }
+    ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}), ...(sourceLanguageCode ? { languageCode: sourceLanguageCode } : {}) }
     : undefined;
 
   (async () => {

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -87,7 +87,7 @@ export interface RunStartOptions {
   /** Guardian trust/identity context for the inbound actor. */
   guardianContext?: GuardianRuntimeContext;
   /** Channel command intent metadata (e.g. Telegram /start). */
-  commandIntent?: { type: string; payload?: string };
+  commandIntent?: { type: string; payload?: string; languageCode?: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -236,6 +236,7 @@ export class RunOrchestrator {
       // same conversation is not incorrectly treated as an HTTP-API client.
       session.setChannelCapabilities(null);
       session.setGuardianContext(null);
+      session.setCommandIntent(null);
       session.setAssistantId('self');
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.


### PR DESCRIPTION
Addresses review feedback on #7479. (1) Includes languageCode from sourceMetadata in the commandIntent object so locale flows through to the model for /start greetings. (2) Adds session.setCommandIntent(null) to run-orchestrator cleanup to prevent stale command intents from leaking to subsequent messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
