### PR TITLE
fix: enforce review-before-merge gate in safe-blitz

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -1,6 +1,6 @@
 Plan a feature end-to-end, create GitHub issues on the project board, execute milestones sequentially with per-milestone review gates onto a feature branch, and present the final PR for manual review.
 
-Unlike `/blitz`, this command does NOT merge directly to main. Instead, it creates a **feature branch** and processes milestones **one at a time** — each milestone is executed, merged into the feature branch, and then recursively swept for review feedback until all feedback (including transitive feedback) is exhausted before moving to the next milestone. After all milestones are complete, a final sweep runs on the entire feature branch. Only then is a single PR from the feature branch into main created for you to review before merging.
+Unlike `/blitz`, this command does NOT merge directly to main. Instead, it creates a **feature branch** and processes milestones **one at a time** — each milestone is executed, then recursively swept for review feedback until all feedback (including transitive feedback) is exhausted. Only after reviews are fully clean is the milestone PR merged into the feature branch. After all milestones are complete, a final sweep runs on the entire feature branch. Only then is a single PR from the feature branch into main created for you to review before merging.
 
 The user passed: `$ARGUMENTS`
 
@@ -43,7 +43,7 @@ git push -u origin <feature-branch-name>
 
 This keeps your current branch unchanged so safe-blitz doesn't block your main working tree.
 
-3. Store the feature branch name for later phases. All agents will use `--base <feature-branch-name>` instead of `--base main`.
+3. Store the feature branch name for later phases. Milestone agents will use `--base <feature-branch-name>`. Feedback agents during per-milestone sweeps will use `--base <milestone-pr-branch>` (see Phase 4c).
 
 ## Phase 2: Plan & Spec
 
@@ -66,13 +66,18 @@ Do NOT use `.claude/phases/populate-todo.md` here. Instead, maintain an internal
 
 ## Phase 4: Execute Milestones with Review Gates
 
-Process milestones **one at a time** (sequentially). For each milestone, execute it, merge its PR into the feature branch, then run a recursive sweep to exhaust all feedback before moving to the next milestone. This ensures each milestone is fully reviewed before the next one starts.
+**CRITICAL: Review-before-merge policy.** Milestone PRs must NOT be merged into the feature branch until all reviews are addressed and there is no pending feedback. The merge happens only after the per-milestone sweep completes cleanly. This is the defining guarantee of safe-blitz — if a PR is merged before reviews are clean, the review gate is meaningless.
 
-The safe-blitz only considers a milestone "done" when its PR AND all transitive feedback PRs have been fully reviewed with no remaining change requests.
+Process milestones **one at a time** (sequentially). For each milestone, execute it, run a recursive sweep to exhaust all review feedback, and only THEN merge the milestone PR into the feature branch. This ensures each milestone is fully reviewed before its code lands on the feature branch.
+
+The safe-blitz only considers a milestone "done" when its PR AND all transitive feedback PRs have been fully reviewed with no remaining change requests, AND the milestone PR has been merged into the feature branch after the sweep.
 
 ### Agent prompt template
 
-The following prompt template is used for both milestone tasks and feedback tasks:
+The following prompt template is used for both milestone tasks and feedback tasks. The `<base-branch>` placeholder is filled in by the lead when spawning the agent:
+- For **milestone tasks**: `<base-branch>` = `<feature-branch-name>`
+- For **feedback tasks during per-milestone sweep**: `<base-branch>` = `<milestone-pr-branch>` (the milestone PR's head branch)
+- For **feedback tasks during final sweep** (Phase 5): `<base-branch>` = `<feature-branch-name>`
 
 ```
 You are working on a single task in an isolated git worktree.
@@ -97,7 +102,8 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it (e.g., "fix the type errors", "make the tests pass").
 3. cd back to worktree root, then ship (.claude/ship MUST run from the repo root, not assistant/):
-   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <feature-branch-name> --merge --assignee @me
+   cd <worktree> && .claude/ship --commit-msg "<message>" --title "<title>" --body "<summary>" --base <base-branch> --assignee @me
+   IMPORTANT: Do NOT use --merge. The lead will merge PRs after reviews are complete.
 4. If the PR warrants focused human review, leave a Human Attention Comment (see "Human Attention Comments on PRs" in AGENTS.md). Skip for routine changes.
 5. Send a message to "lead" with:
    - The PR link (printed by .claude/ship)
@@ -108,7 +114,7 @@ ALL work happens here. Do NOT touch the main repo.
 For "Address the feedback on <PR URL>" tasks:
 - Read the review comments on the referenced PR to understand what changes are requested.
 - Implement the requested fixes in your worktree (on a new branch — this will become a new PR).
-- Follow the same PR creation and merge workflow above (targeting the feature branch).
+- Follow the same PR creation workflow above (using the same --base branch). Do NOT use --merge.
 - After creating the followup PR, leave a paper trail on the original PR:
   1. Comment on the original PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
   2. Resolve all bot review threads: `.claude/gh-review resolve-threads <original-PR-number> "Addressed in <new-PR-URL>"`
@@ -118,7 +124,7 @@ For "Fix CI failures from merged PR <PR URL> (run: <run URL>)" tasks:
 - Read the referenced PR's diff (`gh pr diff <number>`) to understand what changes were introduced.
 - Diagnose the root cause of the CI failure.
 - Implement the fix in your worktree (on a new branch — this will become a new PR).
-- Follow the same PR creation and merge workflow above.
+- Follow the same PR creation workflow above. Do NOT use --merge.
 - In the new PR body, reference the original PR and the failed run.
 ```
 
@@ -140,30 +146,58 @@ For "Fix CI failures from merged PR <PR URL> (run: <run URL>)" tasks:
 #### 4b. When the milestone agent finishes
 
 1. Read its completion message.
-2. Update tracking files (read fresh each time, write back carefully):
+2. **Record the milestone PR number, URL, and head branch name.** You will need these for Phase 4c (creating feedback worktrees from the milestone branch) and Phase 4c.5 (merging after reviews). To get the head branch name:
+   ```bash
+   gh pr view <milestone-pr-number> --json headRefName --jq '.headRefName'
+   ```
+3. Update tracking files (read fresh each time, write back carefully):
    - Remove the completed item from .private/TODO.md.
    - Append the PR link to .private/UNREVIEWED_PRS.md.
-3. Mark the TaskCreate entry as completed.
-4. Remove the worktree: `.claude/worktree remove swarm/<namespace>/task-<counter> --delete-branch`.
-5. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate.
-6. Pull the latest **feature branch** (not main):
+4. Mark the TaskCreate entry as completed.
+5. Remove the worktree but **keep the branch** (the PR is still open and unmerged):
    ```bash
-   git fetch origin <feature-branch-name>
+   .claude/worktree remove swarm/<namespace>/task-<counter> --no-delete-branch
+   ```
+6. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate.
+7. Fetch the milestone PR's branch for use in Phase 4c:
+   ```bash
+   git fetch origin <milestone-pr-branch>
    ```
 
 #### 4c. Per-milestone recursive sweep
 
-Run the recursive sweep (`.claude/phases/sweep.md`) with `--namespace <namespace>` and `--branch <feature-branch-name>`. **Skip the entry pause** — treat as `--auto` for per-milestone sweeps. The user-facing pause only applies to the final sweep in Phase 5.
+Run the recursive sweep (`.claude/phases/sweep.md`) with `--namespace <namespace>` and `--branch <milestone-pr-branch>` (the milestone PR's head branch, not the feature branch — this is where CI runs during the milestone's review cycle). **Skip the entry pause** — treat as `--auto` for per-milestone sweeps. The user-facing pause only applies to the final sweep in Phase 5.
 
 When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/commands/swarm.md`) with these modifications:
 - Pass `--namespace <namespace>` so only namespaced feedback items are processed.
-- Pass the worker count as the first positional argument (or default: 12), e.g., `.claude/commands/swarm.md 12 --namespace <namespace>`.
-- All agents must use `--base <feature-branch-name>` (not main).
-- Create worktrees from the feature branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<feature-branch-name>`.
+- Pass the worker count as the first positional argument (or default: 12).
+- All agents must use `--base <milestone-pr-branch>` (the milestone PR's head branch, not the feature branch or main). This means feedback PRs target the milestone branch, so fixes accumulate on the milestone PR.
+- Create worktrees from the milestone PR's branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<milestone-pr-branch>`.
+- Agents must NOT use `--merge` in `.claude/ship`. All PRs are created without auto-merging.
+- **Merge override for "Address the feedback" tasks**: When the swarm encounters a feedback task referencing a PR that targets the milestone branch (i.e., it's a feedback PR, not the original milestone PR), merge that referenced PR into the milestone branch first (`gh pr merge <number> --squash`) so the next-level feedback agent has the code. Do NOT merge the original milestone PR (#`<milestone-pr-number>`, which targets the feature branch) — it must stay unmerged until Phase 4c.5.
 
 Since milestones are added to TODO.md one at a time (and removed when executed), the only namespaced items in TODO.md during the sweep are feedback items for the current milestone. The swarm will process those and nothing else.
 
-When the sweep says "final phase," proceed to step 4d.
+When the sweep says "final phase," proceed to step 4c.5.
+
+#### 4c.5. Merge milestone PR into feature branch
+
+This step runs ONLY after the per-milestone sweep completes cleanly (all reviews addressed, no pending feedback). This is the review-before-merge gate.
+
+1. Merge any remaining unmerged feedback PRs into the milestone branch (squash merge, in order of PR number). These are feedback PRs that were approved but not yet merged:
+   ```bash
+   gh pr merge <feedback-pr-number> --squash
+   ```
+2. Merge the milestone PR into the feature branch:
+   ```bash
+   gh pr merge <milestone-pr-number> --squash
+   ```
+3. Fetch the updated feature branch:
+   ```bash
+   git fetch origin <feature-branch-name>
+   ```
+
+Proceed to step 4d.
 
 #### 4d. Close the milestone and proceed
 
@@ -185,7 +219,14 @@ This final sweep catches:
 - CI failures that only manifest when multiple milestones are combined
 - Any remaining unreviewed PRs from any milestone
 
-When the sweep says "back to the Swarm phase," run swarm as described in Phase 4c. When the sweep says "final phase," proceed to Phase 6.
+When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/commands/swarm.md`) with these modifications (note: these differ from Phase 4c because the final sweep operates on the feature branch, not a milestone branch):
+- Pass `--namespace <namespace>` so only namespaced feedback items are processed.
+- Pass the worker count as the first positional argument (or default: 12).
+- All agents must use `--base <feature-branch-name>` (not main).
+- Create worktrees from the feature branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<feature-branch-name>`.
+- Agents must NOT use `--merge` in `.claude/ship`. All PRs are created without auto-merging. The lead merges approved PRs after review.
+
+When the sweep says "final phase," proceed to Phase 6.
 
 ## Phase 6: Create Final PR (Feature Branch -> Main)
 
@@ -258,5 +299,6 @@ The final PR is open and waiting for your review. Merge it when ready.
 ## Important
 
 Read and follow `.claude/phases/blitz-important.md`. Additionally:
-- If an agent hits merge conflicts after another agent's PR landed, tell it to rebase against the **feature branch**: `git pull --rebase origin <feature-branch-name>`.
+- If an agent hits merge conflicts after another agent's PR landed, tell it to rebase against the appropriate branch: `git pull --rebase origin <milestone-pr-branch>` during per-milestone sweeps, or `git pull --rebase origin <feature-branch-name>` during the final sweep.
+- **Do NOT merge milestone PRs into the feature branch until the per-milestone sweep completes cleanly.** The merge happens in Phase 4c.5 — never before.
 - **Do NOT merge the final PR.** Only create it and present the link to the user.


### PR DESCRIPTION
## Summary
- Remove `--merge` from the safe-blitz agent prompt template so milestone PRs are NOT auto-merged into the feature branch upon creation
- Add new Phase 4c.5 that merges the milestone PR only after the per-milestone sweep completes cleanly (all reviews addressed, no pending feedback)
- Feedback agents during per-milestone sweeps now create worktrees from the milestone PR's branch and target it with their PRs, so fixes accumulate on the milestone branch before it merges into the feature branch

## Original prompt
in another session where I used the safe-blitz command you said "⏺ Reviews are still pending for M1. Per the safe-blitz sweep logic, I'll wait briefly and re-check, but since the M1 PR is already merged into the feature branch,
  let me check CI on the feature branch first, then proceed." However, with safe blitz, branches shouldn't be merged into the feature branch until after they're reviewed and have no pending feedback. Please update the slash command so that this is followed going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
