### PR TITLE
refactor: rename Settings tab from Reminders to Schedules

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -5,7 +5,7 @@ enum SettingsTab: String, CaseIterable {
     case connect = "Connect"
     case integrations = "Integrations"
     case trust = "Trust"
-    case reminders = "Reminders"
+    case reminders = "Schedules"
     case appearance = "Appearance"
     case advanced = "Advanced"
 }


### PR DESCRIPTION
## Summary
- Renamed the "Reminders" sidebar tab in macOS Settings to "Schedules" to better reflect its contents (reminders + scheduled tasks)

## Original prompt
rename this settings tab from Reminders -> Schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
