### PR TITLE
docs: update macOS/iOS READMEs for HTTP gateway pairing flow

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -75,39 +75,24 @@ cd clients/ios
 
 ### Connected to Mac Mode
 
-Requires the Vellum daemon running on your Mac (either as the macOS desktop app or `bun run src/daemon/main.ts`).
+Requires the Vellum daemon running on your Mac (via the macOS desktop app or `bun run src/index.ts daemon start`). The iOS app connects to the daemon through an HTTP gateway using a bearer token for authentication.
 
-**In the simulator** (same machine as Mac):
+**QR Code Pairing (recommended):**
 
-1. Choose **"Connect to Mac"** in onboarding
-2. Hostname: `localhost`, Port: `8765`
-3. Get the session token from your Mac:
-   ```bash
-   cat ~/.vellum/session-token
-   ```
-4. Paste the token into the Session Token field
+1. On your Mac, open **Settings → Connect → Show QR Code**
+2. On your iPhone, go to **Settings → Connect → Scan QR Code**
+3. Scan the QR code — the app auto-configures the gateway URL and bearer token
 
-**On a real iPhone** (same Wi-Fi network):
+The QR code contains a v3 payload with the gateway URL, bearer token, and local network settings. For LAN-only connections (e.g., development), the QR code includes an `allowLocalHttp` flag that permits plain HTTP for local/private addresses.
 
-1. Find your Mac's local IP:
-   - System Settings → Network → Wi-Fi → Details → IP Address
-   - Or run `ipconfig getifaddr en0` in Terminal
-2. Use that IP as the hostname (e.g. `192.168.1.42`)
-3. Copy the session token from Mac app **Settings → iOS Device → Copy** (or `~/.vellum/session-token`)
+**Manual Setup:**
 
-**Starting the daemon with TCP enabled:**
-```bash
-cd assistant
-# For simulator (localhost only):
-VELLUM_DAEMON_TCP_ENABLED=1 bun run src/index.ts daemon start
+1. On your iPhone, go to **Settings → Connect → Manual Setup**
+2. Enter the gateway URL shown in your Mac's **Settings → Connect → Gateway** section
+3. Enter the bearer token shown in your Mac's **Settings → Connect → Advanced** section
+4. Tap **Connect**
 
-# For real device (all network interfaces):
-VELLUM_DAEMON_TCP_ENABLED=1 VELLUM_DAEMON_TCP_HOST=0.0.0.0 bun run src/index.ts daemon start
-```
-
-TCP is opt-in (`VELLUM_DAEMON_TCP_ENABLED=1`) for security — the Unix socket default binds only to the local filesystem. By default the TCP listener binds to `127.0.0.1` (simulator use). Set `VELLUM_DAEMON_TCP_HOST=0.0.0.0` to accept LAN connections from a real device.
-
-The macOS app sets `VELLUM_DAEMON_TCP_ENABLED=1` automatically when the daemon starts.
+HTTPS is required for non-local connections. HTTP is permitted only for loopback, mDNS `.local`, link-local, and RFC 1918 private addresses.
 
 ## Running Tests
 
@@ -144,14 +129,14 @@ swift test --filter VellumAssistantSharedTests
 
 ## Configuration Reference
 
-| Setting | UserDefaults Key | Default | Description |
-|---------|-----------------|---------|-------------|
-| Connection mode | `connection_mode` | `Standalone` | `Standalone` or `Connected to Mac` |
-| Daemon hostname | `daemon_hostname` | `localhost` | Mac hostname or IP |
-| Daemon port | `daemon_port` | `8765` | Daemon TCP port |
-| Session token | Keychain (device) / UserDefaults (simulator), provider key `"daemon-token"` | — | Token from `~/.vellum/session-token` on Mac |
-| Use TLS | `daemon_tls_enabled` | `false` | Enable TLS for TCP connection |
-| Anthropic API key | (UserDefaults on simulator, Keychain on device) | — | For standalone mode |
+| Setting | Storage | Default | Description |
+|---------|---------|---------|-------------|
+| Gateway URL | UserDefaults `gateway_base_url` | — | HTTP(S) gateway URL from QR code or manual entry |
+| Bearer token | Keychain (device) / UserDefaults (sim), provider `"runtime-bearer-token"` | — | Authentication token for gateway requests |
+| Conversation key | UserDefaults `conversation_key` | — | Auto-generated UUID for session identification |
+| Anthropic API key | Keychain (device) / UserDefaults (sim) | — | For standalone mode (direct API) |
+| Daemon hostname | UserDefaults `daemon_hostname` | `localhost` | Legacy TCP hostname (still used for cert pinning) |
+| Daemon port | UserDefaults `daemon_port` | `8765` | Legacy TCP port |
 
 ## Dependencies
 
@@ -161,7 +146,9 @@ The iOS app depends only on `VellumAssistantShared`. It must **not** import `Vel
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Cannot connect to daemon" | Daemon not running or wrong hostname/port | Start daemon, verify `localhost:8765` in simulator |
-| Auth timeout / immediate disconnect | Missing or wrong session token | Copy from `~/.vellum/session-token` on Mac |
+| "Cannot connect" | Daemon not running or wrong gateway URL | Start the macOS app, verify gateway URL in Settings → Connect |
+| "Connection failed" after QR scan | Gateway unreachable from iPhone | Ensure both devices are on the same network; check firewall settings |
+| "HTTPS is required" on manual entry | Non-local URL with `http://` scheme | Use `https://` or connect via QR code for local HTTP |
+| Auth timeout / immediate disconnect | Missing or wrong bearer token | Re-scan QR code or re-enter token from Mac's Settings → Connect → Advanced |
 | "Failed to save API Key" | Keychain unavailable (simulator) | Expected — key saved to UserDefaults instead |
 | Old version still showing in simulator | Cached build | `xcrun simctl uninstall <UDID> ai.vellum.assistant.ios` then reinstall |

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -223,14 +223,21 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 
 Requires Accessibility, Screen Recording, and Microphone permissions (System Settings > Privacy & Security). `PermissionManager` handles checking/prompting. API key stored in Keychain via `APIKeyManager`.
 
-## Developer Local Pairing
+## iOS Pairing
 
-Developer-only feature for pairing an iOS device over the local network (LAN) for debugging purposes.
+The macOS app pairs with iOS devices via QR code or manual gateway URL entry. The Connect tab (Settings → Connect) is the single entry point for all pairing configuration.
 
-- **What it is:** Allows a macOS instance to expose a local HTTP gateway that an iOS device on the same network can connect to, bypassing the cloud relay.
-- **How to enable:** Settings > Connect > Developer Local Pairing toggle. This is a developer-only feature gated behind the developer settings toggle.
-- **How it works:** The macOS app generates a QR code containing the local HTTP gateway URL. The iOS app scans the QR code and connects directly over LAN if the developer local pairing toggle is enabled on the iOS side.
-- **Security:** HTTP is permitted only for local/private addresses (loopback, mDNS `.local`, link-local, RFC 1918 ranges). Bearer token authentication is still required for all requests. Address validation uses `LocalAddressValidator.isLocalAddress()` in `clients/shared/Utilities/LocalAddressValidator.swift`.
+- **QR Code Pairing:** Settings > Connect > Show QR Code generates a v3 payload containing the gateway URL, bearer token, and an `allowLocalHttp` flag for LAN connections.
+- **Connect Tab Layout:** Pairing hero (QR + status) → Gateway (URL config, collapsed if set) → Advanced (bearer token, developer local pairing overrides) → Diagnostics (test connection) → Channels (Telegram, SMS).
+- **Bearer Token:** Auto-generated and stored at `~/.vellum/http-token`. The pairing hero shows a "Generate Token" button when missing and a "Regenerate Token" link when present.
+
+### Developer Local Pairing
+
+Developer-only feature for pairing over LAN, bypassing the cloud relay. Located in Settings > Connect > Advanced (requires developer settings toggle).
+
+- **What it is:** Allows overriding the gateway URL and bearer token with local network values for debugging.
+- **How it works:** When enabled, the QR code includes the local LAN URL and sets `allowLocalHttp: true`. The iOS app uses `allowLocalHttp` from the QR payload to permit plain HTTP — there is no separate toggle on the iOS side.
+- **Security:** HTTP is permitted only for local/private addresses (loopback, mDNS `.local`, link-local, RFC 1918 ranges). Bearer token authentication is still required. Address validation uses `LocalAddressValidator.isLocalAddress()` in `clients/shared/Utilities/LocalAddressValidator.swift`.
 
 ## Data Storage
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -4,7 +4,7 @@ A native macOS menu bar app that controls your Mac via accessibility APIs and CG
 
 ## iOS Target
 
-This repository also includes an iOS app target (`vellum-assistant-ios`) that shares ~45-50% of code with the macOS app through the `VellumAssistantShared` library. The iOS app is a chat-focused client that connects to a network-accessible daemon via TCP.
+This repository also includes an iOS app target (`vellum-assistant-ios`) that shares ~45-50% of code with the macOS app through the `VellumAssistantShared` library. The iOS app is a chat-focused client that connects to the daemon through an HTTP gateway with bearer token authentication.
 
 **Status:** Fully functional. Build via Xcode (recommended) or `xcodebuild` from the command line — `swift build` on macOS cannot compile the iOS target due to UIKit dependencies. See [clients/ios/README.md](../ios/README.md) for build instructions.
 
@@ -52,7 +52,7 @@ Requires either:
 
 Requires Apple Developer account + App Store Connect setup. Deferred to PR 12-13 (deployment).
 
-**Daemon Connection Note:** The iOS app connects to the daemon via TCP (default: localhost:8765). For Simulator testing, the daemon should run on your Mac. For device testing, configure the daemon hostname to your Mac's IP address in Settings.
+**Daemon Connection Note:** The iOS app connects to the daemon through the HTTP gateway. Pair via QR code (Settings → Connect → Show QR Code on Mac, Scan QR Code on iPhone) or enter the gateway URL and bearer token manually in the iOS app's Settings → Connect → Manual Setup.
 
 ## Download
 


### PR DESCRIPTION
## Summary
Updates all three client documentation files to reflect the current iOS connection flow, which has shifted from direct TCP (hostname:port + session-token) to HTTP gateway (QR code or manual URL + bearer token).

### iOS README (`clients/ios/README.md`)
- **Connected to Mac Mode**: Replaced TCP setup instructions (hostname, port, session-token, `VELLUM_DAEMON_TCP_ENABLED`) with QR code pairing and manual gateway URL + bearer token entry
- **Configuration Reference**: Updated table to show current UserDefaults keys (`gateway_base_url`, `conversation_key`) and Keychain provider (`runtime-bearer-token`)
- **Troubleshooting**: Updated for gateway-based error scenarios (unreachable gateway, HTTPS requirement, bearer token issues)

### macOS README (`clients/macos/README.md`)
- **iOS Target**: Changed "connects via TCP" to "connects through an HTTP gateway with bearer token authentication"
- **Daemon Connection Note**: Replaced TCP localhost:8765 instructions with QR code and manual setup paths

### macOS CLAUDE.md (`clients/macos/CLAUDE.md`)
- Expanded "Developer Local Pairing" into a broader **"iOS Pairing"** section documenting:
  - Connect tab layout (Pairing hero → Gateway → Advanced → Diagnostics → Channels)
  - QR v3 payload format
  - Bearer token generation/regeneration
  - Developer Local Pairing as a subsection (no longer a top-level section)
  - Clarification that iOS no longer has a separate developer local pairing toggle — it uses `allowLocalHttp` from the QR payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
