### PR TITLE
fix: show parameter names in tool call technical details

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -98,7 +98,7 @@ extension ChatViewModel {
     }
 
     /// Format all tool input arguments for display in expanded details.
-    /// The primary value comes first, then remaining keys as `key: value` lines.
+    /// Primary key is listed first, then remaining keys alphabetically. All as `key: value`.
     /// Sensitive keys (passwords, tokens, etc.) are redacted to prevent credential exposure.
     func formatAllToolInput(_ input: [String: AnyCodable]) -> String {
         guard !input.isEmpty else { return "" }
@@ -107,22 +107,16 @@ extension ChatViewModel {
         let primaryKey = Self.toolInputPriorityKeys.first(where: { input[$0] != nil })
             ?? input.keys.sorted().first
 
-        var lines: [String] = []
-
-        // Primary value first (undecorated)
-        if let key = primaryKey, let value = input[key] {
-            if Self.isSensitiveKey(key) {
-                lines.append("[redacted]")
-            } else {
-                lines.append(redactingStringifyValue(value))
-            }
+        // All keys as "key: value", primary key first then rest alphabetically
+        let orderedKeys: [String]
+        if let pk = primaryKey {
+            orderedKeys = [pk] + input.keys.filter { $0 != pk }.sorted()
+        } else {
+            orderedKeys = input.keys.sorted()
         }
 
-        // Remaining keys sorted alphabetically, redacting sensitive values
-        let otherKeys = input.keys
-            .filter { $0 != primaryKey }
-            .sorted()
-        for key in otherKeys {
+        var lines: [String] = []
+        for key in orderedKeys {
             guard let value = input[key] else { continue }
             if Self.isSensitiveKey(key) {
                 lines.append("\(key): [redacted]")


### PR DESCRIPTION
## Summary

- Show all tool input parameters as `key: value` pairs in the Technical Details section, including the primary parameter which was previously shown as a bare value without its name
- Before: showed `Schedule List` then `true` (unclear what `true` means)
- After: shows `name: Schedule List` then `include_completed: true`

## Original prompt
I don't know what the `true` under Schedule List corresponds to here. The arguments should have names associated with them instead of just having the raw values there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
