### PR TITLE
fix: make entire DisclosureGroup labels clickable in Connect tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -178,6 +178,9 @@ struct SettingsConnectTab: View {
                             .truncationMode(.middle)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture { withAnimation(VAnimation.standard) { gatewayExpanded.toggle() } }
             }
         }
         .padding(VSpacing.lg)
@@ -304,6 +307,9 @@ struct SettingsConnectTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture { withAnimation(VAnimation.standard) { advancedExpanded.toggle() } }
             }
         }
         .padding(VSpacing.lg)
@@ -958,7 +964,7 @@ struct SettingsConnectTab: View {
 
     private var diagnosticsSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            DisclosureGroup("Diagnostics", isExpanded: $diagnosticsExpanded) {
+            DisclosureGroup(isExpanded: $diagnosticsExpanded) {
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     statusContent
 
@@ -967,9 +973,14 @@ struct SettingsConnectTab: View {
                     testConnectionContent
                 }
                 .padding(.top, VSpacing.sm)
+            } label: {
+                Text("Diagnostics")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture { withAnimation(VAnimation.standard) { diagnosticsExpanded.toggle() } }
             }
-            .font(VFont.sectionTitle)
-            .foregroundColor(VColor.textPrimary)
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
Makes the entire label area of the Gateway, Advanced, and Diagnostics DisclosureGroups clickable — not just the small chevron. Users can now click anywhere on the section header (title, subtitle, or empty space) to expand/collapse.

## Implementation
Each DisclosureGroup label gets:
- `.frame(maxWidth: .infinity, alignment: .leading)` — extends the hit area to the full card width
- `.contentShape(Rectangle())` — makes the entire frame tappable (not just the text)
- `.onTapGesture { withAnimation(VAnimation.standard) { *Expanded.toggle() } }` — toggles the section with the standard animation

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Updated Gateway, Advanced, and Diagnostics DisclosureGroup labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
