### PR TITLE
fix: bump bun 1.3.8 → 1.3.9 in CI and fix runtime-proxy test

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -636,7 +636,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -664,7 +664,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -686,7 +686,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -90,18 +90,8 @@ describe("runtime proxy handler", () => {
     let capturedBody = "";
     globalThis.fetch = mock(async (_input: any, init?: any) => {
       if (init?.body) {
-        const reader = init.body.getReader();
-        const chunks: Uint8Array[] = [];
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          chunks.push(value);
-        }
-        capturedBody = new TextDecoder().decode(
-          new Uint8Array(chunks.reduce((acc, c) => acc + c.length, 0)),
-        );
-        // Simpler: just read as text
-        capturedBody = Buffer.concat(chunks).toString();
+        // Body is an ArrayBuffer after buffering in the proxy handler
+        capturedBody = new TextDecoder().decode(init.body);
       }
       return new Response("ok", { status: 200 });
     }) as any;


### PR DESCRIPTION
## Summary
- Bump bun from 1.3.8 to 1.3.9 in all CI workflows — bun 1.3.8 has a bug where reassigning `globalThis.fetch` doesn't propagate to bare `fetch()` calls in module code, causing 25+ gateway test failures in CI
- Update runtime-proxy test to handle ArrayBuffer body instead of ReadableStream, matching the source change that buffers request bodies
- Fix applies to ci-assistant.yml, ci-cli.yml, ci-gateway.yml, and release.yml

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22335123428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
