### PR TITLE
fix: remove onTapGesture from DisclosureGroup labels to prevent double-toggle

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -75,7 +75,7 @@ cd clients/ios
 
 ### Connected to Mac Mode
 
-Requires the Vellum daemon running on your Mac (via the macOS desktop app or `bun run src/index.ts daemon start`). The iOS app connects to the daemon through an HTTP gateway using a bearer token for authentication.
+Requires the Vellum daemon running on your Mac (via the macOS desktop app or `cd assistant && bun run src/index.ts daemon start` from the repo root). The iOS app connects to the daemon through an HTTP gateway using a bearer token for authentication.
 
 **QR Code Pairing (recommended):**
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -180,7 +180,6 @@ struct SettingsConnectTab: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
-                .onTapGesture { withAnimation(VAnimation.standard) { gatewayExpanded.toggle() } }
             }
         }
         .padding(VSpacing.lg)
@@ -309,7 +308,6 @@ struct SettingsConnectTab: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
-                .onTapGesture { withAnimation(VAnimation.standard) { advancedExpanded.toggle() } }
             }
         }
         .padding(VSpacing.lg)
@@ -979,7 +977,6 @@ struct SettingsConnectTab: View {
                     .foregroundColor(VColor.textPrimary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
-                    .onTapGesture { withAnimation(VAnimation.standard) { diagnosticsExpanded.toggle() } }
             }
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
Addresses reviewer feedback from [#7527](https://github.com/vellum-ai/vellum-assistant/pull/7527) (Devin) and [#7523](https://github.com/vellum-ai/vellum-assistant/pull/7523) (Codex).

### DisclosureGroup double-toggle fix (#7527)
On macOS, `DisclosureGroup` has a built-in tap handler on the label that toggles `isExpanded`. Adding `.onTapGesture` to the label causes both handlers to fire — toggling the binding twice (net no-op). Fix: remove `.onTapGesture` from all three section labels (Gateway, Advanced, Diagnostics) while keeping `.frame(maxWidth: .infinity)` + `.contentShape(Rectangle())` to extend the built-in hit area to the full card width.

### iOS README daemon command (#7523)
Added `cd assistant &&` before `bun run src/index.ts daemon start` so developers know which directory to be in.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` — Remove `.onTapGesture` from 3 DisclosureGroup labels
- `clients/ios/README.md` — Add directory context to daemon start command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
