### PR TITLE
feat: cross-channel guardian answer resolution

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -18,6 +18,8 @@ import {
 } from '../memory/guardian-action-store.js';
 import { deliverChannelReply } from '../runtime/gateway-client.js';
 import { getUserConsultationTimeoutMs } from './call-constants.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import { addMessage } from '../memory/conversation-store.js';
 import type { CallPendingQuestion } from './types.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
 
@@ -106,27 +108,43 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
-      const delivery = createGuardianActionDelivery({
-        requestId: request.id,
-        destinationChannel: dest.channel,
-        destinationChatId: dest.chatId,
-        destinationExternalUserId: dest.externalUserId,
-      });
-
       if (dest.channel === 'mac') {
-        // Emit IPC event for the mac client
+        // Create a dedicated server-side conversation for the mac guardian thread
+        const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
+        const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
+
+        const delivery = createGuardianActionDelivery({
+          requestId: request.id,
+          destinationChannel: 'mac',
+          destinationConversationId: macConversationId,
+        });
+
+        // Add the guardian question as the initial message in the thread
+        addMessage(
+          macConversationId,
+          'assistant',
+          JSON.stringify(`Your assistant needs your input during a phone call.\n\nQuestion: ${request.questionText}\n\nReply to this message with your answer.`),
+        );
+
+        // Emit IPC event for the mac client with the server-created conversation
         if (broadcast) {
           broadcast({
             type: 'guardian_request_thread_created',
-            conversationId,
+            conversationId: macConversationId,
             requestId: request.id,
             callSessionId,
             title: `Guardian question: ${pendingQuestion.questionText.slice(0, 80)}`,
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');
-        log.info({ deliveryId: delivery.id, channel: 'mac' }, 'Mac guardian delivery emitted');
+        log.info({ deliveryId: delivery.id, channel: 'mac', macConversationId }, 'Mac guardian delivery emitted');
       } else {
+        const delivery = createGuardianActionDelivery({
+          requestId: request.id,
+          destinationChannel: dest.channel,
+          destinationChatId: dest.chatId,
+          destinationExternalUserId: dest.externalUserId,
+        });
         // External channel — POST to gateway
         void deliverToExternalChannel(delivery.id, dest.channel, dest.chatId!, request.questionText, request.requestCode, assistantId);
       }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -14,6 +14,12 @@ import type { QueueDrainReason } from './session-queue-manager.js';
 import type { TraceEmitter } from './trace-emitter.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import {
+  getPendingDeliveryByConversation,
+  getGuardianActionRequest,
+  resolveGuardianActionRequest,
+} from '../memory/guardian-action-store.js';
+import { answerCall } from '../calls/call-domain.js';
 import { resolveSlash, type SlashContext } from './session-slash.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
@@ -222,6 +228,47 @@ export async function processMessage(
 ): Promise<string> {
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
+
+  // ── Guardian action answer interception (mac channel) ──
+  // If this conversation has a pending guardian action delivery, treat the
+  // user message as the guardian's answer instead of running the agent loop.
+  const guardianDelivery = getPendingDeliveryByConversation(session.conversationId);
+  if (guardianDelivery) {
+    const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
+    if (guardianRequest && guardianRequest.status === 'pending') {
+      const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'mac');
+      const userMsg = createUserMessage(content, attachments);
+      const persisted = conversationStore.addMessage(
+        session.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+      );
+      session.messages.push(userMsg);
+
+      if (resolved) {
+        void answerCall({ callSessionId: guardianRequest.callSessionId, answer: content });
+        const confirmMsg = createAssistantMessage('Your answer has been relayed to the call.');
+        conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(confirmMsg.content),
+        );
+        session.messages.push(confirmMsg);
+        onEvent({ type: 'assistant_text_delta', text: 'Your answer has been relayed to the call.' });
+      } else {
+        const staleMsg = createAssistantMessage('This question has already been answered from another channel.');
+        conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(staleMsg.content),
+        );
+        session.messages.push(staleMsg);
+        onEvent({ type: 'assistant_text_delta', text: 'This question has already been answered from another channel.' });
+      }
+      onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      return persisted.id;
+    }
+  }
 
   // Resolve slash commands before persistence
   const slashResult = resolveSlash(content, buildSlashContext(session));

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -338,6 +338,29 @@ export function getPendingDeliveriesByDestination(
   return rows.map((r) => rowToDelivery(r.delivery));
 }
 
+/**
+ * Look up a pending delivery by destination conversation ID (for mac channel routing).
+ */
+export function getPendingDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  const db = getDb();
+  const rows = db
+    .select({ delivery: guardianActionDeliveries })
+    .from(guardianActionDeliveries)
+    .innerJoin(
+      guardianActionRequests,
+      eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+    )
+    .where(
+      and(
+        eq(guardianActionDeliveries.destinationConversationId, conversationId),
+        eq(guardianActionDeliveries.status, 'sent'),
+        eq(guardianActionRequests.status, 'pending'),
+      ),
+    )
+    .all();
+  return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+}
+
 export function updateDeliveryStatus(
   deliveryId: string,
   status: GuardianActionDeliveryStatus,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -19,6 +19,12 @@ import {
   validateAndConsumeChallenge,
 } from '../channel-guardian-service.js';
 import {
+  getPendingDeliveriesByDestination,
+  getGuardianActionRequest,
+  resolveGuardianActionRequest,
+} from '../../memory/guardian-action-store.js';
+import { answerCall } from '../../calls/call-domain.js';
+import {
   createApprovalRequest,
   getPendingApprovalByGuardianChat,
   getPendingApprovalByRunAndGuardianChat,
@@ -550,6 +556,107 @@ export async function handleChannelInbound(
         eventId: result.eventId,
         guardianVerification: verifyResult.success ? 'verified' : 'failed',
       });
+    }
+  }
+
+  // ── Guardian action answer interception ──
+  // Check if this inbound message is a reply to a cross-channel guardian
+  // action request (from a voice call). Must run before approval interception
+  // so guardian answers are not mistakenly routed into the approval flow.
+  if (
+    !result.duplicate &&
+    trimmedContent.length > 0 &&
+    body.senderExternalUserId &&
+    replyCallbackUrl
+  ) {
+    const pendingDeliveries = getPendingDeliveriesByDestination(assistantId, sourceChannel, externalChatId);
+    if (pendingDeliveries.length > 0) {
+      // Identity check: only the designated guardian can answer
+      const validDeliveries = pendingDeliveries.filter(
+        (d) => d.destinationExternalUserId === body.senderExternalUserId,
+      );
+
+      if (validDeliveries.length > 0) {
+        let matchedDelivery = validDeliveries.length === 1 ? validDeliveries[0] : null;
+        let answerText = trimmedContent;
+
+        // Multiple pending deliveries: require request code prefix for disambiguation
+        if (validDeliveries.length > 1) {
+          for (const d of validDeliveries) {
+            const req = getGuardianActionRequest(d.requestId);
+            if (req && trimmedContent.toUpperCase().startsWith(req.requestCode)) {
+              matchedDelivery = d;
+              answerText = trimmedContent.slice(req.requestCode.length).trim();
+              break;
+            }
+          }
+
+          if (!matchedDelivery) {
+            // Send disambiguation message listing the request codes
+            const codes = validDeliveries
+              .map((d) => {
+                const req = getGuardianActionRequest(d.requestId);
+                return req ? req.requestCode : null;
+              })
+              .filter(Boolean);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: `You have multiple pending guardian questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are answering.`,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian action disambiguation message');
+            }
+            return Response.json({
+              accepted: true,
+              duplicate: false,
+              eventId: result.eventId,
+              guardianAnswer: 'disambiguation_sent',
+            });
+          }
+        }
+
+        if (matchedDelivery) {
+          const request = getGuardianActionRequest(matchedDelivery.requestId);
+          if (request) {
+            const resolved = resolveGuardianActionRequest(
+              request.id,
+              answerText,
+              sourceChannel,
+              body.senderExternalUserId,
+            );
+
+            if (resolved) {
+              // Route the answer to the voice call
+              void answerCall({ callSessionId: request.callSessionId, answer: answerText });
+              return Response.json({
+                accepted: true,
+                duplicate: false,
+                eventId: result.eventId,
+                guardianAnswer: 'resolved',
+              });
+            } else {
+              // Already answered from another channel
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: 'This question has already been answered from another channel.',
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver guardian action stale notice');
+              }
+              return Response.json({
+                accepted: true,
+                duplicate: false,
+                eventId: result.eventId,
+                guardianAnswer: 'stale',
+              });
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Intercept guardian action replies on telegram/sms channels early in `handleChannelInbound()` (after verification but before approval), with identity verification, single/multi-delivery disambiguation via request codes, and first-writer-wins resolution via `resolveGuardianActionRequest`
- Intercept guardian replies on the mac channel in `session-process.ts` `processMessage()` before the agent loop, routing the user message as a guardian answer and skipping normal processing
- Fix mac guardian dispatch to create conversations server-side with `getOrCreateConversation()` and seed them with the question text, passing the server-created `conversationId` in both the delivery row and the IPC event
- Add `getPendingDeliveryByConversation()` store function for mac channel routing lookups

## Test plan
- [ ] Send a guardian action request from a voice call; reply on telegram and verify the answer resolves the call
- [ ] Send a guardian action request; reply on SMS and verify resolution
- [ ] Reply to a mac guardian thread and verify the answer is routed to the call
- [ ] Answer from one channel, then try answering from another; verify stale notice is sent
- [ ] When multiple guardian questions are pending on the same channel, verify disambiguation message asks for request code prefix
- [ ] Verify non-guardian users cannot answer (identity check skips non-matching senders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
