### PR TITLE
feat: guardian action expiry sweep, voice thread visibility, and settings

### DIFF
--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -1,0 +1,104 @@
+/**
+ * Periodic sweep for expired guardian action requests.
+ *
+ * Runs on a 60-second interval. When a request has passed its expiresAt
+ * timestamp:
+ * 1. Expires the request and all its deliveries in the store
+ * 2. Expires the associated pending question so the call-side timeout fires
+ * 3. Sends expiry notices to external delivery destinations (telegram, sms)
+ * 4. Adds an expiry message to mac guardian thread conversations
+ */
+
+import { getLogger } from '../util/logger.js';
+import {
+  getExpiredGuardianActionRequests,
+  expireGuardianActionRequest,
+  getDeliveriesByRequestId,
+} from '../memory/guardian-action-store.js';
+import { expirePendingQuestions } from './call-store.js';
+import { deliverChannelReply } from '../runtime/gateway-client.js';
+import { addMessage } from '../memory/conversation-store.js';
+
+const log = getLogger('guardian-action-sweep');
+
+const SWEEP_INTERVAL_MS = 60_000;
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Sweep expired guardian action requests and clean up.
+ */
+export function sweepExpiredGuardianActions(
+  gatewayBaseUrl: string,
+  bearerToken?: string,
+): void {
+  const expired = getExpiredGuardianActionRequests();
+
+  for (const request of expired) {
+    // Capture deliveries before expiring (since expiry changes their status)
+    const deliveries = getDeliveriesByRequestId(request.id);
+
+    // Expire the request and all deliveries
+    expireGuardianActionRequest(request.id);
+
+    // Expire associated pending questions
+    expirePendingQuestions(request.callSessionId);
+
+    log.info(
+      { requestId: request.id, callSessionId: request.callSessionId },
+      'Expired guardian action request',
+    );
+
+    // Send expiry notices to each delivery destination
+    for (const delivery of deliveries) {
+      if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
+
+      if (delivery.destinationChannel === 'mac' && delivery.destinationConversationId) {
+        // Add expiry message to mac guardian thread
+        addMessage(
+          delivery.destinationConversationId,
+          'assistant',
+          JSON.stringify('This guardian question has expired without a response.'),
+        );
+      } else if (delivery.destinationChatId) {
+        // External channel — send expiry notice
+        const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
+        void (async () => {
+          try {
+            await deliverChannelReply(deliverUrl, {
+              chatId: delivery.destinationChatId!,
+              text: 'The guardian question has expired without a response. The call has moved on.',
+              assistantId: request.assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error(
+              { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
+              'Failed to deliver guardian action expiry notice',
+            );
+          }
+        })();
+      }
+    }
+  }
+}
+
+export function startGuardianActionSweep(
+  gatewayBaseUrl: string,
+  bearerToken?: string,
+): void {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => {
+    try {
+      sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken);
+    } catch (err) {
+      log.error({ err }, 'Guardian action sweep failed');
+    }
+  }, SWEEP_INTERVAL_MS);
+}
+
+export function stopGuardianActionSweep(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -7,7 +7,7 @@
  * answer resolves the request and all other deliveries are marked answered.
  */
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import {
@@ -239,6 +239,38 @@ export function expireGuardianActionRequest(id: string): void {
       ),
     )
     .run();
+}
+
+/**
+ * Get all pending guardian action requests that have expired.
+ */
+export function getExpiredGuardianActionRequests(): GuardianActionRequest[] {
+  const db = getDb();
+  const now = Date.now();
+  return db
+    .select()
+    .from(guardianActionRequests)
+    .where(
+      and(
+        eq(guardianActionRequests.status, 'pending'),
+        lt(guardianActionRequests.expiresAt, now),
+      ),
+    )
+    .all()
+    .map(rowToRequest);
+}
+
+/**
+ * Get all deliveries for a specific request.
+ */
+export function getDeliveriesByRequestId(requestId: string): GuardianActionDelivery[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(guardianActionDeliveries)
+    .where(eq(guardianActionDeliveries.requestId, requestId))
+    .all()
+    .map(rowToDelivery);
 }
 
 /**

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -44,6 +44,10 @@ import {
   startGuardianExpirySweep,
   stopGuardianExpirySweep,
 } from './routes/channel-routes.js';
+import {
+  startGuardianActionSweep,
+  stopGuardianActionSweep,
+} from '../calls/guardian-action-sweep.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as externalConversationStore from '../memory/external-conversation-store.js';
@@ -453,6 +457,10 @@ export class RuntimeHttpServer {
       log.info('Guardian approval expiry sweep started');
     }
 
+    // Start guardian action request expiry sweep (cross-channel voice guardian)
+    startGuardianActionSweep(getGatewayBaseUrl(), this.bearerToken);
+    log.info('Guardian action expiry sweep started');
+
     // Startup guard: log gateway-only mode warnings
     log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');
     if (!isLoopbackHost(this.hostname)) {
@@ -464,6 +472,7 @@ export class RuntimeHttpServer {
 
   async stop(): Promise<void> {
     stopGuardianExpirySweep();
+    stopGuardianActionSweep();
     if (this.retrySweepTimer) {
       clearInterval(this.retrySweepTimer);
       this.retrySweepTimer = null;

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -327,7 +327,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         serverOffset += response.sessions.count
 
         let recentSessions = response.sessions.filter {
-            $0.threadType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.threadType != "private" && ($0.channelBinding?.sourceChannel == nil || $0.channelBinding?.sourceChannel == "voice")
         }
 
         for session in recentSessions {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -119,7 +119,7 @@ final class ThreadSessionRestorer {
         // (e.g. Telegram). External channel-bound sessions belong to their own
         // lane and should not appear in the desktop conversation list.
         let recentSessions = response.sessions.filter {
-            $0.threadType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.threadType != "private" && ($0.channelBinding?.sourceChannel == nil || $0.channelBinding?.sourceChannel == "voice")
         }
 
         let defaultThreadIsEmpty = delegate.threads.count == 1

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -272,13 +272,14 @@ struct SettingsConnectTab: View {
                 Text("Channels")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
-                Text("Telegram and SMS integrations")
+                Text("Telegram, SMS, and Voice integrations")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
             }
 
             telegramCard
             twilioCard
+            voiceCard
         }
     }
 
@@ -489,6 +490,66 @@ struct SettingsConnectTab: View {
             if store.twilioHasCredentials {
                 Divider().background(VColor.surfaceBorder)
                 guardianStatusRow(channel: "sms")
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Voice (Phone Calls) Card
+
+    private var voiceCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "phone.fill")
+                        .foregroundColor(VColor.textPrimary)
+                        .font(.system(size: 12))
+                    Text("Voice (Phone Calls)")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+                }
+                Text("Receive and make phone calls via Twilio")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            if store.twilioHasCredentials && store.twilioPhoneNumber != nil {
+                channelStatusRow(
+                    label: "Status",
+                    icon: "checkmark.circle.fill",
+                    iconColor: VColor.success,
+                    value: "Voice calls ready"
+                )
+                channelStatusRow(
+                    label: "Number",
+                    icon: "phone.fill",
+                    iconColor: VColor.success,
+                    value: store.twilioPhoneNumber ?? "",
+                    valueFont: VFont.mono
+                )
+            } else if store.twilioHasCredentials {
+                channelStatusRow(
+                    label: "Credentials",
+                    icon: "checkmark.circle.fill",
+                    iconColor: VColor.success,
+                    value: "Configured"
+                )
+                channelStatusRow(
+                    label: "Number",
+                    icon: "exclamationmark.triangle",
+                    iconColor: VColor.warning,
+                    value: "Assign a phone number in SMS settings above",
+                    valueColor: VColor.textMuted
+                )
+            } else {
+                channelStatusRow(
+                    label: "Status",
+                    icon: "exclamationmark.triangle",
+                    iconColor: VColor.warning,
+                    value: "Configure Twilio credentials in SMS settings above",
+                    valueColor: VColor.textMuted
+                )
             }
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- **Guardian action expiry sweep**: Adds a periodic 60-second sweep that detects expired cross-channel guardian action requests. Expired requests have their deliveries marked expired, pending questions expired, and expiry notices sent to external channels (Telegram, SMS) and mac guardian threads.
- **Voice thread visibility**: Updates the session filter in `ThreadSessionRestorer` and `ThreadManager` to allow voice-channel threads (`sourceChannel == "voice"`) to appear in the desktop conversation list alongside standard threads.
- **Voice settings card**: Adds a "Voice (Phone Calls)" card to the Settings Connect tab showing Twilio credential and phone number readiness status for voice calls.

## Changes
- `assistant/src/memory/guardian-action-store.ts` — Added `getExpiredGuardianActionRequests()` and `getDeliveriesByRequestId()` query functions; imported `lt` from drizzle-orm
- `assistant/src/calls/guardian-action-sweep.ts` — New file implementing the sweep timer with `startGuardianActionSweep()` / `stopGuardianActionSweep()`
- `assistant/src/runtime/http-server.ts` — Wired up sweep start/stop alongside existing guardian expiry sweep
- `clients/macos/.../ThreadSessionRestorer.swift` — Updated filter to pass through voice channel sessions
- `clients/macos/.../ThreadManager.swift` — Updated filter to pass through voice channel sessions (pagination path)
- `clients/macos/.../SettingsConnectTab.swift` — Added voice card with readiness indicators

## Test plan
- [ ] Verify guardian action requests expire correctly after their `expiresAt` timestamp
- [ ] Verify expiry notices are sent to Telegram/SMS delivery destinations
- [ ] Verify voice call threads appear in the desktop thread list
- [ ] Verify Voice card shows correct status based on Twilio credential/number state

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
