### PR TITLE
fix: add missing schedule_run_now to IPC snapshot test

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -374,6 +374,13 @@ exports[`IPC message snapshots ClientMessage types schedule_remove serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types schedule_run_now serializes to expected JSON 1`] = `
+{
+  "id": "sched-001",
+  "type": "schedule_run_now",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types reminders_list serializes to expected JSON 1`] = `
 {
   "type": "reminders_list",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -248,6 +248,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'schedule_remove',
     id: 'sched-001',
   },
+  schedule_run_now: {
+    type: 'schedule_run_now',
+    id: 'sched-001',
+  },
   reminders_list: {
     type: 'reminders_list',
   },


### PR DESCRIPTION
## Summary
- Add `schedule_run_now` client message to the IPC snapshot test fixture, fixing the type check failure caused by the missing entry after the Run Now feature was added in #7532

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22335648162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
