### PR TITLE
fix: suppress NSParagraphStyle Sendable warnings in MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -178,12 +178,12 @@ struct MarkdownSegmentView: View {
                     var prefixAttr = AttributedString(prefix)
                     prefixAttr.foregroundColor = secondaryTextColor
                     prefixAttr.font = .system(size: 13)
-                    prefixAttr.paragraphStyle = paraStyle
+                    prefixAttr.applyParagraphStyle(paraStyle)
                     result += prefixAttr
 
                     var itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
                         ?? AttributedString(item.text)
-                    itemAttr.paragraphStyle = paraStyle
+                    itemAttr.applyParagraphStyle(paraStyle)
                     result += itemAttr
                 }
 
@@ -193,5 +193,17 @@ struct MarkdownSegmentView: View {
         }
 
         return result
+    }
+}
+
+// MARK: - NSParagraphStyle Sendable workaround
+
+private extension AttributedString {
+    /// Applies a paragraph style via NSMutableAttributedString to avoid the
+    /// compiler warning about NSParagraphStyle's revoked Sendable conformance.
+    mutating func applyParagraphStyle(_ style: NSParagraphStyle) {
+        let ns = NSMutableAttributedString(self)
+        ns.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: ns.length))
+        self = AttributedString(ns)
     }
 }


### PR DESCRIPTION
## Summary
- Replace direct `AttributedString.paragraphStyle` assignments with a helper that applies the style via `NSMutableAttributedString`, avoiding the compiler warning about NSParagraphStyle's revoked Sendable conformance

## Original prompt
fix: NSParagraphStyle Sendable warnings in MarkdownSegmentView.swift (lines 181, 186)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
