### PR TITLE
Improve Telegram /start UX with immediate acknowledgement

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -186,7 +186,7 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
 });
 
 describe("telegram webhook handler: /new rejection", () => {
-  test("/start forwards command intent metadata and does not reset conversation", async () => {
+  test("/start forwards command intent metadata, does not reset conversation, and sends start acknowledgement", async () => {
     const config = makeConfig({
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
@@ -212,7 +212,8 @@ describe("telegram webhook handler: /new rejection", () => {
     expect(resetCall).toBeUndefined();
 
     const sendMessageCall = fetchCalls.find((c) => c.url.includes("/sendMessage"));
-    expect(sendMessageCall).toBeUndefined();
+    expect(sendMessageCall).toBeDefined();
+    expect((sendMessageCall!.body as any).text).toContain("Starting up");
   });
 
   test("/start with routing rejection sends setup notice and does not forward", async () => {

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -224,9 +224,10 @@ describe("telegram-webhook callback query acknowledgment", () => {
     expect(answerCalls[0][2]).toEqual({
       callback_query_id: "cbq-42",
     });
+    expect(sendTelegramReplyMock).not.toHaveBeenCalled();
   });
 
-  it("forwards /start as channel command-intent metadata", async () => {
+  it("forwards /start as channel command-intent metadata and sends start acknowledgement", async () => {
     const handler = createTelegramWebhookHandler(baseConfig);
     const body = JSON.stringify({
       update_id: 314,
@@ -250,6 +251,10 @@ describe("telegram-webhook callback query acknowledgment", () => {
       type: "start",
       payload: "ref-123",
     });
+    expect(sendTelegramReplyMock).toHaveBeenCalledTimes(1);
+    const sendArgs = sendTelegramReplyMock.mock.calls[0] as unknown as [GatewayConfig, string, string];
+    expect(sendArgs[1]).toBe("42");
+    expect(sendArgs[2]).toContain("Starting up");
   });
 
   it("does not call answerCallbackQuery for regular text messages", async () => {

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -46,6 +46,7 @@ const MAX_REJECTION_CACHE_SIZE = 10_000;
 const SWEEP_INTERVAL = 100; // sweep every N calls
 const rejectionNoticeTimestamps = new Map<string, number>();
 let rejectionCallCount = 0;
+const START_COMMAND_ACK_TEXT = "Starting up... you'll get my first message in a moment.";
 
 /**
  * Evict expired entries from the rejection notice cache. If the map still
@@ -297,6 +298,16 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
 
       // Forward to runtime with command-intent metadata so the assistant
       // generates a natural greeting via the normal agent loop.
+      if (!normalized.message.callbackQueryId) {
+        sendTelegramReply(
+          config,
+          normalized.message.externalChatId,
+          START_COMMAND_ACK_TEXT,
+        ).catch((err) => {
+          tlog.error({ err, chatId: normalized.message.externalChatId }, "Failed to send /start acknowledgement");
+        });
+      }
+
       try {
         const result = await handleInbound(config, normalized, {
           transportMetadata: buildTelegramTransportMetadata(),


### PR DESCRIPTION
## Summary
- send an immediate Telegram message when `/start` is received so users get visible feedback right away
- keep `/start` forwarding through the existing runtime command-intent path so the daemon still generates the actual welcome
- update webhook tests to assert the new acknowledgement behavior and preserve callback-query behavior

## Testing
- cd gateway && bun test src/__tests__/telegram-webhook-handler.test.ts src/http/routes/telegram-webhook.test.ts
- cd gateway && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
