### PR TITLE
fix: update ChatViewModelTests for connection error UX changes

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -409,10 +409,10 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSending, "Disconnected send should not set isSending")
         XCTAssertFalse(viewModel.isThinking, "Disconnected send should not set isThinking")
 
-        // Error should mention the daemon
+        // Error should mention the assistant
         XCTAssertNotNil(viewModel.errorText)
-        XCTAssertTrue(viewModel.errorText?.contains("daemon") == true,
-                       "Disconnected error should mention daemon")
+        XCTAssertTrue(viewModel.errorText?.contains("assistant") == true,
+                       "Disconnected error should mention assistant")
     }
 
     func testRegenerateWhenDisconnectedShowsError() {
@@ -422,7 +422,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.regenerateLastMessage()
 
         XCTAssertNotNil(viewModel.errorText, "Regenerate when disconnected should show error")
-        XCTAssertTrue(viewModel.errorText?.contains("daemon") == true)
+        XCTAssertTrue(viewModel.errorText?.contains("assistant") == true)
         XCTAssertFalse(viewModel.isSending, "Regenerate should not set isSending when disconnected")
         XCTAssertFalse(viewModel.isThinking)
     }
@@ -1125,7 +1125,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // Error text should be surfaced
         XCTAssertNotNil(viewModel.errorText)
-        XCTAssertTrue(viewModel.errorText?.contains("daemon") == true)
+        XCTAssertTrue(viewModel.errorText?.contains("assistant") == true)
     }
 
     // MARK: - Full Conversation Flow
@@ -1807,16 +1807,20 @@ final class ChatViewModelTests: XCTestCase {
         // a prior send failure.
         viewModel.sessionId = "sess-1"
 
-        // Simulate a prior send failure that cached the message
+        // Simulate a prior connection-error send failure that cached the message.
+        // Connection errors show the Doctor button (isConnectionError), not Retry.
         viewModel.inputText = "Hello"
         daemonClient.isConnected = false
         viewModel.sendMessage()
-        XCTAssertTrue(viewModel.isRetryableError,
-                       "Send failure should make error retryable")
+        XCTAssertTrue(viewModel.isConnectionError,
+                       "Send failure while disconnected should be a connection error")
+        XCTAssertFalse(viewModel.isRetryableError,
+                        "Connection errors show Doctor button, not Retry")
 
         // User dismisses the error
         viewModel.dismissError()
         XCTAssertFalse(viewModel.isRetryableError)
+        XCTAssertFalse(viewModel.isConnectionError)
 
         // Now a non-send error occurs (e.g. confirmation response failure)
         daemonClient.isConnected = true
@@ -1832,9 +1836,12 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.inputText = "Test message"
         viewModel.sendMessage()
 
-        // Send failure should set both lastFailedSendError and lastFailedMessageText
-        XCTAssertTrue(viewModel.isRetryableError,
-                       "Send failure should show retry button")
+        // Connection-error sends show Doctor button (isConnectionError),
+        // not the Retry button (isRetryableError).
+        XCTAssertTrue(viewModel.isConnectionError,
+                       "Send failure while disconnected should show Doctor button")
+        XCTAssertFalse(viewModel.isRetryableError,
+                        "Connection errors should not show Retry button")
         XCTAssertNotNil(viewModel.errorText)
     }
 
@@ -1845,7 +1852,7 @@ final class ChatViewModelTests: XCTestCase {
         // First, simulate a send failure to cache a message
         viewModel.inputText = "Hello"
         viewModel.sendMessage()
-        XCTAssertTrue(viewModel.isRetryableError)
+        XCTAssertTrue(viewModel.isConnectionError)
 
         // Now dismiss and reconnect
         viewModel.dismissError()


### PR DESCRIPTION
## Summary
- Update 6 failing tests in `ChatViewModelTests` to match the error message and retry behavior changes from #6157
- Replace `errorText?.contains("daemon")` assertions with `contains("assistant")` (3 tests)
- Replace `isRetryableError == true` assertions with `isConnectionError == true` for disconnected sends (3 tests), since connection errors now show the Doctor button instead of Retry

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22335648166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
