### PR TITLE
fix: use globalThis.fetch in gateway source for bun mock compatibility

### DIFF
--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -129,7 +129,7 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     let response: Response;
     try {
-      response = await fetch(upstream, {
+      response = await globalThis.fetch(upstream, {
         method: req.method,
         headers: reqHeaders,
         body: bodyBuffer,

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -30,7 +30,7 @@ async function sendTwilioSms(
   const authHeader =
     "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64");
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -107,7 +107,7 @@ export async function forwardToRuntime(
     }
 
     try {
-      const response = await fetch(url, {
+      const response = await globalThis.fetch(url, {
         method: "POST",
         headers: runtimeHeaders(config, extraHeaders),
         body: JSON.stringify(payload),
@@ -165,7 +165,7 @@ export async function resetConversation(
 ): Promise<void> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "DELETE",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ sourceChannel, externalChatId }),
@@ -195,7 +195,7 @@ export async function downloadAttachment(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -219,7 +219,7 @@ export async function downloadAttachmentById(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -253,7 +253,7 @@ export async function forwardTwilioVoiceWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params, originalUrl }),
@@ -277,7 +277,7 @@ export async function forwardTwilioStatusWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/status`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -301,7 +301,7 @@ export async function forwardTwilioConnectActionWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/connect-action`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -323,7 +323,7 @@ export async function uploadAttachment(
 ): Promise<UploadAttachmentResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify(input),
@@ -366,7 +366,7 @@ export async function forwardOAuthCallback(
 ): Promise<OAuthCallbackResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/oauth/callback`;
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ state, code, error }),

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -154,7 +154,7 @@ export async function callTelegramApi<T>(
   body: Record<string, unknown>,
 ): Promise<T> {
   return retryableFetch<T>(config, method, () =>
-    fetch(
+    globalThis.fetch(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",
@@ -172,7 +172,7 @@ export async function callTelegramApiMultipart<T>(
   form: FormData,
 ): Promise<T> {
   return retryableFetch<T>(config, method, () =>
-    fetch(
+    globalThis.fetch(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -33,7 +33,7 @@ export async function downloadTelegramFile(
   }
 
   const downloadUrl = `${config.telegramApiBaseUrl}/file/bot${config.telegramBotToken}/${file.file_path}`;
-  const response = await fetch(downloadUrl, {
+  const response = await globalThis.fetch(downloadUrl, {
     signal: AbortSignal.timeout(config.telegramTimeoutMs),
   });
 

--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -37,7 +37,7 @@ export async function sendSmsReply(
   const authHeader =
     "Basic " + Buffer.from(`${config.twilioAccountSid}:${config.twilioAuthToken}`).toString("base64");
 
-  const response = await fetch(url, {
+  const response = await globalThis.fetch(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,


### PR DESCRIPTION
## Summary
- Replace all bare `fetch()` calls in gateway source with `globalThis.fetch()` to work around a bun bug where reassigning `globalThis.fetch` in tests doesn't propagate to bare `fetch()` calls on Linux
- Affects 6 source files: `telegram/api.ts`, `telegram/download.ts`, `runtime/client.ts`, `twilio/send-sms.ts`, `http/routes/sms-deliver.ts`, `http/routes/runtime-proxy.ts`
- Fixes 26 failing tests in CI gateway checks

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22335476378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
