### PR TITLE
feat: separate scheduled task threads into their own sidebar section

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -22,6 +22,7 @@ struct MainWindowView: View {
     @State private var requestedHomeBaseAtLaunch = false
     @State private var threadPendingDeletion: UUID?
     @State private var showAllThreads: Bool = false
+    @State private var showAllScheduleThreads: Bool = false
     @State private var showAllApps: Bool = false
     @State private var showControlCenterDrawer: Bool = false
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
@@ -925,9 +926,28 @@ struct MainWindowView: View {
         .draggable(thread.id.uuidString)
     }
 
+    private static let schedulePrefixes = ["Schedule: ", "Schedule (manual): "]
+
+    private var regularThreads: [ThreadModel] {
+        threadManager.visibleThreads.filter { thread in
+            !Self.schedulePrefixes.contains(where: { thread.title.hasPrefix($0) })
+        }
+    }
+
+    private var scheduleThreads: [ThreadModel] {
+        threadManager.visibleThreads.filter { thread in
+            Self.schedulePrefixes.contains(where: { thread.title.hasPrefix($0) })
+        }
+    }
+
     private var displayedThreads: [ThreadModel] {
-        let all = threadManager.visibleThreads
+        let all = regularThreads
         return showAllThreads ? all : Array(all.prefix(5))
+    }
+
+    private var displayedScheduleThreads: [ThreadModel] {
+        let all = scheduleThreads
+        return showAllScheduleThreads ? all : Array(all.prefix(3))
     }
 
     private var displayedApps: [AppListManager.AppItem] {
@@ -993,7 +1013,7 @@ struct MainWindowView: View {
                             } isTargeted: { _ in }
                     }
 
-                    if threadManager.visibleThreads.count > 5 {
+                    if regularThreads.count > 5 {
                         Button {
                             withAnimation(VAnimation.standard) { showAllThreads.toggle() }
                         } label: {
@@ -1005,6 +1025,39 @@ struct MainWindowView: View {
                                 .padding(.vertical, VSpacing.xs)
                         }
                         .buttonStyle(.plain)
+                    }
+
+                    if !scheduleThreads.isEmpty {
+                        // Scheduled threads section
+                        HStack {
+                            Text("Scheduled")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                            Spacer()
+                        }
+                        .padding(.leading, 20)
+                        .padding(.trailing, VSpacing.md)
+                        .padding(.top, VSpacing.md)
+                        .padding(.bottom, VSpacing.xs)
+
+                        ForEach(displayedScheduleThreads) { thread in
+                            threadItem(thread)
+                                .padding(.bottom, VSpacing.xxs)
+                        }
+
+                        if scheduleThreads.count > 3 {
+                            Button {
+                                withAnimation(VAnimation.standard) { showAllScheduleThreads.toggle() }
+                            } label: {
+                                Text(showAllScheduleThreads ? "Show less" : "Show more")
+                                    .font(VFont.caption)
+                                    .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.leading, 20)
+                                    .padding(.vertical, VSpacing.xs)
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Threads created by scheduled tasks (title prefix `Schedule:` or `Schedule (manual):`) now appear in a separate "Scheduled" section below regular threads in the sidebar
- Regular threads show top 5 with "Show more"; scheduled threads show top 3 with their own "Show more"
- Uses client-side title prefix matching — no backend changes needed

## Original prompt
I want threads created by scheduled tasks to show up in a separate section below the other threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
