### PR TITLE
fix: always send PKCE params in OAuth2 flows

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -60,6 +60,9 @@ mock.module('../inbound/public-ingress-urls.js', () => ({
   },
 }));
 
+// Track token exchange request body
+let lastTokenRequestBody: URLSearchParams | null = null;
+
 // Mock fetch for token exchange
 let mockTokenResponse: { ok: boolean; status: number; body: Record<string, unknown> } = {
   ok: true,
@@ -77,6 +80,10 @@ const originalFetch = globalThis.fetch;
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
   if (url.includes('token')) {
+    // Capture request body for assertions
+    if (init?.body) {
+      lastTokenRequestBody = new URLSearchParams(init.body as string);
+    }
     if (!mockTokenResponse.ok) {
       return new Response(JSON.stringify({ error: 'invalid_grant' }), {
         status: mockTokenResponse.status,
@@ -108,6 +115,7 @@ beforeEach(() => {
   mockPublicBaseUrl = '';
   mockOAuthCallbackUrl = 'https://gw.example.com/webhooks/oauth/callback';
   pendingCallbacks.clear();
+  lastTokenRequestBody = null;
   mockTokenResponse = {
     ok: true,
     status: 200,
@@ -280,6 +288,40 @@ describe('OAuth2 gateway transport', () => {
       entries[0][1].resolve('code-that-fails-exchange');
 
       await expect(flowPromise).rejects.toThrow('OAuth2 token exchange failed');
+    });
+  });
+
+  describe('PKCE with client secret', () => {
+    test('includes PKCE params in auth URL even when clientSecret is provided', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const configWithSecret: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        clientSecret: 'test-client-secret',
+      };
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(configWithSecret, {
+        openUrl: (url) => { capturedAuthUrl = url; },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Auth URL must include PKCE challenge params despite having a client secret
+      expect(capturedAuthUrl).toContain('code_challenge=');
+      expect(capturedAuthUrl).toContain('code_challenge_method=S256');
+
+      const entries = Array.from(pendingCallbacks.entries());
+      expect(entries.length).toBe(1);
+      entries[0][1].resolve('pkce-with-secret-code');
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+
+      // Token exchange must include code_verifier alongside client_secret
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.get('code_verifier')).toBeTruthy();
+      expect(lastTokenRequestBody!.get('client_secret')).toBe('test-client-secret');
     });
   });
 });

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -23,7 +23,7 @@ export interface OAuth2Config {
   tokenUrl: string;
   scopes: string[];
   clientId: string;
-  /** Client secret for providers that require it (e.g. Slack). If omitted, PKCE is used. */
+  /** Client secret for providers that require it (e.g. Slack). PKCE is always used regardless. */
   clientSecret?: string;
   extraParams?: Record<string, string>;
   /** URL to fetch user identity info after OAuth. If omitted, account info is not fetched. */
@@ -80,17 +80,13 @@ async function exchangeCodeForTokens(
   redirectUri: string,
   codeVerifier: string,
 ): Promise<OAuth2FlowResult> {
-  const usePKCE = !config.clientSecret;
-
   const tokenBody: Record<string, string> = {
     grant_type: 'authorization_code',
     code,
     redirect_uri: redirectUri,
     client_id: config.clientId,
+    code_verifier: codeVerifier,
   };
-  if (usePKCE) {
-    tokenBody.code_verifier = codeVerifier;
-  }
   if (config.clientSecret) {
     tokenBody.client_secret = config.clientSecret;
   }
@@ -160,7 +156,6 @@ async function runGatewayFlow(
     registerPendingCallback(state, resolve, reject);
   });
 
-  const usePKCE = !config.clientSecret;
   const authParams = new URLSearchParams({
     ...config.extraParams,
     client_id: config.clientId,
@@ -168,7 +163,8 @@ async function runGatewayFlow(
     response_type: 'code',
     scope: config.scopes.join(' '),
     state,
-    ...(usePKCE ? { code_challenge: codeChallenge, code_challenge_method: 'S256' } : {}),
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
   });
 
   const authUrl = `${config.authUrl}?${authParams}`;


### PR DESCRIPTION
## Summary
- Always include `code_challenge` and `code_challenge_method` in the authorization URL, even when a `clientSecret` is configured
- Always include `code_verifier` in the token exchange request body alongside `client_secret`
- Add test verifying PKCE params are sent when `clientSecret` is present

## Original prompt

**Bug:** Twitter OAuth2 fails because PKCE parameters (`code_challenge`, `code_challenge_method`) are only sent when there's no client secret. Twitter requires PKCE for ALL OAuth2 flows, including confidential clients that also send a client secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
