### PR TITLE
fix: use HTTP Basic Auth for OAuth2 confidential client token exchange

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -60,8 +60,9 @@ mock.module('../inbound/public-ingress-urls.js', () => ({
   },
 }));
 
-// Track token exchange request body
+// Track token exchange request
 let lastTokenRequestBody: URLSearchParams | null = null;
+let lastTokenRequestHeaders: Record<string, string> = {};
 
 // Mock fetch for token exchange
 let mockTokenResponse: { ok: boolean; status: number; body: Record<string, unknown> } = {
@@ -80,9 +81,12 @@ const originalFetch = globalThis.fetch;
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
   if (url.includes('token')) {
-    // Capture request body for assertions
+    // Capture request body and headers for assertions
     if (init?.body) {
       lastTokenRequestBody = new URLSearchParams(init.body as string);
+    }
+    if (init?.headers) {
+      lastTokenRequestHeaders = init.headers as Record<string, string>;
     }
     if (!mockTokenResponse.ok) {
       return new Response(JSON.stringify({ error: 'invalid_grant' }), {
@@ -116,6 +120,7 @@ beforeEach(() => {
   mockOAuthCallbackUrl = 'https://gw.example.com/webhooks/oauth/callback';
   pendingCallbacks.clear();
   lastTokenRequestBody = null;
+  lastTokenRequestHeaders = {};
   mockTokenResponse = {
     ok: true,
     status: 200,
@@ -318,10 +323,64 @@ describe('OAuth2 gateway transport', () => {
       const result = await flowPromise;
       expect(result.tokens.accessToken).toBe('test-access-token');
 
-      // Token exchange must include code_verifier alongside client_secret
+      // Token exchange must include code_verifier
       expect(lastTokenRequestBody).not.toBeNull();
       expect(lastTokenRequestBody!.get('code_verifier')).toBeTruthy();
-      expect(lastTokenRequestBody!.get('client_secret')).toBe('test-client-secret');
+    });
+
+    test('sends Basic Auth header and omits client_id/client_secret from body when clientSecret is provided', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const configWithSecret: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        clientSecret: 'test-client-secret',
+      };
+
+      const flowPromise = startOAuth2Flow(configWithSecret, {
+        openUrl: () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve('basic-auth-code');
+
+      await flowPromise;
+
+      // Should send Basic Auth header with base64(client_id:client_secret)
+      const expectedCredentials = Buffer.from('test-client-id:test-client-secret').toString('base64');
+      expect(lastTokenRequestHeaders['Authorization']).toBe(`Basic ${expectedCredentials}`);
+
+      // Body should NOT contain client_id or client_secret
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.has('client_id')).toBe(false);
+      expect(lastTokenRequestBody!.has('client_secret')).toBe(false);
+
+      // Body should still contain code_verifier
+      expect(lastTokenRequestBody!.get('code_verifier')).toBeTruthy();
+    });
+
+    test('sends client_id in body without Basic Auth when no clientSecret', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const flowPromise = startOAuth2Flow(BASE_OAUTH_CONFIG, {
+        openUrl: () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve('public-client-code');
+
+      await flowPromise;
+
+      // No Authorization header for public clients
+      expect(lastTokenRequestHeaders['Authorization']).toBeUndefined();
+
+      // Body should contain client_id
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.get('client_id')).toBe('test-client-id');
+      expect(lastTokenRequestBody!.has('client_secret')).toBe(false);
     });
   });
 });

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -84,16 +84,23 @@ async function exchangeCodeForTokens(
     grant_type: 'authorization_code',
     code,
     redirect_uri: redirectUri,
-    client_id: config.clientId,
     code_verifier: codeVerifier,
   };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+
   if (config.clientSecret) {
-    tokenBody.client_secret = config.clientSecret;
+    const credentials = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64');
+    headers['Authorization'] = `Basic ${credentials}`;
+  } else {
+    tokenBody.client_id = config.clientId;
   }
 
   const tokenResp = await fetch(config.tokenUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers,
     body: new URLSearchParams(tokenBody),
   });
 


### PR DESCRIPTION
## Summary
- Send `Authorization: Basic base64(client_id:client_secret)` header for confidential clients instead of `client_secret` in the POST body
- Public clients (no secret) continue sending `client_id` in the body as before
- Add tests verifying Basic Auth header is sent and body omits credentials when `clientSecret` is present

## Original prompt

**Bug:** Twitter OAuth2 token exchange returns `401 unauthorized_client` because the client credentials are sent in the POST body (`client_secret` field) instead of as an HTTP Basic Auth header. Twitter requires confidential clients to authenticate using Basic Auth during the token exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
