### PR TITLE
feat: add source column to conversations schema

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -23,11 +23,12 @@ function monotonicNow(): number {
   return lastTimestamp;
 }
 
-export function createConversation(titleOrOpts?: string | { title?: string; threadType?: 'standard' | 'private' | 'background' }) {
+export function createConversation(titleOrOpts?: string | { title?: string; threadType?: 'standard' | 'private' | 'background'; source?: string }) {
   const db = getDb();
   const now = Date.now();
   const opts = typeof titleOrOpts === 'string' ? { title: titleOrOpts } : (titleOrOpts ?? {});
   const threadType = opts.threadType ?? 'standard';
+  const source = opts.source ?? 'user';
   const id = uuid();
   const memoryScopeId = threadType === 'private' ? `private:${id}` : 'default';
   const conversation = {
@@ -42,6 +43,7 @@ export function createConversation(titleOrOpts?: string | { title?: string; thre
     contextCompactedMessageCount: 0,
     contextCompactedAt: null as number | null,
     threadType,
+    source,
     memoryScopeId,
   };
   db.insert(conversations).values(conversation).run();

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -12,6 +12,7 @@ export const conversations = sqliteTable('conversations', {
   contextCompactedMessageCount: integer('context_compacted_message_count').notNull().default(0),
   contextCompactedAt: integer('context_compacted_at'),
   threadType: text('thread_type').notNull().default('standard'),
+  source: text('source').notNull().default('user'),
   memoryScopeId: text('memory_scope_id').notNull().default('default'),
 });
 


### PR DESCRIPTION
## Summary
- Added `source` column to `conversations` table (default: `'user'`), enabling structured identification of conversation origin
- Extended `createConversation` to accept optional `source` parameter

**PR 1 of 4** — adds the data model foundation. Follow-up PRs will pass source from schedulers, expose it via IPC, and use it for sidebar filtering.

## Original prompt
can we separate them by more than just the title prefix? let's add some more info to the data model if we have to. multiple incremental PRs preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
