### PR TITLE
feat: pass source field when creating schedule/reminder conversations

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -387,7 +387,7 @@ export async function handleScheduleRunNow(
     return;
   }
 
-  const conversation = createConversation(`Schedule (manual): ${schedule.name}`);
+  const conversation = createConversation({ title: `Schedule (manual): ${schedule.name}`, source: 'schedule' });
   const runId = createScheduleRun(schedule.id, conversation.id);
 
   try {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -103,14 +103,14 @@ async function runScheduleOnce(
         const message = err instanceof Error ? err.message : String(err);
         log.warn({ err, jobId: job.id, name: job.name, taskId, syntax: job.syntax, expression: job.expression, isRruleSet }, 'Scheduled task execution failed');
         // Create a fallback conversation for the schedule run record
-        const fallbackConversation = createConversation(`Schedule: ${job.name}`);
+        const fallbackConversation = createConversation({ title: `Schedule: ${job.name}`, source: 'schedule' });
         const runId = createScheduleRun(job.id, fallbackConversation.id);
         completeScheduleRun(runId, { status: 'error', error: message });
       }
       continue;
     }
 
-    const conversation = createConversation(`Schedule: ${job.name}`);
+    const conversation = createConversation({ title: `Schedule: ${job.name}`, source: 'schedule' });
     const runId = createScheduleRun(job.id, conversation.id);
     const isRruleSetMsg = job.syntax === 'rrule' && hasSetConstructs(job.expression);
 
@@ -131,7 +131,7 @@ async function runScheduleOnce(
   const dueReminders = claimDueReminders(now);
   for (const reminder of dueReminders) {
     if (reminder.mode === 'execute') {
-      const conversation = createConversation(`Reminder: ${reminder.label}`);
+      const conversation = createConversation({ title: `Reminder: ${reminder.label}`, source: 'reminder' });
       setReminderConversationId(reminder.id, conversation.id);
       try {
         log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');


### PR DESCRIPTION
## Summary
- Schedule conversations now pass `source: 'schedule'` when creating conversations
- Reminder conversations now pass `source: 'reminder'`
- Manual schedule runs (Run Now) also pass `source: 'schedule'`

**PR 2 of 4** — populates the `source` column added in PR 1.

## Original prompt
can we separate them by more than just the title prefix? let's add some more info to the data model if we have to. multiple incremental PRs preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
