### PR TITLE
feat: expose conversation source in session list IPC response

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -216,6 +216,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
         title: c.title ?? 'Untitled',
         updatedAt: c.updatedAt,
         threadType: normalizeThreadType(c.threadType),
+        source: c.source ?? 'user',
         ...(binding ? {
           channelBinding: {
             sourceChannel: binding.sourceChannel,

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -1378,7 +1378,7 @@ export interface ChannelBinding {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; channelBinding?: ChannelBinding }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2783,14 +2783,16 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let title: String
     public let updatedAt: Int
     public let threadType: String?
+    public let source: String?
     /// Channel binding metadata exposed in session/conversation list APIs.
     public let channelBinding: IPCChannelBinding?
 
-    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, channelBinding: IPCChannelBinding? = nil) {
+    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil) {
         self.id = id
         self.title = title
         self.updatedAt = updatedAt
         self.threadType = threadType
+        self.source = source
         self.channelBinding = channelBinding
     }
 }


### PR DESCRIPTION
## Summary
- Added `source` field to `SessionListResponse` sessions in the IPC contract
- Session handler now includes `source` from the conversation record (defaults to `'user'`)
- Regenerated Swift IPC types — `IPCSessionListResponseSession` now has `source: String?`

**PR 3 of 4** — exposes the source field through IPC so the macOS client can use it.

## Original prompt
can we separate them by more than just the title prefix? let's add some more info to the data model if we have to. multiple incremental PRs preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
