### PR TITLE
feat: use source field for sidebar thread classification

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -926,18 +926,12 @@ struct MainWindowView: View {
         .draggable(thread.id.uuidString)
     }
 
-    private static let schedulePrefixes = ["Schedule: ", "Schedule (manual): "]
-
     private var regularThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { thread in
-            !Self.schedulePrefixes.contains(where: { thread.title.hasPrefix($0) })
-        }
+        threadManager.visibleThreads.filter { $0.source != "schedule" && $0.source != "reminder" }
     }
 
     private var scheduleThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { thread in
-            Self.schedulePrefixes.contains(where: { thread.title.hasPrefix($0) })
-        }
+        threadManager.visibleThreads.filter { $0.source == "schedule" || $0.source == "reminder" }
     }
 
     private var displayedThreads: [ThreadModel] {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -318,7 +318,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
-                kind: session.threadType == "private" ? .private : .standard
+                kind: session.threadType == "private" ? .private : .standard,
+                source: session.source
             )
             let viewModel = makeViewModel()
             viewModel.sessionId = session.id

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -17,8 +17,9 @@ struct ThreadModel: Identifiable, Hashable {
     var pinnedOrder: Int?
     var lastInteractedAt: Date
     var kind: ThreadKind
+    var source: String?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -28,5 +29,6 @@ struct ThreadModel: Identifiable, Hashable {
         self.pinnedOrder = pinnedOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
+        self.source = source
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -143,7 +143,8 @@ final class ThreadSessionRestorer {
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
-                kind: kind
+                kind: kind,
+                source: session.source
             )
             let viewModel = delegate.makeViewModel()
             viewModel.sessionId = session.id


### PR DESCRIPTION
## Summary
- Add `source` property to `ThreadModel` and populate it from IPC session list responses in both `ThreadSessionRestorer` and `ThreadManager.appendThreads`
- Replace fragile title-prefix matching (`schedulePrefixes`) with `source`-based filtering (`schedule` / `reminder`) for sidebar thread classification

## Original prompt
can we separate them by more than just the title prefix? let's add some more info to the data model if we have to. multiple incremental PRs preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
