### PR TITLE
fix: don't delete cached node_modules before actions/cache save

### DIFF
--- a/.github/workflows/ci-macos-dmg.yml
+++ b/.github/workflows/ci-macos-dmg.yml
@@ -142,7 +142,6 @@ jobs:
         working-directory: clients/macos
         run: |
           rm -rf .build daemon-bin cli-bin
-          rm -rf ../../assistant/node_modules ../../cli/node_modules
           rm -rf ~/Library/Developer/Xcode/DerivedData 2>/dev/null || true
           rm -rf ~/Library/Caches/org.swift.swiftpm 2>/dev/null || true
           df -h .


### PR DESCRIPTION
Addresses feedback from PR #7484. The 'Free disk space' step was deleting node_modules before the actions/cache post-job hook could save them, making the Bun dependency caches permanently empty.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
