### PR TITLE
fix: skip all leading trivial segments in compound command preview

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -780,14 +780,16 @@ public struct ToolCallData: Identifiable, Equatable {
         // to describe the meaningful part.
         let trivialPrefixes: Set<String> = ["cd", "pushd", "popd", "export", "source"]
         let segments = cmd.components(separatedBy: "&&").map { $0.trimmingCharacters(in: .whitespaces) }
-        let effectiveCmd: String
-        if segments.count > 1,
-           let firstWord = segments[0].components(separatedBy: .whitespaces).first(where: { !$0.isEmpty }),
-           trivialPrefixes.contains((firstWord as NSString).lastPathComponent.lowercased()) {
-            effectiveCmd = segments.dropFirst().joined(separator: " && ").trimmingCharacters(in: .whitespaces)
-        } else {
-            effectiveCmd = cmd
+        // Skip all leading trivial segments so "cd repo && export FOO=1 && bun test"
+        // resolves to "bun test" rather than stopping after the first trivial segment.
+        var remaining = segments[...]
+        while remaining.count > 1,
+              let firstWord = remaining.first?
+                  .components(separatedBy: .whitespaces).first(where: { !$0.isEmpty }),
+              trivialPrefixes.contains((firstWord as NSString).lastPathComponent.lowercased()) {
+            remaining = remaining.dropFirst()
         }
+        let effectiveCmd = remaining.joined(separator: " && ").trimmingCharacters(in: .whitespaces)
 
         let tokens = effectiveCmd.trimmingCharacters(in: .whitespaces)
             .components(separatedBy: .whitespaces)


### PR DESCRIPTION
Addresses feedback from PR #7469. The compound-command preview now skips all leading trivial segments (cd, export, etc.) instead of just the first one, so chains like `cd repo && export FOO=1 && bun test` correctly show "bun test" instead of "export FOO=1 && bun test".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
