### PR TITLE
fix: refresh updatedAt timestamp on SQLite busy retry

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -124,22 +124,26 @@ export function getLatestConversation() {
 
 export function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>) {
   const db = getDb();
-  const now = monotonicNow();
-  const message = {
-    id: uuid(),
-    conversationId,
-    role,
-    content,
-    createdAt: now,
-    ...(metadata ? { metadata: JSON.stringify(metadata) } : {}),
-  };
+  const messageId = uuid();
+  const metadataStr = metadata ? JSON.stringify(metadata) : undefined;
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
   // Retry on SQLITE_BUSY in case busy_timeout is exhausted under heavy contention.
+  // Timestamp is recomputed each attempt so a late retry doesn't persist a stale updatedAt.
   const MAX_RETRIES = 3;
+  let now!: number;
   for (let attempt = 0; ; attempt++) {
+    now = monotonicNow();
     try {
+      const values = {
+        id: messageId,
+        conversationId,
+        role,
+        content,
+        createdAt: now,
+        ...(metadataStr ? { metadata: metadataStr } : {}),
+      };
       db.transaction((tx) => {
-        tx.insert(messages).values(message).run();
+        tx.insert(messages).values(values).run();
         tx.update(conversations)
           .set({ updatedAt: now })
           .where(eq(conversations.id, conversationId))
@@ -155,6 +159,7 @@ export function addMessage(conversationId: string, role: string, content: string
       throw err;
     }
   }
+  const message = { id: messageId, conversationId, role, content, createdAt: now };
 
   try {
     const config = getConfig();


### PR DESCRIPTION
Addresses feedback from PR #7508. Moves the timestamp computation inside the retry loop so each attempt uses a fresh value, preventing stale ordering when retries succeed after lock contention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
