### PR TITLE
fix: include channelCommandContext in context-too-large retry paths

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -621,6 +621,7 @@ export async function runAgentLoopImpl(
           activeSurface,
           workspaceTopLevelContext: ctx.workspaceTopLevelContext,
           channelCapabilities: ctx.channelCapabilities ?? null,
+          channelCommandContext: ctx.commandIntent ?? null,
           guardianContext: ctx.guardianContext ?? null,
           temporalContext,
         });
@@ -654,6 +655,7 @@ export async function runAgentLoopImpl(
             activeSurface,
             workspaceTopLevelContext: ctx.workspaceTopLevelContext,
             channelCapabilities: ctx.channelCapabilities ?? null,
+            channelCommandContext: ctx.commandIntent ?? null,
             guardianContext: ctx.guardianContext ?? null,
             temporalContext,
           });


### PR DESCRIPTION
Addresses feedback from PR #7521. Adds the missing channelCommandContext parameter to both retry calls to applyRuntimeInjections, preventing Telegram command metadata from being silently dropped during context-too-large retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
