### PR TITLE
fix: handle key-prefixed inputFull in file path checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -275,8 +275,8 @@ private struct UsedToolsRow: View {
     /// Open the image in Preview.app. Tries the original file path first; falls
     /// back to writing the NSImage to a temp file when the path is unavailable.
     private func openImageInPreview(_ image: NSImage) {
-        // Try opening the original file if inputFull points to a real file
-        let path = toolCall.inputFull.components(separatedBy: "\n").first ?? ""
+        // Use inputSummary (bare value without key prefix) for file path checks
+        let path = toolCall.inputSummary
         if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
             openInPreview(URL(fileURLWithPath: path))
             return

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -84,8 +84,8 @@ public struct ToolCallChip: View {
                     // Image preview (for browser_screenshot etc.)
                     if let cachedImage = toolCall.cachedImage {
                         #if os(macOS)
-                        let canOpenImage = !toolCall.inputFull.isEmpty
-                            && FileManager.default.fileExists(atPath: toolCall.inputFull)
+                        let canOpenImage = !toolCall.inputSummary.isEmpty
+                            && FileManager.default.fileExists(atPath: toolCall.inputSummary)
                         if canOpenImage {
                             Image(nsImage: cachedImage)
                                 .resizable()
@@ -94,7 +94,7 @@ public struct ToolCallChip: View {
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                 .padding(.horizontal, VSpacing.sm)
                                 .onTapGesture(count: 2) {
-                                    NSWorkspace.shared.open(URL(fileURLWithPath: toolCall.inputFull))
+                                    NSWorkspace.shared.open(URL(fileURLWithPath: toolCall.inputSummary))
                                 }
                                 .onHover { hovering in
                                     if hovering { NSCursor.pointingHand.push() }


### PR DESCRIPTION
Addresses feedback from PR #7525. Uses inputSummary (bare value without key prefix) instead of inputFull for file path checks in ToolCallChip and UsedToolsList, preserving image preview and double-click-to-open functionality.

After PR #7525 changed inputFull to use key: value format for all parameters, file path extraction broke because FileManager.default.fileExists(atPath:) received strings like 'path: /tmp/foo.png' instead of '/tmp/foo.png'. inputSummary retains the raw value, making it the correct property for path operations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
