### PR TITLE
fix: prevent double scroll events in ScrollWheelPassthrough

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -791,6 +791,7 @@ private struct ScrollWheelPassthrough: NSViewRepresentable {
 
             if let scrollView = coordinator.findScrollView(for: event) {
                 scrollView.scrollWheel(with: event)
+                return nil // consume — we already forwarded it; prevents double-delivery
             }
             return event
         }


### PR DESCRIPTION
## Summary
- Returns `nil` after forwarding scroll events to the NSScrollView in `ScrollWheelPassthrough` to prevent double-delivery
- Previously, the monitor called `scrollView.scrollWheel(with: event)` AND returned the event, allowing AppKit to dispatch it again through normal event handling, causing double-speed scrolling

Addresses feedback from PR #7480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
