### PR TITLE
fix: add drop targets to scheduled threads and fix visible set

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1037,6 +1037,12 @@ struct MainWindowView: View {
                         ForEach(displayedScheduleThreads) { thread in
                             threadItem(thread)
                                 .padding(.bottom, VSpacing.xxs)
+                                .dropDestination(for: String.self) { items, _ in
+                                    guard let droppedId = items.first,
+                                          let sourceUUID = UUID(uuidString: droppedId),
+                                          sourceUUID != thread.id else { return false }
+                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
+                                } isTargeted: { _ in }
                         }
 
                         if scheduleThreads.count > 3 {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -401,9 +401,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func updateLastInteracted(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
-        // Don't reshuffle threads that are already visible in the collapsed top-5 sidebar.
-        let top5Ids = Set(visibleThreads.prefix(5).map(\.id))
-        guard !top5Ids.contains(threadId) else { return }
+        // Don't reshuffle threads that are already visible in the collapsed sidebar.
+        // The sidebar shows regular threads (top 5) and schedule/reminder threads (top 3) separately.
+        let visible = visibleThreads
+        let regularIds = visible.filter { $0.source != "schedule" && $0.source != "reminder" }.prefix(5).map(\.id)
+        let scheduleIds = visible.filter { $0.source == "schedule" || $0.source == "reminder" }.prefix(3).map(\.id)
+        let visibleIds = Set(regularIds + scheduleIds)
+        guard !visibleIds.contains(threadId) else { return }
         threads[index].lastInteractedAt = Date()
     }
 


### PR DESCRIPTION
Addresses feedback from PR #7544.

- Adds `.dropDestination()` to scheduled section rows for drag-and-drop reordering (matching regular thread rows)
- Updates `ThreadManager.updateLastInteracted` to compute the visible thread set correctly for the separate regular (top 5) and schedule/reminder (top 3) sections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
