### PR TITLE
fix: correct tool name matching and fallback in permission previews

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -125,7 +125,9 @@ public final class ToolConfirmationNotificationService {
         case "schedule_update": return "Update Schedule"
         case "schedule_delete": return "Delete Schedule"
         case "schedule_list":   return "List Schedules"
-        case "reminder":        return "Reminder"
+        case "reminder_create":  return "Create Reminder"
+        case "reminder_list":    return "List Reminders"
+        case "reminder_cancel":  return "Cancel Reminder"
         default: return toolName.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
@@ -145,21 +147,24 @@ public final class ToolConfirmationNotificationService {
         case "browser_navigate":
             return "navigate \((input["url"]?.value as? String) ?? "")"
         case "schedule_create", "schedule_update":
+            let verb = toolName == "schedule_create" ? "Create" : "Update"
             let name = (input["name"]?.value as? String) ?? ""
+            let jobId = (input["job_id"]?.value as? String) ?? ""
             let expr = (input["expression"]?.value as? String)
                 ?? (input["cron_expression"]?.value as? String) ?? ""
             let message = (input["message"]?.value as? String) ?? ""
             var parts: [String] = []
             if !name.isEmpty { parts.append("\"\(name)\"") }
+            if !jobId.isEmpty && name.isEmpty { parts.append(jobId) }
             if !expr.isEmpty { parts.append(expr) }
             if parts.isEmpty && !message.isEmpty {
                 let truncated = message.count > 60 ? String(message.prefix(57)) + "..." : message
                 parts.append("\"\(truncated)\"")
             }
-            return parts.isEmpty ? toolName : parts.joined(separator: " — ")
+            return parts.isEmpty ? "\(verb) schedule" : parts.joined(separator: " — ")
         case "schedule_delete":
             return (input["job_id"]?.value as? String) ?? "schedule"
-        case "reminder":
+        case "reminder_create":
             let msg = (input["message"]?.value as? String) ?? ""
             let at = (input["at"]?.value as? String) ?? ""
             let delay = (input["delay"]?.value as? String) ?? ""
@@ -170,7 +175,12 @@ public final class ToolConfirmationNotificationService {
             }
             if !at.isEmpty { parts.append("at \(at)") }
             else if !delay.isEmpty { parts.append("in \(delay)") }
-            return parts.isEmpty ? "reminder" : parts.joined(separator: " ")
+            return parts.isEmpty ? "Set reminder" : parts.joined(separator: " ")
+        case "reminder_list":
+            return "List reminders"
+        case "reminder_cancel":
+            let id = (input["id"]?.value as? String) ?? ""
+            return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         default:
             // Prefer semantically meaningful keys over arbitrary dictionary order
             let preferredKeys = ["name", "query", "message", "description", "title", "url", "path", "command", "id"]

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -89,11 +89,15 @@ public struct ToolConfirmationData: Equatable {
             return "The assistant wants to update a schedule"
         case "schedule_delete":
             return "The assistant wants to delete a schedule"
-        case "reminder":
+        case "reminder_create":
             let msg = (input["message"]?.value as? String) ?? ""
             return msg.isEmpty
                 ? "The assistant wants to set a reminder"
                 : "The assistant wants to remind you: \(msg)"
+        case "reminder_list":
+            return "The assistant wants to list reminders"
+        case "reminder_cancel":
+            return "The assistant wants to cancel a reminder"
         default:
             return "The assistant wants to use \(toolName)"
         }
@@ -155,8 +159,13 @@ public struct ToolConfirmationData: Equatable {
             return jobId.isEmpty ? "Delete schedule" : "Delete schedule \(jobId)"
         case "schedule_list":
             return "List schedules"
-        case "reminder":
+        case "reminder_create":
             return Self.reminderPreview(input: input)
+        case "reminder_list":
+            return "List reminders"
+        case "reminder_cancel":
+            let id = (input["id"]?.value as? String) ?? ""
+            return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         case "credential_store":
             return Self.credentialPreview(input: input)
         default:
@@ -167,6 +176,7 @@ public struct ToolConfirmationData: Equatable {
     /// Build a preview string for schedule_create/schedule_update tools.
     private static func schedulePreview(input: [String: AnyCodable], verb: String) -> String {
         let name = (input["name"]?.value as? String) ?? ""
+        let jobId = (input["job_id"]?.value as? String) ?? ""
         let expr = (input["expression"]?.value as? String)
             ?? (input["cron_expression"]?.value as? String)
             ?? ""
@@ -174,6 +184,7 @@ public struct ToolConfirmationData: Equatable {
 
         var parts: [String] = []
         if !name.isEmpty { parts.append("\"\(name)\"") }
+        if !jobId.isEmpty && name.isEmpty { parts.append(jobId) }
         if !expr.isEmpty { parts.append(expr) }
         if parts.isEmpty && !message.isEmpty {
             parts.append("\"\(message.count > 60 ? String(message.prefix(57)) + "..." : message)\"")
@@ -253,7 +264,7 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("memory_"):   return "Memory"
         case "skill_load":                            return "Skill"
         case "evaluate_typescript_code":              return "Code Sandbox"
-        case "reminder":                              return "Reminder"
+        case _ where toolName.hasPrefix("reminder_"):   return "Reminder"
         case "document_create", "document_update":    return "Document"
         default:
             return toolName
@@ -281,7 +292,7 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("memory_"):   return "brain"
         case "skill_load":                            return "puzzlepiece.extension"
         case "evaluate_typescript_code":              return "chevron.left.forwardslash.chevron.right"
-        case "reminder":                              return "bell"
+        case _ where toolName.hasPrefix("reminder_"):   return "bell"
         case "document_create", "document_update":    return "doc.richtext"
         default:                                      return "puzzlepiece.extension"
         }
@@ -423,13 +434,17 @@ public struct ToolConfirmationData: Equatable {
             return "Allow updating a schedule?"
         case "schedule_delete":
             return "Allow deleting a schedule?"
-        case "reminder":
+        case "reminder_create":
             let msg = (input["message"]?.value as? String) ?? ""
             if !msg.isEmpty {
                 let truncated = msg.count > 40 ? String(msg.prefix(37)) + "..." : msg
                 return "Allow setting a reminder: \"\(truncated)\"?"
             }
             return "Allow setting a reminder?"
+        case "reminder_list":
+            return "Allow listing reminders?"
+        case "reminder_cancel":
+            return "Allow canceling a reminder?"
         default:
             let tc = toolCategory.lowercased()
             if !r.isEmpty { return "Allow using \(tc) \(r)?" }


### PR DESCRIPTION
Addresses feedback from PR #7475. Fixes: (1) reminder preview now matches actual tool names (reminder_create, reminder_list, reminder_cancel) instead of 'reminder', (2) schedule preview includes job_id for updates, (3) notification service uses human-friendly fallback instead of raw tool name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
