### PR TITLE
test: add positive retry case for non-connection send failures

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1845,6 +1845,24 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.errorText)
     }
 
+    func testRetryButtonAppearsForNonConnectionSendFailure() {
+        viewModel.sessionId = "sess-1"
+        daemonClient.isConnected = true
+        // Make the IPC send throw to simulate a non-connection send failure
+        // (e.g. socket write error while technically connected).
+        daemonClient.sendOverride = { _ in throw NSError(domain: "test", code: 1) }
+
+        viewModel.inputText = "Test message"
+        viewModel.sendMessage()
+
+        XCTAssertTrue(viewModel.isRetryableError,
+                       "Non-connection send failure should show Retry button")
+        XCTAssertFalse(viewModel.isConnectionError,
+                        "Non-connection send failure should not be a connection error")
+        XCTAssertNotNil(viewModel.errorText)
+        XCTAssertEqual(viewModel.lastFailedMessageText, "Test message")
+    }
+
     func testRetryButtonNotShownForRegenerateFailure() {
         viewModel.sessionId = "sess-1"
         daemonClient.isConnected = false


### PR DESCRIPTION
Addresses feedback from PR #7542. Adds test coverage for non-connection send failures where `isRetryableError` should be `true`, ensuring the Retry button appears correctly.

The existing `testRetryButtonAppearsOnlySendFailures` only tested the connection-error path (where `isRetryableError == false`). This new test drives a non-connection send failure by making `sendOverride` throw while connected, confirming that `isRetryableError == true` and the Retry button would be shown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
