### PR TITLE
fix: plumb source field through HTTP session-list path

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -926,12 +926,21 @@ struct MainWindowView: View {
         .draggable(thread.id.uuidString)
     }
 
+    /// Whether a thread is a scheduled/reminder conversation, checking source field
+    /// with fallback to legacy title prefixes for HTTP mode where source may be nil.
+    private func isScheduleThread(_ thread: ThreadModel) -> Bool {
+        if let source = thread.source {
+            return source == "schedule" || source == "reminder"
+        }
+        return thread.title.hasPrefix("[Schedule]") || thread.title.hasPrefix("[Reminder]")
+    }
+
     private var regularThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { $0.source != "schedule" && $0.source != "reminder" }
+        threadManager.visibleThreads.filter { !isScheduleThread($0) }
     }
 
     private var scheduleThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { $0.source == "schedule" || $0.source == "reminder" }
+        threadManager.visibleThreads.filter { isScheduleThread($0) }
     }
 
     private var displayedThreads: [ThreadModel] {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -23,6 +23,7 @@ struct ConversationsListResponse: Decodable {
         let title: String
         let updatedAt: Int
         let threadType: String?
+        let source: String?
         let channelBinding: IPCChannelBinding?
     }
     let sessions: [Session]
@@ -410,7 +411,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, channelBinding: $0.channelBinding)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {


### PR DESCRIPTION
Addresses feedback from PR #7551. Adds source field to HTTP session-list decoding in HTTPDaemonClient.swift so remote/HTTP mode correctly classifies scheduled threads. Also adds fallback to legacy title prefix check when source is nil.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
