### PR TITLE
fix: defer scroll untether check until after scroll position updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -718,14 +718,18 @@ private struct ScrollWheelDetector: NSViewRepresentable {
                 // Direct user scroll up (toward older content) — untether,
                 // but only if actually scrolled away from the bottom.
                 // Momentum events are excluded so a flick doesn't accidentally untether.
-                if let scrollView = coordinator.findEnclosingScrollView() {
-                    let clipBounds = scrollView.contentView.bounds
-                    let docHeight = scrollView.documentView?.frame.height ?? 0
-                    if docHeight - clipBounds.maxY >= 50 {
+                // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
+                // reading it synchronously in the event monitor sees the pre-scroll state.
+                DispatchQueue.main.async {
+                    if let scrollView = coordinator.findEnclosingScrollView() {
+                        let clipBounds = scrollView.contentView.bounds
+                        let docHeight = scrollView.documentView?.frame.height ?? 0
+                        if docHeight - clipBounds.maxY >= 50 {
+                            coordinator.onScrollUp?()
+                        }
+                    } else {
                         coordinator.onScrollUp?()
                     }
-                } else {
-                    coordinator.onScrollUp?()
                 }
             } else if event.scrollingDeltaY < -1 {
                 // Scrolling down (direct or momentum) — re-tether if at bottom.


### PR DESCRIPTION
Addresses feedback from PR #7505. Defers the scroll position check to after the event is processed using DispatchQueue.main.async, preventing cases where a large scroll gesture from the bottom doesn't trigger the untether because clipBounds.maxY hasn't updated yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
