### PR TITLE
fix: show all bash parameters in full input preview

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -106,10 +106,22 @@ public struct ToolConfirmationData: Equatable {
     /// Structured preview of ALL input parameters, formatted as key: value lines.
     /// Used in the "More details" section so the user can see exactly what will happen.
     public var fullInputPreview: String {
-        // For bash, the command itself is the full picture
         switch toolName {
         case "bash", "host_bash":
-            return (input["command"]?.value as? String) ?? ""
+            let command = (input["command"]?.value as? String) ?? ""
+            var extras: [String] = []
+            if let networkMode = input["network_mode"]?.value as? String, !networkMode.isEmpty {
+                extras.append("network_mode: \(networkMode)")
+            }
+            if let credentialIds = input["credential_ids"]?.value as? [Any], !credentialIds.isEmpty {
+                let ids = credentialIds.compactMap { $0 as? String }
+                if !ids.isEmpty { extras.append("credential_ids: \(ids.joined(separator: ", "))") }
+            }
+            if let timeout = input["timeout_seconds"]?.value {
+                extras.append("timeout_seconds: \(timeout)")
+            }
+            if extras.isEmpty { return command }
+            return command + "\n\n" + extras.joined(separator: "\n")
         default:
             break
         }


### PR DESCRIPTION
Addresses feedback from PR #7477. The bash branch in fullInputPreview now includes all non-nil fields (network_mode, credential_ids, timeout_seconds) so users see complete risk information when approving bash tool calls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
