### PR TITLE
fix: resolve CI failures on main

### DIFF
--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -8,6 +8,13 @@ mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
   }),
+  getCliLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (value: string, maxLen = 500) => value.length > maxLen ? value.slice(0, maxLen) + '...' : value,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
 }));
 
 mock.module('../util/platform.js', () => ({

--- a/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
+++ b/assistant/src/__tests__/run-orchestrator-assistant-events.test.ts
@@ -70,6 +70,7 @@ function makeSessionEmittingViaClient(...messages: ServerMessage[]): Session {
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -94,6 +95,7 @@ function makeSessionEmittingViaAgentLoop(...messages: ServerMessage[]): Session 
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       for (const msg of messages) {

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -51,6 +51,7 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -74,6 +75,7 @@ function makeSessionWithEvent(message: ServerMessage): Session {
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setGuardianContext: () => {},
+    setCommandIntent: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent(message);
@@ -240,6 +242,7 @@ describe('startRun channel capability resolution', () => {
       },
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -276,6 +279,7 @@ describe('startRun channel capability resolution', () => {
       },
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -308,6 +312,7 @@ describe('startRun channel capability resolution', () => {
       },
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -353,6 +358,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -389,6 +395,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -426,6 +433,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setGuardianContext: () => {},
+    setCommandIntent: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -524,6 +524,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN retry_after INTEGER`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN raw_payload TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'standard'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }


### PR DESCRIPTION
Fixes CI failures that started cascading from PR #7532 onwards. Run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22336412969

Root causes:
1. PR #7547 added a `source` column to the Drizzle schema but forgot the ALTER TABLE migration in db-init.ts, causing `SQLiteError: table conversations has no column named source` in ~40 test files.
2. A recent PR added `setCommandIntent` to run-orchestrator.ts but didn't update mock sessions in run-orchestrator.test.ts and run-orchestrator-assistant-events.test.ts.
3. computer-use-session-working-dir.test.ts had an incomplete logger mock missing `isDebug` and `truncateForLog` exports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
