### PR TITLE
feat: make telegram bot username a clickable link

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -335,6 +335,7 @@ struct SettingsConnectTab: View {
                     icon: "checkmark.circle.fill",
                     iconColor: VColor.success,
                     value: store.telegramBotUsername.map { "@\($0)" } ?? "Configured",
+                    valueURL: store.telegramBotUsername.map { URL(string: "https://web.telegram.org/k/#@\($0)")! },
                     action: .init(label: "Clear", style: .danger, disabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
@@ -690,6 +691,7 @@ struct SettingsConnectTab: View {
         value: String,
         valueFont: Font = VFont.body,
         valueColor: Color = VColor.textSecondary,
+        valueURL: URL? = nil,
         action: RowAction? = nil
     ) -> some View {
         HStack(spacing: VSpacing.sm) {
@@ -702,10 +704,16 @@ struct SettingsConnectTab: View {
                 .foregroundColor(iconColor)
                 .font(.system(size: 12))
 
-            Text(value)
-                .font(valueFont)
-                .foregroundColor(valueColor)
-                .lineLimit(1)
+            if let url = valueURL {
+                Link(value, destination: url)
+                    .font(valueFont)
+                    .lineLimit(1)
+            } else {
+                Text(value)
+                    .font(valueFont)
+                    .foregroundColor(valueColor)
+                    .lineLimit(1)
+            }
 
             Spacer()
 


### PR DESCRIPTION
## Summary
- Makes the `@credence_the_bot` username in Telegram channel settings a clickable link
- Clicking opens `https://web.telegram.org/k/#@credence_the_bot` (or whichever bot is configured)
- Adds optional `valueURL` parameter to `channelStatusRow` helper, uses SwiftUI `Link` when provided

## Original prompt
help me make this a clickable link to take you to https://web.telegram.org/k/#@credence_the_bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
