### PR TITLE
fix: fall back to disambiguation when scoped runId lookup fails

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1386,10 +1386,12 @@ async function handleApprovalInterception(
       ? getPendingApprovalByRunAndGuardianChat(decision.runId, sourceChannel, externalChatId, assistantId)
       : null;
 
-    // For plain-text decisions (no run ID), check how many pending
-    // approvals exist for this guardian chat. If there are multiple,
-    // the guardian must use buttons to disambiguate.
-    if (!guardianApproval && decision && !decision.runId) {
+    // When the scoped lookup didn't resolve an approval (either because
+    // the decision had no runId, or the runId pointed to a stale/expired
+    // run), fall back to checking all pending approvals for this guardian
+    // chat. If there are multiple, the guardian must use buttons to
+    // disambiguate.
+    if (!guardianApproval && decision) {
       const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId, assistantId);
       if (allPending.length > 1) {
         try {


### PR DESCRIPTION
When a guardian reply includes a [ref:runId] tag pointing to a stale/expired run, the scoped lookup returns null but the disambiguation fallback was skipped because decision.runId was truthy. Removed the !decision.runId check so the fallback always applies. Addresses feedback from #7518.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
