### PR TITLE
fix: merge approved feedback PRs before final sweep exit in safe-blitz

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -226,7 +226,30 @@ When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/
 - Create worktrees from the feature branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<feature-branch-name>`.
 - Agents must NOT use `--merge` in `.claude/ship`. All PRs are created without auto-merging. The lead merges approved PRs after review.
 
-When the sweep says "final phase," proceed to Phase 6.
+When the sweep says "final phase," proceed to Phase 5.5.
+
+## Phase 5.5: Merge Approved Final-Sweep PRs
+
+This step runs ONLY after the final sweep completes cleanly (all reviews addressed, no pending feedback). It is the Phase 5 equivalent of Phase 4c.5 — without it, approved feedback PRs from the final sweep would remain unmerged, and their fixes would be missing from the final feature-branch PR.
+
+1. Collect all feedback PRs that were created during the final sweep. These are PRs whose head branch starts with `swarm/<namespace>/` and whose base branch is the feature branch.
+
+2. For each such PR, check if it is approved and unmerged:
+   ```bash
+   gh pr view <pr-number> --json state,mergedAt --jq '{state: .state, mergedAt: .mergedAt}'
+   ```
+
+3. Merge any approved but unmerged feedback PRs into the feature branch (squash merge, in order of PR number):
+   ```bash
+   gh pr merge <feedback-pr-number> --squash
+   ```
+
+4. If any PRs were merged, fetch the updated feature branch:
+   ```bash
+   git fetch origin <feature-branch-name>
+   ```
+
+Proceed to Phase 6.
 
 ## Phase 6: Create Final PR (Feature Branch -> Main)
 


### PR DESCRIPTION
Added Phase 5.5 to merge approved feedback PRs before exiting the sweep phase, ensuring fixes are included in the final feature-branch PR. Without this step, the sweep exit condition could be met (UNREVIEWED_PRS.md cleared by check-reviews) while approved feedback PRs were still unmerged, causing the Phase 6 final PR to be missing those fixes. This mirrors the existing Phase 4c.5 pattern used for per-milestone sweeps. Addresses feedback from #7520.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
