### PR TITLE
fix: cached remote checks never affect readiness when includeRemote=false

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -255,6 +255,28 @@ describe('ChannelReadinessService', () => {
     ]);
   });
 
+  test('fresh cached remote failures do not affect local-only readiness', async () => {
+    const probe = makeProbe(
+      'sms',
+      [{ name: 'creds', passed: true, message: 'ok' }],
+      [{ name: 'api_check', passed: false, message: 'API unreachable' }],
+    );
+    service.registerProbe(probe);
+
+    // Prime remote cache with a failing check
+    await service.getReadiness('sms', true);
+
+    // Immediately call with includeRemote=false (cache is still fresh within TTL).
+    // The cached remote failure should be surfaced for visibility but must NOT
+    // affect readiness when the caller explicitly opted out of remote checks.
+    const [snapshot] = await service.getReadiness('sms', false);
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.reasons).toEqual([]);
+    // Remote checks are still visible for informational purposes
+    expect(snapshot.remoteChecks).toHaveLength(1);
+    expect(snapshot.remoteChecks![0].passed).toBe(false);
+  });
+
   test('stale cached remote failures do not affect local-only readiness', async () => {
     const probe = makeProbe(
       'sms',

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -326,11 +326,11 @@ export class ChannelReadinessService {
           remoteChecksAffectReadiness = true;
         }
       } else if (cached?.remoteChecks) {
-        // Surface cached remote checks when present. Stale checks are included
-        // for visibility but do not affect readiness until explicitly refreshed.
+        // Surface cached remote checks for visibility but never let them affect
+        // readiness when the caller explicitly opted out of remote checks.
         remoteChecks = cached.remoteChecks;
         stale = (now - cached.checkedAt) >= REMOTE_TTL_MS;
-        remoteChecksAffectReadiness = !stale;
+        remoteChecksAffectReadiness = false;
       }
 
       const allLocalPassed = localChecks.every((c) => c.passed);


### PR DESCRIPTION
Addresses review feedback from #7514.

When `getReadiness()` is called with `includeRemote=false`, cached remote checks within the TTL were still affecting the readiness result. This caused toll-free numbers in PENDING_REVIEW/IN_REVIEW to falsely report broken readiness status even though the caller explicitly opted out of remote checks.

The fix ensures that when `includeRemote=false`, cached remote checks are still surfaced for informational visibility but never affect the `ready` flag or contribute to `reasons`. Added a test covering the fresh-cache case to prevent regression.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
