### PR TITLE
fix: make OAuth2 token endpoint auth method configurable and fix refresh

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -328,12 +328,13 @@ describe('OAuth2 gateway transport', () => {
       expect(lastTokenRequestBody!.get('code_verifier')).toBeTruthy();
     });
 
-    test('sends Basic Auth header and omits client_id/client_secret from body when clientSecret is provided', async () => {
+    test('sends Basic Auth header and omits client_id/client_secret from body when tokenEndpointAuthMethod is client_secret_basic', async () => {
       mockPublicBaseUrl = 'https://gw.example.com';
 
       const configWithSecret: OAuth2Config = {
         ...BASE_OAUTH_CONFIG,
         clientSecret: 'test-client-secret',
+        tokenEndpointAuthMethod: 'client_secret_basic',
       };
 
       const flowPromise = startOAuth2Flow(configWithSecret, {
@@ -358,6 +359,34 @@ describe('OAuth2 gateway transport', () => {
 
       // Body should still contain code_verifier
       expect(lastTokenRequestBody!.get('code_verifier')).toBeTruthy();
+    });
+
+    test('sends client_id and client_secret in body when tokenEndpointAuthMethod is client_secret_post (default)', async () => {
+      mockPublicBaseUrl = 'https://gw.example.com';
+
+      const configWithSecret: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        clientSecret: 'test-client-secret',
+      };
+
+      const flowPromise = startOAuth2Flow(configWithSecret, {
+        openUrl: () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve('post-auth-code');
+
+      await flowPromise;
+
+      // No Authorization header for client_secret_post
+      expect(lastTokenRequestHeaders['Authorization']).toBeUndefined();
+
+      // Body should contain client_id and client_secret
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.get('client_id')).toBe('test-client-id');
+      expect(lastTokenRequestBody!.get('client_secret')).toBe('test-client-secret');
     });
 
     test('sends client_id in body without Basic Auth when no clientSecret', async () => {

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -72,6 +72,7 @@ export async function handleTwitterAuthStart(
       clientId,
       clientSecret,
       extraParams: {},
+      tokenEndpointAuthMethod: clientSecret ? 'client_secret_basic' : undefined,
     };
 
     const result = await startOAuth2Flow(oauthConfig, {
@@ -131,6 +132,7 @@ export async function handleTwitterAuthStart(
       oauth2TokenUrl: 'https://api.x.com/2/oauth2/token',
       oauth2ClientId: clientId,
       oauth2ClientSecret: clientSecret ?? null,
+      oauth2TokenEndpointAuthMethod: clientSecret ? 'client_secret_basic' : undefined,
       grantedScopes: result.grantedScopes,
       expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : null,
     });

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -18,6 +18,8 @@ const log = getLogger('oauth2');
 // Types
 // ---------------------------------------------------------------------------
 
+export type TokenEndpointAuthMethod = 'client_secret_basic' | 'client_secret_post';
+
 export interface OAuth2Config {
   authUrl: string;
   tokenUrl: string;
@@ -28,6 +30,13 @@ export interface OAuth2Config {
   extraParams?: Record<string, string>;
   /** URL to fetch user identity info after OAuth. If omitted, account info is not fetched. */
   userinfoUrl?: string;
+  /**
+   * How the client authenticates at the token endpoint when a clientSecret is present.
+   * - `client_secret_post`: Send client_id and client_secret in the POST body (default).
+   * - `client_secret_basic`: Send an HTTP Basic Auth header with base64(client_id:client_secret).
+   * Defaults to `client_secret_post` for backward compatibility.
+   */
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
 }
 
 export interface OAuth2TokenResult {
@@ -80,6 +89,8 @@ async function exchangeCodeForTokens(
   redirectUri: string,
   codeVerifier: string,
 ): Promise<OAuth2FlowResult> {
+  const authMethod = config.tokenEndpointAuthMethod ?? 'client_secret_post';
+
   const tokenBody: Record<string, string> = {
     grant_type: 'authorization_code',
     code,
@@ -91,11 +102,14 @@ async function exchangeCodeForTokens(
     'Content-Type': 'application/x-www-form-urlencoded',
   };
 
-  if (config.clientSecret) {
+  if (config.clientSecret && authMethod === 'client_secret_basic') {
     const credentials = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64');
     headers['Authorization'] = `Basic ${credentials}`;
   } else {
     tokenBody.client_id = config.clientId;
+    if (config.clientSecret) {
+      tokenBody.client_secret = config.clientSecret;
+    }
   }
 
   const tokenResp = await fetch(config.tokenUrl, {
@@ -233,19 +247,32 @@ export async function refreshOAuth2Token(
   clientId: string,
   refreshToken: string,
   clientSecret?: string,
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod,
 ): Promise<OAuth2TokenResult> {
+  const authMethod = tokenEndpointAuthMethod ?? 'client_secret_post';
+
   const body: Record<string, string> = {
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
-    client_id: clientId,
   };
-  if (clientSecret) {
-    body.client_secret = clientSecret;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+
+  if (clientSecret && authMethod === 'client_secret_basic') {
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    headers['Authorization'] = `Basic ${credentials}`;
+  } else {
+    body.client_id = clientId;
+    if (clientSecret) {
+      body.client_secret = clientSecret;
+    }
   }
 
   const resp = await fetch(tokenUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers,
     body: new URLSearchParams(body),
   });
 

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -8,7 +8,7 @@
 
 import { getSecureKey, setSecureKey } from './secure-keys.js';
 import { getCredentialMetadata, upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
-import { refreshOAuth2Token } from './oauth2.js';
+import { refreshOAuth2Token, type TokenEndpointAuthMethod } from './oauth2.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('token-manager');
@@ -66,11 +66,12 @@ async function doRefresh(service: string): Promise<string> {
   }
 
   const clientSecret = meta?.oauth2ClientSecret as string | undefined;
+  const authMethod = meta?.oauth2TokenEndpointAuthMethod as TokenEndpointAuthMethod | undefined;
   const resolvedTokenUrl = tokenUrl;
 
   log.info({ service }, 'Refreshing OAuth2 access token');
 
-  const result = await refreshOAuth2Token(resolvedTokenUrl, clientId, refreshToken, clientSecret);
+  const result = await refreshOAuth2Token(resolvedTokenUrl, clientId, refreshToken, clientSecret, authMethod);
 
   if (!setSecureKey(`credential:${service}:access_token`, result.accessToken)) {
     throw new Error(`Failed to store refreshed access token for "${service}"`);

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -28,6 +28,8 @@ export interface CredentialMetadata {
   oauth2ClientId?: string;
   /** OAuth2 client secret — for providers that require it (e.g. Slack). Stored in metadata for autonomous refresh. */
   oauth2ClientSecret?: string;
+  /** How the client authenticates at the token endpoint (client_secret_basic or client_secret_post). */
+  oauth2TokenEndpointAuthMethod?: string;
   /** Human-friendly name for this credential (e.g. "fal-primary"). */
   alias?: string;
   /** Templates describing how to inject this credential into proxied requests. */
@@ -99,6 +101,7 @@ function migrateRecordV1toV2(record: Record<string, unknown>): CredentialMetadat
     oauth2TokenUrl: typeof record.oauth2TokenUrl === 'string' ? record.oauth2TokenUrl : undefined,
     oauth2ClientId: typeof record.oauth2ClientId === 'string' ? record.oauth2ClientId : undefined,
     oauth2ClientSecret: typeof record.oauth2ClientSecret === 'string' ? record.oauth2ClientSecret : undefined,
+    oauth2TokenEndpointAuthMethod: typeof record.oauth2TokenEndpointAuthMethod === 'string' ? record.oauth2TokenEndpointAuthMethod : undefined,
     alias: typeof record.alias === 'string' ? record.alias : undefined,
     injectionTemplates: Array.isArray(record.injectionTemplates)
       ? (record.injectionTemplates as CredentialInjectionTemplate[])
@@ -186,6 +189,7 @@ export function upsertCredentialMetadata(
     oauth2ClientId?: string;
     /** Pass `null` to explicitly clear a previously-set client secret. */
     oauth2ClientSecret?: string | null;
+    oauth2TokenEndpointAuthMethod?: string;
     /** Pass `null` to explicitly clear a previously-set alias. */
     alias?: string | null;
     /** Pass `null` to explicitly clear injection templates. */
@@ -231,6 +235,7 @@ export function upsertCredentialMetadata(
         existing.oauth2ClientSecret = policy.oauth2ClientSecret;
       }
     }
+    if (policy?.oauth2TokenEndpointAuthMethod !== undefined) existing.oauth2TokenEndpointAuthMethod = policy.oauth2TokenEndpointAuthMethod;
     if (policy?.alias !== undefined) {
       if (policy.alias === null) {
         delete existing.alias;
@@ -263,6 +268,7 @@ export function upsertCredentialMetadata(
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
     oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,
+    oauth2TokenEndpointAuthMethod: policy?.oauth2TokenEndpointAuthMethod,
     alias: policy?.alias ?? undefined,
     injectionTemplates: policy?.injectionTemplates ?? undefined,
     createdAt: now,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -13,7 +13,7 @@ import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetada
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
-import { startOAuth2Flow } from '../../security/oauth2.js';
+import { startOAuth2Flow, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
 import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
@@ -197,6 +197,11 @@ class CredentialStoreTool implements Tool {
           client_secret: {
             type: 'string',
             description: 'OAuth2 client secret for providers that require it (e.g. Google, Slack). If omitted, looked up from previously stored credentials; if still absent, PKCE-only is used (only for oauth2_connect action)',
+          },
+          token_endpoint_auth_method: {
+            type: 'string',
+            enum: ['client_secret_basic', 'client_secret_post'],
+            description: 'How to send client credentials at the token endpoint: "client_secret_post" (default, in POST body) or "client_secret_basic" (HTTP Basic Auth header). Only for oauth2_connect action.',
           },
           alias: {
             type: 'string',
@@ -540,6 +545,7 @@ class CredentialStoreTool implements Tool {
           ?? findStoredOAuthField(service, ['client_id', 'oauth_client_id']);
         const clientSecret = (input.client_secret as string | undefined)
           ?? findStoredOAuthField(service, ['client_secret', 'oauth_client_secret']);
+        const tokenEndpointAuthMethod = input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined;
 
         if (!authUrl) return { content: 'Error: auth_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!tokenUrl) return { content: 'Error: token_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
@@ -560,7 +566,7 @@ class CredentialStoreTool implements Tool {
           const allowedTools = input.allowed_tools as string[] | undefined;
 
           const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
-            { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl },
+            { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl, tokenEndpointAuthMethod },
             {
               openUrl: (url) => {
                 context.sendToClient?.({ type: 'open_url', url, title: `Connect ${service}` });
@@ -610,6 +616,7 @@ class CredentialStoreTool implements Tool {
             oauth2TokenUrl: tokenUrl,
             oauth2ClientId: clientId,
             ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
+            ...(tokenEndpointAuthMethod ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod } : {}),
           });
 
           if (tokens.refreshToken) {


### PR DESCRIPTION
Made the OAuth2 token endpoint auth method configurable (client_secret_basic vs client_secret_post), defaulting to client_secret_post for backward compatibility. Also applied the same auth logic to refreshOAuth2Token. Addresses feedback from #7546.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
