### PR TITLE
fix: resolve CI failures from #7487

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -707,6 +707,11 @@ describe('AssistantConfigSchema', () => {
       callerIdentity: {
         allowPerCallOverride: true,
       },
+      verification: {
+        enabled: false,
+        maxAttempts: 3,
+        codeLength: 6,
+      },
     });
   });
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1593,6 +1593,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     workItemId: 'wi-001',
     title: 'Process report',
   },
+  guardian_request_thread_created: {
+    type: 'guardian_request_thread_created',
+    conversationId: 'conv-guardian-001',
+    requestId: 'req-001',
+    callSessionId: 'call-sess-001',
+    title: 'Guardian action request',
+  },
   subagent_spawned: {
     type: 'subagent_spawned',
     subagentId: 'sub-001',

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -251,6 +251,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     callerIdentity: {
       allowPerCallOverride: true,
     },
+    verification: {
+      enabled: false,
+      maxAttempts: 3,
+      codeLength: 6,
+    },
   },
   sms: {
     enabled: false,


### PR DESCRIPTION
Fixes CI failures introduced by #7487 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22334977993).

Three type errors on main:

1. `config/defaults.ts`: Missing `verification` field in calls defaults (added by CallsVerificationConfigSchema but not reflected in DEFAULT_CONFIG)
2. `config-schema.test.ts`: Test expected calls defaults missing the `verification` field
3. `ipc-snapshot.test.ts`: Missing `guardian_request_thread_created` entry in the ServerMessage snapshot record
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
