### PR TITLE
fix: add missing verification defaults, guardian_request_thread_created snapshot, and config test alignment

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2606,3 +2606,13 @@ exports[`IPC message snapshots ServerMessage types dictation_response serializes
   "type": "dictation_response",
 }
 `;
+
+exports[`IPC message snapshots ServerMessage types guardian_request_thread_created serializes to expected JSON 1`] = `
+{
+  "callSessionId": "call-guardian-001",
+  "conversationId": "conv-guardian-req-001",
+  "requestId": "req-guardian-001",
+  "title": "Guardian action request",
+  "type": "guardian_request_thread_created",
+}
+`;

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -707,6 +707,11 @@ describe('AssistantConfigSchema', () => {
       callerIdentity: {
         allowPerCallOverride: true,
       },
+      verification: {
+        enabled: false,
+        maxAttempts: 3,
+        codeLength: 6,
+      },
     });
   });
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1675,6 +1675,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     mode: 'dictation',
     actionPlan: undefined,
   },
+  guardian_request_thread_created: {
+    type: 'guardian_request_thread_created',
+    conversationId: 'conv-guardian-req-001',
+    requestId: 'req-guardian-001',
+    callSessionId: 'call-guardian-001',
+    title: 'Guardian action request',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -251,6 +251,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     callerIdentity: {
       allowPerCallOverride: true,
     },
+    verification: {
+      enabled: false,
+      maxAttempts: 3,
+      codeLength: 6,
+    },
   },
   sms: {
     enabled: false,


### PR DESCRIPTION
Fixes CI failures introduced by #7468 and #7539 (run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22334545882).

Three type check errors on main:

1. **defaults.ts** — Missing `verification` field in calls config defaults (required by `CallsConfigSchema` after verification was added).
2. **config-schema.test.ts** — `toEqual` assertion for calls defaults did not include the new `verification` sub-object, causing a TS type mismatch.
3. **ipc-snapshot.test.ts** — `guardian_request_thread_created` was added to the `ServerMessage` union but not to the snapshot test's `Record<ServerMessageType, ServerMessage>`, causing a missing-property TS error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
