### PR TITLE
fix: resolve CI failures from PR #7570

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1682,13 +1682,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     mode: 'dictation',
     actionPlan: undefined,
   },
-  guardian_request_thread_created: {
-    type: 'guardian_request_thread_created',
-    conversationId: 'conv-guardian-req-001',
-    requestId: 'req-guardian-001',
-    callSessionId: 'call-guardian-001',
-    title: 'Guardian action request',
-  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes CI failures introduced by #7570 (remove duplicate guardian_request_thread_created entry in ipc-snapshot.test.ts). PRs #7575 and #7576 both added the same entry, causing a TS1117 duplicate property error. Run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22337607081
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
