### PR TITLE
fix: use spyOn for fetch mocking in gateway tests to fix Linux CI

### DIFF
--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,8 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { callTelegramApi } from "../telegram/api.js";
-
-const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -46,18 +44,17 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 }
 
 describe("callTelegramApi transport error redaction", () => {
-  beforeEach(() => {
-    globalThis.fetch = originalFetch;
-  });
+  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
   });
 
   test("redacts bot token from warning logs and thrown error", async () => {
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    globalThis.fetch = mock(async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
       const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
         path?: string;
         code?: string;
@@ -65,7 +62,7 @@ describe("callTelegramApi transport error redaction", () => {
       err.path = `https://api.telegram.org/bot${tgToken}/sendMessage`;
       err.code = "ConnectionRefused";
       throw err;
-    }) as unknown as typeof fetch;
+    });
 
     const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
 
@@ -86,7 +83,7 @@ describe("callTelegramApi transport error redaction", () => {
     // "error-123456789:...") must still be redacted.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    globalThis.fetch = mock(async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -95,7 +92,7 @@ describe("callTelegramApi transport error redaction", () => {
       err.path = `prefix-${tgToken}/sendMessage`;
       err.code = "ConnectionRefused";
       throw err;
-    }) as unknown as typeof fetch;
+    });
 
     const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
 
@@ -116,7 +113,7 @@ describe("callTelegramApi transport error redaction", () => {
     // would fail to match the trailing `-`, leaking part of the token.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz01234567-"].join("");
 
-    globalThis.fetch = mock(async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -124,7 +121,7 @@ describe("callTelegramApi transport error redaction", () => {
       err.path = `https://api.telegram.org/bot${tgToken}/sendMessage`;
       err.code = "ConnectionRefused";
       throw err;
-    }) as unknown as typeof fetch;
+    });
 
     const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
 

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, spyOn, afterEach } from "bun:test";
 import { createTelegramDeliverHandler } from "../http/routes/telegram-deliver.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -45,25 +45,28 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const originalFetch = globalThis.fetch;
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchSpy?.mockRestore();
+  fetchSpy = null;
 });
 
 function mockTelegramApi() {
-  globalThis.fetch = mock(async () => {
+  fetchSpy?.mockRestore();
+  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
-  }) as any;
+  });
 }
 
 describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments without assistantId using assistant-less download path", async () => {
     const calls: string[] = [];
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       // Runtime attachment download (assistant-less path)
@@ -84,7 +87,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
@@ -117,7 +120,8 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
   test("delivers attachments with assistantId using legacy download path", async () => {
     const calls: string[] = [];
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       // Runtime attachment download (legacy path)
@@ -137,7 +141,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
@@ -169,7 +173,8 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 describe("/deliver/telegram ID-only attachment validation", () => {
   test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
     const calls: string[] = [];
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-id-only")) {
@@ -188,7 +193,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
@@ -235,7 +240,8 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
   test("full-metadata attachments still accepted (backward compatibility)", async () => {
     const calls: string[] = [];
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-compat")) {
@@ -254,7 +260,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,12 +1,10 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
 import type { GatewayConfig } from "../config.js";
 
 // Instead of mock.module("../telegram/webhook-manager.js", ...) — which leaks
-// across Bun test files (process-global module mocks) — we mock globalThis.fetch
+// across Bun test files (process-global module mocks) — we use spyOn(globalThis, "fetch")
 // so that the real reconcileTelegramWebhook runs but API calls are intercepted.
-
-const originalFetch = globalThis.fetch;
 
 function makeTelegramResponse(result: unknown) {
   return new Response(JSON.stringify({ ok: true, result }), {
@@ -74,9 +72,11 @@ function makeRequest(
   });
 }
 
-/** Default fetch mock that handles Telegram API calls with success responses. */
-function installDefaultFetchMock() {
-  globalThis.fetch = mock(async (input: string | URL | Request) => {
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+
+/** Default fetch spy that handles Telegram API calls with success responses. */
+function installDefaultFetchSpy() {
+  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
     const url =
       typeof input === "string"
         ? input
@@ -94,16 +94,17 @@ function installDefaultFetchMock() {
       return makeTelegramResponse(true);
     }
     return new Response("Not found", { status: 404 });
-  }) as any;
+  });
 }
 
 describe("POST /internal/telegram/reconcile", () => {
   beforeEach(() => {
-    installDefaultFetchMock();
+    installDefaultFetchSpy();
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
   });
 
   test("rejects non-POST methods", async () => {
@@ -148,7 +149,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     // Fetch was called (getWebhookInfo + setWebhook) proving reconcile ran.
-    expect(globalThis.fetch).toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalled();
   });
 
   test("updates ingressPublicBaseUrl when provided", async () => {
@@ -191,9 +192,10 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 502 when reconcile throws", async () => {
-    globalThis.fetch = mock(async () => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
       throw new Error("Telegram API error");
-    }) as any;
+    });
     const config = makeConfig();
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "test-token"));
@@ -222,7 +224,8 @@ describe("POST /internal/telegram/reconcile", () => {
 
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
-    globalThis.fetch = mock(
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === "string"
@@ -245,7 +248,7 @@ describe("POST /internal/telegram/reconcile", () => {
         }
         return new Response("Not found", { status: 404 });
       },
-    ) as any;
+    );
 
     const config = makeConfig({ ingressPublicBaseUrl: "https://original.com" });
     const handler = createTelegramReconcileHandler(config);

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, spyOn, afterEach } from "bun:test";
 import { sendTelegramAttachments } from "../telegram/send.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
@@ -46,18 +46,18 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+
 function mockFetch(fn: (url: string, init?: RequestInit) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
+  fetchSpy?.mockRestore();
+  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(fn as any);
+  return fetchSpy;
 }
 
 describe("sendTelegramAttachments", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
   });
 
   test("sends image attachment via sendPhoto", async () => {
@@ -293,9 +293,11 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment uses id as filename fallback", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
-    const origMockFetch = mock(async (url: string, init?: RequestInit) => {
-      calls.push({ url, init });
-      if (url.includes("/attachments/my-attachment-id")) {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      calls.push({ url: urlStr, init });
+      if (urlStr.includes("/attachments/my-attachment-id")) {
         return new Response(
           JSON.stringify({
             id: "my-attachment-id",
@@ -307,8 +309,6 @@ describe("sendTelegramAttachments", () => {
       }
       return new Response(JSON.stringify(telegramOk));
     });
-    Object.assign(origMockFetch, { preconnect: () => {} });
-    globalThis.fetch = origMockFetch as unknown as typeof fetch;
 
     const config = makeConfig();
     const meta: RuntimeAttachmentMeta = { id: "my-attachment-id" };

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, test, expect, spyOn, afterEach, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
 
@@ -66,7 +66,7 @@ function makeWebhookRequest(payload: unknown, secret = "test-webhook-secret"): R
   });
 }
 
-const originalFetch = globalThis.fetch;
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 let fetchCalls: { url: string; method: string; body?: unknown; headers?: Record<string, string> }[];
 
 beforeEach(() => {
@@ -74,7 +74,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchSpy?.mockRestore();
+  fetchSpy = null;
 });
 
 /** Extract headers from a fetch call into a plain object. */
@@ -101,7 +102,8 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
  * Runtime forward calls get an eventId response; Telegram API calls get { ok: true }.
  */
 function installFetchMock() {
-  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+  fetchSpy?.mockRestore();
+  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
     let body: unknown;
@@ -137,7 +139,7 @@ function installFetchMock() {
     }
 
     return new Response("Not found", { status: 404 });
-  }) as any;
+  });
 }
 
 describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
@@ -318,7 +320,8 @@ describe("telegram webhook handler: in-flight dedup", () => {
     // Install a fetch mock where the runtime inbound call blocks on the first
     // invocation and responds immediately on subsequent ones.
     let inboundCallCount = 0;
-    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -345,7 +348,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
         });
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const handler = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9001);
@@ -377,7 +380,8 @@ describe("telegram webhook handler: in-flight dedup", () => {
     });
 
     let callCount = 0;
-    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy?.mockRestore();
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -406,7 +410,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
         });
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const handler = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9002);

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock, spyOn, afterEach } from "bun:test";
 import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -43,10 +43,11 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const originalFetch = globalThis.fetch;
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchSpy?.mockRestore();
+  fetchSpy = null;
 });
 
 function makeTelegramResponse(result: unknown) {
@@ -60,7 +61,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -76,7 +77,7 @@ describe("reconcileTelegramWebhook", () => {
         return makeTelegramResponse(true);
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const config = makeConfig();
     await reconcileTelegramWebhook(config);
@@ -92,7 +93,7 @@ describe("reconcileTelegramWebhook", () => {
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {
     const calls: string[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request) => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -107,7 +108,7 @@ describe("reconcileTelegramWebhook", () => {
         return makeTelegramResponse(true);
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const config = makeConfig();
     await reconcileTelegramWebhook(config);
@@ -118,7 +119,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -134,7 +135,7 @@ describe("reconcileTelegramWebhook", () => {
         return makeTelegramResponse(true);
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const config = makeConfig({ ingressPublicBaseUrl: "https://example.ngrok.io/" });
     await reconcileTelegramWebhook(config);
@@ -144,39 +145,36 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when bot token is not configured", async () => {
-    const fetchMock = mock(async () => new Response("", { status: 200 }));
-    globalThis.fetch = fetchMock as any;
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramBotToken: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when webhook secret is not configured", async () => {
-    const fetchMock = mock(async () => new Response("", { status: 200 }));
-    globalThis.fetch = fetchMock as any;
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramWebhookSecret: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when ingress URL is not configured", async () => {
-    const fetchMock = mock(async () => new Response("", { status: 200 }));
-    globalThis.fetch = fetchMock as any;
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ ingressPublicBaseUrl: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 
-    globalThis.fetch = mock(async (input: string | URL | Request) => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -191,7 +189,7 @@ describe("reconcileTelegramWebhook", () => {
         return makeTelegramResponse(true);
       }
       return new Response("Not found", { status: 404 });
-    }) as any;
+    });
 
     const config = makeConfig();
     await reconcileTelegramWebhook(config);


### PR DESCRIPTION
Fix CI failures from #7479 caused by globalThis.fetch = mock(...) not propagating correctly on Linux Bun 1.3.9. All 6 failing test files converted to use spyOn(globalThis, 'fetch').mockImplementation(...) which properly intercepts fetch calls cross-platform.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
