### PR TITLE
M2: Call orchestrator migration to provider abstraction

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -2,7 +2,6 @@ import { describe, test, expect, beforeEach, afterAll, mock, type Mock } from 'b
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { EventEmitter } from 'node:events';
 
 const testDir = mkdtempSync(join(tmpdir(), 'call-orchestrator-test-'));
 
@@ -42,6 +41,8 @@ let mockDisclosure: { enabled: boolean; text: string } = { enabled: false, text:
 
 mock.module('../config/loader.js', () => ({
   getConfig: () => ({
+    provider: 'anthropic',
+    providerOrder: ['anthropic'],
     apiKeys: { anthropic: 'test-key' },
     calls: {
       enabled: true,
@@ -57,48 +58,45 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-// ── Helpers for building mock streaming responses ───────────────────
+// ── Helpers for building mock provider responses ────────────────────
 
 /**
- * Creates a mock Anthropic stream object that emits 'text' events
- * for each token and resolves `finalMessage()` with the full response.
+ * Creates a mock provider sendMessage implementation that emits text_delta
+ * events for each token and resolves with the full response.
  */
-function createMockStream(tokens: string[]) {
-  const emitter = new EventEmitter();
+function createMockProviderResponse(tokens: string[]) {
   const fullText = tokens.join('');
-
-  const stream = {
-    on: (event: string, handler: (...args: unknown[]) => void) => {
-      emitter.on(event, handler);
-      return stream;
-    },
-    finalMessage: () => {
-      // Emit tokens synchronously so the on('text') handler has fired
-      // before finalMessage resolves.
-      for (const token of tokens) {
-        emitter.emit('text', token);
-      }
-      return Promise.resolve({
-        content: [{ type: 'text', text: fullText }],
-      });
-    },
+  return async (
+    _messages: unknown[],
+    _tools: unknown[],
+    _systemPrompt: string,
+    options?: { onEvent?: (event: { type: string; text?: string }) => void; signal?: AbortSignal },
+  ) => {
+    // Emit text_delta events for each token
+    for (const token of tokens) {
+      options?.onEvent?.({ type: 'text_delta', text: token });
+    }
+    return {
+      content: [{ type: 'text', text: fullText }],
+      model: 'claude-sonnet-4-20250514',
+      usage: { inputTokens: 100, outputTokens: 50 },
+      stopReason: 'end_turn',
+    };
   };
-
-  return stream;
 }
 
-// ── Anthropic SDK mock ──────────────────────────────────────────────
+// ── Provider registry mock ──────────────────────────────────────────
 
-let mockStreamFn: Mock<(...args: unknown[]) => unknown>;
+let mockSendMessage: Mock<(...args: unknown[]) => Promise<unknown>>;
 
-mock.module('@anthropic-ai/sdk', () => {
-  mockStreamFn = mock((..._args: unknown[]) => createMockStream(['Hello', ' there']));
+mock.module('../providers/registry.js', () => {
+  mockSendMessage = mock(createMockProviderResponse(['Hello', ' there']));
   return {
-    default: class MockAnthropic {
-      messages = {
-        stream: (...args: unknown[]) => mockStreamFn(...args),
-      };
-    },
+    listProviders: () => ['anthropic'],
+    getFailoverProvider: () => ({
+      name: 'anthropic',
+      sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+    }),
   };
 });
 
@@ -208,14 +206,14 @@ describe('call-orchestrator', () => {
     mockCallModel = undefined;
     mockUserReference = 'my human';
     mockDisclosure = { enabled: false, text: '' };
-    // Reset the stream mock to default behaviour
-    mockStreamFn.mockImplementation(() => createMockStream(['Hello', ' there']));
+    // Reset the provider mock to default behaviour
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello', ' there']));
   });
 
   // ── handleCallerUtterance ─────────────────────────────────────────
 
   test('handleCallerUtterance: streams tokens via sendTextToken', async () => {
-    mockStreamFn.mockImplementation(() => createMockStream(['Hi', ', how', ' are you?']));
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hi', ', how', ' are you?']));
     const { relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('Hello');
@@ -231,7 +229,7 @@ describe('call-orchestrator', () => {
   });
 
   test('handleCallerUtterance: sends last=true at end of turn', async () => {
-    mockStreamFn.mockImplementation(() => createMockStream(['Simple response.']));
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Simple response.']));
     const { relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('Test');
@@ -244,12 +242,18 @@ describe('call-orchestrator', () => {
   });
 
   test('handleCallerUtterance: includes speaker context in model message', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const userMessage = firstArg.messages.find((m) => m.role === 'user');
-      expect(userMessage?.content).toContain('[SPEAKER id="speaker-1" label="Aaron" source="provider" confidence="0.91"]');
-      expect(userMessage?.content).toContain('Can you summarize this meeting?');
-      return createMockStream(['Sure, here is a summary.']);
+    mockSendMessage.mockImplementation(async (messages: unknown[], ..._rest: unknown[]) => {
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const userMessage = msgs.find((m) => m.role === 'user');
+      const userText = userMessage?.content?.[0]?.text ?? '';
+      expect(userText).toContain('[SPEAKER id="speaker-1" label="Aaron" source="provider" confidence="0.91"]');
+      expect(userText).toContain('Can you summarize this meeting?');
+      return {
+        content: [{ type: 'text', text: 'Sure, here is a summary.' }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -265,16 +269,26 @@ describe('call-orchestrator', () => {
   });
 
   test('startInitialGreeting: generates model-driven opening and strips control marker from speech', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const firstUser = firstArg.messages.find((m) => m.role === 'user');
-      expect(firstUser?.content).toContain('[CALL_OPENING]');
-      return createMockStream(['Hi, I am calling about your appointment request. Is now a good time to talk?']);
+    mockSendMessage.mockImplementation(async (messages: unknown[], ..._rest: unknown[]) => {
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const firstUser = msgs.find((m) => m.role === 'user');
+      expect(firstUser?.content?.[0]?.text).toContain('[CALL_OPENING]');
+      const tokens = ['Hi, I am calling about your appointment request. Is now a good time to talk?'];
+      const opts = _rest[2] as { onEvent?: (event: { type: string; text?: string }) => void } | undefined;
+      for (const token of tokens) {
+        opts?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator('Confirm appointment');
 
-    const callCountBefore = mockStreamFn.mock.calls.length;
+    const callCountBefore = mockSendMessage.mock.calls.length;
     await orchestrator.startInitialGreeting();
     await orchestrator.startInitialGreeting();
 
@@ -282,33 +296,42 @@ describe('call-orchestrator', () => {
     expect(allText).toContain('appointment request');
     expect(allText).toContain('good time to talk');
     expect(allText).not.toContain('[CALL_OPENING]');
-    expect(mockStreamFn.mock.calls.length - callCountBefore).toBe(1);
+    expect(mockSendMessage.mock.calls.length - callCountBefore).toBe(1);
 
     orchestrator.destroy();
   });
 
   test('startInitialGreeting: tags only the first caller response with CALL_OPENING_ACK', async () => {
     let callCount = 0;
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
       callCount++;
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
-      const lastUser = userMessages[userMessages.length - 1]?.content ?? '';
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const userMessages = msgs.filter((m) => m.role === 'user');
+      const lastUser = userMessages[userMessages.length - 1]?.content?.[0]?.text ?? '';
 
+      let tokens: string[];
       if (callCount === 1) {
         expect(lastUser).toContain('[CALL_OPENING]');
-        return createMockStream(['Hey Noa, it\'s Credence calling about your joke request. Is now okay for a quick one?']);
-      }
-
-      if (callCount === 2) {
+        tokens = ['Hey Noa, it\'s Credence calling about your joke request. Is now okay for a quick one?'];
+      } else if (callCount === 2) {
         expect(lastUser).toContain('[CALL_OPENING_ACK]');
         expect(lastUser).toContain('Yeah. Sure. What\'s up?');
-        return createMockStream(['Great, here\'s one right away. Why did the scarecrow win an award?']);
+        tokens = ['Great, here\'s one right away. Why did the scarecrow win an award?'];
+      } else {
+        expect(lastUser).not.toContain('[CALL_OPENING_ACK]');
+        expect(lastUser).toContain('Tell me the punchline');
+        tokens = ['Because he was outstanding in his field.'];
       }
 
-      expect(lastUser).not.toContain('[CALL_OPENING_ACK]');
-      expect(lastUser).toContain('Tell me the punchline');
-      return createMockStream(['Because he was outstanding in his field.']);
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator('Tell a joke immediately');
@@ -325,9 +348,9 @@ describe('call-orchestrator', () => {
   // ── ASK_GUARDIAN pattern ──────────────────────────────────────────
 
   test('ASK_GUARDIAN pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Let me check on that. ', '[ASK_GUARDIAN: What date works best?]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Let me check on that. ', '[ASK_GUARDIAN: What date works best?]'],
+    ));
     const { session, relay, orchestrator } = setupOrchestrator('Book appointment');
 
     await orchestrator.handleCallerUtterance('I need to schedule something');
@@ -350,15 +373,13 @@ describe('call-orchestrator', () => {
   });
 
   test('strips internal context markers from spoken output', async () => {
-    mockStreamFn.mockImplementation(() =>
-      createMockStream([
-        'Thanks for waiting. ',
-        '[USER_ANSWERED: The guardian said 3 PM works.] ',
-        '[USER_INSTRUCTION: Keep this short.] ',
-        '[CALL_OPENING_ACK] ',
-        'I can confirm 3 PM works.',
-      ]),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse([
+      'Thanks for waiting. ',
+      '[USER_ANSWERED: The guardian said 3 PM works.] ',
+      '[USER_INSTRUCTION: Keep this short.] ',
+      '[CALL_OPENING_ACK] ',
+      'I can confirm 3 PM works.',
+    ]));
     const { relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('Any update?');
@@ -379,9 +400,9 @@ describe('call-orchestrator', () => {
   // ── END_CALL pattern ──────────────────────────────────────────────
 
   test('END_CALL pattern: detects marker, calls endSession, updates status to completed', async () => {
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Thank you for calling, goodbye! ', '[END_CALL]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Thank you for calling, goodbye! ', '[END_CALL]'],
+    ));
     const { session, relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('That is all, thanks');
@@ -405,20 +426,30 @@ describe('call-orchestrator', () => {
 
   test('handleUserAnswer: returns true immediately and fires LLM asynchronously', async () => {
     // First utterance triggers ASK_GUARDIAN
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_GUARDIAN: Preferred time?]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Hold on. [ASK_GUARDIAN: Preferred time?]'],
+    ));
     const { relay, orchestrator } = setupOrchestrator();
 
     await orchestrator.handleCallerUtterance('I need an appointment');
 
     // Now provide the answer — reset mock for second LLM call
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], ..._rest: unknown[]) => {
       // Verify the messages include the USER_ANSWERED marker
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const lastUserMsg = firstArg.messages.filter((m: { role: string }) => m.role === 'user').pop();
-      expect(lastUserMsg?.content).toContain('[USER_ANSWERED: 3pm tomorrow]');
-      return createMockStream(['Great, I have scheduled for 3pm tomorrow.']);
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const lastUserMsg = msgs.filter((m) => m.role === 'user').pop();
+      expect(lastUserMsg?.content?.[0]?.text).toContain('[USER_ANSWERED: 3pm tomorrow]');
+      const tokens = ['Great, I have scheduled for 3pm tomorrow.'];
+      const opts = _rest[2] as { onEvent?: (event: { type: string; text?: string }) => void } | undefined;
+      for (const token of tokens) {
+        opts?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const accepted = await orchestrator.handleUserAnswer('3pm tomorrow');
@@ -439,9 +470,9 @@ describe('call-orchestrator', () => {
 
   test('mid-call question flow: unavailable time → ask user → user confirms → resumed call', async () => {
     // Step 1: Caller says "7:30" but it's unavailable. The LLM asks the user.
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['I\'m sorry, 7:30 is not available. ', '[ASK_GUARDIAN: Is 8:00 okay instead?]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['I\'m sorry, 7:30 is not available. ', '[ASK_GUARDIAN: Is 8:00 okay instead?]'],
+    ));
 
     const { session, relay, orchestrator } = setupOrchestrator('Schedule a haircut');
 
@@ -458,9 +489,9 @@ describe('call-orchestrator', () => {
     expect(midSession!.status).toBe('waiting_on_user');
 
     // Step 2: User answers "Yes, 8:00 works"
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Great, I\'ve booked you for 8:00. See you then! ', '[END_CALL]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Great, I\'ve booked you for 8:00. See you then! ', '[END_CALL]'],
+    ));
 
     const accepted = await orchestrator.handleUserAnswer('Yes, 8:00 works for me');
     expect(accepted).toBe(true);
@@ -482,16 +513,9 @@ describe('call-orchestrator', () => {
   // ── Provider / LLM failure paths ───────────────────────────────
 
   test('LLM error: sends error message to caller and returns to idle', async () => {
-    // Make the stream throw an error on finalMessage
-    mockStreamFn.mockImplementation(() => {
-      const emitter = new EventEmitter();
-      return {
-        on: (event: string, handler: (...args: unknown[]) => void) => {
-          emitter.on(event, handler);
-          return { on: () => ({ on: () => ({}) }) };
-        },
-        finalMessage: () => Promise.reject(new Error('API rate limit exceeded')),
-      };
+    // Make sendMessage reject with an error
+    mockSendMessage.mockImplementation(async () => {
+      throw new Error('API rate limit exceeded');
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -511,19 +535,10 @@ describe('call-orchestrator', () => {
   });
 
   test('LLM APIUserAbortError: treats as expected abort without technical-issue fallback', async () => {
-    mockStreamFn.mockImplementation(() => {
-      const emitter = new EventEmitter();
-      return {
-        on: (event: string, handler: (...args: unknown[]) => void) => {
-          emitter.on(event, handler);
-          return { on: () => ({ on: () => ({}) }) };
-        },
-        finalMessage: () => {
-          const err = new Error('user abort');
-          err.name = 'APIUserAbortError';
-          return Promise.reject(err);
-        },
-      };
+    mockSendMessage.mockImplementation(async () => {
+      const err = new Error('user abort');
+      err.name = 'APIUserAbortError';
+      throw err;
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -538,22 +553,23 @@ describe('call-orchestrator', () => {
 
   test('stale superseded turn errors do not emit technical-issue fallback', async () => {
     let callCount = 0;
-    mockStreamFn.mockImplementation(() => {
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
       callCount++;
       if (callCount === 1) {
-        const emitter = new EventEmitter();
-        return {
-          on: (event: string, handler: (...args: unknown[]) => void) => {
-            emitter.on(event, handler);
-            return { on: () => ({ on: () => ({}) }) };
-          },
-          finalMessage: () =>
-            new Promise((_, reject) => {
-              setTimeout(() => reject(new Error('stale stream failure')), 20);
-            }),
-        };
+        return new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('stale stream failure')), 20);
+        });
       }
-      return createMockStream(['Second turn response.']);
+      const tokens = ['Second turn response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -572,42 +588,51 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  test('barge-in cleanup never sends empty user turns to Anthropic', async () => {
+  test('barge-in cleanup never sends empty user turns to provider', async () => {
     let callCount = 0;
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void; signal?: AbortSignal }) => {
       callCount++;
 
       // Initial outbound opener
       if (callCount === 1) {
-        return createMockStream(['Hey Noa, this is Credence calling.']);
+        const tokens = ['Hey Noa, this is Credence calling.'];
+        for (const token of tokens) {
+          options?.onEvent?.({ type: 'text_delta', text: token });
+        }
+        return {
+          content: [{ type: 'text', text: tokens.join('') }],
+          model: 'claude-sonnet-4-20250514',
+          usage: { inputTokens: 100, outputTokens: 50 },
+          stopReason: 'end_turn',
+        };
       }
 
       // First caller turn enters an in-flight LLM run that gets interrupted
       if (callCount === 2) {
-        const emitter = new EventEmitter();
-        const options = args[1] as { signal?: AbortSignal } | undefined;
-        return {
-          on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
-            emitter.on(event, handler);
-            return { on: () => ({ on: () => ({}) }) };
-          },
-          finalMessage: () =>
-            new Promise((_, reject) => {
-              options?.signal?.addEventListener('abort', () => {
-                const err = new Error('aborted');
-                err.name = 'AbortError';
-                reject(err);
-              }, { once: true });
-            }),
-        };
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          }, { once: true });
+        });
       }
 
       // Second caller turn should never include an empty user message.
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const userMessages = msgs.filter((m) => m.role === 'user');
       expect(userMessages.length).toBeGreaterThan(0);
-      expect(userMessages.every((m) => m.content.trim().length > 0)).toBe(true);
-      return createMockStream(['Got it, thanks for clarifying.']);
+      expect(userMessages.every((m) => m.content?.[0]?.text?.trim().length > 0)).toBe(true);
+      const tokens = ['Got it, thanks for clarifying.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator('Quick check-in');
@@ -628,37 +653,37 @@ describe('call-orchestrator', () => {
 
   test('rapid caller barge-in coalesces contiguous user turns for role alternation', async () => {
     let callCount = 0;
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void; signal?: AbortSignal }) => {
       callCount++;
       if (callCount === 1) {
-        const emitter = new EventEmitter();
-        const options = args[1] as { signal?: AbortSignal } | undefined;
-        return {
-          on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
-            emitter.on(event, handler);
-            return { on: () => ({ on: () => ({}) }) };
-          },
-          finalMessage: () =>
-            new Promise((_, reject) => {
-              options?.signal?.addEventListener('abort', () => {
-                const err = new Error('aborted');
-                err.name = 'AbortError';
-                reject(err);
-              }, { once: true });
-            }),
-        };
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          }, { once: true });
+        });
       }
 
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const roles = firstArg.messages.map((m) => m.role);
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const roles = msgs.map((m) => m.role);
       for (let i = 1; i < roles.length; i++) {
         expect(!(roles[i - 1] === 'user' && roles[i] === 'user')).toBe(true);
       }
-      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const userMessages = msgs.filter((m) => m.role === 'user');
       const lastUser = userMessages[userMessages.length - 1];
-      expect(lastUser?.content).toContain('First caller utterance');
-      expect(lastUser?.content).toContain('Second caller utterance');
-      return createMockStream(['Merged turn handled.']);
+      expect(lastUser?.content?.[0]?.text).toContain('First caller utterance');
+      expect(lastUser?.content?.[0]?.text).toContain('Second caller utterance');
+      const tokens = ['Merged turn handled.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -676,37 +701,37 @@ describe('call-orchestrator', () => {
 
   test('interrupt then next caller prompt still preserves role alternation', async () => {
     let callCount = 0;
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void; signal?: AbortSignal }) => {
       callCount++;
       if (callCount === 1) {
-        const emitter = new EventEmitter();
-        const options = args[1] as { signal?: AbortSignal } | undefined;
-        return {
-          on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
-            emitter.on(event, handler);
-            return { on: () => ({ on: () => ({}) }) };
-          },
-          finalMessage: () =>
-            new Promise((_, reject) => {
-              options?.signal?.addEventListener('abort', () => {
-                const err = new Error('aborted');
-                err.name = 'AbortError';
-                reject(err);
-              }, { once: true });
-            }),
-        };
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          }, { once: true });
+        });
       }
 
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const roles = firstArg.messages.map((m) => m.role);
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const roles = msgs.map((m) => m.role);
       for (let i = 1; i < roles.length; i++) {
         expect(!(roles[i - 1] === 'user' && roles[i] === 'user')).toBe(true);
       }
-      const userMessages = firstArg.messages.filter((m) => m.role === 'user');
+      const userMessages = msgs.filter((m) => m.role === 'user');
       const lastUser = userMessages[userMessages.length - 1];
-      expect(lastUser?.content).toContain('First caller utterance');
-      expect(lastUser?.content).toContain('Second caller utterance');
-      return createMockStream(['Post-interrupt response.']);
+      expect(lastUser?.content?.[0]?.text).toContain('First caller utterance');
+      expect(lastUser?.content?.[0]?.text).toContain('Second caller utterance');
+      const tokens = ['Post-interrupt response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -746,24 +771,18 @@ describe('call-orchestrator', () => {
   });
 
   test('handleInterrupt: increments llmRunVersion to suppress stale turn side effects', async () => {
-    // Use a stream whose finalMessage resolves immediately but whose
-    // continuation (the code after `await stream.finalMessage()`) will
-    // run asynchronously. This simulates the race where the promise
-    // microtask is queued right as handleInterrupt fires.
-    mockStreamFn.mockImplementation(() => {
-      const emitter = new EventEmitter();
+    // Use a sendMessage that resolves immediately but whose continuation
+    // (the code after `await provider.sendMessage()`) will run asynchronously.
+    // This simulates the race where the promise microtask is queued right
+    // as handleInterrupt fires.
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // Emit some tokens synchronously
+      options?.onEvent?.({ type: 'text_delta', text: 'Stale response that should be suppressed.' });
       return {
-        on: (event: string, handler: (...args: unknown[]) => void) => {
-          emitter.on(event, handler);
-          return { on: () => ({ on: () => ({}) }) };
-        },
-        finalMessage: () => {
-          // Emit some tokens synchronously
-          emitter.emit('text', 'Stale response that should be suppressed.');
-          return Promise.resolve({
-            content: [{ type: 'text', text: 'Stale response that should be suppressed.' }],
-          });
-        },
+        content: [{ type: 'text', text: 'Stale response that should be suppressed.' }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
       };
     });
 
@@ -772,7 +791,7 @@ describe('call-orchestrator', () => {
     // Start an LLM turn (don't await — we want to interrupt mid-flight)
     const turnPromise = orchestrator.handleCallerUtterance('Hello');
 
-    // Interrupt immediately. Because finalMessage resolves as a microtask,
+    // Interrupt immediately. Because sendMessage resolves as a microtask,
     // its continuation hasn't run yet. handleInterrupt increments
     // llmRunVersion so the continuation's isCurrentRun check will fail.
     orchestrator.handleInterrupt();
@@ -795,23 +814,14 @@ describe('call-orchestrator', () => {
   });
 
   test('handleInterrupt: sends turn terminator when interrupting active speech', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const emitter = new EventEmitter();
-      const options = args[1] as { signal?: AbortSignal } | undefined;
-      return {
-        on: (event: string, handler: (...evtArgs: unknown[]) => void) => {
-          emitter.on(event, handler);
-          return { on: () => ({ on: () => ({}) }) };
-        },
-        finalMessage: () =>
-          new Promise((_, reject) => {
-            options?.signal?.addEventListener('abort', () => {
-              const err = new Error('aborted');
-              err.name = 'AbortError';
-              reject(err);
-            }, { once: true });
-          }),
-      };
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void; signal?: AbortSignal }) => {
+      return new Promise((_, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        }, { once: true });
+      });
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -852,10 +862,18 @@ describe('call-orchestrator', () => {
 
   test('uses default model when calls.model is not set', async () => {
     mockCallModel = undefined;
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { model: string };
-      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
-      return createMockStream(['Default model response.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      const tokens = ['Default model response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -865,10 +883,18 @@ describe('call-orchestrator', () => {
 
   test('uses calls.model override from config when set', async () => {
     mockCallModel = 'claude-haiku-4-5-20251001';
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { model: string };
-      expect(firstArg.model).toBe('claude-haiku-4-5-20251001');
-      return createMockStream(['Override model response.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(options?.config?.model).toBe('claude-haiku-4-5-20251001');
+      const tokens = ['Override model response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-haiku-4-5-20251001',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -878,10 +904,18 @@ describe('call-orchestrator', () => {
 
   test('treats empty string calls.model as unset and falls back to default', async () => {
     mockCallModel = '';
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { model: string };
-      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
-      return createMockStream(['Fallback model response.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      const tokens = ['Fallback model response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -891,10 +925,18 @@ describe('call-orchestrator', () => {
 
   test('treats whitespace-only calls.model as unset and falls back to default', async () => {
     mockCallModel = '   ';
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { model: string };
-      expect(firstArg.model).toBe('claude-sonnet-4-20250514');
-      return createMockStream(['Fallback model response.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      const tokens = ['Fallback model response.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -905,14 +947,23 @@ describe('call-orchestrator', () => {
   // ── handleUserInstruction ─────────────────────────────────────────
 
   test('handleUserInstruction: injects instruction marker into conversation history and triggers LLM when idle', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
-      const instructionMsg = firstArg.messages.find((m) =>
-        m.role === 'user' && m.content.includes('[USER_INSTRUCTION:'),
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const instructionMsg = msgs.find((m) =>
+        m.role === 'user' && m.content?.[0]?.text?.includes('[USER_INSTRUCTION:'),
       );
       expect(instructionMsg).toBeDefined();
-      expect(instructionMsg!.content).toContain('[USER_INSTRUCTION: Ask about their weekend plans]');
-      return createMockStream(['Sure, do you have any weekend plans?']);
+      expect(instructionMsg!.content[0].text).toContain('[USER_INSTRUCTION: Ask about their weekend plans]');
+      const tokens = ['Sure, do you have any weekend plans?'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { relay, orchestrator } = setupOrchestrator();
@@ -928,30 +979,38 @@ describe('call-orchestrator', () => {
 
   test('handleUserInstruction: does not break existing answer flow', async () => {
     // Step 1: Caller says something, LLM responds normally
-    mockStreamFn.mockImplementation(() => createMockStream(['Hello! How can I help you today?']));
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello! How can I help you today?']));
     const { session: _session, relay, orchestrator } = setupOrchestrator('Book appointment');
 
     await orchestrator.handleCallerUtterance('Hi there');
 
     // Step 2: Inject an instruction while idle
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { messages: Array<{ role: string; content: string }> };
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
       // Verify the history contains both the original exchange and the instruction
-      const messages = firstArg.messages;
-      expect(messages.length).toBeGreaterThanOrEqual(3); // user utterance + assistant response + instruction
-      const instructionMsg = messages.find((m) =>
-        m.role === 'user' && m.content.includes('[USER_INSTRUCTION:'),
+      expect(msgs.length).toBeGreaterThanOrEqual(3); // user utterance + assistant response + instruction
+      const instructionMsg = msgs.find((m) =>
+        m.role === 'user' && m.content?.[0]?.text?.includes('[USER_INSTRUCTION:'),
       );
       expect(instructionMsg).toBeDefined();
-      return createMockStream(['Of course, let me mention the weekend special.']);
+      const tokens = ['Of course, let me mention the weekend special.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     await orchestrator.handleUserInstruction('Mention the weekend special');
 
     // Step 3: Caller speaks again — the flow should continue normally
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Great choice! The weekend special is 20% off.']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Great choice! The weekend special is 20% off.'],
+    ));
 
     await orchestrator.handleCallerUtterance('Tell me more about that');
 
@@ -967,7 +1026,7 @@ describe('call-orchestrator', () => {
   });
 
   test('handleUserInstruction: emits user_instruction_relayed event', async () => {
-    mockStreamFn.mockImplementation(() => createMockStream(['Understood, adjusting approach.']));
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Understood, adjusting approach.']));
 
     const { session, orchestrator } = setupOrchestrator();
 
@@ -985,19 +1044,24 @@ describe('call-orchestrator', () => {
 
   test('handleUserInstruction: does not trigger LLM when orchestrator is not idle', async () => {
     // First, trigger ASK_GUARDIAN so orchestrator enters waiting_on_user
-    mockStreamFn.mockImplementation(() =>
-      createMockStream(['Hold on. [ASK_GUARDIAN: What time?]']),
-    );
+    mockSendMessage.mockImplementation(createMockProviderResponse(
+      ['Hold on. [ASK_GUARDIAN: What time?]'],
+    ));
 
     const { session, orchestrator } = setupOrchestrator();
     await orchestrator.handleCallerUtterance('I need an appointment');
     expect(orchestrator.getState()).toBe('waiting_on_user');
 
-    // Track how many times the stream mock is called
+    // Track how many times the provider mock is called
     let streamCallCount = 0;
-    mockStreamFn.mockImplementation(() => {
+    mockSendMessage.mockImplementation(async () => {
       streamCallCount++;
-      return createMockStream(['Response after instruction.']);
+      return {
+        content: [{ type: 'text', text: 'Response after instruction.' }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     // Inject instruction while in waiting_on_user state
@@ -1017,10 +1081,18 @@ describe('call-orchestrator', () => {
   // ── System prompt: identity phrasing ────────────────────────────────
 
   test('system prompt contains resolved user reference (default)', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('on behalf of my human');
-      return createMockStream(['Hello.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('on behalf of my human');
+      const tokens = ['Hello.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1030,10 +1102,18 @@ describe('call-orchestrator', () => {
 
   test('system prompt contains resolved user reference when set to a name', async () => {
     mockUserReference = 'John';
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('on behalf of John');
-      return createMockStream(['Hello John\'s contact.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('on behalf of John');
+      const tokens = ['Hello John\'s contact.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1043,11 +1123,19 @@ describe('call-orchestrator', () => {
 
   test('system prompt does not hardcode "your user" in the opening line', async () => {
     mockUserReference = 'Alice';
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).not.toContain('on behalf of your user');
-      expect(firstArg.system).toContain('on behalf of Alice');
-      return createMockStream(['Hi there.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).not.toContain('on behalf of your user');
+      expect(systemPrompt as string).toContain('on behalf of Alice');
+      const tokens = ['Hi there.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1056,11 +1144,19 @@ describe('call-orchestrator', () => {
   });
 
   test('system prompt includes assistant identity bias rule', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('refer to yourself as an assistant');
-      expect(firstArg.system).toContain('Avoid the phrase "AI assistant" unless directly asked');
-      return createMockStream(['Sure thing.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('refer to yourself as an assistant');
+      expect(systemPrompt as string).toContain('Avoid the phrase "AI assistant" unless directly asked');
+      const tokens = ['Sure thing.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1069,11 +1165,19 @@ describe('call-orchestrator', () => {
   });
 
   test('system prompt includes opening-ack guidance to avoid duplicate introductions', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('[CALL_OPENING_ACK]');
-      expect(firstArg.system).toContain('without re-introducing yourself');
-      return createMockStream(['Understood.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('[CALL_OPENING_ACK]');
+      expect(systemPrompt as string).toContain('without re-introducing yourself');
+      const tokens = ['Understood.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1082,15 +1186,23 @@ describe('call-orchestrator', () => {
   });
 
   test('assistant identity rule appears before disclosure rule in prompt', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      const prompt = firstArg.system;
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      const prompt = systemPrompt as string;
       const identityIdx = prompt.indexOf('refer to yourself as an assistant');
       const disclosureIdx = prompt.indexOf('Be concise');
       expect(identityIdx).toBeGreaterThan(-1);
       expect(disclosureIdx).toBeGreaterThan(-1);
       expect(identityIdx).toBeLessThan(disclosureIdx);
-      return createMockStream(['OK.']);
+      const tokens = ['OK.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1103,11 +1215,19 @@ describe('call-orchestrator', () => {
       enabled: true,
       text: 'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
     };
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('introduce yourself as an assistant calling on behalf of the person you represent');
-      expect(firstArg.system).toContain('Do not say "AI assistant"');
-      return createMockStream(['Hello, I am calling on behalf of my human.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('introduce yourself as an assistant calling on behalf of the person you represent');
+      expect(systemPrompt as string).toContain('Do not say "AI assistant"');
+      const tokens = ['Hello, I am calling on behalf of my human.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1117,11 +1237,19 @@ describe('call-orchestrator', () => {
 
   test('system prompt falls back to "Begin the conversation naturally" when disclosure is disabled', async () => {
     mockDisclosure = { enabled: false, text: '' };
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).toContain('Begin the conversation naturally');
-      expect(firstArg.system).not.toContain('introduce yourself as an assistant calling on behalf of the person');
-      return createMockStream(['Hello there.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('Begin the conversation naturally');
+      expect(systemPrompt as string).not.toContain('introduce yourself as an assistant calling on behalf of the person');
+      const tokens = ['Hello there.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();
@@ -1130,10 +1258,18 @@ describe('call-orchestrator', () => {
   });
 
   test('system prompt does not use "AI assistant" as a self-identity label', async () => {
-    mockStreamFn.mockImplementation((...args: unknown[]) => {
-      const firstArg = args[0] as { system: string };
-      expect(firstArg.system).not.toMatch(/(?:you are|call yourself|introduce yourself as).*AI assistant/i);
-      return createMockStream(['Got it.']);
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).not.toMatch(/(?:you are|call yourself|introduce yourself as).*AI assistant/i);
+      const tokens = ['Got it.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
     });
 
     const { orchestrator } = setupOrchestrator();

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -6,8 +6,9 @@
  * streams text tokens back through the RelayConnection for real-time TTS.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from '../config/loader.js';
+import { getFailoverProvider, listProviders } from '../providers/registry.js';
+import type { ProviderEvent } from '../providers/types.js';
 import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
 import {
@@ -336,35 +337,23 @@ export class CallOrchestrator {
    * the response back through the relay.
    */
   private async runLlm(): Promise<void> {
-    const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      log.error({ callSessionId: this.callSessionId }, 'No Anthropic API key available');
+    const config = getConfig();
+    const providerName = config.provider;
+    if (!listProviders().includes(providerName)) {
+      log.error({ callSessionId: this.callSessionId }, 'No provider available');
       this.relay.sendTextToken('I\'m sorry, I\'m having a technical issue. Please try again later.', true);
       this.state = 'idle';
       return;
     }
+    const provider = getFailoverProvider(providerName, config.providerOrder);
 
-    const client = new Anthropic({ apiKey });
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
 
     try {
       this.state = 'speaking';
 
-      const callModel = getConfig().calls.model?.trim() || 'claude-sonnet-4-20250514';
-
-      const stream = client.messages.stream(
-        {
-          model: callModel,
-          max_tokens: 512,
-          system: this.buildSystemPrompt(),
-          messages: this.conversationHistory.map((m) => ({
-            role: m.role,
-            content: m.content,
-          })),
-        },
-        { signal: runSignal },
-      );
+      const callModel = config.calls.model?.trim() || 'claude-sonnet-4-20250514';
 
       // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -430,17 +419,29 @@ export class CallOrchestrator {
         }
       };
 
-      stream.on('text', (text) => {
-        if (!this.isCurrentRun(runVersion)) return;
-        ttsBuffer += text;
-
-        // Remove complete control markers before text reaches TTS.
-        ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
-
-        flushSafeText(false);
-      });
-
-      const finalMessage = await stream.finalMessage();
+      const response = await provider.sendMessage(
+        this.conversationHistory.map((m) => ({
+          role: m.role as 'user' | 'assistant',
+          content: [{ type: 'text' as const, text: m.content }],
+        })),
+        [],  // no tools
+        this.buildSystemPrompt(),
+        {
+          config: {
+            model: callModel,
+            max_tokens: 512,
+          },
+          onEvent: (event: ProviderEvent) => {
+            if (!this.isCurrentRun(runVersion)) return;
+            if (event.type === 'text_delta') {
+              ttsBuffer += event.text;
+              ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
+              flushSafeText(false);
+            }
+          },
+          signal: runSignal,
+        },
+      );
       if (!this.isCurrentRun(runVersion)) return;
 
       // Final sweep: strip any remaining control markers from the buffer
@@ -452,11 +453,10 @@ export class CallOrchestrator {
       // Signal end of this turn's speech
       this.relay.sendTextToken('', true);
 
-      const responseText =
-        finalMessage.content
-          .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-          .map((b) => b.text)
-          .join('') || '';
+      const responseText = response.content
+        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+        .map((b) => b.text)
+        .join('') || '';
 
       // Record the assistant response
       this.conversationHistory.push({ role: 'assistant', content: responseText });


### PR DESCRIPTION
## Summary
- Remove direct `@anthropic-ai/sdk` import from `call-orchestrator.ts`
- Use `getFailoverProvider`/`listProviders` from provider registry for LLM calls
- Replace `client.messages.stream` with `provider.sendMessage` using `onEvent` for text_delta streaming
- Update all tests to mock provider registry instead of Anthropic SDK
- Preserve all existing behavior: ttsBuffer, marker stripping, abort handling, ASK_GUARDIAN, END_CALL

Part of #7583
Closes #7587
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
