### PR TITLE
fix: ensure daemon-bin directory exists before copying bundled skills

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -197,6 +197,7 @@ fi
 # Always refresh bundled skills from source (skill assets like SKILL.md aren't
 # tracked by the daemon binary staleness check, so copy unconditionally)
 if [ -d "$ASSISTANT_SRC_DIR/src/config/bundled-skills" ]; then
+    mkdir -p "$SCRIPT_DIR/daemon-bin"
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
 fi


### PR DESCRIPTION
Addresses review feedback from PR #7555. Adds mkdir -p before the unconditional bundled-skills copy to prevent build failures when daemon-bin/ doesn't exist yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
