### PR TITLE
fix: widen mockSendMessage type to Mock<any> for bun-types compat

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -88,7 +88,7 @@ function createMockProviderResponse(tokens: string[]) {
 // ── Provider registry mock ──────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockSendMessage: Mock<(...args: any[]) => Promise<any>>;
+let mockSendMessage: Mock<any>;
 
 mock.module('../providers/registry.js', () => {
   mockSendMessage = mock(createMockProviderResponse(['Hello', ' there']));


### PR DESCRIPTION
## Summary
- Change `mockSendMessage` type from `Mock<(...args: any[]) => Promise<any>>` to `Mock<any>` in call-orchestrator tests
- Fixes type check failures caused by `Mock<T>` invariance in newer `@types/bun` — typed mock implementations were not assignable to the narrower function signature

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22337842483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
