### PR TITLE
fix: preserve metadata in addMessage return value

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -159,7 +159,7 @@ export function addMessage(conversationId: string, role: string, content: string
       throw err;
     }
   }
-  const message = { id: messageId, conversationId, role, content, createdAt: now };
+  const message = { id: messageId, conversationId, role, content, createdAt: now, ...(metadataStr ? { metadata: metadataStr } : {}) };
 
   try {
     const config = getConfig();


### PR DESCRIPTION
Addresses review feedback from PR #7556. Restores metadata field in the object returned by addMessage so callers can immediately use the persisted data without re-reading from the DB.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
