### PR TITLE
fix: propagate taskRunId in run-now task callback

### DIFF
--- a/assistant/src/daemon/handlers/config.ts
+++ b/assistant/src/daemon/handlers/config.ts
@@ -396,8 +396,9 @@ export async function handleScheduleRunNow(
       const { runTask } = await import('../../tasks/task-runner.js');
       const result = await runTask(
         { taskId, workingDir: process.cwd() },
-        async (conversationId: string, message: string) => {
+        async (conversationId, message, taskRunId) => {
           const session = await ctx.getOrCreateSession(conversationId, socket, true);
+          (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
           await session.processMessage(message, [], (event) => {
             ctx.send(socket, event);
           });


### PR DESCRIPTION
Addresses review feedback from PR #7560. Wires the taskRunId through the processMessage callback in handleScheduleRunNow so ephemeral permission rules are properly applied during manual task execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
