### PR TITLE
fix: use reminder_id key and add verb prefix in permission previews

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -161,7 +161,7 @@ public final class ToolConfirmationNotificationService {
                 let truncated = message.count > 60 ? String(message.prefix(57)) + "..." : message
                 parts.append("\"\(truncated)\"")
             }
-            return parts.isEmpty ? "\(verb) schedule" : parts.joined(separator: " — ")
+            return parts.isEmpty ? "\(verb) schedule" : "\(verb): \(parts.joined(separator: " — "))"
         case "schedule_delete":
             return (input["job_id"]?.value as? String) ?? "schedule"
         case "reminder_create":
@@ -179,7 +179,7 @@ public final class ToolConfirmationNotificationService {
         case "reminder_list":
             return "List reminders"
         case "reminder_cancel":
-            let id = (input["id"]?.value as? String) ?? ""
+            let id = (input["reminder_id"]?.value as? String) ?? ""
             return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         default:
             // Prefer semantically meaningful keys over arbitrary dictionary order

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -164,7 +164,7 @@ public struct ToolConfirmationData: Equatable {
         case "reminder_list":
             return "List reminders"
         case "reminder_cancel":
-            let id = (input["id"]?.value as? String) ?? ""
+            let id = (input["reminder_id"]?.value as? String) ?? ""
             return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         case "credential_store":
             return Self.credentialPreview(input: input)


### PR DESCRIPTION
Addresses review feedback from PR #7563. Fixes reminder_cancel to use reminder_id (matching tool schema) and adds verb prefix to schedule preview in notification service for consistency with ChatMessage.swift.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
