### PR TITLE
fix: use untruncated path for image file existence checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -275,8 +275,8 @@ private struct UsedToolsRow: View {
     /// Open the image in Preview.app. Tries the original file path first; falls
     /// back to writing the NSImage to a temp file when the path is unavailable.
     private func openImageInPreview(_ image: NSImage) {
-        // Use inputSummary (bare value without key prefix) for file path checks
-        let path = toolCall.inputSummary
+        // Use inputRawValue (untruncated) for file path checks
+        let path = toolCall.inputRawValue
         if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
             openInPreview(URL(fileURLWithPath: path))
             return

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -566,6 +566,10 @@ public struct ToolCallData: Identifiable, Equatable {
     public let inputSummary: String
     /// Full (untruncated) input text for display in expanded views.
     public let inputFull: String
+    /// Untruncated raw value of the primary input key (e.g. file path).
+    /// Unlike inputSummary (truncated to 80 chars) this preserves the full value
+    /// for use in file existence checks and opening files.
+    public let inputRawValue: String
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
@@ -598,16 +602,18 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
             && lhs.inputFull == rhs.inputFull
+            && lhs.inputRawValue == rhs.inputRawValue
             && lhs.imageData == rhs.imageData
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
         self.inputFull = inputFull ?? inputSummary
+        self.inputRawValue = inputRawValue ?? inputSummary
         self.result = result
         self.isError = isError
         self.isComplete = isComplete

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -904,6 +904,7 @@ extension ChatViewModel {
                 toolName: msg.toolName,
                 inputSummary: summarizeToolInput(msg.input),
                 inputFull: formatAllToolInput(msg.input),
+                inputRawValue: extractToolInput(msg.input),
                 arrivedBeforeText: !currentAssistantHasText,
                 startedAt: Date()
             )

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -84,8 +84,8 @@ public struct ToolCallChip: View {
                     // Image preview (for browser_screenshot etc.)
                     if let cachedImage = toolCall.cachedImage {
                         #if os(macOS)
-                        let canOpenImage = !toolCall.inputSummary.isEmpty
-                            && FileManager.default.fileExists(atPath: toolCall.inputSummary)
+                        let canOpenImage = !toolCall.inputRawValue.isEmpty
+                            && FileManager.default.fileExists(atPath: toolCall.inputRawValue)
                         if canOpenImage {
                             Image(nsImage: cachedImage)
                                 .resizable()
@@ -94,7 +94,7 @@ public struct ToolCallChip: View {
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                 .padding(.horizontal, VSpacing.sm)
                                 .onTapGesture(count: 2) {
-                                    NSWorkspace.shared.open(URL(fileURLWithPath: toolCall.inputSummary))
+                                    NSWorkspace.shared.open(URL(fileURLWithPath: toolCall.inputRawValue))
                                 }
                                 .onHover { hovering in
                                     if hovering { NSCursor.pointingHand.push() }


### PR DESCRIPTION
Addresses review feedback from PR #7559. Adds inputRawValue property to ToolCallData storing the full untruncated path from extractToolInput(), and uses it for fileExists checks instead of the 80-char-truncated inputSummary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
