### PR TITLE
fix: defer scroll-down re-tether check to next run-loop tick

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -733,12 +733,15 @@ private struct ScrollWheelDetector: NSViewRepresentable {
                 }
             } else if event.scrollingDeltaY < -1 {
                 // Scrolling down (direct or momentum) — re-tether if at bottom.
-                // Scrolling down — check if the underlying NSScrollView is at the bottom
-                if let scrollView = coordinator.findEnclosingScrollView() {
-                    let clipBounds = scrollView.contentView.bounds
-                    let docHeight = scrollView.documentView?.frame.height ?? 0
-                    if docHeight - clipBounds.maxY < 50 {
-                        coordinator.onScrollToBottom?()
+                // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
+                // reading it synchronously in the event monitor sees the pre-scroll state.
+                DispatchQueue.main.async {
+                    if let scrollView = coordinator.findEnclosingScrollView() {
+                        let clipBounds = scrollView.contentView.bounds
+                        let docHeight = scrollView.documentView?.frame.height ?? 0
+                        if docHeight - clipBounds.maxY < 50 {
+                            coordinator.onScrollToBottom?()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Addresses review feedback from PR #7566. Defers the scroll-down re-tether check to DispatchQueue.main.async, matching the scroll-up untether pattern, so clipBounds reflects the post-scroll position.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
