### PR TITLE
fix: unify schedule thread classification between MainWindowView and ThreadManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -926,21 +926,12 @@ struct MainWindowView: View {
         .draggable(thread.id.uuidString)
     }
 
-    /// Whether a thread is a scheduled/reminder conversation, checking source field
-    /// with fallback to legacy title prefixes for HTTP mode where source may be nil.
-    private func isScheduleThread(_ thread: ThreadModel) -> Bool {
-        if let source = thread.source {
-            return source == "schedule" || source == "reminder"
-        }
-        return thread.title.hasPrefix("[Schedule]") || thread.title.hasPrefix("[Reminder]")
-    }
-
     private var regularThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { !isScheduleThread($0) }
+        threadManager.visibleThreads.filter { !$0.isScheduleThread }
     }
 
     private var scheduleThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { isScheduleThread($0) }
+        threadManager.visibleThreads.filter { $0.isScheduleThread }
     }
 
     private var displayedThreads: [ThreadModel] {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -425,8 +425,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Don't reshuffle threads that are already visible in the collapsed sidebar.
         // The sidebar shows regular threads (top 5) and schedule/reminder threads (top 3) separately.
         let visible = visibleThreads
-        let regularIds = visible.filter { $0.source != "schedule" && $0.source != "reminder" }.prefix(5).map(\.id)
-        let scheduleIds = visible.filter { $0.source == "schedule" || $0.source == "reminder" }.prefix(3).map(\.id)
+        let regularIds = visible.filter { !$0.isScheduleThread }.prefix(5).map(\.id)
+        let scheduleIds = visible.filter { $0.isScheduleThread }.prefix(3).map(\.id)
         let visibleIds = Set(regularIds + scheduleIds)
         guard !visibleIds.contains(threadId) else { return }
         threads[index].lastInteractedAt = Date()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -31,4 +31,13 @@ struct ThreadModel: Identifiable, Hashable {
         self.kind = kind
         self.source = source
     }
+
+    /// Whether this thread was created by a schedule or reminder trigger.
+    /// Falls back to title prefix when source is nil (HTTP mode).
+    var isScheduleThread: Bool {
+        if let source = source {
+            return source == "schedule" || source == "reminder"
+        }
+        return title.hasPrefix("[Schedule]") || title.hasPrefix("[Reminder]")
+    }
 }


### PR DESCRIPTION
Addresses review feedback from PR #7565. Extracts isScheduleThread logic into a shared computed property on ThreadModel so both MainWindowView and ThreadManager use the same classification with title-prefix fallback for HTTP mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
