### PR TITLE
Fix: Treat empty callSessionId as inbound in gateway

### DIFF
--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -166,6 +166,24 @@ describe("twilio voice webhook handler", () => {
     expect(lastForwardedAssistantId).toBeUndefined();
   });
 
+  test("empty callSessionId is treated as inbound (resolves assistant by To number)", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest(
+      {
+        CallSid: "CA_empty_session",
+        From: "+14155551234",
+        To: "+15550001111",
+      },
+      "?callSessionId=",
+    );
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("assistant-abc");
+    expect(lastForwardedParams?.CallSid).toBe("CA_empty_session");
+  });
+
   test("inbound call resolves second assistant by To number", async () => {
     const handler = createTwilioVoiceWebhookHandler(baseConfig);
     const req = makeVoiceRequest({

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -17,7 +17,7 @@ export function createTwilioVoiceWebhookHandler(config: GatewayConfig) {
     // For inbound calls (no callSessionId in the URL), resolve the assistant
     // by the "To" phone number so the runtime knows which assistant to use.
     const url = new URL(req.url);
-    const hasCallSessionId = url.searchParams.has("callSessionId");
+    const hasCallSessionId = !!url.searchParams.get("callSessionId");
     let assistantId: string | undefined;
 
     if (!hasCallSessionId && params.To) {


### PR DESCRIPTION
Addresses feedback on #7601. Aligns gateway callSessionId check with runtime by using get() instead of has(), so empty callSessionId is treated as inbound.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
