### PR TITLE
fix: don't show proxy args for host_bash in full input preview

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -107,7 +107,7 @@ public struct ToolConfirmationData: Equatable {
     /// Used in the "More details" section so the user can see exactly what will happen.
     public var fullInputPreview: String {
         switch toolName {
-        case "bash", "host_bash":
+        case "bash":
             let command = (input["command"]?.value as? String) ?? ""
             var extras: [String] = []
             if let networkMode = input["network_mode"]?.value as? String, !networkMode.isEmpty {
@@ -122,6 +122,12 @@ public struct ToolConfirmationData: Equatable {
             }
             if extras.isEmpty { return command }
             return command + "\n\n" + extras.joined(separator: "\n")
+        case "host_bash":
+            let command = (input["command"]?.value as? String) ?? ""
+            if let timeout = input["timeout_seconds"]?.value {
+                return command + "\n\ntimeout_seconds: \(timeout)"
+            }
+            return command
         default:
             break
         }


### PR DESCRIPTION
Addresses review feedback from PR #7567. Separates host_bash from bash in fullInputPreview so that network_mode and credential_ids (which host_bash ignores) are not shown in the confirmation UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
