### PR TITLE
refactor: migrate all direct Anthropic SDK usage to provider abstraction

### DIFF
--- a/assistant/src/__tests__/clarification-resolver.test.ts
+++ b/assistant/src/__tests__/clarification-resolver.test.ts
@@ -6,33 +6,53 @@ let llmResolution: 'keep_existing' | 'keep_candidate' | 'merge' | 'still_unclear
 let llmResolvedStatement = '';
 let llmExplanation = 'Unclear response from user.';
 
-mock.module('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
-    messages = {
-      create: async (_body: unknown, opts?: { signal?: AbortSignal }) => {
-        llmCallCount += 1;
-        if (llmDelayMs > 0) {
-          await new Promise((resolve, reject) => {
-            const timer = setTimeout(resolve, llmDelayMs);
-            opts?.signal?.addEventListener('abort', () => {
-              clearTimeout(timer);
-              reject(new Error('Request was aborted.'));
-            });
+mock.module('../providers/anthropic-send-message.js', () => ({
+  getAnthropicProvider: () => ({
+    sendMessage: async (
+      _messages: unknown,
+      _tools: unknown,
+      _system: unknown,
+      opts?: { signal?: AbortSignal },
+    ) => {
+      llmCallCount += 1;
+      if (llmDelayMs > 0) {
+        await new Promise((resolve, reject) => {
+          const timer = setTimeout(resolve, llmDelayMs);
+          opts?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(new Error('Request was aborted.'));
           });
-        }
-        return {
-          content: [{
-            type: 'tool_use',
-            input: {
-              resolution: llmResolution,
-              resolved_statement: llmResolvedStatement,
-              explanation: llmExplanation,
-            },
-          }],
-        };
-      },
+        });
+      }
+      return {
+        content: [{
+          type: 'tool_use' as const,
+          id: 'test-tool-use-id',
+          name: 'resolve_conflict',
+          input: {
+            resolution: llmResolution,
+            resolved_statement: llmResolvedStatement,
+            explanation: llmExplanation,
+          },
+        }],
+        model: 'claude-haiku-4-5-20251001',
+        stopReason: 'tool_use',
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    },
+  }),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
     };
   },
+  extractToolUse: (response: { content: Array<{ type: string }> }) => {
+    return response.content.find((b: { type: string }) => b.type === 'tool_use');
+  },
+  userMessage: (text: string) => ({ role: 'user', content: [{ type: 'text', text }] }),
 }));
 
 mock.module('../config/loader.js', () => ({

--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -15,22 +15,37 @@ const classifyRelationshipMock = mock(async () => {
   return {
     content: [
       {
-        type: 'tool_use',
+        type: 'tool_use' as const,
+        id: 'test-tool-use-id',
+        name: 'classify_relationship',
         input: {
           relationship: nextRelationship,
           explanation: nextExplanation,
         },
       },
     ],
+    model: 'claude-haiku-4-5-20251001',
+    stopReason: 'tool_use',
+    usage: { inputTokens: 0, outputTokens: 0 },
   };
 });
 
-mock.module('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
-    messages = {
-      create: classifyRelationshipMock,
+mock.module('../providers/anthropic-send-message.js', () => ({
+  getAnthropicProvider: () => ({
+    sendMessage: classifyRelationshipMock,
+  }),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
     };
   },
+  extractToolUse: (response: { content: Array<{ type: string }> }) => {
+    return response.content.find((b: { type: string }) => b.type === 'tool_use');
+  },
+  userMessage: (text: string) => ({ role: 'user', content: [{ type: 'text', text }] }),
 }));
 
 mock.module('../util/platform.js', () => ({

--- a/assistant/src/__tests__/no-direct-anthropic-sdk-imports.test.ts
+++ b/assistant/src/__tests__/no-direct-anthropic-sdk-imports.test.ts
@@ -1,0 +1,42 @@
+import { execSync } from 'node:child_process';
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Guard test: production files under assistant/src must not import
+ * `@anthropic-ai/sdk` directly. Only the canonical provider adapter is
+ * allowed to use the SDK.
+ *
+ * Allowlist entries should be kept minimal — add a path here only if it
+ * genuinely needs to talk to the Anthropic SDK without going through the
+ * provider abstraction.
+ */
+const ALLOWED_FILES = new Set([
+  'assistant/src/providers/anthropic/client.ts',
+]);
+
+describe('no direct @anthropic-ai/sdk imports', () => {
+  test('production files do not import @anthropic-ai/sdk outside allowlist', () => {
+    let grepOutput = '';
+    try {
+      grepOutput = execSync(
+        `git grep -l "@anthropic-ai/sdk" -- 'assistant/src/**/*.ts'`,
+        { encoding: 'utf-8', cwd: process.cwd() + '/../..' },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — that's the happy path
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    const files = grepOutput
+      .split('\n')
+      .filter((f) => f.length > 0)
+      // Exclude test files — they legitimately mock the SDK
+      .filter((f) => !f.includes('/__tests__/'));
+    const violations = files.filter((f) => !ALLOWED_FILES.has(f));
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises';
-import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../../../../config/loader.js';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getAnthropicProvider, extractText, userMessageWithImage } from '../../../../providers/anthropic-send-message.js';
 import {
   getMediaAssetById,
   getKeyframesForAsset,
@@ -70,9 +69,8 @@ export async function analyzeKeyframesForAsset(
 
   updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
 
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     updateProcessingStage(stage.id, {
       status: 'failed',
       lastError: 'Anthropic API key not configured',
@@ -80,7 +78,6 @@ export async function analyzeKeyframesForAsset(
     throw new Error('No Anthropic API key available. Configure it in settings or set ANTHROPIC_API_KEY.');
   }
 
-  const client = new Anthropic({ apiKey });
   let analyzedCount = analyzedKeyframeIds.size;
   const totalKeyframes = keyframes.length;
 
@@ -114,7 +111,7 @@ export async function analyzeKeyframesForAsset(
         }
 
         try {
-          const result = await analyzeKeyframe(client, keyframe);
+          const result = await analyzeKeyframe(provider, keyframe);
           batchResults.push({
             assetId,
             keyframeId: keyframe.id,
@@ -232,7 +229,7 @@ export async function run(
 }
 
 async function analyzeKeyframe(
-  client: Anthropic,
+  provider: import('../../../../providers/types.js').Provider,
   keyframe: MediaKeyframe,
 ): Promise<{ output: Record<string, unknown>; confidence: number }> {
   // Read the image file and encode as base64
@@ -250,33 +247,20 @@ async function analyzeKeyframe(
   };
   const mediaType = mediaTypeMap[ext] ?? 'image/jpeg';
 
-  const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250514',
-    max_tokens: 1024,
-    messages: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'image',
-            source: {
-              type: 'base64',
-              media_type: mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
-              data: base64,
-            },
-          },
-          {
-            type: 'text',
-            text: VLM_PROMPT,
-          },
-        ],
+  const response = await provider.sendMessage(
+    [userMessageWithImage(base64, mediaType, VLM_PROMPT)],
+    undefined,
+    undefined,
+    {
+      config: {
+        model: 'claude-sonnet-4-6-20250514',
+        max_tokens: 1024,
       },
-    ],
-  });
+    },
+  );
 
   // Extract text from response
-  const textBlock = response.content.find((block) => block.type === 'text');
-  const responseText = textBlock && 'text' in textBlock ? textBlock.text : '';
+  const responseText = extractText(response);
 
   // Parse JSON from response
   let output: Record<string, unknown>;

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
-import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from './loader.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
@@ -8,6 +7,7 @@ import { stripCommentLines } from './system-prompt.js';
 import { parseFrontmatterFields } from '../skills/frontmatter.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
+import { getAnthropicProvider, extractAllText, userMessage } from '../providers/anthropic-send-message.js';
 
 const log = getLogger('skills');
 
@@ -887,27 +887,24 @@ export function loadSkillBySelector(selector: string, workspaceSkillsDir?: strin
 // ─── Icon generation ─────────────────────────────────────────────────────────
 
 async function generateSkillIcon(name: string, description: string): Promise<string> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     throw new Error('No Anthropic API key available for icon generation');
   }
 
-  const client = new Anthropic({ apiKey });
-  const response = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 1024,
-    system: 'You are a pixel art icon designer. When asked, return ONLY a single <svg> element — no explanation, no markdown, no code fences. The SVG must be a 16x16 grid pixel art icon using <rect> elements. Use a limited palette (3-5 colors). Keep it under 2KB. The viewBox should be "0 0 16 16" with each pixel being a 1x1 rect.',
-    messages: [{
-      role: 'user',
-      content: `Create a 16x16 pixel art SVG icon representing this skill:\nName: ${name}\nDescription: ${description}`,
-    }],
-  });
+  const response = await provider.sendMessage(
+    [userMessage(`Create a 16x16 pixel art SVG icon representing this skill:\nName: ${name}\nDescription: ${description}`)],
+    undefined,
+    'You are a pixel art icon designer. When asked, return ONLY a single <svg> element — no explanation, no markdown, no code fences. The SVG must be a 16x16 grid pixel art icon using <rect> elements. Use a limited palette (3-5 colors). Keep it under 2KB. The viewBox should be "0 0 16 16" with each pixel being a 1x1 rect.',
+    {
+      config: {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+      },
+    },
+  );
 
-  const text = response.content
-    .filter((block): block is Anthropic.TextBlock => block.type === 'text')
-    .map((block) => block.text)
-    .join('');
+  const text = extractAllText(response);
 
   const svgMatch = text.match(/<svg[\s\S]*<\/svg>/i);
   if (!svgMatch) {

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -1,5 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../config/loader.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('classifier');
@@ -18,21 +17,18 @@ export async function classifyInteraction(task: string, source?: 'voice' | 'text
     return 'text_qa';
   }
 
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.warn('No API key available, falling back to heuristic classification');
     return classifyHeuristic(task);
   }
 
   try {
-    const client = new Anthropic({ apiKey });
-    const response = await Promise.race([
-      client.messages.create({
-        model: 'claude-haiku-4-5-20251001',
-        max_tokens: 128,
-        system: 'You are a classifier. Determine whether the user\'s request requires computer use (controlling the GUI — clicking, scrolling, typing into app windows, navigating between apps) or can be handled with local tools (answering questions, running terminal commands, creating/editing/reading files, web searches, writing code). GUI tasks → computer_use. Everything else → text_qa.',
-        tools: [{
+    const { signal, cleanup } = createTimeout(CLASSIFICATION_TIMEOUT_MS);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(task)],
+        [{
           name: 'classify_interaction',
           description: 'Classify the user interaction type',
           input_schema: {
@@ -51,24 +47,31 @@ export async function classifyInteraction(task: string, source?: 'voice' | 'text
             required: ['interaction_type', 'reasoning'],
           },
         }],
-        tool_choice: { type: 'tool' as const, name: 'classify_interaction' },
-        messages: [{ role: 'user' as const, content: task }],
-      }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Classification timeout')), CLASSIFICATION_TIMEOUT_MS),
-      ),
-    ]);
+        'You are a classifier. Determine whether the user\'s request requires computer use (controlling the GUI — clicking, scrolling, typing into app windows, navigating between apps) or can be handled with local tools (answering questions, running terminal commands, creating/editing/reading files, web searches, writing code). GUI tasks → computer_use. Everything else → text_qa.',
+        {
+          config: {
+            model: 'claude-haiku-4-5-20251001',
+            max_tokens: 128,
+            tool_choice: { type: 'tool' as const, name: 'classify_interaction' },
+          },
+          signal,
+        },
+      );
+      cleanup();
 
-    const toolBlock = response.content.find((b) => b.type === 'tool_use');
-    if (toolBlock && toolBlock.type === 'tool_use') {
-      const input = toolBlock.input as { interaction_type?: string; reasoning?: string };
-      const result = input.interaction_type === 'text_qa' ? 'text_qa' : 'computer_use';
-      log.info({ result, reasoning: input.reasoning }, 'Haiku classification');
-      return result;
+      const toolBlock = extractToolUse(response);
+      if (toolBlock) {
+        const input = toolBlock.input as { interaction_type?: string; reasoning?: string };
+        const result = input.interaction_type === 'text_qa' ? 'text_qa' : 'computer_use';
+        log.info({ result, reasoning: input.reasoning }, 'Haiku classification');
+        return result;
+      }
+
+      log.warn('No tool_use block in classification response, falling back to heuristic');
+      return classifyHeuristic(task);
+    } finally {
+      cleanup();
     }
-
-    log.warn('No tool_use block in classification response, falling back to heuristic');
-    return classifyHeuristic(task);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'Haiku classification failed, falling back to heuristic');

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,6 +1,5 @@
 import type * as net from 'node:net';
-import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../config/loader.js';
+import { getAnthropicProvider, extractText, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 import type { WatchObservation } from './ipc-protocol.js';
 import type { HandlerContext } from './handlers.js';
@@ -85,12 +84,11 @@ export async function handleWatchObservation(
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
+    const provider = getAnthropicProvider();
+    if (!provider) {
       log.warn({ watchId: session.watchId }, 'No Anthropic API key available for commentary generation');
       return;
     }
-    const client = new Anthropic({ apiKey });
     const lastThree = session.observations.slice(-3);
     const previousCommentary = lastCommentaryBySession.get(session.sessionId);
 
@@ -122,16 +120,19 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       '- If nothing interesting or meaningfully different has happened since the last observations, respond with exactly "SKIP" (no quotes, no extra text).',
     ].join('\n');
 
-    const response = await client.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 200,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userContent }],
-    });
+    const response = await provider.sendMessage(
+      [userMessage(userContent)],
+      undefined,
+      systemPrompt,
+      {
+        config: {
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 200,
+        },
+      },
+    );
 
-    const textBlock = response.content.find((b) => b.type === 'text');
-    const commentaryText =
-      textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+    const commentaryText = extractText(response);
 
     if (commentaryText && commentaryText !== 'SKIP') {
       lastCommentaryBySession.set(session.sessionId, commentaryText);
@@ -156,14 +157,13 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       { watchId: session.watchId, sessionId: session.sessionId, observationCount: session.observations.length, commentaryCount: session.commentaryCount },
       'generateSummary starting — calling Sonnet',
     );
-    const apiKey = getConfig().apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
+    const provider = getAnthropicProvider();
+    if (!provider) {
       log.warn({ watchId: session.watchId }, 'No Anthropic API key available for summary generation');
       lastSummaryBySession.set(session.sessionId, '[error] No Anthropic API key configured. Check your settings.');
       fireWatchCompletionNotifier(session.sessionId, session);
       return;
     }
-    const client = new Anthropic({ apiKey });
 
     // Build observations text with truncation (keep most recent if >50K chars)
     let observations = session.observations;
@@ -238,18 +238,21 @@ export async function generateSummary(session: WatchSession): Promise<void> {
         : []),
     ].join('\n');
 
-    const response = await client.messages.create({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 2000,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userContent }],
-    });
+    const response = await provider.sendMessage(
+      [userMessage(userContent)],
+      undefined,
+      systemPrompt,
+      {
+        config: {
+          model: 'claude-sonnet-4-6',
+          max_tokens: 2000,
+        },
+      },
+    );
 
     log.debug({ watchId: session.watchId }, 'Sonnet API call completed successfully');
 
-    const textBlock = response.content.find((b) => b.type === 'text');
-    const summaryText =
-      textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+    const summaryText = extractText(response);
 
     log.debug(
       { watchId: session.watchId, summaryLength: summaryText.length },

--- a/assistant/src/memory/clarification-resolver.ts
+++ b/assistant/src/memory/clarification-resolver.ts
@@ -1,5 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../config/loader.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { truncate } from '../util/truncate.js';
 
 const DEFAULT_RESOLVER_MODEL = 'claude-haiku-4-5-20251001';
@@ -55,9 +54,8 @@ export async function resolveConflictClarification(
   const heuristicResult = resolveWithHeuristics(input);
   if (heuristicResult) return heuristicResult;
 
-  const config = getConfig();
-  const apiKey = options?.apiKey ?? config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     return {
       resolution: 'still_unclear',
       strategy: 'no_llm_key',
@@ -68,7 +66,6 @@ export async function resolveConflictClarification(
 
   try {
     return await resolveWithLlm(input, {
-      apiKey,
       model: options?.model ?? DEFAULT_RESOLVER_MODEL,
       timeoutMs: options?.timeoutMs ?? DEFAULT_RESOLVER_TIMEOUT_MS,
     });
@@ -168,9 +165,9 @@ function resolveWithHeuristics(input: ClarificationResolverInput): Clarification
 
 async function resolveWithLlm(
   input: ClarificationResolverInput,
-  options: { apiKey: string; model: string; timeoutMs: number },
+  options: { model: string; timeoutMs: number },
 ): Promise<ClarificationResolverResult> {
-  const client = new Anthropic({ apiKey: options.apiKey });
+  const provider = getAnthropicProvider()!;
   const userPrompt = [
     'You are resolving a memory clarification response.',
     '',
@@ -179,22 +176,12 @@ async function resolveWithLlm(
     `User clarification: ${input.userMessage}`,
   ].join('\n');
 
-  const abortController = new AbortController();
-  const timer = setTimeout(() => abortController.abort(), options.timeoutMs);
+  const { signal, cleanup } = createTimeout(options.timeoutMs);
 
   try {
-  const response = await client.messages.create({
-      model: options.model,
-      max_tokens: 256,
-      system: [
-        'Classify the user clarification for conflicting memory statements.',
-        'Return exactly one resolution:',
-        '- keep_existing',
-        '- keep_candidate',
-        '- merge',
-        '- still_unclear',
-      ].join('\n'),
-      tools: [{
+    const response = await provider.sendMessage(
+      [userMessage(userPrompt)],
+      [{
         name: 'resolve_conflict_clarification',
         description: 'Resolve a pending memory contradiction using user clarification.',
         input_schema: {
@@ -216,13 +203,27 @@ async function resolveWithLlm(
           required: ['resolution', 'explanation'],
         },
       }],
-      tool_choice: { type: 'tool' as const, name: 'resolve_conflict_clarification' },
-      messages: [{ role: 'user' as const, content: userPrompt }],
-    }, { signal: abortController.signal });
-    clearTimeout(timer);
+      [
+        'Classify the user clarification for conflicting memory statements.',
+        'Return exactly one resolution:',
+        '- keep_existing',
+        '- keep_candidate',
+        '- merge',
+        '- still_unclear',
+      ].join('\n'),
+      {
+        config: {
+          model: options.model,
+          max_tokens: 256,
+          tool_choice: { type: 'tool' as const, name: 'resolve_conflict_clarification' },
+        },
+        signal,
+      },
+    );
+    cleanup();
 
-    const toolBlock = response.content.find((block) => block.type === 'tool_use');
-    if (!toolBlock || toolBlock.type !== 'tool_use') {
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
       throw new Error('No tool_use block in clarification resolver response.');
     }
 
@@ -247,8 +248,8 @@ async function resolveWithLlm(
       explanation: truncate(normalize(parsed.explanation ?? 'Resolved via LLM fallback.'), 500, ''),
     };
   } catch (err) {
-    clearTimeout(timer);
-    if (abortController.signal.aborted) {
+    cleanup();
+    if (signal.aborted) {
       throw new Error('clarification_resolver_timeout');
     }
     throw err;

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -1,8 +1,8 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { areStatementsCoherent } from './conflict-intent.js';
 import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
@@ -56,12 +56,13 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     return;
   }
 
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.debug('No Anthropic API key available for contradiction checking');
     return;
   }
+
+  const config = getConfig();
 
   if (!isConflictKindEligible(newItem.kind, config.memory.conflicts)) {
     log.debug({ newItemId, kind: newItem.kind }, 'Skipping contradiction check — kind not eligible for conflicts');
@@ -91,7 +92,7 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     }
 
     try {
-      const result = await classifyRelationship(apiKey, existing, newItem);
+      const result = await classifyRelationship(existing, newItem);
       await handleRelationship(result, existing, newItem);
       // Only stop when the new item itself is invalidated (update case).
       // For contradiction, the old item is invalidated but the new item remains
@@ -205,25 +206,23 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
  * Use LLM to classify the relationship between two memory items.
  */
 async function classifyRelationship(
-  apiKey: string,
   existingItem: MemoryItemRow,
   newItem: MemoryItemRow,
 ): Promise<ClassifyResult> {
-  const client = new Anthropic({ apiKey });
+  const provider = getAnthropicProvider()!;
 
-  const userMessage = [
+  const userContent = [
     `Subject: ${newItem.subject}`,
     '',
     `Old statement: ${existingItem.statement}`,
     `New statement: ${newItem.statement}`,
   ].join('\n');
 
-  const response = await Promise.race([
-    client.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 256,
-      system: CONTRADICTION_SYSTEM_PROMPT,
-      tools: [{
+  const { signal, cleanup } = createTimeout(CONTRADICTION_LLM_TIMEOUT_MS);
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(userContent)],
+      [{
         name: 'classify_relationship',
         description: 'Classify the relationship between two memory statements',
         input_schema: {
@@ -242,29 +241,36 @@ async function classifyRelationship(
           required: ['relationship', 'explanation'],
         },
       }],
-      tool_choice: { type: 'tool' as const, name: 'classify_relationship' },
-      messages: [{ role: 'user' as const, content: userMessage }],
-    }),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Contradiction check LLM timeout')), CONTRADICTION_LLM_TIMEOUT_MS),
-    ),
-  ]);
+      CONTRADICTION_SYSTEM_PROMPT,
+      {
+        config: {
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 256,
+          tool_choice: { type: 'tool' as const, name: 'classify_relationship' },
+        },
+        signal,
+      },
+    );
+    cleanup();
 
-  const toolBlock = response.content.find((b) => b.type === 'tool_use');
-  if (!toolBlock || toolBlock.type !== 'tool_use') {
-    throw new Error('No tool_use block in contradiction check response');
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      throw new Error('No tool_use block in contradiction check response');
+    }
+
+    const input = toolBlock.input as { relationship?: string; explanation?: string };
+    const relationship = input.relationship as Relationship;
+    if (!['contradiction', 'update', 'complement', 'ambiguous_contradiction'].includes(relationship)) {
+      throw new Error(`Invalid relationship type: ${relationship}`);
+    }
+
+    return {
+      relationship,
+      explanation: truncate(String(input.explanation ?? ''), 500, ''),
+    };
+  } finally {
+    cleanup();
   }
-
-  const input = toolBlock.input as { relationship?: string; explanation?: string };
-  const relationship = input.relationship as Relationship;
-  if (!['contradiction', 'update', 'complement', 'ambiguous_contradiction'].includes(relationship)) {
-    throw new Error(`Invalid relationship type: ${relationship}`);
-  }
-
-  return {
-    relationship,
-    explanation: truncate(String(input.explanation ?? ''), 500, ''),
-  };
 }
 
 /**

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -1,9 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { eq, sql } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getDb } from './db.js';
 import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 
@@ -123,9 +123,8 @@ export async function extractEntitiesWithLLM(
   text: string,
   entityConfig: MemoryEntityConfig,
 ): Promise<ExtractedEntityGraph> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.debug('No Anthropic API key available for entity extraction');
     return { entities: [], relations: [] };
   }
@@ -133,41 +132,46 @@ export async function extractEntitiesWithLLM(
   const extractRelations = entityConfig.extractRelations?.enabled ?? false;
 
   try {
-    const client = new Anthropic({ apiKey });
-    const response = await Promise.race([
-      client.messages.create({
-        model: entityConfig.model,
-        max_tokens: 1024,
-        system: ENTITY_EXTRACTION_SYSTEM_PROMPT,
-        tools: [{
+    const { signal, cleanup } = createTimeout(ENTITY_EXTRACTION_TIMEOUT_MS);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(text)],
+        [{
           name: 'store_entities',
           description: 'Store extracted entities from the text',
           input_schema: buildToolInputSchema(extractRelations),
         }],
-        tool_choice: { type: 'tool' as const, name: 'store_entities' },
-        messages: [{ role: 'user' as const, content: text }],
-      }) as Promise<Anthropic.Message>,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Entity extraction LLM timeout')), ENTITY_EXTRACTION_TIMEOUT_MS),
-      ),
-    ]) as Anthropic.Message;
+        ENTITY_EXTRACTION_SYSTEM_PROMPT,
+        {
+          config: {
+            model: entityConfig.model,
+            max_tokens: 1024,
+            tool_choice: { type: 'tool' as const, name: 'store_entities' },
+          },
+          signal,
+        },
+      );
+      cleanup();
 
-    const toolBlock = response.content.find((block) => block.type === 'tool_use');
-    if (!toolBlock || toolBlock.type !== 'tool_use') {
-      log.warn('No tool_use block in entity extraction response');
-      return { entities: [], relations: [] };
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock) {
+        log.warn('No tool_use block in entity extraction response');
+        return { entities: [], relations: [] };
+      }
+
+      const input = toolBlock.input as { entities?: LLMExtractedEntity[]; relations?: LLMExtractedRelation[] };
+      if (!Array.isArray(input.entities)) {
+        log.warn('Invalid entities in entity extraction response');
+        return { entities: [], relations: [] };
+      }
+
+      const entities = parseExtractedEntities(input.entities);
+      const relations = extractRelations ? parseExtractedRelations(input.relations) : [];
+
+      return { entities, relations };
+    } finally {
+      cleanup();
     }
-
-    const input = toolBlock.input as { entities?: LLMExtractedEntity[]; relations?: LLMExtractedRelation[] };
-    if (!Array.isArray(input.entities)) {
-      log.warn('Invalid entities in entity extraction response');
-      return { entities: [], relations: [] };
-    }
-
-    const entities = parseExtractedEntities(input.entities);
-    const relations = extractRelations ? parseExtractedRelations(input.relations) : [];
-
-    return { entities, relations };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'Entity extraction LLM call failed');

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -1,10 +1,10 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { and, eq, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import type { MemoryExtractionConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { computeMemoryFingerprint } from './fingerprint.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
@@ -114,108 +114,105 @@ async function extractItemsWithLLM(
   extractionConfig: MemoryExtractionConfig,
   scopeId: string,
 ): Promise<ExtractedItem[]> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.debug('No Anthropic API key available for LLM extraction, falling back to pattern-based');
     return extractItemsPatternBased(text, scopeId);
   }
 
   try {
-    const client = new Anthropic({ apiKey });
-    const abortController = new AbortController();
-    let timer: ReturnType<typeof setTimeout>;
-    const apiCall = client.messages.create({
-      model: extractionConfig.model,
-      max_tokens: 1024,
-      system: EXTRACTION_SYSTEM_PROMPT,
-      tools: [{
-        name: 'store_memory_items',
-        description: 'Store extracted memory items from the message',
-        input_schema: {
-          type: 'object' as const,
-          properties: {
-            items: {
-              type: 'array',
+    const { signal, cleanup } = createTimeout(15000);
+
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(text)],
+        [{
+          name: 'store_memory_items',
+          description: 'Store extracted memory items from the message',
+          input_schema: {
+            type: 'object' as const,
+            properties: {
               items: {
-                type: 'object',
-                properties: {
-                  kind: {
-                    type: 'string',
-                    enum: [...VALID_KINDS],
-                    description: 'Category of memory item',
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    kind: {
+                      type: 'string',
+                      enum: [...VALID_KINDS],
+                      description: 'Category of memory item',
+                    },
+                    subject: {
+                      type: 'string',
+                      description: 'Short label (2-8 words) for what this is about',
+                    },
+                    statement: {
+                      type: 'string',
+                      description: 'Full factual statement to remember (1-2 sentences)',
+                    },
+                    confidence: {
+                      type: 'number',
+                      description: 'Confidence that this is accurate (0.0-1.0)',
+                    },
+                    importance: {
+                      type: 'number',
+                      description: 'How valuable this is to remember (0.0-1.0)',
+                    },
                   },
-                  subject: {
-                    type: 'string',
-                    description: 'Short label (2-8 words) for what this is about',
-                  },
-                  statement: {
-                    type: 'string',
-                    description: 'Full factual statement to remember (1-2 sentences)',
-                  },
-                  confidence: {
-                    type: 'number',
-                    description: 'Confidence that this is accurate (0.0-1.0)',
-                  },
-                  importance: {
-                    type: 'number',
-                    description: 'How valuable this is to remember (0.0-1.0)',
-                  },
+                  required: ['kind', 'subject', 'statement', 'confidence', 'importance'],
                 },
-                required: ['kind', 'subject', 'statement', 'confidence', 'importance'],
               },
             },
+            required: ['items'],
           },
-          required: ['items'],
+        }],
+        EXTRACTION_SYSTEM_PROMPT,
+        {
+          config: {
+            model: extractionConfig.model,
+            max_tokens: 1024,
+            tool_choice: { type: 'tool' as const, name: 'store_memory_items' },
+          },
+          signal,
         },
-      }],
-      tool_choice: { type: 'tool' as const, name: 'store_memory_items' },
-      messages: [{ role: 'user' as const, content: text }],
-    }, { signal: abortController.signal });
-    // Swallow the abort rejection that fires when the timeout wins the race
-    apiCall.catch(() => {});
-    const response = await Promise.race([
-      apiCall.finally(() => clearTimeout(timer)),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          abortController.abort();
-          reject(new Error('LLM extraction timeout'));
-        }, 15000);
-      }),
-    ]);
+      );
+      cleanup();
 
-    const toolBlock = response.content.find((b) => b.type === 'tool_use');
-    if (!toolBlock || toolBlock.type !== 'tool_use') {
-      log.warn('No tool_use block in LLM extraction response, falling back to pattern-based');
-      return extractItemsPatternBased(text, scopeId);
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock) {
+        log.warn('No tool_use block in LLM extraction response, falling back to pattern-based');
+        return extractItemsPatternBased(text, scopeId);
+      }
+
+      const input = toolBlock.input as { items?: LLMExtractedItem[] };
+      if (!Array.isArray(input.items)) {
+        log.warn('Invalid items in LLM extraction response, falling back to pattern-based');
+        return extractItemsPatternBased(text, scopeId);
+      }
+
+      const items: ExtractedItem[] = [];
+      for (const raw of input.items) {
+        if (!VALID_KINDS.has(raw.kind)) continue;
+        if (!raw.subject || !raw.statement) continue;
+        const subject = truncate(String(raw.subject), 80, '');
+        const statement = truncate(String(raw.statement), 500, '');
+        const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
+        const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
+        const fingerprint = computeMemoryFingerprint(scopeId, raw.kind, subject, statement);
+        items.push({
+          kind: raw.kind as MemoryItemKind,
+          subject,
+          statement,
+          confidence,
+          importance,
+          fingerprint,
+        });
+      }
+
+      return deduplicateItems(items);
+    } finally {
+      cleanup();
     }
-
-    const input = toolBlock.input as { items?: LLMExtractedItem[] };
-    if (!Array.isArray(input.items)) {
-      log.warn('Invalid items in LLM extraction response, falling back to pattern-based');
-      return extractItemsPatternBased(text, scopeId);
-    }
-
-    const items: ExtractedItem[] = [];
-    for (const raw of input.items) {
-      if (!VALID_KINDS.has(raw.kind)) continue;
-      if (!raw.subject || !raw.statement) continue;
-      const subject = truncate(String(raw.subject), 80, '');
-      const statement = truncate(String(raw.statement), 500, '');
-      const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
-      const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
-      const fingerprint = computeMemoryFingerprint(scopeId, raw.kind, subject, statement);
-      items.push({
-        kind: raw.kind as MemoryItemKind,
-        subject,
-        statement,
-        confidence,
-        importance,
-        fingerprint,
-      });
-    }
-
-    return deduplicateItems(items);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'LLM extraction failed, falling back to pattern-based');

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -1,9 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { and, desc, eq, gte, isNull, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
+import { getAnthropicProvider, createTimeout, extractText, userMessage } from '../../providers/anthropic-send-message.js';
 import { getConversationMemoryScopeId } from '../conversation-store.js';
 import { getDb } from '../db.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
@@ -230,8 +230,8 @@ async function summarizeWithLLM(
     return buildFallbackSummary(existingSummary, newContent, label);
   }
 
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.debug({ label }, 'No Anthropic API key available for summarization, using fallback');
     return buildFallbackSummary(existingSummary, newContent, label);
   }
@@ -247,30 +247,36 @@ async function summarizeWithLLM(
   userParts.push('### New Data', newContent);
 
   try {
-    const client = new Anthropic({ apiKey });
-    const response = await Promise.race([
-      client.messages.create({
-        model: summarizationConfig.model,
-        max_tokens: SUMMARY_MAX_TOKENS,
-        system: systemPrompt,
-        messages: [{ role: 'user' as const, content: userParts.join('\n') }],
-      }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Summarization LLM timeout')), SUMMARY_LLM_TIMEOUT_MS),
-      ),
-    ]);
-
-    const textBlock = response.content.find((b) => b.type === 'text');
-    if (textBlock && textBlock.type === 'text' && textBlock.text.trim().length > 0) {
-      log.debug(
-        { label, inputTokens: response.usage.input_tokens, outputTokens: response.usage.output_tokens },
-        'LLM summarization completed',
+    const { signal, cleanup } = createTimeout(SUMMARY_LLM_TIMEOUT_MS);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(userParts.join('\n'))],
+        undefined,
+        systemPrompt,
+        {
+          config: {
+            model: summarizationConfig.model,
+            max_tokens: SUMMARY_MAX_TOKENS,
+          },
+          signal,
+        },
       );
-      return textBlock.text.trim();
-    }
+      cleanup();
 
-    log.warn({ label }, 'LLM summarization returned empty text, using fallback');
-    return buildFallbackSummary(existingSummary, newContent, label);
+      const text = extractText(response);
+      if (text.length > 0) {
+        log.debug(
+          { label, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
+          'LLM summarization completed',
+        );
+        return text;
+      }
+
+      log.warn({ label }, 'LLM summarization returned empty text, using fallback');
+      return buildFallbackSummary(existingSummary, newContent, label);
+    } finally {
+      cleanup();
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message, label }, 'LLM summarization failed, using fallback');

--- a/assistant/src/memory/search/ranking.ts
+++ b/assistant/src/memory/search/ranking.ts
@@ -1,9 +1,8 @@
 import { inArray, sql } from 'drizzle-orm';
-import Anthropic from '@anthropic-ai/sdk';
 import type { AssistantConfig, MemoryRerankingConfig } from '../../config/types.js';
-import { getConfig } from '../../config/loader.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
+import { getAnthropicProvider, extractText, userMessage } from '../../providers/anthropic-send-message.js';
 import { getDb } from '../db.js';
 import { memoryItems } from '../schema.js';
 import type { Candidate, CandidateSource, ItemMetadata } from './types.js';
@@ -296,9 +295,8 @@ export async function rerankWithLLM(
   candidates: Candidate[],
   rerankingConfig: MemoryRerankingConfig,
 ): Promise<Candidate[]> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.debug('No Anthropic API key available for LLM re-ranking, skipping');
     return candidates;
   }
@@ -309,26 +307,27 @@ export async function rerankWithLLM(
     text: truncate(c.text, 200),
   }));
 
-  const client = new Anthropic({ apiKey });
-  const response = await client.messages.create({
-    model: rerankingConfig.model,
-    max_tokens: 1024,
-    system: 'You are a relevance scoring assistant. Given a query and a list of memory candidates, rate each candidate\'s relevance to the query on a scale of 0-10. Return ONLY a JSON array of objects with "index" (the candidate index) and "score" (0-10 integer). No explanation.',
-    messages: [{
-      role: 'user',
-      content: `Query: ${truncate(query, 200)}\n\nCandidates:\n${candidateList.map((c) => `[${c.index}] ${c.text}`).join('\n')}`,
-    }],
-  });
+  const response = await provider.sendMessage(
+    [userMessage(`Query: ${truncate(query, 200)}\n\nCandidates:\n${candidateList.map((c) => `[${c.index}] ${c.text}`).join('\n')}`)],
+    undefined,
+    'You are a relevance scoring assistant. Given a query and a list of memory candidates, rate each candidate\'s relevance to the query on a scale of 0-10. Return ONLY a JSON array of objects with "index" (the candidate index) and "score" (0-10 integer). No explanation.',
+    {
+      config: {
+        model: rerankingConfig.model,
+        max_tokens: 1024,
+      },
+    },
+  );
 
   // Extract text from the response
-  const textBlock = response.content.find((block) => block.type === 'text');
-  if (!textBlock || textBlock.type !== 'text') {
+  const responseText = extractText(response);
+  if (!responseText) {
     log.warn('LLM re-ranking returned no text block, skipping');
     return candidates;
   }
 
   // Parse the JSON array from the response
-  const jsonMatch = textBlock.text.match(/\[[\s\S]*\]/);
+  const jsonMatch = responseText.match(/\[[\s\S]*\]/);
   if (!jsonMatch) {
     log.warn('LLM re-ranking response did not contain JSON array, skipping');
     return candidates;

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -1,5 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { getConfig } from '../config/loader.js';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
 import type { ThreadMessage, ThreadSummary } from './types.js';
@@ -189,78 +188,71 @@ async function summarizeWithLLM(
   messages: ThreadMessage[],
   maxTokens: number,
 ): Promise<ThreadSummary> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.warn('No Anthropic API key available for thread summarization, returning basic summary');
     return buildFallbackSummary(messages);
   }
 
-  const truncated = truncateMessages(messages, maxTokens);
-  const transcript = formatTranscript(truncated);
+  const truncatedMsgs = truncateMessages(messages, maxTokens);
+  const transcript = formatTranscript(truncatedMsgs);
 
   try {
-    const client = new Anthropic({ apiKey });
-    const abortController = new AbortController();
-    let timer: ReturnType<typeof setTimeout>;
-    const apiCall = client.messages.create({
-      model: SUMMARIZATION_MODEL,
-      max_tokens: 1024,
-      system: SYSTEM_PROMPT,
-      tools: [STORE_SUMMARY_TOOL],
-      tool_choice: { type: 'tool' as const, name: 'store_thread_summary' },
-      messages: [{
-        role: 'user' as const,
-        content: `Summarize this conversation thread (${messages.length} messages):\n\n${transcript}`,
-      }],
-    }, { signal: abortController.signal });
+    const { signal, cleanup } = createTimeout(SUMMARIZATION_TIMEOUT_MS);
 
-    // Swallow the abort rejection that fires when the timeout wins the race
-    apiCall.catch(() => {});
-    const response = await Promise.race([
-      apiCall.finally(() => clearTimeout(timer)),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          abortController.abort();
-          reject(new Error('Thread summarization LLM timeout'));
-        }, SUMMARIZATION_TIMEOUT_MS);
-      }),
-    ]);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(`Summarize this conversation thread (${messages.length} messages):\n\n${transcript}`)],
+        [STORE_SUMMARY_TOOL],
+        SYSTEM_PROMPT,
+        {
+          config: {
+            model: SUMMARIZATION_MODEL,
+            max_tokens: 1024,
+            tool_choice: { type: 'tool' as const, name: 'store_thread_summary' },
+          },
+          signal,
+        },
+      );
+      cleanup();
 
-    const toolBlock = response.content.find((b) => b.type === 'tool_use');
-    if (!toolBlock || toolBlock.type !== 'tool_use') {
-      log.warn('No tool_use block in summarization response, returning fallback');
-      return buildFallbackSummary(messages);
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock) {
+        log.warn('No tool_use block in summarization response, returning fallback');
+        return buildFallbackSummary(messages);
+      }
+
+      const input = toolBlock.input as {
+        summary?: string;
+        participants?: Array<{ name: string; role?: string }>;
+        openQuestions?: string[];
+        lastAction?: string;
+        sentiment?: string;
+      };
+
+      const validSentiments = new Set(['positive', 'neutral', 'negative', 'mixed']);
+      const sentiment = validSentiments.has(input.sentiment ?? '')
+        ? (input.sentiment as ThreadSummary['sentiment'])
+        : 'neutral';
+
+      return {
+        summary: truncate(String(input.summary ?? ''), 2000, ''),
+        participants: Array.isArray(input.participants)
+          ? input.participants.map((p) => ({
+              name: String(p.name),
+              ...(p.role ? { role: String(p.role) } : {}),
+            }))
+          : extractParticipants(messages),
+        openQuestions: Array.isArray(input.openQuestions)
+          ? input.openQuestions.map((q) => String(q))
+          : [],
+        lastAction: truncate(String(input.lastAction ?? ''), 500, ''),
+        sentiment,
+        messageCount: messages.length,
+      };
+    } finally {
+      cleanup();
     }
-
-    const input = toolBlock.input as {
-      summary?: string;
-      participants?: Array<{ name: string; role?: string }>;
-      openQuestions?: string[];
-      lastAction?: string;
-      sentiment?: string;
-    };
-
-    const validSentiments = new Set(['positive', 'neutral', 'negative', 'mixed']);
-    const sentiment = validSentiments.has(input.sentiment ?? '')
-      ? (input.sentiment as ThreadSummary['sentiment'])
-      : 'neutral';
-
-    return {
-      summary: truncate(String(input.summary ?? ''), 2000, ''),
-      participants: Array.isArray(input.participants)
-        ? input.participants.map((p) => ({
-            name: String(p.name),
-            ...(p.role ? { role: String(p.role) } : {}),
-          }))
-        : extractParticipants(messages),
-      openQuestions: Array.isArray(input.openQuestions)
-        ? input.openQuestions.map((q) => String(q))
-        : [],
-      lastAction: truncate(String(input.lastAction ?? ''), 500, ''),
-      sentiment,
-      messageCount: messages.length,
-    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'Thread summarization LLM call failed, returning fallback');

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -7,7 +7,7 @@
  * table for accuracy review.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { truncate } from '../util/truncate.js';
 import { v4 as uuid } from 'uuid';
 import { and, eq, isNull, desc } from 'drizzle-orm';
@@ -189,9 +189,8 @@ export async function triageMessage(
   const playbookMatches = fetchMatchingPlaybooks(message.channel, scopeId);
 
   // Step 3: Classify with LLM
-  const config = getConfig();
-  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = getAnthropicProvider();
+  if (!provider) {
     log.warn('No Anthropic API key available for triage classification, returning fallback');
     const result = buildFallbackResult();
     persistTriageResult(message, result, playbookMatches);
@@ -200,7 +199,7 @@ export async function triageMessage(
 
   let result: TriageResult;
   try {
-    result = await classifyWithLLM(message, contact, playbookMatches, apiKey);
+    result = await classifyWithLLM(message, contact, playbookMatches);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Triage LLM call failed, returning fallback');
@@ -217,77 +216,70 @@ async function classifyWithLLM(
   message: InboundMessage,
   contact: ContactWithChannels | null,
   playbookMatches: PlaybookMatch[],
-  apiKey: string,
 ): Promise<TriageResult> {
-  const client = new Anthropic({ apiKey });
-  const abortController = new AbortController();
-  let timer: ReturnType<typeof setTimeout>;
+  const provider = getAnthropicProvider()!;
+  const { signal, cleanup } = createTimeout(TRIAGE_CLASSIFICATION_TIMEOUT_MS);
 
   const systemPrompt = buildSystemPrompt(contact, playbookMatches);
   const userPrompt = buildUserPrompt(message);
 
-  const apiCall = client.messages.create({
-    model: TRIAGE_MODEL,
-    max_tokens: 1024,
-    system: systemPrompt,
-    tools: [STORE_TRIAGE_TOOL],
-    tool_choice: { type: 'tool' as const, name: 'store_triage_result' },
-    messages: [{
-      role: 'user' as const,
-      content: userPrompt,
-    }],
-  }, { signal: abortController.signal });
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(userPrompt)],
+      [STORE_TRIAGE_TOOL],
+      systemPrompt,
+      {
+        config: {
+          model: TRIAGE_MODEL,
+          max_tokens: 1024,
+          tool_choice: { type: 'tool' as const, name: 'store_triage_result' },
+        },
+        signal,
+      },
+    );
+    cleanup();
 
-  // Swallow the abort rejection that fires when the timeout wins the race
-  apiCall.catch(() => {});
-  const response = await Promise.race([
-    apiCall.finally(() => clearTimeout(timer)),
-    new Promise<never>((_, reject) => {
-      timer = setTimeout(() => {
-        abortController.abort();
-        reject(new Error('Triage classification LLM timeout'));
-      }, TRIAGE_CLASSIFICATION_TIMEOUT_MS);
-    }),
-  ]);
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      log.warn('No tool_use block in triage response, returning fallback');
+      return buildFallbackResult();
+    }
 
-  const toolBlock = response.content.find((b) => b.type === 'tool_use');
-  if (!toolBlock || toolBlock.type !== 'tool_use') {
-    log.warn('No tool_use block in triage response, returning fallback');
-    return buildFallbackResult();
+    const input = toolBlock.input as {
+      category?: string;
+      confidence?: number;
+      suggestedAction?: string;
+      matchedPlaybookTriggers?: string[];
+    };
+
+    const matchedTriggers = new Set(
+      Array.isArray(input.matchedPlaybookTriggers) ? input.matchedPlaybookTriggers : [],
+    );
+
+    // Map LLM-identified triggers back to the full playbook data
+    const matchedPlaybooks = playbookMatches
+      .filter(({ playbook }) => matchedTriggers.has(playbook.trigger))
+      .map(({ playbook }) => ({
+        trigger: playbook.trigger,
+        action: playbook.action,
+        autonomyLevel: playbook.autonomyLevel,
+      }));
+
+    const confidence = typeof input.confidence === 'number'
+      ? Math.max(0, Math.min(1, input.confidence))
+      : 0.5;
+
+    return {
+      category: typeof input.category === 'string' ? input.category : 'needs_response',
+      confidence,
+      suggestedAction: typeof input.suggestedAction === 'string'
+        ? truncate(input.suggestedAction, 500, '')
+        : 'Review manually',
+      matchedPlaybooks,
+    };
+  } finally {
+    cleanup();
   }
-
-  const input = toolBlock.input as {
-    category?: string;
-    confidence?: number;
-    suggestedAction?: string;
-    matchedPlaybookTriggers?: string[];
-  };
-
-  const matchedTriggers = new Set(
-    Array.isArray(input.matchedPlaybookTriggers) ? input.matchedPlaybookTriggers : [],
-  );
-
-  // Map LLM-identified triggers back to the full playbook data
-  const matchedPlaybooks = playbookMatches
-    .filter(({ playbook }) => matchedTriggers.has(playbook.trigger))
-    .map(({ playbook }) => ({
-      trigger: playbook.trigger,
-      action: playbook.action,
-      autonomyLevel: playbook.autonomyLevel,
-    }));
-
-  const confidence = typeof input.confidence === 'number'
-    ? Math.max(0, Math.min(1, input.confidence))
-    : 0.5;
-
-  return {
-    category: typeof input.category === 'string' ? input.category : 'needs_response',
-    confidence,
-    suggestedAction: typeof input.suggestedAction === 'string'
-      ? truncate(input.suggestedAction, 500, '')
-      : 'Review manually',
-    matchedPlaybooks,
-  };
 }
 
 // ── Persistence ─────────────────────────────────────────────────────

--- a/assistant/src/providers/anthropic-send-message.ts
+++ b/assistant/src/providers/anthropic-send-message.ts
@@ -1,0 +1,109 @@
+/**
+ * Helper for callsites that need the Anthropic provider without direct SDK
+ * coupling. Provides lazy Anthropic provider resolution, timeout utilities,
+ * and response extraction helpers.
+ */
+
+import type { Provider, ProviderResponse, Message, ToolDefinition, ContentBlock, ToolUseContent } from './types.js';
+import { getProvider, listProviders, initializeProviders } from './registry.js';
+import { getConfig } from '../config/loader.js';
+
+/**
+ * Lazily resolve the Anthropic provider from the registry.
+ * If providers haven't been initialized yet (e.g. non-daemon code paths),
+ * performs a one-shot `initializeProviders(getConfig())`.
+ *
+ * Returns `null` when no Anthropic API key is configured.
+ */
+export function getAnthropicProvider(): Provider | null {
+  if (!listProviders().includes('anthropic')) {
+    const config = getConfig();
+    if (!config.apiKeys.anthropic && !process.env.ANTHROPIC_API_KEY) {
+      return null;
+    }
+    // Ensure the key is present in the config before initializing
+    const effectiveConfig = {
+      ...config,
+      apiKeys: {
+        ...config.apiKeys,
+        anthropic: config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY!,
+      },
+    };
+    initializeProviders(effectiveConfig);
+  }
+  try {
+    return getProvider('anthropic');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create an AbortSignal that fires after `ms` milliseconds.
+ * Returns the signal and a cleanup function to clear the timer.
+ */
+export function createTimeout(ms: number): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+/**
+ * Extract the first text block's text from a ProviderResponse.
+ * Returns empty string if no text block is found.
+ */
+export function extractText(response: ProviderResponse): string {
+  const block = response.content.find((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text');
+  return block?.text?.trim() ?? '';
+}
+
+/**
+ * Extract all text blocks from a ProviderResponse and join them.
+ */
+export function extractAllText(response: ProviderResponse): string {
+  return response.content
+    .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+/**
+ * Find the first tool_use block in a ProviderResponse.
+ */
+export function extractToolUse(response: ProviderResponse): ToolUseContent | undefined {
+  return response.content.find((b): b is ToolUseContent => b.type === 'tool_use');
+}
+
+/**
+ * Build a single user message in the provider Message format.
+ */
+export function userMessage(text: string): Message {
+  return { role: 'user', content: [{ type: 'text', text }] };
+}
+
+/**
+ * Build a single user message with image + text content.
+ */
+export function userMessageWithImage(
+  imageBase64: string,
+  mediaType: string,
+  text: string,
+): Message {
+  return {
+    role: 'user',
+    content: [
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: mediaType,
+          data: imageBase64,
+        },
+      },
+      { type: 'text', text },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Creates `providers/anthropic-send-message.ts` helper module with `getAnthropicProvider()`, `createTimeout()`, `extractText()`, `extractAllText()`, `extractToolUse()`, `userMessage()`, and `userMessageWithImage()` utilities
- Migrates all 12 production files that directly used `@anthropic-ai/sdk` (`new Anthropic`, `client.messages.create`) to go through the provider abstraction (`Provider.sendMessage`) — covers daemon classifiers, watch handlers, messaging triaging/summarization, memory extraction/contradiction/ranking/summarization, config icon generation, and media keyframe analysis
- Updates 2 test files to mock the provider helper instead of the raw SDK
- Adds a guard test (`no-direct-anthropic-sdk-imports.test.ts`) that fails if any new production file imports `@anthropic-ai/sdk` directly

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/provider-sendmessage-migration-remaining-direct-anthropic-one-pr-plan-2026-02-24.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
