### PR TITLE
fix: resolve CI failures from PR #7575 and related PRs on main

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2609,8 +2609,8 @@ exports[`IPC message snapshots ServerMessage types dictation_response serializes
 
 exports[`IPC message snapshots ServerMessage types guardian_request_thread_created serializes to expected JSON 1`] = `
 {
-  "callSessionId": "call-guardian-001",
-  "conversationId": "conv-guardian-req-001",
+  "callSessionId": "call-001",
+  "conversationId": "conv-guardian-001",
   "requestId": "req-guardian-001",
   "title": "Guardian action request",
   "type": "guardian_request_thread_created",

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -17,6 +17,7 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  readHttpToken: () => null,
 }));
 
 mock.module('../util/logger.js', () => ({
@@ -55,6 +56,7 @@ mock.module('../config/loader.js', () => ({
       safety: { denyCategories: [] },
       model: mockCallModel,
     },
+    memory: { enabled: false },
   }),
 }));
 
@@ -179,6 +181,8 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM tool_invocations');
+  db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
 }

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -23,6 +23,7 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  readHttpToken: () => null,
 }));
 
 mock.module('../util/logger.js', () => ({
@@ -133,6 +134,8 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM tool_invocations');
+  db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
 }

--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -45,6 +45,7 @@ mock.module('../util/platform.js', () => ({
   isMacOS: () => false,
   isLinux: () => true,
   isWindows: () => false,
+  readHttpToken: () => null,
 }));
 
 mock.module('../tools/executor.js', () => ({

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -33,6 +33,7 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  readHttpToken: () => null,
 }));
 
 mock.module('../util/logger.js', () => ({
@@ -59,6 +60,7 @@ const mockConfig = {
       codeLength: 6,
     },
   },
+  memory: { enabled: false },
 };
 
 mock.module('../config/loader.js', () => ({
@@ -170,6 +172,8 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM tool_invocations');
+  db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
 }

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -11,6 +11,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -62,6 +62,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -13,6 +13,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -22,6 +22,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -12,6 +12,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -25,6 +25,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -16,6 +16,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -16,6 +16,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -16,6 +16,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -23,6 +23,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -22,6 +22,12 @@ mock.module('../util/platform.js', () => ({
   getDataDir: () => '/tmp',
 }));
 
+mock.module('../memory/guardian-action-store.js', () => ({
+  getPendingDeliveryByConversation: () => null,
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
 mock.module('../providers/registry.js', () => ({
   getProvider: () => ({ name: 'mock-provider' }),
   initializeProviders: () => {},

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -31,6 +31,7 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  readHttpToken: () => null,
 }));
 
 mock.module('../util/logger.js', () => ({
@@ -115,6 +116,8 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM tool_invocations');
+  db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
   ensuredConvIds = new Set();
 }


### PR DESCRIPTION
## Summary

Fixes CI failures on main introduced by the cascade of PRs #7575, #7539, #7596, and #7595.

**Root causes and fixes:**

1. **DrizzleError on DELETE FROM conversations** (call-orchestrator, relay-server, call-routes-http, twilio-routes tests): PR #7596 migrated the call orchestrator to use provider abstraction, which now calls `conversationStore.addMessage()` creating rows in the `messages` table. The `messages` table has a FK to `conversations` without CASCADE delete, so `resetTables()` failed when trying to delete conversations with existing messages. Fixed by adding `DELETE FROM tool_invocations` and `DELETE FROM messages` before `DELETE FROM conversations`.

2. **readHttpToken export not found** (computer-use-session-working-dir, call-orchestrator, relay-server, call-routes-http, twilio-routes tests): PR #7539 introduced `guardian-dispatch.ts` which imports `readHttpToken` from `platform.ts`. Platform mocks missing this export caused Bun module resolution failures. Fixed by adding `readHttpToken: () => null` to all affected platform mocks.

3. **SQLiteError: unable to open database file** (11 session tests): PR #7539 added `getPendingDeliveryByConversation()` call in `session-process.ts` which triggers DB access via `guardian-action-store.ts`. Session tests with minimal platform mocks didn't mock this module. Fixed by adding `guardian-action-store.js` mock to all 11 session test files.

4. **Missing memory config** (relay-server, call-orchestrator): `conversationStore.addMessage()` calls `getConfig().memory` for indexing, but config mocks didn't include the `memory` field. Fixed by adding `memory: { enabled: false }` to config mocks.

5. **IPC snapshot mismatch** (ipc-snapshot test): Test data used `conv-guardian-001`/`call-001` but snapshot had `conv-guardian-req-001`/`call-guardian-001`. Fixed by updating snapshot to match test data.

CI run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22337653883
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
