### PR TITLE
fix: resolve CI failures from M2 inbound call quality

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1682,13 +1682,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     mode: 'dictation',
     actionPlan: undefined,
   },
-  guardian_request_thread_created: {
-    type: 'guardian_request_thread_created',
-    conversationId: 'conv-guardian-req-001',
-    requestId: 'req-guardian-001',
-    callSessionId: 'call-guardian-001',
-    title: 'Guardian action request',
-  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes CI failures from #7614 (M2: Inbound Call Conversation Quality)
- Failed run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22338314682
- Root cause: duplicate `guardian_request_thread_created` property in the `serverMessages` object literal in `ipc-snapshot.test.ts`, causing TypeScript error TS1117

## Original PR
#7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
