### PR TITLE
fix: derive call model default from active provider

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -100,6 +100,17 @@ mock.module('../providers/registry.js', () => {
       name: 'anthropic',
       sendMessage: (...args: unknown[]) => mockSendMessage(...args),
     }),
+    getDefaultModel: (providerName: string) => {
+      const defaults: Record<string, string> = {
+        anthropic: 'claude-opus-4-6',
+        openai: 'gpt-5.2',
+        gemini: 'gemini-3-flash',
+        ollama: 'llama3.2',
+        fireworks: 'accounts/fireworks/models/kimi-k2p5',
+        openrouter: 'x-ai/grok-4',
+      };
+      return defaults[providerName] ?? defaults.anthropic;
+    },
   };
 });
 
@@ -868,14 +879,15 @@ describe('call-orchestrator', () => {
   test('uses default model when calls.model is not set', async () => {
     mockCallModel = undefined;
     mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      // Default model is derived from the active provider (anthropic → claude-opus-4-6)
+      expect(options?.config?.model).toBe('claude-opus-4-6');
       const tokens = ['Default model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });
       }
       return {
         content: [{ type: 'text', text: tokens.join('') }],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-opus-4-6',
         usage: { inputTokens: 100, outputTokens: 50 },
         stopReason: 'end_turn',
       };
@@ -910,14 +922,15 @@ describe('call-orchestrator', () => {
   test('treats empty string calls.model as unset and falls back to default', async () => {
     mockCallModel = '';
     mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      // Empty string falls back to provider default (anthropic → claude-opus-4-6)
+      expect(options?.config?.model).toBe('claude-opus-4-6');
       const tokens = ['Fallback model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });
       }
       return {
         content: [{ type: 'text', text: tokens.join('') }],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-opus-4-6',
         usage: { inputTokens: 100, outputTokens: 50 },
         stopReason: 'end_turn',
       };
@@ -931,14 +944,15 @@ describe('call-orchestrator', () => {
   test('treats whitespace-only calls.model as unset and falls back to default', async () => {
     mockCallModel = '   ';
     mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      expect(options?.config?.model).toBe('claude-sonnet-4-20250514');
+      // Whitespace-only falls back to provider default (anthropic → claude-opus-4-6)
+      expect(options?.config?.model).toBe('claude-opus-4-6');
       const tokens = ['Fallback model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });
       }
       return {
         content: [{ type: 'text', text: tokens.join('') }],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-opus-4-6',
         usage: { inputTokens: 100, outputTokens: 50 },
         stopReason: 'end_turn',
       };

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -7,7 +7,7 @@
  */
 
 import { getConfig } from '../config/loader.js';
-import { getFailoverProvider, listProviders } from '../providers/registry.js';
+import { getDefaultModel, getFailoverProvider, listProviders } from '../providers/registry.js';
 import type { ProviderEvent } from '../providers/types.js';
 import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
@@ -356,7 +356,7 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      const callModel = config.calls.model?.trim() || 'claude-sonnet-4-20250514';
+      const callModel = config.calls.model?.trim() || getDefaultModel(providerName);
 
       // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -77,6 +77,14 @@ export function listProviders(): string[] {
   return Array.from(providers.keys());
 }
 
+/**
+ * Return the default model for a given provider name.
+ * Falls back to the Anthropic default if the provider name is unknown.
+ */
+export function getDefaultModel(providerName: string): string {
+  return DEFAULT_MODELS[providerName] ?? DEFAULT_MODELS.anthropic;
+}
+
 export interface ProvidersConfig {
   apiKeys: Record<string, string>;
   provider: string;


### PR DESCRIPTION
## Summary
- Export `getDefaultModel(providerName)` from provider registry to look up the default model for any provider
- Replace hardcoded `claude-sonnet-4-20250514` fallback in call orchestrator with `getDefaultModel(providerName)` so non-Anthropic providers get a provider-appropriate model
- Update call orchestrator tests to mock `getDefaultModel` and expect provider-aware defaults

Addresses Codex feedback on PR #7596: when `calls.model` is unset and the active provider is non-Anthropic, the call orchestrator was still sending an Anthropic model name, causing provider-side 4xx errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
