### PR TITLE
fix: pass inputRawValue in populateFromHistory for history-loaded tool calls

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1236,6 +1236,7 @@ public final class ChatViewModel: ObservableObject {
                         toolName: tc.name,
                         inputSummary: summarizeToolInput(tc.input),
                         inputFull: formatAllToolInput(tc.input),
+                        inputRawValue: extractToolInput(tc.input),
                         result: tc.result,
                         isError: tc.isError ?? false,
                         isComplete: true,


### PR DESCRIPTION
Addresses feedback on #7607 — history-loaded tool calls now get the full untruncated path via extractToolInput() instead of defaulting to the 80-char-truncated inputSummary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
