### PR TITLE
fix: match actual schedule/reminder title prefixes in isScheduleThread fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -38,6 +38,6 @@ struct ThreadModel: Identifiable, Hashable {
         if let source = source {
             return source == "schedule" || source == "reminder"
         }
-        return title.hasPrefix("[Schedule]") || title.hasPrefix("[Reminder]")
+        return title.hasPrefix("Schedule: ") || title.hasPrefix("Schedule (manual): ") || title.hasPrefix("Reminder: ")
     }
 }


### PR DESCRIPTION
Addresses feedback on #7609 — updates the isScheduleThread title prefix fallback to match the actual prefixes used when creating schedule/reminder conversations (Schedule:, Schedule (manual):, Reminder:) instead of the incorrect [Schedule]/[Reminder] brackets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
