### PR TITLE
fix: remove unused imports flagged by eslint

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
-import { getConfig } from './loader.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { stripCommentLines } from './system-prompt.js';

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -1,5 +1,4 @@
 import { eq, sql } from 'drizzle-orm';
-import { getConfig } from '../config/loader.js';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -11,7 +11,6 @@ import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from
 import { truncate } from '../util/truncate.js';
 import { v4 as uuid } from 'uuid';
 import { and, eq, isNull, desc } from 'drizzle-orm';
-import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from '../memory/db.js';
 import { memoryItems, triageResults } from '../memory/schema.js';

--- a/assistant/src/providers/anthropic-send-message.ts
+++ b/assistant/src/providers/anthropic-send-message.ts
@@ -4,7 +4,7 @@
  * and response extraction helpers.
  */
 
-import type { Provider, ProviderResponse, Message, ToolDefinition, ContentBlock, ToolUseContent } from './types.js';
+import type { Provider, ProviderResponse, Message, ContentBlock, ToolUseContent } from './types.js';
 import { getProvider, listProviders, initializeProviders } from './registry.js';
 import { getConfig } from '../config/loader.js';
 


### PR DESCRIPTION
## Summary
- Remove unused `getConfig` imports from `skills.ts`, `entity-extractor.ts`, and `triage-engine.ts`
- Remove unused `ToolDefinition` type import from `anthropic-send-message.ts`
- Fixes CI lint failure on main

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22338584232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
