### PR TITLE
fix: narrow guardian-action-store catch to missing-table errors and add getDefaultModel to relay-server mock

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -103,6 +103,17 @@ mock.module('../providers/registry.js', () => {
       name: 'anthropic',
       sendMessage: (...args: unknown[]) => mockSendMessage(...args),
     }),
+    getDefaultModel: (providerName: string) => {
+      const defaults: Record<string, string> = {
+        anthropic: 'claude-opus-4-6',
+        openai: 'gpt-5.2',
+        gemini: 'gemini-3-flash',
+        ollama: 'llama3.2',
+        fireworks: 'accounts/fireworks/models/kimi-k2p5',
+        openrouter: 'x-ai/grok-4',
+      };
+      return defaults[providerName] ?? defaults.anthropic;
+    },
   };
 });
 

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -14,6 +14,7 @@ import {
   guardianActionRequests,
   guardianActionDeliveries,
 } from './schema.js';
+import { getLogger } from '../util/logger.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -344,30 +345,38 @@ export function getPendingDeliveriesByDestination(
   channel: string,
   chatId: string,
 ): GuardianActionDelivery[] {
-  const db = getDb();
+  try {
+    const db = getDb();
 
-  // Join deliveries with requests to filter by assistantId
-  const rows = db
-    .select({
-      delivery: guardianActionDeliveries,
-    })
-    .from(guardianActionDeliveries)
-    .innerJoin(
-      guardianActionRequests,
-      eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
-    )
-    .where(
-      and(
-        eq(guardianActionRequests.assistantId, assistantId),
-        eq(guardianActionRequests.status, 'pending'),
-        eq(guardianActionDeliveries.destinationChannel, channel),
-        eq(guardianActionDeliveries.destinationChatId, chatId),
-        eq(guardianActionDeliveries.status, 'sent'),
-      ),
-    )
-    .all();
+    // Join deliveries with requests to filter by assistantId
+    const rows = db
+      .select({
+        delivery: guardianActionDeliveries,
+      })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionRequests.assistantId, assistantId),
+          eq(guardianActionRequests.status, 'pending'),
+          eq(guardianActionDeliveries.destinationChannel, channel),
+          eq(guardianActionDeliveries.destinationChatId, chatId),
+          eq(guardianActionDeliveries.status, 'sent'),
+        ),
+      )
+      .all();
 
-  return rows.map((r) => rowToDelivery(r.delivery));
+    return rows.map((r) => rowToDelivery(r.delivery));
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      getLogger().warn({ err }, 'guardian tables not yet created');
+      return [];
+    }
+    throw err;
+  }
 }
 
 /**
@@ -392,9 +401,12 @@ export function getPendingDeliveryByConversation(conversationId: string): Guardi
       )
       .all();
     return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
-  } catch {
-    // Table may not exist yet (pre-migration or test environments)
-    return null;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      getLogger().warn({ err }, 'guardian tables not yet created');
+      return null;
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
Addresses feedback on #7623: (1) restricts blanket catch in getPendingDeliveryByConversation to only 'no such table' errors, (2) adds getDefaultModel export to relay-server test mock, (3) adds matching try/catch protection to getPendingDeliveriesByDestination.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
