### PR TITLE
fix: remove unused 'mock' import in gateway test

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, spyOn, afterEach } from "bun:test";
+import { describe, test, expect, spyOn, afterEach } from "bun:test";
 import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
 


### PR DESCRIPTION
## Summary

- Remove unused `mock` import from `gateway/src/__tests__/telegram-webhook-manager.test.ts` that was causing the CI lint step to fail

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22337780011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
