### PR TITLE
fix: suppress WebKit Sendable warnings in InlineVideoWebView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import WebKit
+@preconcurrency import WebKit
 
 /// Isolated WKWebView wrapper for inline video embeds.
 ///


### PR DESCRIPTION
## Summary
- Add `@preconcurrency` to the `import WebKit` in `InlineVideoWebView.swift` to suppress Sendable-related warnings from the WebKit module

## Original prompt
fix the warnings from the Build .app step here: https://github.com/vellum-ai/vellum-assistant/actions/runs/22338853701/job/64637489399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
