### PR TITLE
fix: hide duplicate assistant portrait on consecutive messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -15,6 +15,7 @@ struct ChatBubble: View {
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var daemonHttpPort: Int?
+    var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
 
     @State private var appearance = AvatarAppearanceManager.shared
@@ -190,7 +191,7 @@ struct ChatBubble: View {
                     }
                 }
                 .overlay(alignment: .topLeading) {
-                    if !isUser {
+                    if !isUser && showAvatar {
                         Image(nsImage: appearance.chatAvatarImage)
                             .interpolation(.none)
                             .resizable()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -452,6 +452,9 @@ struct ChatView: View {
                                 return conf
                             }()
 
+                            // Hide the avatar when the previous visible message is also from the assistant
+                            let previousIsAssistant = index > 0 && displayMessages[index - 1].role == .assistant
+
                             ChatBubble(
                                 message: message,
                                 hideToolCalls: nextIsPendingConfirmation,
@@ -464,6 +467,7 @@ struct ChatView: View {
                                 onReportMessage: onReportMessage,
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 daemonHttpPort: daemonHttpPort,
+                                showAvatar: !previousIsAssistant,
                                 isLatestAssistantMessage: message.role == .assistant && displayMessages.last(where: { $0.role == .assistant })?.id == message.id
                             )
                                 .id(message.id)


### PR DESCRIPTION
## Summary
- Add `showAvatar` property to `ChatBubble` (defaults to `true`)
- In `ChatView`, detect when the previous message is also from the assistant and pass `showAvatar: false`
- Only the first message in a consecutive run of assistant messages shows the portrait

## Original prompt
we shouldn't show the assistant's portrait twice in a row if it's just assistant messages back to back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
