### PR TITLE
fix: pass required name arg to getLogger in guardian-action-store

### DIFF
--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -16,6 +16,8 @@ import {
 } from './schema.js';
 import { getLogger } from '../util/logger.js';
 
+const log = getLogger('guardian-action-store');
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -372,7 +374,7 @@ export function getPendingDeliveriesByDestination(
     return rows.map((r) => rowToDelivery(r.delivery));
   } catch (err) {
     if (err instanceof Error && err.message.includes('no such table')) {
-      getLogger().warn({ err }, 'guardian tables not yet created');
+      log.warn({ err }, 'guardian tables not yet created');
       return [];
     }
     throw err;
@@ -403,7 +405,7 @@ export function getPendingDeliveryByConversation(conversationId: string): Guardi
     return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
   } catch (err) {
     if (err instanceof Error && err.message.includes('no such table')) {
-      getLogger().warn({ err }, 'guardian tables not yet created');
+      log.warn({ err }, 'guardian tables not yet created');
       return null;
     }
     throw err;


### PR DESCRIPTION
## Summary
- `getLogger()` requires a module name string argument but was called without one on two error-handling paths in `guardian-action-store.ts`
- Added a module-level `const log = getLogger('guardian-action-store')` and replaced both bare `getLogger()` calls with `log`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22338792651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
