### PR TITLE
ci: pass Sparkle key and enable SKIP_CLEAN in nightly release build

### DIFF
--- a/.github/workflows/ci-nightly-release.yml
+++ b/.github/workflows/ci-nightly-release.yml
@@ -139,7 +139,9 @@ jobs:
       - name: Build release .app
         working-directory: clients/macos
         run: |
+          SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
           SIGN_IDENTITY="Developer ID Application" \
+          SKIP_CLEAN=1 \
           ./build.sh release
 
           APP_PATH="dist/Vellum.app"


### PR DESCRIPTION
Addresses feedback on #7633: (1) passes SU_PUBLIC_ED_KEY from secrets so Sparkle update-signing config is tested, (2) sets SKIP_CLEAN=1 so SPM cache is actually used instead of being deleted on every run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
