### PR TITLE
fix: cast fetch spy in gateway tests for Bun preconnect type

### DIFF
--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -54,7 +54,7 @@ describe("callTelegramApi transport error redaction", () => {
   test("redacts bot token from warning logs and thrown error", async () => {
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
       const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
         path?: string;
         code?: string;
@@ -83,7 +83,7 @@ describe("callTelegramApi transport error redaction", () => {
     // "error-123456789:...") must still be redacted.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -113,7 +113,7 @@ describe("callTelegramApi transport error redaction", () => {
     // would fail to match the trailing `-`, leaking part of the token.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz01234567-"].join("");
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 
 function mockTelegramApi() {
   fetchSpy?.mockRestore();
-  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -66,7 +66,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments without assistantId using assistant-less download path", async () => {
     const calls: string[] = [];
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       // Runtime attachment download (assistant-less path)
@@ -121,7 +121,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments with assistantId using legacy download path", async () => {
     const calls: string[] = [];
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       // Runtime attachment download (legacy path)
@@ -174,7 +174,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
   test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
     const calls: string[] = [];
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-id-only")) {
@@ -241,7 +241,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
   test("full-metadata attachments still accepted (backward compatibility)", async () => {
     const calls: string[] = [];
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-compat")) {

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -76,7 +76,7 @@ let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null
 
 /** Default fetch spy that handles Telegram API calls with success responses. */
 function installDefaultFetchSpy() {
-  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
     const url =
       typeof input === "string"
         ? input
@@ -193,7 +193,7 @@ describe("POST /internal/telegram/reconcile", () => {
 
   test("returns 502 when reconcile throws", async () => {
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
       throw new Error("Telegram API error");
     });
     const config = makeConfig();
@@ -225,7 +225,7 @@ describe("POST /internal/telegram/reconcile", () => {
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === "string"

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -50,7 +50,7 @@ let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null
 
 function mockFetch(fn: (url: string, init?: RequestInit) => Promise<Response>) {
   fetchSpy?.mockRestore();
-  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(fn as any);
+  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(fn as any);
   return fetchSpy;
 }
 
@@ -294,7 +294,7 @@ describe("sendTelegramAttachments", () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       calls.push({ url: urlStr, init });
       if (urlStr.includes("/attachments/my-attachment-id")) {

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -103,7 +103,7 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
  */
 function installFetchMock() {
   fetchSpy?.mockRestore();
-  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
     let body: unknown;
@@ -321,7 +321,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
     // invocation and responds immediately on subsequent ones.
     let inboundCallCount = 0;
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -381,7 +381,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
 
     let callCount = 0;
     fetchSpy?.mockRestore();
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -61,7 +61,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -93,7 +93,7 @@ describe("reconcileTelegramWebhook", () => {
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {
     const calls: string[] = [];
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -119,7 +119,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -145,7 +145,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when bot token is not configured", async () => {
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramBotToken: undefined });
     await reconcileTelegramWebhook(config);
@@ -154,7 +154,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when webhook secret is not configured", async () => {
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramWebhookSecret: undefined });
     await reconcileTelegramWebhook(config);
@@ -163,7 +163,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when ingress URL is not configured", async () => {
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => new Response("", { status: 200 }));
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ ingressPublicBaseUrl: undefined });
     await reconcileTelegramWebhook(config);
@@ -174,7 +174,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 
-    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input: string | URL | Request) => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");


### PR DESCRIPTION
## Summary
- Bun 1.3.9's `@types/bun` added `preconnect` to `typeof fetch`, breaking `spyOn(globalThis, "fetch").mockImplementation(fn)` in 6 gateway test files
- Fix: cast the spy to `any` before `.mockImplementation()` — `(spyOn(globalThis, "fetch") as any).mockImplementation(fn)` — so mock functions don't need the `preconnect` property
- Affects: `telegram-api-redaction`, `telegram-deliver-auth`, `telegram-reconcile-route`, `telegram-send-attachments`, `telegram-webhook-handler`, `telegram-webhook-manager` test files

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22338975126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
