### PR TITLE
feat(macos): add visual feedback to scheduled task play button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -131,6 +131,7 @@ private struct ScheduleRow: View {
     let onDelete: () -> Void
 
     @State private var isExpanded = false
+    @State private var isTriggered = false
 
     private var nextRunText: String {
         guard schedule.enabled else { return "Paused" }
@@ -204,10 +205,16 @@ private struct ScheduleRow: View {
                 Spacer()
 
                 Button {
+                    guard !isTriggered else { return }
                     onRunNow()
+                    withAnimation(.easeInOut(duration: 0.2)) { isTriggered = true }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        withAnimation(.easeInOut(duration: 0.2)) { isTriggered = false }
+                    }
                 } label: {
-                    Image(systemName: "play.fill")
-                        .foregroundStyle(.blue)
+                    Image(systemName: isTriggered ? "checkmark.circle.fill" : "play.fill")
+                        .foregroundStyle(isTriggered ? .green : .blue)
+                        .contentTransition(.symbolEffect(.replace))
                 }
                 .buttonStyle(.borderless)
                 .help("Run now")


### PR DESCRIPTION
## Summary
- When the play button on a scheduled task is clicked, it now transitions from a blue play icon to a green checkmark circle for 1.5 seconds before reverting back
- Uses SwiftUI's `contentTransition(.symbolEffect(.replace))` for a smooth symbol animation
- Guards against double-clicks while the triggered animation is active

## Original prompt
in the desktop app, clicking the play button on a scheduled task to run now should provide some kind of visual feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
