### PR TITLE
feat: auto-display threads created by scheduled tasks in desktop app

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -632,8 +632,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.showTasksWindow()
         }
 
-        // Task run threads are no longer created automatically. Users can
-        // opt in via the "Open in Chat" button in the task output view.
+        // Automatically surface threads created by scheduled task runs so
+        // the user sees them in the sidebar without restarting the app.
+        daemonClient.onTaskRunThreadCreated = { [weak self] msg in
+            guard let self, !self.isAwaitingFirstLaunchReady else { return }
+            self.mainWindow?.threadManager.createTaskRunThread(
+                conversationId: msg.conversationId,
+                workItemId: msg.workItemId,
+                title: msg.title
+            )
+        }
 
         // Guardian request threads — created when a voice call's ASK_GUARDIAN dispatches
         // a question to the mac channel so the user can see and respond in chat.


### PR DESCRIPTION
## Summary
- Re-enable the `onTaskRunThreadCreated` IPC callback in `AppDelegate.swift` that was previously disabled
- When a scheduled task creates a new thread, the daemon broadcasts `task_run_thread_created` — the desktop app now listens for this and inserts the thread into the sidebar automatically
- Unlike guardian request threads, task run threads appear quietly (no window focus or thread auto-selection) to avoid interrupting the user

## Original prompt
the desktop app currently has to be restarted to display new threads that were created by scheduled tasks. this is bad, they should show up automatically (a small delay is acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
