### PR TITLE
fix: use matching seconds in EXDATE for scheduler recurrence tests

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -268,7 +268,7 @@ describe('claimDueSchedules (RRULE set)', () => {
     const ds = `${pastDate.getUTCFullYear()}${pad(pastDate.getUTCMonth() + 1)}${pad(pastDate.getUTCDate())}T${pad(pastDate.getUTCHours())}${pad(pastDate.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
     // Exclude the 2nd minute after DTSTART (safely in the past, won't block the next run)
     const exMinute = new Date(pastDate.getTime() + 60_000);
-    const exDs = `${exMinute.getUTCFullYear()}${pad(exMinute.getUTCMonth() + 1)}${pad(exMinute.getUTCDate())}T${pad(exMinute.getUTCHours())}${pad(exMinute.getUTCMinutes())}00Z`;
+    const exDs = `${exMinute.getUTCFullYear()}${pad(exMinute.getUTCMonth() + 1)}${pad(exMinute.getUTCDate())}T${pad(exMinute.getUTCHours())}${pad(exMinute.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
     const expression = [
       `DTSTART:${ds}`,
       'RRULE:FREQ=MINUTELY;INTERVAL=1',

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -254,8 +254,8 @@ describe('scheduler RRULE execution', () => {
     const currentMinuteDate = new Date(now);
     currentMinuteDate.setUTCSeconds(0);
     currentMinuteDate.setUTCMilliseconds(0);
-    // Round to the previous minute boundary relative to dtstart
-    const exDate = `${currentMinuteDate.getUTCFullYear()}${pad(currentMinuteDate.getUTCMonth() + 1)}${pad(currentMinuteDate.getUTCDate())}T${pad(currentMinuteDate.getUTCHours())}${pad(currentMinuteDate.getUTCMinutes())}00Z`;
+    // Seconds must match DTSTART so the EXDATE aligns with a recurrence instance
+    const exDate = `${currentMinuteDate.getUTCFullYear()}${pad(currentMinuteDate.getUTCMonth() + 1)}${pad(currentMinuteDate.getUTCDate())}T${pad(currentMinuteDate.getUTCHours())}${pad(currentMinuteDate.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
 
     const expression = `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1\nEXDATE:${exDate}`;
 


### PR DESCRIPTION
Addresses feedback on #7639 — EXDATE now derives seconds from the same date as DTSTART instead of hardcoding 00Z, ensuring the exclusion actually matches a recurrence instance and the test properly validates EXDATE handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
