### PR TITLE
perf: speed up qdrant-manager tests from ~271s to ~15s

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -16,6 +16,13 @@ mock.module('../util/logger.js', () => ({
 
 import { QdrantManager } from '../memory/qdrant-manager.js';
 
+/** Short timeouts so tests don't wait 30s+ for readyz / shutdown grace. */
+const FAST_TIMEOUTS = {
+  readyzPollIntervalMs: 50,
+  readyzTimeoutMs: 1_500,
+  shutdownGraceMs: 500,
+} as const;
+
 function placeFakeBinary(script: string): string {
   const binaryPath = join(testDataDir, 'qdrant', 'bin', 'qdrant');
   writeFileSync(binaryPath, script);
@@ -78,11 +85,11 @@ describe('QdrantManager', () => {
     test('enters external mode when QDRANT_URL is set', async () => {
       process.env.QDRANT_URL = 'http://external:6333';
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       // External mode goes straight to waitForReady, which will timeout
       await expect(mgr.start()).rejects.toThrow('did not become ready');
-    }, 35_000);
+    }, 10_000);
 
     test('does not enter external mode when QDRANT_URL is empty', () => {
       process.env.QDRANT_URL = '   ';
@@ -126,12 +133,12 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexit 1');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       try { await mgr.start(); } catch { /* readyz timeout */ }
 
       expect(existsSync(pidPath)).toBe(false);
-    }, 40_000);
+    }, 10_000);
 
     test('handles invalid PID file contents', async () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
@@ -140,12 +147,12 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexit 1');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       try { await mgr.start(); } catch { /* expected */ }
 
       expect(existsSync(pidPath)).toBe(false);
-    }, 40_000);
+    }, 10_000);
 
     test('handles empty PID file', async () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
@@ -154,12 +161,12 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexit 1');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       try { await mgr.start(); } catch { /* expected */ }
 
       expect(existsSync(pidPath)).toBe(false);
-    }, 40_000);
+    }, 10_000);
   });
 
   // ── Process Lifecycle ────────────────────────────────────────
@@ -172,7 +179,7 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexec sleep 300');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       // Start polls readyz forever; we race it with our assertions + stop
       const startPromise = mgr.start();
@@ -192,7 +199,7 @@ describe('QdrantManager', () => {
 
       // start() should now reject because process was killed
       await expect(startPromise).rejects.toThrow('did not become ready');
-    }, 40_000);
+    }, 10_000);
 
     test('stop() escalates to SIGKILL after grace period', async () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
@@ -201,7 +208,7 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\ntrap "" TERM\nexec sleep 300');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       const startPromise = mgr.start();
       await Bun.sleep(500);
@@ -212,12 +219,12 @@ describe('QdrantManager', () => {
       await mgr.stop();
       const stopElapsed = Date.now() - stopStart;
 
-      // Grace period is 5s — should wait at least that long
-      expect(stopElapsed).toBeGreaterThanOrEqual(4500);
+      // Grace period is 500ms with FAST_TIMEOUTS — should wait at least that long
+      expect(stopElapsed).toBeGreaterThanOrEqual(400);
       expect(existsSync(pidPath)).toBe(false);
 
       await expect(startPromise).rejects.toThrow('did not become ready');
-    }, 45_000);
+    }, 10_000);
   });
 
   // ── Start Failure Cleanup ────────────────────────────────────
@@ -230,11 +237,11 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexec sleep 300');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       await expect(mgr.start()).rejects.toThrow('did not become ready');
       expect(existsSync(pidPath)).toBe(false);
-    }, 40_000);
+    }, 10_000);
 
     test('cleans up when process exits immediately', async () => {
       const pidPath = join(testDataDir, 'qdrant', 'qdrant.pid');
@@ -242,11 +249,11 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexit 1');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       await expect(mgr.start()).rejects.toThrow('did not become ready');
       expect(existsSync(pidPath)).toBe(false);
-    }, 40_000);
+    }, 10_000);
   });
 
   // ── Binary Detection ─────────────────────────────────────────
@@ -256,12 +263,12 @@ describe('QdrantManager', () => {
       placeFakeBinary('#!/bin/sh\nexit 1');
 
       const port = getTestPort();
-      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}` });
+      const mgr = new QdrantManager({ url: `http://127.0.0.1:${port}`, ...FAST_TIMEOUTS });
 
       try { await mgr.start(); } catch { /* readyz timeout */ }
 
       const binaryPath = join(testDataDir, 'qdrant', 'bin', 'qdrant');
       expect(existsSync(binaryPath)).toBe(true);
-    }, 40_000);
+    }, 10_000);
   });
 });

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -15,6 +15,12 @@ const SHUTDOWN_GRACE_MS = 5_000;
 export interface QdrantManagerConfig {
   url: string;
   storagePath?: string;
+  /** Override readyz poll interval (ms). Default: 200 */
+  readyzPollIntervalMs?: number;
+  /** Override readyz timeout (ms). Default: 30 000 */
+  readyzTimeoutMs?: number;
+  /** Override SIGTERM→SIGKILL grace period (ms). Default: 5 000 */
+  shutdownGraceMs?: number;
 }
 
 /**
@@ -36,6 +42,9 @@ export class QdrantManager {
   private readonly storagePath: string;
   private readonly pidPath: string;
   private readonly isExternal: boolean;
+  private readonly readyzPollIntervalMs: number;
+  private readonly readyzTimeoutMs: number;
+  private readonly shutdownGraceMs: number;
 
   constructor(config: QdrantManagerConfig) {
     this.url = config.url;
@@ -44,6 +53,10 @@ export class QdrantManager {
     this.port = parseInt(parsed.port || '6333', 10);
     this.storagePath = config.storagePath ?? join(getDataDir(), 'qdrant');
     this.pidPath = join(getDataDir(), 'qdrant', 'qdrant.pid');
+
+    this.readyzPollIntervalMs = config.readyzPollIntervalMs ?? READYZ_POLL_INTERVAL_MS;
+    this.readyzTimeoutMs = config.readyzTimeoutMs ?? READYZ_TIMEOUT_MS;
+    this.shutdownGraceMs = config.shutdownGraceMs ?? SHUTDOWN_GRACE_MS;
 
     // External mode only if QDRANT_URL is explicitly set
     this.isExternal = Boolean(process.env.QDRANT_URL?.trim());
@@ -107,7 +120,7 @@ export class QdrantManager {
     // Wait for graceful shutdown
     const graceful = await Promise.race([
       this.process.exited.then(() => true),
-      new Promise<false>((resolve) => setTimeout(() => resolve(false), SHUTDOWN_GRACE_MS)),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), this.shutdownGraceMs)),
     ]);
 
     if (!graceful) {
@@ -185,16 +198,16 @@ export class QdrantManager {
 
   private async waitForReady(): Promise<void> {
     const start = Date.now();
-    while (Date.now() - start < READYZ_TIMEOUT_MS) {
+    while (Date.now() - start < this.readyzTimeoutMs) {
       try {
         const res = await fetch(`${this.url}/readyz`);
         if (res.ok) return;
       } catch {
         // Not ready yet
       }
-      await Bun.sleep(READYZ_POLL_INTERVAL_MS);
+      await Bun.sleep(this.readyzPollIntervalMs);
     }
-    throw new Error(`Qdrant did not become ready within ${READYZ_TIMEOUT_MS}ms at ${this.url}`);
+    throw new Error(`Qdrant did not become ready within ${this.readyzTimeoutMs}ms at ${this.url}`);
   }
 
   private getBinaryPath(): string {


### PR DESCRIPTION
## Summary

- Add optional `readyzTimeoutMs`, `readyzPollIntervalMs`, and `shutdownGraceMs` fields to `QdrantManagerConfig` (defaults preserve existing behavior)
- Update `qdrant-manager.test.ts` to pass `FAST_TIMEOUTS` (1.5s readyz, 50ms poll, 500ms shutdown grace) so tests don't wait for real 30s+ timeouts
- Reduces this single test file from ~271s to ~15s in CI, cutting the overall CI test step by ~4 minutes

## Original prompt
Fix the qdrant-manager.test.ts CI performance problem. This single test file takes 271 seconds (4.5 minutes) because tests deliberately wait for real timeouts (readyz polling, SIGKILL grace period, etc.).

The fix: Make the QdrantManager's internal timeouts injectable/configurable so tests can use much shorter values (e.g., 2s instead of 30s). Then update the test file to pass short timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
