### PR TITLE
fix: make enrichment timeout test deterministic

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -308,25 +308,30 @@ describe('CommitEnrichmentService', () => {
   });
 
   test('job timeout triggers retry with backoff then fails after max retries', async () => {
-    // Use a very short timeout so the real git notes write times out
     const service = new CommitEnrichmentService({
       maxQueueSize: 10,
       maxConcurrency: 1,
-      jobTimeoutMs: 1, // 1ms timeout — will always time out
+      jobTimeoutMs: 10, // short timeout
       maxRetries: 2,
     });
 
     const commitHash = await createCommit();
+
+    // Use a slow gitService so the timeout always wins the race.
+    // A 1ms timeout against a real git write is flaky on fast CI runners.
+    const slowGitService = new WorkspaceGitService(testDir);
+    await slowGitService.ensureInitialized();
+    slowGitService.writeNote = () => new Promise<void>(() => {});
+
     service.enqueue({
       workspaceDir: testDir,
       commitHash,
       context: makeContext(),
-      gitService,
+      gitService: slowGitService,
     });
 
     // Wait for all retries to complete (initial + 2 retries, with backoff)
     // Backoff: 1s after attempt 1, 2s after attempt 2 = ~3s total
-    // But since the job itself is very fast to time out, total time is dominated by backoff
     await waitForDrain(service, 10000);
     await service.shutdown();
 


### PR DESCRIPTION
## Summary
- Replace flaky 1ms timeout race against real git operations with a deterministic slow mock
- The enrichment retry test now uses a `writeNote` that never resolves, so the timeout always fires
- Previous fix attempt (#7639) resolved logger mock, DTSTART, and git-cwd issues but this race condition remained

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22339502089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
