### PR TITLE
fix: fix remaining EXDATE seconds hardcoding in scheduler-recurrence test

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -294,7 +294,7 @@ describe('scheduler RRULE execution', () => {
     const pad = (n: number) => String(n).padStart(2, '0');
     const ds = `${pastDate.getUTCFullYear()}${pad(pastDate.getUTCMonth() + 1)}${pad(pastDate.getUTCDate())}T${pad(pastDate.getUTCHours())}${pad(pastDate.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
     const exMinute = new Date(pastDate.getTime() + 60_000);
-    const exDs = `${exMinute.getUTCFullYear()}${pad(exMinute.getUTCMonth() + 1)}${pad(exMinute.getUTCDate())}T${pad(exMinute.getUTCHours())}${pad(exMinute.getUTCMinutes())}00Z`;
+    const exDs = `${exMinute.getUTCFullYear()}${pad(exMinute.getUTCMonth() + 1)}${pad(exMinute.getUTCDate())}T${pad(exMinute.getUTCHours())}${pad(exMinute.getUTCMinutes())}${pad(exMinute.getUTCSeconds())}Z`;
     const expression = [
       `DTSTART:${ds}`,
       'RRULE:FREQ=MINUTELY;INTERVAL=1',


### PR DESCRIPTION
Addresses feedback on #7642 — fixes the third instance of EXDATE seconds hardcoded to 00Z that was missed in the previous fix. The 'RRULE set schedule fires and creates cron_runs entry' test now properly derives seconds from the date object.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
