### PR TITLE
fix: use mock() instead of spyOn for fetch in gateway tests

### DIFF
--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { callTelegramApi } from "../telegram/api.js";
+
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -43,18 +47,22 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-describe("callTelegramApi transport error redaction", () => {
-  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
 
+describe("callTelegramApi transport error redaction", () => {
   afterEach(() => {
-    fetchSpy?.mockRestore();
-    fetchSpy = null;
+    globalThis.fetch = originalFetch;
   });
 
   test("redacts bot token from warning logs and thrown error", async () => {
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+    mockFetch(async () => {
       const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
         path?: string;
         code?: string;
@@ -83,7 +91,7 @@ describe("callTelegramApi transport error redaction", () => {
     // "error-123456789:...") must still be redacted.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+    mockFetch(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -113,7 +121,7 @@ describe("callTelegramApi transport error redaction", () => {
     // would fail to match the trailing `-`, leaking part of the token.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz01234567-"].join("");
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+    mockFetch(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect, spyOn, afterEach } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 import { createTelegramDeliverHandler } from "../http/routes/telegram-deliver.js";
 import type { GatewayConfig } from "../config.js";
+
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 const TOKEN = "test-deliver-token";
 
@@ -45,16 +49,19 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
 
 afterEach(() => {
-  fetchSpy?.mockRestore();
-  fetchSpy = null;
+  globalThis.fetch = originalFetch;
 });
 
 function mockTelegramApi() {
-  fetchSpy?.mockRestore();
-  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+  mockFetch(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -65,9 +72,8 @@ function mockTelegramApi() {
 describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments without assistantId using assistant-less download path", async () => {
     const calls: string[] = [];
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    mockFetch(async (input: string | URL | Request) => {
+      const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (assistant-less path)
       if (urlStr.includes("/v1/attachments/att-1")) {
@@ -120,9 +126,8 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
   test("delivers attachments with assistantId using legacy download path", async () => {
     const calls: string[] = [];
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    mockFetch(async (input: string | URL | Request) => {
+      const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (legacy path)
       if (urlStr.includes("/attachments/att-2")) {
@@ -173,9 +178,8 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 describe("/deliver/telegram ID-only attachment validation", () => {
   test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
     const calls: string[] = [];
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    mockFetch(async (input: string | URL | Request) => {
+      const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-id-only")) {
         return new Response(
@@ -240,9 +244,8 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
   test("full-metadata attachments still accepted (backward compatibility)", async () => {
     const calls: string[] = [];
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    mockFetch(async (input: string | URL | Request) => {
+      const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-compat")) {
         return new Response(

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,10 +1,10 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
 import type { GatewayConfig } from "../config.js";
 
-// Instead of mock.module("../telegram/webhook-manager.js", ...) — which leaks
-// across Bun test files (process-global module mocks) — we use spyOn(globalThis, "fetch")
-// so that the real reconcileTelegramWebhook runs but API calls are intercepted.
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 function makeTelegramResponse(result: unknown) {
   return new Response(JSON.stringify({ ok: true, result }), {
@@ -72,11 +72,18 @@ function makeRequest(
   });
 }
 
-let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
 
-/** Default fetch spy that handles Telegram API calls with success responses. */
-function installDefaultFetchSpy() {
-  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
+let fetchMock: ReturnType<typeof mock<(...args: Parameters<typeof fetch>) => Promise<Response>>> | null = null;
+
+/** Default fetch mock that handles Telegram API calls with success responses. */
+function installDefaultFetchMock() {
+  fetchMock = mockFetch(async (input: string | URL | Request) => {
     const url =
       typeof input === "string"
         ? input
@@ -99,12 +106,12 @@ function installDefaultFetchSpy() {
 
 describe("POST /internal/telegram/reconcile", () => {
   beforeEach(() => {
-    installDefaultFetchSpy();
+    installDefaultFetchMock();
   });
 
   afterEach(() => {
-    fetchSpy?.mockRestore();
-    fetchSpy = null;
+    globalThis.fetch = originalFetch;
+    fetchMock = null;
   });
 
   test("rejects non-POST methods", async () => {
@@ -149,7 +156,7 @@ describe("POST /internal/telegram/reconcile", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     // Fetch was called (getWebhookInfo + setWebhook) proving reconcile ran.
-    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   test("updates ingressPublicBaseUrl when provided", async () => {
@@ -192,8 +199,7 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 502 when reconcile throws", async () => {
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+    fetchMock = mockFetch(async () => {
       throw new Error("Telegram API error");
     });
     const config = makeConfig();
@@ -224,8 +230,7 @@ describe("POST /internal/telegram/reconcile", () => {
 
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(
+    fetchMock = mockFetch(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === "string"

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,7 +1,11 @@
-import { describe, test, expect, spyOn, afterEach } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 import { sendTelegramAttachments } from "../telegram/send.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
+
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -46,24 +50,23 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 
-let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
-
-function mockFetch(fn: (url: string, init?: RequestInit) => Promise<Response>) {
-  fetchSpy?.mockRestore();
-  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(fn as any);
-  return fetchSpy;
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
 }
 
 describe("sendTelegramAttachments", () => {
   afterEach(() => {
-    fetchSpy?.mockRestore();
-    fetchSpy = null;
+    globalThis.fetch = originalFetch;
   });
 
   test("sends image attachment via sendPhoto", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // Runtime download endpoint
       if (url.includes("/attachments/att-1")) {
@@ -102,7 +105,8 @@ describe("sendTelegramAttachments", () => {
   test("sends non-image attachment via sendDocument", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-2")) {
         return new Response(
@@ -138,7 +142,8 @@ describe("sendTelegramAttachments", () => {
   test("skips oversized attachments and sends failure notice", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       return new Response(JSON.stringify(telegramOk));
     });
@@ -162,7 +167,8 @@ describe("sendTelegramAttachments", () => {
   test("downloads via assistant-less path when assistantId is undefined", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-no-assist")) {
         return new Response(
@@ -201,7 +207,8 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment hydrates metadata from downloaded payload", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-id-only")) {
         return new Response(
@@ -233,7 +240,8 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment falls back to defaults when download payload also lacks metadata", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-bare")) {
         return new Response(
@@ -260,7 +268,8 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment skipped when hydrated size exceeds limit", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-big")) {
         return new Response(
@@ -293,9 +302,8 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment uses id as filename fallback", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push({ url: urlStr, init });
       if (urlStr.includes("/attachments/my-attachment-id")) {
         return new Response(
@@ -324,7 +332,8 @@ describe("sendTelegramAttachments", () => {
   test("full-metadata payload still works (backward compatibility)", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-full")) {
         return new Response(
@@ -360,7 +369,8 @@ describe("sendTelegramAttachments", () => {
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (url: string) => {
+    mockFetch(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // First attachment download fails
       if (url.includes("/attachments/att-fail")) {

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect, spyOn, afterEach, beforeEach } from "bun:test";
+import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
+
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -66,16 +70,21 @@ function makeWebhookRequest(payload: unknown, secret = "test-webhook-secret"): R
   });
 }
 
-let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 let fetchCalls: { url: string; method: string; body?: unknown; headers?: Record<string, string> }[];
+
+function mockFetchFn(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
 
 beforeEach(() => {
   fetchCalls = [];
 });
 
 afterEach(() => {
-  fetchSpy?.mockRestore();
-  fetchSpy = null;
+  globalThis.fetch = originalFetch;
 });
 
 /** Extract headers from a fetch call into a plain object. */
@@ -102,8 +111,7 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
  * Runtime forward calls get an eventId response; Telegram API calls get { ok: true }.
  */
 function installFetchMock() {
-  fetchSpy?.mockRestore();
-  fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+  mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
     let body: unknown;
@@ -320,8 +328,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
     // Install a fetch mock where the runtime inbound call blocks on the first
     // invocation and responds immediately on subsequent ones.
     let inboundCallCount = 0;
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -380,8 +387,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
     });
 
     let callCount = 0;
-    fetchSpy?.mockRestore();
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect, spyOn, afterEach } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
+
+// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
+// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
+const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -43,11 +47,18 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
+
+let fetchMock: ReturnType<typeof mockFetch> | null = null;
 
 afterEach(() => {
-  fetchSpy?.mockRestore();
-  fetchSpy = null;
+  globalThis.fetch = originalFetch;
+  fetchMock = null;
 });
 
 function makeTelegramResponse(result: unknown) {
@@ -61,7 +72,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -93,7 +104,7 @@ describe("reconcileTelegramWebhook", () => {
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {
     const calls: string[] = [];
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
+    fetchMock = mockFetch(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -119,7 +130,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -145,36 +156,36 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when bot token is not configured", async () => {
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
+    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramBotToken: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when webhook secret is not configured", async () => {
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
+    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramWebhookSecret: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when ingress URL is not configured", async () => {
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => new Response("", { status: 200 }));
+    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ ingressPublicBaseUrl: undefined });
     await reconcileTelegramWebhook(config);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 
-    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async (input: string | URL | Request) => {
+    fetchMock = mockFetch(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");


### PR DESCRIPTION
## Summary
- Migrate 6 gateway test files from spyOn(globalThis, 'fetch') to mock() + direct assignment pattern
- spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9 (call tracking broken despite implementation executing)
- Aligns with the working pattern already used in runtime-client.test.ts

## Original prompt
fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22341172043/job/64644610996

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
