### PR TITLE
perf: upgrade recall cache from FIFO to LRU eviction

### DIFF
--- a/assistant/src/memory/recall-cache.ts
+++ b/assistant/src/memory/recall-cache.ts
@@ -68,11 +68,14 @@ export function getCachedRecall(
     _cache.delete(key);
     return undefined;
   }
+  // Move to end of Map iteration order so it's treated as most-recently-used
+  _cache.delete(key);
+  _cache.set(key, entry);
   return entry.result;
 }
 
 /**
- * Store a recall result in the cache. Evicts oldest entries when full.
+ * Store a recall result in the cache. Evicts least-recently-used entries when full.
  *
  * When `snapshotVersion` is provided, the entry is only stored if the
  * snapshot still matches the current global version — this prevents a


### PR DESCRIPTION
## Summary
- On cache hit in `getCachedRecall`, delete and re-insert the entry to move it to the end of `Map` iteration order (most-recently-used position)
- Eviction in `setCachedRecall` already removes the first map key — now that's the least-recently-used entry instead of just the oldest inserted
- Improves cache hit rate for frequently accessed queries

## Original prompt
Upgrade recall cache from FIFO to LRU (memory/recall-cache.ts) — Current eviction deletes the oldest insertion, not the least recently used. Frequently accessed entries get evicted in favor of rarely accessed ones, reducing cache hit rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
