### PR TITLE
perf: batch memoryItemSources queries to fix N+1 pattern

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 import type { AssistantConfig } from '../config/types.js';
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
@@ -120,13 +120,27 @@ async function collectAndMergeCandidates(
   // comes from excluded messages should not leak back into recall.
   if (excludeMessageIds.length > 0 && directItems.length > 0) {
     const db = getDb();
-    directItems = directItems.filter((candidate) => {
-      const sources = db.select().from(memoryItemSources)
-        .where(eq(memoryItemSources.memoryItemId, candidate.id)).all();
-      if (sources.length === 0) return true;
-      const nonExcluded = sources.filter((s) => !excludeMessageIds.includes(s.messageId));
-      return nonExcluded.length > 0;
-    });
+    const excludedSet = new Set(excludeMessageIds);
+    const allSources = db.select({
+      memoryItemId: memoryItemSources.memoryItemId,
+      messageId: memoryItemSources.messageId,
+    }).from(memoryItemSources)
+      .where(inArray(memoryItemSources.memoryItemId, directItems.map((c) => c.id)))
+      .all();
+
+    // Track which items have at least one non-excluded source
+    const hasNonExcluded = new Set<string>();
+    const hasSources = new Set<string>();
+    for (const s of allSources) {
+      hasSources.add(s.memoryItemId);
+      if (!excludedSet.has(s.messageId)) {
+        hasNonExcluded.add(s.memoryItemId);
+      }
+    }
+
+    directItems = directItems.filter((c) =>
+      !hasSources.has(c.id) || hasNonExcluded.has(c.id),
+    );
     directItems = directItems.slice(0, directLimit);
   }
 

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { getDb } from '../db.js';
 import { getQdrantClient } from '../qdrant-client.js';
 import {
@@ -32,6 +32,27 @@ export async function semanticSearch(
   );
 
   const db = getDb();
+
+  // Batch-fetch sources for all item-type results to avoid N+1 queries
+  const itemTargetIds = results
+    .filter((r) => r.payload.target_type === 'item')
+    .map((r) => r.payload.target_id);
+  const sourcesMap = new Map<string, string[]>();
+  if (itemTargetIds.length > 0) {
+    const allSources = db.select({
+      memoryItemId: memoryItemSources.memoryItemId,
+      messageId: memoryItemSources.messageId,
+    }).from(memoryItemSources)
+      .where(inArray(memoryItemSources.memoryItemId, itemTargetIds))
+      .all();
+    for (const s of allSources) {
+      const existing = sourcesMap.get(s.memoryItemId);
+      if (existing) existing.push(s.messageId);
+      else sourcesMap.set(s.memoryItemId, [s.messageId]);
+    }
+  }
+  const excludedSet = excludedMessageIds.length > 0 ? new Set(excludedMessageIds) : null;
+
   const candidates: Candidate[] = [];
   for (const result of results) {
     const { payload, score } = result;
@@ -43,12 +64,11 @@ export async function semanticSearch(
       const item = db.select().from(memoryItems).where(eq(memoryItems.id, payload.target_id)).get();
       if (!item || item.status !== 'active' || item.invalidAt !== null) continue;
       if (scopeIds && !scopeIds.includes(item.scopeId)) continue;
-      const sources = db.select().from(memoryItemSources)
-        .where(eq(memoryItemSources.memoryItemId, payload.target_id)).all();
-      if (sources.length === 0) continue;
-      if (excludedMessageIds.length > 0) {
-        const nonExcluded = sources.filter((s) => !excludedMessageIds.includes(s.messageId));
-        if (nonExcluded.length === 0) continue;
+      const sources = sourcesMap.get(payload.target_id);
+      if (!sources || sources.length === 0) continue;
+      if (excludedSet) {
+        const hasNonExcluded = sources.some((msgId) => !excludedSet.has(msgId));
+        if (!hasNonExcluded) continue;
       }
       candidates.push({
         key: `item:${payload.target_id}`,


### PR DESCRIPTION
## Summary

- **retriever.ts**: Replaced N+1 per-candidate `memoryItemSources` query in direct-items exclusion filtering with a single batched `inArray()` query, matching the pattern already used in `entity.ts`
- **semantic.ts**: Pre-fetched all `memoryItemSources` rows for item-type Qdrant results in one batch query instead of querying per-result in the loop
- Both fixes use `Set` for O(1) exclusion lookups instead of `Array.includes()`

## Original prompt
Fix N+1 query pattern in memory/retriever.ts — When filtering candidates by excluded message IDs, each candidate triggers a separate memoryItemSources query. With 10+ candidates this is 10+ sequential DB roundtrips. Batch into a single inArray() query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
