### PR TITLE
perf: parallelize semantic and entity search in memory retrieval

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -161,40 +161,50 @@ async function collectAndMergeCandidates(
     && cheapCandidates.filter((c) => c.lexical >= etConfig.confidenceThreshold).length >= etConfig.minHighConfidence;
 
   // -- Phase 2: expensive searches (skipped on early termination) --
+  // Semantic search (async Qdrant network call) and entity search (sync
+  // SQLite graph traversal) are independent. Start the network call first,
+  // run the sync work while it's in flight, then await the result.
   let semantic: Candidate[] = [];
   let semanticSearchFailed = false;
-  if (queryVector && !canTerminateEarly) {
-    try {
-      semantic = await semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds);
-    } catch (err) {
-      semanticSearchFailed = true;
-      if (isQdrantConnectionError(err)) {
-        log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
-      } else {
-        log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
-      }
-    }
-  }
-
   let entity: Candidate[] = [];
   let candidateDepths: Map<string, number> | undefined;
   let relationSeedEntityCount = 0;
   let relationTraversedEdgeCount = 0;
   let relationNeighborEntityCount = 0;
   let relationExpandedItemCount = 0;
-  if (config.memory.entity.enabled && !canTerminateEarly) {
-    const entitySearchResult = entitySearch(
-      query,
-      config.memory.entity,
-      scopeIds,
-      excludeMessageIds,
-    );
-    entity = entitySearchResult.candidates;
-    candidateDepths = entitySearchResult.candidateDepths;
-    relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
-    relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
-    relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
-    relationExpandedItemCount = entitySearchResult.relationExpandedItemCount;
+
+  if (!canTerminateEarly) {
+    const semanticPromise = queryVector
+      ? semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds)
+          .catch((err): Candidate[] => {
+            semanticSearchFailed = true;
+            if (isQdrantConnectionError(err)) {
+              log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
+            } else {
+              log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+            }
+            return [];
+          })
+      : null;
+
+    if (config.memory.entity.enabled) {
+      const entitySearchResult = entitySearch(
+        query,
+        config.memory.entity,
+        scopeIds,
+        excludeMessageIds,
+      );
+      entity = entitySearchResult.candidates;
+      candidateDepths = entitySearchResult.candidateDepths;
+      relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
+      relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
+      relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
+      relationExpandedItemCount = entitySearchResult.relationExpandedItemCount;
+    }
+
+    if (semanticPromise) {
+      semantic = await semanticPromise;
+    }
   }
 
   if (canTerminateEarly) {


### PR DESCRIPTION
## Summary
- Restructured Phase 2 of `collectAndMergeCandidates` to start the async Qdrant vector search before running the synchronous entity graph traversal, then await the result afterward
- Entity search (sync SQLite graph traversal) now executes while the Qdrant network call is in flight, overlapping the two independent operations
- No behavioral changes — same candidates, same error handling, same early termination logic

## Original prompt
Parallelize memory recall strategies — FTS5, Qdrant vector search, and entity graph queries currently run sequentially in the retriever. These are independent and could run via Promise.all() for significant latency reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
