### PR TITLE
perf: add partial covering index for directItemSearch

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -566,6 +566,14 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_status_invalid_at ON memory_items(status, invalid_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_status_kind ON memory_items(scope_id, status, kind)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_last_seen_at ON memory_items(last_seen_at)`);
+  // Partial covering index for directItemSearch: the LIKE '%term%' pattern can't
+  // seek a B-tree, but this index lets SQLite scan only active non-invalidated rows
+  // and evaluate LIKE + return columns without touching the main table.
+  database.run(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
+    ON memory_items(last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
+    WHERE status = 'active' AND invalid_at IS NULL
+  `);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);


### PR DESCRIPTION
## Summary
- Add a partial covering index `idx_memory_items_active_search` on `memory_items` for the `directItemSearch` query
- The index uses `WHERE status = 'active' AND invalid_at IS NULL` to skip inactive/invalidated rows entirely
- Includes `last_seen_at DESC` (for ORDER BY), `subject`/`statement` (for LIKE evaluation), and remaining SELECT columns to avoid table lookups

## Original prompt
Add database indexes for direct item search — The directItemSearch raw SQL uses LIKE '%term%' on subject and statement columns without covering indexes. As memory_items grows, this becomes a full table scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
