### PR TITLE
refactor: standardize error handling to try-catch in session-agent-loop

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -808,9 +808,13 @@ export async function runAgentLoopImpl(
     }
 
     if (isFirstMessage) {
-      generateTitle(ctx, content, firstAssistantText).catch((err) => {
-        log.warn({ err, conversationId: ctx.conversationId }, 'Failed to generate conversation title (non-fatal, using default title)');
-      });
+      void (async () => {
+        try {
+          await generateTitle(ctx, content, firstAssistantText);
+        } catch (err) {
+          log.warn({ err, conversationId: ctx.conversationId }, 'Failed to generate conversation title (non-fatal, using default title)');
+        }
+      })();
     }
   } catch (err) {
     const errorCtx = { phase: 'agent_loop' as const, aborted: abortController.signal.aborted };


### PR DESCRIPTION
## Summary
- Converted the `.catch()` callback on `generateTitle()` to an async IIFE with `try-catch`, matching the pattern used throughout the rest of the file.

## Original prompt
Standardize error handling to async/await + try-catch — Multiple files mix .catch() callbacks and try-catch blocks in the same functions (e.g., session-agent-loop.ts, jobs-worker.ts, run-orchestrator.ts). Pick one pattern. One PR per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
