### PR TITLE
refactor: extract session agent loop event handlers

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -1,0 +1,408 @@
+/**
+ * Extracted event handler functions for the session agent loop.
+ *
+ * Each switch case from the original monolithic event handler is now a
+ * standalone exported function, making individual behaviors independently
+ * testable while keeping shared mutable state bundled in EventHandlerState.
+ */
+
+import type pino from 'pino';
+import type { ContentBlock, ImageContent } from '../providers/types.js';
+import type { ServerMessage } from './ipc-protocol.js';
+import type { AgentEvent } from '../agent/loop.js';
+import type { AgentLoopSessionContext } from './session-agent-loop.js';
+import type { DirectiveRequest } from './assistant-attachments.js';
+import * as conversationStore from '../memory/conversation-store.js';
+import { classifySessionError, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
+import { isProviderOrderingError } from './session-slash.js';
+import { cleanAssistantContent, drainDirectiveDisplayBuffer } from './assistant-attachments.js';
+import { recordRequestLog } from '../memory/llm-request-log-store.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface PendingToolResult {
+  content: string;
+  isError: boolean;
+  contentBlocks?: ContentBlock[];
+}
+
+/** Mutable state shared across event handlers within a single agent loop run. */
+export interface EventHandlerState {
+  llmCallStartedEmitted: boolean;
+  pendingDirectiveDisplayBuffer: string;
+  firstAssistantText: string;
+  exchangeInputTokens: number;
+  exchangeOutputTokens: number;
+  model: string;
+  orderingErrorDetected: boolean;
+  deferredOrderingError: string | null;
+  contextTooLargeDetected: boolean;
+  providerErrorUserMessage: string | null;
+  lastAssistantMessageId: string | undefined;
+  readonly pendingToolResults: Map<string, PendingToolResult>;
+  readonly persistedToolUseIds: Set<string>;
+  readonly accumulatedDirectives: DirectiveRequest[];
+  readonly accumulatedToolContentBlocks: ContentBlock[];
+  readonly directiveWarnings: string[];
+  readonly toolUseIdToName: Map<string, string>;
+  currentTurnToolNames: string[];
+}
+
+/** Immutable context shared across event handlers within a single agent loop run. */
+export interface EventHandlerDeps {
+  readonly ctx: AgentLoopSessionContext;
+  readonly onEvent: (msg: ServerMessage) => void;
+  readonly reqId: string;
+  readonly isFirstMessage: boolean;
+  readonly rlog: pino.Logger;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export function createEventHandlerState(): EventHandlerState {
+  return {
+    llmCallStartedEmitted: false,
+    pendingDirectiveDisplayBuffer: '',
+    firstAssistantText: '',
+    exchangeInputTokens: 0,
+    exchangeOutputTokens: 0,
+    model: '',
+    orderingErrorDetected: false,
+    deferredOrderingError: null,
+    contextTooLargeDetected: false,
+    providerErrorUserMessage: null,
+    lastAssistantMessageId: undefined,
+    pendingToolResults: new Map(),
+    persistedToolUseIds: new Set(),
+    accumulatedDirectives: [],
+    accumulatedToolContentBlocks: [],
+    directiveWarnings: [],
+    toolUseIdToName: new Map(),
+    currentTurnToolNames: [],
+  };
+}
+
+// ── Shared Helper ────────────────────────────────────────────────────
+
+export function emitLlmCallStartedIfNeeded(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+): void {
+  if (state.llmCallStartedEmitted) return;
+  state.llmCallStartedEmitted = true;
+  deps.ctx.traceEmitter.emit('llm_call_started', `LLM call to ${deps.ctx.provider.name}`, {
+    requestId: deps.reqId,
+    status: 'info',
+    attributes: { provider: deps.ctx.provider.name, model: state.model || 'unknown' },
+  });
+}
+
+// ── Individual Handlers ──────────────────────────────────────────────
+
+export function handleTextDelta(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'text_delta' }>,
+): void {
+  emitLlmCallStartedIfNeeded(state, deps);
+  state.pendingDirectiveDisplayBuffer += event.text;
+  const drained = drainDirectiveDisplayBuffer(state.pendingDirectiveDisplayBuffer);
+  state.pendingDirectiveDisplayBuffer = drained.bufferedRemainder;
+  if (drained.emitText.length > 0) {
+    deps.onEvent({ type: 'assistant_text_delta', text: drained.emitText, sessionId: deps.ctx.conversationId });
+    if (deps.isFirstMessage) state.firstAssistantText += drained.emitText;
+  }
+}
+
+export function handleThinkingDelta(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'thinking_delta' }>,
+): void {
+  emitLlmCallStartedIfNeeded(state, deps);
+  deps.onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
+}
+
+export function handleToolUse(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'tool_use' }>,
+): void {
+  state.toolUseIdToName.set(event.id, event.name);
+  state.currentTurnToolNames.push(event.name);
+  deps.onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: deps.ctx.conversationId });
+}
+
+export function handleToolOutputChunk(
+  _state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'tool_output_chunk' }>,
+): void {
+  let structured: {
+    subType?: 'tool_start' | 'tool_complete' | 'status';
+    subToolName?: string;
+    subToolInput?: string;
+    subToolIsError?: boolean;
+    subToolId?: string;
+  } | undefined;
+
+  const trimmed = event.chunk.trimStart();
+  if (trimmed.length > 0 && trimmed.length < 4096 && trimmed[0] === '{') {
+    try {
+      const parsed = JSON.parse(event.chunk);
+      const VALID_SUB_TYPES = new Set(['tool_start', 'tool_complete', 'status']);
+      if (parsed && typeof parsed === 'object' && typeof parsed.subType === 'string' && VALID_SUB_TYPES.has(parsed.subType)) {
+        structured = {
+          subType: parsed.subType as 'tool_start' | 'tool_complete' | 'status',
+          subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
+          subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
+          subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,
+          subToolId: typeof parsed.subToolId === 'string' ? parsed.subToolId : undefined,
+        };
+      }
+    } catch {
+      // Not valid JSON — pass through as plain chunk
+    }
+  }
+
+  if (structured) {
+    deps.onEvent({
+      type: 'tool_output_chunk',
+      chunk: event.chunk,
+      sessionId: deps.ctx.conversationId,
+      subType: structured.subType,
+      subToolName: structured.subToolName,
+      subToolInput: structured.subToolInput,
+      subToolIsError: structured.subToolIsError,
+      subToolId: structured.subToolId,
+    });
+  } else {
+    deps.onEvent({ type: 'tool_output_chunk', chunk: event.chunk, sessionId: deps.ctx.conversationId });
+  }
+}
+
+export function handleInputJsonDelta(
+  _state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'input_json_delta' }>,
+): void {
+  deps.onEvent({ type: 'tool_input_delta', toolName: event.toolName, content: event.accumulatedJson, sessionId: deps.ctx.conversationId });
+}
+
+export function handleToolResult(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'tool_result' }>,
+): void {
+  const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
+  deps.onEvent({
+    type: 'tool_result',
+    toolName: '',
+    result: event.content,
+    isError: event.isError,
+    diff: event.diff,
+    status: event.status,
+    sessionId: deps.ctx.conversationId,
+    imageData: imageBlock?.source.data,
+  });
+  state.pendingToolResults.set(event.toolUseId, {
+    content: event.content,
+    isError: event.isError,
+    contentBlocks: event.contentBlocks,
+  });
+
+  const toolName = state.toolUseIdToName.get(event.toolUseId);
+  if (toolName === 'file_write' || toolName === 'bash') {
+    deps.ctx.markWorkspaceTopLevelDirty();
+  } else if (toolName === 'file_edit' && !event.isError) {
+    deps.ctx.markWorkspaceTopLevelDirty();
+  }
+
+  if (event.contentBlocks) {
+    for (const cb of event.contentBlocks) {
+      if (cb.type === 'image' || cb.type === 'file') {
+        state.accumulatedToolContentBlocks.push(cb);
+      }
+    }
+  }
+}
+
+export function handleError(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'error' }>,
+): void {
+  if (isProviderOrderingError(event.error.message)) {
+    state.orderingErrorDetected = true;
+    state.deferredOrderingError = event.error.message;
+  } else if (isContextTooLarge(event.error.message)) {
+    state.contextTooLargeDetected = true;
+  } else {
+    const classified = classifySessionError(event.error, { phase: 'agent_loop' });
+    deps.onEvent(buildSessionErrorMessage(deps.ctx.conversationId, classified));
+    state.providerErrorUserMessage = classified.userMessage;
+  }
+}
+
+export function handleMessageComplete(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'message_complete' }>,
+): void {
+  // Flush any remaining directive display buffer
+  if (state.pendingDirectiveDisplayBuffer.length > 0) {
+    deps.onEvent({
+      type: 'assistant_text_delta',
+      text: state.pendingDirectiveDisplayBuffer,
+      sessionId: deps.ctx.conversationId,
+    });
+    if (deps.isFirstMessage) state.firstAssistantText += state.pendingDirectiveDisplayBuffer;
+    state.pendingDirectiveDisplayBuffer = '';
+  }
+
+  // Persist pending tool results
+  if (state.pendingToolResults.size > 0) {
+    const toolResultBlocks = Array.from(state.pendingToolResults.entries()).map(
+      ([toolUseId, result]) => ({
+        type: 'tool_result',
+        tool_use_id: toolUseId,
+        content: result.content,
+        is_error: result.isError,
+        ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
+      }),
+    );
+    conversationStore.addMessage(
+      deps.ctx.conversationId,
+      'user',
+      JSON.stringify(toolResultBlocks),
+    );
+    for (const id of state.pendingToolResults.keys()) {
+      state.persistedToolUseIds.add(id);
+    }
+    state.pendingToolResults.clear();
+  }
+
+  // Clean assistant content and accumulate directives
+  const { cleanedContent, directives: msgDirectives, warnings: msgWarnings } =
+    cleanAssistantContent(event.message.content);
+  state.accumulatedDirectives.push(...msgDirectives);
+  state.directiveWarnings.push(...msgWarnings);
+  if (msgDirectives.length > 0) {
+    deps.rlog.info(
+      { parsedDirectives: msgDirectives.map(d => ({ source: d.source, path: d.path, mimeType: d.mimeType })), totalAccumulated: state.accumulatedDirectives.length },
+      'Parsed attachment directives from assistant message',
+    );
+  }
+
+  // Build content with UI surfaces
+  const contentWithSurfaces: ContentBlock[] = [...cleanedContent as ContentBlock[]];
+  for (const surface of deps.ctx.currentTurnSurfaces) {
+    contentWithSurfaces.push({
+      type: 'ui_surface',
+      surfaceId: surface.surfaceId,
+      surfaceType: surface.surfaceType,
+      title: surface.title,
+      data: surface.data,
+      actions: surface.actions,
+      display: surface.display,
+    } as unknown as ContentBlock);
+  }
+
+  const assistantMsg = conversationStore.addMessage(
+    deps.ctx.conversationId,
+    'assistant',
+    JSON.stringify(contentWithSurfaces),
+  );
+  state.lastAssistantMessageId = assistantMsg.id;
+
+  deps.ctx.currentTurnSurfaces = [];
+
+  // Emit trace event
+  const charCount = cleanedContent
+    .filter((b) => (b as Record<string, unknown>).type === 'text')
+    .reduce((sum: number, b) => sum + ((b as { text?: string }).text?.length ?? 0), 0);
+  const toolUseCount = event.message.content
+    .filter((b) => b.type === 'tool_use')
+    .length;
+  deps.ctx.traceEmitter.emit('assistant_message', 'Assistant message complete', {
+    requestId: deps.reqId,
+    status: 'success',
+    attributes: { charCount, toolUseCount },
+  });
+}
+
+export function handleUsage(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: 'usage' }>,
+): void {
+  state.exchangeInputTokens += event.inputTokens;
+  state.exchangeOutputTokens += event.outputTokens;
+  state.model = event.model;
+
+  if (event.rawRequest && event.rawResponse) {
+    try {
+      recordRequestLog(
+        deps.ctx.conversationId,
+        JSON.stringify(event.rawRequest),
+        JSON.stringify(event.rawResponse),
+      );
+    } catch (err) {
+      deps.rlog.warn({ err }, 'Failed to persist LLM request log (non-fatal)');
+    }
+  }
+
+  emitLlmCallStartedIfNeeded(state, deps);
+
+  deps.ctx.traceEmitter.emit('llm_call_finished', `LLM call to ${deps.ctx.provider.name} finished`, {
+    requestId: deps.reqId,
+    status: 'success',
+    attributes: {
+      provider: deps.ctx.provider.name,
+      model: event.model,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      latencyMs: event.providerDurationMs,
+    },
+  });
+  state.llmCallStartedEmitted = false;
+}
+
+// ── Dispatcher ───────────────────────────────────────────────────────
+
+/** Routes an AgentEvent to the appropriate handler. */
+export function dispatchAgentEvent(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: AgentEvent,
+): void {
+  switch (event.type) {
+    case 'text_delta':
+      handleTextDelta(state, deps, event);
+      break;
+    case 'thinking_delta':
+      handleThinkingDelta(state, deps, event);
+      break;
+    case 'tool_use':
+      handleToolUse(state, deps, event);
+      break;
+    case 'tool_output_chunk':
+      handleToolOutputChunk(state, deps, event);
+      break;
+    case 'input_json_delta':
+      handleInputJsonDelta(state, deps, event);
+      break;
+    case 'tool_result':
+      handleToolResult(state, deps, event);
+      break;
+    case 'error':
+      handleError(state, deps, event);
+      break;
+    case 'message_complete':
+      handleMessageComplete(state, deps, event);
+      break;
+    case 'usage':
+      handleUsage(state, deps, event);
+      break;
+  }
+}

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -8,7 +8,7 @@
  */
 
 import { v4 as uuid } from 'uuid';
-import type { Message, ContentBlock, ImageContent } from '../providers/types.js';
+import type { Message, ContentBlock } from '../providers/types.js';
 import type { ServerMessage, UsageStats, SurfaceType, SurfaceData, DynamicPageSurfaceData } from './ipc-protocol.js';
 import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -18,7 +18,7 @@ import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import type { TraceEmitter } from './trace-emitter.js';
-import { classifySessionError, isUserCancellation, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
+import { classifySessionError, isUserCancellation, buildSessionErrorMessage } from './session-error.js';
 import type { ToolProfiler } from '../events/tool-profiling-listener.js';
 import type { ContextWindowManager } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
@@ -37,8 +37,6 @@ import { buildTemporalContext } from './date-context.js';
 import type { ActiveSurfaceContext, ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
-  drainDirectiveDisplayBuffer,
-  type DirectiveRequest,
   type AssistantAttachmentDraft,
 } from './assistant-attachments.js';
 import { prepareMemoryContext } from './session-memory.js';
@@ -49,8 +47,6 @@ import {
 } from './session-attachments.js';
 import { consolidateAssistantMessages } from './session-history.js';
 import { recordUsage } from './session-usage.js';
-import { recordRequestLog } from '../memory/llm-request-log-store.js';
-import { isProviderOrderingError } from './session-slash.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { stripMediaPayloadsForRetry, raceWithTimeout } from './session-media-retry.js';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
@@ -58,6 +54,11 @@ import { getWorkspaceGitService } from '../workspace/git-service.js';
 import { commitAppTurnChanges } from '../memory/app-git-service.js';
 import type { UsageActor } from '../usage/actors.js';
 import type { SkillProjectionCache } from './session-skill-tools.js';
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  type EventHandlerDeps,
+} from './session-agent-loop-handlers.js';
 
 const log = getLogger('session-agent-loop');
 
@@ -205,19 +206,8 @@ export async function runAgentLoopImpl(
       emitUsage(ctx, compacted.summaryInputTokens, compacted.summaryOutputTokens, compacted.summaryModel, onEvent, 'context_compactor', reqId);
     }
 
-    let firstAssistantText = '';
-    let exchangeInputTokens = 0;
-    let exchangeOutputTokens = 0;
-    let model = '';
+    const state = createEventHandlerState();
     let runMessages = ctx.messages;
-    const pendingToolResults = new Map<string, { content: string; isError: boolean; contentBlocks?: ContentBlock[] }>();
-    const persistedToolUseIds = new Set<string>();
-    const accumulatedDirectives: DirectiveRequest[] = [];
-    const accumulatedToolContentBlocks: ContentBlock[] = [];
-    const directiveWarnings: string[] = [];
-    let pendingDirectiveDisplayBuffer = '';
-    let lastAssistantMessageId: string | undefined;
-    let providerErrorUserMessage: string | null = null;
 
     const memoryResult = await prepareMemoryContext(
       {
@@ -311,235 +301,14 @@ export async function runAgentLoopImpl(
       runMessages = preRunRepair.messages;
     }
 
-    let orderingErrorDetected = false;
-    let deferredOrderingError: string | null = null;
-    let contextTooLargeDetected = false;
     let preRunHistoryLength = runMessages.length;
 
-    let llmCallStartedEmitted = false;
-    const toolUseIdToName = new Map<string, string>();
-    let currentTurnToolNames: string[] = [];
-
-    const buildEventHandler = () => (event: AgentEvent) => {
-      const emitLlmCallStartedIfNeeded = () => {
-        if (llmCallStartedEmitted) return;
-        llmCallStartedEmitted = true;
-        ctx.traceEmitter.emit('llm_call_started', `LLM call to ${ctx.provider.name}`, {
-          requestId: reqId,
-          status: 'info',
-          attributes: { provider: ctx.provider.name, model: model || 'unknown' },
-        });
-      };
-
-      switch (event.type) {
-        case 'text_delta': {
-          emitLlmCallStartedIfNeeded();
-          pendingDirectiveDisplayBuffer += event.text;
-          const drained = drainDirectiveDisplayBuffer(pendingDirectiveDisplayBuffer);
-          pendingDirectiveDisplayBuffer = drained.bufferedRemainder;
-          if (drained.emitText.length > 0) {
-            onEvent({ type: 'assistant_text_delta', text: drained.emitText, sessionId: ctx.conversationId });
-            if (isFirstMessage) firstAssistantText += drained.emitText;
-          }
-          break;
-        }
-        case 'thinking_delta':
-          emitLlmCallStartedIfNeeded();
-          onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
-          break;
-        case 'tool_use':
-          toolUseIdToName.set(event.id, event.name);
-          currentTurnToolNames.push(event.name);
-          onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: ctx.conversationId });
-          break;
-        case 'tool_output_chunk': {
-          // Try to parse structured progress fields from the chunk.
-          // Cheap pre-check: only attempt JSON.parse when the chunk looks like an object.
-          let structured: { subType?: 'tool_start' | 'tool_complete' | 'status'; subToolName?: string; subToolInput?: string; subToolIsError?: boolean; subToolId?: string } | undefined;
-          const trimmed = event.chunk.trimStart();
-          if (trimmed.length > 0 && trimmed.length < 4096 && trimmed[0] === '{') {
-            try {
-              const parsed = JSON.parse(event.chunk);
-              const VALID_SUB_TYPES = new Set(['tool_start', 'tool_complete', 'status']);
-              if (parsed && typeof parsed === 'object' && typeof parsed.subType === 'string' && VALID_SUB_TYPES.has(parsed.subType)) {
-                structured = {
-                  subType: parsed.subType as 'tool_start' | 'tool_complete' | 'status',
-                  subToolName: typeof parsed.subToolName === 'string' ? parsed.subToolName : undefined,
-                  subToolInput: typeof parsed.subToolInput === 'string' ? parsed.subToolInput : undefined,
-                  subToolIsError: typeof parsed.subToolIsError === 'boolean' ? parsed.subToolIsError : undefined,
-                  subToolId: typeof parsed.subToolId === 'string' ? parsed.subToolId : undefined,
-                };
-              }
-            } catch {
-              // Not valid JSON — pass through as plain chunk
-            }
-          }
-          if (structured) {
-            onEvent({
-              type: 'tool_output_chunk',
-              chunk: event.chunk,
-              sessionId: ctx.conversationId,
-              subType: structured.subType,
-              subToolName: structured.subToolName,
-              subToolInput: structured.subToolInput,
-              subToolIsError: structured.subToolIsError,
-              subToolId: structured.subToolId,
-            });
-          } else {
-            onEvent({ type: 'tool_output_chunk', chunk: event.chunk, sessionId: ctx.conversationId });
-          }
-          break;
-        }
-        case 'input_json_delta':
-          onEvent({ type: 'tool_input_delta', toolName: event.toolName, content: event.accumulatedJson, sessionId: ctx.conversationId });
-          break;
-        case 'tool_result': {
-          const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
-          onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: ctx.conversationId, imageData: imageBlock?.source.data });
-          pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
-          {
-            const toolName = toolUseIdToName.get(event.toolUseId);
-            if (toolName === 'file_write' || toolName === 'bash') {
-              ctx.markWorkspaceTopLevelDirty();
-            } else if (toolName === 'file_edit' && !event.isError) {
-              ctx.markWorkspaceTopLevelDirty();
-            }
-          }
-          if (event.contentBlocks) {
-            for (const cb of event.contentBlocks) {
-              if (cb.type === 'image' || cb.type === 'file') {
-                accumulatedToolContentBlocks.push(cb);
-              }
-            }
-          }
-          break;
-        }
-        case 'error':
-          if (isProviderOrderingError(event.error.message)) {
-            orderingErrorDetected = true;
-            deferredOrderingError = event.error.message;
-          } else if (isContextTooLarge(event.error.message)) {
-            contextTooLargeDetected = true;
-          } else {
-            const classified = classifySessionError(event.error, { phase: 'agent_loop' });
-            onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
-            providerErrorUserMessage = classified.userMessage;
-          }
-          break;
-        case 'message_complete': {
-          if (pendingDirectiveDisplayBuffer.length > 0) {
-            onEvent({
-              type: 'assistant_text_delta',
-              text: pendingDirectiveDisplayBuffer,
-              sessionId: ctx.conversationId,
-            });
-            if (isFirstMessage) firstAssistantText += pendingDirectiveDisplayBuffer;
-            pendingDirectiveDisplayBuffer = '';
-          }
-          if (pendingToolResults.size > 0) {
-            const toolResultBlocks = Array.from(pendingToolResults.entries()).map(
-              ([toolUseId, result]) => ({
-                type: 'tool_result',
-                tool_use_id: toolUseId,
-                content: result.content,
-                is_error: result.isError,
-                ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
-              }),
-            );
-            conversationStore.addMessage(
-              ctx.conversationId,
-              'user',
-              JSON.stringify(toolResultBlocks),
-            );
-            for (const id of pendingToolResults.keys()) {
-              persistedToolUseIds.add(id);
-            }
-            pendingToolResults.clear();
-          }
-          const { cleanedContent, directives: msgDirectives, warnings: msgWarnings } =
-            cleanAssistantContent(event.message.content);
-          accumulatedDirectives.push(...msgDirectives);
-          directiveWarnings.push(...msgWarnings);
-          if (msgDirectives.length > 0) {
-            rlog.info(
-              { parsedDirectives: msgDirectives.map(d => ({ source: d.source, path: d.path, mimeType: d.mimeType })), totalAccumulated: accumulatedDirectives.length },
-              'Parsed attachment directives from assistant message',
-            );
-          }
-
-          const contentWithSurfaces: ContentBlock[] = [...cleanedContent as ContentBlock[]];
-          for (const surface of ctx.currentTurnSurfaces) {
-            contentWithSurfaces.push({
-              type: 'ui_surface',
-              surfaceId: surface.surfaceId,
-              surfaceType: surface.surfaceType,
-              title: surface.title,
-              data: surface.data,
-              actions: surface.actions,
-              display: surface.display,
-            } as unknown as ContentBlock);
-          }
-
-          const assistantMsg = conversationStore.addMessage(
-            ctx.conversationId,
-            'assistant',
-            JSON.stringify(contentWithSurfaces),
-          );
-          lastAssistantMessageId = assistantMsg.id;
-
-          ctx.currentTurnSurfaces = [];
-
-          const charCount = cleanedContent
-            .filter((b) => (b as Record<string, unknown>).type === 'text')
-            .reduce((sum: number, b) => sum + ((b as { text?: string }).text?.length ?? 0), 0);
-          const toolUseCount = event.message.content
-            .filter((b) => b.type === 'tool_use')
-            .length;
-          ctx.traceEmitter.emit('assistant_message', 'Assistant message complete', {
-            requestId: reqId,
-            status: 'success',
-            attributes: { charCount, toolUseCount },
-          });
-          break;
-        }
-        case 'usage':
-          exchangeInputTokens += event.inputTokens;
-          exchangeOutputTokens += event.outputTokens;
-          model = event.model;
-
-          if (event.rawRequest && event.rawResponse) {
-            try {
-              recordRequestLog(
-                ctx.conversationId,
-                JSON.stringify(event.rawRequest),
-                JSON.stringify(event.rawResponse),
-              );
-            } catch (err) {
-              rlog.warn({ err }, 'Failed to persist LLM request log (non-fatal)');
-            }
-          }
-
-          emitLlmCallStartedIfNeeded();
-
-          ctx.traceEmitter.emit('llm_call_finished', `LLM call to ${ctx.provider.name} finished`, {
-            requestId: reqId,
-            status: 'success',
-            attributes: {
-              provider: ctx.provider.name,
-              model: event.model,
-              inputTokens: event.inputTokens,
-              outputTokens: event.outputTokens,
-              latencyMs: event.providerDurationMs,
-            },
-          });
-          llmCallStartedEmitted = false;
-          break;
-      }
-    };
+    const deps: EventHandlerDeps = { ctx, onEvent, reqId, isFirstMessage, rlog };
+    const eventHandler = (event: AgentEvent) => dispatchAgentEvent(state, deps, event);
 
     const onCheckpoint = (): CheckpointDecision => {
-      const turnTools = currentTurnToolNames;
-      currentTurnToolNames = [];
+      const turnTools = state.currentTurnToolNames;
+      state.currentTurnToolNames = [];
 
       if (ctx.canHandoffAtCheckpoint()) {
         const inBrowserFlow = turnTools.length > 0
@@ -556,37 +325,37 @@ export async function runAgentLoopImpl(
 
     let updatedHistory = await ctx.agentLoop.run(
       runMessages,
-      buildEventHandler(),
+      eventHandler,
       abortController.signal,
       reqId,
       onCheckpoint,
     );
 
     // One-shot ordering error retry
-    if (orderingErrorDetected && updatedHistory.length === preRunHistoryLength) {
+    if (state.orderingErrorDetected && updatedHistory.length === preRunHistoryLength) {
       rlog.warn({ phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
       const retryRepair = deepRepairHistory(runMessages);
       runMessages = retryRepair.messages;
       preRepairMessages = retryRepair.messages;
       preRunHistoryLength = runMessages.length;
-      orderingErrorDetected = false;
-      deferredOrderingError = null;
+      state.orderingErrorDetected = false;
+      state.deferredOrderingError = null;
 
       updatedHistory = await ctx.agentLoop.run(
         runMessages,
-        buildEventHandler(),
+        eventHandler,
         abortController.signal,
         reqId,
         onCheckpoint,
       );
 
-      if (orderingErrorDetected) {
+      if (state.orderingErrorDetected) {
         rlog.error({ phase: 'retry' }, 'Deep-repair retry also failed with ordering error. Consider starting a new conversation if this persists.');
       }
     }
 
     // One-shot context-too-large recovery
-    if (contextTooLargeDetected && updatedHistory.length === preRunHistoryLength) {
+    if (state.contextTooLargeDetected && updatedHistory.length === preRunHistoryLength) {
       rlog.warn({ phase: 'retry' }, 'Context too large — attempting forced compaction and retry');
       const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
         ctx.messages,
@@ -627,18 +396,18 @@ export async function runAgentLoopImpl(
         });
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
-        contextTooLargeDetected = false;
+        state.contextTooLargeDetected = false;
 
         updatedHistory = await ctx.agentLoop.run(
           runMessages,
-          buildEventHandler(),
+          eventHandler,
           abortController.signal,
           reqId,
           onCheckpoint,
         );
       }
 
-      if (contextTooLargeDetected) {
+      if (state.contextTooLargeDetected) {
         const mediaTrimmed = stripMediaPayloadsForRetry(ctx.messages);
         if (mediaTrimmed.modified) {
           rlog.warn(
@@ -661,11 +430,11 @@ export async function runAgentLoopImpl(
           });
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;
-          contextTooLargeDetected = false;
+          state.contextTooLargeDetected = false;
 
           updatedHistory = await ctx.agentLoop.run(
             runMessages,
-            buildEventHandler(),
+            eventHandler,
             abortController.signal,
             reqId,
             onCheckpoint,
@@ -673,7 +442,7 @@ export async function runAgentLoopImpl(
         }
       }
 
-      if (contextTooLargeDetected) {
+      if (state.contextTooLargeDetected) {
         const classified = classifySessionError(
           new Error('context_length_exceeded'),
           { phase: 'agent_loop' },
@@ -682,8 +451,8 @@ export async function runAgentLoopImpl(
       }
     }
 
-    if (deferredOrderingError) {
-      const classified = classifySessionError(new Error(deferredOrderingError), { phase: 'agent_loop' });
+    if (state.deferredOrderingError) {
+      const classified = classifySessionError(new Error(state.deferredOrderingError), { phase: 'agent_loop' });
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
     }
 
@@ -692,8 +461,8 @@ export async function runAgentLoopImpl(
       const msg = updatedHistory[i];
       if (msg.role === 'user') {
         for (const block of msg.content) {
-          if (block.type === 'tool_result' && !pendingToolResults.has(block.tool_use_id) && !persistedToolUseIds.has(block.tool_use_id)) {
-            pendingToolResults.set(block.tool_use_id, {
+          if (block.type === 'tool_result' && !state.pendingToolResults.has(block.tool_use_id) && !state.persistedToolUseIds.has(block.tool_use_id)) {
+            state.pendingToolResults.set(block.tool_use_id, {
               content: block.content,
               isError: block.is_error ?? false,
             });
@@ -703,8 +472,8 @@ export async function runAgentLoopImpl(
     }
 
     // Flush remaining tool results
-    if (pendingToolResults.size > 0) {
-      const toolResultBlocks = Array.from(pendingToolResults.entries()).map(
+    if (state.pendingToolResults.size > 0) {
+      const toolResultBlocks = Array.from(state.pendingToolResults.entries()).map(
         ([toolUseId, result]) => ({
           type: 'tool_result',
           tool_use_id: toolUseId,
@@ -718,7 +487,7 @@ export async function runAgentLoopImpl(
         'user',
         JSON.stringify(toolResultBlocks),
       );
-      pendingToolResults.clear();
+      state.pendingToolResults.clear();
     }
 
     // Reconstruct history
@@ -729,8 +498,8 @@ export async function runAgentLoopImpl(
     });
 
     const hasAssistantResponse = newMessages.some((msg) => msg.role === 'assistant');
-    if (!hasAssistantResponse && providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
-      const errorAssistantMessage = createAssistantMessage(providerErrorUserMessage);
+    if (!hasAssistantResponse && state.providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
+      const errorAssistantMessage = createAssistantMessage(state.providerErrorUserMessage);
       conversationStore.addMessage(
         ctx.conversationId,
         'assistant',
@@ -739,7 +508,7 @@ export async function runAgentLoopImpl(
       newMessages.push(errorAssistantMessage);
       onEvent({
         type: 'assistant_text_delta',
-        text: providerErrorUserMessage,
+        text: state.providerErrorUserMessage,
         sessionId: ctx.conversationId,
       });
     }
@@ -750,7 +519,7 @@ export async function runAgentLoopImpl(
       stripDynamicProfile: (msgs) => stripDynamicProfileMessages(msgs, dynamicProfile.text),
     });
 
-    emitUsage(ctx, exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
+    emitUsage(ctx, state.exchangeInputTokens, state.exchangeOutputTokens, state.model, onEvent, 'main_agent', reqId);
 
     void getHookManager().trigger('post-message', {
       sessionId: ctx.conversationId,
@@ -758,12 +527,12 @@ export async function runAgentLoopImpl(
 
     // Resolve attachments
     const attachmentResult = await resolveAssistantAttachments(
-      accumulatedDirectives,
-      accumulatedToolContentBlocks,
-      directiveWarnings,
+      state.accumulatedDirectives,
+      state.accumulatedToolContentBlocks,
+      state.directiveWarnings,
       ctx.workingDir,
       async (filePath) => approveHostAttachmentRead(filePath, ctx.workingDir, ctx.prompter, ctx.conversationId, ctx.hasNoClient),
-      lastAssistantMessageId,
+      state.lastAssistantMessageId,
     );
     const { assistantAttachments, emittedAttachments } = attachmentResult;
 
@@ -810,7 +579,7 @@ export async function runAgentLoopImpl(
     if (isFirstMessage) {
       void (async () => {
         try {
-          await generateTitle(ctx, content, firstAssistantText);
+          await generateTitle(ctx, content, state.firstAssistantText);
         } catch (err) {
           log.warn({ err, conversationId: ctx.conversationId }, 'Failed to generate conversation title (non-fatal, using default title)');
         }


### PR DESCRIPTION
## Summary
- Extracted the 9-case event handler switch from `session-agent-loop.ts` into standalone handler functions in a new `session-agent-loop-handlers.ts` module
- Bundled shared mutable state into an `EventHandlerState` interface with a factory function, replacing 15+ scattered local variables
- Each handler (`handleTextDelta`, `handleThinkingDelta`, `handleToolUse`, `handleToolOutputChunk`, `handleInputJsonDelta`, `handleToolResult`, `handleError`, `handleMessageComplete`, `handleUsage`) is now independently testable

## Original prompt
Extract session-agent-loop event handler switch (daemon/session-agent-loop.ts, 928 lines) — The main event handling switch has 10+ cases with deeply nested try-catch and async logic. Extract each case into a separate handler function for testability and clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
