### PR TITLE
refactor: enforce isTerminalState() usage in call handlers

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -16,6 +16,7 @@ import {
   answerPendingQuestion,
   expirePendingQuestions,
 } from './call-store.js';
+import { isTerminalState } from './call-state-machine.js';
 import { getCallOrchestrator, unregisterCallOrchestrator } from './call-state.js';
 import { activeRelayConnections } from './relay-server.js';
 import { TwilioConversationRelayProvider } from './twilio-provider.js';
@@ -343,7 +344,7 @@ export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; se
     return { ok: false, error: `No call session found with ID ${callSessionId}`, status: 404 };
   }
 
-  if (session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled') {
+  if (isTerminalState(session.status)) {
     return { ok: false, error: `Call session ${callSessionId} has already ended with status: ${session.status}`, status: 409 };
   }
 
@@ -448,7 +449,7 @@ export async function relayInstruction(input: RelayInstructionInput): Promise<{ 
     return { ok: false, error: `No call session found with ID ${callSessionId}`, status: 404 };
   }
 
-  if (session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled') {
+  if (isTerminalState(session.status)) {
     return { ok: false, error: `Call session ${callSessionId} is not active (status: ${session.status})`, status: 409 };
   }
 

--- a/assistant/src/calls/call-recovery.ts
+++ b/assistant/src/calls/call-recovery.ts
@@ -8,9 +8,10 @@
  */
 
 import { getLogger } from '../util/logger.js';
+import { isTerminalState } from './call-state-machine.js';
 import { listRecoverableCalls, updateCallSession, expirePendingQuestions } from './call-store.js';
-import type { VoiceProvider } from './voice-provider.js';
 import type { CallStatus } from './types.js';
+import type { VoiceProvider } from './voice-provider.js';
 
 type Logger = ReturnType<typeof getLogger>;
 
@@ -57,12 +58,6 @@ function mapProviderStatus(providerStatus: string): CallStatus | null {
   }
 }
 
-/**
- * Check whether a CallStatus is terminal (no further transitions allowed).
- */
-function isTerminal(status: CallStatus): boolean {
-  return status === 'completed' || status === 'failed' || status === 'cancelled';
-}
 
 /**
  * Reconcile all non-terminal call sessions at daemon startup.
@@ -159,7 +154,7 @@ export async function reconcileCallsOnStartup(
         continue;
       }
 
-      if (isTerminal(mappedStatus)) {
+      if (isTerminalState(mappedStatus)) {
         // Provider says the call has ended
         log.info(
           { callSessionId: session.id, providerStatus, mappedStatus },


### PR DESCRIPTION
## Summary
- Replace inline `status === 'completed' || status === 'failed' || status === 'cancelled'` checks in `call-domain.ts` with the shared `isTerminalState()` helper from `call-state-machine.ts`
- Remove duplicate local `isTerminal()` function in `call-recovery.ts` and use the shared `isTerminalState()` instead

## Original prompt
Enforce isTerminalState() usage in call handlers — call-domain.ts and relay-server.ts use inline status === 'completed' || status === 'failed' || status === 'cancelled' checks instead of the existing isTerminalState() helper in call-state-machine.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
