### PR TITLE
refactor: standardize error handling to try-catch in run-orchestrator

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -179,11 +179,14 @@ export class RunOrchestrator {
           : undefined;
       const resolvedSessionId = msgSessionId ?? conversationId;
       const event = buildAssistantEvent('self', msg, resolvedSessionId);
-      hubChain = hubChain
-        .then(() => assistantEventHub.publish(event))
-        .catch((err: unknown) => {
+      hubChain = (async () => {
+        await hubChain;
+        try {
+          await assistantEventHub.publish(event);
+        } catch (err) {
           log.warn({ err }, 'assistant-events hub subscriber threw during HTTP run');
-        });
+        }
+      })();
     };
 
 
@@ -245,32 +248,35 @@ export class RunOrchestrator {
       session.updateClient(() => {}, true);
     };
 
-    session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
-      if (msg.type === 'error') {
-        lastError = msg.message;
-      } else if (msg.type === 'session_error') {
-        lastError = msg.userMessage;
+    void (async () => {
+      try {
+        await session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
+          if (msg.type === 'error') {
+            lastError = msg.message;
+          } else if (msg.type === 'session_error') {
+            lastError = msg.userMessage;
+          }
+          // Mirror agent-loop events (assistant_text_delta, message_complete,
+          // tool_use_start, tool_result, etc.) to the hub. These travel through
+          // the onEvent path, distinct from the updateClient path used by the
+          // prompter (confirmation_request). Both paths must publish so SSE
+          // consumers receive the full response stream.
+          publishToHub(msg);
+        });
+        if (lastError) {
+          log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
+          runsStore.failRun(run.id, lastError);
+        } else {
+          runsStore.completeRun(run.id);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error({ err, runId: run.id }, 'Run failed');
+        runsStore.failRun(run.id, message);
+      } finally {
+        cleanup();
       }
-      // Mirror agent-loop events (assistant_text_delta, message_complete,
-      // tool_use_start, tool_result, etc.) to the hub. These travel through
-      // the onEvent path, distinct from the updateClient path used by the
-      // prompter (confirmation_request). Both paths must publish so SSE
-      // consumers receive the full response stream.
-      publishToHub(msg);
-    }).then(() => {
-      if (lastError) {
-        log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
-        runsStore.failRun(run.id, lastError);
-      } else {
-        runsStore.completeRun(run.id);
-      }
-      cleanup();
-    }).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error({ err, runId: run.id }, 'Run failed');
-      runsStore.failRun(run.id, message);
-      cleanup();
-    });
+    })();
 
     return run;
   }


### PR DESCRIPTION
## Summary
- Converted `.then().catch()` chain on `runAgentLoop()` to async IIFE with `try-catch-finally`, deduplicating the `cleanup()` call.
- Converted `.then().catch()` chain on `hubChain` serialized publishing to async IIFE with `try-catch`.

## Original prompt
Standardize error handling to async/await + try-catch — Multiple files mix .catch() callbacks and try-catch blocks in the same functions (e.g., session-agent-loop.ts, jobs-worker.ts, run-orchestrator.ts). Pick one pattern. One PR per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
