### PR TITLE
refactor: extract parseJsonSafe() utility

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -9,6 +9,7 @@
 import type { ServerWebSocket } from 'bun';
 import { randomInt } from 'node:crypto';
 import { getLogger } from '../util/logger.js';
+import { parseJsonSafe } from '../util/json.js';
 import { getConfig } from '../config/loader.js';
 import {
   getCallSession,
@@ -165,10 +166,8 @@ export class RelayConnection {
    * Handle an inbound message from Twilio via the ConversationRelay WebSocket.
    */
   async handleMessage(data: string): Promise<void> {
-    let parsed: RelayInboundMessage;
-    try {
-      parsed = JSON.parse(data) as RelayInboundMessage;
-    } catch {
+    const parsed = parseJsonSafe<RelayInboundMessage>(data);
+    if (!parsed) {
       log.warn({ callSessionId: this.callSessionId, data }, 'Failed to parse relay message');
       return;
     }

--- a/assistant/src/swarm/router-planner.ts
+++ b/assistant/src/swarm/router-planner.ts
@@ -1,4 +1,5 @@
 import type { Provider, Message } from '../providers/types.js';
+import { parseJsonSafe } from '../util/json.js';
 import type { SwarmPlan, SwarmTaskNode } from './types.js';
 import type { SwarmLimits } from './limits.js';
 import { validateAndNormalizePlan } from './plan-validator.js';
@@ -71,15 +72,11 @@ export function parsePlanJSON(raw: string): { tasks: Array<{ id: string; role: s
 }
 
 function tryParsePlan(jsonStr: string): { tasks: Array<{ id: string; role: string; objective: string; dependencies: string[] }> } | null {
-  try {
-    const parsed = JSON.parse(jsonStr.trim());
-    if (parsed && Array.isArray(parsed.tasks)) {
-      return parsed;
-    }
-    return null;
-  } catch {
-    return null;
+  const parsed = parseJsonSafe<{ tasks?: unknown }>(jsonStr.trim());
+  if (parsed && Array.isArray(parsed.tasks)) {
+    return parsed as { tasks: Array<{ id: string; role: string; objective: string; dependencies: string[] }> };
   }
+  return null;
 }
 
 /**

--- a/assistant/src/swarm/worker-prompts.ts
+++ b/assistant/src/swarm/worker-prompts.ts
@@ -1,5 +1,6 @@
 import type { SwarmRole, SwarmTaskResult } from './types.js';
 import { truncate } from '../util/truncate.js';
+import { parseJsonSafe } from '../util/json.js';
 
 /**
  * Build a role-specific worker prompt for a swarm task.
@@ -56,18 +57,14 @@ export function parseWorkerOutput(raw: string): Pick<SwarmTaskResult, 'summary' 
 
   // Walk backwards to prefer the final valid contract block.
   for (let i = jsonBlocks.length - 1; i >= 0; i--) {
-    try {
-      const parsed = JSON.parse(jsonBlocks[i][1]);
-      if (typeof parsed.summary !== 'string') continue;
-      return {
-        summary: parsed.summary,
-        artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
-        issues: Array.isArray(parsed.issues) ? parsed.issues : [],
-        nextSteps: Array.isArray(parsed.nextSteps) ? parsed.nextSteps : [],
-      };
-    } catch {
-      // Malformed JSON — try the next block up.
-    }
+    const parsed = parseJsonSafe<Record<string, unknown>>(jsonBlocks[i][1]);
+    if (!parsed || typeof parsed.summary !== 'string') continue;
+    return {
+      summary: parsed.summary,
+      artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
+      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+      nextSteps: Array.isArray(parsed.nextSteps) ? parsed.nextSteps : [],
+    };
   }
 
   return {

--- a/assistant/src/tasks/task-compiler.ts
+++ b/assistant/src/tasks/task-compiler.ts
@@ -4,6 +4,7 @@ import { messages as messagesTable } from '../memory/schema.js';
 import { createTask } from './task-store.js';
 import type { Task } from './task-store.js';
 import { truncate } from '../util/truncate.js';
+import { parseJsonSafe } from '../util/json.js';
 import { sanitizeToolList } from './tool-sanitizer.js';
 
 /** Output schema for the task compiler. */
@@ -91,20 +92,14 @@ export function saveCompiledTask(compiled: CompiledTask, conversationId: string)
  * string or a JSON array of Anthropic content blocks.
  */
 function extractTextContent(content: string): string {
-  try {
-    const parsed = JSON.parse(content);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((block: Record<string, unknown>) => block.type === 'text')
-        .map((block: Record<string, unknown>) => block.text as string)
-        .join('\n');
-    }
-    // If it parsed but isn't an array, treat as plain text
-    return content;
-  } catch {
-    // Not JSON — it's a plain text message
-    return content;
+  const parsed = parseJsonSafe(content);
+  if (Array.isArray(parsed)) {
+    return parsed
+      .filter((block: Record<string, unknown>) => block.type === 'text')
+      .map((block: Record<string, unknown>) => block.text as string)
+      .join('\n');
   }
+  return content;
 }
 
 /**
@@ -118,22 +113,18 @@ function extractToolNames(
   for (const msg of msgs) {
     if (msg.role !== 'assistant') continue;
 
-    try {
-      const parsed = JSON.parse(msg.content);
-      if (!Array.isArray(parsed)) continue;
+    const parsed = parseJsonSafe(msg.content);
+    if (!Array.isArray(parsed)) continue;
 
-      for (const block of parsed) {
-        if (
-          block &&
-          typeof block === 'object' &&
-          block.type === 'tool_use' &&
-          typeof block.name === 'string'
-        ) {
-          tools.add(block.name);
-        }
+    for (const block of parsed) {
+      if (
+        block &&
+        typeof block === 'object' &&
+        block.type === 'tool_use' &&
+        typeof block.name === 'string'
+      ) {
+        tools.add(block.name);
       }
-    } catch {
-      // Not JSON content — skip
     }
   }
 

--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -8,6 +8,7 @@ import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { parseJsonSafe } from '../../util/json.js';
 import { wrapCommand } from './sandbox.js';
 import { buildSanitizedEnv } from './safe-env.js';
 
@@ -126,9 +127,7 @@ export class EvaluateTypescriptTool implements Tool {
     if (Buffer.byteLength(mockInputJson) > MAX_MOCK_INPUT_BYTES) {
       return { content: `Error: mock_input_json exceeds maximum size of ${MAX_MOCK_INPUT_BYTES} bytes`, isError: true };
     }
-    try {
-      JSON.parse(mockInputJson);
-    } catch {
+    if (parseJsonSafe(mockInputJson) === null) {
       return { content: 'Error: mock_input_json must be valid JSON', isError: true };
     }
 
@@ -222,14 +221,10 @@ export class EvaluateTypescriptTool implements Tool {
             const lineStart = stdout.lastIndexOf('\n', markerIdx) + 1;
             const lineEnd = stdout.indexOf('\n', markerIdx);
             const line = stdout.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {
-                result = parsed.__eval_result;
-                break;
-              }
-            } catch {
-              // malformed line — continue scanning earlier occurrences
+            const parsed = parseJsonSafe<Record<string, unknown>>(line);
+            if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {
+              result = parsed.__eval_result;
+              break;
             }
             searchFrom = lineStart;
           }

--- a/assistant/src/util/json.ts
+++ b/assistant/src/util/json.ts
@@ -1,0 +1,10 @@
+/**
+ * Parse JSON without throwing — returns null on failure.
+ */
+export function parseJsonSafe<T = unknown>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `parseJsonSafe<T>()` utility in `src/util/json.ts` that wraps `JSON.parse` in a try-catch and returns `null` on failure
- Replace 7 try-catch JSON.parse patterns across 5 files: relay-server.ts, router-planner.ts, worker-prompts.ts, task-compiler.ts, evaluate-typescript.ts
- Eliminates nested try-catch blocks and simplifies control flow at each call site

## Original prompt
Extract parseJsonSafe() utility — At least 5 files (relay-server.ts, router-planner.ts, worker-prompts.ts, task-compiler.ts, evaluate-typescript.ts) have nearly identical JSON parse + try-catch + fallback patterns. Extract to util/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
