### PR TITLE
refactor: enforce custom error classes from util/errors.ts

### DIFF
--- a/assistant/src/calls/elevenlabs-config.ts
+++ b/assistant/src/calls/elevenlabs-config.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '../config/loader.js';
 import { getSecureKey } from '../security/secure-keys.js';
+import { ConfigError } from '../util/errors.js';
 
 export interface ElevenLabsConfig {
   apiKey: string;
@@ -14,12 +15,12 @@ export function getElevenLabsConfig(): ElevenLabsConfig {
 
   const apiKey = getSecureKey('credential:elevenlabs:api_key') ?? '';
   if (!apiKey) {
-    throw new Error('ElevenLabs API key is not configured. Set credential:elevenlabs:api_key in the secure key store.');
+    throw new ConfigError('ElevenLabs API key is not configured. Set credential:elevenlabs:api_key in the secure key store.');
   }
 
   const agentId = voice.elevenlabs.agentId;
   if (!agentId) {
-    throw new Error('ElevenLabs agent ID is not configured. Set calls.voice.elevenlabs.agentId in config.');
+    throw new ConfigError('ElevenLabs agent ID is not configured. Set calls.voice.elevenlabs.agentId in config.');
   }
 
   return {

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -2,6 +2,7 @@ import { getSecureKey } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl, getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
+import { ConfigError } from '../util/errors.js';
 
 const log = getLogger('twilio-config');
 
@@ -48,10 +49,10 @@ export function getTwilioConfig(assistantId?: string): TwilioConfig {
   }
 
   if (!accountSid || !authToken) {
-    throw new Error('Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.');
+    throw new ConfigError('Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.');
   }
   if (!phoneNumber) {
-    throw new Error('Twilio phone number not configured.');
+    throw new ConfigError('Twilio phone number not configured.');
   }
 
   log.debug('Twilio config loaded successfully');

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 import { getLogger } from '../util/logger.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import { getTwilioCredentials, twilioAuthHeader, twilioBaseUrl } from './twilio-rest.js';
+import { ProviderError } from '../util/errors.js';
 import type { VoiceProvider, InitiateCallOptions } from './voice-provider.js';
 
 const log = getLogger('twilio-provider');
@@ -72,7 +73,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     if (!res.ok) {
       const text = await res.text();
       log.error({ status: res.status, body: text }, 'Twilio initiateCall failed');
-      throw new Error(`Twilio API error ${res.status}: ${text}`);
+      throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
     }
 
     const data = (await res.json()) as { sid: string };
@@ -99,7 +100,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     if (!res.ok) {
       const text = await res.text();
       log.error({ status: res.status, body: text, callSid }, 'Twilio endCall failed');
-      throw new Error(`Twilio API error ${res.status}: ${text}`);
+      throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
     }
 
     log.info({ callSid }, 'Twilio call ended');
@@ -118,7 +119,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
     if (!res.ok) {
       const text = await res.text();
       log.error({ status: res.status, body: text, callSid }, 'Twilio getCallStatus failed');
-      throw new Error(`Twilio API error ${res.status}: ${text}`);
+      throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
     }
 
     const data = (await res.json()) as { status: string };
@@ -203,8 +204,9 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
         ...(!incomingOk ? [`IncomingPhoneNumbers: ${incomingRes.status}`] : []),
         ...(!outgoingOk ? [`OutgoingCallerIds: ${outgoingRes.status}`] : []),
       ].join(', ');
-      throw new Error(
+      throw new ProviderError(
         `Unable to verify caller ID eligibility for ${phoneNumber}: Twilio API error (${failedEndpoints}). The number may be eligible but could not be confirmed. Please check your Twilio credentials and try again.`,
+        'twilio',
       );
     }
 

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -7,6 +7,7 @@
  */
 
 import { getSecureKey } from '../security/secure-keys.js';
+import { ProviderError, ConfigError } from '../util/errors.js';
 
 export interface TwilioCredentials {
   accountSid: string;
@@ -18,7 +19,7 @@ export function getTwilioCredentials(): TwilioCredentials {
   const accountSid = getSecureKey('credential:twilio:account_sid');
   const authToken = getSecureKey('credential:twilio:auth_token');
   if (!accountSid || !authToken) {
-    throw new Error(
+    throw new ConfigError(
       'Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.',
     );
   }
@@ -58,7 +59,7 @@ export async function listIncomingPhoneNumbers(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as {
@@ -102,7 +103,7 @@ export async function searchAvailableNumbers(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as {
@@ -139,7 +140,7 @@ export async function provisionPhoneNumber(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as {
@@ -171,7 +172,7 @@ export async function fetchMessageStatus(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as {
@@ -217,7 +218,7 @@ export async function updatePhoneNumberWebhooks(
 
   if (!listRes.ok) {
     const text = await listRes.text();
-    throw new Error(`Twilio API error ${listRes.status} looking up phone number: ${text}`);
+    throw new ProviderError(`Twilio API error ${listRes.status} looking up phone number: ${text}`, 'twilio', listRes.status);
   }
 
   const listData = (await listRes.json()) as {
@@ -226,7 +227,7 @@ export async function updatePhoneNumberWebhooks(
 
   const match = listData.incoming_phone_numbers.find((n) => n.phone_number === phoneNumber);
   if (!match) {
-    throw new Error(`Phone number ${phoneNumber} not found on Twilio account ${accountSid}`);
+    throw new ProviderError(`Phone number ${phoneNumber} not found on Twilio account ${accountSid}`, 'twilio');
   }
 
   // Update the phone number's webhook configuration
@@ -253,7 +254,7 @@ export async function updatePhoneNumberWebhooks(
 
   if (!updateRes.ok) {
     const text = await updateRes.text();
-    throw new Error(`Twilio API error ${updateRes.status} updating webhooks: ${text}`);
+    throw new ProviderError(`Twilio API error ${updateRes.status} updating webhooks: ${text}`, 'twilio', updateRes.status);
   }
 }
 
@@ -310,7 +311,7 @@ export async function getTollFreeVerificationStatus(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio Toll-Free Verification API error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio Toll-Free Verification API error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as { verifications?: Array<Record<string, unknown>> };
@@ -337,7 +338,7 @@ export async function getTollFreeVerificationBySid(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio Toll-Free Verification fetch error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio Toll-Free Verification fetch error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as Record<string, unknown>;
@@ -397,7 +398,7 @@ export async function submitTollFreeVerification(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio Toll-Free Verification submit error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio Toll-Free Verification submit error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as Record<string, unknown>;
@@ -443,7 +444,7 @@ export async function updateTollFreeVerification(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio Toll-Free Verification update error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio Toll-Free Verification update error ${res.status}: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as Record<string, unknown>;
@@ -463,7 +464,7 @@ export async function deleteTollFreeVerification(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio Toll-Free Verification delete error ${res.status}: ${text}`);
+    throw new ProviderError(`Twilio Toll-Free Verification delete error ${res.status}: ${text}`, 'twilio', res.status);
   }
 }
 
@@ -486,7 +487,7 @@ export async function getPhoneNumberSid(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status} looking up phone number SID: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status} looking up phone number SID: ${text}`, 'twilio', res.status);
   }
 
   const data = (await res.json()) as {
@@ -508,7 +509,7 @@ export async function releasePhoneNumber(
 ): Promise<void> {
   const sid = await getPhoneNumberSid(accountSid, authToken, phoneNumber);
   if (!sid) {
-    throw new Error(`Phone number ${phoneNumber} not found on Twilio account ${accountSid}`);
+    throw new ProviderError(`Phone number ${phoneNumber} not found on Twilio account ${accountSid}`, 'twilio');
   }
 
   const res = await fetch(
@@ -521,6 +522,6 @@ export async function releasePhoneNumber(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Twilio API error ${res.status} releasing phone number: ${text}`);
+    throw new ProviderError(`Twilio API error ${res.status} releasing phone number: ${text}`, 'twilio', res.status);
   }
 }

--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -25,6 +25,7 @@ import {
 } from './queries.js';
 import { loadCapturedQueries } from './query-extractor.js';
 import { truncate } from '../util/truncate.js';
+import { ProviderError } from '../util/errors.js';
 
 const GRAPHQL_BASE = 'https://www.doordash.com/graphql';
 const CDP_BASE = 'http://localhost:9222';
@@ -216,10 +217,10 @@ async function graphql<T = unknown>(
 
       if (json.errors?.length) {
         const msgs = json.errors.map(e => e.message || JSON.stringify(e)).join('; ');
-        throw new Error(`Unexpected response from DoorDash API: ${msgs}`);
+        throw new ProviderError(`Unexpected response from DoorDash API: ${msgs}`, 'doordash');
       }
       if (!json.data) {
-        throw new Error('Unexpected response format from DoorDash API');
+        throw new ProviderError('Unexpected response format from DoorDash API', 'doordash');
       }
       return json.data;
     } catch (err) {
@@ -696,7 +697,7 @@ export async function placeOrder(opts: {
     const methods = await getPaymentMethods();
     const defaultMethod = methods.find(m => m.isDefault) ?? methods[0];
     if (!defaultMethod) {
-      throw new Error('No payment method found. Add a payment method in the DoorDash app first.');
+      throw new ProviderError('No payment method found. Add a payment method in the DoorDash app first.', 'doordash');
     }
     pmUuid = defaultMethod.uuid;
     // defaultMethod.type is the card brand (e.g. "Visa"), not the PaymentMethodType enum

--- a/assistant/src/doordash/session.ts
+++ b/assistant/src/doordash/session.ts
@@ -6,6 +6,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir } from '../util/platform.js';
+import { ConfigError } from '../util/errors.js';
 import type { SessionRecording, ExtractedCredential } from '../tools/browser/network-recording-types.js';
 
 export interface DoorDashSession {
@@ -50,11 +51,11 @@ export function clearSession(): void {
  */
 export function importFromRecording(recordingPath: string): DoorDashSession {
   if (!existsSync(recordingPath)) {
-    throw new Error(`Recording not found: ${recordingPath}`);
+    throw new ConfigError(`Recording not found: ${recordingPath}`);
   }
   const recording = JSON.parse(readFileSync(recordingPath, 'utf-8')) as SessionRecording;
   if (!recording.cookies?.length) {
-    throw new Error('Recording contains no cookies');
+    throw new ConfigError('Recording contains no cookies');
   }
   const session: DoorDashSession = {
     cookies: recording.cookies,

--- a/assistant/src/email/providers/agentmail.ts
+++ b/assistant/src/email/providers/agentmail.ts
@@ -7,6 +7,7 @@
 import type { AgentMailClient } from 'agentmail';
 import type { EmailProvider, SetupDomainOpts, CreateInboxOpts, EnsureInboxesOpts, SetupWebhookOpts, CreateDraftOpts, ListDraftsOpts, ListMessagesOpts, ListThreadsOpts } from '../provider.js';
 import type { EmailDomain, DnsRecord, EmailInbox, EmailDraft, EmailMessage, EmailThread, EmailWebhook, ProviderHealth, SendResult } from '../types.js';
+import { ConfigError } from '../../util/errors.js';
 
 const DEFAULT_INBOX_PREFIXES = ['hello', 'support', 'ops'];
 
@@ -201,7 +202,7 @@ export class AgentMailProvider implements EmailProvider {
     if (inboxes.inboxes.length > 0) {
       return inboxes.inboxes[0].inboxId;
     }
-    throw new Error('No inboxes found. Run: vellum email setup inboxes --domain <domain>');
+    throw new ConfigError('No inboxes found. Run: vellum email setup inboxes --domain <domain>');
   }
 }
 

--- a/assistant/src/email/providers/index.ts
+++ b/assistant/src/email/providers/index.ts
@@ -7,6 +7,7 @@
 import type { EmailProvider } from '../provider.js';
 import { getSecureKey } from '../../security/secure-keys.js';
 import { loadRawConfig, getNestedValue } from '../../config/loader.js';
+import { ConfigError } from '../../util/errors.js';
 
 export const SUPPORTED_PROVIDERS = ['agentmail'] as const;
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
@@ -44,7 +45,7 @@ export async function createProvider(name?: SupportedProvider): Promise<EmailPro
         if (apiKey) break;
       }
       if (!apiKey) {
-        throw new Error(
+        throw new ConfigError(
           'No AgentMail API key configured. Run: vellum keys set agentmail <key>',
         );
       }
@@ -53,6 +54,6 @@ export async function createProvider(name?: SupportedProvider): Promise<EmailPro
       return new AgentMailProvider(new AgentMailClient({ apiKey }));
     }
     default:
-      throw new Error(`Unknown email provider: ${providerName}`);
+      throw new ConfigError(`Unknown email provider: ${providerName}`);
   }
 }

--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -31,6 +31,7 @@ import {
 } from '../cli/email-guardrails.js';
 import { createProvider, getActiveProviderName, type SupportedProvider } from './providers/index.js';
 import { loadRawConfig, setNestedValue, saveRawConfig } from '../config/loader.js';
+import { ConfigError } from '../util/errors.js';
 
 // ---------------------------------------------------------------------------
 // Guardrail error
@@ -156,12 +157,12 @@ export class EmailService {
     // Resolve inbox from the "from" address — fail fast if not found
     const health = await p.health();
     if (health.inboxes.length === 0) {
-      throw new Error('No inboxes found. Run: vellum email setup inboxes --domain <domain>');
+      throw new ConfigError('No inboxes found. Run: vellum email setup inboxes --domain <domain>');
     }
     const inbox = health.inboxes.find(i => i.address === input.from || i.id === input.from);
     if (!inbox) {
       const available = health.inboxes.map(i => i.address || i.id).join(', ');
-      throw new Error(`No inbox matches --from "${input.from}". Available: ${available}`);
+      throw new ConfigError(`No inbox matches --from "${input.from}". Available: ${available}`);
     }
     const inboxId = inbox.id;
     return p.createDraft({

--- a/assistant/src/services/vercel-deploy.ts
+++ b/assistant/src/services/vercel-deploy.ts
@@ -2,6 +2,8 @@
  * Thin wrapper around the Vercel REST API for deploying static HTML pages.
  */
 
+import { ProviderError } from '../util/errors.js';
+
 export async function deployHtmlToVercel(opts: {
   html: string;
   name: string;
@@ -37,7 +39,7 @@ export async function deployHtmlToVercel(opts: {
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Vercel deploy failed (${response.status}): ${text}`);
+    throw new ProviderError(`Vercel deploy failed (${response.status}): ${text}`, 'vercel', response.status);
   }
 
   const data = (await response.json()) as { url: string; id: string };
@@ -66,8 +68,10 @@ export async function deleteVercelDeployment(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(
+    throw new ProviderError(
       `Vercel delete deployment failed (${response.status}): ${text}`,
+      'vercel',
+      response.status,
     );
   }
 }

--- a/assistant/src/slack/slack-webhook.ts
+++ b/assistant/src/slack/slack-webhook.ts
@@ -1,4 +1,5 @@
 import { getLogger } from '../util/logger.js';
+import { ProviderError } from '../util/errors.js';
 
 const log = getLogger('slack-webhook');
 
@@ -56,6 +57,6 @@ export async function postToSlackWebhook(
 
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(`Slack webhook returned ${response.status}: ${body}`);
+    throw new ProviderError(`Slack webhook returned ${response.status}: ${body}`, 'slack', response.status);
   }
 }

--- a/assistant/src/twitter/client.ts
+++ b/assistant/src/twitter/client.ts
@@ -8,6 +8,7 @@ import {
   loadSession,
   type TwitterSession,
 } from './session.js';
+import { ProviderError } from '../util/errors.js';
 
 const CDP_BASE = 'http://localhost:9222';
 
@@ -325,7 +326,7 @@ async function graphqlGet(queryId: string, queryName: string, variables: Record<
   const url = graphqlUrl(queryId, queryName, variables);
   const json = await cdpGet(wsUrl, url) as { errors?: Array<{ message: string }> };
   if (json.errors?.length) {
-    throw new Error(`X API errors: ${json.errors.map(e => e.message).join('; ')}`);
+    throw new ProviderError(`X API errors: ${json.errors.map(e => e.message).join('; ')}`, 'x');
   }
   return json;
 }
@@ -463,16 +464,16 @@ export async function postTweet(text: string, opts?: { inReplyToTweetId?: string
   const json = (await cdpFetch(wsUrl, url, body)) as AnyJson;
 
   if (json.errors?.length) {
-    throw new Error(`X API errors: ${json.errors.map((e: AnyJson) => e.message).join('; ')}`);
+    throw new ProviderError(`X API errors: ${json.errors.map((e: AnyJson) => e.message).join('; ')}`, 'x');
   }
 
   const tweetResults = json.data?.create_tweet?.tweet_results;
   const result = tweetResults?.result;
   if (!result?.rest_id) {
     if (tweetResults && !result) {
-      throw new Error('X rejected this post — it may be a duplicate of a recent post. Try different text.');
+      throw new ProviderError('X rejected this post — it may be a duplicate of a recent post. Try different text.', 'x');
     }
-    throw new Error(`Unexpected response from X API. Response: ${JSON.stringify(json).slice(0, 500)}`);
+    throw new ProviderError(`Unexpected response from X API. Response: ${JSON.stringify(json).slice(0, 500)}`, 'x');
   }
 
   return {
@@ -492,7 +493,7 @@ export async function getUserByScreenName(screenName: string): Promise<UserInfo>
 
   const user = json.data?.user?.result;
   if (!user?.rest_id) {
-    throw new Error(`User @${screenName} not found`);
+    throw new ProviderError(`User @${screenName} not found`, 'x');
   }
 
   return {

--- a/assistant/src/twitter/session.ts
+++ b/assistant/src/twitter/session.ts
@@ -6,6 +6,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir } from '../util/platform.js';
+import { ConfigError } from '../util/errors.js';
 import type { SessionRecording, ExtractedCredential } from '../tools/browser/network-recording-types.js';
 
 export interface TwitterSession {
@@ -50,17 +51,17 @@ export function clearSession(): void {
  */
 export function importFromRecording(recordingPath: string): TwitterSession {
   if (!existsSync(recordingPath)) {
-    throw new Error(`Recording not found: ${recordingPath}`);
+    throw new ConfigError(`Recording not found: ${recordingPath}`);
   }
   const recording = JSON.parse(readFileSync(recordingPath, 'utf-8')) as SessionRecording;
   if (!recording.cookies?.length) {
-    throw new Error('Recording contains no cookies');
+    throw new ConfigError('Recording contains no cookies');
   }
   // Require the two cookies that prove a logged-in Twitter session:
   // the auth session cookie and the ct0 CSRF cookie.
   const cookieNames = new Set(recording.cookies.map(c => c.name));
   if (!cookieNames.has('ct0') || !cookieNames.has(`auth_${'token'}`)) {
-    throw new Error(
+    throw new ConfigError(
       'Recording is missing required Twitter session cookies. ' +
       'Make sure you are logged in to x.com before recording.',
     );


### PR DESCRIPTION
## Summary
- Replace bare `throw new Error()` with `ProviderError` (for external API failures) and `ConfigError` (for missing credentials/config) across 13 modules
- Affected services: Twilio (rest, provider, config), ElevenLabs, DoorDash (client, session), X/Twitter (client, session), Slack webhook, Vercel deploy, email (service, providers)
- ~45 throw sites updated to use the well-defined error hierarchy from `util/errors.ts`

## Original prompt
Enforce custom error classes from util/errors.ts — Some modules (twilio-rest.ts, vault.ts) throw bare new Error() instead of using the well-defined AssistantError/ProviderError/ToolError hierarchy. Standardize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
