### PR TITLE
refactor: standardize raw SQL vs Drizzle ORM with type-safe wrappers

### DIFF
--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -1,6 +1,6 @@
 import { eq, and, or, notInArray, desc } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from '../memory/db.js';
+import { getDb, rawChanges, rawGet, rawRun } from '../memory/db.js';
 import { callSessions, callEvents, callPendingQuestions } from '../memory/schema.js';
 import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
 import { validateTransition } from './call-state-machine.js';
@@ -255,10 +255,7 @@ export function answerPendingQuestion(id: string, answerText: string): void {
       ),
     )
     .run();
-  // Drizzle's .run() returns void for bun:sqlite, so check affected rows via raw client.
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  if (changes.c === 0) {
+  if (rawChanges() === 0) {
     log.warn({ questionId: id }, 'answerPendingQuestion: no rows updated — question may have already been answered or expired');
   }
 }
@@ -301,13 +298,7 @@ export function buildCallbackDedupeKey(
  * Returns true if the key already exists, false otherwise.
  */
 export function isCallbackProcessed(dedupeKey: string): boolean {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-
-  const row = raw.query(
-    `SELECT 1 FROM processed_callbacks WHERE dedupe_key = ?`,
-  ).get(dedupeKey);
-  return row != null;
+  return rawGet<{ 1: number }>(`SELECT 1 FROM processed_callbacks WHERE dedupe_key = ?`, dedupeKey) != null;
 }
 
 /**
@@ -321,12 +312,10 @@ export function recordProcessedCallback(
   dedupeKey: string,
   callSessionId: string,
 ): void {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-
-  raw.query(
+  rawRun(
     `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
+    uuid(), dedupeKey, callSessionId, Date.now(),
+  );
 }
 
 /**
@@ -343,15 +332,10 @@ export function tryRecordProcessedCallback(
   dedupeKey: string,
   callSessionId: string,
 ): boolean {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-
-  raw.query(
+  return rawRun(
     `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, Date.now());
-
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  return changes.c > 0;
+    uuid(), dedupeKey, callSessionId, Date.now(),
+  ) > 0;
 }
 
 /**
@@ -371,20 +355,18 @@ export function tryRecordProcessedCallback(
  * finalize a claim that was reclaimed by handler B after expiry.
  */
 export function claimCallback(dedupeKey: string, callSessionId: string): string | null {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-
   // Clear any expired orphaned claims so they can be reprocessed
-  raw.query(
+  rawRun(
     `DELETE FROM processed_callbacks WHERE dedupe_key = ? AND created_at < ?`,
-  ).run(dedupeKey, Date.now() - CLAIM_EXPIRY_MS);
+    dedupeKey, Date.now() - CLAIM_EXPIRY_MS,
+  );
 
   const claimId = uuid();
-  raw.query(
+  const changes = rawRun(
     `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, claim_id, created_at) VALUES (?, ?, ?, ?, ?)`,
-  ).run(uuid(), dedupeKey, callSessionId, claimId, Date.now());
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  return changes.c > 0 ? claimId : null;
+    uuid(), dedupeKey, callSessionId, claimId, Date.now(),
+  );
+  return changes > 0 ? claimId : null;
 }
 
 /**
@@ -395,9 +377,7 @@ export function claimCallback(dedupeKey: string, callSessionId: string): string 
  * handler A from releasing a claim that was reclaimed by handler B.
  */
 export function releaseCallbackClaim(dedupeKey: string, claimId: string): void {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  raw.query(`DELETE FROM processed_callbacks WHERE dedupe_key = ? AND claim_id = ?`).run(dedupeKey, claimId);
+  rawRun(`DELETE FROM processed_callbacks WHERE dedupe_key = ? AND claim_id = ?`, dedupeKey, claimId);
 }
 
 /**
@@ -415,15 +395,13 @@ export function releaseCallbackClaim(dedupeKey: string, claimId: string): void {
  * else, so duplicate processing may occur on later retries.
  */
 export function finalizeCallbackClaim(dedupeKey: string, claimId: string): boolean {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
   // Set created_at far in the future so expiry check never matches
   const NEVER_EXPIRE = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000; // ~100 years
-  raw.query(
+  const changes = rawRun(
     `UPDATE processed_callbacks SET created_at = ? WHERE dedupe_key = ? AND claim_id = ?`,
-  ).run(NEVER_EXPIRE, dedupeKey, claimId);
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  if (changes.c === 0) {
+    NEVER_EXPIRE, dedupeKey, claimId,
+  );
+  if (changes === 0) {
     log.warn({ dedupeKey, claimId }, 'finalizeCallbackClaim: claim was lost — another handler reclaimed this key after expiry');
     return false;
   }

--- a/assistant/src/daemon/handlers/documents.ts
+++ b/assistant/src/daemon/handlers/documents.ts
@@ -2,11 +2,22 @@ import { defineHandlers } from './shared.js';
 import type { HandlerContext } from './shared.js';
 import type { DocumentSaveRequest, DocumentLoadRequest, DocumentListRequest } from '../ipc-protocol.js';
 import type * as net from 'node:net';
-import type { Database } from 'bun:sqlite';
-import { getDb } from '../../memory/db.js';
+import { rawRun, rawGet, rawAll } from '../../memory/db.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('documents');
+
+interface DocumentRow {
+  surface_id: string;
+  conversation_id: string;
+  title: string;
+  content: string;
+  word_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+type DocumentListRow = Omit<DocumentRow, 'content'>;
 
 export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket, ctx: HandlerContext): void {
   log.info({
@@ -18,13 +29,9 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
   }, 'Received save request');
 
   try {
-    const db = getDb();
-    // Get the raw SQLite client from Drizzle
-    const sqlite = (db as unknown as { $client: Database }).$client;
     const now = Date.now();
 
-    // Upsert document (insert or update if exists)
-    sqlite.run(
+    rawRun(
       `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(surface_id) DO UPDATE SET
@@ -32,7 +39,7 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
          content = excluded.content,
          word_count = excluded.word_count,
          updated_at = excluded.updated_at`,
-      [msg.surfaceId, msg.conversationId, msg.title, msg.content, msg.wordCount, now, now]
+      msg.surfaceId, msg.conversationId, msg.title, msg.content, msg.wordCount, now, now,
     );
 
     ctx.send(socket, {
@@ -55,22 +62,11 @@ export function handleDocumentSave(msg: DocumentSaveRequest, socket: net.Socket,
 
 export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket, ctx: HandlerContext): void {
   try {
-    const db = getDb();
-    const sqlite = (db as unknown as { $client: Database }).$client;
-
-    const result = sqlite.prepare(/*sql*/ `
+    const result = rawGet<DocumentRow>(/*sql*/ `
       SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
       FROM documents
       WHERE surface_id = ?
-    `).get(msg.surfaceId) as {
-      surface_id: string;
-      conversation_id: string;
-      title: string;
-      content: string;
-      word_count: number;
-      created_at: number;
-      updated_at: number;
-    } | undefined;
+    `, msg.surfaceId);
 
     if (result) {
       ctx.send(socket, {
@@ -119,9 +115,6 @@ export function handleDocumentLoad(msg: DocumentLoadRequest, socket: net.Socket,
 
 export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket, ctx: HandlerContext): void {
   try {
-    const db = getDb();
-    const sqlite = (db as unknown as { $client: Database }).$client;
-
     let query = /*sql*/ `
       SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
       FROM documents
@@ -135,14 +128,7 @@ export function handleDocumentList(msg: DocumentListRequest, socket: net.Socket,
 
     query += ' ORDER BY updated_at DESC';
 
-    const results = sqlite.prepare(query).all(...params) as Array<{
-      surface_id: string;
-      conversation_id: string;
-      title: string;
-      word_count: number;
-      created_at: number;
-      updated_at: number;
-    }>;
+    const results = rawAll<DocumentListRow>(query, ...params);
 
     ctx.send(socket, {
       type: 'document_list_response',

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { getMemoryBackendStatus } from './embedding-backend.js';
-import { getDb } from './db.js';
+import { rawGet } from './db.js';
 import { enqueueBackfillJob, enqueueRebuildIndexJob } from './indexer.js';
 import {
   enqueueCleanupResolvedConflictsJob,
@@ -43,28 +43,35 @@ export interface MemoryConflictAndCleanupStats {
   cleanup: MemorySystemStatus['cleanup'];
 }
 
+interface ConflictStatsRow {
+  pending_count: number | null;
+  resolved_count: number | null;
+  oldest_pending_created_at: number | null;
+}
+
+interface CleanupStatsRow {
+  resolved_backlog: number | null;
+  superseded_backlog: number | null;
+  resolved_completed_24h: number | null;
+  superseded_completed_24h: number | null;
+}
+
 /** Lightweight query for conflict/cleanup metrics only — no table counts or job totals. */
 export function getMemoryConflictAndCleanupStats(): MemoryConflictAndCleanupStats {
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...args: unknown[]) => unknown } } }).$client;
-  const conflictStats = raw.query(`
+  const conflictStats = rawGet<ConflictStatsRow>(`
     SELECT
       SUM(CASE WHEN status = 'pending_clarification' THEN 1 ELSE 0 END) AS pending_count,
       SUM(CASE WHEN status != 'pending_clarification' THEN 1 ELSE 0 END) AS resolved_count,
       MIN(CASE WHEN status = 'pending_clarification' THEN created_at END) AS oldest_pending_created_at
     FROM memory_item_conflicts
-  `).get() as {
-    pending_count: number | null;
-    resolved_count: number | null;
-    oldest_pending_created_at: number | null;
-  } | null;
+  `);
   const pending = conflictStats?.pending_count ?? 0;
   const oldestPendingCreatedAt = conflictStats?.oldest_pending_created_at ?? null;
   const oldestPendingAgeMs = oldestPendingCreatedAt === null
     ? null
     : Math.max(0, Date.now() - oldestPendingCreatedAt);
   const throughputWindowStartMs = Date.now() - (24 * 60 * 60 * 1000);
-  const cleanupStats = raw.query(`
+  const cleanupStats = rawGet<CleanupStatsRow>(`
     SELECT
       SUM(CASE
         WHEN type = 'cleanup_resolved_conflicts' AND status IN ('pending', 'running')
@@ -83,12 +90,7 @@ export function getMemoryConflictAndCleanupStats(): MemoryConflictAndCleanupStat
         THEN 1 ELSE 0 END
       ) AS superseded_completed_24h
     FROM memory_jobs
-  `).get(throughputWindowStartMs, throughputWindowStartMs) as {
-    resolved_backlog: number | null;
-    superseded_backlog: number | null;
-    resolved_completed_24h: number | null;
-    superseded_completed_24h: number | null;
-  } | null;
+  `, throughputWindowStartMs, throughputWindowStartMs);
   return {
     conflicts: {
       pending,
@@ -107,32 +109,26 @@ export function getMemoryConflictAndCleanupStats(): MemoryConflictAndCleanupStat
 export function getMemorySystemStatus(): MemorySystemStatus {
   const config = getConfig();
   const backend = getMemoryBackendStatus(config);
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...args: unknown[]) => unknown } } }).$client;
   const counts = {
     segments: countTable('memory_segments'),
     items: countTable('memory_items'),
     summaries: countTable('memory_summaries'),
     embeddings: countTable('memory_embeddings'),
   };
-  const conflictStats = raw.query(`
+  const conflictStats = rawGet<ConflictStatsRow>(`
     SELECT
       SUM(CASE WHEN status = 'pending_clarification' THEN 1 ELSE 0 END) AS pending_count,
       SUM(CASE WHEN status != 'pending_clarification' THEN 1 ELSE 0 END) AS resolved_count,
       MIN(CASE WHEN status = 'pending_clarification' THEN created_at END) AS oldest_pending_created_at
     FROM memory_item_conflicts
-  `).get() as {
-    pending_count: number | null;
-    resolved_count: number | null;
-    oldest_pending_created_at: number | null;
-  } | null;
+  `);
   const pending = conflictStats?.pending_count ?? 0;
   const oldestPendingCreatedAt = conflictStats?.oldest_pending_created_at ?? null;
   const oldestPendingAgeMs = oldestPendingCreatedAt === null
     ? null
     : Math.max(0, Date.now() - oldestPendingCreatedAt);
   const throughputWindowStartMs = Date.now() - (24 * 60 * 60 * 1000);
-  const cleanupStats = raw.query(`
+  const cleanupStats = rawGet<CleanupStatsRow>(`
     SELECT
       SUM(CASE
         WHEN type = 'cleanup_resolved_conflicts' AND status IN ('pending', 'running')
@@ -151,12 +147,7 @@ export function getMemorySystemStatus(): MemorySystemStatus {
         THEN 1 ELSE 0 END
       ) AS superseded_completed_24h
     FROM memory_jobs
-  `).get(throughputWindowStartMs, throughputWindowStartMs) as {
-    resolved_backlog: number | null;
-    superseded_backlog: number | null;
-    resolved_completed_24h: number | null;
-    superseded_completed_24h: number | null;
-  } | null;
+  `, throughputWindowStartMs, throughputWindowStartMs);
   return {
     enabled: backend.enabled,
     degraded: backend.degraded,
@@ -179,8 +170,7 @@ export function getMemorySystemStatus(): MemorySystemStatus {
   };
 
   function countTable(table: string): number {
-    const row = raw.query(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number } | null;
-    return row?.c ?? 0;
+    return rawGet<{ c: number }>(`SELECT COUNT(*) AS c FROM ${table}`)?.c ?? 0;
   }
 }
 

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -7,7 +7,7 @@
 
 import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from './db.js';
+import { getDb, rawRun } from './db.js';
 import { attachments, messageAttachments } from './schema.js';
 
 export interface StoredAttachment {
@@ -386,12 +386,9 @@ export function getAttachmentById(
  */
 export function deleteOrphanAttachments(candidateIds: string[]): number {
   if (candidateIds.length === 0) return 0;
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
   const placeholders = candidateIds.map(() => '?').join(', ');
-  const stmt = raw.prepare(
+  return rawRun(
     `DELETE FROM attachments WHERE id IN (${placeholders}) AND id NOT IN (SELECT attachment_id FROM message_attachments)`,
+    ...candidateIds,
   );
-  const result = stmt.run(...candidateIds);
-  return result.changes;
 }

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from './db.js';
+import { getDb, rawAll } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItemConflicts, memoryItems } from './schema.js';
 
@@ -155,9 +155,25 @@ export function listPendingConflicts(scopeId: string, limit = 100): MemoryItemCo
 
 export function listPendingConflictDetails(scopeId: string, limit = 100): PendingConflictDetail[] {
   if (limit <= 0) return [];
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
-  const rows = raw.query(`
+  interface ConflictDetailRow {
+    id: string;
+    scope_id: string;
+    existing_item_id: string;
+    candidate_item_id: string;
+    relationship: string;
+    status: MemoryConflictStatus;
+    clarification_question: string | null;
+    resolution_note: string | null;
+    last_asked_at: number | null;
+    resolved_at: number | null;
+    created_at: number;
+    updated_at: number;
+    existing_statement: string;
+    candidate_statement: string;
+    existing_kind: string;
+    candidate_kind: string;
+  }
+  const rows = rawAll<ConflictDetailRow>(`
     SELECT
       c.id,
       c.scope_id,
@@ -182,24 +198,7 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
       AND c.status = 'pending_clarification'
     ORDER BY c.created_at ASC
     LIMIT ?
-  `).all(scopeId, limit) as Array<{
-    id: string;
-    scope_id: string;
-    existing_item_id: string;
-    candidate_item_id: string;
-    relationship: string;
-    status: MemoryConflictStatus;
-    clarification_question: string | null;
-    resolution_note: string | null;
-    last_asked_at: number | null;
-    resolved_at: number | null;
-    created_at: number;
-    updated_at: number;
-    existing_statement: string;
-    candidate_statement: string;
-    existing_kind: string;
-    candidate_kind: string;
-  }>;
+  `, scopeId, limit);
 
   return rows.map((row) => ({
     id: row.id,

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -6,7 +6,7 @@ import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from
 import { areStatementsCoherent } from './conflict-intent.js';
 import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
-import { getDb } from './db.js';
+import { getDb, rawAll } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItems } from './schema.js';
 
@@ -124,8 +124,6 @@ interface MemoryItemRow {
  * Uses LIKE queries on subject and keyword overlap on statement.
  */
 function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
 
   // Extract significant words from subject for LIKE matching
   const subjectWords = item.subject
@@ -173,7 +171,7 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
   `;
 
   try {
-    const rows = raw.query(sqlQuery).all(item.kind, item.id, item.scopeId) as Array<{
+    interface SimilarItemRow {
       id: string;
       kind: string;
       subject: string;
@@ -183,7 +181,8 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
       importance: number | null;
       scope_id: string;
       last_seen_at: number;
-    }>;
+    }
+    const rows = rawAll<SimilarItemRow>(sqlQuery, item.kind, item.id, item.scopeId);
 
     return rows.map((row) => ({
       id: row.id,

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,6 +1,6 @@
 import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from './db.js';
+import { getDb, rawGet, rawExec } from './db.js';
 import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments, llmRequestLogs } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
@@ -239,30 +239,27 @@ export function updateConversationContextWindow(
  * Returns { conversations, messages } counts.
  */
 export function clearAll(): { conversations: number; messages: number } {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-
-  const msgCount = (raw.query('SELECT COUNT(*) AS c FROM messages').get() as { c: number }).c;
-  const convCount = (raw.query('SELECT COUNT(*) AS c FROM conversations').get() as { c: number }).c;
+  const msgCount = rawGet<{ c: number }>('SELECT COUNT(*) AS c FROM messages')?.c ?? 0;
+  const convCount = rawGet<{ c: number }>('SELECT COUNT(*) AS c FROM conversations')?.c ?? 0;
 
   // Delete in dependency order. Cascades handle memory_segments,
   // memory_item_sources, and tool_invocations, but we explicitly
   // clear non-cascading memory tables too.
-  raw.exec('DELETE FROM memory_segment_fts');
-  raw.exec('DELETE FROM memory_item_sources');
-  raw.exec('DELETE FROM memory_segments');
-  raw.exec('DELETE FROM memory_items');
-  raw.exec('DELETE FROM memory_summaries');
-  raw.exec('DELETE FROM memory_embeddings');
-  raw.exec('DELETE FROM memory_jobs');
-  raw.exec('DELETE FROM memory_checkpoints');
-  raw.exec('DELETE FROM llm_request_logs');
-  raw.exec('DELETE FROM llm_usage_events');
-  raw.exec('DELETE FROM message_attachments');
-  raw.exec('DELETE FROM attachments');
-  raw.exec('DELETE FROM tool_invocations');
-  raw.exec('DELETE FROM messages');
-  raw.exec('DELETE FROM conversations');
+  rawExec('DELETE FROM memory_segment_fts');
+  rawExec('DELETE FROM memory_item_sources');
+  rawExec('DELETE FROM memory_segments');
+  rawExec('DELETE FROM memory_items');
+  rawExec('DELETE FROM memory_summaries');
+  rawExec('DELETE FROM memory_embeddings');
+  rawExec('DELETE FROM memory_jobs');
+  rawExec('DELETE FROM memory_checkpoints');
+  rawExec('DELETE FROM llm_request_logs');
+  rawExec('DELETE FROM llm_usage_events');
+  rawExec('DELETE FROM message_attachments');
+  rawExec('DELETE FROM attachments');
+  rawExec('DELETE FROM tool_invocations');
+  rawExec('DELETE FROM messages');
+  rawExec('DELETE FROM conversations');
 
   return { conversations: convCount, messages: msgCount };
 }

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -3,9 +3,11 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as schema from './schema.js';
 import { getDbPath, ensureDataDir, migrateToDataLayout, migrateToWorkspaceLayout } from '../util/platform.js';
 
-let db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
-export function getDb() {
+let db: DrizzleDb | null = null;
+
+export function getDb(): DrizzleDb {
   if (!db) {
     migrateToDataLayout();
     migrateToWorkspaceLayout();
@@ -19,11 +21,28 @@ export function getDb() {
   return db;
 }
 
+/**
+ * Get the underlying bun:sqlite Database from the global Drizzle instance.
+ *
+ * Use this instead of the raw cast `(db as unknown as { $client: Database }).$client`.
+ * See raw-query.ts for typed query helpers and guidelines on when raw SQL is appropriate.
+ */
+export function getSqlite(): Database {
+  return getSqliteFrom(getDb());
+}
+
+/**
+ * Extract the underlying bun:sqlite Database from any Drizzle instance.
+ * Useful in migrations and tests that receive the Drizzle instance as a parameter.
+ */
+export function getSqliteFrom(drizzleDb: DrizzleDb): Database {
+  return (drizzleDb as unknown as { $client: Database }).$client;
+}
+
 /** Reset the db singleton. Used by tests to ensure isolation between test files. */
 export function resetDb(): void {
   if (db) {
-    const raw = (db as unknown as { $client: Database }).$client;
-    raw.close();
+    getSqliteFrom(db).close();
     db = null;
   }
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1,5 +1,4 @@
-import { Database } from 'bun:sqlite';
-import { getDb } from './db-connection.js';
+import { getDb, getSqliteFrom } from './db-connection.js';
 import { getLogger } from '../util/logger.js';
 import {
   migrateJobDeferrals,
@@ -595,7 +594,7 @@ export function initializeDb(): void {
   // Deduplicate before creating unique index — existing DBs may have duplicate content_hash values.
   // Re-point message_attachments to the survivor (MIN rowid per content_hash), then delete dupes.
   {
-    const raw = (database as unknown as { $client: Database }).$client;
+    const raw = getSqliteFrom(database);
     raw.exec(/*sql*/ `
       UPDATE message_attachments
       SET attachment_id = (

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -1,2 +1,15 @@
-export { getDb, resetDb } from './db-connection.js';
+export { getDb, resetDb, getSqlite, getSqliteFrom, type DrizzleDb } from './db-connection.js';
 export { initializeDb } from './db-init.js';
+export {
+  rawGet,
+  rawAll,
+  rawRun,
+  rawExec,
+  rawChanges,
+  rawGetFrom,
+  rawAllFrom,
+  rawRunFrom,
+  rawExecFrom,
+  rawPrepare,
+  rawPrepareFrom,
+} from './raw-query.js';

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -9,7 +9,7 @@
 
 import { and, eq, lt, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from './db.js';
+import { getDb, rawChanges } from './db.js';
 import {
   guardianActionRequests,
   guardianActionDeliveries,
@@ -203,9 +203,7 @@ export function resolveGuardianActionRequest(
     .run();
 
   // Check if the update took effect
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  const changes = raw.query('SELECT changes() as c').get() as { c: number };
-  if (changes.c === 0) return null;
+  if (rawChanges() === 0) return null;
 
   // Mark all deliveries as 'answered'
   db.update(guardianActionDeliveries)

--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { getLogger } from '../../util/logger.js';
-import { getDb } from '../db.js';
+import { getDb, rawExec } from '../db.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asString, BackendUnavailableError } from '../job-utils.js';
 import { getQdrantClient } from '../qdrant-client.js';
@@ -10,8 +10,8 @@ const log = getLogger('memory-jobs-worker');
 
 export function rebuildIndexJob(): void {
   const db = getDb();
-  db.run(/*sql*/ `DELETE FROM memory_segment_fts`);
-  db.run(/*sql*/ `
+  rawExec(/*sql*/ `DELETE FROM memory_segment_fts`);
+  rawExec(/*sql*/ `
     INSERT INTO memory_segment_fts(segment_id, text)
     SELECT id, text FROM memory_segments
   `);

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, lte, notInArray, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
-import { getDb } from './db.js';
+import { getDb, rawGet, rawAll } from './db.js';
 import { memoryJobs } from './schema.js';
 import { truncate } from '../util/truncate.js';
 
@@ -110,9 +110,8 @@ export function enqueueResolvePendingConflictsForMessageJob(
     throw new Error('enqueueResolvePendingConflictsForMessageJob requires a non-empty messageId');
   }
   const normalizedScopeId = scopeId.trim() || 'default';
-  // Dedup check always uses root db since tx doesn't expose $client
-  const raw = (getDb() as unknown as { $client: { query: (q: string) => { get: (...params: unknown[]) => unknown } } }).$client;
-  const existing = raw.query(`
+  // Dedup check always uses root db since tx doesn't expose raw client
+  const existing = rawGet<{ id: string }>(`
     SELECT id
     FROM memory_jobs
     WHERE type = 'resolve_pending_conflicts_for_message'
@@ -121,7 +120,7 @@ export function enqueueResolvePendingConflictsForMessageJob(
       AND COALESCE(json_extract(payload, '$.scopeId'), 'default') = ?
     ORDER BY created_at ASC
     LIMIT 1
-  `).get(normalizedMessageId, normalizedScopeId) as { id: string } | null;
+  `, normalizedMessageId, normalizedScopeId);
   if (existing?.id) return existing.id;
 
   return enqueueMemoryJob('resolve_pending_conflicts_for_message', {
@@ -366,13 +365,11 @@ export function resetRunningJobsToPending(): number {
 }
 
 export function getMemoryJobCounts(): Record<string, number> {
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: () => unknown[] } } }).$client;
-  const rows = raw.query(`
+  const rows = rawAll<{ status: string; c: number }>(`
     SELECT status, COUNT(*) AS c
     FROM memory_jobs
     GROUP BY status
-  `).all() as Array<{ status: string; c: number }>;
+  `);
   const counts: Record<string, number> = { pending: 0, running: 0, completed: 0, failed: 0 };
   for (const row of rows) {
     counts[row.status] = row.c;

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,7 +1,7 @@
 import type { AssistantConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
-import { getDb } from './db.js';
+import { getDb, rawRun } from './db.js';
 import {
   claimMemoryJobs,
   completeMemoryJob,
@@ -296,16 +296,13 @@ export function sweepStaleItems(config: AssistantConfig): number {
   if (now - lastStaleSweepMs < STALE_SWEEP_INTERVAL_MS) return 0;
   lastStaleSweepMs = now;
 
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { run: (...params: unknown[]) => { changes: number } } } }).$client;
-
   let totalMarked = 0;
   for (const [kind, maxAgeDays] of Object.entries(freshness.maxAgeDays)) {
     if (maxAgeDays <= 0) continue;
     // Mark invalid if: past 2x window, no access in the shield period, and not already invalid
     const cutoffMs = now - maxAgeDays * 2 * 86_400_000;
     const shieldCutoffMs = now - freshness.reinforcementShieldDays * 86_400_000;
-    const result = raw.query(`
+    const changes = rawRun(`
       UPDATE memory_items
       SET invalid_at = ?
       WHERE kind = ?
@@ -313,10 +310,10 @@ export function sweepStaleItems(config: AssistantConfig): number {
         AND invalid_at IS NULL
         AND last_seen_at < ?
         AND (access_count = 0 OR COALESCE(last_used_at, 0) < ?)
-    `).run(now, kind, cutoffMs, shieldCutoffMs);
-    if (result.changes > 0) {
-      log.info({ kind, marked: result.changes, cutoffMs }, 'Marked stale memory items as invalid');
-      totalMarked += result.changes;
+    `, now, kind, cutoffMs, shieldCutoffMs);
+    if (changes > 0) {
+      log.info({ kind, marked: changes, cutoffMs }, 'Marked stale memory items as invalid');
+      totalMarked += changes;
     }
   }
   return totalMarked;

--- a/assistant/src/memory/raw-query.ts
+++ b/assistant/src/memory/raw-query.ts
@@ -1,0 +1,119 @@
+/**
+ * Type-safe wrappers for raw SQL queries against bun:sqlite.
+ *
+ * ## When to use raw SQL vs Drizzle ORM
+ *
+ * **Default to Drizzle** for all standard CRUD operations. Use raw SQL only when
+ * Drizzle cannot express the query or when a raw API is required:
+ *
+ * - **FTS5 operations**: MATCH operator, bm25() ranking, virtual table
+ *   INSERT/DELETE. Drizzle has no FTS5 support.
+ *
+ * - **Schema migrations**: DDL statements (CREATE TABLE, ALTER TABLE, DROP TABLE),
+ *   PRAGMA control, and transaction-wrapped table rebuilds. These are structural
+ *   operations outside Drizzle's query-building scope.
+ *
+ * - **Affected-row checks after Drizzle .run()**: Drizzle's bun:sqlite adapter
+ *   returns void from .run(), so checking changes() requires the raw client.
+ *   Use `rawChanges()` for this.
+ *
+ * - **INSERT OR IGNORE / ON CONFLICT**: SQLite-specific upsert syntax that
+ *   Drizzle's bun:sqlite adapter doesn't fully support.
+ *
+ * - **Atomic in-place updates**: Expressions like `SET count = count + 1` can
+ *   use Drizzle's `sql` template, but raw SQL is acceptable when simpler.
+ *
+ * - **Bulk deletes across virtual tables**: Operations like clearing
+ *   memory_segment_fts that reference virtual tables not modeled in Drizzle.
+ *
+ * For everything else — selects, inserts, updates, deletes, joins, aggregations,
+ * filtering, ordering, pagination — use Drizzle.
+ */
+
+import type { Database, SQLQueryBindings } from 'bun:sqlite';
+import { getSqlite, type DrizzleDb, getSqliteFrom } from './db-connection.js';
+
+type SqlParam = SQLQueryBindings;
+
+// ---------------------------------------------------------------------------
+// Typed query helpers (global Drizzle instance)
+// ---------------------------------------------------------------------------
+
+/** Execute a raw SQL query and return a single typed row, or null if no match. */
+export function rawGet<T>(sql: string, ...params: SqlParam[]): T | null {
+  return (getSqlite().query(sql).get(...params) as T) ?? null;
+}
+
+/** Execute a raw SQL query and return all matching rows with type safety. */
+export function rawAll<T>(sql: string, ...params: SqlParam[]): T[] {
+  return getSqlite().query(sql).all(...params) as T[];
+}
+
+/**
+ * Execute a raw SQL statement (INSERT/UPDATE/DELETE) and return the number
+ * of affected rows.
+ */
+export function rawRun(sql: string, ...params: SqlParam[]): number {
+  getSqlite().query(sql).run(...params);
+  return rawChanges();
+}
+
+/** Execute batch SQL (multiple statements, no bindings). */
+export function rawExec(sql: string): void {
+  getSqlite().exec(sql);
+}
+
+/**
+ * Return the number of rows affected by the most recent INSERT/UPDATE/DELETE.
+ *
+ * Useful after a Drizzle `.run()` call, since Drizzle's bun:sqlite adapter
+ * returns void and discards the changes count.
+ */
+export function rawChanges(): number {
+  return (getSqlite().query('SELECT changes() AS c').get() as { c: number }).c;
+}
+
+// ---------------------------------------------------------------------------
+// Typed query helpers (explicit Drizzle instance)
+//
+// Used by migrations and tests that receive the Drizzle instance as a
+// parameter rather than using the global singleton.
+// ---------------------------------------------------------------------------
+
+/** Execute a raw SQL query against a specific Drizzle instance and return a single typed row. */
+export function rawGetFrom<T>(db: DrizzleDb, sql: string, ...params: SqlParam[]): T | null {
+  return (getSqliteFrom(db).query(sql).get(...params) as T) ?? null;
+}
+
+/** Execute a raw SQL query against a specific Drizzle instance and return all matching rows. */
+export function rawAllFrom<T>(db: DrizzleDb, sql: string, ...params: SqlParam[]): T[] {
+  return getSqliteFrom(db).query(sql).all(...params) as T[];
+}
+
+/**
+ * Execute a raw SQL statement against a specific Drizzle instance and return
+ * affected row count.
+ */
+export function rawRunFrom(db: DrizzleDb, sql: string, ...params: SqlParam[]): number {
+  const sqlite = getSqliteFrom(db);
+  sqlite.query(sql).run(...params);
+  return (sqlite.query('SELECT changes() AS c').get() as { c: number }).c;
+}
+
+/** Execute batch SQL against a specific Drizzle instance. */
+export function rawExecFrom(db: DrizzleDb, sql: string): void {
+  getSqliteFrom(db).exec(sql);
+}
+
+/**
+ * Create a prepared statement from the raw SQLite client.
+ * Useful when you need to execute the same parameterized query in a loop.
+ */
+export function rawPrepare(sql: string): ReturnType<Database['prepare']> {
+  return getSqlite().prepare(sql);
+}
+
+/** Create a prepared statement from a specific Drizzle instance. */
+export function rawPrepareFrom(db: DrizzleDb, sql: string): ReturnType<Database['prepare']> {
+  return getSqliteFrom(db).prepare(sql);
+}

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -1,12 +1,10 @@
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { computeMemoryFingerprint } from './fingerprint.js';
-import type * as schema from './schema.js';
+import { getSqliteFrom, type DrizzleDb } from './db-connection.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('memory-db');
 
-type Db = ReturnType<typeof drizzle<typeof schema>>;
+type Db = DrizzleDb;
 
 /**
  * One-shot migration: reconcile old deferral history into the new `deferrals` column.
@@ -24,7 +22,7 @@ type Db = ReturnType<typeof drizzle<typeof schema>>;
  * We use a `memory_checkpoints` row to ensure the migration runs exactly once.
  */
 export function migrateJobDeferrals(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = 'migration_job_deferrals'`
   ).get();
@@ -58,7 +56,7 @@ export function migrateJobDeferrals(database: Db): void {
  * This is idempotent: it checks whether the FK already exists before migrating.
  */
 export function migrateToolInvocationsFk(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const row = raw.query(`SELECT sql FROM sqlite_master WHERE type='table' AND name='tool_invocations'`).get() as { sql: string } | null;
   if (!row) return; // table doesn't exist yet (will be created above)
 
@@ -99,7 +97,7 @@ export function migrateToolInvocationsFk(database: Db): void {
  * version that may not have had trigger-managed FTS.
  */
 export function migrateMemoryFtsBackfill(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const ftsCountRow = raw.query(`SELECT COUNT(*) AS c FROM memory_segment_fts`).get() as { c: number } | null;
   const ftsCount = ftsCountRow?.c ?? 0;
   if (ftsCount > 0) return;
@@ -115,7 +113,7 @@ export function migrateMemoryFtsBackfill(database: Db): void {
  * enforced on (source_entity_id, target_entity_id, relation).
  */
 export function migrateMemoryEntityRelationDedup(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_memory_entity_relations_dedup_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -194,7 +192,7 @@ export function migrateMemoryEntityRelationDedup(database: Db): void {
  * different scopes independently.
  */
 export function migrateMemoryItemsFingerprintScopeUnique(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_memory_items_fingerprint_scope_unique_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -278,7 +276,7 @@ export function migrateMemoryItemsFingerprintScopeUnique(database: Db): void {
  * causing duplicates and broken deduplication.
  */
 export function migrateMemoryItemsScopeSaltedFingerprints(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_memory_items_scope_salted_fingerprints_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -355,7 +353,7 @@ export function migrateMemoryItemsScopeSaltedFingerprints(database: Db): void {
  *     and key-lookup rows are modified.
  */
 export function migrateAssistantIdToSelf(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_normalize_assistant_id_to_self_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -599,7 +597,7 @@ export function migrateAssistantIdToSelf(database: Db): void {
  *   - llm_usage_events        nullable column with no constraint
  */
 export function migrateRemoveAssistantIdColumns(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_remove_assistant_id_columns_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -798,7 +796,7 @@ export function migrateRemoveAssistantIdColumns(database: Db): void {
  * Safe on fresh installs (DDL guard exits early) and idempotent via checkpoint.
  */
 export function migrateLlmUsageEventsDropAssistantId(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   const checkpointKey = 'migration_remove_assistant_id_lue_v1';
   const checkpoint = raw.query(
     `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
@@ -878,7 +876,7 @@ export function migrateLlmUsageEventsDropAssistantId(database: Db): void {
  * createdAt) is kept; older duplicates are deleted.
  */
 export function migrateExtConvBindingsChannelChatUnique(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
 
   // If the unique index already exists, nothing to do.
   const idxExists = raw.query(
@@ -932,7 +930,7 @@ export function migrateExtConvBindingsChannelChatUnique(database: Db): void {
  * For each set of duplicates, the most recently updated row is kept.
  */
 export function migrateCallSessionsProviderSidDedup(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
 
   // Quick check: if the unique index already exists, no dedup is needed.
   const idxExists = raw.query(
@@ -993,7 +991,7 @@ export function migrateCallSessionsProviderSidDedup(database: Db): void {
  * db-init.ts for similar additive columns).
  */
 export function migrateCallSessionsAddInitiatedFrom(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
   try {
     raw.exec(/*sql*/ `ALTER TABLE call_sessions ADD COLUMN initiated_from_conversation_id TEXT`);
   } catch {
@@ -1009,7 +1007,7 @@ export function migrateCallSessionsAddInitiatedFrom(database: Db): void {
  * idempotency across restarts.
  */
 export function migrateGuardianActionTables(database: Db): void {
-  const raw = (database as unknown as { $client: Database }).$client;
+  const raw = getSqliteFrom(database);
 
   raw.exec(/*sql*/ `
     CREATE TABLE IF NOT EXISTS guardian_action_requests (

--- a/assistant/src/memory/search/entity.ts
+++ b/assistant/src/memory/search/entity.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm';
 import type { MemoryEntityConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
-import { getDb } from '../db.js';
+import { getDb, rawAll } from '../db.js';
 import {
   memoryEntityRelations,
   memoryItemEntities,
@@ -130,8 +130,6 @@ export function findMatchedEntities(query: string, maxMatches: number): MatchedE
   const trimmed = query.trim();
   if (trimmed.length === 0) return [];
 
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
   const safeLimit = Math.max(1, Math.floor(maxMatches));
 
   // Tokenize query into words for entity matching (min length 3 to reduce false positives)
@@ -173,14 +171,12 @@ export function findMatchedEntities(query: string, maxMatches: number): MatchedE
     queryParams = [fullQuery, fullQuery];
   }
 
-  let matchedEntities: MatchedEntityRow[] = [];
   try {
-    matchedEntities = raw.query(entityQuery).all(...queryParams) as MatchedEntityRow[];
+    return rawAll<MatchedEntityRow>(entityQuery, ...queryParams);
   } catch (err) {
     log.warn({ err }, 'Entity search query failed');
     return [];
   }
-  return matchedEntities;
 }
 
 /**
@@ -225,8 +221,9 @@ export function findNeighborEntities(
       const frontierPlaceholders = frontier.map(() => '?').join(',');
       const limit = Math.max(1, edgeBudget);
 
-      const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
       const relationParams = relationTypes && relationTypes.length > 0 ? relationTypes : [];
+
+      type EdgeRow = { sourceEntityId: string; targetEntityId: string };
 
       if (directed) {
         // GROUP BY deduplicates entity pairs that have multiple relation rows
@@ -240,8 +237,7 @@ export function findNeighborEntities(
           ORDER BY MAX(r.last_seen_at) DESC
           LIMIT ?
         `;
-        const params1 = [...frontier, ...relationParams, ...entityTypes, limit];
-        rows = raw.query(q1).all(...params1) as Array<{ sourceEntityId: string; targetEntityId: string }>;
+        rows = rawAll<EdgeRow>(q1, ...frontier, ...relationParams, ...entityTypes, limit);
       } else {
         // Combine both directions in a single query with global recency
         // ordering so the edge budget isn't direction-biased.
@@ -263,17 +259,12 @@ export function findNeighborEntities(
           ORDER BY MAX(last_seen_at) DESC
           LIMIT ?
         `;
-        const params = [
-          ...frontier,
-          ...relationParams,
-          ...entityTypes,
-          ...frontier,
-          ...relationParams,
-          ...entityTypes,
+        rows = rawAll<EdgeRow>(
+          q,
+          ...frontier, ...relationParams, ...entityTypes,
+          ...frontier, ...relationParams, ...entityTypes,
           limit,
-        ];
-
-        rows = raw.query(q).all(...params) as Array<{ sourceEntityId: string; targetEntityId: string }>;
+        );
       }
     } else {
       const frontierCondition = directed

--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, inArray, notInArray } from 'drizzle-orm';
 import { getLogger } from '../../util/logger.js';
-import { getDb } from '../db.js';
+import { getDb, rawAll } from '../db.js';
 import { memorySegments } from '../schema.js';
 import type { Candidate, CandidateType } from './types.js';
 import { computeRecencyScore } from './ranking.js';
@@ -25,31 +25,30 @@ function timedRawQuery<T>(label: string, fn: () => T[]): T[] {
   return result;
 }
 
+interface FtsRow {
+  segment_id: string;
+  message_id: string;
+  text: string;
+  created_at: number;
+  rank: number;
+}
+
 export function lexicalSearch(query: string, limit: number, excludedMessageIds: string[] = [], scopeIds?: string[]): Candidate[] {
   const trimmed = query.trim();
   if (trimmed.length === 0 || limit <= 0) return [];
   const matchQuery = buildFtsMatchQuery(trimmed);
   if (!matchQuery) return [];
   const excluded = new Set(excludedMessageIds);
-  const db = getDb();
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
-  let rows: Array<{
-    segment_id: string;
-    message_id: string;
-    text: string;
-    created_at: number;
-    rank: number;
-  }> = [];
+  let rows: FtsRow[] = [];
   const queryLimit = excluded.size > 0
     ? Math.max(limit + 24, limit * 2)
     : limit;
   const scopeClause = scopeIds
     ? ` AND s.scope_id IN (${scopeIds.map(() => '?').join(',')})`
     : '';
-  const params: unknown[] = [matchQuery, ...(scopeIds ?? []), queryLimit];
   try {
     rows = timedRawQuery('lexicalSearch', () =>
-      raw.query(`
+      rawAll<FtsRow>(`
         SELECT
           f.segment_id AS segment_id,
           s.message_id AS message_id,
@@ -61,14 +60,8 @@ export function lexicalSearch(query: string, limit: number, excludedMessageIds: 
         WHERE memory_segment_fts MATCH ?${scopeClause}
         ORDER BY rank
         LIMIT ?
-      `).all(...params),
-    ) as Array<{
-      segment_id: string;
-      message_id: string;
-      text: string;
-      created_at: number;
-      rank: number;
-    }>;
+      `, matchQuery, ...(scopeIds ?? []), queryLimit),
+    );
   } catch (err) {
     log.warn({ err, query: truncate(trimmed, 80) }, 'Memory lexical search query parse failed');
     return [];
@@ -144,14 +137,12 @@ export function recencySearch(conversationId: string, limit: number, excludedMes
  * Supplements FTS-based lexical search with LIKE-based matching on items.
  */
 export function directItemSearch(query: string, limit: number, scopeIds?: string[]): Candidate[] {
-  const db = getDb();
   const tokens = [...new Set(query
     .toLowerCase()
     .split(/[^a-z0-9_.-]+/g)
     .filter((t) => t.length >= 2))];
   if (tokens.length === 0) return [];
 
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
   const likeClauses = tokens.map(
     () => `(LOWER(subject) LIKE ? OR LOWER(statement) LIKE ?)`,
   );
@@ -169,9 +160,8 @@ export function directItemSearch(query: string, limit: number, scopeIds?: string
     ORDER BY last_seen_at DESC
     LIMIT ?
   `;
-  const params: unknown[] = [...likeParams, ...(scopeIds ?? []), limit];
 
-  let rows: Array<{
+  interface ItemRow {
     id: string;
     kind: string;
     subject: string;
@@ -180,11 +170,13 @@ export function directItemSearch(query: string, limit: number, scopeIds?: string
     importance: number | null;
     first_seen_at: number;
     last_seen_at: number;
-  }> = [];
+  }
+
+  let rows: ItemRow[] = [];
   try {
     rows = timedRawQuery('directItemSearch', () =>
-      raw.query(sqlQuery).all(...params),
-    ) as typeof rows;
+      rawAll<ItemRow>(sqlQuery, ...likeParams, ...(scopeIds ?? []), limit),
+    );
   } catch {
     return [];
   }

--- a/assistant/src/memory/shared-app-links-store.ts
+++ b/assistant/src/memory/shared-app-links-store.ts
@@ -6,7 +6,7 @@
 
 import { eq, lte, or, and, isNull } from 'drizzle-orm';
 import { randomUUID, randomBytes } from 'node:crypto';
-import { getDb } from './db.js';
+import { getDb, rawRun } from './db.js';
 import { sharedAppLinks } from './schema.js';
 import type { AppManifest } from '../bundler/manifest.js';
 
@@ -130,9 +130,8 @@ export function deleteSharedAppLinkByToken(shareToken: string): boolean {
 }
 
 export function incrementDownloadCount(shareToken: string): void {
-  const db = getDb();
-  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  raw.prepare(
+  rawRun(
     `UPDATE shared_app_links SET download_count = download_count + 1 WHERE share_token = ?`,
-  ).run(shareToken);
+    shareToken,
+  );
 }

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -12,7 +12,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { getDb } from '../../memory/db.js';
+import { getDb, rawAll } from '../../memory/db.js';
 import { attachments, messageAttachments, messages, conversations } from '../../memory/schema.js';
 import type { StoredAttachment } from '../../memory/attachments-store.js';
 import { isAttachmentVisible, type AttachmentContext } from '../../daemon/media-visibility-policy.js';
@@ -157,11 +157,10 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       return [];
     }
 
-    // Use raw SQL IN clause for the attachment ID set
-    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
     const placeholders = linkedIds.map(() => '?').join(', ');
 
-    // Build WHERE clauses for raw query
+    // Build WHERE clauses for raw query (FTS5 virtual table not involved,
+    // but dynamic IN-list with optional filters is simpler in raw SQL)
     const whereParts: string[] = [`a.id IN (${placeholders})`];
     const bindValues: (string | number)[] = [...linkedIds];
 
@@ -182,15 +181,8 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       }
     }
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_RESULTS);
-    const stmt = raw.prepare(
-      `SELECT a.id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
-       FROM attachments a
-       WHERE ${whereParts.join(' AND ')}
-       ORDER BY a.created_at DESC
-       LIMIT ?`,
-    );
 
-    const rows = stmt.all(...bindValues, limit) as Array<{
+    interface AttachmentRow {
       id: string;
       original_filename: string;
       mime_type: string;
@@ -198,7 +190,16 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       kind: string;
       thumbnail_base64: string | null;
       created_at: number;
-    }>;
+    }
+
+    const rows = rawAll<AttachmentRow>(
+      `SELECT a.id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
+       FROM attachments a
+       WHERE ${whereParts.join(' AND ')}
+       ORDER BY a.created_at DESC
+       LIMIT ?`,
+      ...bindValues, limit,
+    );
 
     return rows.map((r) => ({
       id: r.id,


### PR DESCRIPTION
## Summary
- Add `getSqlite()` / `getSqliteFrom()` in `db-connection.ts` — single canonical accessor for the raw bun:sqlite client, replacing the ad-hoc `(db as unknown as { $client: Database }).$client` cast scattered across ~50 callsites
- Add `raw-query.ts` with type-safe query helpers (`rawGet<T>`, `rawAll<T>`, `rawRun`, `rawExec`, `rawChanges`) and comprehensive JSDoc documenting when raw SQL is acceptable (FTS5, migrations, affected-row checks, upserts, atomic updates, virtual table operations)
- Migrate all 19 production source files to use the new helpers. Test files are intentionally left unchanged for a follow-up PR

## Original prompt
Standardize raw SQL vs Drizzle ORM usage — Memory search modules mix raw SQL (for FTS5, complex JOINs) with Drizzle ORM. Document when raw SQL is acceptable and add type-safe wrappers around raw queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
