### PR TITLE
refactor: centralize environment variable access via config/env module

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -6,6 +6,7 @@
  */
 
 import { getLogger } from '../util/logger.js';
+import { getTwilioUserPhoneNumber } from '../config/env.js';
 import { isDeniedNumber } from './call-constants.js';
 import {
   createCallSession,
@@ -137,8 +138,8 @@ export async function resolveCallerIdentity(
   if (identityConfig.userNumber) {
     userNumber = identityConfig.userNumber;
     numberSource = 'user_config';
-  } else if (process.env.TWILIO_USER_PHONE_NUMBER) {
-    userNumber = process.env.TWILIO_USER_PHONE_NUMBER;
+  } else if (getTwilioUserPhoneNumber()) {
+    userNumber = getTwilioUserPhoneNumber()!;
     numberSource = 'env_var';
   } else {
     const secureKeyValue = getSecureKey('credential:twilio:user_phone_number');

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -10,6 +10,7 @@
  */
 
 import { getLogger } from '../util/logger.js';
+import { getGatewayInternalBaseUrl } from '../config/env.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import {
   createGuardianActionRequest,
@@ -28,11 +29,7 @@ const log = getLogger('guardian-dispatch');
 
 /** Resolve the gateway base URL for internal delivery callbacks. */
 function getGatewayBaseUrl(): string {
-  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
-    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
-  }
-  const port = Number(process.env.GATEWAY_PORT) || 7830;
-  return `http://127.0.0.1:${port}`;
+  return getGatewayInternalBaseUrl();
 }
 
 export interface GuardianDispatchParams {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -11,6 +11,7 @@ import { randomInt } from 'node:crypto';
 import { getLogger } from '../util/logger.js';
 import { parseJsonSafe } from '../util/json.js';
 import { getConfig } from '../config/loader.js';
+import { getCallWelcomeGreeting } from '../config/env.js';
 import {
   getCallSession,
   updateCallSession,
@@ -361,7 +362,7 @@ export class RelayConnection {
       // configured via CALL_WELCOME_GREETING — Twilio's ConversationRelay will
       // speak it at the transport level, so firing the orchestrator opener too
       // would cause a double greeting.
-      const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
+      const hasStaticGreeting = !!getCallWelcomeGreeting();
       if (!hasStaticGreeting) {
         orchestrator.startInitialGreeting().catch((err) =>
           log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting'),

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -3,6 +3,7 @@ import { getLogger } from '../util/logger.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl, getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { ConfigError } from '../util/errors.js';
+import { getTwilioPhoneNumberEnv, getTwilioWssBaseUrl } from '../config/env.js';
 
 const log = getLogger('twilio-config');
 
@@ -26,7 +27,7 @@ function resolveTwilioPhoneNumber(assistantId: string | undefined, config: Retur
   // 1. TWILIO_PHONE_NUMBER env var (explicit override)
   // 2. config file sms.phoneNumber (primary storage)
   // 3. credential:twilio:phone_number secure key (backward-compat fallback)
-  return process.env.TWILIO_PHONE_NUMBER || config.sms?.phoneNumber || getSecureKey('credential:twilio:phone_number') || '';
+  return getTwilioPhoneNumberEnv() || config.sms?.phoneNumber || getSecureKey('credential:twilio:phone_number') || '';
 }
 
 export function getTwilioConfig(assistantId?: string): TwilioConfig {
@@ -39,8 +40,8 @@ export function getTwilioConfig(assistantId?: string): TwilioConfig {
   // Always use the centralized relay URL derived from the public ingress base URL.
   // TWILIO_WSS_BASE_URL is ignored.
   let wssBaseUrl: string;
-  if (process.env.TWILIO_WSS_BASE_URL) {
-    log.warn('TWILIO_WSS_BASE_URL env var is ignored. Relay URL is derived from ingress.publicBaseUrl.');
+  if (getTwilioWssBaseUrl()) {
+    log.warn('TWILIO_WSS_BASE_URL env var is deprecated. Relay URL is derived from ingress.publicBaseUrl.');
   }
   try {
     wssBaseUrl = getTwilioRelayUrl(config);

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -7,6 +7,7 @@
  */
 
 import { getLogger } from '../util/logger.js';
+import { getCallWelcomeGreeting } from '../config/env.js';
 import {
   getCallSession,
   getCallSessionByCallSid,
@@ -197,7 +198,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     // Fallback to legacy resolution when ingress is not configured
     relayUrl = resolveRelayUrl(twilioConfig.wssBaseUrl, twilioConfig.webhookBaseUrl);
   }
-  const welcomeGreeting = buildWelcomeGreeting(session.task, process.env.CALL_WELCOME_GREETING);
+  const welcomeGreeting = buildWelcomeGreeting(session.task, getCallWelcomeGreeting());
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 

--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -13,6 +13,7 @@ import {
 } from '../daemon/lifecycle.js';
 import { startCli } from '../cli.js';
 import { getSocketPath, getRootDir, getDataDir, getDbPath, getLogPath, getWorkspaceDir, getWorkspaceSkillsDir, getWorkspaceHooksDir } from '../util/platform.js';
+import { getQdrantUrlEnv } from '../config/env.js';
 import { IpcError } from '../util/errors.js';
 import { getCliLogger } from '../util/logger.js';
 import { timeAgo } from '../util/time.js';
@@ -271,7 +272,7 @@ export function registerSessionsCommand(program: Command): void {
       }
 
       const config = getConfig();
-      const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
+      const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
       const qdrant = initQdrantClient({
         url: qdrantUrl,
         collection: config.memory.qdrant.collection,

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -1,0 +1,175 @@
+/**
+ * Centralized environment variable access with validation.
+ *
+ * All runtime environment variables should be accessed through this module
+ * instead of reading process.env directly. This provides:
+ * - Single source of truth for env var names and defaults
+ * - Type-safe accessors (string, number, boolean)
+ * - Fail-fast validation via validateEnv() at startup
+ * - Shared derived values (e.g. gateway base URL) instead of duplicated logic
+ *
+ * Variables NOT centralized here (must resolve before this module loads):
+ * - BASE_DATA_DIR, VELLUM_DAEMON_* — bootstrap/platform layer (util/platform.ts)
+ * - VELLUM_DEBUG, BUN_TEST, NODE_ENV log flags — logger init (util/logger.ts)
+ * - APP_VERSION — compile-time embedding (version.ts)
+ * - __EVAL_INPUT_JSON, __SKILL_*_JSON — internal sandbox IPC
+ */
+
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('env');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Read an env var as a trimmed non-empty string, or undefined. */
+function str(name: string): string | undefined {
+  const v = process.env[name]?.trim();
+  return v || undefined;
+}
+
+/** Read an env var as an integer with fallback. Returns undefined if not set and no fallback given. */
+function int(name: string, fallback: number): number;
+function int(name: string): number | undefined;
+function int(name: string, fallback?: number): number | undefined {
+  const raw = str(name);
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  if (isNaN(n)) {
+    log.warn(`Invalid integer for ${name}: "${raw}", using fallback ${fallback}`);
+    return fallback;
+  }
+  return n;
+}
+
+/** Read an env var as a boolean flag ('true'/'1' → true, everything else → false). */
+function flag(name: string): boolean {
+  const raw = str(name);
+  return raw === 'true' || raw === '1';
+}
+
+// ── Gateway ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_GATEWAY_PORT = 7830;
+
+export function getGatewayPort(): number {
+  return int('GATEWAY_PORT', DEFAULT_GATEWAY_PORT);
+}
+
+/**
+ * Resolve the gateway base URL for internal service-to-service calls.
+ * Prefers GATEWAY_INTERNAL_BASE_URL if set, otherwise derives from port.
+ */
+export function getGatewayInternalBaseUrl(): string {
+  const explicit = str('GATEWAY_INTERNAL_BASE_URL');
+  if (explicit) return explicit.replace(/\/+$/, '');
+  return `http://127.0.0.1:${getGatewayPort()}`;
+}
+
+// ── Ingress ──────────────────────────────────────────────────────────────────
+
+/** Read the INGRESS_PUBLIC_BASE_URL env var (may be mutated at runtime by config handlers). */
+export function getIngressPublicBaseUrl(): string | undefined {
+  return str('INGRESS_PUBLIC_BASE_URL');
+}
+
+/** Set or clear the INGRESS_PUBLIC_BASE_URL env var (used by config handlers). */
+export function setIngressPublicBaseUrl(value: string | undefined): void {
+  if (value) {
+    process.env.INGRESS_PUBLIC_BASE_URL = value;
+  } else {
+    delete process.env.INGRESS_PUBLIC_BASE_URL;
+  }
+}
+
+// ── Runtime HTTP ─────────────────────────────────────────────────────────────
+
+export function getRuntimeHttpPort(): number | undefined {
+  return int('RUNTIME_HTTP_PORT');
+}
+
+export function getRuntimeHttpHost(): string {
+  return str('RUNTIME_HTTP_HOST') || '127.0.0.1';
+}
+
+export function getRuntimeProxyBearerToken(): string | undefined {
+  return str('RUNTIME_PROXY_BEARER_TOKEN');
+}
+
+export function getRuntimeGatewayOriginSecret(): string | undefined {
+  return str('RUNTIME_GATEWAY_ORIGIN_SECRET');
+}
+
+export function isHttpAuthDisabled(): boolean {
+  return str('DISABLE_HTTP_AUTH')?.toLowerCase() === 'true';
+}
+
+// ── Twilio ───────────────────────────────────────────────────────────────────
+
+export function getTwilioPhoneNumberEnv(): string | undefined {
+  return str('TWILIO_PHONE_NUMBER');
+}
+
+export function getTwilioUserPhoneNumber(): string | undefined {
+  return str('TWILIO_USER_PHONE_NUMBER');
+}
+
+export function getTwilioWssBaseUrl(): string | undefined {
+  return str('TWILIO_WSS_BASE_URL');
+}
+
+export function isTwilioWebhookValidationDisabled(): boolean {
+  return flag('TWILIO_WEBHOOK_VALIDATION_DISABLED');
+}
+
+export function getCallWelcomeGreeting(): string | undefined {
+  return str('CALL_WELCOME_GREETING');
+}
+
+// ── Monitoring ───────────────────────────────────────────────────────────────
+
+export function getLogfireToken(): string | undefined {
+  return str('LOGFIRE_TOKEN');
+}
+
+export function isMonitoringEnabled(): boolean {
+  return flag('VELLUM_ENABLE_MONITORING');
+}
+
+export function getSentryDsn(): string | undefined {
+  return str('SENTRY_DSN');
+}
+
+// ── Qdrant ───────────────────────────────────────────────────────────────────
+
+export function getQdrantUrlEnv(): string | undefined {
+  return str('QDRANT_URL');
+}
+
+// ── Ollama ───────────────────────────────────────────────────────────────────
+
+export function getOllamaBaseUrlEnv(): string | undefined {
+  return str('OLLAMA_BASE_URL');
+}
+
+// ── Startup validation ──────────────────────────────────────────────────────
+
+/**
+ * Validate environment at startup. Call early in daemon lifecycle
+ * (after dotenv loads). Throws on invalid required values; warns on
+ * deprecated vars.
+ */
+export function validateEnv(): void {
+  const gatewayPort = getGatewayPort();
+  if (gatewayPort < 1 || gatewayPort > 65535) {
+    throw new Error(`Invalid GATEWAY_PORT: ${gatewayPort} (must be 1-65535)`);
+  }
+
+  const httpPort = getRuntimeHttpPort();
+  if (httpPort !== undefined && (httpPort < 1 || httpPort > 65535)) {
+    throw new Error(`Invalid RUNTIME_HTTP_PORT: ${httpPort} (must be 1-65535)`);
+  }
+
+  if (getTwilioWssBaseUrl()) {
+    log.warn('TWILIO_WSS_BASE_URL env var is deprecated. Relay URL is now derived from ingress.publicBaseUrl.');
+  }
+}

--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getRuntimeHttpPort } from '../../config/env.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp, getAppPreview, createApp, updateApp } from '../../memory/app-store.js';
 import { computeContentId } from '../../util/content-id.js';
 import { packageApp } from '../../bundler/app-bundler.js';
@@ -365,9 +366,7 @@ export async function handleShareAppCloud(
     const bundleData = readFileSync(result.bundlePath);
     const { shareToken } = createSharedAppLink(bundleData, result.manifest);
 
-    const port = process.env.RUNTIME_HTTP_PORT
-      ? parseInt(process.env.RUNTIME_HTTP_PORT, 10)
-      : 7821;
+    const port = getRuntimeHttpPort() ?? 7821;
     const shareUrl = `http://localhost:${port}/v1/apps/shared/${shareToken}`;
 
     ctx.send(socket, {

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -14,6 +14,11 @@ import {
 } from '../../inbound/public-ingress-urls.js';
 import type { IngressConfigRequest } from '../ipc-protocol.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
+import {
+  getGatewayInternalBaseUrl,
+  getIngressPublicBaseUrl,
+  setIngressPublicBaseUrl,
+} from '../../config/env.js';
 
 // Lazily capture the env-provided INGRESS_PUBLIC_BASE_URL on first access
 // rather than at module load time. The daemon loads ~/.vellum/.env inside
@@ -23,19 +28,14 @@ let _originalIngressEnvCaptured = false;
 let _originalIngressEnv: string | undefined;
 function getOriginalIngressEnv(): string | undefined {
   if (!_originalIngressEnvCaptured) {
-    _originalIngressEnv = process.env.INGRESS_PUBLIC_BASE_URL;
+    _originalIngressEnv = getIngressPublicBaseUrl();
     _originalIngressEnvCaptured = true;
   }
   return _originalIngressEnv;
 }
 
 export function computeGatewayTarget(): string {
-  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
-    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
-  }
-  const portRaw = process.env.GATEWAY_PORT || '7830';
-  const port = Number(portRaw) || 7830;
-  return `http://127.0.0.1:${port}`;
+  return getGatewayInternalBaseUrl();
 }
 
 /**
@@ -161,15 +161,15 @@ export async function handleIngressConfig(
       // disabled ensures the gateway stops accepting inbound webhooks.
       const isEnabled = (ingress.enabled as boolean | undefined) ?? (value ? true : false);
       if (value && isEnabled) {
-        process.env.INGRESS_PUBLIC_BASE_URL = value;
+        setIngressPublicBaseUrl(value);
       } else if (isEnabled && getOriginalIngressEnv() !== undefined) {
         // Ingress is enabled but the user cleared the URL — fall back to the
         // env var that was present when the process started.
-        process.env.INGRESS_PUBLIC_BASE_URL = getOriginalIngressEnv()!;
+        setIngressPublicBaseUrl(getOriginalIngressEnv()!);
       } else {
         // Ingress is disabled or no URL is configured and no startup env var
         // exists — remove the env var so the gateway stops accepting webhooks.
-        delete process.env.INGRESS_PUBLIC_BASE_URL;
+        setIngressPublicBaseUrl(undefined);
       }
 
       ctx.send(socket, { type: 'ingress_config_response', enabled: isEnabled, publicBaseUrl: value, localGatewayTarget, success: true });
@@ -181,7 +181,7 @@ export async function handleIngressConfig(
       // credential rotation.
       // Use the effective URL from process.env (which accounts for the
       // fallback branch above) rather than the raw `value` from the UI.
-      const effectiveUrl = isEnabled ? process.env.INGRESS_PUBLIC_BASE_URL : undefined;
+      const effectiveUrl = isEnabled ? getIngressPublicBaseUrl() : undefined;
       triggerGatewayReconcile(effectiveUrl);
 
       // Best-effort Twilio webhook reconciliation: when ingress is being

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -2,6 +2,7 @@ import * as net from 'node:net';
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../../security/secure-keys.js';
 import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { triggerGatewayReconcile } from './config-ingress.js';
+import { getIngressPublicBaseUrl } from '../../config/env.js';
 import type { TelegramConfigRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 
@@ -172,7 +173,7 @@ export async function handleTelegramConfig(
       });
 
       // Trigger gateway reconcile so the webhook registration updates immediately
-      const effectiveUrl = process.env.INGRESS_PUBLIC_BASE_URL;
+      const effectiveUrl = getIngressPublicBaseUrl();
       if (effectiveUrl) {
         triggerGatewayReconcile(effectiveUrl);
       }
@@ -207,7 +208,7 @@ export async function handleTelegramConfig(
       });
 
       // Trigger reconcile to deregister webhook
-      const effectiveUrl = process.env.INGRESS_PUBLIC_BASE_URL;
+      const effectiveUrl = getIngressPublicBaseUrl();
       if (effectiveUrl) {
         triggerGatewayReconcile(effectiveUrl);
       }

--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -23,6 +23,7 @@ import { syncTwilioWebhooks } from './config-ingress.js';
 import { getReadinessService } from './config-channels.js';
 import type { TwilioConfigRequest } from '../ipc-protocol.js';
 import { log, CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, type HandlerContext } from './shared.js';
+import { getGatewayInternalBaseUrl } from '../../config/env.js';
 
 /** In-memory store for the last SMS send test result. Shared between sms_send_test and sms_doctor. */
 let _lastTestResult: {
@@ -827,8 +828,7 @@ export async function handleTwilioConfig(
 
       // Send via gateway's /deliver/sms endpoint
       const bearerToken = readHttpToken();
-      const gatewayPort = Number(process.env.GATEWAY_PORT) || 7830;
-      const gatewayUrl = process.env.GATEWAY_INTERNAL_BASE_URL?.replace(/\/+$/, '') || `http://127.0.0.1:${gatewayPort}`;
+      const gatewayUrl = getGatewayInternalBaseUrl();
 
       const sendResp = await fetch(`${gatewayUrl}/deliver/sms`, {
         method: 'POST',

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -21,6 +21,13 @@ import { rotateToolInvocations } from '../memory/tool-usage-store.js';
 import { initializeProviders, getFailoverProvider, listProviders } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
+import {
+  getQdrantUrlEnv,
+  getRuntimeHttpPort,
+  getRuntimeProxyBearerToken,
+  getRuntimeHttpHost,
+  validateEnv,
+} from '../config/env.js';
 import { ensurePromptFiles } from '../config/system-prompt.js';
 import { loadPrebuiltHtml } from '../home-base/prebuilt/seed.js';
 import { DaemonServer } from './server.js';
@@ -316,6 +323,7 @@ function createApprovalCopyGenerator(): ApprovalCopyGenerator {
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
   loadDotEnv();
+  validateEnv();
   initSentry();
   await initLogfire();
 
@@ -409,7 +417,7 @@ export async function runDaemon(): Promise<void> {
   log.info('Daemon startup: DaemonServer started');
 
   // Initialize Qdrant vector store — non-fatal so the daemon stays up without it
-  const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
+  const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
   log.info({ qdrantUrl }, 'Daemon startup: initializing Qdrant');
   const qdrantManager = new QdrantManager({
     url: qdrantUrl,
@@ -479,55 +487,53 @@ export async function runDaemon(): Promise<void> {
 
   // Start optional runtime HTTP server when RUNTIME_HTTP_PORT is set
   let runtimeHttp: RuntimeHttpServer | null = null;
-  const httpPortEnv = process.env.RUNTIME_HTTP_PORT;
-  log.info({ httpPortEnv }, 'Daemon startup: checking RUNTIME_HTTP_PORT');
-  if (httpPortEnv) {
-    const port = parseInt(httpPortEnv, 10);
-    if (!isNaN(port) && port > 0) {
-      // Resolve the bearer token in priority order:
-      //   1. Explicit env var (e.g. cloud deploys)
-      //   2. Existing token file on disk (preserves QR-paired iOS devices across restarts)
-      //   3. Fresh random token (first-time startup)
-      const httpTokenPath = getHttpTokenPath();
-      let bearerToken = process.env.RUNTIME_PROXY_BEARER_TOKEN;
-      if (!bearerToken) {
-        try {
-          const existing = readFileSync(httpTokenPath, 'utf-8').trim();
-          if (existing) bearerToken = existing;
-        } catch {
-          // File doesn't exist or can't be read — will generate below
-        }
-      }
-      if (!bearerToken) {
-        bearerToken = randomBytes(32).toString('hex');
-      }
-      writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
-      chmodSync(httpTokenPath, 0o600);
-
-      const hostname = process.env.RUNTIME_HTTP_HOST?.trim() || '127.0.0.1';
-
-      runtimeHttp = new RuntimeHttpServer({
-        port,
-        hostname,
-        bearerToken,
-        processMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
-          server.processMessage(conversationId, content, attachmentIds, options, sourceChannel),
-        persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
-          server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel),
-        runOrchestrator: server.createRunOrchestrator(),
-        interfacesDir: getInterfacesDir(),
-        approvalCopyGenerator: createApprovalCopyGenerator(),
-      });
+  const httpPort = getRuntimeHttpPort();
+  log.info({ httpPort }, 'Daemon startup: checking RUNTIME_HTTP_PORT');
+  if (httpPort) {
+    const port = httpPort;
+    // Resolve the bearer token in priority order:
+    //   1. Explicit env var (e.g. cloud deploys)
+    //   2. Existing token file on disk (preserves QR-paired iOS devices across restarts)
+    //   3. Fresh random token (first-time startup)
+    const httpTokenPath = getHttpTokenPath();
+    let bearerToken = getRuntimeProxyBearerToken();
+    if (!bearerToken) {
       try {
-        log.info({ port, hostname }, 'Daemon startup: starting runtime HTTP server');
-        await runtimeHttp.start();
-        setRelayBroadcast((msg) => server.broadcast(msg));
-        server.setHttpPort(port);
-        log.info({ port, hostname }, 'Daemon startup: runtime HTTP server listening');
-      } catch (err) {
-        log.warn({ err, port }, 'Failed to start runtime HTTP server, continuing without it');
-        runtimeHttp = null;
+        const existing = readFileSync(httpTokenPath, 'utf-8').trim();
+        if (existing) bearerToken = existing;
+      } catch {
+        // File doesn't exist or can't be read — will generate below
       }
+    }
+    if (!bearerToken) {
+      bearerToken = randomBytes(32).toString('hex');
+    }
+    writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
+    chmodSync(httpTokenPath, 0o600);
+
+    const hostname = getRuntimeHttpHost();
+
+    runtimeHttp = new RuntimeHttpServer({
+      port,
+      hostname,
+      bearerToken,
+      processMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
+        server.processMessage(conversationId, content, attachmentIds, options, sourceChannel),
+      persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
+        server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel),
+      runOrchestrator: server.createRunOrchestrator(),
+      interfacesDir: getInterfacesDir(),
+      approvalCopyGenerator: createApprovalCopyGenerator(),
+    });
+    try {
+      log.info({ port, hostname }, 'Daemon startup: starting runtime HTTP server');
+      await runtimeHttp.start();
+      setRelayBroadcast((msg) => server.broadcast(msg));
+      server.setHttpPort(port);
+      log.info({ port, hostname }, 'Daemon startup: runtime HTTP server listening');
+    } catch (err) {
+      log.warn({ err, port }, 'Failed to start runtime HTTP server, continuing without it');
+      runtimeHttp = null;
     }
   }
 

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -27,6 +27,8 @@
  * All public-facing ingress URL construction is centralized here.
  */
 
+import { getIngressPublicBaseUrl } from '../config/env.js';
+
 export interface IngressConfig {
   ingress?: { enabled?: boolean; publicBaseUrl?: string };
 }
@@ -61,7 +63,7 @@ export function getPublicBaseUrl(config: IngressConfig): string {
     if (normalized) return normalized;
   }
 
-  const ingressEnvValue = process.env.INGRESS_PUBLIC_BASE_URL;
+  const ingressEnvValue = getIngressPublicBaseUrl();
   if (ingressEnvValue) {
     const normalized = normalizeUrl(ingressEnvValue);
     if (normalized) return normalized;

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { APP_VERSION } from "./version.js";
+import { getSentryDsn } from "./config/env.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
@@ -30,10 +31,10 @@ function redactObject(obj: unknown): unknown {
   return obj;
 }
 
-/** Call after dotenv has loaded so process.env.SENTRY_DSN is available. */
+/** Call after dotenv has loaded so SENTRY_DSN is available. */
 export function initSentry(): void {
   Sentry.init({
-    dsn: process.env.SENTRY_DSN,
+    dsn: getSentryDsn(),
     release: `vellum-assistant@${APP_VERSION}`,
     environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
     sendDefaultPii: false,

--- a/assistant/src/logfire.ts
+++ b/assistant/src/logfire.ts
@@ -1,6 +1,7 @@
 import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './providers/types.js';
 import { APP_VERSION } from './version.js';
 import { getLogger } from './util/logger.js';
+import { getLogfireToken, isMonitoringEnabled } from './config/env.js';
 
 const log = getLogger('logfire');
 
@@ -8,8 +9,8 @@ type LogfireModule = typeof import('@pydantic/logfire-node');
 
 const LOGFIRE_ENABLED: boolean =
   APP_VERSION === '0.0.0-dev' &&
-  !!process.env.LOGFIRE_TOKEN &&
-  process.env.VELLUM_ENABLE_MONITORING === '1';
+  !!getLogfireToken() &&
+  isMonitoringEnabled();
 
 let logfireInstance: LogfireModule | null = null;
 
@@ -24,7 +25,7 @@ export async function initLogfire(): Promise<void> {
   try {
     const logfire = await import('@pydantic/logfire-node');
     logfire.configure({
-      token: process.env.LOGFIRE_TOKEN,
+      token: getLogfireToken(),
       serviceName: 'vellum-assistant',
       serviceVersion: APP_VERSION,
     });

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { AssistantConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
+import { getOllamaBaseUrlEnv } from '../config/env.js';
 import { GeminiEmbeddingBackend } from './embedding-gemini.js';
 import { LocalEmbeddingBackend } from './embedding-local.js';
 import { OllamaEmbeddingBackend } from './embedding-ollama.js';
@@ -293,5 +294,5 @@ function selectFallbackBackends(config: AssistantConfig, exclude: EmbeddingProvi
 function isOllamaConfigured(config: AssistantConfig): boolean {
   return config.provider === 'ollama'
     || Boolean(config.apiKeys.ollama)
-    || Boolean(process.env.OLLAMA_BASE_URL);
+    || Boolean(getOllamaBaseUrlEnv());
 }

--- a/assistant/src/memory/embedding-ollama.ts
+++ b/assistant/src/memory/embedding-ollama.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
+import { getOllamaBaseUrlEnv } from '../config/env.js';
 
 interface OllamaEmbeddingsResponse {
   data?: Array<{ embedding: number[] }>;
@@ -49,7 +50,7 @@ export class OllamaEmbeddingBackend implements EmbeddingBackend {
 }
 
 function resolveBaseUrl(override?: string): string {
-  const value = (override ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_OLLAMA_BASE_URL).trim();
+  const value = (override ?? getOllamaBaseUrlEnv() ?? DEFAULT_OLLAMA_BASE_URL).trim();
   if (value.endsWith('/')) return value.slice(0, -1);
   return value;
 }

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -4,6 +4,7 @@ import { arch, platform } from 'node:os';
 import type { Subprocess } from 'bun';
 import { getLogger } from '../util/logger.js';
 import { getDataDir } from '../util/platform.js';
+import { getQdrantUrlEnv } from '../config/env.js';
 
 const log = getLogger('qdrant-manager');
 
@@ -59,7 +60,7 @@ export class QdrantManager {
     this.shutdownGraceMs = config.shutdownGraceMs ?? SHUTDOWN_GRACE_MS;
 
     // External mode only if QDRANT_URL is explicitly set
-    this.isExternal = Boolean(process.env.QDRANT_URL?.trim());
+    this.isExternal = Boolean(getQdrantUrlEnv());
   }
 
   async start(): Promise<void> {

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -29,17 +29,14 @@ import type {
 import { getSecureKey } from '../../../security/secure-keys.js';
 import { readHttpToken } from '../../../util/platform.js';
 import { loadConfig } from '../../../config/loader.js';
+import { getGatewayInternalBaseUrl, getTwilioPhoneNumberEnv } from '../../../config/env.js';
 import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import * as sms from './client.js';
 
 /** Resolve the gateway base URL, preferring GATEWAY_INTERNAL_BASE_URL if set. */
 function getGatewayUrl(): string {
-  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
-    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
-  }
-  const port = Number(process.env.GATEWAY_PORT) || 7830;
-  return `http://127.0.0.1:${port}`;
+  return getGatewayInternalBaseUrl();
 }
 
 /** Read the runtime HTTP bearer token used to authenticate with the gateway. */
@@ -75,7 +72,7 @@ function getPhoneNumber(assistantId?: string): string | undefined {
     }
   }
 
-  const fromEnv = process.env.TWILIO_PHONE_NUMBER;
+  const fromEnv = getTwilioPhoneNumberEnv();
   if (fromEnv) return fromEnv;
 
   try {

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -25,17 +25,14 @@ import type {
 } from '../../provider-types.js';
 import { getSecureKey } from '../../../security/secure-keys.js';
 import { readHttpToken } from '../../../util/platform.js';
+import { getGatewayInternalBaseUrl } from '../../../config/env.js';
 import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../../memory/external-conversation-store.js';
 import * as telegram from './client.js';
 
 /** Resolve the gateway base URL, preferring GATEWAY_INTERNAL_BASE_URL if set. */
 function getGatewayUrl(): string {
-  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
-    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, "");
-  }
-  const port = Number(process.env.GATEWAY_PORT) || 7830;
-  return `http://127.0.0.1:${port}`;
+  return getGatewayInternalBaseUrl();
 }
 
 /** Read the runtime HTTP bearer token used to authenticate with the gateway. */

--- a/assistant/src/providers/ollama/client.ts
+++ b/assistant/src/providers/ollama/client.ts
@@ -1,4 +1,5 @@
 import { OpenAIProvider } from '../openai/client.js';
+import { getOllamaBaseUrlEnv } from '../../config/env.js';
 
 export interface OllamaProviderOptions {
   apiKey?: string;
@@ -20,7 +21,7 @@ export class OllamaProvider extends OpenAIProvider {
 }
 
 function resolveBaseUrl(optionBaseUrl?: string): string {
-  for (const candidate of [optionBaseUrl, process.env.OLLAMA_BASE_URL]) {
+  for (const candidate of [optionBaseUrl, getOllamaBaseUrlEnv()]) {
     if (typeof candidate === 'string') {
       const trimmed = candidate.trim();
       if (trimmed.length > 0) return trimmed;

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -12,6 +12,7 @@ import {
 } from '../calls/twilio-rest.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import { loadRawConfig } from '../config/loader.js';
+import { getTwilioPhoneNumberEnv } from '../config/env.js';
 
 /** Remote check results are cached for 5 minutes before being considered stale. */
 export const REMOTE_TTL_MS = 5 * 60 * 1000;
@@ -64,12 +65,12 @@ function resolveSmsPhoneNumber(assistantId?: string): string {
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
     const mapped = getAssistantMappedPhoneNumber(smsConfig, assistantId);
     return mapped
-      || process.env.TWILIO_PHONE_NUMBER
+      || getTwilioPhoneNumberEnv()
       || (smsConfig.phoneNumber as string)
       || getSecureKey('credential:twilio:phone_number')
       || '';
   } catch {
-    return process.env.TWILIO_PHONE_NUMBER
+    return getTwilioPhoneNumberEnv()
       || getSecureKey('credential:twilio:phone_number')
       || '';
   }
@@ -180,12 +181,12 @@ function resolveVoicePhoneNumber(assistantId?: string): string {
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
     const mapped = getAssistantMappedPhoneNumber(smsConfig, assistantId);
     return mapped
-      || process.env.TWILIO_PHONE_NUMBER
+      || getTwilioPhoneNumberEnv()
       || (smsConfig.phoneNumber as string)
       || getSecureKey('credential:twilio:phone_number')
       || '';
   } catch {
-    return process.env.TWILIO_PHONE_NUMBER
+    return getTwilioPhoneNumberEnv()
       || getSecureKey('credential:twilio:phone_number')
       || '';
   }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -12,6 +12,12 @@ import { timingSafeEqual } from 'node:crypto';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspacePromptPath, readLockfile } from '../util/platform.js';
+import {
+  getGatewayInternalBaseUrl,
+  isTwilioWebhookValidationDisabled,
+  isHttpAuthDisabled,
+  getRuntimeGatewayOriginSecret,
+} from '../config/env.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl } from '../inbound/public-ingress-urls.js';
@@ -104,11 +110,7 @@ const DEFAULT_HOSTNAME = '127.0.0.1';
 
 /** Resolve the gateway base URL for internal delivery callbacks. */
 function getGatewayBaseUrl(): string {
-  if (process.env.GATEWAY_INTERNAL_BASE_URL) {
-    return process.env.GATEWAY_INTERNAL_BASE_URL.replace(/\/+$/, '');
-  }
-  const port = Number(process.env.GATEWAY_PORT) || 7830;
-  return `http://127.0.0.1:${port}`;
+  return getGatewayInternalBaseUrl();
 }
 
 /** Global hard cap on request body size (50 MB). Bun rejects larger payloads before they reach handlers. */
@@ -310,7 +312,7 @@ async function validateTwilioWebhook(
   const rawBody = await req.text();
 
   // Allow explicit local-dev bypass — must be exactly "true"
-  if (process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED === 'true') {
+  if (isTwilioWebhookValidationDisabled()) {
     log.warn('Twilio webhook signature validation explicitly disabled via TWILIO_WEBHOOK_VALIDATION_DISABLED');
     return { body: rawBody };
   }
@@ -578,7 +580,7 @@ export class RuntimeHttpServer {
     }
 
     // Require bearer token when configured
-    if ((process.env.DISABLE_HTTP_AUTH ?? "").toLowerCase() !== "true" && this.bearerToken) {
+    if (!isHttpAuthDisabled() && this.bearerToken) {
       const authHeader = req.headers.get('authorization');
       const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
       if (!token || !this.verifyToken(token)) {
@@ -789,7 +791,7 @@ export class RuntimeHttpServer {
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
-        const gatewayOriginSecret = process.env.RUNTIME_GATEWAY_ORIGIN_SECRET || undefined;
+        const gatewayOriginSecret = getRuntimeGatewayOriginSecret();
         return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId, gatewayOriginSecret, this.approvalCopyGenerator);
       }
 


### PR DESCRIPTION
## Summary
- Created `assistant/src/config/env.ts` — a centralized module with typed, validated accessors for all runtime environment variables (gateway, ingress, Twilio, monitoring, Qdrant, Ollama, etc.)
- Updated ~20 source files to use the new module, eliminating 5 duplicated `getGatewayBaseUrl()` functions and dozens of raw `process.env` reads scattered across the codebase
- Added `validateEnv()` startup validation in daemon lifecycle to fail fast on invalid configuration

## Original prompt
Centralize environment variable access — 20+ files read process.env directly without validation. Create a validated config module that fails fast on missing required vars at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
