### PR TITLE
fix: pre-commit hook false positive on TS clientSecret property names

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -65,6 +65,10 @@ declare -a SAFE_LINE_PATTERNS=(
     "[Pp]rivate[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
     "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here|[a-zA-Z][a-zA-Z_/ '-]*[A-Z_/][a-zA-Z_/ '.-]*)>['\"]"
     "[a-zA-Z_-]*[[:space:]]*[:=][[:space:]]*\\\$\\{\\{[[:space:]]*secrets\\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\\}\\}([[:space:]]+#.*)?[[:space:]]*$"
+    # TS/JS: camelCase property names containing clientSecret used as identifiers
+    # (typeof checks, null/undefined comparisons, variable/property references).
+    # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
+    "[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*[:=]+[[:space:]]*(typeof[[:space:]]|null[[:space:];,){}]|undefined[[:space:];,){}]|[a-zA-Z_][a-zA-Z0-9_]*[.?]+[a-zA-Z_])"
 )
 
 matches_safe_line_pattern() {
@@ -142,6 +146,12 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_GHA_SECRETS_LINE='          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}'
     SAFE_GHA_SECRETS_COMMENT_LINE='          client_secret: ${{ secrets.CLIENT_SECRET }} # rotated monthly'
     UNSAFE_GHA_SECRETS_FALLBACK='          client_secret: ${{ secrets.CLIENT_SECRET || "SuperSecretFallback12345" }}'
+
+    # TS/JS: camelCase property identifiers (false positives to avoid)
+    SAFE_TS_TYPEOF_LINE='    oauth2ClientSecret: typeof record.oauth2ClientSecret === '\''string'\'' ? record.oauth2ClientSecret : undefined,'
+    SAFE_TS_DOTREF_LINE='    existing.oauth2ClientSecret = policy.oauth2ClientSecret;'
+    SAFE_TS_NULLCHECK_LINE='      if (policy.oauth2ClientSecret === null) {'
+    SAFE_TS_OPTIONAL_LINE='    oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -293,6 +303,22 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$UNSAFE_GHA_SECRETS_FALLBACK" && matches_safe_line_pattern "$UNSAFE_GHA_SECRETS_FALLBACK"; then
         echo -e "${RED}Self-test failed:${NC} GHA secrets with fallback value was incorrectly whitelisted"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_TYPEOF_LINE" && ! matches_safe_line_pattern "$SAFE_TS_TYPEOF_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} TS typeof clientSecret property check false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_DOTREF_LINE" && ! matches_safe_line_pattern "$SAFE_TS_DOTREF_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} TS dotted clientSecret assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_NULLCHECK_LINE" && ! matches_safe_line_pattern "$SAFE_TS_NULLCHECK_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} TS clientSecret null comparison false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_OPTIONAL_LINE" && ! matches_safe_line_pattern "$SAFE_TS_OPTIONAL_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} TS optional chaining clientSecret false positive"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- Added a safe-line pattern to the secret scanner for TypeScript/JavaScript camelCase property identifiers containing `clientSecret` (e.g. `oauth2ClientSecret: typeof record.oauth2ClientSecret`)
- Covers typeof checks, null/undefined comparisons, dotted property references, and optional chaining — all cases where `clientSecret` is a property name, not a secret value
- Added 4 self-test cases to validate the new pattern and prevent regressions

## Original prompt
fix the pre-commit hook to avoid the false positive (adding a comment explaining your changes). then in another PR, add back the changes you skipped because of the pre-commit failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
