### PR TITLE
fix: remove unused getDb import in jobs-worker.ts

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,7 +1,7 @@
 import type { AssistantConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
-import { getDb, rawRun } from './db.js';
+import { rawRun } from './db.js';
 import {
   claimMemoryJobs,
   completeMemoryJob,


### PR DESCRIPTION
## Summary
- Removed unused `getDb` import from `assistant/src/memory/jobs-worker.ts` that was causing lint failure in CI

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22342632046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
