### PR TITLE
fix: handle JSON literal null in parseJsonSafe validation

### DIFF
--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -127,7 +127,7 @@ export class EvaluateTypescriptTool implements Tool {
     if (Buffer.byteLength(mockInputJson) > MAX_MOCK_INPUT_BYTES) {
       return { content: `Error: mock_input_json exceeds maximum size of ${MAX_MOCK_INPUT_BYTES} bytes`, isError: true };
     }
-    if (parseJsonSafe(mockInputJson) === null) {
+    if (parseJsonSafe(mockInputJson) === null && mockInputJson.trim() !== 'null') {
       return { content: 'Error: mock_input_json must be valid JSON', isError: true };
     }
 


### PR DESCRIPTION
Addresses feedback on #7658 — parseJsonSafe returns null both on parse failure and for valid JSON null, so the mock_input_json validation now also checks that the raw input isn't the literal string 'null' before rejecting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
