### PR TITLE
fix: abort file_write preview when safeStatSync fails instead of falling through

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -794,7 +794,7 @@ function computePreviewDiff(
       const isNewFile = !pathExists(filePath);
       if (!isNewFile) {
         const stat = safeStatSync(filePath);
-        if (stat && stat.size > MAX_FILE_SIZE_BYTES) return undefined;
+        if (!stat || stat.size > MAX_FILE_SIZE_BYTES) return undefined;
       }
       const oldContent = isNewFile ? '' : readFileSync(filePath, 'utf-8');
       return { filePath, oldContent, newContent: content, isNewFile };


### PR DESCRIPTION
Addresses feedback on #7663 — when safeStatSync returns null for an existing file in the file_write preview path, the code now skips the read instead of falling through past the MAX_FILE_SIZE_BYTES guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
