### PR TITLE
fix: restrict Twilio bypass to exact 'true' and throw on malformed numeric env values

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -35,8 +35,7 @@ function int(name: string, fallback?: number): number | undefined {
   if (!raw) return fallback;
   const n = parseInt(raw, 10);
   if (isNaN(n)) {
-    log.warn(`Invalid integer for ${name}: "${raw}", using fallback ${fallback}`);
-    return fallback;
+    throw new Error(`Invalid integer for ${name}: "${raw}"${fallback !== undefined ? ` (fallback: ${fallback})` : ''}`);
   }
   return n;
 }
@@ -118,7 +117,10 @@ export function getTwilioWssBaseUrl(): string | undefined {
 }
 
 export function isTwilioWebhookValidationDisabled(): boolean {
-  return flag('TWILIO_WEBHOOK_VALIDATION_DISABLED');
+  // Intentionally strict: only exact "true" disables validation (not "1").
+  // This is a security-sensitive bypass — we don't want environments that
+  // template booleans as "1" to silently skip webhook signature checks.
+  return process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED === 'true';
 }
 
 export function getCallWelcomeGreeting(): string | undefined {


### PR DESCRIPTION
Addresses feedback on #7665: (1) isTwilioWebhookValidationDisabled() now checks for exact 'true' instead of using flag() which also accepts '1', preventing environments that template booleans as '1' from silently disabling webhook signature verification. (2) numeric env parser now throws an error when a set value can't be parsed instead of silently returning the default, ensuring misconfigurations like GATEWAY_PORT=abc fail fast at startup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
