### PR TITLE
fix: use mock.module for gateway fetch mocking to fix Linux CI

### DIFF
--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -1,6 +1,14 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
-import { createOAuthCallbackHandler } from "../http/routes/oauth-callback.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createOAuthCallbackHandler } = await import("../http/routes/oauth-callback.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -43,23 +51,14 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: () => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("OAuth callback handler", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("forwards valid state+code to runtime and returns success page", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    fetchMock = mock(async () =>
+      Response.json({ ok: true }, { status: 200 }),
     );
 
     const handler = createOAuthCallbackHandler(makeConfig());
@@ -105,8 +104,8 @@ describe("OAuth callback handler", () => {
   });
 
   test("error param is forwarded to runtime", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    fetchMock = mock(async () =>
+      Response.json({ ok: true }, { status: 200 }),
     );
 
     const handler = createOAuthCallbackHandler(makeConfig());
@@ -126,10 +125,8 @@ describe("OAuth callback handler", () => {
   });
 
   test("runtime returning 404 (unknown state) shows error page", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        Response.json({ error: "Unknown state" }, { status: 404 }),
-      ),
+    fetchMock = mock(async () =>
+      Response.json({ error: "Unknown state" }, { status: 404 }),
     );
 
     const handler = createOAuthCallbackHandler(makeConfig());
@@ -146,7 +143,7 @@ describe("OAuth callback handler", () => {
   });
 
   test("runtime unreachable returns 502 error page", async () => {
-    mockFetch(() => Promise.reject(new Error("Connection refused")));
+    fetchMock = mock(async () => { throw new Error("Connection refused"); });
 
     const handler = createOAuthCallbackHandler(makeConfig());
     const req = new Request(
@@ -162,8 +159,8 @@ describe("OAuth callback handler", () => {
   });
 
   test("omits Authorization header when runtimeBearerToken is undefined", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(Response.json({ ok: true }, { status: 200 })),
+    fetchMock = mock(async () =>
+      Response.json({ ok: true }, { status: 200 }),
     );
 
     const handler = createOAuthCallbackHandler(

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,13 +1,21 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import {
+import type { RuntimeAttachmentMeta } from "../runtime/client.js";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const {
   forwardToRuntime,
   downloadAttachment,
   forwardTwilioVoiceWebhook,
   forwardTwilioStatusWebhook,
   forwardTwilioConnectActionWebhook,
-} from "../runtime/client.js";
-import type { RuntimeAttachmentMeta } from "../runtime/client.js";
-import type { GatewayConfig } from "../config.js";
+} = await import("../runtime/client.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -79,25 +87,14 @@ const successBody = {
   },
 };
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("forwardToRuntime", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("successful forward returns runtime response", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(successBody), { status: 200 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(JSON.stringify(successBody), { status: 200 }),
     );
 
     const config = makeConfig();
@@ -108,8 +105,8 @@ describe("forwardToRuntime", () => {
   });
 
   test("4xx error throws immediately without retry", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(new Response("Bad request", { status: 400 })),
+    fetchMock = mock(async () =>
+      new Response("Bad request", { status: 400 }),
     );
 
     const config = makeConfig();
@@ -124,7 +121,7 @@ describe("forwardToRuntime", () => {
     const config = makeConfig();
     const expectedUrl = `${config.assistantRuntimeBaseUrl}/v1/assistants/assistant-a/channels/inbound`;
     let inboundCallCount = 0;
-    const fetchMock = mockFetch((input) => {
+    fetchMock = mock(async (input) => {
       const calledUrl =
         typeof input === "string"
           ? input
@@ -136,13 +133,9 @@ describe("forwardToRuntime", () => {
       }
 
       if (inboundCallCount <= 2) {
-        return Promise.resolve(
-          new Response("Internal error", { status: 500 }),
-        );
+        return new Response("Internal error", { status: 500 });
       }
-      return Promise.resolve(
-        new Response(JSON.stringify(successBody), { status: 200 }),
-      );
+      return new Response(JSON.stringify(successBody), { status: 200 });
     });
 
     const result = await forwardToRuntime(config, "assistant-a", payload);
@@ -155,8 +148,8 @@ describe("forwardToRuntime", () => {
   });
 
   test("5xx error exhausts retries and throws", async () => {
-    mockFetch(() =>
-      Promise.resolve(new Response("Server error", { status: 500 })),
+    fetchMock = mock(async () =>
+      new Response("Server error", { status: 500 }),
     );
 
     const config = makeConfig();
@@ -166,10 +159,8 @@ describe("forwardToRuntime", () => {
   });
 
   test("response includes typed attachment metadata", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(successBody), { status: 200 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(JSON.stringify(successBody), { status: 200 }),
     );
 
     const config = makeConfig();
@@ -184,10 +175,8 @@ describe("forwardToRuntime", () => {
   });
 
   test("sends Authorization header when runtimeBearerToken is configured", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(successBody), { status: 200 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(JSON.stringify(successBody), { status: 200 }),
     );
 
     const config = makeConfig({ runtimeBearerToken: "my-secret-token" });
@@ -199,10 +188,8 @@ describe("forwardToRuntime", () => {
   });
 
   test("omits Authorization header when runtimeBearerToken is undefined", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(successBody), { status: 200 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(JSON.stringify(successBody), { status: 200 }),
     );
 
     const config = makeConfig();
@@ -215,10 +202,8 @@ describe("forwardToRuntime", () => {
 });
 
 describe("downloadAttachment", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("downloads attachment payload with base64 data", async () => {
@@ -231,10 +216,8 @@ describe("downloadAttachment", () => {
       data: "iVBORw0KGgo=",
     };
 
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(attachmentPayload), { status: 200 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(JSON.stringify(attachmentPayload), { status: 200 }),
     );
 
     const config = makeConfig();
@@ -248,10 +231,8 @@ describe("downloadAttachment", () => {
   });
 
   test("throws on 404 not found", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response('{"error":"Attachment not found"}', { status: 404 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response('{"error":"Attachment not found"}', { status: 404 }),
     );
 
     const config = makeConfig();
@@ -262,21 +243,17 @@ describe("downloadAttachment", () => {
 });
 
 describe("forwardTwilioVoiceWebhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("sends params and originalUrl to runtime internal endpoint", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(twiml, {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(twiml, {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const config = makeConfig({ runtimeBearerToken: "rt-tok" });
@@ -302,16 +279,12 @@ describe("forwardTwilioVoiceWebhook", () => {
 });
 
 describe("forwardTwilioStatusWebhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("sends params to runtime internal status endpoint", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(new Response(null, { status: 200 })),
-    );
+    fetchMock = mock(async () => new Response(null, { status: 200 }));
 
     const config = makeConfig({ runtimeBearerToken: "rt-tok" });
     const params = { CallSid: "CA123", CallStatus: "completed" };
@@ -329,21 +302,17 @@ describe("forwardTwilioStatusWebhook", () => {
 });
 
 describe("forwardTwilioConnectActionWebhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("sends params to runtime internal connect-action endpoint", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(twiml, {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(twiml, {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const config = makeConfig({ runtimeBearerToken: "rt-tok" });
@@ -358,10 +327,8 @@ describe("forwardTwilioConnectActionWebhook", () => {
   });
 
   test("returns runtime error status and body", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response('{"error":"Not found"}', { status: 404 }),
-      ),
+    fetchMock = mock(async () =>
+      new Response('{"error":"Not found"}', { status: 404 }),
     );
 
     const config = makeConfig();

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -1,6 +1,14 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
 import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createRuntimeProxyHandler } = await import("../http/routes/runtime-proxy.js");
 
 const TOKEN = "test-secret-token";
 
@@ -45,19 +53,17 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const originalFetch = globalThis.fetch;
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchMock = mock(async () => new Response());
 });
 
 function mockUpstream() {
-  globalThis.fetch = mock(async () => {
+  fetchMock = mock(async () => {
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
-  }) as any;
+  });
 }
 
 describe("runtime proxy auth enforcement", () => {
@@ -98,13 +104,13 @@ describe("runtime proxy auth enforcement", () => {
 
   test("auth required: replaces client authorization with configured bearer token for upstream", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
-      capturedHeaders = init?.headers;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health", {

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -1,6 +1,14 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
 import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createRuntimeProxyHandler } = await import("../http/routes/runtime-proxy.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -43,19 +51,17 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const originalFetch = globalThis.fetch;
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchMock = mock(async () => new Response());
 });
 
 describe("runtime proxy handler", () => {
   test("rewrites /v1/assistants/:assistantId/... to /v1/... for upstream", async () => {
     const captured: { url: string }[] = [];
-    globalThis.fetch = mock(async (input: any) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       captured.push({ url: String(input) });
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test-assistant/channels/inbound");
@@ -66,13 +72,13 @@ describe("runtime proxy handler", () => {
 
   test("forwards request to upstream with correct path and query (assistant-scoped rewrite)", async () => {
     const captured: { url: string; method: string }[] = [];
-    globalThis.fetch = mock(async (input: any, init?: any) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       captured.push({ url: String(input), method: init?.method ?? "GET" });
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/assistants/test/health?foo=bar");
@@ -88,13 +94,13 @@ describe("runtime proxy handler", () => {
 
   test("forwards POST body to upstream", async () => {
     let capturedBody = "";
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       if (init?.body) {
         // Body is an ArrayBuffer after buffering in the proxy handler
-        capturedBody = new TextDecoder().decode(init.body);
+        capturedBody = new TextDecoder().decode(init.body as ArrayBuffer);
       }
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/chat", {
@@ -109,9 +115,9 @@ describe("runtime proxy handler", () => {
   });
 
   test("relays upstream status code", async () => {
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       return new Response("Not Found", { status: 404 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/nonexistent");
@@ -121,9 +127,9 @@ describe("runtime proxy handler", () => {
   });
 
   test("returns 502 on upstream connection failure", async () => {
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       throw new Error("Connection refused");
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health");
@@ -136,10 +142,10 @@ describe("runtime proxy handler", () => {
 
   test("strips hop-by-hop headers from request", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
-      capturedHeaders = init?.headers;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health", {
@@ -159,7 +165,7 @@ describe("runtime proxy handler", () => {
   });
 
   test("strips hop-by-hop headers from response", async () => {
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       return new Response("ok", {
         status: 200,
         headers: {
@@ -169,7 +175,7 @@ describe("runtime proxy handler", () => {
           "content-type": "text/plain",
         },
       });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health");
@@ -183,9 +189,9 @@ describe("runtime proxy handler", () => {
 
   test("returns 504 on upstream timeout", async () => {
     const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       throw timeoutError;
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
     const req = new Request("http://localhost:7830/v1/health");
@@ -198,10 +204,10 @@ describe("runtime proxy handler", () => {
 
   test("passes AbortSignal.timeout to upstream fetch", async () => {
     let capturedSignal: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
       capturedSignal = init?.signal;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 5000 }));
     const req = new Request("http://localhost:7830/v1/health");
@@ -213,10 +219,10 @@ describe("runtime proxy handler", () => {
 
   test("forwards authorization header when auth is not required", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
-      capturedHeaders = init?.headers;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health", {
@@ -229,10 +235,10 @@ describe("runtime proxy handler", () => {
 
   test("replaces client authorization with configured bearer token for upstream", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
-      capturedHeaders = init?.headers;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(
       makeConfig({ runtimeProxyBearerToken: "daemon-token" }),
@@ -247,9 +253,9 @@ describe("runtime proxy handler", () => {
 
   test("truncates long upstream error bodies in logs", async () => {
     const longBody = "x".repeat(512);
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       return new Response(longBody, { status: 500 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/fail");
@@ -263,10 +269,10 @@ describe("runtime proxy handler", () => {
 
   test("does not forward host header to upstream", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
-      capturedHeaders = init?.headers;
+    fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers as unknown as Headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/health", {
@@ -282,10 +288,10 @@ describe("runtime proxy handler", () => {
   describe("webhook path guard", () => {
     test("blocks /webhooks/telegram from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/webhooks/telegram", {
@@ -304,10 +310,10 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/twilio/voice from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
@@ -321,10 +327,10 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/oauth/callback from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/webhooks/oauth/callback");
@@ -336,10 +342,10 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/any-future-channel from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/webhooks/any-future-channel", {
@@ -353,10 +359,10 @@ describe("runtime proxy handler", () => {
 
     test("allows /v1/channels/inbound to be proxied (non-webhook path)", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/v1/channels/inbound", {
@@ -372,10 +378,10 @@ describe("runtime proxy handler", () => {
 
     test("allows /v1/health to be proxied (non-webhook path)", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      fetchMock = mock(async (input: string | URL | Request) => {
         fetchCalls.push(String(input));
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(makeConfig());
       const req = new Request("http://localhost:7830/v1/health");
@@ -391,10 +397,10 @@ describe("runtime proxy handler", () => {
   describe("gateway-origin header", () => {
     test("sets X-Gateway-Origin header when runtimeBearerToken is configured", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = mock(async (_input: any, init?: any) => {
-        capturedHeaders = init?.headers;
+      fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = init?.headers as unknown as Headers;
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(
         makeConfig({ runtimeBearerToken: "runtime-secret" }),
@@ -411,10 +417,10 @@ describe("runtime proxy handler", () => {
 
     test("does not set X-Gateway-Origin header when no runtimeBearerToken", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = mock(async (_input: any, init?: any) => {
-        capturedHeaders = init?.headers;
+      fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = init?.headers as unknown as Headers;
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(
         makeConfig({ runtimeBearerToken: undefined }),

--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { GatewayConfig } from "../config.js";
-import { callTelegramApi } from "../telegram/api.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { callTelegramApi } = await import("../telegram/api.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -47,22 +51,15 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("callTelegramApi transport error redaction", () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("redacts bot token from warning logs and thrown error", async () => {
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    mockFetch(async () => {
+    fetchMock = mock(async () => {
       const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
         path?: string;
         code?: string;
@@ -91,7 +88,7 @@ describe("callTelegramApi transport error redaction", () => {
     // "error-123456789:...") must still be redacted.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    mockFetch(async () => {
+    fetchMock = mock(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -121,7 +118,7 @@ describe("callTelegramApi transport error redaction", () => {
     // would fail to match the trailing `-`, leaking part of the token.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz01234567-"].join("");
 
-    mockFetch(async () => {
+    fetchMock = mock(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,10 +1,14 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { createTelegramDeliverHandler } from "../http/routes/telegram-deliver.js";
 import type { GatewayConfig } from "../config.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createTelegramDeliverHandler } = await import("../http/routes/telegram-deliver.js");
 
 const TOKEN = "test-deliver-token";
 
@@ -49,19 +53,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchMock = mock(async () => new Response());
 });
 
 function mockTelegramApi() {
-  mockFetch(async () => {
+  fetchMock = mock(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -72,7 +69,7 @@ function mockTelegramApi() {
 describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments without assistantId using assistant-less download path", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (assistant-less path)
@@ -126,7 +123,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
   test("delivers attachments with assistantId using legacy download path", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (legacy path)
@@ -178,7 +175,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 describe("/deliver/telegram ID-only attachment validation", () => {
   test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-id-only")) {
@@ -244,7 +241,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
   test("full-metadata attachments still accepted (backward compatibility)", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-compat")) {

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,10 +1,14 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
 import type { GatewayConfig } from "../config.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createTelegramReconcileHandler } = await import("../http/routes/telegram-reconcile.js");
 
 function makeTelegramResponse(result: unknown) {
   return new Response(JSON.stringify({ ok: true, result }), {
@@ -72,18 +76,9 @@ function makeRequest(
   });
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
-let fetchMock: ReturnType<typeof mock<(...args: Parameters<typeof fetch>) => Promise<Response>>> | null = null;
-
 /** Default fetch mock that handles Telegram API calls with success responses. */
 function installDefaultFetchMock() {
-  fetchMock = mockFetch(async (input: string | URL | Request) => {
+  fetchMock = mock(async (input: string | URL | Request) => {
     const url =
       typeof input === "string"
         ? input
@@ -110,8 +105,7 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
-    fetchMock = null;
+    fetchMock = mock(async () => new Response());
   });
 
   test("rejects non-POST methods", async () => {
@@ -199,7 +193,7 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 502 when reconcile throws", async () => {
-    fetchMock = mockFetch(async () => {
+    fetchMock = mock(async () => {
       throw new Error("Telegram API error");
     });
     const config = makeConfig();
@@ -230,7 +224,7 @@ describe("POST /internal/telegram/reconcile", () => {
 
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
-    fetchMock = mockFetch(
+    fetchMock = mock(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === "string"

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,11 +1,15 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { sendTelegramAttachments } from "../telegram/send.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { sendTelegramAttachments } = await import("../telegram/send.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -50,22 +54,15 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("sendTelegramAttachments", () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("sends image attachment via sendPhoto", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // Runtime download endpoint
@@ -105,7 +102,7 @@ describe("sendTelegramAttachments", () => {
   test("sends non-image attachment via sendDocument", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-2")) {
@@ -142,7 +139,7 @@ describe("sendTelegramAttachments", () => {
   test("skips oversized attachments and sends failure notice", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       return new Response(JSON.stringify(telegramOk));
@@ -167,7 +164,7 @@ describe("sendTelegramAttachments", () => {
   test("downloads via assistant-less path when assistantId is undefined", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-no-assist")) {
@@ -207,7 +204,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment hydrates metadata from downloaded payload", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-id-only")) {
@@ -240,7 +237,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment falls back to defaults when download payload also lacks metadata", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-bare")) {
@@ -268,7 +265,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment skipped when hydrated size exceeds limit", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-big")) {
@@ -302,7 +299,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment uses id as filename fallback", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
-    mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push({ url: urlStr, init });
       if (urlStr.includes("/attachments/my-attachment-id")) {
@@ -332,7 +329,7 @@ describe("sendTelegramAttachments", () => {
   test("full-metadata payload still works (backward compatibility)", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-full")) {
@@ -369,7 +366,7 @@ describe("sendTelegramAttachments", () => {
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // First attachment download fails

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -1,10 +1,14 @@
 import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
-import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createTelegramWebhookHandler } = await import("../http/routes/telegram-webhook.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -72,19 +76,12 @@ function makeWebhookRequest(payload: unknown, secret = "test-webhook-secret"): R
 
 let fetchCalls: { url: string; method: string; body?: unknown; headers?: Record<string, string> }[];
 
-function mockFetchFn(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 beforeEach(() => {
   fetchCalls = [];
 });
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchMock = mock(async () => new Response());
 });
 
 /** Extract headers from a fetch call into a plain object. */
@@ -111,7 +108,7 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
  * Runtime forward calls get an eventId response; Telegram API calls get { ok: true }.
  */
 function installFetchMock() {
-  mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+  fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
     let body: unknown;
@@ -328,7 +325,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
     // Install a fetch mock where the runtime inbound call blocks on the first
     // invocation and responds immediately on subsequent ones.
     let inboundCallCount = 0;
-    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -387,7 +384,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
     });
 
     let callCount = 0;
-    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -1,10 +1,14 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
 
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { reconcileTelegramWebhook } = await import("../telegram/webhook-manager.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -47,18 +51,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
-let fetchMock: ReturnType<typeof mockFetch> | null = null;
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
-  fetchMock = null;
+  fetchMock = mock(async () => new Response());
 });
 
 function makeTelegramResponse(result: unknown) {
@@ -72,7 +66,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -104,7 +98,7 @@ describe("reconcileTelegramWebhook", () => {
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {
     const calls: string[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -130,7 +124,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -156,7 +150,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when bot token is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    fetchMock = mock(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramBotToken: undefined });
     await reconcileTelegramWebhook(config);
@@ -165,7 +159,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when webhook secret is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    fetchMock = mock(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ telegramWebhookSecret: undefined });
     await reconcileTelegramWebhook(config);
@@ -174,7 +168,7 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when ingress URL is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    fetchMock = mock(async () => new Response("", { status: 200 }));
 
     const config = makeConfig({ ingressPublicBaseUrl: undefined });
     await reconcileTelegramWebhook(config);
@@ -185,7 +179,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request) => {
+    fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -1,9 +1,17 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import { createHmac } from "node:crypto";
 import type { GatewayConfig } from "../config.js";
-import { createTwilioVoiceWebhookHandler } from "../http/routes/twilio-voice-webhook.js";
-import { createTwilioStatusWebhookHandler } from "../http/routes/twilio-status-webhook.js";
-import { createTwilioConnectActionWebhookHandler } from "../http/routes/twilio-connect-action-webhook.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createTwilioVoiceWebhookHandler } = await import("../http/routes/twilio-voice-webhook.js");
+const { createTwilioStatusWebhookHandler } = await import("../http/routes/twilio-status-webhook.js");
+const { createTwilioConnectActionWebhookHandler } = await import("../http/routes/twilio-connect-action-webhook.js");
 
 const AUTH_TOKEN = "test-twilio-auth-token";
 
@@ -86,18 +94,9 @@ function buildSignedRequest(
   });
 }
 
-function mockFetch(fn: () => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("Twilio voice webhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("rejects GET requests with 405", async () => {
@@ -149,13 +148,11 @@ describe("Twilio voice webhook", () => {
 
   test("forwards valid signed request to runtime and returns response", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(twiml, {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(twiml, {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const handler = createTwilioVoiceWebhookHandler(makeConfig());
@@ -175,7 +172,7 @@ describe("Twilio voice webhook", () => {
   });
 
   test("returns 502 when runtime is unreachable", async () => {
-    mockFetch(() => Promise.reject(new Error("Connection refused")));
+    fetchMock = mock(async () => { throw new Error("Connection refused"); });
 
     const handler = createTwilioVoiceWebhookHandler(makeConfig());
     const url = "http://localhost:7830/webhooks/twilio/voice";
@@ -228,10 +225,8 @@ describe("Twilio voice webhook", () => {
 });
 
 describe("Twilio status webhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("rejects invalid signature with 403", async () => {
@@ -249,9 +244,7 @@ describe("Twilio status webhook", () => {
   });
 
   test("forwards valid signed request to runtime", async () => {
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(new Response(null, { status: 200 })),
-    );
+    fetchMock = mock(async () => new Response(null, { status: 200 }));
 
     const handler = createTwilioStatusWebhookHandler(makeConfig());
     const url = "http://localhost:7830/webhooks/twilio/status";
@@ -266,7 +259,7 @@ describe("Twilio status webhook", () => {
   });
 
   test("returns 502 when runtime returns error", async () => {
-    mockFetch(() => Promise.reject(new Error("Runtime down")));
+    fetchMock = mock(async () => { throw new Error("Runtime down"); });
 
     const handler = createTwilioStatusWebhookHandler(makeConfig());
     const url = "http://localhost:7830/webhooks/twilio/status";
@@ -279,10 +272,8 @@ describe("Twilio status webhook", () => {
 });
 
 describe("Twilio connect-action webhook", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("rejects invalid signature with 403", async () => {
@@ -301,13 +292,11 @@ describe("Twilio connect-action webhook", () => {
 
   test("forwards valid signed request to runtime", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
-    const fetchMock = mockFetch(() =>
-      Promise.resolve(
-        new Response(twiml, {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(twiml, {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const handler = createTwilioConnectActionWebhookHandler(makeConfig());
@@ -327,21 +316,17 @@ describe("Twilio connect-action webhook", () => {
 });
 
 describe("Twilio webhook signature with canonical ingress base URL", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchMock = mock(async () => new Response());
   });
 
   test("validates signature against ingressPublicBaseUrl when configured", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
-    mockFetch(() =>
-      Promise.resolve(
-        new Response(twiml, {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response(twiml, {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const publicBaseUrl = "https://public.example.com";
@@ -370,13 +355,11 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
   });
 
   test("accepts when signature matches raw request URL even with public URL configured", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const publicBaseUrl = "https://public.example.com";
@@ -404,13 +387,11 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
   });
 
   test("accepts signature from forwarded public URL headers when configured URL is stale", async () => {
-    mockFetch(() =>
-      Promise.resolve(
-        new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
-          status: 200,
-          headers: { "Content-Type": "text/xml" },
-        }),
-      ),
+    fetchMock = mock(async () =>
+      new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
     );
 
     const staleConfiguredBase = "https://stale.example.com";

--- a/gateway/src/fetch.ts
+++ b/gateway/src/fetch.ts
@@ -1,0 +1,13 @@
+/**
+ * Thin wrapper around globalThis.fetch exposed through a module boundary.
+ * On some platforms (Bun 1.3.9 on Linux) replacing globalThis.fetch at
+ * runtime does not reliably intercept outgoing requests.  Importing fetch
+ * via this module allows tests to use mock.module() for deterministic,
+ * cross-platform interception.
+ */
+export function fetchImpl(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  return globalThis.fetch(input, init);
+}

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
 import { validateBearerToken } from "../auth/bearer.js";
 import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
@@ -129,7 +130,7 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     let response: Response;
     try {
-      response = await globalThis.fetch(upstream, {
+      response = await fetchImpl(upstream, {
         method: req.method,
         headers: reqHeaders,
         body: bodyBuffer,

--- a/gateway/src/http/routes/sms-deliver.test.ts
+++ b/gateway/src/http/routes/sms-deliver.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../../config.js";
-import { createSmsDeliverHandler } from "./sms-deliver.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createSmsDeliverHandler } = await import("./sms-deliver.js");
 
 // --- Helpers ---------------------------------------------------------------
 
@@ -58,19 +66,17 @@ function makeRequest(body: unknown, headers?: Record<string, string>): Request {
   });
 }
 
-const originalFetch = globalThis.fetch;
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  fetchMock = mock(async () => new Response());
 });
 
 function mockTwilioApi(overrides?: Record<string, unknown>) {
-  globalThis.fetch = mock(async () => {
+  fetchMock = mock(async () => {
     return new Response(JSON.stringify({ sid: "SM-sent", status: "queued", error_code: null, error_message: null, ...overrides }), {
       status: 201,
       headers: { "content-type": "application/json" },
     });
-  }) as unknown as typeof fetch;
+  });
 }
 
 // --- Tests -----------------------------------------------------------------
@@ -189,11 +195,11 @@ describe("/deliver/sms", () => {
   });
 
   it("returns 502 when Twilio API fails", async () => {
-    globalThis.fetch = mock(async () => {
+    fetchMock = mock(async () => {
       return new Response(JSON.stringify({ message: "Bad Request" }), {
         status: 400,
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
@@ -207,14 +213,14 @@ describe("/deliver/sms", () => {
 
   it("accepts { chatId, text } and sends Twilio request to chatId", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
-    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       fetchCalls.push({ url: urlStr, init: init ?? {} });
       return new Response(JSON.stringify({ sid: "SM-sent" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
@@ -246,14 +252,14 @@ describe("/deliver/sms", () => {
 
   it("sends correct Twilio API request", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
-    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       fetchCalls.push({ url: urlStr, init: init ?? {} });
       return new Response(JSON.stringify({ sid: "SM-sent" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),
@@ -274,14 +280,14 @@ describe("/deliver/sms", () => {
 
   it("uses assistant-specific From number when assistantId mapping exists", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
-    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       fetchCalls.push({ url: urlStr, init: init ?? {} });
       return new Response(JSON.stringify({ sid: "SM-sent" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({
@@ -306,14 +312,14 @@ describe("/deliver/sms", () => {
 
   it("falls back to global From number when assistant mapping is missing", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
-    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       fetchCalls.push({ url: urlStr, init: init ?? {} });
       return new Response(JSON.stringify({ sid: "SM-sent" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({
@@ -338,14 +344,14 @@ describe("/deliver/sms", () => {
 
   it("attachment-only request (no text) uses fallback text", async () => {
     const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
-    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    fetchMock = mock(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       fetchCalls.push({ url: urlStr, init: init ?? {} });
       return new Response(JSON.stringify({ sid: "SM-sent" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
 
     const handler = createSmsDeliverHandler(
       makeConfig({ runtimeProxyBearerToken: undefined, smsDeliverAuthBypass: true }),

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
 import { validateBearerToken } from "../auth/bearer.js";
 import { getLogger } from "../../logger.js";
 
@@ -30,7 +31,7 @@ async function sendTwilioSms(
   const authHeader =
     "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64");
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../config.js";
+import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("runtime-client");
@@ -107,7 +108,7 @@ export async function forwardToRuntime(
     }
 
     try {
-      const response = await globalThis.fetch(url, {
+      const response = await fetchImpl(url, {
         method: "POST",
         headers: runtimeHeaders(config, extraHeaders),
         body: JSON.stringify(payload),
@@ -165,7 +166,7 @@ export async function resetConversation(
 ): Promise<void> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "DELETE",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ sourceChannel, externalChatId }),
@@ -195,7 +196,7 @@ export async function downloadAttachment(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -219,7 +220,7 @@ export async function downloadAttachmentById(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -253,7 +254,7 @@ export async function forwardTwilioVoiceWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params, originalUrl }),
@@ -277,7 +278,7 @@ export async function forwardTwilioStatusWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/status`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -301,7 +302,7 @@ export async function forwardTwilioConnectActionWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/connect-action`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -323,7 +324,7 @@ export async function uploadAttachment(
 ): Promise<UploadAttachmentResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify(input),
@@ -366,7 +367,7 @@ export async function forwardOAuthCallback(
 ): Promise<OAuthCallbackResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/oauth/callback`;
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ state, code, error }),

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../config.js";
+import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("telegram-api");
@@ -154,7 +155,7 @@ export async function callTelegramApi<T>(
   body: Record<string, unknown>,
 ): Promise<T> {
   return retryableFetch<T>(config, method, () =>
-    globalThis.fetch(
+    fetchImpl(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",
@@ -172,7 +173,7 @@ export async function callTelegramApiMultipart<T>(
   form: FormData,
 ): Promise<T> {
   return retryableFetch<T>(config, method, () =>
-    globalThis.fetch(
+    fetchImpl(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -1,5 +1,6 @@
 import { fileTypeFromBuffer } from "file-type";
 import type { GatewayConfig } from "../config.js";
+import { fetchImpl } from "../fetch.js";
 import { callTelegramApi } from "./api.js";
 
 interface TelegramFile {
@@ -33,7 +34,7 @@ export async function downloadTelegramFile(
   }
 
   const downloadUrl = `${config.telegramApiBaseUrl}/file/bot${config.telegramBotToken}/${file.file_path}`;
-  const response = await globalThis.fetch(downloadUrl, {
+  const response = await fetchImpl(downloadUrl, {
     signal: AbortSignal.timeout(config.telegramTimeoutMs),
   });
 

--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../config.js";
+import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("twilio-send-sms");
@@ -37,7 +38,7 @@ export async function sendSmsReply(
   const authHeader =
     "Basic " + Buffer.from(`${config.twilioAccountSid}:${config.twilioAuthToken}`).toString("base64");
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchImpl(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,


### PR DESCRIPTION
## Summary
- Created `gateway/src/fetch.ts` — thin `fetchImpl` wrapper around `globalThis.fetch` exposed through a module boundary
- Updated 6 source files (`telegram/api.ts`, `runtime/client.ts`, `telegram/download.ts`, `twilio/send-sms.ts`, `http/routes/sms-deliver.ts`, `http/routes/runtime-proxy.ts`) to import and use `fetchImpl` instead of calling `globalThis.fetch` directly
- Migrated all 12 gateway test files from `globalThis.fetch` replacement to `mock.module("../fetch.js", ...)` pattern for deterministic, cross-platform fetch interception

## Context
On Bun 1.3.9 running on Linux (CI), replacing `globalThis.fetch` at runtime does not reliably intercept outgoing requests — tests pass on macOS but fail on CI. Using `mock.module()` to mock at the ESM resolution level works cross-platform.

## Test plan
- [x] All 369 gateway tests pass locally (0 failures)
- CI should now pass on Linux

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22341172043

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
