### PR TITLE
fix: use dependency injection for fetch in gateway tests to fix Linux CI

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -43,21 +43,15 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const originalFetch = globalThis.fetch;
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
 describe("runtime proxy handler", () => {
   test("rewrites /v1/assistants/:assistantId/... to /v1/... for upstream", async () => {
     const captured: { url: string }[] = [];
-    globalThis.fetch = mock(async (input: any) => {
+    const fetchMock = mock(async (input: any) => {
       captured.push({ url: String(input) });
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/assistants/test-assistant/channels/inbound");
     await handler(req);
 
@@ -66,15 +60,15 @@ describe("runtime proxy handler", () => {
 
   test("forwards request to upstream with correct path and query (assistant-scoped rewrite)", async () => {
     const captured: { url: string; method: string }[] = [];
-    globalThis.fetch = mock(async (input: any, init?: any) => {
+    const fetchMock = mock(async (input: any, init?: any) => {
       captured.push({ url: String(input), method: init?.method ?? "GET" });
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/assistants/test/health?foo=bar");
     const res = await handler(req);
 
@@ -88,15 +82,15 @@ describe("runtime proxy handler", () => {
 
   test("forwards POST body to upstream", async () => {
     let capturedBody = "";
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       if (init?.body) {
         // Body is an ArrayBuffer after buffering in the proxy handler
         capturedBody = new TextDecoder().decode(init.body);
       }
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/chat", {
       method: "POST",
       body: JSON.stringify({ message: "hello" }),
@@ -109,11 +103,11 @@ describe("runtime proxy handler", () => {
   });
 
   test("relays upstream status code", async () => {
-    globalThis.fetch = mock(async () => {
+    const fetchMock = mock(async () => {
       return new Response("Not Found", { status: 404 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/nonexistent");
     const res = await handler(req);
 
@@ -121,11 +115,11 @@ describe("runtime proxy handler", () => {
   });
 
   test("returns 502 on upstream connection failure", async () => {
-    globalThis.fetch = mock(async () => {
+    const fetchMock = mock(async () => {
       throw new Error("Connection refused");
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health");
     const res = await handler(req);
 
@@ -136,12 +130,12 @@ describe("runtime proxy handler", () => {
 
   test("strips hop-by-hop headers from request", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       capturedHeaders = init?.headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health", {
       headers: {
         connection: "keep-alive",
@@ -159,7 +153,7 @@ describe("runtime proxy handler", () => {
   });
 
   test("strips hop-by-hop headers from response", async () => {
-    globalThis.fetch = mock(async () => {
+    const fetchMock = mock(async () => {
       return new Response("ok", {
         status: 200,
         headers: {
@@ -169,9 +163,9 @@ describe("runtime proxy handler", () => {
           "content-type": "text/plain",
         },
       });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health");
     const res = await handler(req);
 
@@ -183,11 +177,11 @@ describe("runtime proxy handler", () => {
 
   test("returns 504 on upstream timeout", async () => {
     const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    globalThis.fetch = mock(async () => {
+    const fetchMock = mock(async () => {
       throw timeoutError;
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
+    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 100, fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health");
     const res = await handler(req);
 
@@ -198,12 +192,12 @@ describe("runtime proxy handler", () => {
 
   test("passes AbortSignal.timeout to upstream fetch", async () => {
     let capturedSignal: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       capturedSignal = init?.signal;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 5000 }));
+    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 5000, fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health");
     await handler(req);
 
@@ -213,12 +207,12 @@ describe("runtime proxy handler", () => {
 
   test("forwards authorization header when auth is not required", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       capturedHeaders = init?.headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health", {
       headers: { authorization: "Bearer upstream-token" },
     });
@@ -229,13 +223,13 @@ describe("runtime proxy handler", () => {
 
   test("replaces client authorization with configured bearer token for upstream", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       capturedHeaders = init?.headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
     const handler = createRuntimeProxyHandler(
-      makeConfig({ runtimeProxyBearerToken: "daemon-token" }),
+      makeConfig({ runtimeProxyBearerToken: "daemon-token", fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/v1/health", {
       headers: { authorization: "Bearer client-token" },
@@ -247,11 +241,11 @@ describe("runtime proxy handler", () => {
 
   test("truncates long upstream error bodies in logs", async () => {
     const longBody = "x".repeat(512);
-    globalThis.fetch = mock(async () => {
+    const fetchMock = mock(async () => {
       return new Response(longBody, { status: 500 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/fail");
     const res = await handler(req);
 
@@ -263,12 +257,12 @@ describe("runtime proxy handler", () => {
 
   test("does not forward host header to upstream", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock(async (_input: any, init?: any) => {
+    const fetchMock = mock(async (_input: any, init?: any) => {
       capturedHeaders = init?.headers;
       return new Response("ok", { status: 200 });
-    }) as any;
+    });
 
-    const handler = createRuntimeProxyHandler(makeConfig());
+    const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/v1/health", {
       headers: { host: "localhost:7830" },
     });
@@ -282,12 +276,12 @@ describe("runtime proxy handler", () => {
   describe("webhook path guard", () => {
     test("blocks /webhooks/telegram from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/webhooks/telegram", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -304,12 +298,12 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/twilio/voice from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
         method: "POST",
       });
@@ -321,12 +315,12 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/oauth/callback from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/webhooks/oauth/callback");
       const res = await handler(req);
 
@@ -336,12 +330,12 @@ describe("runtime proxy handler", () => {
 
     test("blocks /webhooks/any-future-channel from being proxied", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/webhooks/any-future-channel", {
         method: "POST",
       });
@@ -353,12 +347,12 @@ describe("runtime proxy handler", () => {
 
     test("allows /v1/channels/inbound to be proxied (non-webhook path)", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/v1/channels/inbound", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -372,12 +366,12 @@ describe("runtime proxy handler", () => {
 
     test("allows /v1/health to be proxied (non-webhook path)", async () => {
       const fetchCalls: string[] = [];
-      globalThis.fetch = mock(async (input: any) => {
+      const fetchMock = mock(async (input: any) => {
         fetchCalls.push(String(input));
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }) as any;
+      });
 
-      const handler = createRuntimeProxyHandler(makeConfig());
+      const handler = createRuntimeProxyHandler(makeConfig({ fetch: fetchMock as any }));
       const req = new Request("http://localhost:7830/v1/health");
       const res = await handler(req);
 
@@ -391,13 +385,13 @@ describe("runtime proxy handler", () => {
   describe("gateway-origin header", () => {
     test("sets X-Gateway-Origin header when runtimeBearerToken is configured", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = mock(async (_input: any, init?: any) => {
+      const fetchMock = mock(async (_input: any, init?: any) => {
         capturedHeaders = init?.headers;
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(
-        makeConfig({ runtimeBearerToken: "runtime-secret" }),
+        makeConfig({ runtimeBearerToken: "runtime-secret", fetch: fetchMock as any }),
       );
       const req = new Request("http://localhost:7830/v1/channels/inbound", {
         method: "POST",
@@ -411,13 +405,13 @@ describe("runtime proxy handler", () => {
 
     test("does not set X-Gateway-Origin header when no runtimeBearerToken", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = mock(async (_input: any, init?: any) => {
+      const fetchMock = mock(async (_input: any, init?: any) => {
         capturedHeaders = init?.headers;
         return new Response("ok", { status: 200 });
-      }) as any;
+      });
 
       const handler = createRuntimeProxyHandler(
-        makeConfig({ runtimeBearerToken: undefined }),
+        makeConfig({ runtimeBearerToken: undefined, fetch: fetchMock as any }),
       );
       const req = new Request("http://localhost:7830/v1/channels/inbound", {
         method: "POST",

--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,10 +1,6 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { callTelegramApi } from "../telegram/api.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -47,22 +43,11 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("callTelegramApi transport error redaction", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   test("redacts bot token from warning logs and thrown error", async () => {
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    mockFetch(async () => {
+    const fetchMock = mock(async () => {
       const err = new Error("Unable to connect. Is the computer able to access the url?") as Error & {
         path?: string;
         code?: string;
@@ -72,7 +57,7 @@ describe("callTelegramApi transport error redaction", () => {
       throw err;
     });
 
-    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
+    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0, fetch: fetchMock as any });
 
     let thrown: Error | null = null;
     try {
@@ -87,22 +72,19 @@ describe("callTelegramApi transport error redaction", () => {
   });
 
   test("redacts bot token preceded by hyphen delimiter", async () => {
-    // Tokens embedded after a hyphen (e.g., diagnostic strings like
-    // "error-123456789:...") must still be redacted.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz012345678"].join("");
 
-    mockFetch(async () => {
+    const fetchMock = mock(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
       };
-      // Simulate a diagnostic string where the token is preceded by a hyphen
       err.path = `prefix-${tgToken}/sendMessage`;
       err.code = "ConnectionRefused";
       throw err;
     });
 
-    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
+    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0, fetch: fetchMock as any });
 
     let thrown: Error | null = null;
     try {
@@ -117,11 +99,9 @@ describe("callTelegramApi transport error redaction", () => {
   });
 
   test("redacts bot token ending with hyphen", async () => {
-    // Tokens can end with `-` which is a non-word character; \b boundaries
-    // would fail to match the trailing `-`, leaking part of the token.
     const tgToken = ["123456789", ":", "ABCDefGHIJklmnopQRSTuvwxyz01234567-"].join("");
 
-    mockFetch(async () => {
+    const fetchMock = mock(async () => {
       const err = new Error("Connection refused") as Error & {
         path?: string;
         code?: string;
@@ -131,7 +111,7 @@ describe("callTelegramApi transport error redaction", () => {
       throw err;
     });
 
-    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0 });
+    const config = makeConfig({ telegramBotToken: tgToken, telegramMaxRetries: 0, fetch: fetchMock as any });
 
     let thrown: Error | null = null;
     try {

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,10 +1,6 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { createTelegramDeliverHandler } from "../http/routes/telegram-deliver.js";
 import type { GatewayConfig } from "../config.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 const TOKEN = "test-deliver-token";
 
@@ -49,19 +45,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
-function mockTelegramApi() {
-  mockFetch(async () => {
+function makeTelegramApiMock() {
+  return mock(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -72,7 +57,7 @@ function mockTelegramApi() {
 describe("/deliver/telegram attachment delivery without assistantId", () => {
   test("delivers attachments without assistantId using assistant-less download path", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (assistant-less path)
@@ -96,7 +81,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
     });
 
     const handler = createTelegramDeliverHandler(
-      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true, fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -126,7 +111,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
   test("delivers attachments with assistantId using legacy download path", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       // Runtime attachment download (legacy path)
@@ -149,7 +134,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
     });
 
     const handler = createTelegramDeliverHandler(
-      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true, fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -178,7 +163,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 describe("/deliver/telegram ID-only attachment validation", () => {
   test("accepts ID-only attachments (no filename, mimeType, sizeBytes)", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-id-only")) {
@@ -200,7 +185,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
     });
 
     const handler = createTelegramDeliverHandler(
-      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true, fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -244,7 +229,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
   test("full-metadata attachments still accepted (backward compatibility)", async () => {
     const calls: string[] = [];
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(urlStr);
       if (urlStr.includes("/v1/attachments/att-compat")) {
@@ -266,7 +251,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
     });
 
     const handler = createTelegramDeliverHandler(
-      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true, fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -334,8 +319,8 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("accepts request with correct bearer token", async () => {
-    mockTelegramApi();
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const fetchMock = makeTelegramApiMock();
+    const handler = createTelegramDeliverHandler(makeConfig({ fetch: fetchMock as any }));
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: {
@@ -368,9 +353,9 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("allows unauthenticated access when bypass flag is set and no token configured", async () => {
-    mockTelegramApi();
+    const fetchMock = makeTelegramApiMock();
     const handler = createTelegramDeliverHandler(
-      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true }),
+      makeConfig({ runtimeProxyBearerToken: undefined, telegramDeliverAuthBypass: true, fetch: fetchMock as any }),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",

--- a/gateway/src/__tests__/telegram-reconcile-route.test.ts
+++ b/gateway/src/__tests__/telegram-reconcile-route.test.ts
@@ -1,10 +1,6 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { createTelegramReconcileHandler } from "../http/routes/telegram-reconcile.js";
 import type { GatewayConfig } from "../config.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 function makeTelegramResponse(result: unknown) {
   return new Response(JSON.stringify({ ok: true, result }), {
@@ -72,18 +68,9 @@ function makeRequest(
   });
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
-let fetchMock: ReturnType<typeof mock<(...args: Parameters<typeof fetch>) => Promise<Response>>> | null = null;
-
-/** Default fetch mock that handles Telegram API calls with success responses. */
-function installDefaultFetchMock() {
-  fetchMock = mockFetch(async (input: string | URL | Request) => {
+/** Creates a default fetch mock that handles Telegram API calls with success responses. */
+function makeDefaultFetchMock() {
+  const fn = mock(async (input: string | URL | Request) => {
     const url =
       typeof input === "string"
         ? input
@@ -102,20 +89,14 @@ function installDefaultFetchMock() {
     }
     return new Response("Not found", { status: 404 });
   });
+  Object.assign(fn, { preconnect: () => {} });
+  return fn as unknown as typeof fetch & ReturnType<typeof mock>;
 }
 
 describe("POST /internal/telegram/reconcile", () => {
-  beforeEach(() => {
-    installDefaultFetchMock();
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-    fetchMock = null;
-  });
-
   test("rejects non-POST methods", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(
       new Request("http://localhost:7830/internal/telegram/reconcile", {
@@ -126,7 +107,8 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 503 when no bearer token is configured", async () => {
-    const config = makeConfig({ runtimeProxyBearerToken: undefined });
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock, runtimeProxyBearerToken: undefined });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "any-token"));
     expect(res.status).toBe(503);
@@ -135,21 +117,24 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 401 for missing auth header", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST"));
     expect(res.status).toBe(401);
   });
 
   test("returns 401 for wrong token", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "wrong-token"));
     expect(res.status).toBe(401);
   });
 
   test("triggers reconcile with correct auth", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "test-token"));
     expect(res.status).toBe(200);
@@ -160,7 +145,8 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("updates ingressPublicBaseUrl when provided", async () => {
-    const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock, ingressPublicBaseUrl: "https://old.example.com" });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(
       makeRequest("POST", "test-token", {
@@ -173,7 +159,8 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("clears ingressPublicBaseUrl when empty string is provided", async () => {
-    const config = makeConfig({ ingressPublicBaseUrl: "https://old.example.com" });
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock, ingressPublicBaseUrl: "https://old.example.com" });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(
       makeRequest("POST", "test-token", {
@@ -185,7 +172,8 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("works with empty body (no URL update)", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
       method: "POST",
@@ -199,10 +187,11 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 502 when reconcile throws", async () => {
-    fetchMock = mockFetch(async () => {
+    const fetchMock = mock(async () => {
       throw new Error("Telegram API error");
     });
-    const config = makeConfig();
+    Object.assign(fetchMock, { preconnect: () => {} });
+    const config = makeConfig({ fetch: fetchMock as unknown as typeof fetch });
     const handler = createTelegramReconcileHandler(config);
     const res = await handler(makeRequest("POST", "test-token"));
     expect(res.status).toBe(502);
@@ -211,7 +200,8 @@ describe("POST /internal/telegram/reconcile", () => {
   });
 
   test("returns 400 for invalid JSON body", async () => {
-    const config = makeConfig();
+    const fetchMock = makeDefaultFetchMock();
+    const config = makeConfig({ fetch: fetchMock });
     const handler = createTelegramReconcileHandler(config);
     const req = new Request("http://localhost:7830/internal/telegram/reconcile", {
       method: "POST",
@@ -230,7 +220,7 @@ describe("POST /internal/telegram/reconcile", () => {
 
     // Make reconcile slow enough that the first call is still in-flight
     // when the second one arrives.
-    fetchMock = mockFetch(
+    const fetchMock = mock(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === "string"
@@ -254,8 +244,9 @@ describe("POST /internal/telegram/reconcile", () => {
         return new Response("Not found", { status: 404 });
       },
     );
+    Object.assign(fetchMock, { preconnect: () => {} });
 
-    const config = makeConfig({ ingressPublicBaseUrl: "https://original.com" });
+    const config = makeConfig({ fetch: fetchMock as unknown as typeof fetch, ingressPublicBaseUrl: "https://original.com" });
     const handler = createTelegramReconcileHandler(config);
 
     // Fire two requests concurrently — without serialization the second

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,11 +1,7 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { sendTelegramAttachments } from "../telegram/send.js";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -50,22 +46,11 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 describe("sendTelegramAttachments", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   test("sends image attachment via sendPhoto", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // Runtime download endpoint
@@ -85,7 +70,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = {
       id: "att-1",
       filename: "photo.png",
@@ -105,7 +90,7 @@ describe("sendTelegramAttachments", () => {
   test("sends non-image attachment via sendDocument", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-2")) {
@@ -123,7 +108,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = {
       id: "att-2",
       filename: "report.pdf",
@@ -142,13 +127,13 @@ describe("sendTelegramAttachments", () => {
   test("skips oversized attachments and sends failure notice", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig({ maxAttachmentBytes: 50 });
+    const config = makeConfig({ fetch: fetchMock as any, maxAttachmentBytes: 50 });
     const meta: RuntimeAttachmentMeta = {
       id: "att-3",
       filename: "huge.zip",
@@ -167,7 +152,7 @@ describe("sendTelegramAttachments", () => {
   test("downloads via assistant-less path when assistantId is undefined", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-no-assist")) {
@@ -185,7 +170,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = {
       id: "att-no-assist",
       filename: "image.jpg",
@@ -207,7 +192,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment hydrates metadata from downloaded payload", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-id-only")) {
@@ -225,7 +210,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     // Only provide `id` — no filename, mimeType, sizeBytes, or kind
     const meta: RuntimeAttachmentMeta = { id: "att-id-only" };
 
@@ -240,7 +225,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment falls back to defaults when download payload also lacks metadata", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-bare")) {
@@ -254,7 +239,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = { id: "att-bare" };
 
     await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
@@ -268,7 +253,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment skipped when hydrated size exceeds limit", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-big")) {
@@ -286,7 +271,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig({ maxAttachmentBytes: 50 });
+    const config = makeConfig({ fetch: fetchMock as any, maxAttachmentBytes: 50 });
     // No sizeBytes in meta — will be hydrated from download payload (200 > 50 limit)
     const meta: RuntimeAttachmentMeta = { id: "att-big" };
 
@@ -302,7 +287,7 @@ describe("sendTelegramAttachments", () => {
   test("ID-only attachment uses id as filename fallback", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
-    mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push({ url: urlStr, init });
       if (urlStr.includes("/attachments/my-attachment-id")) {
@@ -318,7 +303,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = { id: "my-attachment-id" };
 
     await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
@@ -332,7 +317,7 @@ describe("sendTelegramAttachments", () => {
   test("full-metadata payload still works (backward compatibility)", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       if (url.includes("/attachments/att-full")) {
@@ -350,7 +335,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const meta: RuntimeAttachmentMeta = {
       id: "att-full",
       filename: "photo.jpg",
@@ -369,7 +354,7 @@ describe("sendTelegramAttachments", () => {
   test("continues sending remaining attachments on individual failure", async () => {
     const calls: string[] = [];
 
-    mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       calls.push(url);
       // First attachment download fails
@@ -392,7 +377,7 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     const attachments: RuntimeAttachmentMeta[] = [
       { id: "att-fail", filename: "bad.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },
       { id: "att-ok", filename: "good.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -1,10 +1,6 @@
-import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -72,19 +68,8 @@ function makeWebhookRequest(payload: unknown, secret = "test-webhook-secret"): R
 
 let fetchCalls: { url: string; method: string; body?: unknown; headers?: Record<string, string> }[];
 
-function mockFetchFn(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
 beforeEach(() => {
   fetchCalls = [];
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
 });
 
 /** Extract headers from a fetch call into a plain object. */
@@ -107,11 +92,11 @@ function extractHeaders(input: string | URL | Request, init?: RequestInit): Reco
 }
 
 /**
- * Install a mock fetch that records calls and returns a 200 JSON response.
+ * Create a mock fetch that records calls and returns a 200 JSON response.
  * Runtime forward calls get an eventId response; Telegram API calls get { ok: true }.
  */
-function installFetchMock() {
-  mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+function createFetchMock() {
+  return mock(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
     let body: unknown;
@@ -147,16 +132,16 @@ function installFetchMock() {
     }
 
     return new Response("Not found", { status: 404 });
-  });
+  }) as unknown as typeof fetch;
 }
 
 describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
   test("uses configured gatewayInternalBaseUrl in replyCallbackUrl", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       gatewayInternalBaseUrl: "http://gateway.internal:9000",
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello");
@@ -175,10 +160,10 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
 
   test("falls back to localhost URL when gatewayInternalBaseUrl uses default", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       gatewayInternalBaseUrl: "http://127.0.0.1:7830",
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 2001);
@@ -198,9 +183,9 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
 describe("telegram webhook handler: /new rejection", () => {
   test("/start forwards command intent metadata, does not reset conversation, and sends start acknowledgement", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/start deep-link-token", 2501);
@@ -227,8 +212,10 @@ describe("telegram webhook handler: /new rejection", () => {
   });
 
   test("/start with routing rejection sends setup notice and does not forward", async () => {
-    const config = makeConfig({ unmappedPolicy: "reject" });
-    installFetchMock();
+    const config = makeConfig({
+      fetch: createFetchMock(),
+      unmappedPolicy: "reject",
+    });
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/start", 2502);
@@ -250,8 +237,10 @@ describe("telegram webhook handler: /new rejection", () => {
 
   test("sends rejection notice when /new command routing is rejected", async () => {
     // No routing entries and unmappedPolicy is "reject" — routing will fail
-    const config = makeConfig({ unmappedPolicy: "reject" });
-    installFetchMock();
+    const config = makeConfig({
+      fetch: createFetchMock(),
+      unmappedPolicy: "reject",
+    });
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 3001);
@@ -273,9 +262,9 @@ describe("telegram webhook handler: /new rejection", () => {
 
   test("/new succeeds and sends confirmation when routing matches", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 4001);
@@ -301,8 +290,10 @@ describe("telegram webhook handler: /new rejection", () => {
   });
 
   test("/new rejection does not call resetConversation", async () => {
-    const config = makeConfig({ unmappedPolicy: "reject" });
-    installFetchMock();
+    const config = makeConfig({
+      fetch: createFetchMock(),
+      unmappedPolicy: "reject",
+    });
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 5001);
@@ -321,14 +312,10 @@ describe("telegram webhook handler: in-flight dedup", () => {
     let resolveFirst!: () => void;
     const firstBlocks = new Promise<void>((r) => { resolveFirst = r; });
 
-    const config = makeConfig({
-      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
-    });
-
     // Install a fetch mock where the runtime inbound call blocks on the first
     // invocation and responds immediately on subsequent ones.
     let inboundCallCount = 0;
-    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -355,6 +342,11 @@ describe("telegram webhook handler: in-flight dedup", () => {
         });
       }
       return new Response("Not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      fetch: fetchMock,
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
 
     const handler = createTelegramWebhookHandler(config);
@@ -381,13 +373,8 @@ describe("telegram webhook handler: in-flight dedup", () => {
   });
 
   test("failed processing unreserves, allowing retry to be processed normally", async () => {
-    const config = makeConfig({
-      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
-      runtimeMaxRetries: 0,
-    });
-
     let callCount = 0;
-    mockFetchFn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
       let body: unknown;
@@ -416,6 +403,12 @@ describe("telegram webhook handler: in-flight dedup", () => {
         });
       }
       return new Response("Not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      fetch: fetchMock,
+      routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
+      runtimeMaxRetries: 0,
     });
 
     const handler = createTelegramWebhookHandler(config);
@@ -434,9 +427,9 @@ describe("telegram webhook handler: in-flight dedup", () => {
 
   test("after successful processing, duplicates return cached success", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9003);
 
@@ -474,9 +467,9 @@ function makeCallbackQueryPayload(data: string, updateId = 7001) {
 describe("telegram webhook handler: callback_query forwarding", () => {
   test("forwards callback_query data to the runtime with callback metadata", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeCallbackQueryPayload("apr:run-abc:approve", 7001);
@@ -498,9 +491,9 @@ describe("telegram webhook handler: callback_query forwarding", () => {
 
   test("acknowledges the callback query via answerCallbackQuery after forwarding", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeCallbackQueryPayload("apr:run-xyz:reject", 7002);
@@ -518,9 +511,9 @@ describe("telegram webhook handler: callback_query forwarding", () => {
 
   test("does not call answerCallbackQuery for regular text messages", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 7003);
@@ -537,9 +530,9 @@ describe("telegram webhook handler: callback_query forwarding", () => {
 
   test("regular text messages do not include callback metadata in runtime payload", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 7004);
@@ -558,10 +551,10 @@ describe("telegram webhook handler: gateway-origin marker", () => {
   test("forwards X-Gateway-Origin header when runtimeBearerToken is configured", async () => {
     const bearerToken = "secret-runtime-token";
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
       runtimeBearerToken: bearerToken,
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 8001);
@@ -577,10 +570,10 @@ describe("telegram webhook handler: gateway-origin marker", () => {
 
   test("does not include X-Gateway-Origin header when no runtimeBearerToken", async () => {
     const config = makeConfig({
+      fetch: createFetchMock(),
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
       runtimeBearerToken: undefined,
     });
-    installFetchMock();
     const handler = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 8002);

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -1,10 +1,6 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { reconcileTelegramWebhook } from "../telegram/webhook-manager.js";
 import type { GatewayConfig } from "../config.js";
-
-// Use mock() + direct globalThis.fetch assignment instead of spyOn(globalThis, "fetch")
-// because spyOn doesn't reliably intercept fetch on Linux in Bun 1.3.9.
-const originalFetch = globalThis.fetch;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -47,20 +43,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-function mockFetch(fn: (...args: Parameters<typeof fetch>) => Promise<Response>) {
-  const m = mock(fn);
-  Object.assign(m, { preconnect: () => {} });
-  globalThis.fetch = m as unknown as typeof fetch;
-  return m;
-}
-
-let fetchMock: ReturnType<typeof mockFetch> | null = null;
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-  fetchMock = null;
-});
-
 function makeTelegramResponse(result: unknown) {
   return new Response(JSON.stringify({ ok: true, result }), {
     status: 200,
@@ -72,7 +54,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when URL does not match", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -90,7 +72,7 @@ describe("reconcileTelegramWebhook", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(calls).toHaveLength(2);
@@ -104,7 +86,7 @@ describe("reconcileTelegramWebhook", () => {
   test("always calls setWebhook even when URL already matches (secret may have rotated)", async () => {
     const calls: string[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -121,7 +103,7 @@ describe("reconcileTelegramWebhook", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(calls).toEqual(["getWebhookInfo", "setWebhook"]);
@@ -130,7 +112,7 @@ describe("reconcileTelegramWebhook", () => {
   test("normalizes trailing slash on ingress base URL", async () => {
     const calls: { method: string; body: unknown }[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push({ method: "getWebhookInfo", body: null });
@@ -148,7 +130,7 @@ describe("reconcileTelegramWebhook", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const config = makeConfig({ ingressPublicBaseUrl: "https://example.ngrok.io/" });
+    const config = makeConfig({ ingressPublicBaseUrl: "https://example.ngrok.io/", fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(calls).toHaveLength(2);
@@ -156,27 +138,27 @@ describe("reconcileTelegramWebhook", () => {
   });
 
   test("skips reconciliation when bot token is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    const fetchMock = mock(async () => new Response("", { status: 200 }));
 
-    const config = makeConfig({ telegramBotToken: undefined });
+    const config = makeConfig({ telegramBotToken: undefined, fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when webhook secret is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    const fetchMock = mock(async () => new Response("", { status: 200 }));
 
-    const config = makeConfig({ telegramWebhookSecret: undefined });
+    const config = makeConfig({ telegramWebhookSecret: undefined, fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips reconciliation when ingress URL is not configured", async () => {
-    fetchMock = mockFetch(async () => new Response("", { status: 200 }));
+    const fetchMock = mock(async () => new Response("", { status: 200 }));
 
-    const config = makeConfig({ ingressPublicBaseUrl: undefined });
+    const config = makeConfig({ ingressPublicBaseUrl: undefined, fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -185,7 +167,7 @@ describe("reconcileTelegramWebhook", () => {
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 
-    fetchMock = mockFetch(async (input: string | URL | Request) => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/getWebhookInfo")) {
         calls.push("getWebhookInfo");
@@ -202,7 +184,7 @@ describe("reconcileTelegramWebhook", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const config = makeConfig();
+    const config = makeConfig({ fetch: fetchMock as any });
     await reconcileTelegramWebhook(config);
 
     expect(calls).toEqual(["getWebhookInfo", "setWebhook"]);

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -60,6 +60,8 @@ export type GatewayConfig = {
   /** Canonical public ingress base URL, used for webhook signature reconstruction. */
   ingressPublicBaseUrl: string | undefined;
   unmappedPolicy: "reject" | "default";
+  /** Optional fetch override for testing. Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -129,7 +129,8 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     let response: Response;
     try {
-      response = await globalThis.fetch(upstream, {
+      const doFetch = config.fetch ?? globalThis.fetch;
+      response = await doFetch(upstream, {
         method: req.method,
         headers: reqHeaders,
         body: bodyBuffer,

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -24,13 +24,14 @@ async function sendTwilioSms(
   from: string,
   to: string,
   body: string,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<TwilioSmsResult> {
   const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
   const params = new URLSearchParams({ From: from, To: to, Body: body });
   const authHeader =
     "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64");
 
-  const response = await globalThis.fetch(url, {
+  const response = await fetchFn(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,
@@ -171,6 +172,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
         from,
         to,
         effectiveText,
+        config.fetch,
       );
     } catch (err) {
       tlog.error({ err, to }, "Failed to send SMS via Twilio");

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -107,7 +107,8 @@ export async function forwardToRuntime(
     }
 
     try {
-      const response = await globalThis.fetch(url, {
+      const doFetch = config.fetch ?? globalThis.fetch;
+      const response = await doFetch(url, {
         method: "POST",
         headers: runtimeHeaders(config, extraHeaders),
         body: JSON.stringify(payload),
@@ -165,7 +166,8 @@ export async function resetConversation(
 ): Promise<void> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "DELETE",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ sourceChannel, externalChatId }),
@@ -195,7 +197,8 @@ export async function downloadAttachment(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -219,7 +222,8 @@ export async function downloadAttachmentById(
 ): Promise<RuntimeAttachmentPayload> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "GET",
     headers: runtimeHeaders(config),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
@@ -253,7 +257,8 @@ export async function forwardTwilioVoiceWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params, originalUrl }),
@@ -277,7 +282,8 @@ export async function forwardTwilioStatusWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/status`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -301,7 +307,8 @@ export async function forwardTwilioConnectActionWebhook(
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/connect-action`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ params }),
@@ -323,7 +330,8 @@ export async function uploadAttachment(
 ): Promise<UploadAttachmentResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify(input),
@@ -366,7 +374,8 @@ export async function forwardOAuthCallback(
 ): Promise<OAuthCallbackResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/oauth/callback`;
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
     body: JSON.stringify({ state, code, error }),

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -153,8 +153,9 @@ export async function callTelegramApi<T>(
   method: string,
   body: Record<string, unknown>,
 ): Promise<T> {
+  const doFetch = config.fetch ?? globalThis.fetch;
   return retryableFetch<T>(config, method, () =>
-    globalThis.fetch(
+    doFetch(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",
@@ -171,8 +172,9 @@ export async function callTelegramApiMultipart<T>(
   method: string,
   form: FormData,
 ): Promise<T> {
+  const doFetch = config.fetch ?? globalThis.fetch;
   return retryableFetch<T>(config, method, () =>
-    globalThis.fetch(
+    doFetch(
       `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
       {
         method: "POST",

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -33,7 +33,8 @@ export async function downloadTelegramFile(
   }
 
   const downloadUrl = `${config.telegramApiBaseUrl}/file/bot${config.telegramBotToken}/${file.file_path}`;
-  const response = await globalThis.fetch(downloadUrl, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(downloadUrl, {
     signal: AbortSignal.timeout(config.telegramTimeoutMs),
   });
 

--- a/gateway/src/twilio/send-sms.ts
+++ b/gateway/src/twilio/send-sms.ts
@@ -37,7 +37,8 @@ export async function sendSmsReply(
   const authHeader =
     "Basic " + Buffer.from(`${config.twilioAccountSid}:${config.twilioAuthToken}`).toString("base64");
 
-  const response = await globalThis.fetch(url, {
+  const doFetch = config.fetch ?? globalThis.fetch;
+  const response = await doFetch(url, {
     method: "POST",
     headers: {
       Authorization: authHeader,


### PR DESCRIPTION
## Summary
- Add optional `fetch` field to `GatewayConfig` for test-time dependency injection
- Update all gateway source files (api.ts, client.ts, download.ts, runtime-proxy.ts, send-sms.ts, sms-deliver.ts) to use `config.fetch ?? globalThis.fetch` instead of `globalThis.fetch` directly
- Rewrite all 7 gateway test files to pass mock fetch via config instead of mutating `globalThis.fetch`, which Bun 1.3.9 on Linux doesn't reliably intercept

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22342017073

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
