### PR TITLE
fix: repair two CI test failures (RRULE timeout + missing statSync mock)

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -410,8 +410,12 @@ describe('claimDueSchedules', () => {
   });
 
   test('claims due RRULE schedules and advances nextRunAt', () => {
-    // Use an RRULE that fires every minute (roughly), with a DTSTART in the past
-    const rrule = 'DTSTART:20250101T000000Z\nRRULE:FREQ=MINUTELY;INTERVAL=1';
+    // Use a recent DTSTART (1 hour ago) so rrule doesn't iterate through
+    // hundreds of thousands of occurrences when computing the next run.
+    const pastDate = new Date(Date.now() - 3_600_000);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const ds = `${pastDate.getUTCFullYear()}${pad(pastDate.getUTCMonth() + 1)}${pad(pastDate.getUTCDate())}T${pad(pastDate.getUTCHours())}${pad(pastDate.getUTCMinutes())}${pad(pastDate.getUTCSeconds())}Z`;
+    const rrule = `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1`;
     const job = createSchedule({
       name: 'Claim RRULE',
       cronExpression: rrule,

--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import { join } from 'node:path';
+import * as realFs from 'node:fs';
 
 const TEST_DIR = '/tmp/vellum-user-ref-test';
 
@@ -12,6 +13,7 @@ let mockFileExists = false;
 let mockFileContent = '';
 
 mock.module('node:fs', () => ({
+  ...realFs,
   existsSync: (path: string) => {
     if (path === join(TEST_DIR, 'USER.md')) return mockFileExists;
     return false;


### PR DESCRIPTION
## Summary

- **schedule-store.test.ts**: Fixed RRULE test timeout by using a dynamic DTSTART (1 hour ago) instead of hardcoded `20250101T000000Z`, which forced rrule to iterate through ~14 months of minute-by-minute occurrences
- **user-reference.test.ts**: Fixed `SyntaxError: Export named 'statSync' not found in module 'node:fs'` by spreading the real `node:fs` module in the mock so all exports are preserved

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22342836941

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
