### PR TITLE
fix: add 10s timeout and exponential backoff to iOS daemon connection

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -60,17 +60,39 @@ struct ContentView: View {
 
     // MARK: - Initial Connection
 
+    /// How many consecutive connection failures have occurred (used for exponential backoff on retry).
+    @State private var retryCount: Int = 0
+
     private func attemptInitialConnection() async {
         guard hasSavedSettings, !clientProvider.isConnected else {
             connectPhase = .ready
             return
         }
         connectPhase = .connecting
+
+        // Apply exponential backoff when retrying: 0s, 2s, 4s, 8s … capped at 30s.
+        if retryCount > 0 {
+            let delaySeconds = min(pow(2.0, Double(retryCount - 1)) * 2.0, 30.0)
+            try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+        }
+
+        // Race the connect call against a 10-second timeout so a hung gateway
+        // never leaves the UI stuck on the spinner indefinitely.
+        let connectTask = Task { try await clientProvider.client.connect() }
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: 10_000_000_000)
+            connectTask.cancel()
+        }
+
         do {
-            try await clientProvider.client.connect()
+            try await connectTask.value
+            timeoutTask.cancel()
+            retryCount = 0
             clientProvider.isConnected = true
             connectPhase = .ready
         } catch {
+            timeoutTask.cancel()
+            retryCount += 1
             connectPhase = .failed
         }
     }
@@ -105,6 +127,13 @@ struct ContentView: View {
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
+
+            if retryCount > 1 {
+                let delaySeconds = Int(min(pow(2.0, Double(retryCount - 1)) * 2.0, 30.0))
+                Text("Retrying in \(delaySeconds)s…")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
 
             VStack(spacing: VSpacing.md) {
                 Button {


### PR DESCRIPTION
## Summary
- `attemptInitialConnection()` now races the `connect()` call against a 10-second `Task.sleep` so a hung or unreachable gateway never leaves the iOS UI stuck on the connecting spinner indefinitely
- Retry attempts apply exponential backoff: 2s, 4s, 8s, 16s… capped at 30s
- The "Unable to Connect" screen shows the upcoming retry delay when multiple failures have occurred

## Test plan
- [ ] Start the iOS app with no Mac daemon running; verify it transitions to the failed state within ~10 seconds
- [ ] Tap Retry; verify the backoff delay is applied before retrying
- [ ] Start the daemon; verify automatic connection recovery still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
