### PR TITLE
fix: verify SHA-256 checksum of downloaded Qdrant binary

### DIFF
--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { arch, platform } from 'node:os';
+import { createHash } from 'node:crypto';
 import type { Subprocess } from 'bun';
 import { getLogger } from '../util/logger.js';
 import { getDataDir } from '../util/platform.js';
@@ -160,15 +161,41 @@ export class QdrantManager {
     }
 
     const filename = `qdrant-${target}.tar.gz`;
-    const url = `https://github.com/qdrant/qdrant/releases/download/v${QDRANT_VERSION}/${filename}`;
+    const baseUrl = `https://github.com/qdrant/qdrant/releases/download/v${QDRANT_VERSION}`;
+    const url = `${baseUrl}/${filename}`;
+    const checksumUrl = `${baseUrl}/${filename}.sha256`;
+
     log.info({ url, binaryPath }, 'Downloading Qdrant binary');
 
-    const response = await fetch(url);
+    // Fetch the tarball and its SHA-256 checksum in parallel
+    const [response, checksumResponse] = await Promise.all([
+      fetch(url),
+      fetch(checksumUrl),
+    ]);
+
     if (!response.ok) {
       throw new Error(`Failed to download Qdrant: ${response.status} ${response.statusText} from ${url}`);
     }
 
     const tarball = await response.arrayBuffer();
+
+    // Verify SHA-256 integrity if the checksum file is available
+    if (checksumResponse.ok) {
+      const checksumText = (await checksumResponse.text()).trim();
+      // Checksum files contain "<hex>  <filename>" or just "<hex>"
+      const expectedHash = checksumText.split(/\s+/)[0].toLowerCase();
+      const actualHash = createHash('sha256').update(Buffer.from(tarball)).digest('hex');
+
+      if (actualHash !== expectedHash) {
+        throw new Error(
+          `Qdrant binary checksum mismatch! ` +
+          `expected=${expectedHash} actual=${actualHash} url=${url}`,
+        );
+      }
+      log.info({ hash: actualHash }, 'Qdrant binary checksum verified');
+    } else {
+      log.warn({ checksumUrl, status: checksumResponse.status }, 'Could not fetch Qdrant checksum — skipping integrity check');
+    }
 
     // Extract the qdrant binary from the tarball
     const binDir = dirname(binaryPath);


### PR DESCRIPTION
## Summary
- `qdrant-manager.ts` now downloads the `.sha256` checksum file from the GitHub release alongside the tarball
- After download, the SHA-256 of the tarball is computed and compared against the expected value
- A mismatch throws immediately to prevent executing a tampered or corrupted binary
- If the checksum file is unavailable (non-200 response), a warning is logged and installation continues in degraded mode

## Test plan
- [ ] Install Qdrant from scratch; verify checksum log appears and installation completes
- [ ] Manually corrupt the expected hash in a test build; verify it throws `checksum mismatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
