### PR TITLE
fix: increase ImageCache countLimit from 50 to 250

### DIFF
--- a/clients/shared/Features/Chat/ImageCache.swift
+++ b/clients/shared/Features/Chat/ImageCache.swift
@@ -14,7 +14,7 @@ public actor ImageCache {
     private var inFlight: [URL: Task<Data, Error>] = [:]
 
     private init() {
-        dataCache.countLimit = 50
+        dataCache.countLimit = 250
     }
 
     /// Returns raw `Data` for the URL (needed for GIF animation frames).


### PR DESCRIPTION
## Summary
- `ImageCache.dataCache.countLimit` raised from 50 → 250
- The old limit caused frequent NSCache evictions in long conversations that contain many inline images, GIF avatars, or embedded media
- NSCache automatically evicts entries under memory pressure regardless of `countLimit`, so this change is safe on low-memory devices

## Test plan
- [ ] Open a conversation with many images; verify images don't flicker on scroll after the fix
- [ ] Monitor memory usage on a low-memory device; verify NSCache still evicts correctly under pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
