### PR TITLE
feat: early abort check in tool executor

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -53,6 +53,31 @@ export class ToolExecutor {
       startedAtMs: startTime,
     });
 
+    // Bail out immediately if the session was aborted before this tool started.
+    // Individual tool implementations check the signal themselves for mid-run
+    // cancellation, but a pre-execution check prevents expensive permission
+    // lookups and prompter interactions after the user has already cancelled.
+    if (context.signal?.aborted) {
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent(context, {
+        type: 'error',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'error',
+        durationMs,
+        errorMessage: 'Cancelled',
+        isExpected: true,
+        errorCategory: 'tool_failure',
+      });
+      return { content: 'Cancelled', isError: true };
+    }
+
     // Gate tools not active for the current turn
     if (context.allowedToolNames && !context.allowedToolNames.has(name)) {
       const msg = `Tool "${name}" is not currently active. Load the skill that provides this tool first.`;


### PR DESCRIPTION
## Summary
- Adds an early `context.signal?.aborted` check at the top of `ToolExecutor.execute()`, before the permission pipeline and tool lookup
- When a session is aborted (e.g. user presses stop), any tool invocations that haven't started yet now return immediately with `{ content: 'Cancelled', isError: true }` instead of running through the full permission/prompter flow
- Individual tool implementations (shell, web-fetch, swarm workers) already check the signal themselves for mid-run cancellation — this is a pre-execution guard for tools that haven't begun yet
- The shell/host-shell/sandbox-runner tools already kill child processes via SIGKILL when the signal fires; the swarm orchestrator already breaks its scheduling loop on abort

## Why this matters
Without this check, if a session is aborted while the agent loop is dispatching multiple parallel tool calls, each pending tool still runs the full permission-check / prompter pipeline before executing and discovering the abort. With this check those pending calls bail out cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
