### PR TITLE
test: fix renderTemplate tests to match <MISSING: key> behavior

### DIFF
--- a/assistant/src/__tests__/task-management-tools.test.ts
+++ b/assistant/src/__tests__/task-management-tools.test.ts
@@ -464,8 +464,8 @@ describe('renderTemplate', () => {
     expect(renderTemplate('Hello {{name}}', { name: 'World' })).toBe('Hello World');
   });
 
-  test('leaves unknown placeholders unchanged', () => {
-    expect(renderTemplate('{{unknown}} text', {})).toBe('{{unknown}} text');
+  test('replaces unknown placeholders with <MISSING: key>', () => {
+    expect(renderTemplate('{{unknown}} text', {})).toBe('<MISSING: unknown> text');
   });
 
   test('handles multiple placeholders', () => {

--- a/assistant/src/__tests__/task-runner.test.ts
+++ b/assistant/src/__tests__/task-runner.test.ts
@@ -46,10 +46,10 @@ describe('renderTemplate', () => {
     expect(result).toBe('Hello Alice, welcome to Wonderland!');
   });
 
-  test('leaves unmatched placeholders as-is', () => {
+  test('replaces missing placeholders with <MISSING: key>', () => {
     const template = 'Hello {{name}}, your id is {{id}}';
     const result = renderTemplate(template, { name: 'Bob' });
-    expect(result).toBe('Hello Bob, your id is {{id}}');
+    expect(result).toBe('Hello Bob, your id is <MISSING: id>');
   });
 
   test('handles template with no placeholders', () => {
@@ -58,10 +58,20 @@ describe('renderTemplate', () => {
     expect(result).toBe('No placeholders here.');
   });
 
-  test('handles empty inputs', () => {
+  test('replaces all missing placeholders with <MISSING: key>', () => {
     const template = '{{greeting}} world';
     const result = renderTemplate(template, {});
-    expect(result).toBe('{{greeting}} world');
+    expect(result).toBe('<MISSING: greeting> world');
+  });
+
+  test('input values containing {{key}} patterns are not double-interpolated', () => {
+    // JavaScript String.replace with a regex callback is single-pass: it scans
+    // the ORIGINAL template left-to-right, so substituted values are never
+    // re-scanned for further matches. This test documents that guarantee.
+    const template = 'Message: {{body}}';
+    const result = renderTemplate(template, { body: 'hello {{secret}}', secret: 'PRIVATE' });
+    // The {{secret}} inside the value is not expanded — it remains literal.
+    expect(result).toBe('Message: hello {{secret}}');
   });
 });
 


### PR DESCRIPTION
## Summary
- Updates stale test expectations left from the `renderTemplate` change in #7676, which changed missing-placeholder behavior from `{{key}}` → `<MISSING: key>`
- Two tests in `task-runner.test.ts` and one in `task-management-tools.test.ts` were asserting the old verbatim-pass-through behavior and would have been failing since #7676 merged
- Adds a new regression test documenting that user-supplied input values containing `{{key}}` patterns are **not** double-interpolated: `String.replace` with a regex callback operates as a single left-to-right scan on the original template string, so substituted values are never re-processed — this is the safe behavior for the template injection concern

## Test plan
- [ ] `bun test --filter task-runner` passes
- [ ] `bun test --filter task-management-tools` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
