### PR TITLE
fix: filter Available Skills to only Vellum-provided bundled skills

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -689,6 +689,7 @@ function escapeXml(str: string): string {
 function formatSkillsCatalog(skills: SkillSummary[]): string {
   // Filter out skills with disableModelInvocation or unsupported OS
   const visible = skills.filter(s => {
+    if (s.source !== 'bundled') return false;
     if (s.disableModelInvocation) return false;
     const os = s.metadata?.os;
     if (os && os.length > 0 && !os.includes(process.platform)) return false;


### PR DESCRIPTION
## Summary
- Filters the `<available_skills>` section in the system prompt to only include skills with `source: 'bundled'`
- Excludes workspace, managed (clawhub/catalog-installed), and extra skills from the model's available skills list

## Test plan
- [ ] Verify system prompt only lists bundled skills (not workspace/managed/extra)
- [ ] Confirm bundled skills still appear and work correctly via `skill_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
