### PR TITLE
feat: silentlyWithLog helper — replace silent promise swallows with debug logging

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,4 +1,5 @@
 import * as net from 'node:net';
+import { silentlyWithLog } from '../../util/silently.js';
 import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
@@ -405,9 +406,12 @@ export function handleHistoryRequest(
           if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {
             const attachmentId = a.id;
             const base64 = a.dataBase64;
-            generateVideoThumbnail(base64).then((thumb) => {
-              if (thumb) setAttachmentThumbnail(attachmentId, thumb);
-            }).catch(() => {});
+            silentlyWithLog(
+              generateVideoThumbnail(base64).then((thumb) => {
+                if (thumb) setAttachmentThumbnail(attachmentId, thumb);
+              }),
+              'video thumbnail generation',
+            );
           }
 
           return {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../../util/logger.js';
 import { checkBrowserRuntime } from './runtime-check.js';
 import { authSessionCache } from './auth-cache.js';
 import type { ExtractedCredential } from './network-recording-types.js';
+import { silentlyWithLog } from '../../util/silently.js';
 
 const log = getLogger('browser-manager');
 
@@ -477,7 +478,7 @@ class BrowserManager {
 
     cdp.on('Page.screencastFrame', (params) => {
       onFrame({ data: params.data as string, metadata: params.metadata as ScreencastFrameMetadata });
-      cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {});
+      silentlyWithLog(cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }), 'screencast frame ack');
     });
 
     await cdp.send('Page.startScreencast', {

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -21,6 +21,7 @@ import type { CredentialInjectionTemplate } from '../../credentials/policy-types
 import { getSecureKey } from '../../../security/secure-keys.js';
 import { buildDecisionTrace, stripQueryString } from './logging.js';
 import { getLogger } from '../../../util/logger.js';
+import { silentlyWithLog } from '../../../util/silently.js';
 
 const log = getLogger('proxy-session');
 
@@ -68,7 +69,7 @@ function resetIdleTimer(managed: ManagedSession): void {
   }
   managed.idleTimer = setTimeout(() => {
     if (managed.session.status === 'active') {
-      stopSession(managed.session.id).catch(() => {});
+      silentlyWithLog(stopSession(managed.session.id), 'idle session cleanup');
     }
   }, managed.config.idleTimeoutMs);
 }
@@ -529,6 +530,6 @@ export function getSessionsForConversation(conversationId: string): ProxySession
  */
 export async function stopAllSessions(): Promise<void> {
   const ids = [...sessions.keys()];
-  await Promise.all(ids.map((id) => stopSession(id).catch(() => {})));
+  await Promise.all(ids.map((id) => silentlyWithLog(stopSession(id), 'session shutdown')));
   sessions.clear();
 }

--- a/assistant/src/util/silently.ts
+++ b/assistant/src/util/silently.ts
@@ -1,0 +1,21 @@
+import { getLogger } from './logger.js';
+
+const log = getLogger('silently');
+
+/**
+ * Attaches a `.catch()` to `promise` that emits a debug-level log instead of
+ * swallowing the rejection completely.  Use this in place of bare
+ * `.catch(() => {})` when you need fire-and-forget semantics but still want
+ * visibility into unexpected errors during debugging.
+ *
+ * The original promise is returned unchanged so callers can still chain it.
+ *
+ * @example
+ *   silentlyWithLog(stopSession(id), 'idle session cleanup');
+ */
+export function silentlyWithLog<T>(promise: Promise<T>, context: string): Promise<T> {
+  promise.catch((err: unknown) => {
+    log.debug({ err, context }, 'Suppressed async error');
+  });
+  return promise;
+}


### PR DESCRIPTION
## Summary

- Adds \`util/silently.ts\` with \`silentlyWithLog(promise, context)\` that logs at debug level instead of completely swallowing errors
- Replaces the most impactful bare \`.catch(() => {})\` suppressions where debug visibility helps

## Changes

- \`util/silently.ts\` — new utility: logs \`{ err, context }\` via \`getLogger('silently')\` at debug level; returns the original promise for optional chaining
- \`daemon/handlers/sessions.ts\` — video thumbnail generation failure now logged
- \`tools/network/script-proxy/session-manager.ts\` — idle session cleanup and shutdown failures now logged
- \`tools/browser/browser-manager.ts\` — CDP screencast frame ack failure now logged

## Not changed

Remaining \`.catch(() => {})\` patterns left intentional:
- \`rm(...).catch(() => {})\` cleanup in transcribe/extract-keyframes — file-not-found errors are expected in finally blocks
- \`agent/loop.ts\` — prevents unhandled rejection after Promise.race
- \`swarm/orchestrator.ts\` — fire-and-forget with documented comment
- \`session-manager.ts:490\` — rejection handled by \`await promise\` below (documented)
- Browser CDP Page.enable/Runtime.evaluate — best-effort ops where failure is expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
