### PR TITLE
fix(memory): adaptive fetching to handle dense exclusion sets in memory retriever

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -108,27 +108,21 @@ async function collectAndMergeCandidates(
     : [];
 
   // Direct item search supplements FTS with LIKE-based matching.
-  // Overfetch when exclusions are present so that filtering doesn't
-  // silently drop valid candidates just below the SQL LIMIT cutoff.
+  // When exclusions are present, adaptively increase the fetch size until
+  // we collect directLimit valid (non-excluded) items or exhaust the DB.
   const directLimit = Math.max(10, config.memory.retrieval.lexicalTopK);
-  const directFetchLimit = excludeMessageIds.length > 0
-    ? Math.max(directLimit + 24, directLimit * 2)
-    : directLimit;
-  let directItems = directItemSearch(query, directFetchLimit, scopeIds);
 
-  // Filter direct items by excluded message IDs -- items whose only evidence
-  // comes from excluded messages should not leak back into recall.
-  if (excludeMessageIds.length > 0 && directItems.length > 0) {
+  // Helper: filter fetched direct items to those with at least one non-excluded source.
+  const filterDirectItems = (items: Candidate[]): Candidate[] => {
+    if (items.length === 0) return items;
     const db = getDb();
     const excludedSet = new Set(excludeMessageIds);
     const allSources = db.select({
       memoryItemId: memoryItemSources.memoryItemId,
       messageId: memoryItemSources.messageId,
     }).from(memoryItemSources)
-      .where(inArray(memoryItemSources.memoryItemId, directItems.map((c) => c.id)))
+      .where(inArray(memoryItemSources.memoryItemId, items.map((c) => c.id)))
       .all();
-
-    // Track which items have at least one non-excluded source
     const hasNonExcluded = new Set<string>();
     const hasSources = new Set<string>();
     for (const s of allSources) {
@@ -137,11 +131,25 @@ async function collectAndMergeCandidates(
         hasNonExcluded.add(s.memoryItemId);
       }
     }
+    return items.filter((c) => !hasSources.has(c.id) || hasNonExcluded.has(c.id));
+  };
 
-    directItems = directItems.filter((c) =>
-      !hasSources.has(c.id) || hasNonExcluded.has(c.id),
-    );
-    directItems = directItems.slice(0, directLimit);
+  let directItems: Candidate[];
+  if (excludeMessageIds.length > 0) {
+    // Adaptive loop: double fetch size on each iteration until quota met or DB exhausted.
+    const MAX_FETCH_MULTIPLIER = 8;
+    let fetchSize = Math.max(directLimit * 2, directLimit + 24);
+    directItems = [];
+    while (true) {
+      const fetched = directItemSearch(query, fetchSize, scopeIds);
+      directItems = filterDirectItems(fetched).slice(0, directLimit);
+      if (directItems.length >= directLimit || fetched.length < fetchSize || fetchSize >= directLimit * MAX_FETCH_MULTIPLIER) {
+        break;
+      }
+      fetchSize = Math.min(fetchSize * 2, directLimit * MAX_FETCH_MULTIPLIER);
+    }
+  } else {
+    directItems = directItemSearch(query, directLimit, scopeIds);
   }
 
   // -- Early termination check --

--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -39,37 +39,53 @@ export function lexicalSearch(query: string, limit: number, excludedMessageIds: 
   const matchQuery = buildFtsMatchQuery(trimmed);
   if (!matchQuery) return [];
   const excluded = new Set(excludedMessageIds);
-  let rows: FtsRow[] = [];
-  const queryLimit = excluded.size > 0
-    ? Math.max(limit + 24, limit * 2)
-    : limit;
   const scopeClause = scopeIds
     ? ` AND s.scope_id IN (${scopeIds.map(() => '?').join(',')})`
     : '';
-  try {
-    rows = timedRawQuery('lexicalSearch', () =>
-      rawAll<FtsRow>(`
-        SELECT
-          f.segment_id AS segment_id,
-          s.message_id AS message_id,
-          s.text AS text,
-          s.created_at AS created_at,
-          bm25(memory_segment_fts) AS rank
-        FROM memory_segment_fts f
-        JOIN memory_segments s ON s.id = f.segment_id
-        WHERE memory_segment_fts MATCH ?${scopeClause}
-        ORDER BY rank
-        LIMIT ?
-      `, matchQuery, ...(scopeIds ?? []), queryLimit),
-    );
-  } catch (err) {
-    log.warn({ err, query: truncate(trimmed, 80) }, 'Memory lexical search query parse failed');
-    return [];
+
+  // Adaptive overfetch: when exclusions are present, double the SQL LIMIT until we
+  // collect `limit` visible rows or the DB has no more matching results to offer.
+  // This handles dense exclusion sets without wasteful fixed-ratio over-fetching.
+  const MAX_FETCH_MULTIPLIER = 8;
+  let queryLimit = excluded.size > 0 ? Math.max(limit * 2, limit + 24) : limit;
+  let visibleRows: FtsRow[] = [];
+
+  while (true) {
+    let rows: FtsRow[] = [];
+    try {
+      rows = timedRawQuery('lexicalSearch', () =>
+        rawAll<FtsRow>(`
+          SELECT
+            f.segment_id AS segment_id,
+            s.message_id AS message_id,
+            s.text AS text,
+            s.created_at AS created_at,
+            bm25(memory_segment_fts) AS rank
+          FROM memory_segment_fts f
+          JOIN memory_segments s ON s.id = f.segment_id
+          WHERE memory_segment_fts MATCH ?${scopeClause}
+          ORDER BY rank
+          LIMIT ?
+        `, matchQuery, ...(scopeIds ?? []), queryLimit),
+      );
+    } catch (err) {
+      log.warn({ err, query: truncate(trimmed, 80) }, 'Memory lexical search query parse failed');
+      return [];
+    }
+
+    visibleRows = excluded.size > 0
+      ? rows.filter((row) => !excluded.has(row.message_id))
+      : rows;
+
+    // Stop when we have enough rows, the DB returned fewer than requested
+    // (no more results exist), or we've reached the safety cap.
+    if (visibleRows.length >= limit || rows.length < queryLimit || queryLimit >= limit * MAX_FETCH_MULTIPLIER) {
+      break;
+    }
+    queryLimit = Math.min(queryLimit * 2, limit * MAX_FETCH_MULTIPLIER);
   }
 
-  const visibleRows = excluded.size > 0
-    ? rows.filter((row) => !excluded.has(row.message_id)).slice(0, limit)
-    : rows;
+  visibleRows = visibleRows.slice(0, limit);
 
   const finiteRanks = visibleRows
     .map((row) => row.rank)


### PR DESCRIPTION
The fixed directLimit*2 overfetch in lexicalSearch and directItemSearch didn't account for dense exclusion sets — when many items were excluded, the filter left far fewer than the requested quota.

**Changes:**
- `lexical.ts`: replaced the fixed `Math.max(limit+24, limit*2)` SQL LIMIT with an adaptive loop that doubles the fetch size (up to 8x) until `limit` visible rows are collected or the DB has no more results
- `retriever.ts`: same adaptive loop for direct item search, extracted the exclusion-filter logic into an inline helper `filterDirectItems`

**Note:** The TODO item also mentioned BM25 normalization — that was already implemented via `lexicalRankToScore` (min-max normalization to 0–1) and `confidenceThreshold` already validates to [0,1] in the schema. No normalization changes needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
