### PR TITLE
fix: add missing parental control IPC snapshot entries

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -938,6 +938,43 @@ exports[`IPC message snapshots ClientMessage types dictation_request serializes 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types parental_control_get serializes to expected JSON 1`] = `
+{
+  "type": "parental_control_get",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types parental_control_verify_pin serializes to expected JSON 1`] = `
+{
+  "pin": "123456",
+  "type": "parental_control_verify_pin",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types parental_control_set_pin serializes to expected JSON 1`] = `
+{
+  "current_pin": "123456",
+  "new_pin": "654321",
+  "type": "parental_control_set_pin",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types parental_control_update serializes to expected JSON 1`] = `
+{
+  "blocked_tool_categories": [
+    "shell",
+    "network",
+  ],
+  "content_restrictions": [
+    "violence",
+    "adult_content",
+  ],
+  "enabled": true,
+  "pin": "123456",
+  "type": "parental_control_update",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -2482,6 +2519,16 @@ exports[`IPC message snapshots ServerMessage types task_run_thread_created seria
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types guardian_request_thread_created serializes to expected JSON 1`] = `
+{
+  "callSessionId": "call-001",
+  "conversationId": "conv-guardian-001",
+  "requestId": "req-guardian-001",
+  "title": "Guardian action request",
+  "type": "guardian_request_thread_created",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types subagent_spawned serializes to expected JSON 1`] = `
 {
   "label": "Research Agent",
@@ -2607,12 +2654,49 @@ exports[`IPC message snapshots ServerMessage types dictation_response serializes
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types guardian_request_thread_created serializes to expected JSON 1`] = `
+exports[`IPC message snapshots ServerMessage types parental_control_get_response serializes to expected JSON 1`] = `
 {
-  "callSessionId": "call-001",
-  "conversationId": "conv-guardian-001",
-  "requestId": "req-guardian-001",
-  "title": "Guardian action request",
-  "type": "guardian_request_thread_created",
+  "blocked_tool_categories": [
+    "shell",
+    "network",
+  ],
+  "content_restrictions": [
+    "violence",
+    "adult_content",
+  ],
+  "enabled": true,
+  "has_pin": true,
+  "type": "parental_control_get_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types parental_control_verify_pin_response serializes to expected JSON 1`] = `
+{
+  "type": "parental_control_verify_pin_response",
+  "verified": true,
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types parental_control_set_pin_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "parental_control_set_pin_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types parental_control_update_response serializes to expected JSON 1`] = `
+{
+  "blocked_tool_categories": [
+    "shell",
+    "network",
+  ],
+  "content_restrictions": [
+    "violence",
+    "adult_content",
+  ],
+  "enabled": true,
+  "has_pin": true,
+  "success": true,
+  "type": "parental_control_update_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -585,6 +585,25 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
       cursorInTextField: true,
     },
   },
+  parental_control_get: {
+    type: 'parental_control_get',
+  },
+  parental_control_verify_pin: {
+    type: 'parental_control_verify_pin',
+    pin: '123456',
+  },
+  parental_control_set_pin: {
+    type: 'parental_control_set_pin',
+    current_pin: '123456',
+    new_pin: '654321',
+  },
+  parental_control_update: {
+    type: 'parental_control_update',
+    pin: '123456',
+    enabled: true,
+    content_restrictions: ['violence', 'adult_content'],
+    blocked_tool_categories: ['shell', 'network'],
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1681,6 +1700,29 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     text: 'Hello world',
     mode: 'dictation',
     actionPlan: undefined,
+  },
+  parental_control_get_response: {
+    type: 'parental_control_get_response',
+    enabled: true,
+    has_pin: true,
+    content_restrictions: ['violence', 'adult_content'],
+    blocked_tool_categories: ['shell', 'network'],
+  },
+  parental_control_verify_pin_response: {
+    type: 'parental_control_verify_pin_response',
+    verified: true,
+  },
+  parental_control_set_pin_response: {
+    type: 'parental_control_set_pin_response',
+    success: true,
+  },
+  parental_control_update_response: {
+    type: 'parental_control_update_response',
+    success: true,
+    enabled: true,
+    has_pin: true,
+    content_restrictions: ['violence', 'adult_content'],
+    blocked_tool_categories: ['shell', 'network'],
   },
 };
 


### PR DESCRIPTION
## Summary
- Added 4 missing client message entries (`parental_control_get`, `parental_control_verify_pin`, `parental_control_set_pin`, `parental_control_update`) and 4 missing server message entries (`parental_control_get_response`, `parental_control_verify_pin_response`, `parental_control_set_pin_response`, `parental_control_update_response`) to the IPC snapshot test
- Updated snapshot file with the new entries

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22349431917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
