### PR TITLE
Fix collapsed nav hit area (#7696 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1257,11 +1257,15 @@ private struct SidebarNavRow: View {
                     .foregroundColor(VColor.textPrimary)
                     .fixedSize()
                     .opacity(isExpanded ? 1 : 0)
-                Spacer()
+                    .allowsHitTesting(false)
+                if isExpanded {
+                    Spacer()
+                }
             }
             .padding(.leading, VSpacing.md)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: isExpanded ? .infinity : nil)
             .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())


### PR DESCRIPTION
## Summary
- Constrain SidebarNavRow width when isExpanded is false so the interactive hit area doesn't extend beyond the visible 52pt collapsed sidebar
- Addresses Codex review feedback on #7696
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
