### PR TITLE
Redesign initial screen with DinoFace avatar & fix composer jitter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -26,31 +26,11 @@ struct ChatEmptyStateView: View {
     @Binding var isComposerExpanded: Bool
 
     @State private var visible = false
-    @State private var title: String = titles.randomElement()!
-    @State private var placeholder: String = placeholderTexts.randomElement()!
 
     // MARK: - Greeting Data
 
-    static let defaultGreetings = [
-        "What are we working on?",
-        "I'm here whenever you need me.",
-        "What's on your mind?",
-        "Let's make something happen.",
-        "Ready when you are.",
-    ]
-
-    static var titles: [String] {
-        let custom = IdentityInfo.loadGreetings()
-        return custom.isEmpty ? defaultGreetings : custom
-    }
-
-    static let placeholderTexts = [
-        "Ask me anything...",
-        "Tell me what you need...",
-        "Say the word...",
-        "Go ahead, I'm listening...",
-        "Type or hold Fn to talk...",
-    ]
+    private let title = "Let\u{2019}s make something happen."
+    private let placeholder = "What you need chief?"
 
     // MARK: - Body
 
@@ -59,8 +39,10 @@ struct ChatEmptyStateView: View {
             Spacer()
             Spacer()
 
-            Text("🍃")
-                .font(.system(size: 48))
+            DinoFaceView(seed: "default")
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .allowsHitTesting(false)
                 .opacity(visible ? 1 : 0)
                 .scaleEffect(visible ? 1 : 0.8)
                 .padding(.bottom, VSpacing.lg)
@@ -107,6 +89,7 @@ struct ChatEmptyStateView: View {
                     onPaste: onPaste,
                     onMicrophoneToggle: onMicrophoneToggle,
                     placeholderText: placeholder,
+                    composerCompactHeight: 68,
                     editorContentHeight: $editorContentHeight,
                     isComposerExpanded: $isComposerExpanded
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -22,7 +22,6 @@ enum SlashNavigation {
 }
 
 struct ComposerView: View {
-    private let composerCompactHeight: CGFloat = 34
     private let composerMaxHeight: CGFloat = 200
     private let composerActionButtonSize: CGFloat = 34
     private let composerActionIconSize: CGFloat = 14
@@ -49,6 +48,7 @@ struct ComposerView: View {
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
     var placeholderText: String = "What would you like to do?"
+    var composerCompactHeight: CGFloat = 34
     /// Bound to ChatView's state so it can compute composerReservedHeight for safe area insets.
     @Binding var editorContentHeight: CGFloat
 
@@ -160,7 +160,6 @@ struct ComposerView: View {
         .padding(.top, VSpacing.sm)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
-        .animation(VAnimation.fast, value: editorContentHeight)
         .animation(VAnimation.fast, value: isComposerExpanded)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
@@ -244,10 +243,12 @@ struct ComposerView: View {
             }
         }
         .onChange(of: editorContentHeight) {
+            // Only expand — never collapse based on height alone.
+            // Collapsing is handled when inputText becomes empty (see above).
+            // This prevents layout oscillation: expand → buttons move → text
+            // has more width → unwrap → collapse → buttons back → re-wrap → loop.
             if editorContentHeight > composerCompactHeight && !isComposerExpanded {
                 withAnimation(VAnimation.fast) { isComposerExpanded = true }
-            } else if editorContentHeight <= composerCompactHeight && isComposerExpanded {
-                withAnimation(VAnimation.fast) { isComposerExpanded = false }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces the 🍃 emoji on the initial empty chat screen with the DinoFaceView avatar at 48pt
- Sets a fixed greeting title ("Let's make something happen.") and placeholder ("What you need chief?")
- Makes the composer input 2 lines tall on the empty state (composerCompactHeight: 68)
- Fixes the composer text input jitter bug: when text wrapped to a new line, a layout oscillation occurred because the expand/collapse toggle in `onChange(of: editorContentHeight)` would expand → shift button layout → give text more width → unwrap → collapse → repeat. Fixed by making expansion sticky (collapse only when text is cleared)
- Removes duplicate `.animation(VAnimation.fast, value: editorContentHeight)` that caused visual doubling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
