### PR TITLE
fix(db): clean up orphaned temp table before entity-relation dedup migration

### DIFF
--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -238,6 +238,14 @@ export function migrateMemoryEntityRelationDedup(database: Db): void {
   ).get(checkpointKey);
   if (checkpoint) return;
 
+  // Drop the staging temp table if it was left behind by a previous failed
+  // attempt in the same connection.  TEMP tables survive ROLLBACK (they live
+  // in a separate SQLite schema) so a mid-migration exception can leave the
+  // table present even after the transaction rolls back.  Clearing it here
+  // makes re-entry safe without needing IF NOT EXISTS semantics on the full
+  // CREATE … AS SELECT.
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_entity_relation_merge`);
+
   try {
     raw.exec('BEGIN');
 


### PR DESCRIPTION
## Summary

- Adds `DROP TABLE IF EXISTS memory_entity_relation_merge` immediately before the `BEGIN` in `migrateMemoryEntityRelationDedup`

## Problem

SQLite `TEMP TABLE`s live in a separate `temp` schema and **are not rolled back** when a transaction rolls back. If `migrateMemoryEntityRelationDedup` fails after creating the staging table but before dropping it (e.g., an SQL error mid-migration triggers `ROLLBACK`), the temp table persists for the lifetime of the current connection.

On a subsequent re-entry attempt within the same connection (or if `initializeDb` is ever called more than once), `CREATE TEMP TABLE memory_entity_relation_merge AS ...` would fail with a "table already exists" error, preventing the migration from completing.

## Fix

Unconditionally drop the staging table before the transaction begins. This is a no-op on a fresh run and a safe cleanup on retry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
