### PR TITLE
M3: Identity panel background color #F5F3EB (#7692)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -448,6 +448,7 @@ extension MainWindowView {
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
         case .generated:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -76,7 +76,7 @@ struct IdentityPanel: View {
                 }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.background)
+            .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         }
         .overlay {
             if let path = viewingFilePath {


### PR DESCRIPTION
## Summary
- Sets the identity panel background to warm off-white (#F5F3EB) in light mode
- Dark mode background unchanged
- Uses adaptiveColor for light/dark mode handling

Closes #7692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
