### PR TITLE
feat(ux): surface memory backend degradation in chat UI

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -145,6 +145,12 @@ struct ChatContentView: View {
                 genericErrorBanner(errorText)
             }
 
+            // Memory degradation banner — shown when embedding fails and recall
+            // falls back to lexical-only search so users aren't caught off guard.
+            if viewModel.isMemoryDegraded {
+                memoryDegradedBanner
+            }
+
             // Input bar
             InputBarView(
                 text: $viewModel.inputText,
@@ -164,6 +170,7 @@ struct ChatContentView: View {
         .background(VColor.chatBackground)
         .animation(.easeInOut(duration: 0.2), value: viewModel.sessionError != nil)
         .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isMemoryDegraded)
         .onChange(of: viewModel.messages.isEmpty) { _, isEmpty in
             if isEmpty {
                 greeting = greetingChoices.randomElement()!
@@ -264,6 +271,37 @@ struct ChatContentView: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .background(VColor.error)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    /// Subtle banner shown when memory embedding fails so users know recall is lexical-only.
+    private var memoryDegradedBanner: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "memorychip")
+                .font(VFont.caption)
+                .foregroundColor(VColor.warning)
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Memory search limited")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
+                if let reason = viewModel.memoryDegradedReason {
+                    Text(reason)
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.warning.opacity(0.1))
+        .overlay(
+            Rectangle()
+                .fill(VColor.warning)
+                .frame(width: 3),
+            alignment: .leading
+        )
         .transition(.move(edge: .top).combined(with: .opacity))
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -54,6 +54,8 @@ struct ChatView: View {
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
+    var isMemoryDegraded: Bool = false
+    var memoryDegradedReason: String? = nil
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Sums utf8.count over each segment (O(1) per contiguous segment) instead of joining first,
@@ -87,6 +89,7 @@ struct ChatView: View {
         ZStack {
             VStack(spacing: 0) {
                 apiKeyBanner
+                memoryDegradedBanner
                 if messages.isEmpty && !isHistoryLoaded {
                     Spacer()
                     HStack {
@@ -671,6 +674,39 @@ struct ChatView: View {
     }
 
     @ViewBuilder
+    @ViewBuilder
+    private var memoryDegradedBanner: some View {
+        if isMemoryDegraded {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "memorychip")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.warning)
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Memory search limited")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textPrimary)
+                    if let reason = memoryDegradedReason {
+                        Text(reason)
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.warning.opacity(0.1))
+            .overlay(
+                Rectangle()
+                    .fill(VColor.warning)
+                    .frame(width: 3),
+                alignment: .leading
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
     private var apiKeyBanner: some View {
         if !hasAPIKey {
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -659,7 +659,9 @@ struct ActiveChatViewWrapper: View {
             daemonHttpPort: daemonClient.httpPort,
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
-            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) }
+            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
+            isMemoryDegraded: viewModel.isMemoryDegraded,
+            memoryDegradedReason: viewModel.memoryDegradedReason
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -81,6 +81,32 @@ struct DebugPanel: View {
                 }
 
                 if let memory = daemonClient.latestMemoryStatus {
+                    let memoryDegraded = memory.enabled && memory.degraded
+                    metric(
+                        icon: memoryDegraded ? "memorychip.fill" : "memorychip",
+                        label: "Memory",
+                        value: !memory.enabled ? "Disabled"
+                            : memoryDegraded ? "Degraded"
+                            : "Healthy",
+                        color: !memory.enabled ? VColor.textMuted
+                            : memoryDegraded ? Amber._400
+                            : Emerald._400
+                    )
+                    if let provider = memory.provider {
+                        metric(
+                            icon: "cpu",
+                            label: "Embed Provider",
+                            value: memory.model.map { "\(provider)/\($0)" } ?? provider
+                        )
+                    }
+                    if memoryDegraded, let reason = memory.reason {
+                        metric(
+                            icon: "exclamationmark.triangle",
+                            label: "Degradation Reason",
+                            value: reason,
+                            color: Amber._400
+                        )
+                    }
                     metric(
                         icon: "memorychip",
                         label: "Pending Conflicts",

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1289,6 +1289,12 @@ extension ChatViewModel {
                 configuredProviders = Set(providers)
             }
 
+        case .memoryStatus(let status):
+            // Update degradation state so the UI can surface a subtle warning banner.
+            let degraded = status.enabled && status.degraded
+            isMemoryDegraded = degraded
+            memoryDegradedReason = degraded ? status.reason : nil
+
         default:
             break
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -52,6 +52,14 @@ public final class ChatViewModel: ObservableObject {
     /// Set of provider keys with configured API keys, updated via `model_info` IPC messages.
     @Published public var configuredProviders: Set<String> = ["anthropic"]
 
+    /// Whether the memory backend is currently degraded (e.g. embedding failures).
+    /// Updated from `memory_status` IPC messages. When `true`, semantic recall is
+    /// unavailable and the assistant falls back to lexical-only search.
+    @Published public var isMemoryDegraded: Bool = false
+    /// Human-readable reason for degradation (e.g. "memory.embedding_failure: API 401").
+    /// Nil when memory is healthy or memory is disabled.
+    @Published public var memoryDegradedReason: String? = nil
+
     /// Maximum file size per attachment (20 MB).
     static let maxFileSize = 20 * 1024 * 1024
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).


### PR DESCRIPTION
## Summary

When the memory embedding backend fails, the assistant falls back to lexical-only recall — but users had no indication this was happening. This PR surfaces the `degraded` flag (already present in the `memory_status` IPC message) as a subtle inline banner and expands the debug panel.

### Changes

**Shared (`ChatViewModel`)**
- Added `@Published var isMemoryDegraded: Bool` and `@Published var memoryDegradedReason: String?`
- Added `case .memoryStatus` handler in `handleServerMessage` — updates these from the `memory_status` IPC event (already received every turn)

**iOS (`ChatContentView`)**
- Added `memoryDegradedBanner`: amber left-accent banner showing "Memory search limited" + reason string (shown above the input bar when `viewModel.isMemoryDegraded`)
- Animated in/out with `.move(edge: .top).combined(with: .opacity)`

**macOS (`ChatView`)**
- Added `isMemoryDegraded: Bool` and `memoryDegradedReason: String?` parameters (both default false/nil)
- Added `memoryDegradedBanner`: same amber left-accent style, shown below the API key banner

**macOS (`PanelCoordinator`)**
- Passes `viewModel.isMemoryDegraded` and `viewModel.memoryDegradedReason` through to `ChatView`

**macOS (`DebugPanel`)**
- Added "Memory" metric (Healthy / Degraded / Disabled) with colour-coded dot
- Added "Embed Provider" metric showing provider + model
- Added "Degradation Reason" metric (Amber, only when degraded)

## Notes

- The `memory_status.degraded` flag is only `true` when `memory.enabled && memory.degraded`, so the banner never shows for users who have memory disabled
- The `reason` field is optional — the banner degrades gracefully if nil
- No changes to the IPC contract or TypeScript daemon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
