### PR TITLE
feat(ux): surface actionable diagnostic hints on daemon connect errors

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -236,10 +236,18 @@ struct ChatContentView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.white)
                 .font(VFont.caption)
-            Text(errorText)
-                .font(VFont.caption)
-                .foregroundColor(.white)
-                .lineLimit(2)
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(errorText)
+                    .font(VFont.caption)
+                    .foregroundColor(.white)
+                    .lineLimit(2)
+                if viewModel.isConnectionError, let hint = viewModel.connectionDiagnosticHint {
+                    Text(hint)
+                        .font(VFont.small)
+                        .foregroundColor(.white.opacity(0.8))
+                        .lineLimit(2)
+                }
+            }
             Spacer()
             if viewModel.isSecretBlockError {
                 Button(action: { viewModel.sendAnyway() }) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -9,6 +9,7 @@ struct ChatErrorBanner: View {
     let isRetryableError: Bool
     let onRetryError: () -> Void
     let isConnectionError: Bool
+    var connectionDiagnosticHint: String? = nil
     let onOpenDoctor: () -> Void
     let onDismissError: () -> Void
 
@@ -17,9 +18,17 @@ struct ChatErrorBanner: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(VFont.caption)
 
-            Text(text)
-                .font(VFont.caption)
-                .lineLimit(4)
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(text)
+                    .font(VFont.caption)
+                    .lineLimit(4)
+                if let hint = connectionDiagnosticHint {
+                    Text(hint)
+                        .font(VFont.small)
+                        .opacity(0.8)
+                        .lineLimit(2)
+                }
+            }
 
             Spacer()
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -56,6 +56,7 @@ struct ChatView: View {
     var onDismissDocumentWidget: ((String) -> Void)?
     var isMemoryDegraded: Bool = false
     var memoryDegradedReason: String? = nil
+    var connectionDiagnosticHint: String? = nil
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     /// Sums utf8.count over each segment (O(1) per contiguous segment) instead of joining first,
@@ -239,6 +240,7 @@ struct ChatView: View {
                     isRetryableError: isRetryableError,
                     onRetryError: onRetryError,
                     isConnectionError: isConnectionError,
+                    connectionDiagnosticHint: connectionDiagnosticHint,
                     onOpenDoctor: onOpenDoctor,
                     onDismissError: onDismissError
                 )

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -661,7 +661,8 @@ struct ActiveChatViewWrapper: View {
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
             isMemoryDegraded: viewModel.isMemoryDegraded,
-            memoryDegradedReason: viewModel.memoryDegradedReason
+            memoryDegradedReason: viewModel.memoryDegradedReason,
+            connectionDiagnosticHint: viewModel.connectionDiagnosticHint
         )
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import os
 import UniformTypeIdentifiers
 #if os(macOS)
@@ -59,6 +60,10 @@ public final class ChatViewModel: ObservableObject {
     /// Human-readable reason for degradation (e.g. "memory.embedding_failure: API 401").
     /// Nil when memory is healthy or memory is disabled.
     @Published public var memoryDegradedReason: String? = nil
+
+    /// Supplemental diagnostic hint shown alongside a daemon connection error.
+    /// Nil when no connection error is active or the error has been dismissed.
+    @Published public var connectionDiagnosticHint: String? = nil
 
     /// Maximum file size per attachment (20 MB).
     static let maxFileSize = 20 * 1024 * 1024
@@ -401,6 +406,7 @@ public final class ChatViewModel: ObservableObject {
                     self.lastFailedMessageText = self.pendingUserMessage
                     self.lastFailedMessageAttachments = self.pendingUserAttachments
                     self.lastFailedSendError = "Failed to connect to the assistant."
+                    self.connectionDiagnosticHint = Self.connectionDiagnosticHint(for: error)
                     self.pendingUserMessage = nil
                     self.pendingUserAttachments = nil
                     self.errorText = self.lastFailedSendError
@@ -934,6 +940,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
+        connectionDiagnosticHint = nil
         secretBlockedMessageText = nil
         secretBlockedAttachments = nil
         secretBlockedActiveSurfaceId = nil
@@ -1445,5 +1452,60 @@ public final class ChatViewModel: ObservableObject {
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+    }
+
+    // MARK: - Connection diagnostics
+
+    /// Map a raw connection error to a short, actionable diagnostic hint.
+    ///
+    /// The hint is shown below the generic "Failed to connect" error banner so
+    /// users can understand *why* the connection failed without opening the
+    /// debug panel or contacting support.
+    static func connectionDiagnosticHint(for error: Error) -> String? {
+        #if os(macOS)
+        if let nwErr = error as? NWError {
+            switch nwErr {
+            case .posix(let code):
+                switch code {
+                case .ECONNREFUSED:
+                    return "Daemon is not accepting connections — it may still be starting."
+                case .ENOENT:
+                    return "Daemon socket not found — the daemon may not be running."
+                case .ETIMEDOUT:
+                    return "Connection timed out — the daemon may be unresponsive or the socket path may be wrong."
+                default:
+                    return "POSIX error \(code.rawValue): \(nwErr.localizedDescription)"
+                }
+            default:
+                return nwErr.localizedDescription
+            }
+        }
+        if let authErr = error as? DaemonClient.AuthError {
+            switch authErr {
+            case .missingToken:
+                return "Session token not found — try restarting the daemon."
+            case .timeout:
+                return "Authentication timed out — daemon may be overloaded."
+            case .rejected:
+                return "Session token rejected — token may have changed; try restarting the daemon."
+            }
+        }
+        #endif
+        // HTTP transport / iOS
+        if let urlErr = error as? URLError {
+            switch urlErr.code {
+            case .notConnectedToInternet:
+                return "Device is not connected to the internet."
+            case .timedOut:
+                return "Gateway request timed out — check your host and port."
+            case .cannotConnectToHost:
+                return "Cannot connect to gateway host — verify the address and that the daemon is running."
+            case .networkConnectionLost:
+                return "Network connection lost."
+            default:
+                return urlErr.localizedDescription
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Summary

Connection errors previously showed only "Failed to connect to the assistant." — no indication of *why* (daemon not running, wrong socket path, auth token mismatch, etc.).

### Changes

**Shared (`ChatViewModel`)**
- Added `@Published var connectionDiagnosticHint: String?` — cleared on `dismissError()`
- Added `static func connectionDiagnosticHint(for:) -> String?` — maps known error types to short, actionable strings:
  - macOS NWError (`ECONNREFUSED`) → "Daemon is not accepting connections — it may still be starting."
  - macOS NWError (`ENOENT`) → "Daemon socket not found — the daemon may not be running."
  - macOS NWError (`ETIMEDOUT`) → "Connection timed out — the daemon may be unresponsive..."
  - `DaemonClient.AuthError.missingToken` → "Session token not found — try restarting the daemon."
  - `DaemonClient.AuthError.rejected` → "Session token rejected — token may have changed..."
  - iOS `URLError.cannotConnectToHost` → "Cannot connect to gateway host — verify the address..."
  - iOS `URLError.timedOut` → "Gateway request timed out — check your host and port."
  - etc.
- Sets `connectionDiagnosticHint` in the connect catch block alongside the existing `errorText`

**macOS (`ChatErrorToastView`)**
- `ChatErrorBanner` now accepts optional `connectionDiagnosticHint: String?` and renders it as a smaller secondary line below the main error text

**macOS (`ChatView` + `PanelCoordinator`)**
- Adds `connectionDiagnosticHint` parameter to `ChatView` (default nil), threads it through from `viewModel.connectionDiagnosticHint`

**iOS (`ChatContentView`)**
- `genericErrorBanner` shows the hint below the main error when `viewModel.isConnectionError` and hint is non-nil
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
