### PR TITLE
fix(ios): surface inline errors for all voice recording failure modes

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -192,6 +192,9 @@ struct InputBarView: View {
         AVAudioApplication.requestRecordPermission { granted in
             guard granted else {
                 log.warning("Microphone access denied")
+                DispatchQueue.main.async {
+                    viewModel.errorText = "Microphone access denied — enable it in Settings > Privacy > Microphone."
+                }
                 return
             }
             // Request speech recognition access
@@ -199,6 +202,7 @@ struct InputBarView: View {
                 DispatchQueue.main.async {
                     guard status == .authorized else {
                         log.warning("Speech recognition not authorized: \(String(describing: status))")
+                        viewModel.errorText = "Speech recognition not authorized — enable it in Settings > Privacy > Speech Recognition."
                         return
                     }
                     beginRecording()
@@ -210,6 +214,7 @@ struct InputBarView: View {
     private func beginRecording() {
         guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
             log.error("Speech recognizer not available")
+            viewModel.errorText = "Voice input is not available on this device."
             return
         }
 
@@ -219,6 +224,7 @@ struct InputBarView: View {
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             log.error("Failed to configure AVAudioSession: \(error.localizedDescription)")
+            viewModel.errorText = "Could not start voice input: \(error.localizedDescription)"
             return
         }
 
@@ -231,6 +237,7 @@ struct InputBarView: View {
 
         guard recordingFormat.channelCount > 0 else {
             log.error("No audio input channels available")
+            viewModel.errorText = "No microphone input available."
             return
         }
 
@@ -267,6 +274,7 @@ struct InputBarView: View {
             log.info("Voice recording started")
         } catch {
             log.error("Audio engine failed to start: \(error.localizedDescription)")
+            viewModel.errorText = "Voice input failed: \(error.localizedDescription)"
             // Remove the tap installed above before cleanupRecognition — otherwise the
             // next recording attempt fails trying to install a second tap on bus 0.
             audioEngine.inputNode.removeTap(onBus: 0)


### PR DESCRIPTION
## Summary

`InputBarView.beginRecording()` and its permission-request path silently returned on every failure path — users had no idea why the mic button didn't start recording.

### Failure modes now surfaced via `viewModel.errorText`:

| Failure | Before | After |
|---------|--------|-------|
| Microphone permission denied | silent | "Microphone access denied — enable it in Settings > Privacy > Microphone." |
| Speech recognition not authorized | silent | "Speech recognition not authorized — enable it in Settings > Privacy > Speech Recognition." |
| `SFSpeechRecognizer` unavailable | silent | "Voice input is not available on this device." |
| `AVAudioSession` config failed | silent | "Could not start voice input: \<error\>" |
| No audio input channels | silent | "No microphone input available." |
| Audio engine failed to start | silent | "Voice input failed: \<error\>" |

All failure paths still log at the appropriate level; the `viewModel.errorText` assignment is additive.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
