### PR TITLE
Fix VDisclosureSection subtitle truncation

### DIFF
--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -46,6 +46,8 @@ public struct VDisclosureSection<Content: View>: View {
                             Text(subtitle)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Adds `.lineLimit(1)` and `.truncationMode(.middle)` to the subtitle text in VDisclosureSection
- Prevents long URLs (like gateway URLs) from wrapping to multiple lines when section is collapsed

Addresses feedback on #7708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
