### PR TITLE
Fix VDisclosureSection accessibility for subtitle and state

### DIFF
--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -63,7 +63,8 @@ public struct VDisclosureSection<Content: View>: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("\(title), \(isExpanded ? "expanded" : "collapsed")")
+            .accessibilityLabel(subtitle.map { "\(title), \($0)" } ?? title)
+            .accessibilityValue(isExpanded ? "expanded" : "collapsed")
             .accessibilityHint("Double-tap to \(isExpanded ? "collapse" : "expand")")
 
             if isExpanded {


### PR DESCRIPTION
Include subtitle in accessibilityLabel and use accessibilityValue for expanded/collapsed state so VoiceOver reads both the section description and its current state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
