### PR TITLE
perf(settings): debounce UserDefaults writes to avoid disk thrashing on slider drag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -57,14 +57,8 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Settings Values
 
-    @Published var maxSteps: Double {
-        didSet { UserDefaults.standard.set(maxSteps, forKey: "maxStepsPerSession") }
-    }
-    @Published var activityNotificationsEnabled: Bool {
-        didSet {
-            UserDefaults.standard.set(activityNotificationsEnabled, forKey: "activityNotificationsEnabled")
-        }
-    }
+    @Published var maxSteps: Double
+    @Published var activityNotificationsEnabled: Bool
 
     // MARK: - Media Embed Settings
 
@@ -252,6 +246,19 @@ public final class SettingsStore: ObservableObject {
         NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.refreshAPIKeyState() }
+            .store(in: &cancellables)
+
+        // Debounce UserDefaults writes so rapid slider movements don't thrash disk I/O
+        $maxSteps
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "maxStepsPerSession") }
+            .store(in: &cancellables)
+
+        $activityNotificationsEnabled
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "activityNotificationsEnabled") }
             .store(in: &cancellables)
 
         // Mirror DaemonClient's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary

- Remove `didSet` observer-based UserDefaults writes from `maxSteps` and `activityNotificationsEnabled` in `SettingsStore`
- Replace with Combine `debounce(for: .milliseconds(300))` subscriptions so rapid slider drags (which can fire 60+ times/sec) coalesce into a single write at the end of the gesture
- `dropFirst()` prevents an unnecessary write on init when the value is restored from UserDefaults

## Why

The macOS max-steps slider previously wrote to UserDefaults on every `didSet`, meaning dragging the slider fired a synchronous disk write for every pixel of movement — potentially 60+ writes per second. Debouncing reduces this to a single write 300 ms after the drag settles.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
