### PR TITLE
Center directory search and fix close button spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -38,15 +38,17 @@ struct AppDirectoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Header row: title + search
-                HStack(alignment: .center) {
-                    Text("Directory")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
+                // Header row: title (left) + centered search + space for close button
+                ZStack {
+                    // Title pinned to the leading edge
+                    HStack {
+                        Text("Directory")
+                            .font(VFont.panelTitle)
+                            .foregroundColor(VColor.textPrimary)
+                        Spacer()
+                    }
 
-                    Spacer()
-
-                    // Search bar (compact, fits within title line height)
+                    // Centered search bar
                     if !displayItems.isEmpty || !searchText.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             Image(systemName: "magnifyingglass")
@@ -75,11 +77,13 @@ struct AppDirectoryView: View {
                             RoundedRectangle(cornerRadius: VRadius.sm)
                                 .stroke(VColor.surfaceBorder, lineWidth: 1)
                         )
-                        .frame(maxWidth: 220)
+                        .frame(maxWidth: 280)
                     }
                 }
                 .padding(.top, VSpacing.xxl)
                 .padding(.bottom, VSpacing.xl)
+                // Extra trailing padding so the search bar doesn't crowd the close button
+                .padding(.trailing, VSpacing.xxl)
 
                 Divider().background(VColor.surfaceBorder)
                     .padding(.bottom, VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -38,17 +38,14 @@ struct AppDirectoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Header row: title (left) + centered search + space for close button
-                ZStack {
-                    // Title pinned to the leading edge
-                    HStack {
-                        Text("Directory")
-                            .font(VFont.panelTitle)
-                            .foregroundColor(VColor.textPrimary)
-                        Spacer()
-                    }
+                // Header row: title (left) + centered search + trailing space for close button
+                HStack(spacing: 0) {
+                    Text("Directory")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
 
-                    // Centered search bar
+                    Spacer(minLength: VSpacing.lg)
+
                     if !displayItems.isEmpty || !searchText.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             Image(systemName: "magnifyingglass")
@@ -79,10 +76,11 @@ struct AppDirectoryView: View {
                         )
                         .frame(maxWidth: 280)
                     }
+
+                    Spacer(minLength: VSpacing.lg)
                 }
                 .padding(.top, VSpacing.xxl)
                 .padding(.bottom, VSpacing.xl)
-                // Extra trailing padding so the search bar doesn't crowd the close button
                 .padding(.trailing, VSpacing.xxl)
 
                 Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
Center the search field in the directory panel header and add spacing between the search and close button to prevent crowding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
