### PR TITLE
a11y: add missing accessibilityLabel to icon-only buttons

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -217,6 +217,7 @@ struct ChatContentView: View {
                     .font(.system(size: 10, weight: .medium))
                     .foregroundColor(VColor.textMuted)
             }
+            .accessibilityLabel("Dismiss")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
@@ -275,6 +276,7 @@ struct ChatContentView: View {
                     .font(VFont.caption)
                     .foregroundColor(.white)
             }
+            .accessibilityLabel("Dismiss")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -42,6 +42,7 @@ struct InputBarView: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textSecondary)
                 }
+                .accessibilityLabel("Attach file")
                 .contextMenu {
                     Button {
                         showPhotosPicker = true
@@ -114,6 +115,7 @@ struct InputBarView: View {
                             .foregroundColor(isRecording ? .red : VColor.textMuted)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(isRecording ? "Stop voice input" : "Start voice input")
 
                     // Send button
                     Button(action: {
@@ -125,6 +127,7 @@ struct InputBarView: View {
                             .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
                     }
                     .disabled(!canSend)
+                    .accessibilityLabel("Send message")
                 }
             }
             .padding(VSpacing.md)

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
@@ -37,6 +37,7 @@ struct VoiceModePanel: View {
                         .frame(width: 28, height: 28)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(showingInfo ? "Hide info" : "Show info")
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .semibold))
@@ -46,6 +47,7 @@ struct VoiceModePanel: View {
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Close voice mode")
             }
             .padding(.horizontal, VSpacing.xl)
             .padding(.top, VSpacing.xl)

--- a/clients/shared/Features/Chat/AttachmentStripView.swift
+++ b/clients/shared/Features/Chat/AttachmentStripView.swift
@@ -43,6 +43,7 @@ private struct AttachmentChip: View {
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(.white, .black.opacity(0.6))
             }
+            .accessibilityLabel("Remove \(attachment.filename)")
             .offset(x: 6, y: -6)
         }
     }

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -102,6 +102,7 @@ public struct ToolCallProgressBar: View {
         }
         .buttonStyle(.plain)
         .disabled(!toolCall.isComplete)
+        .accessibilityLabel(toolCall.isError ? "\(toolCall.friendlyName), failed" : toolCall.isComplete ? "\(toolCall.friendlyName), completed" : "\(toolCall.friendlyName), in progress")
     }
 
     // MARK: - Step Label
@@ -164,6 +165,7 @@ public struct ToolCallProgressBar: View {
                         .foregroundColor(VColor.textMuted)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Close details")
             }
 
             // Input summary


### PR DESCRIPTION
## Summary

Add `.accessibilityLabel()` to icon-only buttons that were not reachable by screen readers:

**iOS (InputBarView.swift)**
- Attachment button: "Attach file"
- Mic button: "Start voice input" / "Stop voice input" (dynamic)
- Send button: "Send message"

**iOS (ChatContentView.swift)**
- Session error banner dismiss: "Dismiss"
- Generic error banner dismiss: "Dismiss"

**macOS (VoiceModePanel.swift)**
- Info toggle: "Show info" / "Hide info" (dynamic)
- Close button: "Close voice mode"

**Shared (AttachmentStripView.swift)**
- Attachment remove chip: "Remove <filename>"

**Shared (ToolCallProgressBar.swift)**
- Step circle buttons: "<step name>, completed" / "<step name>, failed" / "<step name>, in progress"
- Expanded details close button: "Close details"

## Test plan
- [ ] Enable VoiceOver on iOS and verify mic, send, attach, dismiss buttons speak their labels
- [ ] Enable VoiceOver on macOS and verify voice mode panel info/close buttons speak their labels
- [ ] Verify ToolCallProgressBar step circles announce step name and status

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
