### PR TITLE
Fix directory search bar overlap at narrow widths

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -48,7 +48,7 @@ struct AppDirectoryView: View {
                         Spacer()
                     }
 
-                    // Centered search bar
+                    // Centered search bar with leading padding to avoid overlapping title
                     if !displayItems.isEmpty || !searchText.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             Image(systemName: "magnifyingglass")
@@ -78,6 +78,7 @@ struct AppDirectoryView: View {
                                 .stroke(VColor.surfaceBorder, lineWidth: 1)
                         )
                         .frame(maxWidth: 280)
+                        .padding(.leading, 100)
                     }
                 }
                 .padding(.top, VSpacing.xxl)


### PR DESCRIPTION
Add leading padding to the centered search bar so it doesn't visually overlap the Directory title text at narrow window widths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
