### PR TITLE
Fix directory search layout with HStack and symmetric spacers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -38,17 +38,14 @@ struct AppDirectoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Header row: title (left) + centered search + space for close button
-                ZStack {
-                    // Title pinned to the leading edge
-                    HStack {
-                        Text("Directory")
-                            .font(VFont.panelTitle)
-                            .foregroundColor(VColor.textPrimary)
-                        Spacer()
-                    }
+                // Header row: title (left) + centered search + trailing space for close button
+                HStack(spacing: 0) {
+                    Text("Directory")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
 
-                    // Centered search bar
+                    Spacer(minLength: VSpacing.lg)
+
                     if !displayItems.isEmpty || !searchText.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             Image(systemName: "magnifyingglass")
@@ -79,10 +76,11 @@ struct AppDirectoryView: View {
                         )
                         .frame(maxWidth: 280)
                     }
+
+                    Spacer(minLength: VSpacing.lg)
                 }
                 .padding(.top, VSpacing.xxl)
                 .padding(.bottom, VSpacing.xl)
-                // Extra trailing padding so the search bar doesn't crowd the close button
                 .padding(.trailing, VSpacing.xxl)
 
                 Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
Replace ZStack overlay approach with HStack + symmetric Spacers to center the search bar while naturally preventing overlap with the title at any width. No hardcoded padding needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
