### PR TITLE
fix: resolve duplicate @ViewBuilder and missing @ViewBuilder in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -676,7 +676,6 @@ struct ChatView: View {
     }
 
     @ViewBuilder
-    @ViewBuilder
     private var memoryDegradedBanner: some View {
         if isMemoryDegraded {
             HStack(spacing: VSpacing.sm) {
@@ -709,6 +708,7 @@ struct ChatView: View {
         }
     }
 
+    @ViewBuilder
     private var apiKeyBanner: some View {
         if !hasAPIKey {
             HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary

- Remove duplicate `@ViewBuilder` attribute on `memoryDegradedBanner` (caused \"only one result builder attribute\" error)
- Add missing `@ViewBuilder` attribute on `apiKeyBanner` (caused \"no return statements\" error)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22350872884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
