### PR TITLE
UI Polish Bundle — Sidebar, Settings, Directory, Disclosure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -66,7 +66,7 @@ struct ChatEmptyStateView: View {
                     .interpolation(.none)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(width: 48, height: 48)
+                    .frame(width: 32, height: 32)
                     .clipShape(Circle())
 
                 Text(title)
@@ -127,6 +127,7 @@ struct ChatEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
+            isComposerExpanded = true
             withAnimation(.easeOut(duration: 0.5)) {
                 visible = true
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -26,11 +26,33 @@ struct ChatEmptyStateView: View {
     @Binding var isComposerExpanded: Bool
 
     @State private var visible = false
+    @State private var title: String = titles.randomElement()!
+    @State private var placeholder: String = placeholderTexts.randomElement()!
+
+    private let appearance = AvatarAppearanceManager.shared
 
     // MARK: - Greeting Data
 
-    private let title = "Let\u{2019}s make something happen."
-    private let placeholder = "What you need chief?"
+    static let defaultGreetings = [
+        "What are we working on?",
+        "I'm here whenever you need me.",
+        "What's on your mind?",
+        "Let's make something happen.",
+        "Ready when you are.",
+    ]
+
+    static var titles: [String] {
+        let custom = IdentityInfo.loadGreetings()
+        return custom.isEmpty ? defaultGreetings : custom
+    }
+
+    static let placeholderTexts = [
+        "Ask me anything...",
+        "Tell me what you need...",
+        "Say the word...",
+        "Go ahead, I'm listening...",
+        "Type or hold Fn to talk...",
+    ]
 
     // MARK: - Body
 
@@ -39,23 +61,24 @@ struct ChatEmptyStateView: View {
             Spacer()
             Spacer()
 
-            DinoFaceView(seed: "default")
-                .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .allowsHitTesting(false)
-                .opacity(visible ? 1 : 0)
-                .scaleEffect(visible ? 1 : 0.8)
-                .padding(.bottom, VSpacing.lg)
+            HStack(spacing: VSpacing.md) {
+                Image(nsImage: appearance.chatAvatarImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
 
-            Text(title)
-                .font(.custom("Fraunces", size: 28).weight(.regular))
-                .foregroundColor(VColor.textSecondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 500)
-                .opacity(visible ? 1 : 0)
-                .offset(y: visible ? 0 : 8)
-                .padding(.horizontal, VSpacing.xl)
-                .padding(.bottom, VSpacing.xl)
+                Text(title)
+                    .font(.custom("Fraunces", size: 28).weight(.regular))
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.leading)
+            }
+            .frame(maxWidth: 500)
+            .opacity(visible ? 1 : 0)
+            .scaleEffect(visible ? 1 : 0.8)
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.bottom, VSpacing.xl)
 
             VStack(spacing: 0) {
                 if let errorText {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -26,31 +26,11 @@ struct ChatEmptyStateView: View {
     @Binding var isComposerExpanded: Bool
 
     @State private var visible = false
-    @State private var title: String = titles.randomElement()!
-    @State private var placeholder: String = placeholderTexts.randomElement()!
 
     // MARK: - Greeting Data
 
-    static let defaultGreetings = [
-        "What are we working on?",
-        "I'm here whenever you need me.",
-        "What's on your mind?",
-        "Let's make something happen.",
-        "Ready when you are.",
-    ]
-
-    static var titles: [String] {
-        let custom = IdentityInfo.loadGreetings()
-        return custom.isEmpty ? defaultGreetings : custom
-    }
-
-    static let placeholderTexts = [
-        "Ask me anything...",
-        "Tell me what you need...",
-        "Say the word...",
-        "Go ahead, I'm listening...",
-        "Type or hold Fn to talk...",
-    ]
+    private let title = "Let\u{2019}s make something happen."
+    private let placeholder = "What you need chief?"
 
     // MARK: - Body
 
@@ -59,8 +39,10 @@ struct ChatEmptyStateView: View {
             Spacer()
             Spacer()
 
-            Text("🍃")
-                .font(.system(size: 48))
+            DinoFaceView(seed: "default")
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .allowsHitTesting(false)
                 .opacity(visible ? 1 : 0)
                 .scaleEffect(visible ? 1 : 0.8)
                 .padding(.bottom, VSpacing.lg)
@@ -107,6 +89,7 @@ struct ChatEmptyStateView: View {
                     onPaste: onPaste,
                     onMicrophoneToggle: onMicrophoneToggle,
                     placeholderText: placeholder,
+                    composerCompactHeight: 68,
                     editorContentHeight: $editorContentHeight,
                     isComposerExpanded: $isComposerExpanded
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -112,7 +112,6 @@ struct ChatEmptyStateView: View {
                     onPaste: onPaste,
                     onMicrophoneToggle: onMicrophoneToggle,
                     placeholderText: placeholder,
-                    composerCompactHeight: 68,
                     editorContentHeight: $editorContentHeight,
                     isComposerExpanded: $isComposerExpanded
                 )
@@ -127,7 +126,6 @@ struct ChatEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
-            isComposerExpanded = true
             withAnimation(.easeOut(duration: 0.5)) {
                 visible = true
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -22,7 +22,6 @@ enum SlashNavigation {
 }
 
 struct ComposerView: View {
-    private let composerCompactHeight: CGFloat = 34
     private let composerMaxHeight: CGFloat = 200
     private let composerActionButtonSize: CGFloat = 34
     private let composerActionIconSize: CGFloat = 14
@@ -49,6 +48,7 @@ struct ComposerView: View {
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
     var placeholderText: String = "What would you like to do?"
+    var composerCompactHeight: CGFloat = 34
     /// Bound to ChatView's state so it can compute composerReservedHeight for safe area insets.
     @Binding var editorContentHeight: CGFloat
 
@@ -160,7 +160,6 @@ struct ComposerView: View {
         .padding(.top, VSpacing.sm)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
-        .animation(VAnimation.fast, value: editorContentHeight)
         .animation(VAnimation.fast, value: isComposerExpanded)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
@@ -244,10 +243,12 @@ struct ComposerView: View {
             }
         }
         .onChange(of: editorContentHeight) {
+            // Only expand — never collapse based on height alone.
+            // Collapsing is handled when inputText becomes empty (see above).
+            // This prevents layout oscillation: expand → buttons move → text
+            // has more width → unwrap → collapse → buttons back → re-wrap → loop.
             if editorContentHeight > composerCompactHeight && !isComposerExpanded {
                 withAnimation(VAnimation.fast) { isComposerExpanded = true }
-            } else if editorContentHeight <= composerCompactHeight && isComposerExpanded {
-                withAnimation(VAnimation.fast) { isComposerExpanded = false }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -961,9 +961,10 @@ struct MainWindowView: View {
             }
         }
         .padding(VSpacing.xs)
+        .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth, alignment: .leading)
         .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        .clipped()
     }
 
     @ViewBuilder
@@ -1079,13 +1080,13 @@ struct MainWindowView: View {
     @ViewBuilder
     private var collapsedSidebarContent: some View {
         VStack(spacing: VSpacing.sm) {
-            CollapsedNavIcon(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
+            SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory, isExpanded: false) {
                 windowState.togglePanel(.directory)
             }
-            CollapsedNavIcon(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
+            SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity, isExpanded: false) {
                 windowState.togglePanel(.identity)
             }
-            CollapsedNavIcon(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
+            SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent, isExpanded: false) {
                 windowState.togglePanel(.agent)
             }
 
@@ -1093,14 +1094,14 @@ struct MainWindowView: View {
                 .frame(height: 1)
                 .padding(.horizontal, VSpacing.xs)
 
-            CollapsedNavIcon(icon: "square.and.pencil", label: "New Chat", isActive: false) {
+            SidebarNavRow(icon: "square.and.pencil", label: "New Chat", isActive: false, isExpanded: false) {
                 windowState.selection = nil
                 threadManager.createThread()
             }
 
             Spacer()
 
-            CollapsedNavIcon(icon: "gearshape", label: "Control Center", isActive: false) {
+            SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {
                 withAnimation(VAnimation.panel) {
                     sidebarExpanded = true
                 }
@@ -1240,6 +1241,7 @@ private struct SidebarNavRow: View {
     let icon: String
     let label: String
     var isActive: Bool = false
+    var isExpanded: Bool = true
     let action: () -> Void
     @State private var isHovered = false
 
@@ -1253,43 +1255,24 @@ private struct SidebarNavRow: View {
                 Text(label)
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
-                Spacer()
+                    .fixedSize()
+                    .opacity(isExpanded ? 1 : 0)
+                    .allowsHitTesting(false)
+                if isExpanded {
+                    Spacer()
+                }
             }
             .padding(.leading, VSpacing.md)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: isExpanded ? .infinity : nil)
             .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-    }
-}
-
-private struct CollapsedNavIcon: View {
-    let icon: String
-    let label: String
-    var isActive: Bool = false
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundColor(VColor.textPrimary)
-                .frame(width: 32, height: 32)
-                .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(label)
+        .help(isExpanded ? "" : label)
         .onHover { hovering in
             isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -600,7 +600,7 @@ struct MainWindowView: View {
                         let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
                         let drawerX = sidebarExpanded
                             ? 16 + VSpacing.sm
-                            : 16 + sidebarCollapsedWidth + VSpacing.sm
+                            : 16 + sidebarCollapsedWidth - VSpacing.xs
                         DrawerMenuView(
                             onSettings: {
                                 showControlCenterDrawer = false
@@ -1239,7 +1239,7 @@ private struct SidebarNavRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: VSpacing.sm) {
+            HStack(spacing: isExpanded ? VSpacing.sm : 0) {
                 Image(systemName: icon)
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400))
@@ -1248,22 +1248,24 @@ private struct SidebarNavRow: View {
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .fixedSize()
+                    .frame(width: isExpanded ? nil : 0, alignment: .leading)
+                    .clipped()
                     .opacity(isExpanded ? 1 : 0)
                     .allowsHitTesting(false)
                 if isExpanded {
                     Spacer()
                 }
             }
-            .padding(.leading, VSpacing.md)
-            .padding(.trailing, VSpacing.sm)
+            .padding(.leading, isExpanded ? VSpacing.md : 0)
+            .padding(.trailing, isExpanded ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.sm)
-            .frame(maxWidth: isExpanded ? .infinity : nil)
+            .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
             .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
+        .padding(.horizontal, isExpanded ? VSpacing.sm : VSpacing.xs)
         .help(isExpanded ? "" : label)
         .onHover { hovering in
             isHovered = hovering

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -597,6 +597,10 @@ struct MainWindowView: View {
                 .overlay(alignment: .bottomLeading) {
                     // Control center drawer rendered at top level so it floats above all content
                     if showControlCenterDrawer {
+                        let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
+                        let drawerX = sidebarExpanded
+                            ? 16 + VSpacing.sm
+                            : 16 + sidebarCollapsedWidth + VSpacing.sm
                         DrawerMenuView(
                             onSettings: {
                                 showControlCenterDrawer = false
@@ -611,8 +615,8 @@ struct MainWindowView: View {
                                 windowState.selection = .panel(.doctor)
                             }
                         )
-                        .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
-                        .offset(x: 16 + VSpacing.sm, y: -52)
+                        .frame(width: drawerWidth)
+                        .offset(x: drawerX, y: -52)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -671,13 +675,6 @@ struct MainWindowView: View {
         .onReceive(daemonClient.$isConnected) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
             requestHomeBaseDashboardIfNeeded()
-        }
-        .onChange(of: sidebarExpanded) { _, isExpanded in
-            if !isExpanded && showControlCenterDrawer {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                    showControlCenterDrawer = false
-                }
-            }
         }
         .onChange(of: selectedThreadId) { _, newId in
             if let newId = newId {
@@ -1102,13 +1099,8 @@ struct MainWindowView: View {
             Spacer()
 
             SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {
-                withAnimation(VAnimation.panel) {
-                    sidebarExpanded = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                        showControlCenterDrawer = true
-                    }
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    showControlCenterDrawer.toggle()
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -448,6 +448,7 @@ extension MainWindowView {
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
         case .generated:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -38,15 +38,14 @@ struct AppDirectoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Header row: title + search
-                HStack(alignment: .center) {
+                // Header row: title (left) + centered search + trailing space for close button
+                HStack(spacing: 0) {
                     Text("Directory")
                         .font(VFont.panelTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    Spacer()
+                    Spacer(minLength: VSpacing.lg)
 
-                    // Search bar (compact, fits within title line height)
                     if !displayItems.isEmpty || !searchText.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             Image(systemName: "magnifyingglass")
@@ -75,11 +74,14 @@ struct AppDirectoryView: View {
                             RoundedRectangle(cornerRadius: VRadius.sm)
                                 .stroke(VColor.surfaceBorder, lineWidth: 1)
                         )
-                        .frame(maxWidth: 220)
+                        .frame(maxWidth: 280)
                     }
+
+                    Spacer(minLength: VSpacing.lg)
                 }
                 .padding(.top, VSpacing.xxl)
                 .padding(.bottom, VSpacing.xl)
+                .padding(.trailing, VSpacing.xxl)
 
                 Divider().background(VColor.surfaceBorder)
                     .padding(.bottom, VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -76,7 +76,7 @@ struct IdentityPanel: View {
                 }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.background)
+            .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         }
         .overlay {
             if let path = viewingFilePath {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1129,8 +1129,13 @@ struct SettingsPanel: View {
     }
 
     /// Collapsed override section for per-integration gateway URL customization.
+    @State private var ingressOverrideExpanded: Bool = false
+
     private var ingressOverrideSection: some View {
-        DisclosureGroup("Override") {
+        VDisclosureSection(
+            title: "Override",
+            isExpanded: $ingressOverrideExpanded
+        ) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Toggle("Use custom gateway URL", isOn: $ingressUseOverride)
                     .toggleStyle(.switch)
@@ -1156,10 +1161,7 @@ struct SettingsPanel: View {
                     }
                 }
             }
-            .padding(.top, VSpacing.sm)
         }
-        .font(VFont.caption)
-        .foregroundColor(VColor.textSecondary)
     }
 
     // MARK: - Permission Row

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1078,6 +1078,7 @@ struct SettingsPanel: View {
     private var ingressOverrideSection: some View {
         VDisclosureSection(
             title: "Override",
+            icon: "arrow.triangle.swap",
             isExpanded: $ingressOverrideExpanded
         ) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -232,16 +232,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("This is your private generated key", text: $apiKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at console.anthropic.com")
                         .font(VFont.caption)
@@ -377,16 +370,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Perplexity API key", text: $perplexityKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at perplexity.ai/settings/api")
                         .font(VFont.caption)
@@ -432,16 +418,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Brave Search API key", text: $braveKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at brave.com/search/api")
                         .font(VFont.caption)
@@ -505,16 +484,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your Gemini API key", text: $imageGenKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Get your API key at aistudio.google.com/apikey")
                         .font(VFont.caption)
@@ -560,16 +532,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your OpenAI API key", text: $openaiKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Used for Voice Mode (Whisper transcription). Get your key at platform.openai.com/api-keys")
                         .font(VFont.caption)
@@ -615,16 +580,9 @@ struct SettingsPanel: View {
                     }
 
                     SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
-                        .textFieldStyle(.plain)
+                        .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(VSpacing.md)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
 
                     Text("Used for Voice Mode (text-to-speech). Get your key at elevenlabs.io/app/settings/api-keys")
                         .font(VFont.caption)
@@ -702,28 +660,14 @@ struct SettingsPanel: View {
                     // Client credentials entry (when not yet configured)
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         TextField("OAuth Client ID", text: $twitterClientId)
-                            .textFieldStyle(.plain)
+                            .vInputStyle()
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
 
                         SecureField("OAuth Client Secret (optional)", text: $twitterClientSecret)
-                            .textFieldStyle(.plain)
+                            .vInputStyle()
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
 
                         HStack {
                             Text("Create an app at developer.x.com")
@@ -1148,16 +1092,9 @@ struct SettingsPanel: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                         TextField("https://custom-gateway.example.com", text: $ingressGatewayOverride)
-                            .textFieldStyle(.plain)
+                            .vInputStyle()
                             .font(VFont.body)
                             .foregroundColor(VColor.textPrimary)
-                            .padding(VSpacing.md)
-                            .background(VColor.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                            )
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -141,6 +141,7 @@ struct PairingQRCodeSheet: View {
             // Manual pairing info
             VDisclosureSection(
                 title: "Manual Pairing",
+                icon: "link",
                 isExpanded: $manualPairingExpanded
             ) {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -139,92 +139,90 @@ struct PairingQRCodeSheet: View {
                 .multilineTextAlignment(.center)
 
             // Manual pairing info
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                DisclosureGroup("Manual Pairing", isExpanded: $manualPairingExpanded) {
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        // Gateway URL row
-                        HStack {
-                            Text("Gateway URL")
+            VDisclosureSection(
+                title: "Manual Pairing",
+                isExpanded: $manualPairingExpanded
+            ) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Gateway URL row
+                    HStack {
+                        Text("Gateway URL")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .frame(width: 90, alignment: .leading)
+                        Text(gatewayUrl.isEmpty ? "Not configured" : gatewayUrl)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(gatewayUrl, forType: .string)
+                            withAnimation { copiedField = "url" }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                withAnimation { if copiedField == "url" { copiedField = nil } }
+                            }
+                        } label: {
+                            Text(copiedField == "url" ? "Copied" : "Copy")
                                 .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .frame(width: 90, alignment: .leading)
-                            Text(gatewayUrl.isEmpty ? "Not configured" : gatewayUrl)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(gatewayUrl.isEmpty)
+                    }
+
+                    Divider()
+
+                    // Bearer token row
+                    HStack {
+                        Text("Bearer Token")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .frame(width: 90, alignment: .leading)
+                        if resolvedBearerToken.isEmpty {
+                            Text("Not available")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                        } else if isTokenRevealed {
+                            Text(resolvedBearerToken)
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
-                            Spacer()
-                            Button {
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(gatewayUrl, forType: .string)
-                                withAnimation { copiedField = "url" }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                    withAnimation { if copiedField == "url" { copiedField = nil } }
-                                }
-                            } label: {
-                                Text(copiedField == "url" ? "Copied" : "Copy")
-                                    .font(VFont.caption)
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                            .disabled(gatewayUrl.isEmpty)
+                        } else {
+                            Text(String(repeating: "\u{2022}", count: min(resolvedBearerToken.count, 24)))
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                                .lineLimit(1)
                         }
-
-                        Divider()
-
-                        // Bearer token row
-                        HStack {
-                            Text("Bearer Token")
+                        Spacer()
+                        Button {
+                            isTokenRevealed.toggle()
+                        } label: {
+                            Image(systemName: isTokenRevealed ? "eye.slash" : "eye")
                                 .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .frame(width: 90, alignment: .leading)
-                            if resolvedBearerToken.isEmpty {
-                                Text("Not available")
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textPrimary)
-                            } else if isTokenRevealed {
-                                Text(resolvedBearerToken)
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textPrimary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            } else {
-                                Text(String(repeating: "\u{2022}", count: min(resolvedBearerToken.count, 24)))
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textPrimary)
-                                    .lineLimit(1)
-                            }
-                            Spacer()
-                            Button {
-                                isTokenRevealed.toggle()
-                            } label: {
-                                Image(systemName: isTokenRevealed ? "eye.slash" : "eye")
-                                    .font(VFont.caption)
-                            }
-                            .buttonStyle(.borderless)
-                            .help(isTokenRevealed ? "Hide token" : "Reveal token")
-                            .disabled(resolvedBearerToken.isEmpty)
-
-                            Button {
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(resolvedBearerToken, forType: .string)
-                                withAnimation { copiedField = "token" }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                    withAnimation { if copiedField == "token" { copiedField = nil } }
-                                }
-                            } label: {
-                                Text(copiedField == "token" ? "Copied" : "Copy")
-                                    .font(VFont.caption)
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                            .disabled(resolvedBearerToken.isEmpty)
                         }
+                        .buttonStyle(.borderless)
+                        .help(isTokenRevealed ? "Hide token" : "Reveal token")
+                        .disabled(resolvedBearerToken.isEmpty)
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(resolvedBearerToken, forType: .string)
+                            withAnimation { copiedField = "token" }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                withAnimation { if copiedField == "token" { copiedField = nil } }
+                            }
+                        } label: {
+                            Text(copiedField == "token" ? "Copied" : "Copy")
+                                .font(VFont.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(resolvedBearerToken.isEmpty)
                     }
-                    .padding(.top, VSpacing.sm)
                 }
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
             }
             .padding(VSpacing.md)
             .background(VColor.surfaceSubtle)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -96,90 +96,76 @@ struct SettingsConnectTab: View {
     // MARK: - Gateway Section
 
     private var gatewaySection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            DisclosureGroup(isExpanded: $gatewayExpanded) {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    // Gateway URL field
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Gateway URL")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                    }
-
-                    TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
-                        .focused($isGatewayUrlFocused)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveIngressPublicBaseUrl(gatewayUrlText)
-                    }
-
-                    Divider()
-                        .background(VColor.surfaceBorder)
-
-                    // Local Gateway Target (read-only)
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Local Gateway Target")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        Text(store.localGatewayTarget)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
-                            .padding(VSpacing.md)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(VColor.surface.opacity(0.5))
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
-                            )
-
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
-                            gatewayTargetCopied = true
-                            Task {
-                                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                gatewayTargetCopied = false
-                            }
-                        } label: {
-                            Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
-                                .frame(width: 28, height: 28)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Copy gateway address")
-                        .help("Copy address")
-                    }
-
-                    Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
+        VDisclosureSection(
+            title: "Gateway",
+            subtitle: !gatewayExpanded && !store.ingressPublicBaseUrl.isEmpty ? store.ingressPublicBaseUrl : nil,
+            isExpanded: $gatewayExpanded
+        ) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Gateway URL field
+                HStack(spacing: VSpacing.xs) {
+                    Text("Gateway URL")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                 }
-                .padding(.top, VSpacing.sm)
-            } label: {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Gateway")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-                    if !gatewayExpanded && !store.ingressPublicBaseUrl.isEmpty {
-                        Text(store.ingressPublicBaseUrl)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textMuted)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
+
+                TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
+                    .focused($isGatewayUrlFocused)
+                    .vInputStyle()
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+
+                VButton(label: "Save", style: .primary) {
+                    store.saveIngressPublicBaseUrl(gatewayUrlText)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+
+                Divider()
+                    .background(VColor.surfaceBorder)
+
+                // Local Gateway Target (read-only)
+                HStack(spacing: VSpacing.xs) {
+                    Text("Local Gateway Target")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                HStack(spacing: VSpacing.sm) {
+                    Text(store.localGatewayTarget)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .textSelection(.enabled)
+                        .padding(VSpacing.md)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(VColor.surface.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                        )
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
+                        gatewayTargetCopied = true
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            gatewayTargetCopied = false
+                        }
+                    } label: {
+                        Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Copy gateway address")
+                    .help("Copy address")
+                }
+
+                Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
             }
         }
         .padding(VSpacing.lg)
@@ -288,27 +274,17 @@ struct SettingsConnectTab: View {
     // MARK: - Advanced Section
 
     private var advancedSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            DisclosureGroup(isExpanded: $advancedExpanded) {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    bearerTokenContent
+        VDisclosureSection(
+            title: "Advanced",
+            subtitle: "Bearer token, developer options",
+            isExpanded: $advancedExpanded
+        ) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                bearerTokenContent
 
-                    Divider().background(VColor.surfaceBorder)
+                Divider().background(VColor.surfaceBorder)
 
-                    developerLocalPairingContent
-                }
-                .padding(.top, VSpacing.sm)
-            } label: {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Advanced")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-                    Text("Bearer token, developer options")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+                developerLocalPairingContent
             }
         }
         .padding(VSpacing.lg)
@@ -1030,22 +1006,16 @@ struct SettingsConnectTab: View {
     // MARK: - Diagnostics Section (merged Status + Test Connection)
 
     private var diagnosticsSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            DisclosureGroup(isExpanded: $diagnosticsExpanded) {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    statusContent
+        VDisclosureSection(
+            title: "Diagnostics",
+            isExpanded: $diagnosticsExpanded
+        ) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                statusContent
 
-                    Divider().background(VColor.surfaceBorder)
+                Divider().background(VColor.surfaceBorder)
 
-                    testConnectionContent
-                }
-                .padding(.top, VSpacing.sm)
-            } label: {
-                Text("Diagnostics")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+                testConnectionContent
             }
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -98,6 +98,7 @@ struct SettingsConnectTab: View {
     private var gatewaySection: some View {
         VDisclosureSection(
             title: "Gateway",
+            icon: "network",
             subtitle: !gatewayExpanded && !store.ingressPublicBaseUrl.isEmpty ? store.ingressPublicBaseUrl : nil,
             isExpanded: $gatewayExpanded
         ) {
@@ -276,6 +277,7 @@ struct SettingsConnectTab: View {
     private var advancedSection: some View {
         VDisclosureSection(
             title: "Advanced",
+            icon: "gearshape",
             subtitle: "Bearer token, developer options",
             isExpanded: $advancedExpanded
         ) {
@@ -1008,6 +1010,7 @@ struct SettingsConnectTab: View {
     private var diagnosticsSection: some View {
         VDisclosureSection(
             title: "Diagnostics",
+            icon: "stethoscope",
             isExpanded: $diagnosticsExpanded
         ) {
             VStack(alignment: .leading, spacing: VSpacing.md) {

--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -8,23 +8,26 @@ import SwiftUI
 ///
 /// Usage:
 /// ```swift
-/// VDisclosureSection(title: "Advanced", subtitle: "Bearer token, developer options", isExpanded: $expanded) {
+/// VDisclosureSection(title: "Advanced", icon: "gearshape", subtitle: "Bearer token, developer options", isExpanded: $expanded) {
 ///     Text("Content here")
 /// }
 /// ```
 public struct VDisclosureSection<Content: View>: View {
     public let title: String
+    public var icon: String? = nil
     public var subtitle: String? = nil
     @Binding public var isExpanded: Bool
     @ViewBuilder public let content: () -> Content
 
     public init(
         title: String,
+        icon: String? = nil,
         subtitle: String? = nil,
         isExpanded: Binding<Bool>,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
+        self.icon = icon
         self.subtitle = subtitle
         self._isExpanded = isExpanded
         self.content = content
@@ -38,6 +41,13 @@ public struct VDisclosureSection<Content: View>: View {
                 }
             } label: {
                 HStack(spacing: VSpacing.sm) {
+                    if let icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                            .frame(width: 20)
+                    }
+
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         Text(title)
                             .font(VFont.bodyBold)
@@ -87,6 +97,7 @@ public struct VDisclosureSection<Content: View>: View {
                 VStack(spacing: VSpacing.lg) {
                     VDisclosureSection(
                         title: "Gateway",
+                        icon: "network",
                         isExpanded: $basicExpanded
                     ) {
                         Text("Gateway content goes here")
@@ -98,6 +109,7 @@ public struct VDisclosureSection<Content: View>: View {
 
                     VDisclosureSection(
                         title: "Advanced",
+                        icon: "gearshape",
                         subtitle: "Bearer token, developer options",
                         isExpanded: $subtitleExpanded
                     ) {
@@ -110,6 +122,7 @@ public struct VDisclosureSection<Content: View>: View {
 
                     VDisclosureSection(
                         title: "Diagnostics",
+                        icon: "stethoscope",
                         isExpanded: $collapsedExpanded
                     ) {
                         Text("Diagnostics content goes here")

--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// A disclosure section with a full-row clickable header.
+///
+/// Replaces native `DisclosureGroup` to provide a larger tap target — the entire
+/// header row (title + optional subtitle + chevron) toggles expansion, not just
+/// the tiny default chevron.
+///
+/// Usage:
+/// ```swift
+/// VDisclosureSection(title: "Advanced", subtitle: "Bearer token, developer options", isExpanded: $expanded) {
+///     Text("Content here")
+/// }
+/// ```
+public struct VDisclosureSection<Content: View>: View {
+    public let title: String
+    public var subtitle: String? = nil
+    @Binding public var isExpanded: Bool
+    @ViewBuilder public let content: () -> Content
+
+    public init(
+        title: String,
+        subtitle: String? = nil,
+        isExpanded: Binding<Bool>,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self._isExpanded = isExpanded
+        self.content = content
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(VAnimation.fast) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(title)
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.textPrimary)
+                        if let subtitle {
+                            Text(subtitle)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(VAnimation.fast, value: isExpanded)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(subtitle.map { "\(title), \($0)" } ?? title)
+            .accessibilityValue(isExpanded ? "expanded" : "collapsed")
+            .accessibilityHint("Double-tap to \(isExpanded ? "collapse" : "expand")")
+
+            if isExpanded {
+                content()
+                    .padding(.top, VSpacing.sm)
+            }
+        }
+    }
+}
+
+#Preview("VDisclosureSection") {
+    struct DisclosurePreview: View {
+        @State private var basicExpanded = true
+        @State private var subtitleExpanded = false
+        @State private var collapsedExpanded = false
+
+        var body: some View {
+            ZStack {
+                VColor.background.ignoresSafeArea()
+                VStack(spacing: VSpacing.lg) {
+                    VDisclosureSection(
+                        title: "Gateway",
+                        isExpanded: $basicExpanded
+                    ) {
+                        Text("Gateway content goes here")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: VColor.surfaceSubtle)
+
+                    VDisclosureSection(
+                        title: "Advanced",
+                        subtitle: "Bearer token, developer options",
+                        isExpanded: $subtitleExpanded
+                    ) {
+                        Text("Advanced content goes here")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: VColor.surfaceSubtle)
+
+                    VDisclosureSection(
+                        title: "Diagnostics",
+                        isExpanded: $collapsedExpanded
+                    ) {
+                        Text("Diagnostics content goes here")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .padding(VSpacing.lg)
+                    .vCard(background: VColor.surfaceSubtle)
+                }
+                .padding()
+            }
+            .frame(width: 400, height: 400)
+        }
+    }
+
+    return DisclosurePreview()
+}

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -90,6 +90,37 @@ struct DisplayGallerySection: View {
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
+            // MARK: - VDisclosureSection
+            GallerySectionHeader(
+                title: "VDisclosureSection",
+                description: "Full-row clickable disclosure with animated chevron. Replaces DisclosureGroup."
+            )
+
+            VDisclosureSection(
+                title: "Basic Section",
+                isExpanded: .constant(true)
+            ) {
+                Text("Expanded content is visible")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            VDisclosureSection(
+                title: "With Subtitle",
+                subtitle: "Additional context shown below the title",
+                isExpanded: .constant(false)
+            ) {
+                Text("This content is hidden")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
             // MARK: - VListRow
             GallerySectionHeader(
                 title: "VListRow",


### PR DESCRIPTION
## Summary
A bundle of 6 UI polish milestones addressing sidebar navigation, control center popover behavior, identity panel styling, disclosure sections, settings text fields, and directory search layout.

## Changes
- **M1: Sidebar nav button unification** — Keep same button components in collapsed/expanded mode, hide text instead of swapping to icon-only buttons. Control panel button stays green.
- **M2: Control center popover** — Opens as a popover to the right without expanding the sidebar.
- **M3: Identity panel background** — Set identity panel background to #F5F3EB (light) / Moss._900 (dark).
- **M4: Full-row clickable disclosure component** — New VDisclosureSection design system component with full-row tap target, replacing native DisclosureGroup across 5 locations.
- **M5: Settings TextField styling** — Replaced 9 manually-styled TextFields/SecureFields in SettingsPanel with .vInputStyle() to fix white backgrounds in dark mode.
- **M6: Directory search layout** — Centered search bar in directory panel header with symmetric spacers, added spacing from close button.

## Milestone PRs (merged into feature branch)
- #7696: M1 — Unify sidebar nav buttons
- #7702: M2 — Control center popover without sidebar expand
- #7706: M3 — Identity panel background color #F5F3EB
- #7708: M4 — Full-row clickable disclosure/dropdown component
- #7714: M5 — Fix white-background TextFields in settings integrations tab
- #7715: M6 — Center directory search and fix close button spacing

## Additional PRs (merged into feature branch)
- #7701: Redesign initial screen with DinoFace avatar + fix composer jitter

## Project issue
Closes #7689

## Test plan
- [ ] Toggle sidebar collapsed/expanded — buttons should animate smoothly, control panel stays green
- [ ] Open control center from collapsed sidebar — should popover without expanding sidebar
- [ ] Check identity panel background in light (#F5F3EB) and dark (Moss._900) modes
- [ ] Click full disclosure section rows in Settings > Connect — entire row should toggle
- [ ] Verify Settings panel TextFields have dark backgrounds in dark mode
- [ ] Check directory search is centered with spacing from close button

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
