### PR TITLE
feat(ios): animated typing indicator shown while assistant is thinking

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -110,17 +110,33 @@ struct ChatContentView: View {
                                 .id("subagent-\(subagent.id)")
                         }
 
-                        // Current step indicator shown while generating
+                        // Typing / step indicator shown while generating
                         let hasPendingConfirmation = viewModel.messages.last?.confirmation?.state == .pending
                         if viewModel.isSending && !hasPendingConfirmation {
                             let allToolCalls = viewModel.messages.last?.toolCalls ?? []
-                            CurrentStepIndicator(
-                                toolCalls: allToolCalls,
-                                isStreaming: viewModel.isSending,
-                                onTap: {}
-                            )
-                            .padding(.horizontal, VSpacing.lg)
-                            .id("step-indicator")
+                            let isStreaming = viewModel.messages.last?.isStreaming == true
+                            let hasActiveToolCall = allToolCalls.contains { !$0.isComplete }
+
+                            if !isStreaming && !hasActiveToolCall {
+                                // No streaming text or active tool call yet — show typing dots
+                                HStack {
+                                    TypingIndicatorView()
+                                    Spacer()
+                                }
+                                .padding(.horizontal, VSpacing.lg)
+                                .id("step-indicator")
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            } else if hasActiveToolCall {
+                                // Tool execution in progress — show step indicator
+                                CurrentStepIndicator(
+                                    toolCalls: allToolCalls,
+                                    isStreaming: viewModel.isSending,
+                                    onTap: {}
+                                )
+                                .padding(.horizontal, VSpacing.lg)
+                                .id("step-indicator")
+                            }
+                            // When isStreaming: the growing message bubble is the indicator
                         }
 
                         // Invisible anchor at the very bottom of all content

--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Animated three-dot typing bubble shown while the assistant is thinking
+/// (before the first token or tool call arrives).
+public struct TypingIndicatorView: View {
+    @State private var animate = false
+
+    public init() {}
+
+    public var body: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.textMuted)
+                    .frame(width: 8, height: 8)
+                    .scaleEffect(animate ? 1.0 : 0.5)
+                    .animation(
+                        .easeInOut(duration: 0.5)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(index) * 0.18),
+                        value: animate
+                    )
+            }
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface)
+        )
+        .onAppear {
+            animate = true
+        }
+        .onDisappear {
+            animate = false
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("TypingIndicatorView") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack {
+            TypingIndicatorView()
+            Spacer()
+        }
+        .padding(VSpacing.xl)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a proper three-dot animated typing indicator to iOS chat that appears before the assistant's first token or tool call arrives.

**New component:** `clients/shared/Features/Chat/TypingIndicatorView.swift`
- Three circles that scale between 0.5× and 1.0× with staggered 180ms delays, creating a classic "typing dots" bounce effect
- Uses design tokens: `VColor.textMuted`, `VColor.surface`, `VSpacing`, `VRadius.lg`
- Handles appear/disappear correctly (resets animation on disappear to avoid ghost animations)

**iOS `ChatContentView.swift` changes:**
- When `isSending && !pendingConfirmation`:
  - **No streaming, no active tool calls** → show `TypingIndicatorView` (new, pre-response phase)
  - **Active tool call** → show `CurrentStepIndicator` (unchanged)
  - **Streaming text** → no extra indicator (the growing message bubble is the indicator)

This aligns iOS behaviour with macOS, which shows `RunningIndicator` (animated dots) during the thinking phase and nothing extra during text streaming.

## Test plan
- [ ] Send a message — three dots should bounce while waiting for the first response token
- [ ] Once streaming starts, dots should disappear and the growing message bubble takes over
- [ ] Tool calls should show `CurrentStepIndicator` as before
- [ ] Typing indicator should appear with a slide-up + fade transition (from `VAnimation.standard`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
