### PR TITLE
M1: Fix learn mode reliability (captures counter + early stop data loss)

### DIFF
--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -121,6 +121,8 @@ export interface RideShotgunProgress {
   type: 'ride_shotgun_progress';
   watchId: string;
   message: string;
+  networkEntryCount?: number;
+  statusMessage?: string;
 }
 
 export interface RideShotgunResult {

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -135,6 +135,21 @@ export async function handleRideShotgunStart(
           activeRecorders.set(watchId, recorder);
           log.info({ watchId, targetDomain, attempt }, 'Network recording started for learn session');
 
+          // Send periodic progress updates with network entry counts
+          const progressInterval = setInterval(() => {
+            if (session.status !== 'active') {
+              clearInterval(progressInterval);
+              return;
+            }
+            ctx.send(socket, {
+              type: 'ride_shotgun_progress',
+              watchId,
+              message: `Recording network traffic...`,
+              networkEntryCount: recorder.entryCount,
+              statusMessage: 'Recording network traffic...',
+            });
+          }, 5000);
+
           // For x.com, auto-navigate Chrome through key pages to capture the full API surface.
           // Skip login detection — auto-navigation will complete the session when done.
           if (targetDomain === 'x.com' || targetDomain === 'twitter.com') {

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -106,6 +106,11 @@ export class NetworkRecorder {
   /** URL patterns that indicate a successful login (checked via `includes`). */
   loginSignals: string[] = [];
 
+  /** Number of network entries recorded so far. */
+  get entryCount(): number {
+    return this.entries.size;
+  }
+
   constructor(targetDomain?: string) {
     this.targetDomain = targetDomain;
   }

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -21,6 +21,8 @@ public final class RideShotgunSession: ObservableObject {
     @Published public var observationCount: Int = 0
     @Published public var recordingId: String?
     @Published public var recordingPath: String?
+    @Published public var networkEntryCount: Int = 0
+    @Published public var statusMessage: String = ""
 
     // Pass-through from WatchSession
     @Published public var elapsedSeconds: Double = 0
@@ -31,6 +33,7 @@ public final class RideShotgunSession: ObservableObject {
     public let intervalSeconds: Int
     public let mode: String?
     public let targetDomain: String?
+    public var isLearnMode: Bool { mode == "learn" }
 
     private var watchSession: WatchSession?
     private var daemonClient: DaemonClient?
@@ -63,6 +66,13 @@ public final class RideShotgunSession: ObservableObject {
                 switch message {
                 case .watchStarted(let started):
                     self.handleWatchStarted(started, daemonClient: daemonClient)
+                case .rideShotgunProgress(let progress):
+                    if let count = progress.networkEntryCount {
+                        self.networkEntryCount = count
+                    }
+                    if let msg = progress.statusMessage, !msg.isEmpty {
+                        self.statusMessage = msg
+                    }
                 case .rideShotgunResult(let result):
                     self.handleRideShotgunResult(result)
                 default:
@@ -128,7 +138,8 @@ public final class RideShotgunSession: ObservableObject {
             watchId: message.watchId,
             sessionId: message.sessionId,
             durationSeconds: durationSeconds,
-            intervalSeconds: intervalSeconds
+            intervalSeconds: intervalSeconds,
+            isLearnMode: isLearnMode
         )
         self.watchSession = session
         session.start(daemonClient: daemonClient)

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -19,6 +19,7 @@ public final class WatchSession: ObservableObject {
     public let sessionId: String
     public let durationSeconds: Int
     public let intervalSeconds: Int
+    public let isLearnMode: Bool
 
     private var daemonClient: (any DaemonClientProtocol)?
     private var captureTask: Task<Void, Never>?
@@ -28,11 +29,12 @@ public final class WatchSession: ObservableObject {
     private let ocr = ScreenOCR()
     private var previousOcrText: String = ""
 
-    public init(watchId: String, sessionId: String, durationSeconds: Int, intervalSeconds: Int) {
+    public init(watchId: String, sessionId: String, durationSeconds: Int, intervalSeconds: Int, isLearnMode: Bool = false) {
         self.watchId = watchId
         self.sessionId = sessionId
         self.durationSeconds = durationSeconds
         self.intervalSeconds = intervalSeconds
+        self.isLearnMode = isLearnMode
     }
 
     public func start(daemonClient: any DaemonClientProtocol) {
@@ -41,9 +43,12 @@ public final class WatchSession: ObservableObject {
         totalExpected = durationSeconds / intervalSeconds
         elapsedSeconds = 0
         startedAt = Date()
-        log.info("Watch session started: watchId=\(self.watchId) duration=\(self.durationSeconds)s interval=\(self.intervalSeconds)s")
-        captureTask = Task { [weak self] in
-            await self?.captureLoop()
+        log.info("Watch session started: watchId=\(self.watchId) duration=\(self.durationSeconds)s interval=\(self.intervalSeconds)s isLearnMode=\(self.isLearnMode)")
+        // In learn mode the daemon records network traffic via CDP — skip the screen capture loop
+        if !isLearnMode {
+            captureTask = Task { [weak self] in
+                await self?.captureLoop()
+            }
         }
         elapsedTask = Task { [weak self] in
             await self?.elapsedLoop()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -42,6 +42,8 @@ struct ChatView: View {
     let onDismissSessionError: () -> Void
     let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
+    var isLearnMode: Bool = false
+    var networkEntryCount: Int = 0
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -226,7 +228,7 @@ struct ChatView: View {
     @MainActor private var composerOverlay: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
-                WatchProgressView(session: watchSession, onStop: onStopWatch)
+                WatchProgressView(session: watchSession, onStop: onStopWatch, isLearnMode: isLearnMode, networkEntryCount: networkEntryCount)
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.sm)
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
@@ -4,6 +4,8 @@ import VellumAssistantShared
 struct WatchProgressView: View {
     @ObservedObject var session: WatchSession
     let onStop: () -> Void
+    var isLearnMode: Bool = false
+    var networkEntryCount: Int = 0
 
     @State private var isPulsing = false
 
@@ -26,9 +28,9 @@ struct WatchProgressView: View {
 
     var body: some View {
         VStack(spacing: VSpacing.md) {
-            // Pulsing eye icon + label
+            // Pulsing icon + label
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: "eye.fill")
+                Image(systemName: isLearnMode ? "antenna.radiowaves.left.and.right" : "eye.fill")
                     .foregroundColor(VColor.accent)
                     .opacity(isPulsing ? 0.4 : 1.0)
                     .animation(
@@ -36,7 +38,7 @@ struct WatchProgressView: View {
                         value: isPulsing
                     )
 
-                Text("Watching your workflow...")
+                Text(isLearnMode ? "Recording network traffic..." : "Watching your workflow...")
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
 
@@ -62,9 +64,15 @@ struct WatchProgressView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Text("\(session.captureCount)/\(session.totalExpected) captures")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
+                    if isLearnMode {
+                        Text("\(networkEntryCount) network entries")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    } else {
+                        Text("\(session.captureCount)/\(session.totalExpected) captures")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -627,6 +627,8 @@ struct ActiveChatViewWrapper: View {
             onDismissSessionError: { viewModel.dismissSessionError() },
             onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
             watchSession: ambientAgent.activeWatchSession,
+            isLearnMode: ambientAgent.currentSession?.isLearnMode ?? false,
+            networkEntryCount: ambientAgent.currentSession?.networkEntryCount ?? 0,
             onStopWatch: { viewModel.stopWatchSession() },
             onReportMessage: { daemonMessageId in
                 guard let sessionId = viewModel.sessionId else { return }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2605,11 +2605,15 @@ public struct IPCRideShotgunProgress: Codable, Sendable {
     public let type: String
     public let watchId: String
     public let message: String
+    public let networkEntryCount: Int?
+    public let statusMessage: String?
 
-    public init(type: String, watchId: String, message: String) {
+    public init(type: String, watchId: String, message: String, networkEntryCount: Int? = nil, statusMessage: String? = nil) {
         self.type = type
         self.watchId = watchId
         self.message = message
+        self.networkEntryCount = networkEntryCount
+        self.statusMessage = statusMessage
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes learn mode to show network entry counts instead of screen capture counts (which were always 0)
- Adds periodic `ride_shotgun_progress` IPC messages with `networkEntryCount` and `statusMessage` fields
- Skips the screen capture loop in `WatchSession` when `isLearnMode` is true (daemon records via CDP)
- Updates `WatchProgressView` to display network recording progress with antenna icon in learn mode

## Test plan
- [ ] Start a learn mode session and verify the progress view shows "Recording network traffic..." with antenna icon
- [ ] Verify network entry count increments every 5 seconds as traffic is recorded
- [ ] Verify normal (observe) mode still shows "Watching your workflow..." with eye icon and capture counts
- [ ] Verify stopping a learn mode session early still finalizes the recording correctly

Part of #7718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
