### PR TITLE
M3: Add auto/manual mapping mode flag

### DIFF
--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -159,6 +159,7 @@ async function startLearnSession(
   navigateDomain: string,
   recordDomain: string,
   durationSeconds: number,
+  autoNavigate: boolean = true,
 ): Promise<LearnResult> {
   await ensureChromeWithCDP(navigateDomain);
 
@@ -195,7 +196,7 @@ async function startLearnSession(
           mode: 'learn',
           targetDomain: recordDomain,
           navigateDomain,
-          autoNavigate: true,
+          autoNavigate,
         } as unknown as import('../daemon/ipc-protocol.js').ClientMessage),
       );
     };
@@ -266,11 +267,15 @@ export function registerMapCommand(program: Command): void {
       'then analyzes captured network traffic.',
     )
     .argument('<domain>', 'Domain to map (e.g., example.com)')
-    .option('--duration <seconds>', 'Recording duration in seconds', '120')
+    .option('--duration <seconds>', 'Recording duration in seconds')
+    .option('--manual', 'Manual mode: browse the site yourself while network traffic is recorded')
     .option('--json', 'Machine-readable JSON output')
-    .action(async (domain: string, opts: { duration: string; json?: boolean }, cmd: Command) => {
+    .action(async (domain: string, opts: { duration?: string; manual?: boolean; json?: boolean }, cmd: Command) => {
       const json = getJson(cmd);
-      const duration = parseInt(opts.duration, 10);
+      const manual = opts.manual ?? false;
+      const duration = opts.duration
+        ? parseInt(opts.duration, 10)
+        : manual ? 60 : 120;
 
       try {
         // Split into navigation domain (what Chrome browses) and recording domain (network filter).
@@ -279,13 +284,16 @@ export function registerMapCommand(program: Command): void {
         const recordDomain = getBaseDomain(domain);
 
         if (!json) {
-          if (navigateDomain !== recordDomain) {
+          if (manual) {
+            console.log(`Starting manual API map session for ${domain} (${duration}s)...`);
+            console.log('Browse the site manually. Press Ctrl+C or wait for idle detection to stop recording.');
+          } else if (navigateDomain !== recordDomain) {
             console.log(`Starting API map session: navigating ${navigateDomain}, recording *.${recordDomain} (${duration}s)...`);
           } else {
             console.log(`Starting API map session for ${domain} (${duration}s)...`);
           }
         }
-        const result = await startLearnSession(navigateDomain, recordDomain, duration);
+        const result = await startLearnSession(navigateDomain, recordDomain, duration, !manual);
 
         if (!result.recordingId) {
           outputError('Recording completed but no recording ID returned');

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -192,13 +192,15 @@ export async function handleRideShotgunStart(
                 completeSession(session);
               }
             });
-          } else {
+          } else if (!targetDomain) {
             // No targetDomain: use login detection as before
             recorder.onLoginDetected = () => {
               log.info({ watchId }, 'Login detected — auto-stopping learn session');
               completeSession(session);
             };
           }
+          // When autoNavigate is false but targetDomain is set (manual mode),
+          // just record network traffic until timeout or early stop — no login detection shortcut.
 
           return;
         } catch (err) {


### PR DESCRIPTION
Adds --manual flag to the map CLI command. When set, Chrome launches but the user browses manually while network traffic is recorded. Defaults to 60s duration for manual mode. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
