### PR TITLE
M5: CLI PATH resolution — standalone launchers

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -5,62 +5,62 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\uD83C\uDF55"}}
 ---
 
-You can order food from DoorDash for the user using the `vellum doordash` CLI.
+You can order food from DoorDash for the user using the `doordash` CLI.
 
 ## CLI Setup
 
-**IMPORTANT: Always use `host_bash` (not `bash`) for all `vellum doordash` commands.** The DoorDash CLI needs host access for Chrome CDP, session cookies, and the `vellum` binary — none of which are available inside the sandbox.
+**IMPORTANT: Always use `host_bash` (not `bash`) for all `doordash` commands.** The DoorDash CLI needs host access for Chrome CDP, session cookies, and the CLI binary — none of which are available inside the sandbox.
 
-`vellum doordash` is a built-in subcommand of the Vellum assistant CLI — it is NOT a separate tool you need to find or install. It should already be on your PATH. If `vellum` is not found, prepend `PATH="$HOME/.local/bin:$PATH"` to the command. Do NOT search for the binary, inspect wrapper scripts, or try to discover how the CLI works. Just run the commands as documented below.
+`doordash` is a standalone CLI tool installed at `~/.vellum/bin/doordash`. It should already be on your PATH. If `doordash` is not found, prepend `PATH="$HOME/.vellum/bin:$PATH"` to the command. Do NOT search for the binary, inspect wrapper scripts, or try to discover how the CLI works. Just run the commands as documented below.
 
 ## Task Progress Widget
 
-A task progress card is shown automatically when you run your first `vellum doordash` command. Its surface ID is `doordash-progress`. As each step completes, call `ui_update` with surface ID `doordash-progress` to update step statuses. Update `data.templateData.steps` — set completed steps to `"status": "completed"` with a `"detail"` string, the current step to `"status": "in_progress"`, and future steps to `"status": "pending"`. Adapt the steps to the actual flow (e.g. skip "Search restaurants" if the user named a specific store).
+A task progress card is shown automatically when you run your first `doordash` command. Its surface ID is `doordash-progress`. As each step completes, call `ui_update` with surface ID `doordash-progress` to update step statuses. Update `data.templateData.steps` — set completed steps to `"status": "completed"` with a `"detail"` string, the current step to `"status": "in_progress"`, and future steps to `"status": "pending"`. Adapt the steps to the actual flow (e.g. skip "Search restaurants" if the user named a specific store).
 
 ## Typical Flow
 
 When the user asks you to order food (e.g. "Order pizza from Andiamo's"):
 
-1. **Check session** — run `vellum doordash status --json`. If `loggedIn` is false or the session is expired, tell the user: "A Chrome window will open to the DoorDash login page. Please sign in there — I'll detect your login automatically and minimize the window." Then run `vellum doordash refresh --json`. This starts a Ride Shotgun learn session that records your login and auto-stops once it detects you've signed in. The session is imported automatically. **This command blocks until login is complete — just wait for it.**
+1. **Check session** — run `doordash status --json`. If `loggedIn` is false or the session is expired, tell the user: "A Chrome window will open to the DoorDash login page. Please sign in there — I'll detect your login automatically and minimize the window." Then run `doordash refresh --json`. This starts a Ride Shotgun learn session that records your login and auto-stops once it detects you've signed in. The session is imported automatically. **This command blocks until login is complete — just wait for it.**
 
    Keep the DoorDash Chrome window open in the background — it's needed for API requests.
 
-2. **Search** — run `vellum doordash search "<query>" --json` to find matching restaurants. Present the top results to the user with name, rating, and delivery info. If the user named a specific restaurant, pick the best match. If ambiguous, ask.
+2. **Search** — run `doordash search "<query>" --json` to find matching restaurants. Present the top results to the user with name, rating, and delivery info. If the user named a specific restaurant, pick the best match. If ambiguous, ask.
 
-3. **Browse menu** — run `vellum doordash menu <storeId> --json` to get the menu. Show the user the categories and items with prices. If the user already said what they want (e.g. "pepperoni pizza"), find the matching item(s). **For convenience/pharmacy stores** (CVS, Duane Reade, Walgreens etc.), the response will have `isRetail: true` and empty items — use `store-search` instead (see step 3b).
+3. **Browse menu** — run `doordash menu <storeId> --json` to get the menu. Show the user the categories and items with prices. If the user already said what they want (e.g. "pepperoni pizza"), find the matching item(s). **For convenience/pharmacy stores** (CVS, Duane Reade, Walgreens etc.), the response will have `isRetail: true` and empty items — use `store-search` instead (see step 3b).
 
-3b. **Search within a retail store** — for convenience/pharmacy stores, run `vellum doordash store-search <storeId> "<query>" --json` to find specific products. This returns items with IDs, prices, and menuIds that can be added to cart directly.
+3b. **Search within a retail store** — for convenience/pharmacy stores, run `doordash store-search <storeId> "<query>" --json` to find specific products. This returns items with IDs, prices, and menuIds that can be added to cart directly.
 
-4. **Get item details** (if needed) — run `vellum doordash item <storeId> <itemId> --json` to see options/customizations. The response includes:
+4. **Get item details** (if needed) — run `doordash item <storeId> <itemId> --json` to see options/customizations. The response includes:
    - `options`: each option group has `minSelections`/`maxSelections` indicating how many choices are required
    - Each choice has `unitAmount` (price impact in cents), `defaultQuantity`, and possibly `nestedOptions` (sub-choices like milk type within a size selection)
    - `specialInstructionsConfig`: whether special instructions are accepted, max length, and placeholder text
 
    If the item has required options (like size or toppings), construct the `nestedOptions` JSON from the option/choice IDs and pass it via `--options`. Ask the user for preferences or pick sensible defaults.
 
-5. **Add to cart** — run `vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--options '<json>'] [--special-instructions "<text>"] --json`. For subsequent items at the same store, pass `--cart-id <id>` from the first add response. Use `--special-instructions` for requests like "extra hot", "no ice", etc. Use `--options` to pass customization choices (see Customization Options below).
+5. **Add to cart** — run `doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--options '<json>'] [--special-instructions "<text>"] --json`. For subsequent items at the same store, pass `--cart-id <id>` from the first add response. Use `--special-instructions` for requests like "extra hot", "no ice", etc. Use `--options` to pass customization choices (see Customization Options below).
 
-6. **Review cart** — run `vellum doordash cart view <cartId> --json` and show the user what's in their cart with prices. Ask if they want to add anything else or proceed.
+6. **Review cart** — run `doordash cart view <cartId> --json` and show the user what's in their cart with prices. Ask if they want to add anything else or proceed.
 
-7. **Checkout** — run `vellum doordash checkout <cartId> --json` to get delivery options. Present them to the user.
+7. **Checkout** — run `doordash checkout <cartId> --json` to get delivery options. Present them to the user.
 
-8. **Payment methods** — run `vellum doordash payment-methods --json` to see saved cards. Show the user which card will be used (the default one).
+8. **Payment methods** — run `doordash payment-methods --json` to see saved cards. Show the user which card will be used (the default one).
 
-9. **Place order** — after the user explicitly confirms, run `vellum doordash order place --cart-id <id> --store-id <id> --total <cents> [--tip <cents>] [--dropoff-option <id>] --json`. The command auto-selects the default payment method if `--payment-uuid` is not provided. The response contains `orderUuid` on success.
+9. **Place order** — after the user explicitly confirms, run `doordash order place --cart-id <id> --store-id <id> --total <cents> [--tip <cents>] [--dropoff-option <id>] --json`. The command auto-selects the default payment method if `--payment-uuid` is not provided. The response contains `orderUuid` on success.
 
 ## Important Behavior
 
 - **Always confirm before checkout.** Never place an order without explicit user approval.
 - **Be proactive.** If the user says "order pizza from Andiamo's", don't ask clarifying questions upfront — search, find the store, show the menu, and suggest items. Only ask when you need a choice the user hasn't specified.
-- **Handle expired sessions gracefully.** If any command returns `"error": "session_expired"`, run `vellum doordash refresh --json` to re-capture the session.
+- **Handle expired sessions gracefully.** If any command returns `"error": "session_expired"`, run `doordash refresh --json` to re-capture the session.
 - **Show prices.** Always show prices when presenting items or the cart summary.
 - **Use `--json` flag** on all commands for reliable parsing.
 - **Do NOT use the browser skill.** All DoorDash interaction goes through the CLI, not browser automation.
-- **Rate limiting.** DoorDash rate-limits rapid sequential requests. When adding multiple items (e.g. a team order), wait 8–10 seconds between `cart add` calls. If you get a 403 error, wait 15–20 seconds and retry. For large orders (5+ items), consider running `vellum doordash refresh --json` midway through if you hit repeated 403s.
+- **Rate limiting.** DoorDash rate-limits rapid sequential requests. When adding multiple items (e.g. a team order), wait 8–10 seconds between `cart add` calls. If you get a 403 error, wait 15–20 seconds and retry. For large orders (5+ items), consider running `doordash refresh --json` midway through if you hit repeated 403s.
 - **Special instructions are unreliable.** Some merchants disable special instructions entirely. Always prefer `--options` for customizations (size, milk type, etc.). Only use `--special-instructions` for free-text requests that aren't covered by the item's option groups. If the merchant rejects special instructions, drop them and proceed without.
 - **Customization fallback.** If `cart add` with `--options` fails, or if the item details show options that are hard to construct (deeply nested, unusual format), proactively offer to use `cart learn` so the user can customize the item visually in the browser. Don't silently drop customizations — tell the user what happened and offer alternatives.
-- **Always-allow tip.** At the start of an ordering flow, suggest the user enable "always allow" for `vellum doordash` commands: "Tip: You can type 'a' to always allow `vellum doordash` commands for this session so you won't be prompted each time."
-- **Error attribution.** When errors occur, assume it's more likely a bug in our query/parsing than a DoorDash API change. Suggest running `vellum doordash record` to capture fresh queries before assuming the schema changed.
+- **Always-allow tip.** At the start of an ordering flow, suggest the user enable "always allow" for `doordash` commands: "Tip: You can type 'a' to always allow `doordash` commands for this session so you won't be prompted each time."
+- **Error attribution.** When errors occur, assume it's more likely a bug in our query/parsing than a DoorDash API change. Suggest running `doordash record` to capture fresh queries before assuming the schema changed.
 
 ## Customization Options
 
@@ -68,7 +68,7 @@ Many items (especially coffee, boba, sandwiches) have required customization opt
 
 ### Constructing nestedOptions JSON
 
-1. Run `vellum doordash item <storeId> <itemId> --json` to get the item's option groups
+1. Run `doordash item <storeId> <itemId> --json` to get the item's option groups
 2. Each option group has `id`, `name`, `required`, `minSelections`, `maxSelections`, and `choices`
 3. Build a JSON array of selections matching the DoorDash format:
 
@@ -97,67 +97,67 @@ Use `--special-instructions` on `cart add` for free-text requests like "extra ho
 
 For complex items where constructing the JSON manually is difficult, use `cart learn`:
 
-1. Run `vellum doordash cart learn --json`
+1. Run `doordash cart learn --json`
 2. A Chrome window opens — navigate to the item, customize it visually, and click "Add to Cart"
 3. The command auto-detects the `updateCartItem` operation and extracts the exact `nestedOptions` and `specialInstructions`
 4. Use the extracted options directly with `cart add --options '<json>'`
 
-You can also extract options from an existing recording with `vellum doordash inspect <recordingId> --extract-options --json`.
+You can also extract options from an existing recording with `doordash inspect <recordingId> --extract-options --json`.
 
 ### Coffee Order Example
 
 **User**: "Order a large oat milk latte with an extra shot from Blue Bottle"
 
-1. `vellum doordash search "Blue Bottle" --json` -> finds store
-2. `vellum doordash menu <storeId> --json` -> finds "Latte" item
-3. `vellum doordash item <storeId> <latteItemId> --json` -> returns options:
+1. `doordash search "Blue Bottle" --json` -> finds store
+2. `doordash menu <storeId> --json` -> finds "Latte" item
+3. `doordash item <storeId> <latteItemId> --json` -> returns options:
    - Size (required, min:1, max:1): Small (id:101), Medium (id:102), Large (id:103, +$1.00)
    - Milk (required, min:1, max:1): Whole (id:201), Oat (id:202, +$0.70), Almond (id:203, +$0.70)
    - Extras (optional, min:0, max:5): Extra Shot (id:301, +$0.90), Vanilla Syrup (id:302, +$0.60)
 4. Construct options JSON and add to cart:
 ```
-vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "Latte" --unit-price 550 --options '[{"optionId":"size-group-id","optionChoiceId":"103","quantity":1,"nestedOptions":[]},{"optionId":"milk-group-id","optionChoiceId":"202","quantity":1,"nestedOptions":[]},{"optionId":"extras-group-id","optionChoiceId":"301","quantity":1,"nestedOptions":[]}]' --special-instructions "Extra hot" --json
+doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "Latte" --unit-price 550 --options '[{"optionId":"size-group-id","optionChoiceId":"103","quantity":1,"nestedOptions":[]},{"optionId":"milk-group-id","optionChoiceId":"202","quantity":1,"nestedOptions":[]},{"optionId":"extras-group-id","optionChoiceId":"301","quantity":1,"nestedOptions":[]}]' --special-instructions "Extra hot" --json
 ```
 
 ## Command Reference
 
 ```
-vellum doordash status --json              # Check if logged in
-vellum doordash refresh --json             # Capture fresh session via Ride Shotgun (auto-stops after login)
-vellum doordash login --recording <path>   # Import session from a recording file manually
-vellum doordash logout --json              # Clear session
-vellum doordash search "<query>" --json    # Search restaurants
-vellum doordash menu <storeId> --json      # Get store menu (auto-detects retail stores)
-vellum doordash store-search <storeId> "<query>" --json  # Search items within a convenience/pharmacy store
-vellum doordash item <storeId> <itemId> --json  # Get item details + options
-vellum doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--quantity <n>] [--cart-id <id>] [--options '<json>'] [--special-instructions "<text>"] --json
-vellum doordash cart remove --cart-id <id> --item-id <orderItemId> --json
-vellum doordash cart view <cartId> --json
-vellum doordash cart list [--store-id <id>] --json
-vellum doordash cart learn --json                 # Learn customization options by recording browser interaction
-vellum doordash inspect <recordingId> --extract-options --json  # Extract nestedOptions from a recording
-vellum doordash checkout <cartId> [--address-id <id>] --json
-vellum doordash payment-methods --json     # List saved payment methods
-vellum doordash order place --cart-id <id> --store-id <id> --total <cents> [--tip <cents>] [--delivery-option <type>] [--dropoff-option <id>] [--payment-uuid <uuid>] --json
+doordash status --json              # Check if logged in
+doordash refresh --json             # Capture fresh session via Ride Shotgun (auto-stops after login)
+doordash login --recording <path>   # Import session from a recording file manually
+doordash logout --json              # Clear session
+doordash search "<query>" --json    # Search restaurants
+doordash menu <storeId> --json      # Get store menu (auto-detects retail stores)
+doordash store-search <storeId> "<query>" --json  # Search items within a convenience/pharmacy store
+doordash item <storeId> <itemId> --json  # Get item details + options
+doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "<name>" --unit-price <cents> [--quantity <n>] [--cart-id <id>] [--options '<json>'] [--special-instructions "<text>"] --json
+doordash cart remove --cart-id <id> --item-id <orderItemId> --json
+doordash cart view <cartId> --json
+doordash cart list [--store-id <id>] --json
+doordash cart learn --json                 # Learn customization options by recording browser interaction
+doordash inspect <recordingId> --extract-options --json  # Extract nestedOptions from a recording
+doordash checkout <cartId> [--address-id <id>] --json
+doordash payment-methods --json     # List saved payment methods
+doordash order place --cart-id <id> --store-id <id> --total <cents> [--tip <cents>] [--delivery-option <type>] [--dropoff-option <id>] [--payment-uuid <uuid>] --json
 ```
 
 ## Example Interaction
 
 **User**: "Order a pepperoni pizza from Andiamo's"
 
-1. `vellum doordash status --json` -> logged in
-2. `vellum doordash search "Andiamo's" --json` -> finds store 22926474
-3. `vellum doordash menu 22926474 --json` -> finds "Pepperoni Pizza Pie" (item 2956709006, $28.00)
+1. `doordash status --json` -> logged in
+2. `doordash search "Andiamo's" --json` -> finds store 22926474
+3. `doordash menu 22926474 --json` -> finds "Pepperoni Pizza Pie" (item 2956709006, $28.00)
 4. Tell user: "I found Pepperoni Pizza Pie at Andiamo's for $28.00. Adding it to your cart."
-5. `vellum doordash cart add --store-id 22926474 --menu-id 12847574 --item-id 2956709006 --item-name "Pepperoni Pizza Pie" --unit-price 2800 --json`
-6. `vellum doordash cart view <cartId> --json` -> show summary
+5. `doordash cart add --store-id 22926474 --menu-id 12847574 --item-id 2956709006 --item-name "Pepperoni Pizza Pie" --unit-price 2800 --json`
+6. `doordash cart view <cartId> --json` -> show summary
 7. "Your cart has 1x Pepperoni Pizza Pie ($28.00), total $28.00. Ready to check out?"
 
 **User**: "I need Tylenol from CVS"
 
-1. `vellum doordash status --json` -> logged in
-2. `vellum doordash search "CVS" --json` -> finds store 1231787
-3. `vellum doordash menu 1231787 --json` -> isRetail: true, categories but no items
-4. `vellum doordash store-search 1231787 "tylenol" --json` -> finds results
+1. `doordash status --json` -> logged in
+2. `doordash search "CVS" --json` -> finds store 1231787
+3. `doordash menu 1231787 --json` -> isRetail: true, categories but no items
+4. `doordash store-search 1231787 "tylenol" --json` -> finds results
 5. Show top results: "Tylenol Extra Strength Gelcaps (24 ct) - $8.79, Tylenol Extra Strength Caplets (100 ct) - $13.49..."
 6. User picks one -> add to cart with the item's `id`, `menuId`, and `unitAmount`

--- a/assistant/src/daemon/install-cli-launchers.ts
+++ b/assistant/src/daemon/install-cli-launchers.ts
@@ -1,0 +1,109 @@
+/**
+ * Installs standalone CLI launcher scripts in ~/.vellum/bin/ so that
+ * integration commands (e.g. `doordash`, `map`) can be invoked directly
+ * without requiring `vellum` on PATH.
+ *
+ * Each launcher is a shell script that hardcodes absolute paths to `bun`
+ * and the CLI entrypoint, forwarding all arguments to the appropriate
+ * subcommand.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('install-cli-launchers');
+
+/** Integration subcommands that should get standalone launchers. */
+const INTEGRATION_COMMANDS = ['doordash', 'map'];
+
+/**
+ * Resolve the absolute path to the bun binary.
+ * Prefers process.execPath (works when running under bun), then falls
+ * back to `which bun`.
+ */
+function resolveBunPath(): string {
+  // process.execPath points to the bun binary when running under bun
+  if (process.execPath && process.execPath.includes('bun')) {
+    return process.execPath;
+  }
+  try {
+    return execSync('which bun', { encoding: 'utf-8' }).trim();
+  } catch {
+    throw new Error('Could not find bun binary');
+  }
+}
+
+/**
+ * Resolve the absolute path to the CLI entrypoint (index.ts).
+ * Uses import.meta.dirname to find the source tree root.
+ */
+function resolveCliEntrypoint(): string {
+  // This file is at assistant/src/daemon/install-cli-launchers.ts
+  // The CLI entrypoint is at assistant/src/index.ts
+  const thisDir = import.meta.dirname ?? __dirname;
+  return join(thisDir, '..', 'index.ts');
+}
+
+/**
+ * Check whether a given command name conflicts with an existing system
+ * binary (i.e. something other than our own launcher).
+ */
+function hasSystemConflict(name: string, binDir: string): boolean {
+  try {
+    const result = execSync(`which ${name}`, { encoding: 'utf-8' }).trim();
+    // If `which` resolves to our own bin dir, that's not a conflict
+    if (result.startsWith(binDir)) return false;
+    return true;
+  } catch {
+    // `which` failed — no conflict
+    return false;
+  }
+}
+
+/**
+ * Install standalone CLI launcher scripts in ~/.vellum/bin/.
+ *
+ * For each integration command, generates a shell script that execs
+ * bun with the CLI entrypoint and the subcommand name prepended.
+ * Uses the short name by default (e.g. `doordash`), falling back to
+ * `vellum-<name>` if the short name conflicts with an existing system binary.
+ */
+export function installCliLaunchers(): void {
+  const binDir = join(homedir(), '.vellum', 'bin');
+
+  let bunPath: string;
+  try {
+    bunPath = resolveBunPath();
+  } catch (err) {
+    log.warn({ err }, 'Cannot install CLI launchers: bun not found');
+    return;
+  }
+
+  const entrypoint = resolveCliEntrypoint();
+  if (!existsSync(entrypoint)) {
+    log.warn({ entrypoint }, 'Cannot install CLI launchers: CLI entrypoint not found');
+    return;
+  }
+
+  if (!existsSync(binDir)) {
+    mkdirSync(binDir, { recursive: true });
+  }
+
+  for (const name of INTEGRATION_COMMANDS) {
+    const launcherName = hasSystemConflict(name, binDir) ? `vellum-${name}` : name;
+    const launcherPath = join(binDir, launcherName);
+
+    const script = `#!/bin/bash
+exec ${bunPath} ${entrypoint} ${name} "$@"
+`;
+
+    writeFileSync(launcherPath, script);
+    chmodSync(launcherPath, 0o755);
+    log.debug({ launcherName, launcherPath }, 'Installed CLI launcher');
+  }
+
+  log.info({ binDir, commands: INTEGRATION_COMMANDS }, 'CLI launchers installed');
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -65,6 +65,7 @@ import {
 } from '../runtime/approval-message-composer.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
+import { installCliLaunchers } from './install-cli-launchers.js';
 import { HeartbeatService } from '../workspace/heartbeat-service.js';
 import { AgentHeartbeatService } from '../agent-heartbeat/agent-heartbeat-service.js';
 import { getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
@@ -374,6 +375,13 @@ export async function runDaemon(): Promise<void> {
   log.info('Daemon startup: installing templates and initializing DB');
   installTemplates();
   ensurePromptFiles();
+
+  // Install standalone CLI launchers (e.g. doordash, map) in ~/.vellum/bin/
+  try {
+    installCliLaunchers();
+  } catch (err) {
+    log.warn({ err }, 'CLI launcher installation failed — continuing startup');
+  }
   initializeDb();
   log.info('Daemon startup: DB initialized');
 


### PR DESCRIPTION
Creates a launcher system that installs standalone CLI scripts (doordash, map) in ~/.vellum/bin/ with hardcoded paths to bun and the CLI entrypoint. Called on daemon startup. Updates SKILL.md files to reference standalone commands. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
