### PR TITLE
refactor: replace inline animation durations with VAnimation design tokens

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -201,9 +201,9 @@ struct ChatContentView: View {
         }
         .background(alignment: .bottom) { chatBackground }
         .background(VColor.chatBackground)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.sessionError != nil)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.errorText)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isMemoryDegraded)
+        .animation(VAnimation.standard, value: viewModel.sessionError != nil)
+        .animation(VAnimation.standard, value: viewModel.errorText)
+        .animation(VAnimation.standard, value: viewModel.isMemoryDegraded)
         .onChange(of: viewModel.messages.isEmpty) { _, isEmpty in
             if isEmpty {
                 greeting = greetingChoices.randomElement()!

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -85,12 +85,12 @@ struct InputBarView: View {
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .stroke(VColor.surfaceBorder, lineWidth: isInputFocused.wrappedValue ? 1.5 : 1)
                     )
-                    .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
+                    .animation(VAnimation.fast, value: isInputFocused.wrappedValue)
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .stroke(VColor.surfaceBorder.opacity(0.12), lineWidth: 3)
                             .opacity(isInputFocused.wrappedValue ? 1 : 0)
-                            .animation(.easeInOut(duration: 0.15), value: isInputFocused.wrappedValue)
+                            .animation(VAnimation.fast, value: isInputFocused.wrappedValue)
                     )
                     .shadow(color: VColor.textPrimary.opacity(0.06), radius: 8, x: 0, y: 2)
 

--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -107,7 +107,7 @@ public struct VSlider: View {
             }
         }
         .scaleEffect(isDragging ? 1.05 : 1.0)
-        .animation(.easeOut(duration: 0.15), value: isDragging)
+        .animation(VAnimation.fast, value: isDragging)
     }
 
     // MARK: - Tick Marks

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -103,7 +103,7 @@ public struct SubagentStatusChip: View {
     private func startDotAnimation() {
         guard !subagent.isTerminal else { return }
         timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(VAnimation.standard) {
                 phase += 1
             }
         }

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -183,7 +183,7 @@ public struct SubagentThreadView: View {
     private func startDotAnimation() {
         guard isRunning else { return }
         timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(VAnimation.standard) {
                 phase += 1
             }
         }


### PR DESCRIPTION
## Summary

Sweeps iOS and shared code for raw inline animation values and replaces them with `VAnimation` design tokens for consistency.

| Before | After | Token |
|--------|-------|-------|
| `.easeInOut(duration: 0.15)` | `VAnimation.fast` | `easeOut(0.15)` |
| `.easeOut(duration: 0.15)` | `VAnimation.fast` | exact match |
| `.easeInOut(duration: 0.2)` | `VAnimation.standard` | closest (0.25s easeInOut) |

**Files changed:**
- `clients/ios/Views/InputBarView.swift` — input field focus ring (×2)
- `clients/ios/Views/ChatContentView.swift` — banner/error show/hide (×3)
- `clients/shared/DesignSystem/Core/Inputs/VSlider.swift` — slider drag scale (×1)
- `clients/shared/Features/Chat/SubagentStatusChip.swift` — dot animation timer (×1)
- `clients/shared/Features/Chat/SubagentThreadView.swift` — dot animation timer (×1)

Intentionally left as-is (custom timing that doesn't map to a token):
- Scroll animations (`easeOut(0.3)`, `easeOut(0.5)`) in ChatContentView
- Waveform bar animation (`easeInOut(0.1)`) in VWaveformView
- RepeatForever pulse/bounce animations in CurrentStepIndicator and TypingIndicatorView
- Onboarding step transition (no-duration `.easeInOut`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
