### PR TITLE
M2: Auto-complete learn sessions + idle detection

### DIFF
--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -123,6 +123,7 @@ export interface RideShotgunProgress {
   message: string;
   networkEntryCount?: number;
   statusMessage?: string;
+  idleHint?: boolean;
 }
 
 export interface RideShotgunResult {

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -135,18 +135,41 @@ export async function handleRideShotgunStart(
           activeRecorders.set(watchId, recorder);
           log.info({ watchId, targetDomain, attempt }, 'Network recording started for learn session');
 
-          // Send periodic progress updates with network entry counts
+          // Send periodic progress updates with network entry counts and idle detection
+          let lastNetworkEntryCount = 0;
+          let lastActivityTimestamp = Date.now();
+          let idleHintSent = false;
+
           const progressInterval = setInterval(() => {
             if (session.status !== 'active') {
               clearInterval(progressInterval);
               return;
             }
+
+            const currentCount = recorder.entryCount;
+
+            // Track activity: reset idle timer when count changes
+            if (currentCount !== lastNetworkEntryCount) {
+              lastNetworkEntryCount = currentCount;
+              lastActivityTimestamp = Date.now();
+            }
+
+            // Idle detection: if some initial activity happened and no new entries for 15s, hint once
+            const idleMs = Date.now() - lastActivityTimestamp;
+            let idleHint: boolean | undefined;
+            if (!idleHintSent && currentCount > 0 && idleMs >= 15_000) {
+              idleHint = true;
+              idleHintSent = true;
+              log.info({ watchId, currentCount, idleMs }, 'Idle detected — sending idleHint');
+            }
+
             ctx.send(socket, {
               type: 'ride_shotgun_progress',
               watchId,
               message: `Recording network traffic...`,
-              networkEntryCount: recorder.entryCount,
+              networkEntryCount: currentCount,
               statusMessage: 'Recording network traffic...',
+              ...(idleHint !== undefined ? { idleHint } : {}),
             });
           }, 5000);
 

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -23,6 +23,7 @@ public final class RideShotgunSession: ObservableObject {
     @Published public var recordingPath: String?
     @Published public var networkEntryCount: Int = 0
     @Published public var statusMessage: String = ""
+    @Published public var idleHint: Bool = false
 
     // Pass-through from WatchSession
     @Published public var elapsedSeconds: Double = 0
@@ -72,6 +73,9 @@ public final class RideShotgunSession: ObservableObject {
                     }
                     if let msg = progress.statusMessage, !msg.isEmpty {
                         self.statusMessage = msg
+                    }
+                    if let idle = progress.idleHint, idle {
+                        self.idleHint = true
                     }
                 case .rideShotgunResult(let result):
                     self.handleRideShotgunResult(result)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -44,6 +44,7 @@ struct ChatView: View {
     let watchSession: WatchSession?
     var isLearnMode: Bool = false
     var networkEntryCount: Int = 0
+    var idleHint: Bool = false
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -228,7 +229,7 @@ struct ChatView: View {
     @MainActor private var composerOverlay: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
-                WatchProgressView(session: watchSession, onStop: onStopWatch, isLearnMode: isLearnMode, networkEntryCount: networkEntryCount)
+                WatchProgressView(session: watchSession, onStop: onStopWatch, isLearnMode: isLearnMode, networkEntryCount: networkEntryCount, idleHint: idleHint)
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.sm)
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
@@ -6,6 +6,7 @@ struct WatchProgressView: View {
     let onStop: () -> Void
     var isLearnMode: Bool = false
     var networkEntryCount: Int = 0
+    var idleHint: Bool = false
 
     @State private var isPulsing = false
 
@@ -44,11 +45,11 @@ struct WatchProgressView: View {
 
                 Spacer()
 
-                // Stop button
+                // Stop button — highlighted when idle hint is active
                 Button(action: onStop) {
                     Image(systemName: "stop.fill")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.error)
+                        .foregroundColor(idleHint ? VColor.accent : VColor.error)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop watching")
@@ -74,6 +75,20 @@ struct WatchProgressView: View {
                             .foregroundColor(VColor.textSecondary)
                     }
                 }
+            }
+
+            // Idle hint prompt
+            if idleHint {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle")
+                        .foregroundColor(VColor.accent)
+                        .font(.system(size: 12))
+                    Text("No new activity detected. Ready to stop?")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.accent)
+                    Spacer()
+                }
+                .transition(.opacity)
             }
 
             // Current app badge

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -629,6 +629,7 @@ struct ActiveChatViewWrapper: View {
             watchSession: ambientAgent.activeWatchSession,
             isLearnMode: ambientAgent.currentSession?.isLearnMode ?? false,
             networkEntryCount: ambientAgent.currentSession?.networkEntryCount ?? 0,
+            idleHint: ambientAgent.currentSession?.idleHint ?? false,
             onStopWatch: { viewModel.stopWatchSession() },
             onReportMessage: { daemonMessageId in
                 guard let sessionId = viewModel.sessionId else { return }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2607,13 +2607,15 @@ public struct IPCRideShotgunProgress: Codable, Sendable {
     public let message: String
     public let networkEntryCount: Int?
     public let statusMessage: String?
+    public let idleHint: Bool?
 
-    public init(type: String, watchId: String, message: String, networkEntryCount: Int? = nil, statusMessage: String? = nil) {
+    public init(type: String, watchId: String, message: String, networkEntryCount: Int? = nil, statusMessage: String? = nil, idleHint: Bool? = nil) {
         self.type = type
         self.watchId = watchId
         self.message = message
         self.networkEntryCount = networkEntryCount
         self.statusMessage = statusMessage
+        self.idleHint = idleHint
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds idle detection to learn mode: after 15s of no new network entries (once initial activity is detected), sends an `idleHint` flag via `ride_shotgun_progress`
- Swift UI surfaces this as a "Ready to stop?" prompt with highlighted stop button
- Threads `idleHint` through the full stack: IPC contract -> codegen -> RideShotgunSession -> ChatView -> WatchProgressView

Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
