### PR TITLE
refactor: replace remaining print() calls with os.Logger

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -1,8 +1,11 @@
 #if canImport(UIKit)
 import Combine
+import os
 import UIKit
 import UserNotifications
 import VellumAssistantShared
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "AppDelegate")
 
 /// Observable wrapper that holds the active DaemonClientProtocol implementation.
 /// Allows SwiftUI views to receive the client via @EnvironmentObject without
@@ -112,7 +115,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         // Log failure but don't crash — push is optional
-        print("[APNS] Failed to register: \(error.localizedDescription)")
+        log.error("APNS registration failed: \(error.localizedDescription)")
     }
 
     private func sendDeviceTokenToDaemon(_ token: String) async throws {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -304,7 +304,7 @@ struct InlineVideoAttachmentView: View {
                         try FileManager.default.moveItem(at: tempURL, to: destURL)
                     }
                 } catch {
-                    print("Failed to save video: \(error)")
+                    log.error("Failed to save video: \(error)")
                 }
                 await MainActor.run { isSaving = false }
             }

--- a/clients/macos/vellum-assistant/Logging/LogViewer.swift
+++ b/clients/macos/vellum-assistant/Logging/LogViewer.swift
@@ -1,5 +1,8 @@
+import os
 import SwiftUI
 import Foundation
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "LogViewer")
 
 struct LogViewer: View {
     @State private var logFiles: [URL] = []
@@ -79,7 +82,7 @@ struct LogViewer: View {
             decoder.dateDecodingStrategy = .iso8601
             selectedLog = try decoder.decode(SessionLog.self, from: data)
         } catch {
-            print("Failed to load log: \(error)")
+            log.error("Failed to load log: \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the last 3 production `print()` calls with `os.Logger` so all Swift log output goes through the unified logging system with proper subsystem/category routing and privacy controls.

**Changes:**

- `clients/macos/.../MediaEmbeds/InlineVideoAttachmentView.swift` — `print("Failed to save video:")` → `log.error(...)` (logger already existed in this file)
- `clients/macos/.../Logging/LogViewer.swift` — added `import os` + `private let log`, `print("Failed to load log:")` → `log.error(...)`
- `clients/ios/App/AppDelegate.swift` — added `import os` + `private let log`, `print("[APNS] Failed to register:")` → `log.error(...)`

**Left intentionally unchanged:**
- `DocumentReopenWidget.swift` lines 83-84 — inside `#if DEBUG #Preview` block (preview actions only)
- `MarkdownRenderer.swift` line 314 — `print(greeting)` is inside a multi-line markdown string literal (a code example), not executable Swift code

All loggers use `"com.vellum.vellum-assistant"` as subsystem (per CLAUDE.md pattern for `Bundle.main.bundleIdentifier` being nil in SPM builds).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
