### PR TITLE
security: add privacy: .private annotations to sensitive os.Logger interpolations

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -11,7 +11,7 @@ extension AppDelegate {
     public func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
             guard url.pathExtension == "vellumapp" else { continue }
-            log.info("Opening .vellumapp file: \(url.path)")
+            log.info("Opening .vellumapp file: \(url.path, privacy: .private)")
 
             guard daemonClient.isConnected else {
                 log.warning("Cannot open bundle: daemon not connected")
@@ -111,7 +111,7 @@ extension AppDelegate {
                         .replacingOccurrences(of: "\\", with: "")
                         .replacingOccurrences(of: "'", with: "")
                     let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/\(sanitizedEntry)"
-                    log.info("Loading shared app at \(entryURL)")
+                    log.info("Loading shared app at \(entryURL, privacy: .private)")
 
                     // HTML-escape manifest.name to prevent XSS injection.
                     let safeName = Self.htmlEscape(manifest.name)

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -346,7 +346,7 @@ extension AppDelegate {
         do {
             try daemonClient.sendAppOpen(appId: appId)
         } catch {
-            log.error("Failed to send app open for \(appId): \(error)")
+            log.error("Failed to send app open for \(appId, privacy: .private): \(error)")
         }
     }
 
@@ -356,13 +356,13 @@ extension AppDelegate {
             do {
                 try daemonClient.disableSkill(name)
             } catch {
-                log.error("Failed to disable skill \(name): \(error)")
+                log.error("Failed to disable skill \(name, privacy: .private): \(error)")
             }
         } else {
             do {
                 try daemonClient.enableSkill(name)
             } catch {
-                log.error("Failed to enable skill \(name): \(error)")
+                log.error("Failed to enable skill \(name, privacy: .private): \(error)")
             }
         }
         refreshSkillsCache()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -157,7 +157,7 @@ extension AppDelegate {
                     break
                 }
                 if case .error(let err) = message {
-                    log.error("Task routing failed: \(err.message)")
+                    log.error("Task routing failed: \(err.message, privacy: .private)")
                     break
                 }
             }

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -109,7 +109,7 @@ final class AssistantCli {
             return
         }
 
-        log.info("Running hatch via CLI at \(binaryURL.path)")
+        log.info("Running hatch via CLI at \(binaryURL.path, privacy: .private)")
 
         var arguments = ["hatch", "-d"]
         if daemonOnly {
@@ -122,7 +122,7 @@ final class AssistantCli {
         let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: arguments)
 
         if status != 0 {
-            log.error("CLI hatch failed with exit code \(status): \(stderr)")
+            log.error("CLI hatch failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
             throw CLIError.executionFailed(stderr)
         }
 
@@ -153,7 +153,7 @@ final class AssistantCli {
             throw CLIError.binaryNotFound
         }
 
-        log.info("Running retire via CLI at \(binaryURL.path) for '\(name)'")
+        log.info("Running retire via CLI at \(binaryURL.path, privacy: .private) for '\(name, privacy: .private)'")
 
         let (stderr, status) = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(String, Int32), Error>) in
             let proc = Process()
@@ -172,7 +172,7 @@ final class AssistantCli {
                 guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
                 let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
-                    log.info("[retire stdout] \(trimmed)")
+                    log.info("[retire stdout] \(trimmed, privacy: .private)")
                 }
             }
             stderrPipe.fileHandleForReading.readabilityHandler = { handle in
@@ -180,7 +180,7 @@ final class AssistantCli {
                 guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
                 let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
-                    log.warning("[retire stderr] \(trimmed)")
+                    log.warning("[retire stderr] \(trimmed, privacy: .private)")
                 }
             }
 
@@ -241,7 +241,7 @@ final class AssistantCli {
         }
 
         if status != 0 {
-            log.error("CLI retire failed with exit code \(status): \(stderr)")
+            log.error("CLI retire failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
             throw CLIError.executionFailed(stderr)
         }
 
@@ -261,7 +261,7 @@ final class AssistantCli {
             return
         }
 
-        log.info("Running stop via CLI at \(binaryURL.path)")
+        log.info("Running stop via CLI at \(binaryURL.path, privacy: .private)")
 
         // stop must be synchronous (called from applicationWillTerminate)
         let proc = Process()
@@ -297,7 +297,7 @@ final class AssistantCli {
         // Don't start monitoring if the assistant isn't in the lock file
         let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         if let assistantId, !isAssistantInLockFile(assistantId: assistantId) {
-            log.info("Assistant '\(assistantId)' not in lock file — skipping monitor start")
+            log.info("Assistant '\(assistantId, privacy: .private)' not in lock file — skipping monitor start")
             return
         }
 
@@ -348,7 +348,7 @@ final class AssistantCli {
             throw CLIError.binaryNotFound
         }
 
-        log.info("Running remote hatch via CLI at \(binaryURL.path) --remote \(config.remote)")
+        log.info("Running remote hatch via CLI at \(binaryURL.path, privacy: .private) --remote \(config.remote, privacy: .private)")
 
         let proc = Process()
         proc.executableURL = binaryURL
@@ -479,7 +479,7 @@ final class AssistantCli {
         do {
             pidData = try Data(contentsOf: pidFileURL)
         } catch {
-            log.error("Failed to read PID file at \(self.pidFileURL.path): \(error)")
+            log.error("Failed to read PID file at \(self.pidFileURL.path, privacy: .private): \(error)")
             return false
         }
         guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -538,7 +538,7 @@ final class AssistantCli {
         do {
             pidData = try Data(contentsOf: pidFileURL)
         } catch {
-            log.error("Failed to read PID file at \(self.pidFileURL.path): \(error)")
+            log.error("Failed to read PID file at \(self.pidFileURL.path, privacy: .private): \(error)")
             return
         }
         guard let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -747,7 +747,7 @@ extension ChatViewModel {
             }
 
         case .error(let err):
-            log.error("Server error: \(err.message)")
+            log.error("Server error: \(err.message, privacy: .private)")
             // Only process errors relevant to this chat session. Generic daemon
             // errors (e.g., IPC validation failures from unrelated message types
             // like work_item_delete) should not pollute the chat UI.
@@ -1169,7 +1169,7 @@ extension ChatViewModel {
 
         case .sessionError(let msg):
             guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
-            log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
+            log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
             isWorkspaceRefinementInFlight = false
             refinementMessagePreview = nil
             refinementStreamingText = nil

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -50,7 +50,7 @@ func readSessionToken(environment: [String: String]? = nil) -> String? {
     do {
         data = try Data(contentsOf: URL(fileURLWithPath: tokenPath))
     } catch {
-        log.error("Failed to read session token from \(tokenPath): \(error)")
+        log.error("Failed to read session token from \(tokenPath, privacy: .private): \(error)")
         return nil
     }
     guard let token = String(data: data, encoding: .utf8)?
@@ -93,7 +93,7 @@ public func readHttpToken(environment: [String: String]? = nil) -> String? {
     do {
         data = try Data(contentsOf: URL(fileURLWithPath: tokenPath))
     } catch {
-        log.error("Failed to read HTTP token from \(tokenPath): \(error)")
+        log.error("Failed to read HTTP token from \(tokenPath, privacy: .private): \(error)")
         return nil
     }
     guard let token = String(data: data, encoding: .utf8)?
@@ -1178,7 +1178,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             do {
                 bearerToken = try String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
             } catch {
-                log.error("Failed to read HTTP bearer token from \(tokenPath): \(error)")
+                log.error("Failed to read HTTP bearer token from \(tokenPath, privacy: .private): \(error)")
                 bearerToken = nil
             }
         } else {

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -45,7 +45,7 @@ extension DaemonClient {
             parameters = NWParameters()
             parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
         } else if case .tcp(let h, let p, let tls, _) = config.transport {
-            log.info("Connecting to daemon at \(h):\(p) (tls=\(tls))")
+            log.info("Connecting to daemon at \(h, privacy: .private):\(p, privacy: .public) (tls=\(tls, privacy: .public))")
             endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(h), port: NWEndpoint.Port(integerLiteral: p))
             parameters = tls ? .tls : .tcp
         } else {


### PR DESCRIPTION
## Summary

Annotates string interpolations in `os.Logger` calls that contain user-generated or sensitive content with `privacy: .private`. Without these annotations, values are already redacted in release builds by the OS, but adding them explicitly makes the intent clear and prevents accidental exposure if logging levels change.

**What gets `.private`:**
- User error messages (`err.message`, `msg.userMessage`) — may contain task context
- File paths (`tokenPath`, `binaryURL.path`, `url.path`, `pidFileURL.path`, `entryURL`) — reveals filesystem layout
- CLI stdout/stderr output (`trimmed`, `stderr`) — may contain user data
- App/skill/assistant identifiers (`appId`, `name`, `assistantId`) — user preferences
- Remote config values (`config.remote`) — connection configuration
- TCP hostname (`h`) — connection target

**What gets `.public` (intentionally visible for debugging):**
- Error/exit codes (`msg.code.rawValue`, `status`) — numeric system codes
- Boolean TLS flag and port number — network metadata, not user data

**Files changed (7):**
- `clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift`
- `clients/shared/IPC/DaemonClient.swift`
- `clients/shared/IPC/DaemonConnection.swift`
- `clients/macos/.../App/AppDelegate+MenuBar.swift`
- `clients/macos/.../App/AppDelegate+Sessions.swift`
- `clients/macos/.../App/AppDelegate+BundleHandling.swift`
- `clients/macos/.../App/AssistantCli.swift`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
