### PR TITLE
fix: use correct model ID in media vision analysis

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -132,7 +132,7 @@ Use `media_diagnostics` to get a full diagnostic report:
 3. Check `durationMs` to see if a stage timed out or ran unusually long.
 4. Common failure causes:
    - **keyframe_extraction**: ffmpeg not installed, corrupt video file, disk full.
-   - **vision_analysis**: ANTHROPIC_API_KEY not set, API rate limits, network errors.
+   - **vision_analysis**: Anthropic API key not configured (add one in Settings → Integrations), API rate limits, network errors.
    - **timeline_generation**: No keyframes or vision outputs exist (earlier stage skipped or failed).
    - **event_detection**: No timeline segments exist.
 
@@ -183,7 +183,7 @@ Increasing the keyframe interval reduces cost proportionally but may miss short-
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
 | "No keyframes found" | extract_keyframes not run or failed | Check keyframe_extraction stage status; re-run if needed |
-| "ANTHROPIC_API_KEY not set" | Missing env var | Set ANTHROPIC_API_KEY in the environment |
+| "No Anthropic API key available" | API key not configured | Add one in Settings → Integrations |
 | Vision analysis very slow | Large video, small interval | Increase interval_seconds or use smaller batch_size |
 | Low event confidence | Detection rules too broad | Tune rules: increase weights on high-signal rules, use tighter regex patterns |
 | Many false positives | Rules overfitting on noise | Submit `incorrect` feedback, then run `recalibrate` |

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { getAnthropicProvider, extractText, userMessageWithImage } from '../../../../providers/anthropic-send-message.js';
+import { getProvider, listProviders, initializeProviders } from '../../../../providers/registry.js';
+import { loadConfig } from '../../../../config/loader.js';
 import {
   getMediaAssetById,
   getKeyframesForAsset,
@@ -69,13 +71,23 @@ export async function analyzeKeyframesForAsset(
 
   updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
 
-  const provider = getAnthropicProvider();
+  // Use the same provider the main agent uses. If the provider registry
+  // was cleared or not yet initialized, force-reload the config from
+  // keychain/secure storage and re-initialize providers.
+  let provider = getAnthropicProvider();
+  if (!provider) {
+    const freshConfig = loadConfig();
+    if (freshConfig.apiKeys.anthropic) {
+      initializeProviders(freshConfig);
+      provider = getAnthropicProvider();
+    }
+  }
   if (!provider) {
     updateProcessingStage(stage.id, {
       status: 'failed',
       lastError: 'Anthropic API key not configured',
     });
-    throw new Error('No Anthropic API key available. Configure it in settings or set ANTHROPIC_API_KEY.');
+    throw new Error('No Anthropic API key available. Add one in Settings → Integrations.');
   }
 
   let analyzedCount = analyzedKeyframeIds.size;
@@ -220,7 +232,7 @@ export async function run(
       msg === 'batch_size must be greater than 0.' ||
       msg.startsWith('Media asset not found:') ||
       msg === 'No keyframes found for this asset. Run extract_keyframes first.' ||
-      msg === 'No Anthropic API key available. Configure it in settings or set ANTHROPIC_API_KEY.'
+      msg === 'No Anthropic API key available. Add one in Settings → Integrations.'
     ) {
       return { content: msg, isError: true };
     }
@@ -253,7 +265,7 @@ async function analyzeKeyframe(
     undefined,
     {
       config: {
-        model: 'claude-sonnet-4-6-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 1024,
       },
     },

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
 import { getAnthropicProvider, extractText, userMessageWithImage } from '../../../../providers/anthropic-send-message.js';
-import { getProvider, listProviders, initializeProviders } from '../../../../providers/registry.js';
-import { loadConfig } from '../../../../config/loader.js';
+import { initializeProviders } from '../../../../providers/registry.js';
+import { loadConfig, invalidateConfigCache } from '../../../../config/loader.js';
 import {
   getMediaAssetById,
   getKeyframesForAsset,
@@ -76,6 +76,7 @@ export async function analyzeKeyframesForAsset(
   // keychain/secure storage and re-initialize providers.
   let provider = getAnthropicProvider();
   if (!provider) {
+    invalidateConfigCache();
     const freshConfig = loadConfig();
     if (freshConfig.apiKeys.anthropic) {
       initializeProviders(freshConfig);


### PR DESCRIPTION
## Summary
- Fix `analyze_keyframes` tool using non-existent model ID `claude-sonnet-4-6-20250514` → `claude-sonnet-4-6`, which caused every frame to fail with a 404 that the agent misinterpreted as a missing API key
- Add resilient provider resolution: if `getAnthropicProvider()` returns null, force-reload config from keychain and re-initialize providers
- Update error messages and SKILL.md troubleshooting to reference Settings → Integrations instead of `ANTHROPIC_API_KEY` env var

## Test plan
- [x] Verified `claude-sonnet-4-6` model ID works via direct API call
- [x] Confirmed vision analysis processes frames successfully (5% / 10 frames before tool timeout, resumes on next run)
- [ ] Full pipeline completion on a test video

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
