### PR TITLE
security: enforce HTTPS for OIDC URLs in AuthService; document ImageCache ATS

### DIFF
--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -59,7 +59,8 @@ public final class AuthService {
     }
 
     public func fetchOIDCDiscovery(url: String) async throws -> OIDCDiscovery {
-        guard let requestURL = URL(string: url) else {
+        guard let requestURL = URL(string: url),
+              requestURL.scheme?.lowercased() == "https" else {
             throw AuthServiceError.invalidURL
         }
         let (data, _) = try await URLSession.shared.data(from: requestURL)
@@ -73,7 +74,8 @@ public final class AuthService {
         codeVerifier: String,
         redirectURI: String
     ) async throws -> OIDCTokenResponse {
-        guard let url = URL(string: tokenEndpoint) else {
+        guard let url = URL(string: tokenEndpoint),
+              url.scheme?.lowercased() == "https" else {
             throw AuthServiceError.invalidURL
         }
 
@@ -149,7 +151,7 @@ public final class AuthService {
             decoded = try JSONDecoder().decode(AllauthResponse<T>.self, from: data)
         } catch {
             let rawBody = String(data: data, encoding: .utf8) ?? "<non-utf8>"
-            log.error("Failed to decode auth response for \(method) \(path): \(error)\nRaw body: \(rawBody)")
+            log.error("Failed to decode auth response for \(method, privacy: .public) \(path, privacy: .public): \(error)\nRaw body: \(rawBody, privacy: .private)")
             throw AuthServiceError.decodingError(error)
         }
 

--- a/clients/shared/Features/Chat/ImageCache.swift
+++ b/clients/shared/Features/Chat/ImageCache.swift
@@ -32,6 +32,10 @@ public actor ImageCache {
         }
 
         let task = Task<Data, Error> {
+            // URLSession.shared is intentional here: inline chat images may come from any
+            // user-provided domain, so domain pinning would break legitimate use.
+            // ATS (App Transport Security) enforces HTTPS on iOS/macOS in production
+            // builds, providing baseline transport security without explicit cert pinning.
             let (data, response) = try await URLSession.shared.data(from: url)
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                 throw URLError(.badServerResponse)


### PR DESCRIPTION
## Summary

Addresses the URLSession.shared security audit for `AuthService` and `ImageCache`.

### AuthService (clients/shared/App/Auth/AuthService.swift)

**`fetchOIDCDiscovery(url:)`** and **`exchangeOIDCCode(tokenEndpoint:...)`** accept caller-supplied URL strings and make network requests against them. Without scheme validation, a malformed or attacker-controlled URL could:
- Direct the request to `http://` (cleartext), bypassing TLS
- In debug builds (where ATS is relaxed), allow data to flow to unexpected hosts

Fix: added `url.scheme?.lowercased() == "https"` check to both methods. Non-HTTPS URLs now throw `AuthServiceError.invalidURL` before any network call is made.

Also added `privacy: .private` to the raw response body in the decode-error log path — the raw body may contain auth tokens or user data.

### ImageCache (clients/shared/Features/Chat/ImageCache.swift)

No code change needed. Chat images may legitimately come from any user-supplied domain, so domain pinning would break valid use. iOS/macOS ATS enforces HTTPS in production builds, providing the baseline transport guarantee.

Added a comment explaining this rationale so future reviewers don't flag it as an oversight.

## Test plan
- [ ] OIDC login flow still works (HTTPS endpoints pass validation)
- [ ] Passing an `http://` URL to `fetchOIDCDiscovery` throws `invalidURL`
- [ ] Image cache loads images from various HTTPS sources correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
