### PR TITLE
Fix M2 feedback: reset idle hint on activity resume

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -152,6 +152,19 @@ export async function handleRideShotgunStart(
             if (currentCount !== lastNetworkEntryCount) {
               lastNetworkEntryCount = currentCount;
               lastActivityTimestamp = Date.now();
+              // If we previously sent an idle hint, clear it now that activity resumed
+              if (idleHintSent) {
+                idleHintSent = false;
+                log.info({ watchId, currentCount }, 'Activity resumed — clearing idleHint');
+                ctx.send(socket, {
+                  type: 'ride_shotgun_progress',
+                  watchId,
+                  message: `Recording network traffic...`,
+                  networkEntryCount: currentCount,
+                  statusMessage: 'Recording network traffic...',
+                  idleHint: false,
+                });
+              }
             }
 
             // Idle detection: if some initial activity happened and no new entries for 15s, hint once

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -74,8 +74,8 @@ public final class RideShotgunSession: ObservableObject {
                     if let msg = progress.statusMessage, !msg.isEmpty {
                         self.statusMessage = msg
                     }
-                    if let idle = progress.idleHint, idle {
-                        self.idleHint = true
+                    if let idle = progress.idleHint {
+                        self.idleHint = idle
                     }
                 case .rideShotgunResult(let result):
                     self.handleRideShotgunResult(result)


### PR DESCRIPTION
Addresses review feedback on #7737: When network activity resumes after an idle hint was sent, reset the idleHintSent flag and send idleHint: false to clear the UI prompt. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
