### PR TITLE
Fix M5 feedback: compiled builds, path quoting, progress hooks

### DIFF
--- a/assistant/src/daemon/install-cli-launchers.ts
+++ b/assistant/src/daemon/install-cli-launchers.ts
@@ -84,7 +84,11 @@ export function installCliLaunchers(): void {
 
   const entrypoint = resolveCliEntrypoint();
   if (!existsSync(entrypoint)) {
-    log.warn({ entrypoint }, 'Cannot install CLI launchers: CLI entrypoint not found');
+    // In compiled builds (e.g. macOS app via `bun build --compile`), the
+    // source tree isn't available.  Launcher scripts are a dev-mode
+    // convenience; compiled builds use their own command dispatch, so we
+    // silently skip installation.
+    log.debug({ entrypoint }, 'CLI entrypoint not found (compiled build?) — skipping launcher installation');
     return;
   }
 
@@ -97,7 +101,7 @@ export function installCliLaunchers(): void {
     const launcherPath = join(binDir, launcherName);
 
     const script = `#!/bin/bash
-exec ${bunPath} ${entrypoint} ${name} "$@"
+exec "${bunPath}" "${entrypoint}" ${name} "$@"
 `;
 
     writeFileSync(launcherPath, script);

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -84,15 +84,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 interface DoordashStep { label: string; status: string; detail?: string }
 
 /**
- * Map a `vellum doordash <subcommand>` to the step label it corresponds to.
+ * Map a `doordash <subcommand>` (or `vellum doordash <subcommand>`) to the
+ * step label it corresponds to.
  */
 function doordashCommandToStep(cmd: string): string | null {
-  if (/vellum doordash status\b/.test(cmd) || /vellum doordash refresh\b/.test(cmd) || /vellum doordash login\b/.test(cmd)) return 'Check session';
-  if (/vellum doordash search\b/.test(cmd) || /vellum doordash search-items\b/.test(cmd)) return 'Search restaurants';
-  if (/vellum doordash menu\b/.test(cmd) || /vellum doordash item\b/.test(cmd) || /vellum doordash store-search\b/.test(cmd)) return 'Browse menu';
-  if (/vellum doordash cart\b/.test(cmd)) return 'Add to cart';
-  if (/vellum doordash checkout\b/.test(cmd) || /vellum doordash payment-methods\b/.test(cmd)) return 'Add to cart';
-  if (/vellum doordash order\b/.test(cmd)) return 'Place order';
+  // Match both standalone `doordash` and legacy `vellum doordash` prefixes
+  const dd = /(?:vellum )?doordash /;
+  if (new RegExp(dd.source + 'status\\b').test(cmd) || new RegExp(dd.source + 'refresh\\b').test(cmd) || new RegExp(dd.source + 'login\\b').test(cmd)) return 'Check session';
+  if (new RegExp(dd.source + 'search\\b').test(cmd) || new RegExp(dd.source + 'search-items\\b').test(cmd)) return 'Search restaurants';
+  if (new RegExp(dd.source + 'menu\\b').test(cmd) || new RegExp(dd.source + 'item\\b').test(cmd) || new RegExp(dd.source + 'store-search\\b').test(cmd)) return 'Browse menu';
+  if (new RegExp(dd.source + 'cart\\b').test(cmd)) return 'Add to cart';
+  if (new RegExp(dd.source + 'checkout\\b').test(cmd) || new RegExp(dd.source + 'payment-methods\\b').test(cmd)) return 'Add to cart';
+  if (new RegExp(dd.source + 'order\\b').test(cmd)) return 'Place order';
   return null;
 }
 
@@ -151,7 +154,7 @@ export function createToolExecutor(
     // Pre-execution: mark the current DoorDash step as in_progress when command starts
     if (name === 'bash' || name === 'host_bash') {
       const preCmd = input.command as string | undefined;
-      if (preCmd?.includes('vellum doordash')) {
+      if (preCmd && (preCmd.includes('vellum doordash') || preCmd.includes('doordash '))) {
         const surfaceId = 'doordash-progress';
         const stored = ctx.surfaceState.get(surfaceId);
         if (stored && stored.surfaceType === 'card') {
@@ -312,7 +315,7 @@ export function createToolExecutor(
     // Auto-emit task_progress card on first DoorDash CLI command
     if (name === 'bash' || name === 'host_bash') {
       const cmd = input.command as string | undefined;
-      if (cmd?.includes('vellum doordash')) {
+      if (cmd && (cmd.includes('vellum doordash') || cmd.includes('doordash '))) {
         const surfaceId = 'doordash-progress';
 
         if (!ctx.surfaceState.has(surfaceId)) {


### PR DESCRIPTION
Addresses review feedback on #7735: (1) Gracefully skip launcher install when source tree is missing (compiled builds), (2) Quote paths in generated launcher scripts to handle spaces, (3) Update doordash progress hook regex to match standalone command. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
