### PR TITLE
Fix M1 feedback: reactive progress, time-based bar, interval cleanup

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -23,6 +23,9 @@ const log = getLogger('ride-shotgun-handler');
 /** Active network recorders keyed by watchId. */
 const activeRecorders = new Map<string, NetworkRecorder>();
 
+/** Active progress interval timers keyed by watchId, cleared on session completion. */
+const activeProgressIntervals = new Map<string, NodeJS.Timeout>();
+
 /** Return domain-specific URL patterns that indicate a successful login. */
 function getLoginSignals(targetDomain?: string): string[] {
   if (targetDomain === 'x.com' || targetDomain === 'twitter.com') {
@@ -50,6 +53,13 @@ async function completeSession(session: WatchSession): Promise<void> {
   if (session.timeoutHandle) {
     clearTimeout(session.timeoutHandle);
     session.timeoutHandle = undefined;
+  }
+
+  // Clear progress interval timer if one was registered for this session
+  const progressTimer = activeProgressIntervals.get(session.watchId);
+  if (progressTimer) {
+    clearInterval(progressTimer);
+    activeProgressIntervals.delete(session.watchId);
   }
 
   const { watchId, sessionId } = session;
@@ -140,7 +150,7 @@ export async function handleRideShotgunStart(
           let lastActivityTimestamp = Date.now();
           let idleHintSent = false;
 
-          const progressInterval = setInterval(() => {
+          const progressInterval: NodeJS.Timeout = setInterval(() => {
             if (session.status !== 'active') {
               clearInterval(progressInterval);
               return;
@@ -185,6 +195,7 @@ export async function handleRideShotgunStart(
               ...(idleHint !== undefined ? { idleHint } : {}),
             });
           }, 5000);
+          activeProgressIntervals.set(watchId, progressInterval);
 
           // For x.com, auto-navigate Chrome through key pages to capture the full API surface.
           // Skip login detection — auto-navigation will complete the session when done.

--- a/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
@@ -11,6 +11,11 @@ struct WatchProgressView: View {
     @State private var isPulsing = false
 
     private var progress: Double {
+        if isLearnMode {
+            // In learn mode the capture loop is skipped, so use time-based progress
+            guard session.durationSeconds > 0 else { return 0 }
+            return min(session.elapsedSeconds / Double(session.durationSeconds), 1.0)
+        }
         guard session.totalExpected > 0 else { return 0 }
         return Double(session.captureCount) / Double(session.totalExpected)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -561,7 +561,7 @@ struct ActiveChatViewWrapper: View {
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var windowState: MainWindowState
     let daemonClient: DaemonClient
-    let ambientAgent: AmbientAgent
+    @ObservedObject var ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false


### PR DESCRIPTION
Addresses review feedback on #7733: (1) Make networkEntryCount update reactively in SwiftUI, (2) Use time-based progress bar in learn mode instead of capture-based, (3) Explicitly clear progress interval on session completion. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
