### PR TITLE
Fix duplicate progress message on idle hint reset

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -174,6 +174,7 @@ export async function handleRideShotgunStart(
                   statusMessage: 'Recording network traffic...',
                   idleHint: false,
                 });
+                return;
               }
             }
 


### PR DESCRIPTION
Adds early return after sending idleHint: false progress message to prevent a redundant second progress message in the same interval tick. Addresses review feedback on #7743. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
