### PR TITLE
Redact secrets from voice TTS responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -262,7 +262,8 @@ final class OpenAIVoiceService: ObservableObject {
 
     /// Called when the full response is complete — sends accumulated text to ElevenLabs.
     func finishTextStream(onComplete: @escaping () -> Void) {
-        let text = ttsTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let raw = ttsTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = TTSRedactor.redact(raw)
         ttsTextBuffer = ""
 
         guard !text.isEmpty, elevenLabsKey != nil else {

--- a/clients/macos/vellum-assistant/Features/Voice/TTSRedactor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/TTSRedactor.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Redacts credential-like patterns from assistant text before TTS synthesis.
+///
+/// Secrets that appear in spoken text (API keys echoed back, tokens mentioned in
+/// tool output, etc.) must not be read aloud. Each matched pattern is replaced
+/// with a short, naturally spoken placeholder.
+enum TTSRedactor {
+
+    // Each entry is (compiled regex, spoken replacement).
+    // Patterns are ordered from most specific to most general so that a
+    // more-specific rule wins when multiple patterns could match.
+    private static let rules: [(NSRegularExpression, String)] = {
+        let specs: [(String, String)] = [
+            // Anthropic API keys (sk-ant-...)
+            (#"sk-ant-[A-Za-z0-9\-_]{20,}"#, "a redacted Anthropic key"),
+            // OpenAI project API keys (sk-proj-...)
+            (#"sk-proj-[A-Za-z0-9\-_]{20,}"#, "a redacted API key"),
+            // Generic OpenAI API keys (sk-...)
+            (#"sk-[A-Za-z0-9]{20,}"#, "a redacted API key"),
+            // GitHub fine-grained PATs
+            (#"github_pat_[A-Za-z0-9_]{82}"#, "a redacted GitHub token"),
+            // GitHub classic tokens (ghp_, ghs_, gho_, ghr_)
+            (#"gh[phsor]_[A-Za-z0-9]{36}"#, "a redacted GitHub token"),
+            // JWT: three base64url segments separated by dots
+            (#"eyJ[A-Za-z0-9\-_]{10,}\.[A-Za-z0-9\-_]{10,}\.[A-Za-z0-9\-_]{10,}"#, "a redacted token"),
+            // Bearer tokens (Authorization header value)
+            (#"Bearer [A-Za-z0-9\-_.]{20,}"#, "a redacted bearer token"),
+            // ElevenLabs-style 32-char alphanumeric keys (no spaces, mixed case)
+            (#"\b[0-9a-fA-F]{32}\b"#, "a redacted key"),
+            // Long hex strings (40+ chars) — SHA-1/SHA-256 hashes and token IDs
+            (#"\b[0-9a-f]{40,}\b"#, "a redacted hash"),
+        ]
+        return specs.compactMap { (pattern, replacement) in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                return nil
+            }
+            return (regex, replacement)
+        }
+    }()
+
+    /// Returns `text` with all detected credential patterns replaced by spoken placeholders.
+    static func redact(_ text: String) -> String {
+        var result = text
+        for (regex, replacement) in rules {
+            let range = NSRange(result.startIndex..., in: result)
+            result = regex.stringByReplacingMatches(
+                in: result,
+                range: range,
+                withTemplate: replacement
+            )
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TTSRedactor.swift` with regex patterns that detect common credential formats (OpenAI keys, Anthropic keys, GitHub tokens, JWTs, Bearer tokens, hex hashes) in free-form text
- Apply `TTSRedactor.redact()` in `OpenAIVoiceService.finishTextStream()` before the accumulated response text is sent to ElevenLabs, replacing matched patterns with naturally spoken placeholders (e.g. "a redacted API key")
- Protects against assistant responses that echo back credential-adjacent content (e.g. keys mentioned in tool output) from being read aloud via voice mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
