### PR TITLE
Fix #7731 feedback: CDP command timeout and error handling

### DIFF
--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -94,15 +94,35 @@ async function bringChromeToFront(navigateUrl?: string): Promise<string | null> 
     const cdpSend = (method: string, params?: Record<string, unknown>): Promise<unknown> =>
       new Promise((resolve, reject) => {
         const id = nextId++;
+        const timeout = setTimeout(() => {
+          ws.removeEventListener('message', handler);
+          reject(new Error(`CDP command ${method} timed out`));
+        }, 5000);
+        const onClose = () => {
+          clearTimeout(timeout);
+          ws.removeEventListener('message', handler);
+          reject(new Error('WebSocket closed before CDP response'));
+        };
+        const onError = (e: Event) => {
+          clearTimeout(timeout);
+          ws.removeEventListener('message', handler);
+          ws.removeEventListener('close', onClose);
+          reject(new Error(`WebSocket error: ${e}`));
+        };
         const handler = (event: MessageEvent) => {
           const msg = JSON.parse(String(event.data));
           if (msg.id === id) {
+            clearTimeout(timeout);
             ws.removeEventListener('message', handler);
+            ws.removeEventListener('close', onClose);
+            ws.removeEventListener('error', onError);
             if (msg.error) reject(new Error(msg.error.message));
             else resolve(msg.result);
           }
         };
         ws.addEventListener('message', handler);
+        ws.addEventListener('close', onClose);
+        ws.addEventListener('error', onError);
         ws.send(JSON.stringify({ id, method, params }));
       });
 


### PR DESCRIPTION
Adds timeout (5s), close, and error handling to the cdpSend helper in bringChromeToFront() to prevent indefinite hangs when the Chrome tab is closed between discovery and response. Addresses review feedback on #7731. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
