### PR TITLE
fix: add pre-injection clipboard equality check in SessionLoop

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -13,6 +13,7 @@ enum ExecutorError: LocalizedError {
     case appleScriptError(String)
     case appleScriptMissingScript
     case appleScriptTimeout
+    case clipboardMismatch
 
     var errorDescription: String? {
         switch self {
@@ -26,6 +27,7 @@ enum ExecutorError: LocalizedError {
         case .appleScriptError(let msg): return "AppleScript error: \(msg)"
         case .appleScriptMissingScript: return "run_applescript requires a script"
         case .appleScriptTimeout: return "AppleScript timed out after 5 seconds"
+        case .clipboardMismatch: return "Clipboard contents changed before paste injection; aborting to prevent wrong text from being typed"
         }
     }
 }
@@ -113,6 +115,22 @@ final class ActionExecutor: ActionExecuting {
 
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+
+        // Pre-injection equality check: verify the clipboard now holds exactly
+        // what we queued before issuing the paste keystroke. If another process
+        // wrote to the clipboard between our setString and this read-back, the
+        // paste would inject wrong content — catch that here instead of silently
+        // typing unintended text.
+        let verifiedContents = pasteboard.string(forType: .string)
+        guard verifiedContents == text else {
+            // Restore whatever was on the clipboard before we cleared it so the
+            // user's data is not lost, then surface a clear error.
+            pasteboard.clearContents()
+            if let saved = previousContents {
+                pasteboard.setString(saved, forType: .string)
+            }
+            throw ExecutorError.clipboardMismatch
+        }
 
         try keyCombo(keyCode: 9, modifiers: .maskCommand) // Cmd+V
         usleep(100_000)


### PR DESCRIPTION
Add a pre-injection equality check in the clipboard-paste path of SessionLoop to verify injected text matches what was queued, preventing wrong content injection if clipboard changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
