### PR TITLE
feat: add Notion integration skill

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -64,12 +64,21 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
       user_scope: 'channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write',
     },
   },
+  // Notion uses a simple OAuth2 flow with client_secret_basic auth at the token endpoint.
+  // The access token is long-lived (no expiry) and scopes are configured per-integration in Notion.
+  'integration:notion': {
+    authUrl: 'https://api.notion.com/v1/oauth/authorize',
+    tokenUrl: 'https://api.notion.com/v1/oauth/token',
+    scopes: [],
+    extraParams: { owner: 'user' },
+  },
 };
 
 /** Map shorthand aliases to canonical service names. */
 const SERVICE_ALIASES: Record<string, string> = {
   gmail: 'integration:gmail',
   slack: 'integration:slack',
+  notion: 'integration:notion',
 };
 
 /** Resolve a service name through aliases. */

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -53,6 +53,19 @@
       "name": "SMS Setup",
       "description": "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification",
       "emoji": "\ud83d\udce8"
+    },
+    {
+      "id": "notion-oauth-setup",
+      "name": "Notion OAuth Setup",
+      "description": "Create a Notion integration and OAuth credentials for Notion integration using browser automation",
+      "emoji": "\ud83d\udd11",
+      "includes": ["browser", "public-ingress"]
+    },
+    {
+      "id": "notion",
+      "name": "Notion",
+      "description": "Read and write Notion pages and databases using the Notion API",
+      "emoji": "\ud83d\udcdd"
     }
   ]
 }

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: "Notion OAuth Setup"
+description: "Create a Notion integration and OAuth credentials for Notion integration using browser automation"
+user-invocable: true
+includes: ["browser", "public-ingress"]
+metadata: {"vellum": {"emoji": "🔑"}}
+---
+
+You are helping your user create a Notion integration (OAuth app) so Vellum can connect to their Notion workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
+
+**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+
+## Prerequisites
+
+Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
+
+## Before You Start
+
+Tell the user:
+- "I'll walk you through creating a Notion integration so Vellum can read and write pages and databases in your workspace. The whole process takes a few minutes."
+- "I'll be automating the Notion integrations page in the browser — you'll be able to see everything I'm doing."
+- "I'll ask for your approval before each major step, so nothing happens without your say-so."
+- "No sensitive credentials will be shown in the conversation."
+
+## Step 1: Navigate to Notion Integrations
+
+Tell the user: "First, let me open the Notion integrations page."
+
+Use `browser_navigate` to go to `https://www.notion.so/my-integrations`.
+
+Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+- **If a sign-in page appears:** Tell the user "Please sign in to your Notion account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
+- **If the integrations dashboard loads:** Tell the user "Notion integrations page is loaded. Let's create your integration!" and continue to Step 2.
+
+## Step 2: Create a New Integration
+
+**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+
+> **Create a Notion Integration**
+>
+> I'm about to create a new Notion integration called "Vellum Assistant". This integration will only have the capabilities you approve — it won't access any pages or databases until you explicitly share them with it or authorize it via OAuth.
+
+Wait for the user to approve. If they decline, explain that the integration is required for OAuth and offer to try again or cancel.
+
+Once approved:
+1. Click "New integration" (or the "+" button)
+2. Select "Public" as the integration type (required for OAuth)
+3. Enter integration name: "Vellum Assistant"
+4. Select the user's workspace
+5. Click "Submit" or "Create"
+
+Take a `browser_screenshot` to show the result.
+
+Tell the user: "Integration created! Now let's configure the OAuth settings."
+
+## Step 3: Configure OAuth Settings
+
+Navigate to the integration's "Distribution" or "OAuth Domain & URIs" tab.
+
+**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+
+> **Configure OAuth Redirect URI**
+>
+> I'm about to add the OAuth redirect URI to your Notion integration. This allows Notion to send the authorization code back to Vellum after you approve the connection.
+
+Wait for the user to approve.
+
+Once approved:
+1. Find the "Redirect URIs" field
+2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable.
+3. Save the settings
+
+Take a `browser_snapshot` to confirm.
+
+Tell the user: "Redirect URI configured. Now let's get your OAuth credentials."
+
+## Step 4: Extract Client ID and Client Secret
+
+Stay on the integration settings page and navigate to the "Secrets" or "OAuth Clients" section.
+
+Use `browser_extract` to read:
+1. **OAuth client_id** — this is the integration's OAuth client ID
+2. **OAuth client_secret** — click "Show" or "Reveal" first, then extract the value
+
+**Important:** Notion requires a client secret for the token exchange (sent via HTTP Basic Auth). Both values are needed.
+
+Tell the user: "Credentials extracted! Now let's connect your Notion workspace."
+
+## Step 5: Connect Notion
+
+Tell the user: "Opening Notion authorization so you can grant Vellum access to your workspace. You'll see a Notion consent page — just click 'Allow access'."
+
+Use the `credential_store` tool to connect Notion via OAuth2:
+
+```
+action: "oauth2_connect"
+service: "integration:notion"
+client_id: "<the extracted OAuth client_id>"
+client_secret: "<the extracted OAuth client_secret>"
+auth_url: "https://api.notion.com/v1/oauth/authorize"
+token_url: "https://api.notion.com/v1/oauth/token"
+scopes: []
+extra_params: {"owner": "user"}
+token_endpoint_auth_method: "client_secret_basic"
+```
+
+This will open the Notion authorization page in the user's browser. Wait for the flow to complete.
+
+## Step 6: Celebrate!
+
+Once connected, tell the user:
+
+"**Notion is connected!** You're all set. You can now read and write pages and databases in your Notion workspace through Vellum. Try asking me to list your databases or read a specific page!"
+
+Summarize what was accomplished:
+- Created a Notion public integration called "Vellum Assistant"
+- Configured the OAuth redirect URI
+- Connected your Notion workspace with read and write access
+
+## Error Handling
+
+- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
+- **"Public" integration type not available:** The user may need to enable public integrations in their workspace settings. Guide them to Workspace Settings > Integrations.
+- **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. Notion's UI may have changed; adapt your selectors.
+- **User declines an approval gate:** Don't push back. Explain briefly why the step matters, offer to try again, or cancel gracefully.
+- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry. The integration is already created, so they only need to re-run the connect step.
+- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: "Notion"
+description: "Read and write Notion pages and databases using the Notion API"
+user-invocable: false
+metadata: {"vellum": {"emoji": "📝"}}
+---
+
+You have access to the Notion API via the stored OAuth token for `integration:notion`. Use `fetch` (or the HTTP proxy tool) with Bearer token authentication to call the Notion API directly.
+
+## Authentication
+
+Retrieve the stored access token:
+```
+credential_store action=list
+```
+Look for `service: "integration:notion"`, `field: "access_token"`.
+
+Use it as:
+```
+Authorization: Bearer <access_token>
+Notion-Version: 2022-06-28
+Content-Type: application/json
+```
+
+All Notion API calls go to `https://api.notion.com/v1/`.
+
+If no token is found, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
+
+## Reading Pages
+
+### Get a page by ID
+```
+GET https://api.notion.com/v1/pages/{page_id}
+```
+Returns page properties. Use the page ID from a Notion URL — the last segment of the URL, e.g. for `https://notion.so/My-Page-abc123def456` the ID is `abc123def456` (formatted as UUID: `abc123de-f456-...`).
+
+### Get page content (blocks)
+```
+GET https://api.notion.com/v1/blocks/{block_id}/children?page_size=100
+```
+Pages are blocks too — use the page ID as the `block_id`. Iterates through the page's child blocks. Use `start_cursor` for pagination when `has_more` is `true`.
+
+**Block types and how to render them:**
+- `paragraph`: Read `paragraph.rich_text[].plain_text`
+- `heading_1`, `heading_2`, `heading_3`: Read `heading_N.rich_text[].plain_text`
+- `bulleted_list_item`, `numbered_list_item`: Read `*.rich_text[].plain_text`
+- `to_do`: Read `to_do.rich_text[].plain_text` and `to_do.checked`
+- `toggle`: Read `toggle.rich_text[].plain_text`; children are nested blocks
+- `code`: Read `code.rich_text[].plain_text` and `code.language`
+- `quote`: Read `quote.rich_text[].plain_text`
+- `callout`: Read `callout.rich_text[].plain_text`
+- `divider`: Render as `---`
+- `image`: Read `image.external.url` or `image.file.url`
+- `child_page`: Read `child_page.title`; use its `id` to recursively fetch if needed
+
+## Searching
+
+### Search pages and databases
+```
+POST https://api.notion.com/v1/search
+{
+  "query": "your search term",
+  "filter": { "value": "page", "property": "object" },
+  "sort": { "direction": "descending", "timestamp": "last_edited_time" },
+  "page_size": 10
+}
+```
+Omit `filter` to search both pages and databases. Use `filter.value: "database"` to search only databases.
+
+Returns `results[]` with `id`, `url`, `properties.title` (for pages), and `title[]` (for databases).
+
+## Reading Databases
+
+### Get database metadata
+```
+GET https://api.notion.com/v1/databases/{database_id}
+```
+Returns the database schema (all property definitions).
+
+### Query a database
+```
+POST https://api.notion.com/v1/databases/{database_id}/query
+{
+  "filter": {
+    "property": "Status",
+    "select": { "equals": "In Progress" }
+  },
+  "sorts": [
+    { "property": "Created", "direction": "descending" }
+  ],
+  "page_size": 20
+}
+```
+Omit `filter` to retrieve all rows. Returns `results[]` where each item is a page (database row).
+
+**Extracting property values from database rows:**
+- `title`: `properties.Name.title[].plain_text`
+- `rich_text`: `properties.Notes.rich_text[].plain_text`
+- `number`: `properties.Price.number`
+- `select`: `properties.Status.select.name`
+- `multi_select`: `properties.Tags.multi_select[].name`
+- `date`: `properties.Due.date.start` (ISO 8601)
+- `checkbox`: `properties.Done.checkbox`
+- `url`: `properties.Link.url`
+- `email`: `properties.Email.email`
+- `people`: `properties.Owner.people[].name`
+- `relation`: `properties.Projects.relation[].id` (array of page IDs)
+
+## Creating Pages
+
+### Create a new page
+```
+POST https://api.notion.com/v1/pages
+{
+  "parent": { "page_id": "<parent_page_id>" },
+  "properties": {
+    "title": {
+      "title": [{ "text": { "content": "My New Page" } }]
+    }
+  },
+  "children": [
+    {
+      "object": "block",
+      "type": "paragraph",
+      "paragraph": {
+        "rich_text": [{ "text": { "content": "Page content here." } }]
+      }
+    }
+  ]
+}
+```
+
+For database rows, use `"parent": { "database_id": "<database_id>" }` and include the database's required properties.
+
+## Updating Pages
+
+### Update page properties
+```
+PATCH https://api.notion.com/v1/pages/{page_id}
+{
+  "properties": {
+    "Status": { "select": { "name": "Done" } },
+    "Due": { "date": { "start": "2024-12-31" } }
+  }
+}
+```
+
+### Append blocks to a page
+```
+PATCH https://api.notion.com/v1/blocks/{block_id}/children
+{
+  "children": [
+    {
+      "object": "block",
+      "type": "paragraph",
+      "paragraph": {
+        "rich_text": [{ "text": { "content": "Appended content." } }]
+      }
+    },
+    {
+      "object": "block",
+      "type": "heading_2",
+      "heading_2": {
+        "rich_text": [{ "text": { "content": "A heading" } }]
+      }
+    },
+    {
+      "object": "block",
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "rich_text": [{ "text": { "content": "A bullet point" } }]
+      }
+    },
+    {
+      "object": "block",
+      "type": "to_do",
+      "to_do": {
+        "rich_text": [{ "text": { "content": "A task" } }],
+        "checked": false
+      }
+    }
+  ]
+}
+```
+
+### Update a block's content
+```
+PATCH https://api.notion.com/v1/blocks/{block_id}
+{
+  "paragraph": {
+    "rich_text": [{ "text": { "content": "Updated text." } }]
+  }
+}
+```
+
+### Delete (archive) a block
+```
+DELETE https://api.notion.com/v1/blocks/{block_id}
+```
+
+## Archive / Delete Pages
+
+Notion does not permanently delete pages via the API — it archives them:
+```
+PATCH https://api.notion.com/v1/pages/{page_id}
+{
+  "archived": true
+}
+```
+
+## Pagination
+
+When a response includes `"has_more": true`, pass `"start_cursor": response.next_cursor` in the next request to get the next page of results.
+
+## Error Handling
+
+- **401 Unauthorized**: The access token is missing or expired. Ask the user to reconnect Notion via the **notion-oauth-setup** skill.
+- **403 Forbidden**: The integration doesn't have access to the requested page or database. Remind the user that they need to share the page/database with the "Vellum Assistant" integration in Notion (via the Share menu → "Add connections").
+- **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
+- **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.
+- **429 Too Many Requests**: Wait a few seconds and retry.
+
+## Tips
+
+- Notion page IDs in URLs are formatted without hyphens. The API accepts both forms: `abc123def456...` or `abc123de-f456-...`.
+- When extracting IDs from Notion URLs, strip any query parameters and trailing path components after the 32-character ID segment.
+- Always include `Notion-Version: 2022-06-28` header to get stable API behavior.
+- For rich text, concatenate all `plain_text` values in the array to get the full text content.
+- When creating content with rich text formatting (bold, italic, links), use the `annotations` and `href` fields in rich_text objects.


### PR DESCRIPTION
Add Notion integration skill for reading/writing pages and databases. Uses WELL_KNOWN_OAUTH registry pattern for OAuth setup, following existing integration patterns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
