### PR TITLE
Fix #7750 feedback: consistent CDP listener cleanup

### DIFF
--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -94,28 +94,28 @@ async function bringChromeToFront(navigateUrl?: string): Promise<string | null> 
     const cdpSend = (method: string, params?: Record<string, unknown>): Promise<unknown> =>
       new Promise((resolve, reject) => {
         const id = nextId++;
-        const timeout = setTimeout(() => {
-          ws.removeEventListener('message', handler);
-          reject(new Error(`CDP command ${method} timed out`));
-        }, 5000);
-        const onClose = () => {
-          clearTimeout(timeout);
-          ws.removeEventListener('message', handler);
-          reject(new Error('WebSocket closed before CDP response'));
-        };
-        const onError = (e: Event) => {
+        const cleanup = () => {
           clearTimeout(timeout);
           ws.removeEventListener('message', handler);
           ws.removeEventListener('close', onClose);
+          ws.removeEventListener('error', onError);
+        };
+        const timeout = setTimeout(() => {
+          cleanup();
+          reject(new Error(`CDP command ${method} timed out`));
+        }, 5000);
+        const onClose = () => {
+          cleanup();
+          reject(new Error('WebSocket closed before CDP response'));
+        };
+        const onError = (e: Event) => {
+          cleanup();
           reject(new Error(`WebSocket error: ${e}`));
         };
         const handler = (event: MessageEvent) => {
           const msg = JSON.parse(String(event.data));
           if (msg.id === id) {
-            clearTimeout(timeout);
-            ws.removeEventListener('message', handler);
-            ws.removeEventListener('close', onClose);
-            ws.removeEventListener('error', onError);
+            cleanup();
             if (msg.error) reject(new Error(msg.error.message));
             else resolve(msg.result);
           }


### PR DESCRIPTION
Extracts a cleanup() helper in cdpSend that removes all event listeners and clears the timeout. Called from every exit path (success, timeout, close, error) for consistent resource cleanup. Addresses review feedback on #7750. Part of #7718.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
