### PR TITLE
feat: add Tasks window to iOS

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
     @State private var selectedTab: Tab = .home
     @State private var navigateToConnect = false
 
-    private enum Tab { case home, chats, identity, settings }
+    private enum Tab { case home, chats, tasks, identity, settings }
 
     private enum ConnectPhase {
         case initial    // Haven't attempted connection yet
@@ -175,6 +175,14 @@ struct ContentView: View {
                 .tag(Tab.chats)
                 .tabItem {
                     Label("Chats", systemImage: "message")
+                }
+
+            TasksTabView(onConnectTapped: navigateToConnectSettings)
+                .environmentObject(clientProvider)
+                .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tag(Tab.tasks)
+                .tabItem {
+                    Label("Tasks", systemImage: "list.bullet.clipboard")
                 }
 
             IdentityView(onConnectTapped: navigateToConnectSettings)

--- a/clients/ios/Views/Tasks/IOSTaskOutputDetailView.swift
+++ b/clients/ios/Views/Tasks/IOSTaskOutputDetailView.swift
@@ -1,0 +1,161 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// A sheet that displays the output details of a completed task on iOS.
+/// Adapted from macOS TaskOutputDetailView for mobile — uses NavigationStack
+/// header and full-height layout instead of a fixed-size floating sheet.
+struct IOSTaskOutputDetailView: View {
+    let itemTitle: String
+    let state: IOSTaskOutputState
+    let onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            contentBody
+                .navigationTitle(itemTitle)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done", action: onDismiss)
+                    }
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentBody: some View {
+        switch state {
+        case .loading:
+            VStack(spacing: VSpacing.md) {
+                Spacer()
+                ProgressView()
+                Text("Loading output…")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .error(let message):
+            VStack(spacing: VSpacing.lg) {
+                Spacer()
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 40))
+                    .foregroundColor(VColor.warning)
+                Text(message)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .loaded(let output):
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    metadataSection(output)
+                    summarySection(output)
+                    if !output.highlights.isEmpty {
+                        highlightsSection(output.highlights)
+                    }
+                }
+                .padding(VSpacing.lg)
+            }
+        }
+    }
+
+    // MARK: - Metadata
+
+    private func metadataSection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            // Status badge
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(iosStatusColor(for: output.status))
+                    .frame(width: 8, height: 8)
+                Text(iosStatusLabel(for: output.status))
+                    .font(VFont.caption)
+                    .foregroundColor(iosStatusColor(for: output.status))
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, 4)
+            .background(iosStatusColor(for: output.status).opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+
+            if let completedAt = output.completedAt {
+                HStack(spacing: 4) {
+                    Image(systemName: "clock")
+                        .font(.system(size: 11))
+                    Text(formattedDate(from: completedAt))
+                        .font(VFont.caption)
+                }
+                .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Summary
+
+    private func summarySection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Summary")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+            Text(output.summary)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Highlights
+
+    private func highlightsSection(_ highlights: [String]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Highlights")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(Array(highlights.enumerated()), id: \.offset) { _, highlight in
+                    HStack(alignment: .top, spacing: VSpacing.sm) {
+                        Text("\u{2022}")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                        Text(highlight)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func iosStatusColor(for status: String) -> Color {
+        let normalized = WorkItemStatus(rawStatus: status)
+        return TasksTableContract.statusStyle(for: normalized).color
+    }
+
+    private func iosStatusLabel(for status: String) -> String {
+        let normalized = WorkItemStatus(rawStatus: status)
+        return TasksTableContract.statusStyle(for: normalized).label
+    }
+
+    private func formattedDate(from timestamp: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+#endif

--- a/clients/ios/Views/Tasks/IOSTaskPermissionPreflightView.swift
+++ b/clients/ios/Views/Tasks/IOSTaskPermissionPreflightView.swift
@@ -1,0 +1,183 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// A sheet that shows required permissions before running a task on iOS.
+/// Adapted from macOS TaskPermissionPreflightView for mobile — uses
+/// NavigationStack for consistent header and standard iOS toggle UX.
+struct IOSTaskPermissionPreflightView: View {
+    let itemTitle: String
+    let state: IOSPreflightState
+    let onApprove: ([String]) -> Void
+    let onDismiss: () -> Void
+
+    @State private var approvedTools: Set<String> = []
+    @State private var didInitApproved = false
+
+    var body: some View {
+        NavigationStack {
+            contentBody
+                .navigationTitle("Permission Preflight")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel", action: onDismiss)
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        if case .loaded(let permissions) = state, !permissions.isEmpty {
+                            Button("Approve & Run") {
+                                onApprove(Array(approvedTools))
+                            }
+                            .disabled(approvedTools.isEmpty)
+                            .fontWeight(.semibold)
+                        }
+                    }
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentBody: some View {
+        switch state {
+        case .loading:
+            VStack(spacing: VSpacing.md) {
+                Spacer()
+                ProgressView()
+                Text("Checking required permissions…")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .error(let message):
+            VStack(spacing: VSpacing.lg) {
+                Spacer()
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 40))
+                    .foregroundColor(VColor.warning)
+                Text(message)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .loaded(let permissions):
+            if permissions.isEmpty {
+                VStack(spacing: VSpacing.lg) {
+                    Spacer()
+                    Image(systemName: "checkmark.shield")
+                        .font(.system(size: 48))
+                        .foregroundColor(VColor.success)
+                    Text("No Permissions Required")
+                        .font(VFont.title)
+                        .foregroundColor(VColor.textPrimary)
+                    Text("This task can run without additional approvals.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, VSpacing.xl)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                permissionsList(permissions)
+            }
+        }
+    }
+
+    // MARK: - Permissions List
+
+    private func permissionsList(_ permissions: [IPCWorkItemPreflightResponsePermission]) -> some View {
+        List {
+            Section {
+                Text("Task: \(itemTitle)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .listRowBackground(Color.clear)
+            } header: {
+                Text("This task requires the following permissions:")
+            }
+
+            Section {
+                ForEach(permissions, id: \.tool) { permission in
+                    permissionRow(permission)
+                }
+                .onAppear {
+                    if !didInitApproved {
+                        approvedTools = Set(permissions.map(\.tool))
+                        didInitApproved = true
+                    }
+                }
+            } footer: {
+                Text("\(approvedTools.count) of \(permissions.count) approved")
+                    .font(VFont.caption)
+            }
+        }
+    }
+
+    private func permissionRow(_ permission: IPCWorkItemPreflightResponsePermission) -> some View {
+        let isApproved = approvedTools.contains(permission.tool)
+        return HStack(spacing: VSpacing.sm) {
+            Button {
+                if isApproved {
+                    approvedTools.remove(permission.tool)
+                } else {
+                    approvedTools.insert(permission.tool)
+                }
+            } label: {
+                Image(systemName: isApproved ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20))
+                    .foregroundColor(isApproved ? VColor.accent : VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isApproved ? "Approved" : "Not approved")
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(permission.tool)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Text(permission.description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            Spacer()
+
+            riskBadge(for: permission.riskLevel)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if isApproved {
+                approvedTools.remove(permission.tool)
+            } else {
+                approvedTools.insert(permission.tool)
+            }
+        }
+    }
+
+    private func riskBadge(for level: String) -> some View {
+        let color: Color = {
+            switch level.lowercased() {
+            case "low": return VColor.success
+            case "medium": return VColor.warning
+            case "high": return VColor.error
+            default: return VColor.textMuted
+            }
+        }()
+        return Text(level.capitalized)
+            .font(VFont.small)
+            .foregroundColor(color)
+            .padding(.horizontal, VSpacing.xs)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+}
+
+#endif

--- a/clients/ios/Views/Tasks/TasksView.swift
+++ b/clients/ios/Views/Tasks/TasksView.swift
@@ -1,0 +1,390 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// iOS Tasks tab — lets users view, run, and monitor one-shot tasks.
+/// Mirrors macOS TasksWindowView adapted for iPhone navigation patterns.
+struct TasksView: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    @StateObject private var viewModel: TasksViewModel
+
+    init(daemonClient: DaemonClient) {
+        _viewModel = StateObject(wrappedValue: TasksViewModel(daemonClient: daemonClient))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Tasks")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            viewModel.fetchItems()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .accessibilityLabel("Refresh tasks")
+                    }
+                }
+                .refreshable {
+                    viewModel.fetchItems()
+                }
+        }
+        .sheet(isPresented: Binding(
+            get: { viewModel.selectedOutputItem != nil },
+            set: { if !$0 { viewModel.dismissOutput() } }
+        )) {
+            if let item = viewModel.selectedOutputItem {
+                IOSTaskOutputDetailView(
+                    itemTitle: item.title,
+                    state: viewModel.outputState,
+                    onDismiss: { viewModel.dismissOutput() }
+                )
+            }
+        }
+        .sheet(isPresented: Binding(
+            get: { viewModel.preflightItem != nil },
+            set: { if !$0 { viewModel.dismissPreflight() } }
+        )) {
+            if let item = viewModel.preflightItem {
+                IOSTaskPermissionPreflightView(
+                    itemTitle: item.title,
+                    state: viewModel.preflightState,
+                    onApprove: { approvedTools in
+                        viewModel.approveAndRun(id: item.id, approvedTools: approvedTools)
+                    },
+                    onDismiss: { viewModel.dismissPreflight() }
+                )
+            }
+        }
+        .alert("Error", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading {
+            VStack(spacing: VSpacing.md) {
+                ProgressView()
+                Text("Loading tasks…")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.items.isEmpty {
+            emptyState
+        } else {
+            taskList
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: VSpacing.lg) {
+            Image(systemName: "list.bullet.clipboard")
+                .font(.system(size: 48))
+                .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
+            Text("No Tasks")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+            Text("Your one-shot tasks will appear here.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Task List
+
+    private var taskList: some View {
+        List {
+            ForEach(viewModel.items, id: \.id) { item in
+                TaskRow(
+                    item: item,
+                    hasOutput: viewModel.taskHasOutput(item),
+                    runningIds: viewModel.runInFlightIds,
+                    timeoutIds: viewModel.runTimeoutIds,
+                    cancelInFlightIds: viewModel.cancelInFlightIds,
+                    onViewOutput: { viewModel.fetchOutput(for: item) },
+                    onRun: { viewModel.initiateRun(item: item) },
+                    onCancel: { viewModel.cancelTask(id: item.id) },
+                    onPriorityChange: { tier in viewModel.updatePriority(id: item.id, tier: tier) }
+                )
+                .listRowInsets(EdgeInsets(top: VSpacing.xs, leading: VSpacing.md, bottom: VSpacing.xs, trailing: VSpacing.md))
+            }
+            .onDelete { indexSet in
+                for index in indexSet {
+                    let item = viewModel.items[index]
+                    viewModel.removeTask(id: item.id)
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+// MARK: - Task Row
+
+/// A single task row in the iOS task list.
+private struct TaskRow: View {
+    let item: IPCWorkItemsListResponseItem
+    let hasOutput: Bool
+    let runningIds: Set<String>
+    let timeoutIds: Set<String>
+    let cancelInFlightIds: Set<String>
+    let onViewOutput: () -> Void
+    let onRun: () -> Void
+    let onCancel: () -> Void
+    let onPriorityChange: (Double) -> Void
+
+    private var status: WorkItemStatus { WorkItemStatus(rawStatus: item.status) }
+    private var isRunning: Bool { runningIds.contains(item.id) || status == .running }
+    private var isCancelling: Bool { cancelInFlightIds.contains(item.id) }
+    private var isTimedOut: Bool { timeoutIds.contains(item.id) }
+    private var isFailed: Bool { status == .failed || status == .cancelled }
+    private var isCompleted: Bool { status == .done || status == .awaitingReview }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Title and status badge
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Text(item.title)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                statusBadge
+            }
+
+            // Priority and action buttons
+            HStack(spacing: VSpacing.sm) {
+                priorityBadge
+                Spacer()
+                actionButtons
+            }
+        }
+        .padding(.vertical, VSpacing.xs)
+    }
+
+    // MARK: - Status Badge
+
+    private var statusBadge: some View {
+        let style = TasksTableContract.statusStyle(for: status)
+        return HStack(spacing: 4) {
+            if isRunning {
+                ProgressView()
+                    .scaleEffect(0.65)
+                    .frame(width: 10, height: 10)
+            } else {
+                Circle()
+                    .fill(statusBadgeColor)
+                    .frame(width: 7, height: 7)
+            }
+            Text(style.label)
+                .font(VFont.caption)
+                .foregroundColor(statusBadgeColor)
+        }
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, 3)
+        .background(statusBadgeColor.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    private var statusBadgeColor: Color {
+        if isTimedOut { return VColor.warning }
+        if isFailed { return VColor.error }
+        if isRunning { return VColor.accent }
+        if isCompleted { return VColor.success }
+        return VColor.textSecondary
+    }
+
+    // MARK: - Priority Badge
+
+    private var priorityBadge: some View {
+        let style = TasksTableContract.priorityStyle(for: item.priorityTier)
+        return Menu {
+            ForEach(TasksTableContract.allPriorityTiers, id: \.tier) { option in
+                Button {
+                    onPriorityChange(option.tier)
+                } label: {
+                    Label {
+                        Text(option.label)
+                    } icon: {
+                        Image(systemName: option.tier == item.priorityTier ? "checkmark.circle.fill" : "circle.fill")
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(style.color)
+                    .frame(width: 7, height: 7)
+                Text(style.label)
+                    .font(VFont.caption)
+                    .foregroundColor(style.color)
+            }
+            .padding(.horizontal, VSpacing.xs)
+            .padding(.vertical, 3)
+            .background(style.color.opacity(0.10))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .accessibilityLabel("Priority: \(style.label)")
+    }
+
+    // MARK: - Action Buttons
+
+    // Archived tasks show no actions — they can't be run or have output fetched.
+    private var isArchived: Bool { status == .archived }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if isArchived {
+            EmptyView()
+        } else if isRunning {
+            Button(action: onCancel) {
+                HStack(spacing: 4) {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 11))
+                    Text(isCancelling ? "Stopping…" : "Stop")
+                        .font(VFont.caption)
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.error)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .buttonStyle(.plain)
+            .disabled(isCancelling)
+            .opacity(isCancelling ? 0.5 : 1.0)
+            .accessibilityLabel(isCancelling ? "Stopping task" : "Stop task")
+        } else if isCompleted && hasOutput {
+            Button(action: onViewOutput) {
+                HStack(spacing: 4) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 11))
+                    Text("Result")
+                        .font(VFont.caption)
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.accent)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("View task result")
+        } else {
+            VStack(spacing: 2) {
+                Button(action: onRun) {
+                    HStack(spacing: 4) {
+                        Image(systemName: runButtonIcon)
+                            .font(.system(size: 11))
+                        Text(runButtonLabel)
+                            .font(VFont.caption)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xs)
+                    .background(runButtonColor)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(runButtonLabel)
+
+                if isTimedOut {
+                    Text("No response")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.warning)
+                }
+            }
+        }
+    }
+
+    private var runButtonLabel: String {
+        if isTimedOut || isFailed { return "Retry" }
+        if isCompleted { return "Rerun" }
+        return "Run"
+    }
+
+    private var runButtonIcon: String {
+        (isFailed || isTimedOut || isCompleted) ? "arrow.clockwise" : "play.fill"
+    }
+
+    private var runButtonColor: Color {
+        (isFailed || isTimedOut) ? VColor.warning : VColor.accent
+    }
+}
+
+// MARK: - Disconnected Wrapper
+
+/// Shown when the app has no daemon connection — tasks require Connected mode.
+struct TasksDisconnectedView: View {
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: VSpacing.lg) {
+                Image(systemName: "list.bullet.clipboard")
+                    .font(.system(size: 48))
+                    .foregroundColor(VColor.textMuted)
+                    .accessibilityHidden(true)
+                Text("Tasks Require Connection")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Connect to your Mac to create and run one-shot tasks.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+                if onConnectTapped != nil {
+                    Button {
+                        onConnectTapped?()
+                    } label: {
+                        Text("Go to Settings")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("Tasks")
+        }
+    }
+}
+
+// MARK: - Tab Entry Point
+
+/// The tab-level Tasks entry point. Switches between connected and disconnected
+/// states so TasksView only mounts when a live DaemonClient is available.
+struct TasksTabView: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        if let daemon = clientProvider.client as? DaemonClient, clientProvider.isConnected {
+            TasksView(daemonClient: daemon)
+                .environmentObject(clientProvider)
+        } else {
+            TasksDisconnectedView(onConnectTapped: onConnectTapped)
+        }
+    }
+}
+
+#Preview {
+    TasksDisconnectedView()
+        .environmentObject(ClientProvider(client: DaemonClient(config: .default)))
+}
+
+#endif

--- a/clients/ios/Views/Tasks/TasksViewModel.swift
+++ b/clients/ios/Views/Tasks/TasksViewModel.swift
@@ -1,0 +1,341 @@
+#if canImport(UIKit)
+import os
+import SwiftUI
+import VellumAssistantShared
+
+/// Centralizes task queue state and daemon callbacks for the iOS Tasks tab.
+/// Mirrors TasksWindowViewModel on macOS — same callback wiring and run/cancel
+/// lifecycle, adapted for UIKit (no NSWindow, no onOpenInChat cross-window jump).
+@MainActor
+class TasksViewModel: ObservableObject {
+    @Published var items: [IPCWorkItemsListResponseItem] = []
+    @Published var isLoading = true
+    @Published var errorMessage: String?
+
+    private let logger = Logger(subsystem: "com.vellum.vellum-assistant", category: "TasksView")
+    private let daemonClient: DaemonClient
+    private var refreshTask: Task<Void, Never>?
+
+    /// Tracks work item IDs with an in-flight run request to prevent duplicate taps.
+    @Published var runInFlightIds: Set<String> = []
+    /// Tracks IDs where the run request timed out without a daemon response.
+    @Published var runTimeoutIds: Set<String> = []
+    /// Tracks work item IDs with an in-flight cancel request.
+    @Published var cancelInFlightIds: Set<String> = []
+
+    /// The currently selected item for output detail viewing.
+    @Published var selectedOutputItem: IPCWorkItemsListResponseItem?
+    /// Loading/loaded/error state for the output detail sheet.
+    @Published var outputState: IOSTaskOutputState = .loading
+
+    /// The item currently undergoing permission preflight.
+    @Published var preflightItem: IPCWorkItemsListResponseItem?
+    /// Loading/loaded/error state for the preflight sheet.
+    @Published var preflightState: IOSPreflightState = .loading
+
+    /// Tracks the item awaiting a preflight response from the daemon.
+    /// Unlike `preflightItem`, this does NOT trigger the sheet.
+    private var pendingPreflightItem: IPCWorkItemsListResponseItem?
+
+    private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
+
+    /// How long to wait for a daemon run-task response before treating
+    /// the request as timed out (matches macOS behaviour).
+    private static let runTimeoutSeconds: UInt64 = 10
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        setupCallbacks()
+        fetchItems()
+    }
+
+    // MARK: - Callback Setup
+
+    private func setupCallbacks() {
+        daemonClient.onWorkItemsListResponse = { [weak self] response in
+            self?.items = response.items
+            self?.isLoading = false
+            self?.runTimeoutIds.removeAll()
+            if let self {
+                let nonRunningIds = Set(response.items
+                    .filter { WorkItemStatus(rawStatus: $0.status) != .running }
+                    .map(\.id))
+                self.runInFlightIds.subtract(nonRunningIds)
+            }
+        }
+
+        // Debounce rapid broadcasts so multiple mutations coalesce.
+        let scheduleRefresh = { [weak self] in
+            self?.refreshTask?.cancel()
+            self?.refreshTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 300_000_000) // 300 ms
+                guard !Task.isCancelled else { return }
+                self?.fetchItems()
+            }
+        }
+
+        daemonClient.onWorkItemStatusChanged = { [weak self] notification in
+            let id = notification.item.id
+            self?.runInFlightIds.remove(id)
+            self?.cancelRunTimeout(id: id)
+            scheduleRefresh()
+        }
+        daemonClient.onTasksChanged = { _ in scheduleRefresh() }
+
+        daemonClient.onWorkItemRunTaskResponse = { [weak self] response in
+            guard let self else { return }
+            self.runInFlightIds.remove(response.id)
+            self.cancelRunTimeout(id: response.id)
+            if !response.success {
+                self.logger.error("onWorkItemRunTaskResponse: run failed for id=\(response.id, privacy: .public) errorCode=\(response.errorCode ?? "none", privacy: .public)")
+                if response.errorCode == "permission_required",
+                   let item = self.items.first(where: { $0.id == response.id }) {
+                    self.initiateRun(item: item)
+                } else {
+                    self.errorMessage = response.error ?? "Failed to run task"
+                }
+                self.fetchItems()
+            }
+        }
+
+        daemonClient.onWorkItemDeleteResponse = { [weak self] response in
+            guard let self else { return }
+            if !response.success {
+                self.logger.warning("onWorkItemDeleteResponse: server rejected delete for id=\(response.id, privacy: .public)")
+                self.fetchItems()
+            }
+        }
+
+        daemonClient.onWorkItemOutputResponse = { [weak self] response in
+            guard let self else { return }
+            guard self.selectedOutputItem?.id == response.id else { return }
+            if response.success, let output = response.output {
+                self.outputState = .loaded(output)
+            } else {
+                self.outputState = .error(response.error ?? "Output not available for this task.")
+            }
+        }
+
+        daemonClient.onWorkItemPreflightResponse = { [weak self] response in
+            guard let self else { return }
+            guard self.pendingPreflightItem?.id == response.id else { return }
+            if response.success, let permissions = response.permissions {
+                if permissions.isEmpty {
+                    self.pendingPreflightItem = nil
+                    self.runTask(id: response.id)
+                } else {
+                    self.preflightItem = self.pendingPreflightItem
+                    self.pendingPreflightItem = nil
+                    self.preflightState = .loaded(permissions)
+                }
+            } else {
+                self.pendingPreflightItem = nil
+                self.errorMessage = response.error ?? "Failed to check permissions."
+            }
+        }
+
+        daemonClient.onWorkItemApprovePermissionsResponse = { [weak self] response in
+            guard let self else { return }
+            if response.success {
+                let itemId = response.id
+                self.dismissPreflight()
+                self.runTask(id: itemId)
+            } else {
+                self.preflightState = .error(response.error ?? "Failed to save permission approvals.")
+            }
+        }
+
+        daemonClient.onWorkItemCancelResponse = { [weak self] response in
+            guard let self else { return }
+            self.cancelInFlightIds.remove(response.id)
+            if !response.success {
+                self.logger.error("onWorkItemCancelResponse: cancel failed for id=\(response.id, privacy: .public)")
+                self.errorMessage = response.error ?? "Failed to cancel task"
+            }
+            self.fetchItems()
+        }
+    }
+
+    // MARK: - Data
+
+    func fetchItems() {
+        isLoading = items.isEmpty
+        errorMessage = nil
+        do {
+            try daemonClient.sendWorkItemsList()
+        } catch {
+            logger.error("fetchItems failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    /// Whether a task's status indicates it may have output to display.
+    func taskHasOutput(_ item: IPCWorkItemsListResponseItem) -> Bool {
+        let status = WorkItemStatus(rawStatus: item.status)
+        switch status {
+        case .awaitingReview, .done, .failed: return true
+        default: return false
+        }
+    }
+
+    // MARK: - Run / Preflight
+
+    /// Initiates the run flow via a preflight check. The permission sheet only
+    /// appears if the daemon reports non-empty permissions.
+    func initiateRun(item: IPCWorkItemsListResponseItem) {
+        logger.info("initiateRun: id=\(item.id, privacy: .public)")
+        guard !runInFlightIds.contains(item.id) else {
+            logger.warning("initiateRun: skipping — already in flight for id=\(item.id, privacy: .public)")
+            return
+        }
+        pendingPreflightItem = item
+        preflightState = .loading
+        do {
+            try daemonClient.sendWorkItemPreflight(id: item.id)
+        } catch {
+            logger.error("initiateRun: preflight transport error for id=\(item.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            pendingPreflightItem = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func approveAndRun(id: String, approvedTools: [String]) {
+        logger.info("approveAndRun: id=\(id, privacy: .public)")
+        do {
+            try daemonClient.sendWorkItemApprovePermissions(id: id, approvedTools: approvedTools)
+        } catch {
+            logger.error("approveAndRun: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            preflightState = .error(error.localizedDescription)
+        }
+    }
+
+    func dismissPreflight() { preflightItem = nil }
+
+    func runTask(id: String) {
+        let alreadyInFlight = runInFlightIds.contains(id)
+        guard !alreadyInFlight else {
+            logger.warning("runTask: skipping duplicate run request for id=\(id, privacy: .public)")
+            return
+        }
+        runTimeoutIds.remove(id)
+        runInFlightIds.insert(id)
+        startRunTimeout(id: id)
+        do {
+            try daemonClient.sendWorkItemRunTask(id: id)
+        } catch {
+            logger.error("runTask: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            runInFlightIds.remove(id)
+            cancelRunTimeout(id: id)
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Cancel
+
+    func cancelTask(id: String) {
+        logger.info("cancelTask: id=\(id, privacy: .public)")
+        guard !cancelInFlightIds.contains(id) else { return }
+        cancelInFlightIds.insert(id)
+        do {
+            try daemonClient.sendWorkItemCancel(id: id)
+        } catch {
+            logger.error("cancelTask: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            cancelInFlightIds.remove(id)
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Remove
+
+    func removeTask(id: String) {
+        logger.info("removeTask: id=\(id, privacy: .public)")
+        let snapshot = items
+        withAnimation { items.removeAll { $0.id == id } }
+        do {
+            try daemonClient.sendWorkItemDelete(id: id)
+        } catch {
+            logger.error("removeTask: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            withAnimation { items = snapshot }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Output
+
+    func fetchOutput(for item: IPCWorkItemsListResponseItem) {
+        logger.info("fetchOutput: id=\(item.id, privacy: .public)")
+        selectedOutputItem = item
+        outputState = .loading
+        do {
+            try daemonClient.sendWorkItemOutput(id: item.id)
+        } catch {
+            logger.error("fetchOutput: transport error for id=\(item.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            outputState = .error(error.localizedDescription)
+        }
+    }
+
+    func dismissOutput() { selectedOutputItem = nil }
+
+    // MARK: - Priority
+
+    func updatePriority(id: String, tier: Double) {
+        let snapshot = items
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            var updated = items
+            updated[index] = updated[index].withPriorityTier(tier)
+            updated.sort {
+                if $0.priorityTier != $1.priorityTier { return $0.priorityTier < $1.priorityTier }
+                if let s0 = $0.sortIndex, let s1 = $1.sortIndex, s0 != s1 { return s0 < s1 }
+                return $0.updatedAt > $1.updatedAt
+            }
+            withAnimation(.linear(duration: 0.15)) { items = updated }
+        }
+        do {
+            try daemonClient.sendWorkItemUpdate(id: id, priorityTier: tier)
+        } catch {
+            logger.error("updatePriority: transport error for id=\(id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            withAnimation(.linear(duration: 0.15)) { items = snapshot }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Run Timeout
+
+    private func startRunTimeout(id: String) {
+        cancelRunTimeout(id: id)
+        runTimeoutTasks[id] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.runTimeoutSeconds * 1_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+            guard self.runInFlightIds.contains(id) else { return }
+            self.logger.warning("runTask timeout: no response after \(Self.runTimeoutSeconds)s for id=\(id, privacy: .public)")
+            self.runInFlightIds.remove(id)
+            self.runTimeoutIds.insert(id)
+            self.runTimeoutTasks.removeValue(forKey: id)
+        }
+    }
+
+    private func cancelRunTimeout(id: String) {
+        runTimeoutTasks[id]?.cancel()
+        runTimeoutTasks.removeValue(forKey: id)
+        runTimeoutIds.remove(id)
+    }
+}
+
+// MARK: - State Types
+
+/// Loading/loaded/error state for fetching task output on iOS.
+enum IOSTaskOutputState {
+    case loading
+    case loaded(IPCWorkItemOutputResponseOutput)
+    case error(String)
+}
+
+/// Loading/loaded/error state for the permission preflight check on iOS.
+enum IOSPreflightState {
+    case loading
+    case loaded([IPCWorkItemPreflightResponsePermission])
+    case error(String)
+}
+
+#endif

--- a/clients/shared/Features/Tasks/TasksTableContract.swift
+++ b/clients/shared/Features/Tasks/TasksTableContract.swift
@@ -1,11 +1,12 @@
 import SwiftUI
-import VellumAssistantShared
+import Foundation
 
 // MARK: - Work Item Status
 
 /// Normalized status enum that maps daemon status strings to typed cases.
 /// Case-insensitive matching protects against transport casing/serialization drift.
-enum WorkItemStatus: Equatable {
+/// Shared between macOS and iOS so both platforms use the same mapping.
+public enum WorkItemStatus: Equatable {
     case queued
     case running
     case awaitingReview
@@ -16,7 +17,7 @@ enum WorkItemStatus: Equatable {
     case unknown(String)
 
     /// Case-insensitive mapping from the raw daemon status string.
-    init(rawStatus: String) {
+    public init(rawStatus: String) {
         switch rawStatus.lowercased() {
         case "queued":          self = .queued
         case "running":         self = .running
@@ -32,53 +33,58 @@ enum WorkItemStatus: Equatable {
 
 // MARK: - Table Column Definitions
 
-/// Single source of truth for the Tasks table layout, column sizing,
+/// Single source of truth for the Tasks table/list layout, column sizing,
 /// priority/status display mappings, and sort order.
+/// Shared between macOS and iOS.
 ///
 /// Sorting rules (applied server-side, mirrored here for documentation):
 ///   1. `priority_tier ASC`  — high (0) surfaces first
 ///   2. `sort_index ASC`     — manual ordering within a tier
 ///   3. `updated_at DESC`    — most recently touched wins ties
-enum TasksTableContract {
+public enum TasksTableContract {
 
     // MARK: Columns
 
-    enum Column: String, CaseIterable {
+    public enum Column: String, CaseIterable {
         case task
         case priority
         case status
         case actions
     }
 
-    // MARK: Column Widths
+    // MARK: Column Widths (macOS table layout)
 
     /// Fixed-width columns. The `task` column is flexible and fills remaining space.
-    static let taskMinWidth: CGFloat = 200
-    static let priorityWidth: CGFloat = 80
-    static let statusWidth: CGFloat = 120
-    static let actionsWidth: CGFloat = 90
+    public static let taskMinWidth: CGFloat = 200
+    public static let priorityWidth: CGFloat = 80
+    public static let statusWidth: CGFloat = 120
+    public static let actionsWidth: CGFloat = 90
 
     // MARK: Truncation
 
     /// Title truncates with trailing ellipsis at the column boundary (lineLimit 1).
-    /// Notes are not displayed in the table view — they belong to the detail/card layout.
-    static let titleLineLimit = 1
+    public static let titleLineLimit = 1
 
     // MARK: Priority Mapping
 
-    struct PriorityStyle {
-        let label: String
-        let color: Color
+    public struct PriorityStyle {
+        public let label: String
+        public let color: Color
+
+        public init(label: String, color: Color) {
+            self.label = label
+            self.color = color
+        }
     }
 
     /// All priority tiers in display order, used to populate the priority edit menu.
-    static let allPriorityTiers: [(tier: Double, label: String, color: Color)] = [
+    public static let allPriorityTiers: [(tier: Double, label: String, color: Color)] = [
         (0, "High",   VColor.error),
         (1, "Medium", VColor.accent),
         (2, "Low",    VColor.textMuted),
     ]
 
-    static func priorityStyle(for tier: Double) -> PriorityStyle {
+    public static func priorityStyle(for tier: Double) -> PriorityStyle {
         switch tier {
         case 0:  return PriorityStyle(label: "High",   color: VColor.error)
         case 1:  return PriorityStyle(label: "Medium", color: VColor.accent)
@@ -88,12 +94,17 @@ enum TasksTableContract {
 
     // MARK: Status Mapping
 
-    struct StatusStyle {
-        let label: String
-        let color: Color
+    public struct StatusStyle {
+        public let label: String
+        public let color: Color
+
+        public init(label: String, color: Color) {
+            self.label = label
+            self.color = color
+        }
     }
 
-    static func statusStyle(for status: WorkItemStatus) -> StatusStyle {
+    public static func statusStyle(for status: WorkItemStatus) -> StatusStyle {
         switch status {
         case .queued:          return StatusStyle(label: "Queued",    color: VColor.textSecondary)
         case .running:         return StatusStyle(label: "Running",   color: VColor.textSecondary)


### PR DESCRIPTION
Port macOS TasksWindowView to iOS, allowing users to create, run, and monitor one-shot tasks from iPhone. Includes task list, status indicators, and detail view.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
