### PR TITLE
style: standardize null vs undefined via ESLint

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -10,6 +10,38 @@ const eslintConfig = defineConfig([
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+
+      // Standardize on `undefined` only — avoid `null` in new code.
+      // Prefer `=== undefined`, `?? fallback`, or `?.` optional chaining
+      // instead of `=== null`. Existing code is grandfathered in (warn, not
+      // error) so we don't need a mass refactor.
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector:
+            "BinaryExpression[operator='==='][right.type='Literal'][right.raw='null']",
+          message:
+            "Avoid `=== null`. Prefer `=== undefined`, `?? fallback`, or optional chaining `?.` instead.",
+        },
+        {
+          selector:
+            "BinaryExpression[operator='==='][left.type='Literal'][left.raw='null']",
+          message:
+            "Avoid `null ===`. Prefer `=== undefined`, `?? fallback`, or optional chaining `?.` instead.",
+        },
+        {
+          selector:
+            "BinaryExpression[operator='!=='][right.type='Literal'][right.raw='null']",
+          message:
+            "Avoid `!== null`. Prefer `!== undefined`, nullish coalescing `??`, or optional chaining `?.` instead.",
+        },
+        {
+          selector:
+            "BinaryExpression[operator='!=='][left.type='Literal'][left.raw='null']",
+          message:
+            "Avoid `null !==`. Prefer `!== undefined`, nullish coalescing `??`, or optional chaining `?.` instead.",
+        },
+      ],
     },
   },
 ]);


### PR DESCRIPTION
Add ESLint rule to enforce consistent null/undefined handling across the TypeScript daemon. Standardize on undefined-only patterns going forward.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
