### PR TITLE
feat: enable cloud login path in iOS OnboardingView

### DIFF
--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -4,6 +4,8 @@ import VellumAssistantShared
 
 struct LoginView: View {
     @Bindable var authManager: AuthManager
+    /// Called after a successful login so the onboarding flow can advance.
+    var onContinue: (() -> Void)?
 
     var body: some View {
         VStack(spacing: VSpacing.xl) {
@@ -32,7 +34,13 @@ struct LoginView: View {
             }
 
             Button {
-                Task { await authManager.startWorkOSLogin() }
+                Task {
+                    await authManager.startWorkOSLogin()
+                    // Advance once the auth state reflects a successful login.
+                    if authManager.isAuthenticated {
+                        onContinue?()
+                    }
+                }
             } label: {
                 if authManager.isSubmitting {
                     ProgressView()

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -2,30 +2,48 @@
 import SwiftUI
 import VellumAssistantShared
 
+// Onboarding step identifiers. The path branches at ChoosePath:
+//   Welcome → ChoosePath → (LoginView | DaemonSetup) → Permissions → Ready
+private enum OnboardingStep: Hashable {
+    case welcome
+    case choosePath
+    case login
+    case daemonSetup
+    case permissions
+    case ready
+}
+
 struct OnboardingView: View {
     @Binding var isCompleted: Bool
     @Bindable var authManager: AuthManager
-    @State private var currentStep = 0
-
-    // Steps: Welcome(0) → DaemonSetup(1) → Permissions(2) → Ready(3)
-    // Note: Cloud login path (ChoosePath/LoginView) is disabled until
-    // platform.vellum.ai is deployed. Re-enable when the platform is live.
+    @State private var currentStep: OnboardingStep = .welcome
 
     var body: some View {
-        TabView(selection: $currentStep) {
-            WelcomeStep(onContinue: { currentStep = 1 })
-                .tag(0)
-
-            DaemonSetupStep(onContinue: { currentStep = 2 })
-                .tag(1)
-
-            PermissionsStep(onContinue: { currentStep = 3 })
-                .tag(2)
-
-            ReadyStep(isCompleted: $isCompleted)
-                .tag(3)
+        ZStack {
+            switch currentStep {
+            case .welcome:
+                WelcomeStep(onContinue: { currentStep = .choosePath })
+                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            case .choosePath:
+                ChoosePathStep(
+                    onLoginWithVellum: { currentStep = .login },
+                    onConnectToMac: { currentStep = .daemonSetup }
+                )
+                .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            case .login:
+                LoginView(authManager: authManager, onContinue: { currentStep = .permissions })
+                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            case .daemonSetup:
+                DaemonSetupStep(onContinue: { currentStep = .permissions })
+                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            case .permissions:
+                PermissionsStep(onContinue: { currentStep = .ready })
+                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            case .ready:
+                ReadyStep(isCompleted: $isCompleted)
+                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+            }
         }
-        .tabViewStyle(.page(indexDisplayMode: .never))
         .animation(.easeInOut, value: currentStep)
     }
 }


### PR DESCRIPTION
Wire up the previously commented-out ChoosePathStep/LoginView cloud login path in iOS OnboardingView now that platform.vellum.ai is live.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
