### PR TITLE
feat: add WhatsApp channel support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,6 +187,8 @@ graph TB
         GW_TWILIO_RELAY["Twilio Relay WS<br/>/webhooks/twilio/relay<br/>(bidirectional proxy)"]
         GW_SMS_WEBHOOK["Twilio SMS Webhook<br/>/webhooks/twilio/sms<br/>(HMAC-SHA1 validated)"]
         GW_SMS_DELIVER["SMS Deliver<br/>/deliver/sms<br/>(internal, from runtime)"]
+        GW_WA_WEBHOOK["WhatsApp Webhook<br/>/webhooks/whatsapp<br/>(HMAC-SHA256 validated)"]
+        GW_WA_DELIVER["WhatsApp Deliver<br/>/deliver/whatsapp<br/>(internal, from runtime)"]
         GW_OAUTH["OAuth Callback<br/>/webhooks/oauth/callback"]
         GW_PROXY["Runtime Proxy<br/>(optional, bearer auth)"]
         GW_PROBES["/healthz + /readyz<br/>k8s liveness/readiness"]
@@ -329,6 +331,11 @@ graph TB
     HTTP_SERVER -->|"POST /deliver/sms<br/>(via gatewayInternalBaseUrl)"| GW_SMS_DELIVER
     GW_SMS_DELIVER -->|"Twilio Messages API<br/>(text-only, no MMS in v1)"| GW_SMS_WEBHOOK
 
+    %% Gateway flow — WhatsApp channel (Meta Cloud API)
+    GW_WA_WEBHOOK -->|"HMAC-SHA256 verify<br/>+ normalize + dedup<br/>+ route resolver"| GW_FORWARD
+    HTTP_SERVER -->|"POST /deliver/whatsapp<br/>(via gatewayInternalBaseUrl)"| GW_WA_DELIVER
+    GW_WA_DELIVER -->|"Meta Cloud API<br/>/{phoneNumberId}/messages"| GW_WA_WEBHOOK
+
     %% Gateway flow — OAuth callback
     GW_OAUTH -->|"forward code + state"| HTTP_SERVER
 
@@ -450,6 +457,37 @@ The SMS channel provides text-only messaging via Twilio, sharing the same teleph
 All three paths are best-effort: webhook sync failures do not prevent the primary operation from succeeding.
 
 **Limitations (v1)**: Text-only — MMS payloads are explicitly rejected with a user-facing notice rather than silently dropped.
+
+### WhatsApp Channel (Meta Cloud API)
+
+The WhatsApp channel enables inbound and outbound messaging via the Meta WhatsApp Business Cloud API. It follows the same ingress/egress pattern as SMS but uses Meta's HMAC-SHA256 signature validation (`X-Hub-Signature-256`) instead of Twilio's HMAC-SHA1.
+
+**Ingress** (`GET /webhooks/whatsapp` — verification, `POST /webhooks/whatsapp` — messages):
+
+1. **Webhook verification**: Meta sends a `GET` with `hub.mode=subscribe`, `hub.verify_token`, and `hub.challenge`. The gateway compares `hub.verify_token` against `WHATSAPP_WEBHOOK_VERIFY_TOKEN` and echoes `hub.challenge` as plain text.
+2. On `POST`, the gateway verifies the `X-Hub-Signature-256` header (HMAC-SHA256 of the raw request body using `WHATSAPP_APP_SECRET`) when the app secret is configured. Fail-closed: requests are rejected when the secret is set but the signature fails.
+3. **Normalization**: Only `type=text` messages from `messages` change fields are forwarded. Delivery receipts, read receipts, and non-text message types (image, audio, video, document, sticker) are silently acknowledged with `{ ok: true }`.
+4. **`/new` command**: When the message body is `/new` (case-insensitive), the gateway resolves routing, resets the conversation, and sends a confirmation message without forwarding to the runtime.
+5. The payload is normalized into a `GatewayInboundEventV1` with `sourceChannel: "whatsapp"` and `externalChatId` set to the sender's WhatsApp phone number (E.164).
+6. WhatsApp message IDs are deduplicated via `StringDedupCache` (24-hour TTL).
+7. The gateway marks each inbound message as read (best-effort, fire-and-forget).
+8. The event is forwarded to the runtime via `POST /channels/inbound` with WhatsApp-specific transport hints and a `replyCallbackUrl` pointing to `/deliver/whatsapp`.
+
+**Egress** (`POST /deliver/whatsapp`):
+1. The runtime calls the gateway's `/deliver/whatsapp` endpoint with `{ to, text }` or `{ chatId, text }` (alias).
+2. The gateway authenticates the request via bearer token (same fail-closed model as other deliver endpoints).
+3. The gateway sends the message via the WhatsApp Cloud API `/{phoneNumberId}/messages` endpoint using the configured access token.
+4. Text is split at 4096 characters if needed.
+
+**Required credentials**:
+- `WHATSAPP_PHONE_NUMBER_ID` — the numeric WhatsApp Business phone number ID from Meta
+- `WHATSAPP_ACCESS_TOKEN` — System User or temporary access token
+- `WHATSAPP_APP_SECRET` — App secret for webhook signature verification
+- `WHATSAPP_WEBHOOK_VERIFY_TOKEN` — Token for the Meta webhook subscription handshake
+
+These can be set via environment variables or stored in the credential vault (keychain / encrypted store) under the `whatsapp` service prefix.
+
+**Limitations (v1)**: Text-only — non-text message types are acknowledged but not forwarded; rich approval UI (inline buttons) is not supported.
 
 **Channel Readiness**: The `channel_readiness` IPC contract (`ChannelReadinessService` in `src/runtime/channel-readiness-service.ts`) provides a unified readiness subsystem for all channels. Each channel registers a `ChannelProbe` that runs synchronous local checks (credential presence, phone number, ingress config) and optional async remote checks with a 5-minute TTL cache. Built-in probes: SMS (Twilio credentials, phone number, ingress; remote checks query Twilio toll-free verification status for toll-free numbers) and Telegram (bot token, webhook secret, ingress). The `get` action returns cached snapshots; `refresh` invalidates the cache first. Unknown channels return `unsupported_channel`.
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -52,6 +52,7 @@ import { slackProvider as slackMessagingProvider } from '../messaging/providers/
 import { gmailMessagingProvider } from '../messaging/providers/gmail/adapter.js';
 import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bot/adapter.js';
 import { smsMessagingProvider } from '../messaging/providers/sms/adapter.js';
+import { whatsappMessagingProvider } from '../messaging/providers/whatsapp/adapter.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import type { ApprovalCopyGenerator } from '../runtime/http-types.js';
@@ -459,6 +460,7 @@ export async function runDaemon(): Promise<void> {
   registerMessagingProvider(gmailMessagingProvider);
   registerMessagingProvider(telegramBotMessagingProvider);
   registerMessagingProvider(smsMessagingProvider);
+  registerMessagingProvider(whatsappMessagingProvider);
 
   const scheduler = startScheduler(
     async (conversationId, message) => {

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -1,0 +1,136 @@
+/**
+ * WhatsApp Business messaging provider adapter.
+ *
+ * Enables proactive outbound WhatsApp messaging via the gateway's /deliver/whatsapp
+ * endpoint. Delivery is proxied through the gateway which owns the Meta Cloud API
+ * credentials (phone_number_id + access_token).
+ *
+ * The `token` parameter in MessagingProvider methods is unused for WhatsApp
+ * because delivery is authenticated via the gateway's bearer token, not
+ * a per-user OAuth token.
+ */
+
+import type { MessagingProvider } from '../../provider.js';
+import type {
+  Conversation,
+  Message,
+  SearchResult,
+  SendResult,
+  ConnectionInfo,
+  ListOptions,
+  HistoryOptions,
+  SearchOptions,
+  SendOptions,
+} from '../../provider-types.js';
+import { getSecureKey } from '../../../security/secure-keys.js';
+import { readHttpToken } from '../../../util/platform.js';
+import { getGatewayInternalBaseUrl } from '../../../config/env.js';
+import { getOrCreateConversation } from '../../../memory/conversation-key-store.js';
+import * as externalConversationStore from '../../../memory/external-conversation-store.js';
+import * as whatsapp from './client.js';
+
+/** Resolve the gateway base URL. */
+function getGatewayUrl(): string {
+  return getGatewayInternalBaseUrl();
+}
+
+/** Read the runtime HTTP bearer token used to authenticate with the gateway. */
+function getBearerToken(): string {
+  const token = readHttpToken();
+  if (!token) {
+    throw new Error('No runtime HTTP bearer token available — is the daemon running?');
+  }
+  return token;
+}
+
+/** Check whether WhatsApp credentials are stored. */
+function hasWhatsAppCredentials(): boolean {
+  return (
+    !!getSecureKey('credential:whatsapp:phone_number_id') &&
+    !!getSecureKey('credential:whatsapp:access_token')
+  );
+}
+
+export const whatsappMessagingProvider: MessagingProvider = {
+  id: 'whatsapp',
+  displayName: 'WhatsApp',
+  credentialService: 'whatsapp',
+  capabilities: new Set(['send']),
+
+  /**
+   * WhatsApp is connected when Meta Cloud API credentials are stored.
+   */
+  isConnected(): boolean {
+    return hasWhatsAppCredentials();
+  },
+
+  async testConnection(_token: string): Promise<ConnectionInfo> {
+    if (!hasWhatsAppCredentials()) {
+      return {
+        connected: false,
+        user: 'unknown',
+        platform: 'whatsapp',
+        metadata: { error: 'No WhatsApp credentials found. Configure WHATSAPP_PHONE_NUMBER_ID and WHATSAPP_ACCESS_TOKEN.' },
+      };
+    }
+
+    const phoneNumberId = getSecureKey('credential:whatsapp:phone_number_id')!;
+
+    return {
+      connected: true,
+      user: phoneNumberId,
+      platform: 'whatsapp',
+      metadata: {
+        phoneNumberId: phoneNumberId.slice(0, 6) + '...',
+      },
+    };
+  },
+
+  async sendMessage(_token: string, conversationId: string, text: string, options?: SendOptions): Promise<SendResult> {
+    const gatewayUrl = getGatewayUrl();
+    const bearerToken = getBearerToken();
+    const assistantId = options?.assistantId;
+
+    await whatsapp.sendMessage(gatewayUrl, bearerToken, conversationId, text, assistantId);
+
+    // Upsert external conversation binding so the conversation key mapping
+    // exists for the next inbound WhatsApp message from this number.
+    try {
+      const sourceChannel = 'whatsapp';
+      const conversationKey = assistantId && assistantId !== 'self'
+        ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
+        : `${sourceChannel}:${conversationId}`;
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      if (!assistantId || assistantId === 'self') {
+        externalConversationStore.upsertOutboundBinding({
+          conversationId: internalId,
+          sourceChannel,
+          externalChatId: conversationId,
+        });
+      }
+    } catch {
+      // Best-effort — don't fail the send if binding upsert fails
+    }
+
+    return {
+      id: `whatsapp-${Date.now()}`,
+      timestamp: Date.now(),
+      conversationId,
+    };
+  },
+
+  // WhatsApp does not support listing conversations via this provider.
+  async listConversations(_token: string, _options?: ListOptions): Promise<Conversation[]> {
+    return [];
+  },
+
+  // WhatsApp does not provide message history retrieval via the gateway.
+  async getHistory(_token: string, _conversationId: string, _options?: HistoryOptions): Promise<Message[]> {
+    return [];
+  },
+
+  // WhatsApp does not support message search.
+  async search(_token: string, _query: string, _options?: SearchOptions): Promise<SearchResult> {
+    return { total: 0, messages: [], hasMore: false };
+  },
+};

--- a/assistant/src/messaging/providers/whatsapp/client.ts
+++ b/assistant/src/messaging/providers/whatsapp/client.ts
@@ -1,0 +1,67 @@
+/**
+ * Low-level WhatsApp operations.
+ *
+ * Outbound message delivery routes through the gateway's /deliver/whatsapp
+ * endpoint, which handles WhatsApp credential management and the Meta Cloud API.
+ */
+
+const DELIVERY_TIMEOUT_MS = 30_000;
+
+export class WhatsAppApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WhatsAppApiError';
+  }
+}
+
+/** Payload accepted by the gateway's /deliver/whatsapp endpoint. */
+interface DeliverPayload {
+  to: string;
+  text: string;
+  assistantId?: string;
+}
+
+/** Result returned by sendMessage. */
+export interface WhatsAppSendResult {
+  ok: boolean;
+}
+
+/**
+ * Send a WhatsApp message via the gateway's /deliver/whatsapp endpoint.
+ */
+export async function sendMessage(
+  gatewayUrl: string,
+  bearerToken: string,
+  to: string,
+  text: string,
+  assistantId?: string,
+): Promise<WhatsAppSendResult> {
+  const payload: DeliverPayload = { to, text };
+  if (assistantId) {
+    payload.assistantId = assistantId;
+  }
+
+  const url = `${gatewayUrl}/deliver/whatsapp`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '<unreadable>');
+    throw new WhatsAppApiError(
+      resp.status,
+      `Gateway /deliver/whatsapp failed (${resp.status}): ${body}`,
+    );
+  }
+
+  return { ok: true };
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { getLogger, type LogFileConfig } from "./logger.js";
-import { getRootDir, readKeychainCredential, readCredential, readTwilioCredentials } from "./credential-reader.js";
+import { getRootDir, readKeychainCredential, readCredential, readTwilioCredentials, readWhatsAppCredentials } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -60,6 +60,22 @@ export type GatewayConfig = {
   /** Canonical public ingress base URL, used for webhook signature reconstruction. */
   ingressPublicBaseUrl: string | undefined;
   unmappedPolicy: "reject" | "default";
+  /** WhatsApp Business phone number ID (numeric string, e.g. "123456789012345"). */
+  whatsappPhoneNumberId: string | undefined;
+  /** WhatsApp access token (System User token or temporary token from Meta developer portal). */
+  whatsappAccessToken: string | undefined;
+  /** WhatsApp app secret used to verify X-Hub-Signature-256 on incoming webhooks. */
+  whatsappAppSecret: string | undefined;
+  /** Webhook verify token used during the Meta webhook subscription handshake. */
+  whatsappWebhookVerifyToken: string | undefined;
+  /**
+   * When true, the /deliver/whatsapp endpoint allows unauthenticated access
+   * even when no bearer token is configured. Intended for local development only.
+   */
+  whatsappDeliverAuthBypass: boolean;
+  whatsappTimeoutMs: number;
+  whatsappMaxRetries: number;
+  whatsappInitialBackoffMs: number;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -283,6 +299,44 @@ export function loadConfig(): GatewayConfig {
       || undefined;
   }
 
+  // WhatsApp credentials: env var > credential store (keychain / encrypted file)
+  const whatsappCreds = readWhatsAppCredentials();
+  const whatsappPhoneNumberId =
+    process.env.WHATSAPP_PHONE_NUMBER_ID || whatsappCreds?.phoneNumberId || undefined;
+  const whatsappAccessToken =
+    process.env.WHATSAPP_ACCESS_TOKEN || whatsappCreds?.accessToken || undefined;
+  const whatsappAppSecret =
+    process.env.WHATSAPP_APP_SECRET || whatsappCreds?.appSecret || undefined;
+  const whatsappWebhookVerifyToken =
+    process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN || whatsappCreds?.webhookVerifyToken || undefined;
+
+  const whatsappDeliverAuthBypassRaw = process.env.GATEWAY_WHATSAPP_DELIVER_AUTH_BYPASS;
+  if (
+    whatsappDeliverAuthBypassRaw !== undefined &&
+    whatsappDeliverAuthBypassRaw !== "true" &&
+    whatsappDeliverAuthBypassRaw !== "false"
+  ) {
+    throw new Error(
+      `GATEWAY_WHATSAPP_DELIVER_AUTH_BYPASS must be "true" or "false", got "${whatsappDeliverAuthBypassRaw}"`,
+    );
+  }
+  const whatsappDeliverAuthBypass = whatsappDeliverAuthBypassRaw === "true";
+
+  const whatsappTimeoutMs = Number(process.env.GATEWAY_WHATSAPP_TIMEOUT_MS || "15000");
+  if (!Number.isFinite(whatsappTimeoutMs) || whatsappTimeoutMs <= 0) {
+    throw new Error("GATEWAY_WHATSAPP_TIMEOUT_MS must be a positive number");
+  }
+
+  const whatsappMaxRetries = Number(process.env.GATEWAY_WHATSAPP_MAX_RETRIES || "3");
+  if (!Number.isInteger(whatsappMaxRetries) || whatsappMaxRetries < 0) {
+    throw new Error("GATEWAY_WHATSAPP_MAX_RETRIES must be a non-negative integer");
+  }
+
+  const whatsappInitialBackoffMs = Number(process.env.GATEWAY_WHATSAPP_INITIAL_BACKOFF_MS || "1000");
+  if (!Number.isFinite(whatsappInitialBackoffMs) || whatsappInitialBackoffMs <= 0) {
+    throw new Error("GATEWAY_WHATSAPP_INITIAL_BACKOFF_MS must be a positive number");
+  }
+
   const smsDeliverAuthBypassRaw = process.env.GATEWAY_SMS_DELIVER_AUTH_BYPASS;
   if (
     smsDeliverAuthBypassRaw !== undefined &&
@@ -327,6 +381,11 @@ export function loadConfig(): GatewayConfig {
       assistantPhoneNumberCount: assistantPhoneNumbers ? Object.keys(assistantPhoneNumbers).length : 0,
       smsDeliverAuthBypass,
       ingressPublicBaseUrl,
+      hasWhatsAppPhoneNumberId: !!whatsappPhoneNumberId,
+      hasWhatsAppAccessToken: !!whatsappAccessToken,
+      hasWhatsAppAppSecret: !!whatsappAppSecret,
+      hasWhatsAppWebhookVerifyToken: !!whatsappWebhookVerifyToken,
+      whatsappDeliverAuthBypass,
     },
     "Configuration loaded",
   );
@@ -364,5 +423,13 @@ export function loadConfig(): GatewayConfig {
     smsDeliverAuthBypass,
     ingressPublicBaseUrl,
     unmappedPolicy,
+    whatsappPhoneNumberId,
+    whatsappAccessToken,
+    whatsappAppSecret,
+    whatsappWebhookVerifyToken,
+    whatsappDeliverAuthBypass,
+    whatsappTimeoutMs,
+    whatsappMaxRetries,
+    whatsappInitialBackoffMs,
   };
 }

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -298,3 +298,70 @@ export function readTwilioCredentials(): TwilioCredentials | null {
     return null;
   }
 }
+
+export type WhatsAppCredentials = {
+  /** WhatsApp Business phone number ID (numeric string). */
+  phoneNumberId: string;
+  /** Long-lived System User access token or temporary access token. */
+  accessToken: string;
+  /** App secret used to verify X-Hub-Signature-256 on incoming webhooks. */
+  appSecret: string;
+  /** Webhook verify token used during the Meta webhook subscription handshake. */
+  webhookVerifyToken: string;
+};
+
+/**
+ * Check the credential metadata file for WhatsApp credentials and read
+ * them from secure storage (keychain on macOS, then encrypted store).
+ *
+ * Returns `null` if:
+ * - The metadata file doesn't exist or can't be parsed
+ * - Required WhatsApp entries are missing from metadata
+ * - The actual secret values can't be read from any backend
+ */
+export function readWhatsAppCredentials(): WhatsAppCredentials | null {
+  try {
+    const metadataPath = getMetadataPath();
+    if (!existsSync(metadataPath)) return null;
+
+    const raw = readFileSync(metadataPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || !Array.isArray(data.credentials)) return null;
+
+    const hasPhoneNumberId = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "whatsapp" && c.field === "phone_number_id",
+    );
+    const hasAccessToken = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "whatsapp" && c.field === "access_token",
+    );
+    const hasAppSecret = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "whatsapp" && c.field === "app_secret",
+    );
+    const hasWebhookVerifyToken = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "whatsapp" && c.field === "webhook_verify_token",
+    );
+
+    if (!hasPhoneNumberId || !hasAccessToken || !hasAppSecret || !hasWebhookVerifyToken) return null;
+
+    const phoneNumberId = readCredentialWithFallback("credential:whatsapp:phone_number_id");
+    const accessToken = readCredentialWithFallback("credential:whatsapp:access_token");
+    const appSecret = readCredentialWithFallback("credential:whatsapp:app_secret");
+    const webhookVerifyToken = readCredentialWithFallback("credential:whatsapp:webhook_verify_token");
+
+    if (!phoneNumberId || !accessToken || !appSecret || !webhookVerifyToken) {
+      log.warn(
+        "WhatsApp credential metadata exists but secrets could not be read from any backend",
+      );
+      return null;
+    }
+
+    return { phoneNumberId, accessToken, appSecret, webhookVerifyToken };
+  } catch (err) {
+    log.debug({ err }, "Failed to read WhatsApp credentials");
+    return null;
+  }
+}

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -14,8 +14,10 @@ import {
   getMetadataPath,
   readTelegramCredentials,
   readTwilioCredentials,
+  readWhatsAppCredentials,
   type TelegramCredentials,
   type TwilioCredentials,
+  type WhatsAppCredentials,
 } from "./credential-reader.js";
 
 const log = getLogger("credential-watcher");
@@ -27,6 +29,8 @@ export type CredentialChangeEvent = {
   telegramChanged: boolean;
   twilioCredentials: TwilioCredentials | null;
   twilioChanged: boolean;
+  whatsappCredentials: WhatsAppCredentials | null;
+  whatsappChanged: boolean;
 };
 
 export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
@@ -39,6 +43,10 @@ export class CredentialWatcher {
   private lastWebhookSecret: string | undefined;
   private lastTwilioAccountSid: string | undefined;
   private lastTwilioAuthToken: string | undefined;
+  private lastWhatsAppPhoneNumberId: string | undefined;
+  private lastWhatsAppAccessToken: string | undefined;
+  private lastWhatsAppAppSecret: string | undefined;
+  private lastWhatsAppWebhookVerifyToken: string | undefined;
   private callback: CredentialChangeCallback;
   private metadataPath: string;
 
@@ -123,11 +131,16 @@ export class CredentialWatcher {
   private pollOnce(): void {
     const telegramCredentials = readTelegramCredentials();
     const twilioCredentials = readTwilioCredentials();
+    const whatsappCredentials = readWhatsAppCredentials();
 
     const newBotToken = telegramCredentials?.botToken;
     const newWebhookSecret = telegramCredentials?.webhookSecret;
     const newTwilioAccountSid = twilioCredentials?.accountSid;
     const newTwilioAuthToken = twilioCredentials?.authToken;
+    const newWhatsAppPhoneNumberId = whatsappCredentials?.phoneNumberId;
+    const newWhatsAppAccessToken = whatsappCredentials?.accessToken;
+    const newWhatsAppAppSecret = whatsappCredentials?.appSecret;
+    const newWhatsAppWebhookVerifyToken = whatsappCredentials?.webhookVerifyToken;
 
     const telegramChanged =
       newBotToken !== this.lastBotToken ||
@@ -137,7 +150,13 @@ export class CredentialWatcher {
       newTwilioAccountSid !== this.lastTwilioAccountSid ||
       newTwilioAuthToken !== this.lastTwilioAuthToken;
 
-    if (!telegramChanged && !twilioChanged) {
+    const whatsappChanged =
+      newWhatsAppPhoneNumberId !== this.lastWhatsAppPhoneNumberId ||
+      newWhatsAppAccessToken !== this.lastWhatsAppAccessToken ||
+      newWhatsAppAppSecret !== this.lastWhatsAppAppSecret ||
+      newWhatsAppWebhookVerifyToken !== this.lastWhatsAppWebhookVerifyToken;
+
+    if (!telegramChanged && !twilioChanged && !whatsappChanged) {
       return;
     }
 
@@ -145,6 +164,10 @@ export class CredentialWatcher {
     this.lastWebhookSecret = newWebhookSecret;
     this.lastTwilioAccountSid = newTwilioAccountSid;
     this.lastTwilioAuthToken = newTwilioAuthToken;
+    this.lastWhatsAppPhoneNumberId = newWhatsAppPhoneNumberId;
+    this.lastWhatsAppAccessToken = newWhatsAppAccessToken;
+    this.lastWhatsAppAppSecret = newWhatsAppAppSecret;
+    this.lastWhatsAppWebhookVerifyToken = newWhatsAppWebhookVerifyToken;
 
     if (telegramChanged) {
       log.info(
@@ -158,12 +181,20 @@ export class CredentialWatcher {
         "Twilio credentials changed",
       );
     }
+    if (whatsappChanged) {
+      log.info(
+        { hasCredentials: !!whatsappCredentials },
+        "WhatsApp credentials changed",
+      );
+    }
 
     this.callback({
       telegramCredentials,
       telegramChanged,
       twilioCredentials,
       twilioChanged,
+      whatsappCredentials,
+      whatsappChanged,
     });
   }
 }

--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -1,0 +1,92 @@
+import type { GatewayConfig } from "../../config.js";
+import { validateBearerToken } from "../auth/bearer.js";
+import { getLogger } from "../../logger.js";
+import { sendWhatsAppReply } from "../../whatsapp/send.js";
+
+const log = getLogger("whatsapp-deliver");
+
+export function createWhatsAppDeliverHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    // Fail-closed auth: when no bearer token is configured and the explicit
+    // dev-only bypass flag is not set, refuse to serve requests (503) rather
+    // than silently allowing unauthenticated access.
+    if (!config.runtimeProxyBearerToken) {
+      if (config.whatsappDeliverAuthBypass) {
+        // Dev-only bypass — skip auth entirely.
+      } else {
+        return Response.json(
+          { error: "Service not configured: bearer token required" },
+          { status: 503 },
+        );
+      }
+    } else {
+      const authResult = validateBearerToken(
+        req.headers.get("authorization"),
+        config.runtimeProxyBearerToken,
+      );
+      if (!authResult.authorized) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
+    }
+
+    // Verify WhatsApp sending is configured
+    if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+      tlog.error("WhatsApp credentials not configured");
+      return Response.json(
+        { error: "WhatsApp integration not configured" },
+        { status: 503 },
+      );
+    }
+
+    let body: {
+      chatId?: string;
+      to?: string;
+      text?: string;
+      assistantId?: string;
+      attachments?: unknown[];
+    };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Accept `chatId` as an alias for `to` — runtime channel callbacks send `{ chatId, text }`.
+    const to = body.to ?? body.chatId;
+
+    if (!to || typeof to !== "string") {
+      return Response.json({ error: "to is required" }, { status: 400 });
+    }
+
+    const { text } = body;
+
+    // When text is missing but attachments are present, produce a graceful fallback
+    // since WhatsApp media delivery is not yet implemented.
+    const hasAttachments = Array.isArray(body.attachments) && body.attachments.length > 0;
+    const effectiveText =
+      (!text || (typeof text === "string" && text.trim().length === 0)) && hasAttachments
+        ? "I have a media attachment to share, but WhatsApp media delivery is not yet supported."
+        : text;
+
+    if (!effectiveText || typeof effectiveText !== "string") {
+      return Response.json({ error: "text is required" }, { status: 400 });
+    }
+
+    try {
+      await sendWhatsAppReply(config, to, effectiveText);
+    } catch (err) {
+      tlog.error({ err, to }, "Failed to deliver WhatsApp reply");
+      return Response.json({ error: "Delivery failed" }, { status: 502 });
+    }
+
+    tlog.info({ to, textLength: effectiveText.length }, "WhatsApp reply sent");
+    return Response.json({ ok: true });
+  };
+}

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -1,0 +1,258 @@
+import type { GatewayConfig } from "../../config.js";
+import { StringDedupCache } from "../../dedup-cache.js";
+import { handleInbound } from "../../handlers/handle-inbound.js";
+import { getLogger } from "../../logger.js";
+import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
+import { resetConversation } from "../../runtime/client.js";
+import { markWhatsAppMessageRead } from "../../whatsapp/api.js";
+import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
+import { sendWhatsAppReply } from "../../whatsapp/send.js";
+import { verifyWhatsAppWebhookSignature } from "../../whatsapp/verify.js";
+
+const log = getLogger("whatsapp-webhook");
+
+// Rate limiter for routing rejection notices — at most one reply per sender
+// within the cooldown window to avoid spamming the user.
+const REJECTION_NOTICE_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_REJECTION_CACHE_SIZE = 10_000;
+const SWEEP_INTERVAL = 100;
+const rejectionNoticeTimestamps = new Map<string, number>();
+let rejectionCallCount = 0;
+
+function sweepRejectionCache(now: number): void {
+  for (const [key, ts] of rejectionNoticeTimestamps) {
+    if (now - ts >= REJECTION_NOTICE_COOLDOWN_MS) {
+      rejectionNoticeTimestamps.delete(key);
+    }
+  }
+  if (rejectionNoticeTimestamps.size > MAX_REJECTION_CACHE_SIZE) {
+    const sorted = [...rejectionNoticeTimestamps.entries()].sort((a, b) => a[1] - b[1]);
+    const toRemove = sorted.length - MAX_REJECTION_CACHE_SIZE;
+    for (let i = 0; i < toRemove; i++) {
+      rejectionNoticeTimestamps.delete(sorted[i][0]);
+    }
+  }
+}
+
+function shouldSendRejectionNotice(senderId: string): boolean {
+  const now = Date.now();
+  rejectionCallCount++;
+  if (rejectionCallCount >= SWEEP_INTERVAL) {
+    rejectionCallCount = 0;
+    sweepRejectionCache(now);
+  }
+  const lastSent = rejectionNoticeTimestamps.get(senderId);
+  if (lastSent !== undefined && now - lastSent < REJECTION_NOTICE_COOLDOWN_MS) {
+    return false;
+  }
+  rejectionNoticeTimestamps.set(senderId, now);
+  return true;
+}
+
+export const WHATSAPP_CHANNEL_TRANSPORT_HINTS = [
+  "chat-first-medium",
+  "channel-safe-onboarding",
+  "defer-dashboard-only-tasks",
+  "whatsapp-formatting",
+] as const;
+
+export const WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF =
+  "WhatsApp is a mobile messaging channel. Keep responses concise and use plain text; avoid markdown tables and complex formatting.";
+
+export function buildWhatsAppTransportMetadata(): { hints: string[]; uxBrief: string } {
+  return {
+    hints: [...WHATSAPP_CHANNEL_TRANSPORT_HINTS],
+    uxBrief: WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF,
+  };
+}
+
+export function createWhatsAppWebhookHandler(config: GatewayConfig) {
+  // 24-hour TTL — WhatsApp message IDs are globally unique and never reused
+  const dedupCache = new StringDedupCache(24 * 60 * 60_000);
+
+  return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
+    // Meta sends a GET request to verify the webhook subscription
+    if (req.method === "GET") {
+      const url = new URL(req.url);
+      const mode = url.searchParams.get("hub.mode");
+      const token = url.searchParams.get("hub.verify_token");
+      const challenge = url.searchParams.get("hub.challenge");
+
+      if (mode === "subscribe" && token && config.whatsappWebhookVerifyToken) {
+        if (token === config.whatsappWebhookVerifyToken) {
+          tlog.info("WhatsApp webhook verify token validated");
+          // Return the challenge as plain text to complete the handshake
+          return new Response(challenge ?? "", { status: 200 });
+        }
+        tlog.warn("WhatsApp webhook verify token mismatch");
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+      }
+      return Response.json({ error: "Bad Request" }, { status: 400 });
+    }
+
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    // Payload size guard
+    const contentLength = req.headers.get("content-length");
+    if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
+      tlog.warn({ contentLength }, "WhatsApp webhook payload too large");
+      return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    let rawBody: string;
+    try {
+      rawBody = await req.text();
+    } catch {
+      return Response.json({ error: "Failed to read body" }, { status: 400 });
+    }
+
+    if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
+      tlog.warn({ bodyLength: Buffer.byteLength(rawBody) }, "WhatsApp webhook payload too large");
+      return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    // Verify HMAC-SHA256 signature when app secret is configured.
+    // Fail-closed: reject if the secret is set but verification fails.
+    if (config.whatsappAppSecret) {
+      if (!verifyWhatsAppWebhookSignature(req.headers, rawBody, config.whatsappAppSecret)) {
+        tlog.warn("WhatsApp webhook signature verification failed");
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const normalized = normalizeWhatsAppWebhook(payload);
+    if (!normalized) {
+      // Deliver receipts, status updates, non-text messages, etc. — acknowledge silently
+      return Response.json({ ok: true });
+    }
+
+    const { event, whatsappMessageId } = normalized;
+    const from = event.message.externalChatId;
+
+    // Dedup by WhatsApp message ID — atomically reserve so concurrent retries
+    // are blocked while the first request is still processing.
+    if (!dedupCache.reserve(whatsappMessageId)) {
+      tlog.info({ whatsappMessageId }, "Duplicate WhatsApp message ID, ignoring");
+      return Response.json({ ok: true });
+    }
+
+    tlog.info(
+      {
+        source: "whatsapp",
+        messageId: whatsappMessageId,
+        from,
+      },
+      "WhatsApp webhook received",
+    );
+
+    // Mark message as read (best-effort, do not await)
+    markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
+      tlog.debug({ err, messageId: whatsappMessageId }, "Failed to mark WhatsApp message as read");
+    });
+
+    // Resolve routing once so we can gate further operations on it
+    const routing = resolveAssistant(config, from, from);
+
+    // Handle /new command — reset conversation before it reaches the runtime
+    if (event.message.content.trim().toLowerCase() === "/new") {
+      if (isRejection(routing)) {
+        tlog.warn({ from, reason: routing.reason }, "Routing rejected /new command");
+        sendWhatsAppReply(
+          config,
+          from,
+          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+        ).catch((err) => {
+          tlog.error({ err, to: from }, "Failed to send /new routing rejection notice");
+        });
+      } else {
+        try {
+          await resetConversation(
+            config,
+            routing.assistantId,
+            event.sourceChannel,
+            event.message.externalChatId,
+          );
+          sendWhatsAppReply(config, from, "Starting a new conversation!").catch((err) => {
+            tlog.error({ err }, "Failed to send /new confirmation");
+          });
+        } catch (err) {
+          tlog.error({ err }, "Failed to reset conversation");
+          sendWhatsAppReply(config, from, "Failed to reset conversation. Please try again.").catch(
+            (replyErr) => {
+              tlog.error({ err: replyErr }, "Failed to send /new error reply");
+            },
+          );
+        }
+      }
+
+      dedupCache.mark(whatsappMessageId);
+      return Response.json({ ok: true });
+    }
+
+    if (isRejection(routing)) {
+      tlog.warn({ from, reason: routing.reason }, "Routing rejected inbound WhatsApp message");
+      if (shouldSendRejectionNotice(from)) {
+        sendWhatsAppReply(
+          config,
+          from,
+          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+        ).catch((err) => {
+          tlog.error({ err, to: from }, "Failed to send routing rejection notice");
+        });
+      }
+      dedupCache.mark(whatsappMessageId);
+      return Response.json({ ok: true });
+    }
+
+    try {
+      const result = await handleInbound(config, event, {
+        transportMetadata: buildWhatsAppTransportMetadata(),
+        replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/whatsapp`,
+        traceId,
+        routingOverride: routing,
+      });
+
+      if (result.rejected) {
+        tlog.warn({ from, reason: result.rejectionReason }, "Routing rejected inbound WhatsApp message");
+        if (shouldSendRejectionNotice(from)) {
+          sendWhatsAppReply(
+            config,
+            from,
+            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+          ).catch((err) => {
+            tlog.error({ err, to: from }, "Failed to send routing rejection notice");
+          });
+        }
+        dedupCache.mark(whatsappMessageId);
+        return Response.json({ ok: true });
+      }
+
+      if (!result.forwarded) {
+        tlog.error({ whatsappMessageId }, "Failed to forward WhatsApp message to runtime");
+        dedupCache.unreserve(whatsappMessageId);
+        return Response.json({ error: "Internal error" }, { status: 500 });
+      }
+
+      dedupCache.mark(whatsappMessageId);
+      tlog.info({ status: "forwarded", whatsappMessageId }, "WhatsApp message forwarded to runtime");
+    } catch (err) {
+      tlog.error({ err, whatsappMessageId }, "Failed to process inbound WhatsApp message");
+      dedupCache.unreserve(whatsappMessageId);
+      return Response.json({ error: "Internal error" }, { status: 500 });
+    }
+
+    return Response.json({ ok: true });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -12,6 +12,8 @@ import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-co
 import { createTwilioRelayWebsocketHandler, getRelayWebsocketHandlers } from "./http/routes/twilio-relay-websocket.js";
 import { createTwilioSmsWebhookHandler } from "./http/routes/twilio-sms-webhook.js";
 import { createSmsDeliverHandler } from "./http/routes/sms-deliver.js";
+import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
+import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { getLogger, initLogger } from "./logger.js";
 import { buildSchema } from "./schema.js";
@@ -39,12 +41,17 @@ function main() {
   const isTelegramConfigured = () =>
     !!(config.telegramBotToken && config.telegramWebhookSecret);
 
+  const isWhatsAppConfigured = () =>
+    !!(config.whatsappPhoneNumberId && config.whatsappAccessToken);
+
   const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(config);
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
   const handleTwilioSmsWebhook = createTwilioSmsWebhookHandler(config);
   const handleSmsDeliver = createSmsDeliverHandler(config);
+  const handleWhatsAppWebhook = createWhatsAppWebhookHandler(config);
+  const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
@@ -136,6 +143,26 @@ function main() {
         return handleSmsDeliver(tracedReq);
       }
 
+      if (url.pathname === "/webhooks/whatsapp") {
+        if (!isWhatsAppConfigured()) {
+          return Response.json(
+            { error: "WhatsApp integration not configured" },
+            { status: 503 },
+          );
+        }
+        return handleWhatsAppWebhook(tracedReq);
+      }
+
+      if (url.pathname === "/deliver/whatsapp") {
+        if (!isWhatsAppConfigured()) {
+          return Response.json(
+            { error: "WhatsApp integration not configured" },
+            { status: 503 },
+          );
+        }
+        return handleWhatsAppDeliver(tracedReq);
+      }
+
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
@@ -203,6 +230,22 @@ function main() {
         config.twilioAccountSid = undefined;
         config.twilioAuthToken = undefined;
         log.info("Twilio credentials cleared");
+      }
+    }
+
+    if (event.whatsappChanged) {
+      if (event.whatsappCredentials) {
+        config.whatsappPhoneNumberId = event.whatsappCredentials.phoneNumberId;
+        config.whatsappAccessToken = event.whatsappCredentials.accessToken;
+        config.whatsappAppSecret = event.whatsappCredentials.appSecret;
+        config.whatsappWebhookVerifyToken = event.whatsappCredentials.webhookVerifyToken;
+        log.info("WhatsApp credentials loaded from credential vault");
+      } else {
+        config.whatsappPhoneNumberId = undefined;
+        config.whatsappAccessToken = undefined;
+        config.whatsappAppSecret = undefined;
+        config.whatsappWebhookVerifyToken = undefined;
+        log.info("WhatsApp credentials cleared");
       }
     }
   });

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -440,6 +440,197 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/webhooks/whatsapp": {
+        get: {
+          summary: "WhatsApp webhook verification",
+          description:
+            "Handles the Meta webhook subscription verification handshake (hub.mode=subscribe). Returns the hub.challenge value as plain text to complete verification.",
+          operationId: "whatsappWebhookVerify",
+          parameters: [
+            {
+              name: "hub.mode",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "hub.verify_token",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "hub.challenge",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Verification successful — challenge echoed as plain text",
+              content: {
+                "text/plain": { schema: { type: "string" } },
+              },
+            },
+            "400": {
+              description: "Missing parameters",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "403": {
+              description: "Verify token mismatch",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+        post: {
+          summary: "WhatsApp webhook",
+          description:
+            "Receives inbound WhatsApp Cloud API webhook events, verifies the X-Hub-Signature-256 signature, normalizes text messages, and forwards them to the assistant runtime.",
+          operationId: "whatsappWebhook",
+          security: [{ WhatsAppHubSignature: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WhatsAppWebhookPayload" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Webhook accepted",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/WhatsAppOk" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid JSON or unreadable body",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "403": {
+              description: "Signature verification failed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "413": {
+              description: "Payload too large",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "500": {
+              description: "Internal error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "WhatsApp integration not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/deliver/whatsapp": {
+        post: {
+          summary: "WhatsApp delivery (internal)",
+          description:
+            "Internal endpoint called by the assistant runtime to deliver outbound WhatsApp messages. Not intended for external use.",
+          operationId: "whatsappDeliver",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WhatsAppDeliverRequest" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Message delivered",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/WhatsAppOk" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid JSON or missing required fields",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to deliver via WhatsApp API",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "WhatsApp integration not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/webhooks/twilio/relay": {
         get: {
           summary: "Twilio ConversationRelay WebSocket",
@@ -836,6 +1027,53 @@ export function buildSchema(): Record<string, unknown> {
             file_size: { type: "integer" },
           },
         },
+        WhatsAppOk: {
+          type: "object",
+          required: ["ok"],
+          properties: {
+            ok: { type: "boolean" },
+          },
+        },
+        WhatsAppWebhookPayload: {
+          type: "object",
+          description: "WhatsApp Cloud API webhook notification payload",
+          properties: {
+            object: { type: "string", enum: ["whatsapp_business_account"] },
+            entry: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  changes: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        field: { type: "string" },
+                        value: { type: "object", additionalProperties: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        WhatsAppDeliverRequest: {
+          type: "object",
+          description: "Request to deliver a WhatsApp text message. Accepts either `to` or `chatId` (alias).",
+          properties: {
+            to: { type: "string", description: "Recipient WhatsApp phone number in E.164 format" },
+            chatId: { type: "string", description: "Alias for `to` — used by runtime channel callback payloads" },
+            text: { type: "string", description: "Text content to send", minLength: 1 },
+            assistantId: { type: "string", description: "Optional assistant ID" },
+            attachments: { type: "array", items: { type: "object" }, description: "Attachments (not yet supported — a fallback text is sent instead)" },
+          },
+          allOf: [
+            { anyOf: [{ required: ["to"] }, { required: ["chatId"] }] },
+          ],
+        },
         TelegramDeliverRequest: {
           type: "object",
           required: ["chatId"],
@@ -885,6 +1123,12 @@ export function buildSchema(): Record<string, unknown> {
           in: "header",
           name: "X-Twilio-Signature",
           description: "HMAC-SHA1 signature computed by Twilio over the request URL and form parameters.",
+        },
+        WhatsAppHubSignature: {
+          type: "apiKey",
+          in: "header",
+          name: "X-Hub-Signature-256",
+          description: "HMAC-SHA256 signature computed by Meta over the raw request body using the app secret.",
         },
       },
     },

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -1,6 +1,6 @@
 export type GatewayInboundEventV1 = {
   version: "v1";
-  sourceChannel: "telegram" | "sms";
+  sourceChannel: "telegram" | "sms" | "whatsapp";
   receivedAt: string;
   routing: {
     assistantId: string;

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -1,0 +1,184 @@
+import type { GatewayConfig } from "../config.js";
+import { fetchImpl } from "../fetch.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("whatsapp-api");
+
+// Meta Cloud API v20 endpoint template
+const WHATSAPP_API_BASE = "https://graph.facebook.com/v20.0";
+
+interface WhatsAppApiErrorDetail {
+  message?: string;
+  type?: string;
+  code?: number;
+  fbtrace_id?: string;
+}
+
+interface WhatsAppApiErrorResponse {
+  error?: WhatsAppApiErrorDetail;
+}
+
+function isRetryable(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function computeDelay(
+  attempt: number,
+  initialBackoffMs: number,
+  retryAfterHeader: string | null,
+): number {
+  if (retryAfterHeader) {
+    const seconds = Number(retryAfterHeader);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, 2_147_483_647);
+    }
+    const targetTime = new Date(retryAfterHeader).getTime();
+    if (Number.isFinite(targetTime)) {
+      const delayMs = targetTime - Date.now();
+      if (delayMs > 0) {
+        return Math.min(delayMs, 2_147_483_647);
+      }
+    }
+  }
+
+  const exponential = initialBackoffMs * Math.pow(2, attempt - 1);
+  const jitter = Math.random() * exponential * 0.5;
+  return exponential + jitter;
+}
+
+async function retryableWhatsAppFetch<T>(
+  config: GatewayConfig,
+  operation: string,
+  doFetch: () => Promise<Response>,
+): Promise<T> {
+  let lastError: Error | null = null;
+  let lastRetryAfter: string | null = null;
+
+  for (let attempt = 0; attempt <= config.whatsappMaxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = computeDelay(
+        attempt,
+        config.whatsappInitialBackoffMs,
+        lastRetryAfter,
+      );
+      log.debug({ attempt, delay, operation }, "Retrying WhatsApp API call");
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    lastRetryAfter = null;
+
+    let response: Response;
+    try {
+      response = await doFetch();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError = new Error(`WhatsApp ${operation} request failed: ${message}`);
+      log.warn({ error: message, attempt, operation }, "WhatsApp API fetch failed");
+      continue;
+    }
+
+    if (!isRetryable(response.status) && !response.ok) {
+      const data = (await response.json().catch(() => ({}))) as WhatsAppApiErrorResponse;
+      throw new Error(
+        data.error?.message
+          ? `WhatsApp ${operation} failed: ${data.error.message}`
+          : `WhatsApp ${operation} failed with status ${response.status}`,
+      );
+    }
+
+    if (isRetryable(response.status)) {
+      lastRetryAfter = response.headers.get("retry-after");
+      const data = (await response.json().catch(() => ({}))) as WhatsAppApiErrorResponse;
+      lastError = new Error(
+        data.error?.message
+          ? `WhatsApp ${operation} failed: ${data.error.message}`
+          : `WhatsApp ${operation} failed with status ${response.status}`,
+      );
+      log.warn(
+        { status: response.status, attempt, operation, retryAfter: lastRetryAfter },
+        "WhatsApp API returned retryable error",
+      );
+      continue;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
+}
+
+export interface WhatsAppSendMessageResult {
+  messaging_product: string;
+  contacts: Array<{ input: string; wa_id: string }>;
+  messages: Array<{ id: string }>;
+}
+
+/**
+ * Send a text message via the WhatsApp Business Cloud API.
+ * phoneNumberId is the WhatsApp Business phone number ID (not the phone number itself).
+ */
+export async function sendWhatsAppTextMessage(
+  config: GatewayConfig,
+  to: string,
+  text: string,
+): Promise<WhatsAppSendMessageResult> {
+  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  return retryableWhatsAppFetch<WhatsAppSendMessageResult>(
+    config,
+    "sendMessage",
+    () =>
+      fetchImpl(
+        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.whatsappAccessToken}`,
+          },
+          body: JSON.stringify({
+            messaging_product: "whatsapp",
+            recipient_type: "individual",
+            to,
+            type: "text",
+            text: { body: text, preview_url: false },
+          }),
+          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+        },
+      ),
+  );
+}
+
+/**
+ * Mark an incoming WhatsApp message as read.
+ * Best-effort — callers should not propagate errors from this.
+ */
+export async function markWhatsAppMessageRead(
+  config: GatewayConfig,
+  messageId: string,
+): Promise<void> {
+  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) return;
+
+  try {
+    await fetchImpl(
+      `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.whatsappAccessToken}`,
+        },
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          status: "read",
+          message_id: messageId,
+        }),
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      },
+    );
+  } catch (err) {
+    log.debug({ err, messageId }, "Failed to mark WhatsApp message as read");
+  }
+}

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -1,0 +1,126 @@
+import type { GatewayInboundEventV1 } from "../types.js";
+
+// WhatsApp Cloud API webhook payload shapes
+// https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples
+
+interface WhatsAppContact {
+  profile?: { name?: string };
+  wa_id?: string;
+}
+
+interface WhatsAppTextMessage {
+  id: string;
+  from: string;
+  timestamp: string;
+  type: "text";
+  text: { body: string };
+}
+
+interface WhatsAppAudioMessage {
+  id: string;
+  from: string;
+  timestamp: string;
+  type: "audio" | "video" | "image" | "document" | "sticker";
+}
+
+type WhatsAppMessage = WhatsAppTextMessage | WhatsAppAudioMessage;
+
+interface WhatsAppValue {
+  messaging_product: "whatsapp";
+  metadata?: { phone_number_id?: string; display_phone_number?: string };
+  contacts?: WhatsAppContact[];
+  messages?: WhatsAppMessage[];
+  // statuses are delivery/read receipts — we ignore them
+  statuses?: unknown[];
+}
+
+interface WhatsAppChange {
+  field: string;
+  value?: WhatsAppValue;
+}
+
+interface WhatsAppEntry {
+  id?: string;
+  changes?: WhatsAppChange[];
+}
+
+interface WhatsAppWebhookPayload {
+  object?: string;
+  entry?: WhatsAppEntry[];
+}
+
+export interface NormalizedWhatsAppMessage {
+  event: Omit<GatewayInboundEventV1, "routing">;
+  /** Original WhatsApp message ID — used for marking as read. */
+  whatsappMessageId: string;
+}
+
+/**
+ * Normalize a WhatsApp Cloud API webhook payload into a GatewayInboundEventV1.
+ *
+ * Returns null if:
+ * - The payload is not a WhatsApp messages webhook
+ * - The message type is not text (audio/video/image/document are unsupported)
+ * - Required fields are missing
+ *
+ * Only processes the first text message from the first entry/change to keep the
+ * handler simple. Meta recommends acknowledging all webhooks regardless.
+ */
+export function normalizeWhatsAppWebhook(
+  payload: Record<string, unknown>,
+): NormalizedWhatsAppMessage | null {
+  const wh = payload as WhatsAppWebhookPayload;
+
+  if (wh.object !== "whatsapp_business_account") return null;
+
+  const entry = wh.entry?.[0];
+  if (!entry) return null;
+
+  const change = entry.changes?.find((c) => c.field === "messages");
+  if (!change?.value) return null;
+
+  const value = change.value;
+  const messages = value.messages;
+  if (!messages || messages.length === 0) return null;
+
+  const msg = messages[0];
+
+  // Only forward text messages; other types (image, audio, etc.) are not supported
+  if (msg.type !== "text") return null;
+
+  const textMsg = msg as WhatsAppTextMessage;
+  const body = textMsg.text?.body?.trim() ?? "";
+
+  // from is the sender's WhatsApp phone number in E.164 format
+  const from = textMsg.from;
+  if (!from) return null;
+
+  // Resolve display name from contacts array when available
+  const contact = value.contacts?.find((c) => c.wa_id === from);
+  const displayName = contact?.profile?.name ?? from;
+
+  return {
+    whatsappMessageId: textMsg.id,
+    event: {
+      version: "v1",
+      sourceChannel: "whatsapp",
+      receivedAt: new Date(Number(textMsg.timestamp) * 1000).toISOString(),
+      message: {
+        content: body,
+        // Use sender phone number as the chat identifier for 1:1 conversations
+        externalChatId: from,
+        externalMessageId: textMsg.id,
+      },
+      sender: {
+        externalUserId: from,
+        displayName,
+      },
+      source: {
+        updateId: textMsg.id,
+        messageId: textMsg.id,
+        chatType: "private",
+      },
+      raw: payload,
+    },
+  };
+}

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -1,0 +1,45 @@
+import type { GatewayConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+import { sendWhatsAppTextMessage } from "./api.js";
+
+const log = getLogger("whatsapp-send");
+
+// WhatsApp supports up to 4096 characters per text message
+const WHATSAPP_MAX_MESSAGE_LEN = 4096;
+
+function splitText(text: string): string[] {
+  if (text.length <= WHATSAPP_MAX_MESSAGE_LEN) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    let end = Math.min(cursor + WHATSAPP_MAX_MESSAGE_LEN, text.length);
+    // Avoid splitting a surrogate pair
+    if (
+      end < text.length &&
+      text.charCodeAt(end - 1) >= 0xd800 &&
+      text.charCodeAt(end - 1) <= 0xdbff
+    ) {
+      end--;
+    }
+    chunks.push(text.slice(cursor, end));
+    cursor = end;
+  }
+  return chunks;
+}
+
+export async function sendWhatsAppReply(
+  config: GatewayConfig,
+  to: string,
+  text: string,
+): Promise<void> {
+  const chunks = splitText(text);
+
+  for (const chunk of chunks) {
+    await sendWhatsAppTextMessage(config, to, chunk);
+  }
+
+  log.debug({ to, chunks: chunks.length }, "WhatsApp reply sent");
+}

--- a/gateway/src/whatsapp/verify.ts
+++ b/gateway/src/whatsapp/verify.ts
@@ -1,0 +1,31 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verify the X-Hub-Signature-256 header sent by Meta's webhook delivery.
+ *
+ * Meta computes: HMAC-SHA256(appSecret, rawBody) and sends it as
+ *   X-Hub-Signature-256: sha256=<hex-digest>
+ *
+ * We must compare with a constant-time comparison to avoid timing attacks.
+ */
+export function verifyWhatsAppWebhookSignature(
+  headers: Headers,
+  rawBody: string,
+  appSecret: string,
+): boolean {
+  const signatureHeader = headers.get("x-hub-signature-256");
+  if (!signatureHeader || !appSecret) return false;
+
+  // Header format: "sha256=<hex-digest>"
+  if (!signatureHeader.startsWith("sha256=")) return false;
+  const providedHex = signatureHeader.slice(7);
+
+  const expected = createHmac("sha256", appSecret)
+    .update(rawBody, "utf8")
+    .digest("hex");
+
+  // Lengths must match before timingSafeEqual to avoid Buffer size mismatch error
+  if (providedHex.length !== expected.length) return false;
+
+  return timingSafeEqual(Buffer.from(providedHex), Buffer.from(expected));
+}


### PR DESCRIPTION
Add WhatsApp gateway and inbound handler mirroring the existing Telegram/SMS architecture. Handles inbound webhooks via Meta Cloud API, parses messages, and routes to the assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
