### PR TITLE
feat: add message pagination to iOS

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -48,6 +48,10 @@ private struct PersistedThread: Codable {
 class IOSThreadStore: ObservableObject {
     @Published var threads: [IOSThread] = []
     @Published var isConnectedMode: Bool = false
+    /// True while an additional page of threads is being fetched from the daemon.
+    @Published var isLoadingMoreThreads: Bool = false
+    /// Whether the daemon indicated more sessions exist beyond what is currently loaded.
+    @Published var hasMoreThreads: Bool = false
 
     /// ViewModels keyed by thread ID, created lazily on first access.
     private var viewModels: [UUID: ChatViewModel] = [:]
@@ -58,6 +62,10 @@ class IOSThreadStore: ObservableObject {
     private var pendingHistoryBySessionId: [String: UUID] = [:]
     /// Tracks thread IDs that already have an activity-tracking observer to avoid duplicates.
     private var observedActivityThreadIds: Set<UUID> = []
+    /// Number of threads per page when listing sessions from the daemon.
+    private static let threadPageSize = 50
+    /// Current offset used for the next page fetch; advances by `threadPageSize` on each load.
+    private var threadListOffset: Int = 0
 
     init(daemonClient: any DaemonClientProtocol) {
         self.daemonClient = daemonClient
@@ -97,25 +105,35 @@ class IOSThreadStore: ObservableObject {
         // Fetch session list once connected. Try immediately if already connected,
         // otherwise wait for the daemonDidReconnect notification.
         if daemon.isConnected {
-            try? daemon.sendSessionList()
+            threadListOffset = 0
+            try? daemon.sendSessionList(offset: 0, limit: Self.threadPageSize)
         }
 
         NotificationCenter.default.publisher(for: .daemonDidReconnect)
             .sink { [weak self, weak daemon] _ in
-                guard let daemon, self != nil else { return }
-                try? daemon.sendSessionList()
+                guard let self, let daemon else { return }
+                // Reset pagination state on reconnect so the list refreshes from page 1.
+                self.threadListOffset = 0
+                self.hasMoreThreads = false
+                try? daemon.sendSessionList(offset: 0, limit: Self.threadPageSize)
             }
             .store(in: &cancellables)
     }
 
     private func handleSessionListResponse(_ response: SessionListResponseMessage) {
-        guard !response.sessions.isEmpty else { return }
+        let filteredSessions = response.sessions.filter { $0.threadType != "private" }
+        guard !filteredSessions.isEmpty || (response.hasMore == false && threadListOffset == 0) else {
+            // Empty non-first page means nothing more to append.
+            isLoadingMoreThreads = false
+            hasMoreThreads = response.hasMore ?? false
+            return
+        }
 
-        let recentSessions = Array(response.sessions.filter { $0.threadType != "private" }.prefix(10))
-        guard !recentSessions.isEmpty else { return }
+        hasMoreThreads = response.hasMore ?? false
+        isLoadingMoreThreads = false
 
         var restoredThreads: [IOSThread] = []
-        for session in recentSessions {
+        for session in filteredSessions {
             let thread = IOSThread(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
@@ -127,34 +145,60 @@ class IOSThreadStore: ObservableObject {
             restoredThreads.append(thread)
         }
 
-        // Replace the default empty thread with daemon threads
-        let defaultIsEmpty = threads.count == 1
-            && viewModels[threads[0].id]?.messages.isEmpty ?? true
-            && viewModels[threads[0].id]?.sessionId == nil
-        if defaultIsEmpty, let defaultThread = threads.first {
-            viewModels.removeValue(forKey: defaultThread.id)
-            threads = restoredThreads
-        } else {
-            // Deduplicate: only prepend restored threads whose sessionId
-            // doesn't already exist in the current thread list.
-            let existingSessionIds: Set<String> = Set(
-                threads.compactMap { thread -> String? in
-                    // Check both the thread's own sessionId AND the VM's bound sessionId
-                    if let sid = thread.sessionId { return sid }
-                    return viewModels[thread.id]?.sessionId
+        // First page: replace the default empty placeholder thread if present.
+        if threadListOffset == 0 {
+            let defaultIsEmpty = threads.count == 1
+                && viewModels[threads[0].id]?.messages.isEmpty ?? true
+                && viewModels[threads[0].id]?.sessionId == nil
+            if defaultIsEmpty, let defaultThread = threads.first {
+                viewModels.removeValue(forKey: defaultThread.id)
+                threads = restoredThreads
+            } else {
+                // Deduplicate: only prepend restored threads whose sessionId
+                // doesn't already exist in the current thread list.
+                let existingSessionIds: Set<String> = Set(
+                    threads.compactMap { thread -> String? in
+                        // Check both the thread's own sessionId AND the VM's bound sessionId
+                        if let sid = thread.sessionId { return sid }
+                        return viewModels[thread.id]?.sessionId
+                    }
+                )
+                var newThreads: [IOSThread] = []
+                for restored in restoredThreads {
+                    if let sid = restored.sessionId, existingSessionIds.contains(sid) {
+                        // Already have a thread for this session — discard the duplicate VM.
+                        viewModels.removeValue(forKey: restored.id)
+                    } else {
+                        newThreads.append(restored)
+                    }
                 }
-            )
-            var newThreads: [IOSThread] = []
+                threads = newThreads + threads
+            }
+        } else {
+            // Subsequent pages: append only sessions not already in the list.
+            let existingSessionIds: Set<String> = Set(threads.compactMap { thread -> String? in
+                if let sid = thread.sessionId { return sid }
+                return viewModels[thread.id]?.sessionId
+            })
             for restored in restoredThreads {
                 if let sid = restored.sessionId, existingSessionIds.contains(sid) {
-                    // Already have a thread for this session — discard the duplicate VM.
                     viewModels.removeValue(forKey: restored.id)
                 } else {
-                    newThreads.append(restored)
+                    threads.append(restored)
                 }
             }
-            threads = newThreads + threads
         }
+    }
+
+    /// Load the next page of threads from the daemon (Connected mode only).
+    func loadMoreThreads() {
+        guard isConnectedMode,
+              let daemon = daemonClient as? DaemonClient,
+              !isLoadingMoreThreads,
+              hasMoreThreads else { return }
+        isLoadingMoreThreads = true
+        threadListOffset += Self.threadPageSize
+        try? daemon.sendSessionList(offset: threadListOffset, limit: Self.threadPageSize)
     }
 
     private func handleHistoryResponse(_ response: HistoryResponseMessage) {

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -23,6 +23,14 @@ struct ChatContentView: View {
     @State private var emptyStateVisible = false
     @State private var greeting: String = greetingChoices.randomElement()!
 
+    /// The slice of messages shown in the view, honoring the pagination window.
+    private var visibleMessages: [ChatMessage] {
+        let all = viewModel.messages.filter { !$0.isSubagentNotification }
+        // displayedMessageCount tracks how many of the most-recent messages to show.
+        let count = min(viewModel.displayedMessageCount, all.count)
+        return Array(all.suffix(count))
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Messages area — empty state when no messages, otherwise scrollable list
@@ -32,7 +40,37 @@ struct ChatContentView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: VSpacing.md) {
-                        let messages = viewModel.messages.filter { !$0.isSubagentNotification }
+                        // Loading indicator shown at the very top when fetching an older page.
+                        if viewModel.isLoadingMoreMessages {
+                            HStack {
+                                Spacer()
+                                VLoadingIndicator(size: 18)
+                                Spacer()
+                            }
+                            .padding(.vertical, VSpacing.sm)
+                            .id("page-loading-indicator")
+                        } else if viewModel.hasMoreMessages {
+                            // Invisible sentinel: fires when the user scrolls to the top,
+                            // triggering the next-older page of messages to be revealed.
+                            Color.clear
+                                .frame(height: 1)
+                                .id("page-load-trigger")
+                                .onAppear {
+                                    // Capture the current first-visible message ID before the
+                                    // pagination window expands so we can restore scroll position.
+                                    let anchorId = visibleMessages.first?.id
+                                    Task {
+                                        let hadMore = await viewModel.loadPreviousMessagePage()
+                                        // Restore position to the message that was previously at
+                                        // the top so the content doesn't jump unexpectedly.
+                                        if hadMore, let id = anchorId {
+                                            proxy.scrollTo(id, anchor: .top)
+                                        }
+                                    }
+                                }
+                        }
+
+                        let messages = visibleMessages
                         ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
                             if message.modelPicker != nil {
                                 ModelPickerBubble(

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -153,6 +153,25 @@ struct ThreadListView: View {
                     }
                 }
             }
+
+            // Load-more trigger: appears when the daemon has additional sessions beyond
+            // the current page. Becomes visible as the user scrolls toward the bottom.
+            if store.hasMoreThreads || store.isLoadingMoreThreads {
+                HStack {
+                    Spacer()
+                    if store.isLoadingMoreThreads {
+                        VLoadingIndicator(size: 18)
+                    } else {
+                        // Invisible sentinel: triggers the next page fetch on appear.
+                        Color.clear.frame(height: 1)
+                    }
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
+                .onAppear {
+                    store.loadMoreThreads()
+                }
+            }
         }
         .searchable(text: $searchText, prompt: "Search chats")
         .navigationTitle("Chats")

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -202,6 +202,40 @@ public final class ChatViewModel: ObservableObject {
     /// Observers can check this to avoid treating the history hydration as new activity.
     public private(set) var isLoadingHistory: Bool = false
 
+    // MARK: - Message Pagination
+
+    /// Page size for chat message display; older messages are loaded in this increment.
+    public static let messagePageSize = 50
+
+    /// Number of messages currently revealed at the top of the conversation.
+    /// The view slices `messages` to `messages.suffix(displayedMessageCount)`.
+    /// Grows by `messagePageSize` each time the user scrolls to the top.
+    @Published public var displayedMessageCount: Int = messagePageSize
+
+    /// True while a previous-page load is in progress (brief async delay for UX).
+    @Published public var isLoadingMoreMessages: Bool = false
+
+    /// Whether there are more messages above the current display window.
+    public var hasMoreMessages: Bool { displayedMessageCount < messages.count }
+
+    /// Load the previous page of messages by expanding the display window.
+    /// Returns `true` if there were additional messages to reveal.
+    @discardableResult
+    public func loadPreviousMessagePage() async -> Bool {
+        guard hasMoreMessages, !isLoadingMoreMessages else { return false }
+        isLoadingMoreMessages = true
+        // Brief delay so the loading indicator is visible before the list shifts.
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        displayedMessageCount = min(displayedMessageCount + Self.messagePageSize, messages.count)
+        isLoadingMoreMessages = false
+        return true
+    }
+
+    /// Reset pagination when the thread switches or history is reloaded.
+    public func resetMessagePagination() {
+        displayedMessageCount = Self.messagePageSize
+    }
+
     /// Surface the user is currently viewing in workspace mode.
     /// Set by MainWindowView when the dynamic workspace is expanded.
     public var activeSurfaceId: String? {
@@ -1444,6 +1478,8 @@ public final class ChatViewModel: ObservableObject {
         }
         self.isLoadingHistory = false
         self.isHistoryLoaded = true
+        // Reset pagination so the view shows the most-recent page after history loads.
+        self.displayedMessageCount = Self.messagePageSize
         // Surfaces are now included directly in the history response and populated above
     }
 


### PR DESCRIPTION
Implement pagination for iOS ChatContentView and ThreadListView, loading 50 messages at a time instead of all history at once. Load-on-scroll when approaching edges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
