### PR TITLE
feat: add private threads management to iOS Settings

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -15,14 +15,18 @@ struct IOSThread: Identifiable {
     /// When non-nil, this thread is backed by a daemon session (Connected mode).
     var sessionId: String?
     var isArchived: Bool
+    /// Private threads are excluded from the normal thread list and persist only
+    /// for the current session. They match the macOS "temporary chat" behavior.
+    var isPrivate: Bool
 
-    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, sessionId: String? = nil, isArchived: Bool = false) {
+    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, sessionId: String? = nil, isArchived: Bool = false, isPrivate: Bool = false) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.lastActivityAt = lastActivityAt ?? createdAt
         self.sessionId = sessionId
         self.isArchived = isArchived
+        self.isPrivate = isPrivate
     }
 }
 
@@ -35,6 +39,7 @@ private struct PersistedThread: Codable {
     var createdAt: Date
     var lastActivityAt: Date?
     var isArchived: Bool?
+    var isPrivate: Bool?
 }
 
 // MARK: - IOSThreadStore
@@ -78,6 +83,28 @@ class IOSThreadStore: ObservableObject {
             } else {
                 threads = loaded
             }
+        }
+    }
+
+    /// Initializer for secondary stores (e.g. the Private Threads settings panel)
+    /// that need access to the daemon client for sending messages but should not
+    /// register global session-list callbacks that would clobber the main store's
+    /// handlers. In standalone mode, loads persisted threads from UserDefaults.
+    init(daemonClient: any DaemonClientProtocol, registerDaemonCallbacks: Bool) {
+        self.daemonClient = daemonClient
+
+        if daemonClient is DaemonClient {
+            isConnectedMode = true
+            // No default thread — secondary stores start empty and show only
+            // what has been created within the current session.
+            threads = []
+        } else {
+            let loaded = Self.load()
+            threads = loaded
+        }
+
+        if registerDaemonCallbacks, let daemon = daemonClient as? DaemonClient {
+            setupDaemonCallbacks(daemon)
         }
     }
 
@@ -249,6 +276,12 @@ class IOSThreadStore: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// Private threads are excluded from the session list response filter, so they
+    /// won't appear in the normal active thread list.
+    var privateThreads: [IOSThread] {
+        threads.filter { $0.isPrivate }
+    }
+
     @discardableResult
     func newThread() -> IOSThread {
         let thread = IOSThread()
@@ -257,11 +290,28 @@ class IOSThreadStore: ObservableObject {
         return thread
     }
 
+    /// Create a new private thread with the given name. The thread is immediately
+    /// backed by a daemon session with threadType "private" so it is persisted on
+    /// the daemon side and excluded from normal thread restoration.
+    @discardableResult
+    func newPrivateThread(name: String = "Private Thread") -> IOSThread {
+        let thread = IOSThread(title: name, isPrivate: true)
+        threads.append(thread)
+        // Get or create the view model after appending so activity tracking
+        // can find the thread in self.threads.
+        let vm = viewModel(for: thread.id)
+        vm.createSessionIfNeeded(threadType: "private")
+        save()
+        return thread
+    }
+
     func deleteThread(_ thread: IOSThread) {
         viewModels.removeValue(forKey: thread.id)
         threads.removeAll { $0.id == thread.id }
-        // Always keep at least one active (non-archived) thread.
-        if threads.filter({ !$0.isArchived }).isEmpty {
+        // Always keep at least one active (non-archived) non-private thread.
+        // Private threads are managed separately and should not prevent the
+        // regular thread list from being empty.
+        if threads.filter({ !$0.isArchived && !$0.isPrivate }).isEmpty {
             newThread()
         } else {
             save()
@@ -307,7 +357,7 @@ class IOSThreadStore: ObservableObject {
     private func save() {
         // Don't persist daemon-synced threads — they're loaded on connect.
         guard !isConnectedMode else { return }
-        let persisted = threads.map { PersistedThread(id: $0.id, title: $0.title, createdAt: $0.createdAt, lastActivityAt: $0.lastActivityAt, isArchived: $0.isArchived) }
+        let persisted = threads.map { PersistedThread(id: $0.id, title: $0.title, createdAt: $0.createdAt, lastActivityAt: $0.lastActivityAt, isArchived: $0.isArchived, isPrivate: $0.isPrivate) }
         if let data = try? JSONEncoder().encode(persisted) {
             UserDefaults.standard.set(data, forKey: Self.persistenceKey)
         }
@@ -318,7 +368,7 @@ class IOSThreadStore: ObservableObject {
               let persisted = try? JSONDecoder().decode([PersistedThread].self, from: data) else {
             return []
         }
-        return persisted.map { IOSThread(id: $0.id, title: $0.title, createdAt: $0.createdAt, lastActivityAt: $0.lastActivityAt, isArchived: $0.isArchived ?? false) }
+        return persisted.map { IOSThread(id: $0.id, title: $0.title, createdAt: $0.createdAt, lastActivityAt: $0.lastActivityAt, isArchived: $0.isArchived ?? false, isPrivate: $0.isPrivate ?? false) }
     }
 }
 #endif

--- a/clients/ios/Views/Settings/PrivateThreadsSection.swift
+++ b/clients/ios/Views/Settings/PrivateThreadsSection.swift
@@ -1,0 +1,183 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Manages private (temporary) threads on iOS, mirroring the macOS private thread
+/// workflow. Private threads are backed by daemon sessions with threadType "private"
+/// so they are excluded from normal session restoration and the main thread list.
+struct PrivateThreadsSection: View {
+    @StateObject private var store: IOSThreadStore
+    @State private var showingCreateSheet = false
+    @State private var newThreadName = ""
+    @State private var renamingThread: IOSThread?
+    @State private var renameText = ""
+    @State private var threadToDelete: IOSThread?
+    @State private var showingDeleteConfirmation = false
+
+    init(daemonClient: any DaemonClientProtocol) {
+        // Use the secondary initializer so this store does not register global
+        // session-list callbacks that would overwrite the main thread store's handlers.
+        _store = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient, registerDaemonCallbacks: false))
+    }
+
+    var body: some View {
+        Form {
+            if store.privateThreads.isEmpty {
+                Section {
+                    Text("No private threads yet.")
+                        .foregroundStyle(.secondary)
+                    Text("Private threads are excluded from your main chat history. Use them for sensitive conversations that you don't want mixed with your regular threads.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section {
+                    ForEach(store.privateThreads) { thread in
+                        NavigationLink {
+                            privateThreadChatView(for: thread)
+                        } label: {
+                            privateThreadRow(thread)
+                        }
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                threadToDelete = thread
+                                showingDeleteConfirmation = true
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                renamingThread = thread
+                                renameText = thread.title
+                            } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            .tint(.blue) // Intentional: system blue for non-destructive swipe actions
+                        }
+                    }
+                } header: {
+                    Text("Private Threads")
+                } footer: {
+                    Text("These threads are not included in your regular chat history and are excluded from session restoration.")
+                }
+            }
+
+            Section {
+                Button {
+                    newThreadName = ""
+                    showingCreateSheet = true
+                } label: {
+                    Label("New Private Thread", systemImage: "lock.shield")
+                }
+            }
+        }
+        .navigationTitle("Private Threads")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showingCreateSheet) {
+            createThreadSheet
+        }
+        .alert("Rename Thread", isPresented: Binding(
+            get: { renamingThread != nil },
+            set: { if !$0 { renamingThread = nil } }
+        )) {
+            TextField("Thread name", text: $renameText)
+            Button("Cancel", role: .cancel) { renamingThread = nil }
+            Button("Save") {
+                if let thread = renamingThread, !renameText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    store.updateTitle(renameText.trimmingCharacters(in: .whitespacesAndNewlines), for: thread.id)
+                }
+                renamingThread = nil
+            }
+        } message: {
+            Text("Enter a new name for this private thread.")
+        }
+        .alert("Delete Thread", isPresented: $showingDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { threadToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let thread = threadToDelete {
+                    store.deleteThread(thread)
+                }
+                threadToDelete = nil
+            }
+        } message: {
+            if let thread = threadToDelete {
+                Text("Delete \"\(thread.title)\"? This cannot be undone.")
+            }
+        }
+    }
+
+    // MARK: - Thread Row
+
+    private func privateThreadRow(_ thread: IOSThread) -> some View {
+        HStack {
+            Image(systemName: "lock.shield")
+                .foregroundStyle(VColor.accent)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(thread.title)
+                    .lineLimit(1)
+                Text(relativeDate(thread.lastActivityAt))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Thread Chat
+
+    @ViewBuilder
+    private func privateThreadChatView(for thread: IOSThread) -> some View {
+        ThreadChatView(
+            viewModel: store.viewModel(for: thread.id),
+            threadTitle: thread.title
+        )
+        .onAppear {
+            store.loadHistoryIfNeeded(for: thread.id)
+        }
+    }
+
+    // MARK: - Create Sheet
+
+    private var createThreadSheet: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Thread name", text: $newThreadName)
+                        .autocapitalization(.words)
+                } footer: {
+                    Text("Give this private thread a name so you can identify it later.")
+                }
+            }
+            .navigationTitle("New Private Thread")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        showingCreateSheet = false
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create") {
+                        let name = newThreadName.trimmingCharacters(in: .whitespacesAndNewlines)
+                        _ = store.newPrivateThread(name: name.isEmpty ? "Private Thread" : name)
+                        showingCreateSheet = false
+                    }
+                }
+            }
+        }
+    }
+
+    private func relativeDate(_ date: Date) -> String {
+        DateFormatting.relativeTimestamp(date)
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        PrivateThreadsSection(daemonClient: MockDaemonClient())
+    }
+}
+#endif
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -54,6 +54,11 @@ struct SettingsView: View {
                     } label: {
                         Label("Parental Controls", systemImage: "lock.shield")
                     }
+                    NavigationLink {
+                        PrivateThreadsSection(daemonClient: clientProvider.client)
+                    } label: {
+                        Label("Private Threads", systemImage: "lock.shield.fill")
+                    }
                 }
 
                 Section("Appearance") {


### PR DESCRIPTION
Port macOS SettingsAdvancedTab private thread creation/management to iOS. Adds a Private Threads section in iOS Settings for creating, renaming, and deleting private threads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
