### PR TITLE
refactor: define error class hierarchy in TypeScript

### DIFF
--- a/assistant/src/doordash/client.ts
+++ b/assistant/src/doordash/client.ts
@@ -25,7 +25,9 @@ import {
 } from './queries.js';
 import { loadCapturedQueries } from './query-extractor.js';
 import { truncate } from '../util/truncate.js';
-import { ProviderError } from '../util/errors.js';
+import { ProviderError, RateLimitError } from '../util/errors.js';
+
+export { RateLimitError };
 
 const GRAPHQL_BASE = 'https://www.doordash.com/graphql';
 const CDP_BASE = 'http://localhost:9222';
@@ -49,14 +51,6 @@ export class SessionExpiredError extends Error {
   constructor(reason: string) {
     super(reason);
     this.name = 'SessionExpiredError';
-  }
-}
-
-/** Thrown when DoorDash returns HTTP 403 (rate limited). */
-export class RateLimitError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = 'RateLimitError';
   }
 }
 

--- a/assistant/src/errors.ts
+++ b/assistant/src/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * Central export point for the Vellum error hierarchy.
+ *
+ * Import from this module to access any named error class:
+ *
+ *   import { VellumError, BackendUnavailableError, RateLimitError, ... } from '../errors.js';
+ *
+ * Full hierarchy (defined in util/errors.ts):
+ *
+ *   VellumError                     — root base
+ *   ├─ BackendError                 — infrastructure / external-service failures
+ *   │  ├─ BackendUnavailableError   — service not reachable or not configured
+ *   │  └─ RateLimitError            — request or token quota exceeded
+ *   ├─ UserError                    — user input / policy violations
+ *   └─ AssistantError               — assistant-logic errors (carries ErrorCode)
+ *      ├─ ProviderError
+ *      ├─ ToolError
+ *      ├─ PermissionDeniedError
+ *      ├─ ConfigError
+ *      ├─ DaemonError
+ *      ├─ IpcError
+ *      ├─ PlatformError
+ *      ├─ IntegrityError
+ *      └─ IngressBlockedError
+ */
+export {
+  ErrorCode,
+  VellumError,
+  BackendError,
+  BackendUnavailableError,
+  RateLimitError,
+  UserError,
+  AssistantError,
+  ProviderError,
+  ToolError,
+  PermissionDeniedError,
+  ConfigError,
+  DaemonError,
+  IpcError,
+  PlatformError,
+  IntegrityError,
+  IngressBlockedError,
+} from './util/errors.js';

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -6,18 +6,11 @@ import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
 import { memoryEmbeddings } from './schema.js';
 import type { AssistantConfig } from '../config/types.js';
+import { BackendUnavailableError } from '../util/errors.js';
+
+export { BackendUnavailableError };
 
 const log = getLogger('memory-jobs-worker');
-
-// ── Sentinel error ─────────────────────────────────────────────────
-
-/** Sentinel error: the embedding backend is not configured yet. */
-export class BackendUnavailableError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = 'BackendUnavailableError';
-  }
-}
 
 // ── Error classification for LLM / API errors ─────────────────────
 

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -33,7 +33,71 @@ export enum ErrorCode {
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
 
-export class AssistantError extends Error {
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+/** Root base class for all named Vellum errors. */
+export class VellumError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'VellumError';
+  }
+}
+
+// ── Backend errors ────────────────────────────────────────────────────────────
+
+/**
+ * Errors originating from infrastructure or external service calls.
+ * Catch this when you want to handle any backend failure uniformly.
+ */
+export class BackendError extends VellumError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'BackendError';
+  }
+}
+
+/**
+ * The embedding or vector-search backend is not configured or not reachable.
+ * Thrown before attempting an embedding operation so callers can skip or defer.
+ */
+export class BackendUnavailableError extends BackendError {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'BackendUnavailableError';
+  }
+}
+
+/**
+ * A request or token-budget quota was exceeded.
+ * Thrown by the provider rate-limiter and by domain-specific clients (e.g. DoorDash).
+ */
+export class RateLimitError extends BackendError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RateLimitError';
+  }
+}
+
+// ── User errors ───────────────────────────────────────────────────────────────
+
+/**
+ * Errors caused by user input, policy violations, or user-facing constraints.
+ * Catch this when you want to present an actionable message to the user.
+ */
+export class UserError extends VellumError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'UserError';
+  }
+}
+
+// ── AssistantError subtree ────────────────────────────────────────────────────
+
+/**
+ * Base class for errors originating from assistant logic (providers, tools,
+ * permissions, config). Extends VellumError and carries a structured ErrorCode.
+ */
+export class AssistantError extends VellumError {
   constructor(
     message: string,
     public readonly code: ErrorCode,
@@ -108,13 +172,6 @@ export class IntegrityError extends AssistantError {
   constructor(message: string) {
     super(message, ErrorCode.INTEGRITY_ERROR);
     this.name = 'IntegrityError';
-  }
-}
-
-export class RateLimitError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.RATE_LIMIT_ERROR);
-    this.name = 'RateLimitError';
   }
 }
 


### PR DESCRIPTION
Define a central VellumError base class hierarchy and migrate existing named error classes (BackendUnavailableError, RateLimitError, etc.) to extend it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
