### PR TITLE
feat: add appearance/theme settings to iOS

### DIFF
--- a/clients/ios/Views/Settings/AppearanceSection.swift
+++ b/clients/ios/Views/Settings/AppearanceSection.swift
@@ -1,0 +1,35 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Appearance settings screen — theme selection and display preferences.
+/// Mirrors the macOS SettingsAppearanceTab, adapted for iOS Form-based navigation.
+struct AppearanceSection: View {
+    @AppStorage(UserDefaultsKeys.appearanceMode) private var appearanceMode: String = "system"
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Theme", selection: $appearanceMode) {
+                    Text("System").tag("system")
+                    Text("Light").tag("light")
+                    Text("Dark").tag("dark")
+                }
+                .pickerStyle(.segmented)
+            } header: {
+                Text("Color Scheme")
+            } footer: {
+                Text("\"System\" follows your device's Light/Dark Mode setting.")
+            }
+        }
+        .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AppearanceSection()
+    }
+}
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -5,7 +5,6 @@ import VellumAssistantShared
 struct SettingsView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @Bindable var authManager: AuthManager
-    @AppStorage(UserDefaultsKeys.appearanceMode) private var appearanceMode: String = "system"
     @Binding var navigateToConnect: Bool
 
     var body: some View {
@@ -61,13 +60,10 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Appearance") {
-                    Picker("Theme", selection: $appearanceMode) {
-                        Text("System").tag("system")
-                        Text("Light").tag("light")
-                        Text("Dark").tag("dark")
-                    }
-                    .pickerStyle(.segmented)
+                NavigationLink {
+                    AppearanceSection()
+                } label: {
+                    Label("Appearance", systemImage: "paintbrush")
                 }
 
                 Section("Permissions") {


### PR DESCRIPTION
Add Appearance section to iOS Settings with theme picker (system/light/dark) using the existing themePreference AppStorage key, mirroring macOS SettingsAppearanceTab.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
