### PR TITLE
feat: add media embed controls to iOS Settings

### DIFF
--- a/clients/ios/App/UserDefaultsKeys.swift
+++ b/clients/ios/App/UserDefaultsKeys.swift
@@ -20,5 +20,9 @@ enum UserDefaultsKeys {
     static func daemonHostId(host: String, port: UInt16) -> String {
         "daemon_host_id:\(host):\(port)"
     }
+
+    // Media embed settings
+    static let mediaEmbedsEnabled = "media_embeds_enabled"
+    static let mediaEmbedVideoAllowlistDomains = "media_embed_video_allowlist_domains"
 }
 #endif

--- a/clients/ios/Views/MessageMediaEmbedsView.swift
+++ b/clients/ios/Views/MessageMediaEmbedsView.swift
@@ -6,25 +6,35 @@ import VellumAssistantShared
 ///
 /// Runs the async MediaEmbedResolver when the message text changes
 /// (but not during streaming to avoid per-token re-resolution).
+/// Settings are read from UserDefaults so they stay in sync with
+/// MediaEmbedSettingsSection without requiring a restart.
 struct MessageMediaEmbedsView: View {
     let message: ChatMessage
 
     @State private var intents: [MediaEmbedIntent] = []
 
-    /// Default settings: embeds always enabled, all major video domains allowed.
-    private static let defaultSettings = MediaEmbedResolverSettings(
-        enabled: true,
-        enabledSince: nil,
-        allowedDomains: [
-            "youtube.com", "youtu.be",
-            "vimeo.com",
-            "loom.com",
-        ]
-    )
+    @AppStorage(UserDefaultsKeys.mediaEmbedsEnabled)
+    private var mediaEmbedsEnabled: Bool = true
 
+    @AppStorage(UserDefaultsKeys.mediaEmbedVideoAllowlistDomains)
+    private var domainsRaw: String = MediaEmbedSettings.defaultDomains.joined(separator: "\n")
+
+    private var resolverSettings: MediaEmbedResolverSettings {
+        let domains = domainsRaw
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return MediaEmbedResolverSettings(
+            enabled: mediaEmbedsEnabled,
+            enabledSince: nil,
+            allowedDomains: domains.isEmpty ? MediaEmbedSettings.defaultDomains : domains
+        )
+    }
+
+    /// Re-resolve when message content or settings change.
     private var taskID: String {
         if message.isStreaming { return "streaming-\(message.id)" }
-        return "\(message.text.hashValue)"
+        return "\(message.text.hashValue)-\(mediaEmbedsEnabled)-\(domainsRaw.hashValue)"
     }
 
     var body: some View {
@@ -46,7 +56,7 @@ struct MessageMediaEmbedsView: View {
                 guard !message.isStreaming else { return }
                 let resolved = await MediaEmbedResolver.resolve(
                     message: message,
-                    settings: Self.defaultSettings
+                    settings: resolverSettings
                 )
                 guard !Task.isCancelled else { return }
                 intents = resolved

--- a/clients/ios/Views/Settings/MediaEmbedSettingsSection.swift
+++ b/clients/ios/Views/Settings/MediaEmbedSettingsSection.swift
@@ -1,0 +1,142 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// iOS settings screen for configuring media embed behaviour in chat.
+/// Mirrors the macOS SettingsAppearanceTab "Media Embeds" section,
+/// persisting state via UserDefaults rather than the workspace config file.
+struct MediaEmbedSettingsSection: View {
+    @AppStorage(UserDefaultsKeys.mediaEmbedsEnabled) private var mediaEmbedsEnabled: Bool = true
+
+    /// Domain allowlist stored as a newline-joined string so @AppStorage can handle it.
+    @AppStorage(UserDefaultsKeys.mediaEmbedVideoAllowlistDomains)
+    private var domainsRaw: String = MediaEmbedSettings.defaultDomains.joined(separator: "\n")
+
+    @State private var newDomain: String = ""
+    @State private var showingAddDomain: Bool = false
+
+    private var domains: [String] {
+        domainsRaw
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable inline video embeds", isOn: $mediaEmbedsEnabled)
+            } footer: {
+                Text("Automatically embed videos from allowed domains inline in chat messages.")
+            }
+
+            if mediaEmbedsEnabled {
+                domainAllowlistSection
+            }
+        }
+        .navigationTitle("Media Embeds")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showingAddDomain) {
+            AddDomainSheet { domain in
+                addDomain(domain)
+            }
+        }
+    }
+
+    private var domainAllowlistSection: some View {
+        Section {
+            if domains.isEmpty {
+                Text("No domains configured")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(domains, id: \.self) { domain in
+                    Text(domain)
+                        .font(.body)
+                }
+                .onDelete { indexSet in
+                    removeDomains(at: indexSet)
+                }
+            }
+
+            Button {
+                showingAddDomain = true
+            } label: {
+                Label("Add Domain", systemImage: "plus")
+            }
+
+            if domains != MediaEmbedSettings.defaultDomains {
+                Button("Reset to Defaults", role: .destructive) {
+                    resetToDefaults()
+                }
+            }
+        } header: {
+            Text("Video Domain Allowlist")
+        } footer: {
+            Text("Videos are only embedded if their domain appears in this list.")
+        }
+    }
+
+    private func addDomain(_ raw: String) {
+        let normalized = MediaEmbedSettings.normalizeDomains([raw])
+        guard let domain = normalized.first, !domains.contains(domain) else { return }
+        var updated = domains
+        updated.append(domain)
+        domainsRaw = updated.joined(separator: "\n")
+    }
+
+    private func removeDomains(at indexSet: IndexSet) {
+        var updated = domains
+        updated.remove(atOffsets: indexSet)
+        domainsRaw = updated.joined(separator: "\n")
+    }
+
+    private func resetToDefaults() {
+        domainsRaw = MediaEmbedSettings.defaultDomains.joined(separator: "\n")
+    }
+}
+
+// MARK: - Add Domain Sheet
+
+private struct AddDomainSheet: View {
+    let onAdd: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var domain: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("e.g. example.com", text: $domain)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                } footer: {
+                    Text("Enter a hostname such as youtube.com. URL schemes and paths are stripped automatically.")
+                }
+            }
+            .navigationTitle("Add Domain")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        onAdd(domain)
+                        dismiss()
+                    }
+                    .disabled(domain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        MediaEmbedSettingsSection()
+    }
+}
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -58,6 +58,11 @@ struct SettingsView: View {
                     } label: {
                         Label("Private Threads", systemImage: "lock.shield.fill")
                     }
+                    NavigationLink {
+                        MediaEmbedSettingsSection()
+                    } label: {
+                        Label("Media Embeds", systemImage: "play.rectangle")
+                    }
                 }
 
                 NavigationLink {


### PR DESCRIPTION
Port macOS MediaEmbedSettings to iOS: inline video toggle and domain allowlist for controlling video embeds in chat.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
