### PR TITLE
M1: Add multi-image message helper to provider layer

### DIFF
--- a/assistant/src/providers/anthropic-send-message.ts
+++ b/assistant/src/providers/anthropic-send-message.ts
@@ -107,3 +107,27 @@ export function userMessageWithImage(
     ],
   };
 }
+
+/**
+ * Build a single user message with multiple images followed by a text block.
+ * Each image becomes its own content block; the text block comes last.
+ */
+export function userMessageWithImages(
+  images: Array<{ base64: string; mediaType: string }>,
+  text: string,
+): Message {
+  return {
+    role: 'user',
+    content: [
+      ...images.map((img) => ({
+        type: 'image' as const,
+        source: {
+          type: 'base64' as const,
+          media_type: img.mediaType,
+          data: img.base64,
+        },
+      })),
+      { type: 'text' as const, text },
+    ],
+  };
+}


### PR DESCRIPTION
Part of #7766. Adds userMessageWithImages() to anthropic-send-message.ts for sending multiple images in a single API call. This enables chunked video frame analysis where groups of frames are sent together for temporal context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
