### PR TITLE
feat: add offline message queue to iOS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3550,6 +3550,19 @@ iOS App  --HTTPS-->  Ingress (tunnel/public URL)  -->  Gateway  -->  Runtime
 | `clients/shared/IPC/DaemonConfig.swift` | Transport config; iOS uses `.http` exclusively |
 | `clients/shared/IPC/HTTPDaemonClient.swift` | HTTP+SSE client implementation |
 
+### Offline Message Queue (iOS)
+
+When the daemon is unreachable, outgoing user messages are buffered in `OfflineMessageQueue` (a persistent FIFO stored in UserDefaults) instead of surfacing an error. The message bubble shows a "Pending" indicator (`ChatMessageStatus.pendingOffline`) while offline. On reconnect (`daemonDidReconnect`), `ChatViewModel.flushOfflineQueue()` drains the queue and sends messages in order, clearing the pending indicator.
+
+| Component | Role |
+|-----------|------|
+| `clients/ios/App/OfflineMessageQueue.swift` | Persistent FIFO queue; serialized to `offline_message_queue_v1` in UserDefaults |
+| `ChatMessageStatus.pendingOffline` | Message status for locally buffered, unsent messages |
+| `ChatViewModel.flushOfflineQueue()` | Drains the queue on reconnect, sending messages in FIFO order |
+| `MessageBubbleView` | Renders a clock icon + "Pending" label for `.pendingOffline` messages |
+
+Storage key: `offline_message_queue_v1` (UserDefaults).
+
 ---
 
 ## Ingress Boundary Architecture — Gateway-Only Public Ingress

--- a/clients/ios/App/OfflineMessageQueue.swift
+++ b/clients/ios/App/OfflineMessageQueue.swift
@@ -1,0 +1,119 @@
+#if canImport(UIKit)
+import Foundation
+import os
+import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "OfflineMessageQueue")
+
+// MARK: - Queued Message
+
+/// A single message buffered while the daemon was unreachable.
+struct OfflineQueuedMessage: Codable, Identifiable {
+    let id: UUID
+    let sessionId: String?
+    let text: String
+    let attachments: [OfflineQueuedAttachment]
+    let enqueuedAt: Date
+
+    init(sessionId: String?, text: String, attachments: [IPCAttachment]?) {
+        self.id = UUID()
+        self.sessionId = sessionId
+        self.text = text
+        self.enqueuedAt = Date()
+        self.attachments = (attachments ?? []).map {
+            OfflineQueuedAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)
+        }
+    }
+
+    /// Reconstruct the IPC attachment list for dispatch.
+    var ipcAttachments: [IPCAttachment]? {
+        guard !attachments.isEmpty else { return nil }
+        return attachments.map {
+            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)
+        }
+    }
+}
+
+struct OfflineQueuedAttachment: Codable {
+    let filename: String
+    let mimeType: String
+    /// Base64-encoded attachment data, matching the `IPCAttachment.data` string format.
+    let data: String
+    let extractedText: String?
+}
+
+// MARK: - Offline Message Queue
+
+/// Persistent FIFO queue that buffers outgoing messages when the daemon is unreachable.
+///
+/// Messages are stored in UserDefaults so they survive app restarts. When the daemon
+/// reconnects, the caller is responsible for flushing via `dequeueAll()` and sending
+/// the messages in order.
+///
+/// Thread-safety: all mutations must occur on the main actor, consistent with ChatViewModel.
+@MainActor
+final class OfflineMessageQueue {
+
+    static let shared = OfflineMessageQueue()
+
+    private static let userDefaultsKey = "offline_message_queue_v1"
+
+    private var queue: [OfflineQueuedMessage] = []
+
+    var isEmpty: Bool { queue.isEmpty }
+    var count: Int { queue.count }
+
+    private init() {
+        queue = Self.load()
+        log.info("OfflineMessageQueue: loaded \(self.queue.count) queued message(s)")
+    }
+
+    // MARK: - Enqueue
+
+    /// Append a message to the end of the offline queue and persist it.
+    func enqueue(sessionId: String?, text: String, attachments: [IPCAttachment]?) {
+        let message = OfflineQueuedMessage(sessionId: sessionId, text: text, attachments: attachments)
+        queue.append(message)
+        save()
+        log.info("OfflineMessageQueue: enqueued message (queue depth: \(self.queue.count))")
+    }
+
+    // MARK: - Dequeue
+
+    /// Remove and return all queued messages in FIFO order, then clear persistence.
+    func dequeueAll() -> [OfflineQueuedMessage] {
+        let all = queue
+        queue.removeAll()
+        save()
+        log.info("OfflineMessageQueue: dequeued \(all.count) message(s) for flush")
+        return all
+    }
+
+    /// Remove the message with the given ID (e.g. after a successful send).
+    func remove(id: UUID) {
+        queue.removeAll { $0.id == id }
+        save()
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(queue) else { return }
+        UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
+    }
+
+    private static func load() -> [OfflineQueuedMessage] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let messages = try? JSONDecoder().decode([OfflineQueuedMessage].self, from: data) else {
+            return []
+        }
+        return messages
+    }
+
+    /// Drop all persisted messages. Intended for testing or manual reset.
+    func clear() {
+        queue.removeAll()
+        UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -16,6 +16,8 @@ public enum ChatMessageStatus: Equatable {
     case sent
     case queued(position: Int)
     case processing
+    /// Message is buffered in the local offline queue pending daemon reconnect.
+    case pendingOffline
 }
 
 /// Tracks the state of an inline tool confirmation request.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -235,6 +235,9 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
                 self?.pendingLocalDeletions.removeAll()
+                #if os(iOS)
+                self?.flushOfflineQueue()
+                #endif
             }
         }
     }
@@ -446,6 +449,26 @@ public final class ChatViewModel: ObservableObject {
         // daemon has disconnected between turns.
         guard daemonClient.isConnected else {
             log.error("Cannot send user_message: daemon not connected")
+
+            #if os(iOS)
+            // On iOS, buffer the primary (non-queued-retry) send in the offline queue
+            // instead of surfacing an error. The message stays visible with a
+            // "pending" indicator and is flushed automatically on reconnect.
+            if queuedMessageId == nil {
+                log.info("Buffering message in offline queue (session: \(sessionId))")
+                OfflineMessageQueue.shared.enqueue(sessionId: sessionId, text: text, attachments: attachments)
+                // Mark the corresponding chat message as offline-pending so the UI
+                // can show a visual indicator. Find the last user message with this
+                // text — it is the one just appended by sendMessage().
+                if let idx = messages.indices.reversed().first(where: { messages[$0].role == .user && messages[$0].text == text }) {
+                    messages[idx].status = .pendingOffline
+                }
+                // Don't show the error banner — the pending indicator on the bubble
+                // communicates the offline state without interrupting the conversation.
+                return
+            }
+            #endif
+
             // Always track the failed message for retry support.
             lastFailedMessageText = text
             lastFailedMessageAttachments = attachments
@@ -511,6 +534,57 @@ public final class ChatViewModel: ObservableObject {
             }
         }
     }
+
+    // MARK: - Offline Queue Flush (iOS only)
+
+    #if os(iOS)
+    /// Drain the persistent offline queue and send all buffered messages in order.
+    ///
+    /// Called automatically when the daemon reconnects. Only flushes messages whose
+    /// sessionId matches this view model's current session, so concurrent view models
+    /// on different threads don't steal each other's queued messages.
+    func flushOfflineQueue() {
+        let queue = OfflineMessageQueue.shared
+        guard !queue.isEmpty else { return }
+
+        guard let currentSessionId = sessionId else {
+            // No session yet — nothing to flush for this view model.
+            return
+        }
+
+        // Dequeue only the messages that belong to this session.
+        // Messages for other sessions are left in place for their respective VMs to flush.
+        let allQueued = queue.dequeueAll()
+        let mine = allQueued.filter { $0.sessionId == currentSessionId }
+        let others = allQueued.filter { $0.sessionId != currentSessionId }
+
+        // Re-enqueue messages belonging to other sessions.
+        for msg in others {
+            queue.enqueue(sessionId: msg.sessionId, text: msg.text, attachments: msg.ipcAttachments)
+        }
+
+        guard !mine.isEmpty else { return }
+
+        log.info("Flushing \(mine.count) offline-queued message(s) for session \(currentSessionId)")
+
+        // Update message bubbles: clear pendingOffline status so they show as sent.
+        for queued in mine {
+            if let idx = messages.indices.reversed().first(where: {
+                messages[$0].role == .user
+                    && messages[$0].text == queued.text
+                    && messages[$0].status == .pendingOffline
+            }) {
+                messages[idx].status = .sent
+            }
+        }
+
+        // Send messages sequentially. Each send is async in the HTTP transport but
+        // the daemon processes messages in order, so fire them all immediately.
+        for queued in mine {
+            sendUserMessage(queued.text, attachments: queued.ipcAttachments)
+        }
+    }
+    #endif
 
     public func startMessageLoop() {
         messageLoopTask?.cancel()

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -88,6 +88,20 @@ public struct MessageBubbleView: View {
                     }
                 }
 
+                // Offline-pending indicator: shown when the message is buffered
+                // locally awaiting daemon reconnect. Replaces the streaming dots.
+                if message.status == .pendingOffline {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                        Text("Pending")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .padding(.horizontal, VSpacing.sm)
+                }
+
                 // Streaming indicator
                 if message.isStreaming {
                     TimelineView(.animation(minimumInterval: 0.05)) { context in


### PR DESCRIPTION
Buffer outgoing messages when the daemon is unreachable and automatically flush the queue on reconnect. Includes persistent storage and UI pending indicators.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
