### PR TITLE
feat: add voice mode settings panel to iOS

### DIFF
--- a/clients/ios/App/UserDefaultsKeys.swift
+++ b/clients/ios/App/UserDefaultsKeys.swift
@@ -12,6 +12,11 @@ enum UserDefaultsKeys {
     static let gatewayBaseURL = "gateway_base_url"
     static let conversationKey = "conversation_key"
 
+    // Voice mode settings
+    static let voiceListeningTimeout = "voice_listening_timeout"
+    static let voiceTTSProvider = "voice_tts_provider"
+    static let voiceSilenceThreshold = "voice_silence_threshold"
+
     // Per-host:port keys for multi-Mac QR pairing support.
     // Actual keys are namespaced: "daemon_fingerprint:<host>:<port>", etc.
     static func daemonCertFingerprint(host: String, port: UInt16) -> String {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -29,6 +29,18 @@ struct InputBarView: View {
     @State private var showPhotosPicker = false
     @State private var showDocumentPicker = false
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    /// Timer that fires after the listening timeout to auto-stop recording.
+    @State private var listeningTimeoutTimer: Timer?
+    /// Timer that drives silence detection by comparing last-speech time to the threshold.
+    @State private var silenceTimer: Timer?
+    /// Tracks the last time meaningful audio amplitude was observed.
+    @State private var lastSpeechTime: Date = .distantPast
+    /// Set to true once audible speech has been detected during the current recording.
+    @State private var hasSpeechOccurred = false
+
+    // Voice settings read from UserDefaults — updated live without restart.
+    @AppStorage(UserDefaultsKeys.voiceListeningTimeout) private var listeningTimeout: Double = 30.0
+    @AppStorage(UserDefaultsKeys.voiceSilenceThreshold) private var silenceThreshold: Double = 1.0
 
     /// Current audio input amplitude [0,1] — updated while recording for the orb animation.
     @State private var micAmplitude: Float = 0
@@ -311,21 +323,33 @@ struct InputBarView: View {
             return
         }
 
+        // Reset silence-detection state for the new recording session.
+        lastSpeechTime = Date()
+        hasSpeechOccurred = false
+
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
             request.append(buffer)
 
-            // Compute RMS amplitude so the voice orb can react to input level
-            if let floatData = buffer.floatChannelData {
-                let frameCount = Int(buffer.frameLength)
-                guard frameCount > 0 else { return }
-                var sum: Float = 0
-                for i in 0..<frameCount {
-                    let s = floatData[0][i]
-                    sum += s * s
-                }
-                let rms = (sum / Float(frameCount)).squareRoot()
-                Task { @MainActor in
-                    micAmplitude = min(rms * 5, 1.0)
+            // Compute RMS amplitude for both voice orb animation and silence detection.
+            guard let floatData = buffer.floatChannelData else { return }
+            let frameCount = Int(buffer.frameLength)
+            guard frameCount > 0 else { return }
+            var sum: Float = 0
+            for i in 0..<frameCount {
+                let s = floatData[0][i]
+                sum += s * s
+            }
+            let rms = (sum / Float(frameCount)).squareRoot()
+
+            Task { @MainActor in
+                // Drive the orb animation with the scaled amplitude.
+                micAmplitude = min(rms * 5, 1.0)
+
+                // Update last-speech timestamp whenever the mic picks up audible signal
+                // (used by the silence detection timer to decide when to auto-stop).
+                if rms > 0.015 {
+                    self.lastSpeechTime = Date()
+                    self.hasSpeechOccurred = true
                 }
             }
         }
@@ -359,6 +383,31 @@ struct InputBarView: View {
             try audioEngine.start()
             isRecording = true
             log.info("Voice recording started")
+
+            // Silence detection timer: polls every 0.25 s to check how long
+            // the mic has been quiet. Stops recording once the threshold is met
+            // and at least some speech has occurred (avoids cutting off immediately).
+            let capturedThreshold = silenceThreshold
+            silenceTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
+                DispatchQueue.main.async {
+                    guard self.isRecording, self.hasSpeechOccurred else { return }
+                    let silenceDuration = Date().timeIntervalSince(self.lastSpeechTime)
+                    if silenceDuration >= capturedThreshold {
+                        log.info("Silence threshold reached (\(capturedThreshold, privacy: .public)s), stopping recording")
+                        self.stopRecording()
+                    }
+                }
+            }
+
+            // Listening timeout: hard upper bound on recording duration.
+            let capturedTimeout = listeningTimeout
+            listeningTimeoutTimer = Timer.scheduledTimer(withTimeInterval: capturedTimeout, repeats: false) { _ in
+                DispatchQueue.main.async {
+                    guard self.isRecording else { return }
+                    log.info("Listening timeout (\(capturedTimeout, privacy: .public)s), stopping recording")
+                    self.stopRecording()
+                }
+            }
         } catch {
             log.error("Audio engine failed to start: \(error.localizedDescription)")
             viewModel.errorText = "Voice input failed: \(error.localizedDescription)"
@@ -373,6 +422,13 @@ struct InputBarView: View {
     private func stopRecording() {
         guard isRecording else { return }
         log.info("Voice recording stopped")
+
+        // Cancel auto-stop timers before tearing down the session.
+        listeningTimeoutTimer?.invalidate()
+        listeningTimeoutTimer = nil
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
         recognitionRequest?.endAudio()

--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -1,0 +1,167 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// TTS provider options surfaced in Voice settings.
+/// The system provider uses iOS AVSpeechSynthesizer; ElevenLabs uses the
+/// ElevenLabs REST API (requires an API key stored in the keychain under "elevenlabs").
+enum TTSProvider: String, CaseIterable {
+    case system = "system"
+    case elevenLabs = "elevenlabs"
+
+    var displayName: String {
+        switch self {
+        case .system: return "System (Apple)"
+        case .elevenLabs: return "ElevenLabs"
+        }
+    }
+}
+
+/// Voice mode settings — listening timeout, TTS provider, and silence detection
+/// threshold. These mirror the equivalent options available on macOS.
+struct VoiceSettingsSection: View {
+    /// Seconds of silence that trigger end-of-speech detection. iOS SFSpeechRecognizer
+    /// does not have a built-in silence threshold API, so this value controls how long
+    /// the InputBarView waits after the last speech activity before stopping the
+    /// recognition task automatically. Range 0.5 – 3.0 s.
+    @AppStorage(UserDefaultsKeys.voiceSilenceThreshold) private var silenceThreshold: Double = 1.0
+
+    /// Maximum recording duration in seconds before the recogniser is stopped
+    /// automatically (listening timeout). A value of 0 means no auto-stop.
+    /// Range 5 – 60 s.
+    @AppStorage(UserDefaultsKeys.voiceListeningTimeout) private var listeningTimeout: Double = 30.0
+
+    /// TTS provider used when the assistant speaks a response.
+    @AppStorage(UserDefaultsKeys.voiceTTSProvider) private var ttsProviderRaw: String = TTSProvider.system.rawValue
+
+    private var ttsProvider: TTSProvider {
+        TTSProvider(rawValue: ttsProviderRaw) ?? .system
+    }
+
+    var body: some View {
+        Form {
+            // MARK: - Listening
+
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Listening Timeout")
+                        Spacer()
+                        Text(listeningTimeout == 0 ? "Off" : "\(Int(listeningTimeout))s")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                    Slider(value: $listeningTimeout, in: 5...60, step: 5)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Listening")
+            } footer: {
+                Text("Maximum recording duration before the microphone stops automatically. Set to 5 s for short commands or up to 60 s for long dictation.")
+            }
+
+            // MARK: - Silence Detection
+
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Silence Threshold")
+                        Spacer()
+                        Text(String(format: "%.1fs", silenceThreshold))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                    Slider(value: $silenceThreshold, in: 0.5...3.0, step: 0.5)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Silence Detection")
+            } footer: {
+                Text("How long silence must last before speech is considered finished and the recording stops. Lower values respond faster; higher values give more time for pauses.")
+            }
+
+            // MARK: - TTS Provider
+
+            Section {
+                Picker("TTS Provider", selection: $ttsProviderRaw) {
+                    ForEach(TTSProvider.allCases, id: \.rawValue) { provider in
+                        Text(provider.displayName).tag(provider.rawValue)
+                    }
+                }
+                .pickerStyle(.navigationLink)
+            } header: {
+                Text("Text-to-Speech")
+            } footer: {
+                Group {
+                    if ttsProvider == .elevenLabs {
+                        Text("ElevenLabs requires an API key. Get yours at elevenlabs.io — this is the same provider used by voice mode on macOS.")
+                    } else {
+                        Text("System uses Apple's built-in AVSpeechSynthesizer. No API key required.")
+                    }
+                }
+            }
+
+            // ElevenLabs API key entry (shown only when ElevenLabs is selected)
+            if ttsProvider == .elevenLabs {
+                ElevenLabsKeySection()
+            }
+        }
+        .navigationTitle("Voice")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - ElevenLabs Key Section
+
+/// Inline key management for ElevenLabs — shown when ElevenLabs TTS is selected.
+private struct ElevenLabsKeySection: View {
+    @State private var keyText: String = ""
+    @State private var isSaved = false
+    @State private var hasExistingKey = false
+
+    var body: some View {
+        Section {
+            if hasExistingKey {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                    Text("API key saved")
+                    Spacer()
+                    Button("Remove", role: .destructive) {
+                        APIKeyManager.shared.deleteAPIKey(provider: "elevenlabs")
+                        hasExistingKey = false
+                        keyText = ""
+                    }
+                    .font(.caption)
+                }
+            } else {
+                SecureField("ElevenLabs API Key", text: $keyText)
+                    .textContentType(.password)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+
+                Button("Save") {
+                    let trimmed = keyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    _ = APIKeyManager.shared.setAPIKey(trimmed, provider: "elevenlabs")
+                    hasExistingKey = true
+                    keyText = ""
+                }
+                .disabled(keyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        } header: {
+            Text("ElevenLabs API Key")
+        } footer: {
+            Text("Your key is stored securely in the iOS Keychain and never sent to Vellum servers.")
+        }
+        .onAppear {
+            hasExistingKey = APIKeyManager.shared.getAPIKey(provider: "elevenlabs") != nil
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        VoiceSettingsSection()
+    }
+}
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -63,6 +63,11 @@ struct SettingsView: View {
                     } label: {
                         Label("Media Embeds", systemImage: "play.rectangle")
                     }
+                    NavigationLink {
+                        VoiceSettingsSection()
+                    } label: {
+                        Label("Voice", systemImage: "waveform")
+                    }
                 }
 
                 NavigationLink {


### PR DESCRIPTION
Add Voice section to iOS Settings exposing listening timeout, TTS provider selection, and silence detection threshold — matching macOS voice mode settings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
