### PR TITLE
fix: add Error conformance to ChatViewModel.AttachmentError

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+Attachments.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+Attachments.swift
@@ -107,7 +107,7 @@ extension ChatViewModel {
 
     // MARK: - Private background helpers
 
-    private enum AttachmentError {
+    private enum AttachmentError: Error {
         case message(String)
         var message: String {
             if case .message(let m) = self { return m }


### PR DESCRIPTION
## Summary
- `ChatViewModel.AttachmentError` was missing `Error` protocol conformance, which is required by `Result<Success, Failure>` where `Failure: Error`
- Added `: Error` to the enum declaration to fix the macOS build

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22352923286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
