### PR TITLE
fix: guard buildChunks infinite loop and use ?? for chunk inputs

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -40,7 +40,7 @@ Return a JSON array of these objects, one per frame. Return ONLY the JSON array,
 
 function buildChunks(keyframes: MediaKeyframe[], chunkSize: number, overlap: number): MediaKeyframe[][] {
   const chunks: MediaKeyframe[][] = [];
-  const step = chunkSize - overlap;
+  const step = Math.max(1, chunkSize - overlap);
   for (let i = 0; i < keyframes.length; i += step) {
     chunks.push(keyframes.slice(i, i + chunkSize));
   }
@@ -275,9 +275,9 @@ export async function run(
   }
 
   const analysisType = (input.analysis_type as string) || 'scene_description';
-  const batchSize = (input.batch_size as number) || 10;
-  const chunkSizeInput = (input.chunk_size as number) || 10;
-  const overlapInput = (input.overlap as number) || 2;
+  const batchSize = (input.batch_size as number) ?? 10;
+  const chunkSizeInput = (input.chunk_size as number) ?? 10;
+  const overlapInput = (input.overlap as number) ?? 2;
 
   try {
     // Check if all keyframes are already analyzed before calling the core function


### PR DESCRIPTION
Addresses review feedback on #7781. Clamps buildChunks step to minimum 1 to prevent infinite loop when overlap >= chunkSize. Uses ?? instead of || for chunk_size, overlap, and batch_size inputs so that explicit 0 values are respected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
