### PR TITLE
fix: add minimum constraints to chunk_size/overlap schema

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -97,10 +97,12 @@
           },
           "chunk_size": {
             "type": "number",
+            "minimum": 1,
             "description": "Number of frames per analysis chunk. Default: 10"
           },
           "overlap": {
             "type": "number",
+            "minimum": 0,
             "description": "Number of overlapping frames between adjacent chunks to avoid missing boundary events. Default: 2"
           }
         },


### PR DESCRIPTION
Addresses review feedback on #7784. Adds minimum constraints to chunk_size (>=1) and overlap (>=0) in the TOOLS.json schema as defense-in-depth alongside the runtime guard added in #7787.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
