### PR TITLE
fix: validate chunk_size and overlap to reject non-positive values

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -130,6 +130,12 @@ export async function analyzeKeyframesForAsset(
   if (batch <= 0) {
     throw new Error('batch_size must be greater than 0.');
   }
+  if (chunkSize !== undefined && chunkSize <= 0) {
+    throw new Error('chunk_size must be at least 1.');
+  }
+  if (overlap !== undefined && overlap < 0) {
+    throw new Error('overlap must be non-negative.');
+  }
 
   const asset = getMediaAssetById(assetId);
   if (!asset) {
@@ -278,6 +284,14 @@ export async function run(
   const batchSize = (input.batch_size as number) ?? 10;
   const chunkSizeInput = (input.chunk_size as number) ?? 10;
   const overlapInput = (input.overlap as number) ?? 2;
+
+  // Validate: chunk_size must be at least 1, overlap must be non-negative
+  if (chunkSizeInput < 1) {
+    return { content: 'chunk_size must be at least 1.', isError: true };
+  }
+  if (overlapInput < 0) {
+    return { content: 'overlap must be non-negative.', isError: true };
+  }
 
   try {
     // Check if all keyframes are already analyzed before calling the core function


### PR DESCRIPTION
Addresses review feedback on #7787. Validates chunk_size >= 1 and overlap >= 0 at both the tool run() entry point and the core analyzeKeyframesForAsset() function, preventing empty-chunk behavior when chunk_size=0 passes through nullish coalescing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
