### PR TITLE
fix(session-manager): swallow rejection in stopAllSessions after silentlyWithLog refactor

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -530,6 +530,6 @@ export function getSessionsForConversation(conversationId: string): ProxySession
  */
 export async function stopAllSessions(): Promise<void> {
   const ids = [...sessions.keys()];
-  await Promise.all(ids.map((id) => silentlyWithLog(stopSession(id), 'session shutdown')));
+  await Promise.all(ids.map((id) => stopSession(id).catch((err: unknown) => log.debug({ err, id }, 'session shutdown error'))));
   sessions.clear();
 }


### PR DESCRIPTION
Addresses review feedback on #7688: silentlyWithLog returns the original rejecting promise, so using it in Promise.all propagates errors. Fix stopAllSessions to actually swallow the rejection while still logging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
