### PR TITLE
fix(db): qualify preflight DROP TABLE with temp schema

### DIFF
--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -244,7 +244,7 @@ export function migrateMemoryEntityRelationDedup(database: Db): void {
   // table present even after the transaction rolls back.  Clearing it here
   // makes re-entry safe without needing IF NOT EXISTS semantics on the full
   // CREATE … AS SELECT.
-  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_entity_relation_merge`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS temp.memory_entity_relation_merge`);
 
   try {
     raw.exec('BEGIN');


### PR DESCRIPTION
Addresses review feedback on #7704: DROP TABLE IF EXISTS memory_entity_relation_merge lacked a schema qualifier. In SQLite, unqualified DROP TABLE could remove a permanent table in an attached schema. Fix by using temp.memory_entity_relation_merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
