### PR TITLE
fix(memory-ux): reset memory degradation state on IPC reconnect

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -398,6 +398,11 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
                 self?.pendingLocalDeletions.removeAll()
+                // Clear stale degradation state so users don't see a warning banner
+                // from a previous session if the new session is healthy. The daemon
+                // will re-emit memory_status if degradation persists after reconnect.
+                self?.isMemoryDegraded = false
+                self?.memoryDegradedReason = nil
                 #if os(iOS)
                 self?.flushOfflineQueue()
                 #endif


### PR DESCRIPTION
Addresses review feedback on #7707: isMemoryDegraded and memoryDegradedReason were never cleared when the IPC stream reconnected, so stale degradation warnings persisted across sessions. Reset them on reconnect.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
