### PR TITLE
fix(ios): show thinking indicator between tool call completion and next text chunk

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -151,9 +151,13 @@ struct ChatContentView: View {
                         // Typing / step indicator shown while generating
                         let hasPendingConfirmation = viewModel.messages.last?.confirmation?.state == .pending
                         if viewModel.isSending && !hasPendingConfirmation {
-                            let allToolCalls = viewModel.messages.last?.toolCalls ?? []
-                            let isStreaming = viewModel.messages.last?.isStreaming == true
+                            let lastMessage = viewModel.messages.last
+                            let allToolCalls = lastMessage?.toolCalls ?? []
+                            let isStreaming = lastMessage?.isStreaming == true
                             let hasActiveToolCall = allToolCalls.contains { !$0.isComplete }
+                            // True when the assistant is streaming but has not yet emitted any text.
+                            // This happens between tool-call completion and the next text chunk.
+                            let isStreamingWithoutText = isStreaming && (lastMessage?.text.isEmpty ?? true)
 
                             if !isStreaming && !hasActiveToolCall {
                                 // No streaming text or active tool call yet — show typing dots
@@ -173,8 +177,18 @@ struct ChatContentView: View {
                                 )
                                 .padding(.horizontal, VSpacing.lg)
                                 .id("step-indicator")
+                            } else if isStreamingWithoutText {
+                                // Tool call just finished but no text has arrived yet — show
+                                // typing dots so the user isn't left without feedback.
+                                HStack {
+                                    TypingIndicatorView()
+                                    Spacer()
+                                }
+                                .padding(.horizontal, VSpacing.lg)
+                                .id("step-indicator")
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
                             }
-                            // When isStreaming: the growing message bubble is the indicator
+                            // Otherwise isStreaming with text: the growing message bubble is the indicator
                         }
 
                         // Invisible anchor at the very bottom of all content


### PR DESCRIPTION
Addresses review feedback on #7730: typing indicator was not shown after a tool call finished but before the assistant emitted new text, leaving users with no visual feedback during multi-step tool use.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
