### PR TITLE
fix(ux): clear connectionDiagnosticHint when non-connection error is shown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -22,7 +22,7 @@ struct ChatErrorBanner: View {
                 Text(text)
                     .font(VFont.caption)
                     .lineLimit(4)
-                if let hint = connectionDiagnosticHint {
+                if isConnectionError, let hint = connectionDiagnosticHint {
                     Text(hint)
                         .font(VFont.small)
                         .opacity(0.8)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -472,6 +472,7 @@ public final class ChatViewModel: ObservableObject {
                 lastFailedMessageText = nil
                 lastFailedMessageAttachments = nil
                 lastFailedSendError = nil
+                connectionDiagnosticHint = nil
                 secretBlockedMessageText = nil
                 secretBlockedAttachments = nil
                 secretBlockedActiveSurfaceId = nil
@@ -518,6 +519,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
+        connectionDiagnosticHint = nil
         secretBlockedMessageText = nil
         secretBlockedAttachments = nil
         secretBlockedActiveSurfaceId = nil
@@ -1306,6 +1308,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         errorText = nil
+        connectionDiagnosticHint = nil
 
         if sessionId == nil {
             bootstrapSession(userMessage: text, attachments: attachments)


### PR DESCRIPTION
Addresses review feedback on #7709: connectionDiagnosticHint was never cleared when a non-connection error replaced it, so a stale connection hint appeared alongside unrelated errors. Also clear it in sendMessage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
