### PR TITLE
fix(clipboard): skip restore on mismatch to avoid overwriting concurrent pasteboard changes

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import AppKit
 import ApplicationServices
+import os
 
 enum ExecutorError: LocalizedError {
     case eventCreationFailed
@@ -35,6 +36,8 @@ enum ExecutorError: LocalizedError {
 protocol ActionExecuting {
     func execute(_ action: AgentAction) async throws -> String?
 }
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ActionExecutor")
 
 final class ActionExecutor: ActionExecuting {
     private let eventSource: CGEventSource?
@@ -123,12 +126,11 @@ final class ActionExecutor: ActionExecuting {
         // typing unintended text.
         let verifiedContents = pasteboard.string(forType: .string)
         guard verifiedContents == text else {
-            // Restore whatever was on the clipboard before we cleared it so the
-            // user's data is not lost, then surface a clear error.
-            pasteboard.clearContents()
-            if let saved = previousContents {
-                pasteboard.setString(saved, forType: .string)
-            }
+            // Another process updated the clipboard between our setString and
+            // this read-back. We don't know what the current state should be, so
+            // restoring previousContents would overwrite that other process's
+            // data. Leave the clipboard as-is and surface a clear error.
+            log.warning("Clipboard read-back mismatch — another process may have modified the pasteboard; skipping injection")
             throw ExecutorError.clipboardMismatch
         }
 


### PR DESCRIPTION
Addresses review feedback on #7752: on clipboard read-back mismatch, restoring previousContents would overwrite another process's concurrent update. Now logs a warning and skips the restore on mismatch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
