### PR TITLE
fix(parental-controls): forward PIN in settings updates and guard unknown tool categories

### DIFF
--- a/assistant/src/security/parental-control-store.ts
+++ b/assistant/src/security/parental-control-store.ts
@@ -174,6 +174,9 @@ export function isToolBlocked(toolName: string): boolean {
 
   for (const category of blockedToolCategories) {
     const prefixes = TOOL_CATEGORY_PREFIXES[category];
+    // Guard against unknown categories that may appear after deserialization of
+    // settings written by a newer client version — skip rather than throw.
+    if (!prefixes) continue;
     if (prefixes.some((p) => toolName.startsWith(p))) return true;
   }
   return false;

--- a/clients/ios/Views/Settings/IOSParentalControlSection.swift
+++ b/clients/ios/Views/Settings/IOSParentalControlSection.swift
@@ -23,6 +23,9 @@ struct IOSParentalControlSection: View {
     @State private var showingClearPIN: Bool = false
     @State private var showingUnlock: Bool = false
     @State private var isUnlocked: Bool = false
+    // Retained after a successful unlock so that subsequent update calls can
+    // forward the PIN to the daemon (required when parental mode is enabled).
+    @State private var unlockedPIN: String?
 
     private var daemon: DaemonClient? { clientProvider.client as? DaemonClient }
 
@@ -101,12 +104,14 @@ struct IOSParentalControlSection: View {
             }
         }
         .sheet(isPresented: $showingUnlock) {
-            IOSUnlockSheet(daemon: daemon) { unlocked in
+            IOSUnlockSheet(daemon: daemon) { result in
                 showingUnlock = false
-                if unlocked {
+                switch result {
+                case .success(let pin):
                     isUnlocked = true
+                    unlockedPIN = pin
                     errorMessage = nil
-                } else {
+                case .failure:
                     errorMessage = "Incorrect PIN."
                 }
             }
@@ -209,8 +214,9 @@ struct IOSParentalControlSection: View {
     private func updateEnabled(_ enabled: Bool) {
         isLoading = true; errorMessage = nil; successMessage = nil
         let stream = daemon?.subscribe()
+        let pin = unlockedPIN
         Task {
-            do { try daemon?.sendParentalControlUpdate(enabled: enabled) } catch {
+            do { try daemon?.sendParentalControlUpdate(pin: pin, enabled: enabled) } catch {
                 await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
                 return
             }
@@ -239,8 +245,9 @@ struct IOSParentalControlSection: View {
     private func updateContentRestrictions(_ restrictions: [String]) {
         isLoading = true; errorMessage = nil; successMessage = nil
         let stream = daemon?.subscribe()
+        let pin = unlockedPIN
         Task {
-            do { try daemon?.sendParentalControlUpdate(contentRestrictions: restrictions) } catch {
+            do { try daemon?.sendParentalControlUpdate(pin: pin, contentRestrictions: restrictions) } catch {
                 await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
                 return
             }
@@ -265,8 +272,9 @@ struct IOSParentalControlSection: View {
     private func updateToolCategories(_ categories: [String]) {
         isLoading = true; errorMessage = nil; successMessage = nil
         let stream = daemon?.subscribe()
+        let pin = unlockedPIN
         Task {
-            do { try daemon?.sendParentalControlUpdate(blockedToolCategories: categories) } catch {
+            do { try daemon?.sendParentalControlUpdate(pin: pin, blockedToolCategories: categories) } catch {
                 await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
                 return
             }
@@ -294,7 +302,7 @@ struct IOSParentalControlSection: View {
             switch mode {
             case .set: hasPIN = true; successMessage = "PIN set."
             case .change: successMessage = "PIN changed."
-            case .clear: hasPIN = false; isUnlocked = false; successMessage = "PIN cleared."
+            case .clear: hasPIN = false; isUnlocked = false; unlockedPIN = nil; successMessage = "PIN cleared."
             }
         case .failure(let msg):
             errorMessage = msg
@@ -409,9 +417,11 @@ struct IOSPINSheet: View {
 
 // MARK: - Unlock Sheet (iOS)
 
+enum IOSUnlockResult { case success(pin: String); case failure }
+
 struct IOSUnlockSheet: View {
     let daemon: DaemonClient?
-    let onComplete: (Bool) -> Void
+    let onComplete: (IOSUnlockResult) -> Void
 
     @State private var pin: String = ""
     @State private var isLoading: Bool = false
@@ -466,8 +476,10 @@ struct IOSUnlockSheet: View {
             }
             await MainActor.run {
                 isLoading = false
-                if let r = response { onComplete(r.verified); if !r.verified { errorMessage = "Incorrect PIN." } }
-                else { errorMessage = "No response from assistant." }
+                if let r = response {
+                    if r.verified { onComplete(.success(pin: pin)) }
+                    else { onComplete(.failure); errorMessage = "Incorrect PIN." }
+                } else { errorMessage = "No response from assistant." }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -27,6 +27,9 @@ struct SettingsParentalTab: View {
     // -- Unlock overlay (shown when settings are locked) --
     @State private var showingUnlockSheet: Bool = false
     @State private var isUnlocked: Bool = false
+    // Retained after a successful unlock so that subsequent update calls can
+    // forward the PIN to the daemon (required when parental mode is enabled).
+    @State private var unlockedPIN: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -73,6 +76,7 @@ struct SettingsParentalTab: View {
                         case .clear:
                             hasPIN = false
                             isUnlocked = false
+                            unlockedPIN = nil
                             successMessage = "PIN cleared."
                         }
                     case .failure(let msg):
@@ -84,12 +88,14 @@ struct SettingsParentalTab: View {
         }
         .sheet(isPresented: $showingUnlockSheet) {
             UnlockSheet(
-                onComplete: { unlocked in
+                onComplete: { result in
                     showingUnlockSheet = false
-                    if unlocked {
+                    switch result {
+                    case .success(let pin):
                         isUnlocked = true
+                        unlockedPIN = pin
                         errorMessage = nil
-                    } else {
+                    case .failure:
                         errorMessage = "Incorrect PIN."
                     }
                 },
@@ -313,9 +319,10 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         let stream = daemonClient?.subscribe()
+        let pin = unlockedPIN
         Task {
             do {
-                try daemonClient?.sendParentalControlUpdate(enabled: enabled)
+                try daemonClient?.sendParentalControlUpdate(pin: pin, enabled: enabled)
             } catch {
                 await MainActor.run {
                     isLoading = false
@@ -365,9 +372,10 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         let stream = daemonClient?.subscribe()
+        let pin = unlockedPIN
         Task {
             do {
-                try daemonClient?.sendParentalControlUpdate(contentRestrictions: restrictions)
+                try daemonClient?.sendParentalControlUpdate(pin: pin, contentRestrictions: restrictions)
             } catch {
                 await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
                 return
@@ -409,9 +417,10 @@ struct SettingsParentalTab: View {
         successMessage = nil
 
         let stream = daemonClient?.subscribe()
+        let pin = unlockedPIN
         Task {
             do {
-                try daemonClient?.sendParentalControlUpdate(blockedToolCategories: categories)
+                try daemonClient?.sendParentalControlUpdate(pin: pin, blockedToolCategories: categories)
             } catch {
                 await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
                 return
@@ -605,9 +614,14 @@ private struct PINSheet: View {
 
 // MARK: - Unlock Sheet
 
+private enum UnlockResult {
+    case success(pin: String)
+    case failure
+}
+
 @MainActor
 private struct UnlockSheet: View {
-    let onComplete: (Bool) -> Void
+    let onComplete: (UnlockResult) -> Void
     var daemonClient: DaemonClient?
 
     @State private var pin: String = ""
@@ -686,8 +700,12 @@ private struct UnlockSheet: View {
             await MainActor.run {
                 isLoading = false
                 if let r = response {
-                    onComplete(r.verified)
-                    if !r.verified { errorMessage = "Incorrect PIN." }
+                    if r.verified {
+                        onComplete(.success(pin: pin))
+                    } else {
+                        onComplete(.failure)
+                        errorMessage = "Incorrect PIN."
+                    }
                 } else {
                     errorMessage = "No response from daemon."
                 }


### PR DESCRIPTION
Addresses review feedback on #7687: pass PIN when sending parental control updates from macOS and iOS settings screens (daemon rejects updates without PIN when parental mode is enabled), and guard against unknown tool categories in isToolBlocked to prevent crashes on deserialized settings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
