### PR TITLE
Hide composer scrollbar when text exceeds max height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -577,9 +577,8 @@ private struct ComposerTextView: NSViewRepresentable {
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
         scrollView.borderType = .noBorder
-        scrollView.hasVerticalScroller = true
+        scrollView.hasVerticalScroller = false
         scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
         // Ensure text content is clipped to the scroll view frame so it
         // never renders outside the composer box.
         scrollView.wantsLayer = true


### PR DESCRIPTION
## Summary
- Remove visible vertical scrollbar from the composer text input
- Content still scrolls via trackpad/wheel when text exceeds max height (200pt), but no scrollbar indicator is shown
- Fixes visual clutter and jittery scrollbar appearing while typing long messages

## Original prompt
Hide composer scrollbar when text exceeds max height

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
