### PR TITLE
fix(attachments): prevent premature send, re-check cap async, NSImage thread safety

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -209,7 +209,9 @@ struct InputBarView: View {
     private var canSend: Bool {
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasAttachments = !viewModel.pendingAttachments.isEmpty
-        return (hasText || hasAttachments) && !isGenerating
+        // Block send while an attachment is still loading so the attachment
+        // isn't dropped from the message if the user taps Send too quickly.
+        return (hasText || hasAttachments) && !isGenerating && !viewModel.isLoadingAttachment
     }
 
     private func handlePhotoSelection(_ items: [PhotosPickerItem]) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -13,6 +13,7 @@ struct ChatEmptyStateView: View {
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    var isLoadingAttachment: Bool = false
     let errorText: String?
     let onSend: () -> Void
     let onStop: () -> Void
@@ -99,6 +100,7 @@ struct ChatEmptyStateView: View {
                     isRecording: isRecording,
                     suggestion: suggestion,
                     pendingAttachments: pendingAttachments,
+                    isLoadingAttachment: isLoadingAttachment,
                     onSend: onSend,
                     onStop: onStop,
                     onAcceptSuggestion: onAcceptSuggestion,
@@ -142,6 +144,7 @@ struct ChatTemporaryChatEmptyStateView: View {
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    var isLoadingAttachment: Bool = false
     let errorText: String?
     let onSend: () -> Void
     let onStop: () -> Void
@@ -201,6 +204,7 @@ struct ChatTemporaryChatEmptyStateView: View {
                     isRecording: isRecording,
                     suggestion: suggestion,
                     pendingAttachments: pendingAttachments,
+                    isLoadingAttachment: isLoadingAttachment,
                     onSend: onSend,
                     onStop: onStop,
                     onAcceptSuggestion: onAcceptSuggestion,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -12,6 +12,7 @@ struct ChatView: View {
     let pendingQueuedCount: Int
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    var isLoadingAttachment: Bool = false
     let isRecording: Bool
     let onOpenSettings: () -> Void
     let onSend: () -> Void
@@ -112,6 +113,7 @@ struct ChatView: View {
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
+                            isLoadingAttachment: isLoadingAttachment,
                             errorText: errorText,
                             onSend: onSend,
                             onStop: onStop,
@@ -132,6 +134,7 @@ struct ChatView: View {
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
+                            isLoadingAttachment: isLoadingAttachment,
                             errorText: errorText,
                             onSend: onSend,
                             onStop: onStop,
@@ -255,6 +258,7 @@ struct ChatView: View {
                 isRecording: isRecording,
                 suggestion: suggestion,
                 pendingAttachments: pendingAttachments,
+                isLoadingAttachment: isLoadingAttachment,
                 onSend: onSend,
                 onStop: onStop,
                 onAcceptSuggestion: onAcceptSuggestion,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -41,6 +41,7 @@ struct ComposerView: View {
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    var isLoadingAttachment: Bool = false
     let onSend: () -> Void
     let onStop: () -> Void
     let onAcceptSuggestion: () -> Void
@@ -474,7 +475,11 @@ struct ComposerView: View {
     }
 
     var canSend: Bool {
-        hasAPIKey && (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty)
+        // Block send while an attachment is still loading: the user tapping Send
+        // before the async load completes would drop the attachment from the message.
+        hasAPIKey
+            && !isLoadingAttachment
+            && (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty)
     }
 
     // MARK: - Slash Command Logic

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -580,6 +580,7 @@ struct ActiveChatViewWrapper: View {
             pendingQueuedCount: viewModel.pendingQueuedCount,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,
+            isLoadingAttachment: viewModel.isLoadingAttachment,
             isRecording: viewModel.isRecording,
             onOpenSettings: {
                 windowState.selection = .panel(.settings)

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -20,6 +20,14 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 public final class ChatAttachmentManager: ObservableObject {
 
     @Published public var pendingAttachments: [ChatAttachment] = []
+    /// True while at least one attachment is being loaded in the background.
+    /// The send button checks this so a user can't send before async load finishes.
+    @Published public var isLoadingAttachment: Bool = false
+
+    // Counts in-flight background loads; isLoadingAttachment is true when > 0.
+    private var loadingCount: Int = 0 {
+        didSet { isLoadingAttachment = loadingCount > 0 }
+    }
 
     // MARK: - Limits
 
@@ -57,12 +65,21 @@ public final class ChatAttachmentManager: ObservableObject {
         // Move file reading, compression, and thumbnail generation off the main
         // thread — Data(contentsOf:) is a blocking syscall that can stall the UI
         // for up to 20 MB worth of I/O before we even begin image processing.
+        loadingCount += 1
         Task {
+            defer { self.loadingCount -= 1 }
             let result = await Self.loadAttachment(url: url)
             switch result {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
             case .success(let attachment):
+                // Re-check cap here: multiple concurrent adds may have all passed
+                // the guard above before any of them appended, so we must verify
+                // again inside the async task before committing.
+                guard self.pendingAttachments.count < Self.maxAttachments else {
+                    self.onError?("Maximum \(Self.maxAttachments) attachments per message.")
+                    return
+                }
                 self.pendingAttachments.append(attachment)
             }
         }
@@ -113,12 +130,20 @@ public final class ChatAttachmentManager: ObservableObject {
         // Move image conversion, compression, and thumbnail generation off the
         // main thread — these are CPU-bound and can take tens of milliseconds
         // for large images.
+        loadingCount += 1
         Task {
+            defer { self.loadingCount -= 1 }
             let result = await Self.loadAttachment(imageData: imageData, filename: filename)
             switch result {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
             case .success(let attachment):
+                // Re-check cap: multiple concurrent adds may all pass the guard
+                // above before any appends occur.
+                guard self.pendingAttachments.count < Self.maxAttachments else {
+                    self.onError?("Maximum \(Self.maxAttachments) attachments per message.")
+                    return
+                }
                 self.pendingAttachments.append(attachment)
             }
         }
@@ -303,13 +328,19 @@ public final class ChatAttachmentManager: ObservableObject {
         guard size.width > 0 && size.height > 0 else { return nil }
         let scale = min(maxDimension / size.width, maxDimension / size.height, 1.0)
         let newSize = NSSize(width: size.width * scale, height: size.height * scale)
-        let resized = NSImage(size: newSize)
-        resized.lockFocus()
-        image.draw(in: NSRect(origin: .zero, size: newSize),
-                   from: NSRect(origin: .zero, size: size),
-                   operation: .copy, fraction: 1.0)
-        resized.unlockFocus()
-        guard let tiffData = resized.tiffRepresentation,
+        // NSImage.lockFocus()/draw()/unlockFocus() must run on the main thread.
+        // This helper may be called from a Task.detached context, so we hop to
+        // MainActor explicitly before touching the AppKit drawing APIs.
+        let tiffData: Data? = DispatchQueue.main.sync {
+            let resized = NSImage(size: newSize)
+            resized.lockFocus()
+            image.draw(in: NSRect(origin: .zero, size: newSize),
+                       from: NSRect(origin: .zero, size: size),
+                       operation: .copy, fraction: 1.0)
+            resized.unlockFocus()
+            return resized.tiffRepresentation
+        }
+        guard let tiffData,
               let bitmap = NSBitmapImageRep(data: tiffData),
               let png = bitmap.representation(using: .png, properties: [:]) else { return nil }
         return png

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -153,6 +153,11 @@ public final class ChatViewModel: ObservableObject {
         get { attachmentManager.pendingAttachments }
         set { attachmentManager.pendingAttachments = newValue }
     }
+    /// True while at least one attachment is still being loaded in the background.
+    /// The send button checks this to prevent sending before async load finishes.
+    public var isLoadingAttachment: Bool {
+        attachmentManager.isLoadingAttachment
+    }
 
     // MARK: - Forwarding properties — ChatErrorManager
 


### PR DESCRIPTION
Addresses review feedback on #7751: (1) addAttachment returned before async load completed, allowing sends without the attachment; (2) max-attachments cap was bypassed on concurrent adds; (3) NSImage.lockFocus() was called off main thread.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
