### PR TITLE
fix(test): record root completion after its delay in DAG tests

### DIFF
--- a/assistant/src/__tests__/swarm-dag-pathological.test.ts
+++ b/assistant/src/__tests__/swarm-dag-pathological.test.ts
@@ -408,9 +408,11 @@ describe('very wide fan-outs', () => {
       runTask: async (input) => {
         const isRoot = input.prompt.includes('Root task');
         if (isRoot) {
-          completionOrder.push('root');
           // Introduce a tiny delay so leaves clearly start after root ends.
           await new Promise((r) => setTimeout(r, 10));
+          // Record completion only after the delay finishes so completionOrder
+          // reflects actual completion time, not when execution started.
+          completionOrder.push('root');
         }
         return { success: true, output: SUCCESS_OUTPUT, durationMs: 2 };
       },


### PR DESCRIPTION
Addresses review feedback on #7755: completionOrder.push('root') was recorded before the root task's artificial delay completed, making the ordering assertion test a pre-completion state rather than actual completion order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
