### PR TITLE
fix(voice-orb): pre-recording cancel and live amplitude in jitter timer

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -46,6 +46,9 @@ struct InputBarView: View {
     @State private var micAmplitude: Float = 0
     /// Tracks whether the orb panel is expanded (voice orb replaces the normal input row).
     @State private var isVoiceOrbExpanded = false
+    /// Set to true when Cancel is tapped before recording has started; checked by beginRecording()
+    /// so that a cancel during the mic-permission or setup window aborts the session.
+    @State private var isCancelledBeforeRecording = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -79,9 +82,12 @@ struct InputBarView: View {
                 listeningAmplitude: micAmplitude
             )
 
-            // Dismiss / stop button — tapping cancels recording and collapses the orb
+            // Dismiss / stop button — tapping cancels recording and collapses the orb.
+            // If tapped before recording has started (e.g. during the mic-permission dialog),
+            // isCancelledBeforeRecording signals beginRecording() to abort setup immediately.
             Button(action: {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                isCancelledBeforeRecording = true
                 stopRecording()
                 isVoiceOrbExpanded = false
             }) {
@@ -258,7 +264,9 @@ struct InputBarView: View {
             stopRecording()
             isVoiceOrbExpanded = false
         } else {
-            // Expand the orb panel immediately so the user sees it before permissions are checked
+            // Expand the orb panel immediately so the user sees it before permissions are checked.
+            // Reset the cancel flag for this new session before the async permission flow begins.
+            isCancelledBeforeRecording = false
             isVoiceOrbExpanded = true
             requestPermissionsAndRecord()
         }
@@ -291,6 +299,13 @@ struct InputBarView: View {
     }
 
     private func beginRecording() {
+        // If the user tapped Cancel while permissions were being requested, abort here
+        // rather than starting a session they've already dismissed.
+        guard !isCancelledBeforeRecording else {
+            log.info("Recording cancelled before it started — aborting setup")
+            return
+        }
+
         guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
             log.error("Speech recognizer not available")
             isVoiceOrbExpanded = false

--- a/clients/ios/Views/VoiceOrbView.swift
+++ b/clients/ios/Views/VoiceOrbView.swift
@@ -29,6 +29,12 @@ struct VoiceOrbView: View {
     @State private var spinAngle: Double = 0
     @State private var ringJitter: [CGFloat] = [0, 0, 0]
     @State private var jitterTimer: Timer?
+    // Mutable @State copies of the incoming amplitudes so the timer closure can read
+    // the current value on every tick. SwiftUI struct properties are copied by value
+    // into closures at capture time; @State provides stable heap-allocated storage that
+    // the timer sees fresh on each fire.
+    @State private var currentListeningAmplitude: Float = 0
+    @State private var currentSpeakingAmplitude: Float = 0
 
     private let orbSize: CGFloat = 72
 
@@ -43,6 +49,14 @@ struct VoiceOrbView: View {
             } else {
                 stopRingJitter()
             }
+        }
+        // Keep the @State amplitude mirrors in sync so the timer closure always reads
+        // the live value rather than a stale copy from the last struct update.
+        .onChange(of: listeningAmplitude) { _, newValue in
+            currentListeningAmplitude = newValue
+        }
+        .onChange(of: speakingAmplitude) { _, newValue in
+            currentSpeakingAmplitude = newValue
         }
         .onDisappear {
             stopRingJitter()
@@ -203,7 +217,11 @@ struct VoiceOrbView: View {
         jitterTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
             Task { @MainActor in
                 if isListening {
-                    let amp = CGFloat(listeningAmplitude)
+                    // Read currentListeningAmplitude — the @State mirror updated by onChange —
+                    // so the intensity reflects the live audio level on every tick.
+                    // @State uses heap-allocated storage, so the closure captures a reference
+                    // to the same box even though VoiceOrbView is a struct.
+                    let amp = CGFloat(currentListeningAmplitude)
                     let intensity: CGFloat = 3 + amp * 12
                     withAnimation(.easeInOut(duration: 0.07)) {
                         ringJitter = (0..<3).map { _ in CGFloat.random(in: -intensity...intensity) }


### PR DESCRIPTION
Addresses review feedback on #7759: (1) tapping Cancel before mic setup completed was silently ignored — added isCancelled flag to abort setup; (2) jitter timer captured listeningAmplitude by value so ring never reflected live audio — now reads from self on each tick.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
