### PR TITLE
fix(eslint): enforce null comparison rules as errors not warnings

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -13,10 +13,9 @@ const eslintConfig = defineConfig([
 
       // Standardize on `undefined` only — avoid `null` in new code.
       // Prefer `=== undefined`, `?? fallback`, or `?.` optional chaining
-      // instead of `=== null`. Existing code is grandfathered in (warn, not
-      // error) so we don't need a mass refactor.
+      // instead of `=== null`.
       "no-restricted-syntax": [
-        "warn",
+        "error",
         {
           selector:
             "BinaryExpression[operator='==='][right.type='Literal'][right.raw='null']",


### PR DESCRIPTION
Addresses review feedback on #7763: no-restricted-syntax rules for null comparisons were set to 'warn' which CI doesn't fail on. Changed to 'error' to actually enforce the policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
