### PR TITLE
fix(ios-tasks): fix multi-delete index mutation and async pull-to-refresh

### DIFF
--- a/clients/ios/Views/Tasks/TasksView.swift
+++ b/clients/ios/Views/Tasks/TasksView.swift
@@ -27,7 +27,7 @@ struct TasksView: View {
                     }
                 }
                 .refreshable {
-                    viewModel.fetchItems()
+                    await viewModel.fetchItemsAsync()
                 }
         }
         .sheet(isPresented: Binding(
@@ -125,9 +125,11 @@ struct TasksView: View {
                 .listRowInsets(EdgeInsets(top: VSpacing.xs, leading: VSpacing.md, bottom: VSpacing.xs, trailing: VSpacing.md))
             }
             .onDelete { indexSet in
-                for index in indexSet {
-                    let item = viewModel.items[index]
-                    viewModel.removeTask(id: item.id)
+                // Resolve all IDs before any removal so index shifts
+                // from earlier removeTask calls don't corrupt later lookups.
+                let ids = indexSet.map { viewModel.items[$0].id }
+                for id in ids {
+                    viewModel.removeTask(id: id)
                 }
             }
         }

--- a/clients/ios/Views/Tasks/TasksViewModel.swift
+++ b/clients/ios/Views/Tasks/TasksViewModel.swift
@@ -39,6 +39,10 @@ class TasksViewModel: ObservableObject {
 
     private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
 
+    /// One-shot continuation set by `fetchItemsAsync()` so the pull-to-refresh
+    /// indicator waits until the daemon responds rather than dismissing immediately.
+    private var pendingRefreshContinuation: CheckedContinuation<Void, Never>?
+
     /// How long to wait for a daemon run-task response before treating
     /// the request as timed out (matches macOS behaviour).
     private static let runTimeoutSeconds: UInt64 = 10
@@ -61,6 +65,11 @@ class TasksViewModel: ObservableObject {
                     .filter { WorkItemStatus(rawStatus: $0.status) != .running }
                     .map(\.id))
                 self.runInFlightIds.subtract(nonRunningIds)
+                // Signal pull-to-refresh completion if one is in flight.
+                if let continuation = self.pendingRefreshContinuation {
+                    self.pendingRefreshContinuation = nil
+                    continuation.resume()
+                }
             }
         }
 
@@ -167,6 +176,18 @@ class TasksViewModel: ObservableObject {
             logger.error("fetchItems failed: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription
             isLoading = false
+        }
+    }
+
+    /// Async variant used by `.refreshable` so the pull-to-refresh indicator
+    /// stays visible until the daemon actually responds (not just until the
+    /// request is sent).
+    func fetchItemsAsync() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            // Register a one-shot listener that resumes the continuation once
+            // the next work-items-list response arrives, then clears itself.
+            pendingRefreshContinuation = continuation
+            fetchItems()
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on #7762: (1) onDelete iterated and removed items in the same loop causing shifted indices and potential crash — now resolves all IDs before removing; (2) refreshable closure called synchronous fetchItems so refresh indicator dismissed immediately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
