### PR TITLE
fix(whatsapp): require app secret for signature validation and process all batch messages

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -116,13 +116,16 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
-    // Verify HMAC-SHA256 signature when app secret is configured.
-    // Fail-closed: reject if the secret is set but verification fails.
-    if (config.whatsappAppSecret) {
-      if (!verifyWhatsAppWebhookSignature(req.headers, rawBody, config.whatsappAppSecret)) {
-        tlog.warn("WhatsApp webhook signature verification failed");
-        return Response.json({ error: "Forbidden" }, { status: 403 });
-      }
+    // Signature validation is required — reject requests when the app secret is not configured
+    // rather than silently accepting unauthenticated payloads (fail-closed).
+    if (!config.whatsappAppSecret) {
+      tlog.warn("WhatsApp app secret is not configured — rejecting request");
+      return Response.json({ error: "Webhook signature validation not configured" }, { status: 500 });
+    }
+
+    if (!verifyWhatsAppWebhookSignature(req.headers, rawBody, config.whatsappAppSecret)) {
+      tlog.warn("WhatsApp webhook signature verification failed");
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
     let payload: Record<string, unknown>;
@@ -132,100 +135,78 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const normalized = normalizeWhatsAppWebhook(payload);
-    if (!normalized) {
-      // Deliver receipts, status updates, non-text messages, etc. — acknowledge silently
+    const normalizedMessages = normalizeWhatsAppWebhook(payload);
+    if (normalizedMessages.length === 0) {
+      // Delivery receipts, status updates, non-text messages, etc. — acknowledge silently
       return Response.json({ ok: true });
     }
 
-    const { event, whatsappMessageId } = normalized;
-    const from = event.message.externalChatId;
+    for (const normalized of normalizedMessages) {
+      const { event, whatsappMessageId } = normalized;
+      const from = event.message.externalChatId;
 
-    // Dedup by WhatsApp message ID — atomically reserve so concurrent retries
-    // are blocked while the first request is still processing.
-    if (!dedupCache.reserve(whatsappMessageId)) {
-      tlog.info({ whatsappMessageId }, "Duplicate WhatsApp message ID, ignoring");
-      return Response.json({ ok: true });
-    }
-
-    tlog.info(
-      {
-        source: "whatsapp",
-        messageId: whatsappMessageId,
-        from,
-      },
-      "WhatsApp webhook received",
-    );
-
-    // Mark message as read (best-effort, do not await)
-    markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
-      tlog.debug({ err, messageId: whatsappMessageId }, "Failed to mark WhatsApp message as read");
-    });
-
-    // Resolve routing once so we can gate further operations on it
-    const routing = resolveAssistant(config, from, from);
-
-    // Handle /new command — reset conversation before it reaches the runtime
-    if (event.message.content.trim().toLowerCase() === "/new") {
-      if (isRejection(routing)) {
-        tlog.warn({ from, reason: routing.reason }, "Routing rejected /new command");
-        sendWhatsAppReply(
-          config,
-          from,
-          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-        ).catch((err) => {
-          tlog.error({ err, to: from }, "Failed to send /new routing rejection notice");
-        });
-      } else {
-        try {
-          await resetConversation(
-            config,
-            routing.assistantId,
-            event.sourceChannel,
-            event.message.externalChatId,
-          );
-          sendWhatsAppReply(config, from, "Starting a new conversation!").catch((err) => {
-            tlog.error({ err }, "Failed to send /new confirmation");
-          });
-        } catch (err) {
-          tlog.error({ err }, "Failed to reset conversation");
-          sendWhatsAppReply(config, from, "Failed to reset conversation. Please try again.").catch(
-            (replyErr) => {
-              tlog.error({ err: replyErr }, "Failed to send /new error reply");
-            },
-          );
-        }
+      // Dedup by WhatsApp message ID — atomically reserve so concurrent retries
+      // are blocked while the first request is still processing.
+      if (!dedupCache.reserve(whatsappMessageId)) {
+        tlog.info({ whatsappMessageId }, "Duplicate WhatsApp message ID, ignoring");
+        continue;
       }
 
-      dedupCache.mark(whatsappMessageId);
-      return Response.json({ ok: true });
-    }
-
-    if (isRejection(routing)) {
-      tlog.warn({ from, reason: routing.reason }, "Routing rejected inbound WhatsApp message");
-      if (shouldSendRejectionNotice(from)) {
-        sendWhatsAppReply(
-          config,
+      tlog.info(
+        {
+          source: "whatsapp",
+          messageId: whatsappMessageId,
           from,
-          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-        ).catch((err) => {
-          tlog.error({ err, to: from }, "Failed to send routing rejection notice");
-        });
-      }
-      dedupCache.mark(whatsappMessageId);
-      return Response.json({ ok: true });
-    }
+        },
+        "WhatsApp webhook received",
+      );
 
-    try {
-      const result = await handleInbound(config, event, {
-        transportMetadata: buildWhatsAppTransportMetadata(),
-        replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/whatsapp`,
-        traceId,
-        routingOverride: routing,
+      // Mark message as read (best-effort, do not await)
+      markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
+        tlog.debug({ err, messageId: whatsappMessageId }, "Failed to mark WhatsApp message as read");
       });
 
-      if (result.rejected) {
-        tlog.warn({ from, reason: result.rejectionReason }, "Routing rejected inbound WhatsApp message");
+      // Resolve routing once so we can gate further operations on it
+      const routing = resolveAssistant(config, from, from);
+
+      // Handle /new command — reset conversation before it reaches the runtime
+      if (event.message.content.trim().toLowerCase() === "/new") {
+        if (isRejection(routing)) {
+          tlog.warn({ from, reason: routing.reason }, "Routing rejected /new command");
+          sendWhatsAppReply(
+            config,
+            from,
+            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+          ).catch((err) => {
+            tlog.error({ err, to: from }, "Failed to send /new routing rejection notice");
+          });
+        } else {
+          try {
+            await resetConversation(
+              config,
+              routing.assistantId,
+              event.sourceChannel,
+              event.message.externalChatId,
+            );
+            sendWhatsAppReply(config, from, "Starting a new conversation!").catch((err) => {
+              tlog.error({ err }, "Failed to send /new confirmation");
+            });
+          } catch (err) {
+            tlog.error({ err }, "Failed to reset conversation");
+            sendWhatsAppReply(config, from, "Failed to reset conversation. Please try again.").catch(
+              (replyErr) => {
+                tlog.error({ err: replyErr }, "Failed to send /new error reply");
+              },
+            );
+          }
+        }
+
+        dedupCache.mark(whatsappMessageId);
+        continue;
+      }
+
+      if (isRejection(routing)) {
+        tlog.warn({ from, reason: routing.reason }, "Routing rejected inbound WhatsApp message");
         if (shouldSendRejectionNotice(from)) {
           sendWhatsAppReply(
             config,
@@ -236,21 +217,46 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           });
         }
         dedupCache.mark(whatsappMessageId);
-        return Response.json({ ok: true });
+        continue;
       }
 
-      if (!result.forwarded) {
-        tlog.error({ whatsappMessageId }, "Failed to forward WhatsApp message to runtime");
+      try {
+        const result = await handleInbound(config, event, {
+          transportMetadata: buildWhatsAppTransportMetadata(),
+          replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/whatsapp`,
+          traceId,
+          routingOverride: routing,
+        });
+
+        if (result.rejected) {
+          tlog.warn({ from, reason: result.rejectionReason }, "Routing rejected inbound WhatsApp message");
+          if (shouldSendRejectionNotice(from)) {
+            sendWhatsAppReply(
+              config,
+              from,
+              "This message could not be routed to an assistant. Please check your gateway routing configuration.",
+            ).catch((err) => {
+              tlog.error({ err, to: from }, "Failed to send routing rejection notice");
+            });
+          }
+          dedupCache.mark(whatsappMessageId);
+          continue;
+        }
+
+        if (!result.forwarded) {
+          tlog.error({ whatsappMessageId }, "Failed to forward WhatsApp message to runtime");
+          dedupCache.unreserve(whatsappMessageId);
+          // Continue processing remaining messages even if one fails to forward
+          continue;
+        }
+
+        dedupCache.mark(whatsappMessageId);
+        tlog.info({ status: "forwarded", whatsappMessageId }, "WhatsApp message forwarded to runtime");
+      } catch (err) {
+        tlog.error({ err, whatsappMessageId }, "Failed to process inbound WhatsApp message");
         dedupCache.unreserve(whatsappMessageId);
-        return Response.json({ error: "Internal error" }, { status: 500 });
+        // Continue processing remaining messages even if one throws
       }
-
-      dedupCache.mark(whatsappMessageId);
-      tlog.info({ status: "forwarded", whatsappMessageId }, "WhatsApp message forwarded to runtime");
-    } catch (err) {
-      tlog.error({ err, whatsappMessageId }, "Failed to process inbound WhatsApp message");
-      dedupCache.unreserve(whatsappMessageId);
-      return Response.json({ error: "Internal error" }, { status: 500 });
     }
 
     return Response.json({ ok: true });

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -56,71 +56,74 @@ export interface NormalizedWhatsAppMessage {
 }
 
 /**
- * Normalize a WhatsApp Cloud API webhook payload into a GatewayInboundEventV1.
+ * Normalize a WhatsApp Cloud API webhook payload into an array of GatewayInboundEventV1 events.
  *
- * Returns null if:
+ * Returns an empty array if:
  * - The payload is not a WhatsApp messages webhook
- * - The message type is not text (audio/video/image/document are unsupported)
  * - Required fields are missing
  *
- * Only processes the first text message from the first entry/change to keep the
- * handler simple. Meta recommends acknowledging all webhooks regardless.
+ * Non-text messages (audio/video/image/document) within the batch are skipped.
+ * Meta may batch multiple messages in a single webhook payload; we process all
+ * of them rather than discarding messages beyond the first.
  */
 export function normalizeWhatsAppWebhook(
   payload: Record<string, unknown>,
-): NormalizedWhatsAppMessage | null {
+): NormalizedWhatsAppMessage[] {
   const wh = payload as WhatsAppWebhookPayload;
 
-  if (wh.object !== "whatsapp_business_account") return null;
+  if (wh.object !== "whatsapp_business_account") return [];
 
-  const entry = wh.entry?.[0];
-  if (!entry) return null;
+  const results: NormalizedWhatsAppMessage[] = [];
 
-  const change = entry.changes?.find((c) => c.field === "messages");
-  if (!change?.value) return null;
+  for (const entry of wh.entry ?? []) {
+    const change = entry.changes?.find((c) => c.field === "messages");
+    if (!change?.value) continue;
 
-  const value = change.value;
-  const messages = value.messages;
-  if (!messages || messages.length === 0) return null;
+    const value = change.value;
+    const messages = value.messages;
+    if (!messages || messages.length === 0) continue;
 
-  const msg = messages[0];
+    for (const msg of messages) {
+      // Only forward text messages; other types (image, audio, etc.) are not supported
+      if (msg.type !== "text") continue;
 
-  // Only forward text messages; other types (image, audio, etc.) are not supported
-  if (msg.type !== "text") return null;
+      const textMsg = msg as WhatsAppTextMessage;
+      const body = textMsg.text?.body?.trim() ?? "";
 
-  const textMsg = msg as WhatsAppTextMessage;
-  const body = textMsg.text?.body?.trim() ?? "";
+      // from is the sender's WhatsApp phone number in E.164 format
+      const from = textMsg.from;
+      if (!from) continue;
 
-  // from is the sender's WhatsApp phone number in E.164 format
-  const from = textMsg.from;
-  if (!from) return null;
+      // Resolve display name from contacts array when available
+      const contact = value.contacts?.find((c) => c.wa_id === from);
+      const displayName = contact?.profile?.name ?? from;
 
-  // Resolve display name from contacts array when available
-  const contact = value.contacts?.find((c) => c.wa_id === from);
-  const displayName = contact?.profile?.name ?? from;
+      results.push({
+        whatsappMessageId: textMsg.id,
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date(Number(textMsg.timestamp) * 1000).toISOString(),
+          message: {
+            content: body,
+            // Use sender phone number as the chat identifier for 1:1 conversations
+            externalChatId: from,
+            externalMessageId: textMsg.id,
+          },
+          sender: {
+            externalUserId: from,
+            displayName,
+          },
+          source: {
+            updateId: textMsg.id,
+            messageId: textMsg.id,
+            chatType: "private",
+          },
+          raw: payload,
+        },
+      });
+    }
+  }
 
-  return {
-    whatsappMessageId: textMsg.id,
-    event: {
-      version: "v1",
-      sourceChannel: "whatsapp",
-      receivedAt: new Date(Number(textMsg.timestamp) * 1000).toISOString(),
-      message: {
-        content: body,
-        // Use sender phone number as the chat identifier for 1:1 conversations
-        externalChatId: from,
-        externalMessageId: textMsg.id,
-      },
-      sender: {
-        externalUserId: from,
-        displayName,
-      },
-      source: {
-        updateId: textMsg.id,
-        messageId: textMsg.id,
-        chatType: "private",
-      },
-      raw: payload,
-    },
-  };
+  return results;
 }


### PR DESCRIPTION
Addresses review feedback on #7765: (1) signature validation was optional when WHATSAPP_APP_SECRET unset — now required; (2) normalizer only processed messages[0] dropping remaining messages in batched payloads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
