### PR TITLE
fix(notion): fix OAuth config and skill token retrieval instructions

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -32,6 +32,10 @@ interface WellKnownOAuthConfig {
   scopes: string[];
   userinfoUrl?: string;
   extraParams?: Record<string, string>;
+  /** How to send client credentials at the token endpoint. Defaults to client_secret_post. */
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  /** Injection templates auto-applied to the access_token credential after a successful OAuth2 connect. */
+  injectionTemplates?: CredentialInjectionTemplate[];
 }
 
 const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
@@ -65,12 +69,25 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
     },
   },
   // Notion uses a simple OAuth2 flow with client_secret_basic auth at the token endpoint.
-  // The access token is long-lived (no expiry) and scopes are configured per-integration in Notion.
+  // The access token is long-lived (no expiry) and scopes are configured per-integration in Notion
+  // (the authorization URL accepts owner=user but there are no traditional scope strings to request).
   'integration:notion': {
     authUrl: 'https://api.notion.com/v1/oauth/authorize',
     tokenUrl: 'https://api.notion.com/v1/oauth/token',
     scopes: [],
     extraParams: { owner: 'user' },
+    // Notion requires HTTP Basic Auth (base64 of client_id:client_secret) at the token endpoint,
+    // not the default client_secret_post form-body approach.
+    tokenEndpointAuthMethod: 'client_secret_basic',
+    // Auto-inject the Bearer token for all Notion API calls made through the sandbox proxy.
+    injectionTemplates: [
+      {
+        hostPattern: 'api.notion.com',
+        injectionType: 'header',
+        headerName: 'Authorization',
+        valuePrefix: 'Bearer ',
+      },
+    ],
   },
 };
 
@@ -554,11 +571,15 @@ class CredentialStoreTool implements Tool {
           ?? findStoredOAuthField(service, ['client_id', 'oauth_client_id']);
         const clientSecret = (input.client_secret as string | undefined)
           ?? findStoredOAuthField(service, ['client_secret', 'oauth_client_secret']);
-        const tokenEndpointAuthMethod = input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined;
+        const tokenEndpointAuthMethod = (input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined)
+          ?? wellKnown?.tokenEndpointAuthMethod;
 
         if (!authUrl) return { content: 'Error: auth_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!tokenUrl) return { content: 'Error: token_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
-        if (!scopes || scopes.length === 0) return { content: 'Error: scopes is required for oauth2_connect action (no well-known config for this service)', isError: true };
+        // Scopes are optional — some providers (e.g. Notion) configure authorization at the integration
+        // level and don't use traditional scope strings. Reject only when scopes is entirely absent (not
+        // provided and no well-known config), not when it is an empty array.
+        if (!scopes) return { content: 'Error: scopes is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!clientId) return { content: 'Error: client_id is required for oauth2_connect action. Provide it directly or store it first with credential_store.', isError: true };
 
         if (!context.isInteractive) {
@@ -617,6 +638,10 @@ class CredentialStoreTool implements Tool {
             }
           }
 
+          // Well-known configs may supply injection templates (e.g. auto-inject Bearer header for
+          // api.notion.com) so that bash/network_mode=proxied works without manual setup.
+          const wellKnownInjectionTemplates = wellKnown?.injectionTemplates;
+
           upsertCredentialMetadata(service, 'access_token', {
             allowedTools: allowedTools ?? [],
             expiresAt,
@@ -626,6 +651,7 @@ class CredentialStoreTool implements Tool {
             oauth2ClientId: clientId,
             ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
             ...(tokenEndpointAuthMethod ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod } : {}),
+            ...(wellKnownInjectionTemplates ? { injectionTemplates: wellKnownInjectionTemplates } : {}),
           });
 
           if (tokens.refreshToken) {

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -5,26 +5,37 @@ user-invocable: false
 metadata: {"vellum": {"emoji": "📝"}}
 ---
 
-You have access to the Notion API via the stored OAuth token for `integration:notion`. Use `fetch` (or the HTTP proxy tool) with Bearer token authentication to call the Notion API directly.
+You have access to the Notion API via the stored OAuth token for `integration:notion`. Use `bash` with `network_mode: "proxied"` to call the Notion API — the proxy automatically injects the Bearer token for `api.notion.com`.
 
 ## Authentication
 
-Retrieve the stored access token:
+The Notion access token is stored securely and never exposed as plaintext. Use the credential proxy to inject the Bearer token automatically.
+
+**Step 1 — Get the credential ID:**
 ```
 credential_store action=list
 ```
-Look for `service: "integration:notion"`, `field: "access_token"`.
+Find the entry with `service: "integration:notion"` and `field: "access_token"`. Note its `credential_id`.
 
-Use it as:
+If no such entry exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
+
+**Step 2 — Make authenticated API calls via the proxy:**
+
+Use `bash` with `network_mode: "proxied"` and `credential_ids: ["<credential_id>"]`. The proxy automatically injects `Authorization: Bearer <token>` and any required headers into requests to `api.notion.com`.
+
+Example:
 ```
-Authorization: Bearer <access_token>
-Notion-Version: 2022-06-28
-Content-Type: application/json
+bash:
+  network_mode: proxied
+  credential_ids: ["<credential_id from step 1>"]
+  command: |
+    curl -s -X POST https://api.notion.com/v1/search \
+      -H "Notion-Version: 2022-06-28" \
+      -H "Content-Type: application/json" \
+      -d '{}'
 ```
 
-All Notion API calls go to `https://api.notion.com/v1/`.
-
-If no token is found, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
+All Notion API calls go to `https://api.notion.com/v1/`. Always include the `Notion-Version: 2022-06-28` header.
 
 ## Reading Pages
 


### PR DESCRIPTION
Addresses review feedback on #7754: (1) empty scopes array was causing oauth2_connect to reject Notion OAuth; (2) missing tokenEndpointAuthMethod was using wrong auth method; (3) skill instructions incorrectly told model to use credential_store action=list to get access token.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
