### PR TITLE
fix: resolve TS7022 circular type inference in linear watcher provider

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -140,10 +140,12 @@ async function fetchNotifications(
   const allNodes: LinearNotification[] = [];
   let cursor: string | null = null;
 
+  type NotificationsResponse = {
+    notifications: { nodes: LinearNotification[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
+  };
+
   do {
-    const data = await graphql<{
-      notifications: { nodes: LinearNotification[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
-    }>(token, `
+    const data: NotificationsResponse = await graphql<NotificationsResponse>(token, `
       query FetchNotifications($after: DateTime, $cursor: String) {
         notifications(
           filter: { updatedAt: { gte: $after } }
@@ -222,10 +224,12 @@ async function fetchAssignedIssueUpdates(
   const allNodes: LinearIssue[] = [];
   let cursor: string | null = null;
 
+  type IssuesResponse = {
+    issues: { nodes: LinearIssue[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
+  };
+
   do {
-    const data = await graphql<{
-      issues: { nodes: LinearIssue[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
-    }>(token, `
+    const data: IssuesResponse = await graphql<IssuesResponse>(token, `
       query FetchAssignedIssues($assigneeId: ID, $after: DateTime, $cursor: String) {
         issues(
           filter: {


### PR DESCRIPTION
## Summary

- Add explicit type annotations to `data` variables in `fetchNotifications` and `fetchAssignedIssueUpdates` do-while loops
- TypeScript could not infer the type of `data` because it was indirectly referenced through `cursor` in its own initializer (TS7022)
- Extracted `NotificationsResponse` and `IssuesResponse` type aliases to break the circular inference chain

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22354063612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
