### PR TITLE
fix: honor empty domain allowlist in iOS media embed resolver

### DIFF
--- a/clients/ios/Views/MessageMediaEmbedsView.swift
+++ b/clients/ios/Views/MessageMediaEmbedsView.swift
@@ -27,7 +27,7 @@ struct MessageMediaEmbedsView: View {
         return MediaEmbedResolverSettings(
             enabled: mediaEmbedsEnabled,
             enabledSince: nil,
-            allowedDomains: domains.isEmpty ? MediaEmbedSettings.defaultDomains : domains
+            allowedDomains: domains
         )
     }
 


### PR DESCRIPTION
When a user removes all domains from the allowlist in MediaEmbedSettingsSection, the UI correctly shows 'No domains configured'. However, the resolver in MessageMediaEmbedsView silently fell back to MediaEmbedSettings.defaultDomains when the list was empty, causing videos from default hosts (YouTube, Vimeo, Loom) to still embed despite the user's intent to block all embeds.

Fix: pass the parsed domains array directly to MediaEmbedResolverSettings.allowedDomains without the isEmpty fallback. An empty list now correctly means no domains are allowed.

Addresses feedback from PR #7775.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
