### PR TITLE
fix: send ride_shotgun_stop on cancel and delay summary sheet to prevent silent drop

### DIFF
--- a/clients/ios/App/AmbientAgentManager.swift
+++ b/clients/ios/App/AmbientAgentManager.swift
@@ -139,8 +139,18 @@ final class AmbientAgentManager: ObservableObject {
             } else {
                 displayText = summary
             }
-            completedSummary = CompletedSummary(text: displayText, recordingId: recordingId)
             trigger.recordCompleted()
+
+            // SwiftUI cannot present a new sheet while another is being dismissed.
+            // Setting completedSummary immediately after nil-ing activeSession would
+            // race with the progress-sheet dismissal animation and the summary sheet
+            // would be silently dropped on many iOS versions.  A short delay lets
+            // the dismissal animation finish before we request the next presentation.
+            let pendingSummary = CompletedSummary(text: displayText, recordingId: recordingId)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 600_000_000) // 0.6 s
+                self?.completedSummary = pendingSummary
+            }
 
         case .failed(let reason):
             log.error("Ride shotgun session failed: \(reason)")

--- a/clients/ios/App/RideShotgunSession.swift
+++ b/clients/ios/App/RideShotgunSession.swift
@@ -96,6 +96,19 @@ final class RideShotgunSession: ObservableObject, Identifiable {
     }
 
     func cancel() {
+        // Send ride_shotgun_stop so the daemon terminates the capture session
+        // immediately rather than running to timeout.  Use the watchId if we
+        // have one; if we cancelled before watch_started arrived, skip the IPC
+        // (the daemon will time out on its own shortly after never receiving
+        // any client activity).
+        if let watchId = expectedWatchId, let daemonClient {
+            do {
+                try daemonClient.send(RideShotgunStopMessage(watchId: watchId))
+                log.info("ride_shotgun_stop sent on cancel: watchId=\(watchId)")
+            } catch {
+                log.error("Failed to send ride_shotgun_stop on cancel: \(error.localizedDescription)")
+            }
+        }
         log.info("Session cancelled")
         state = .cancelled
         cleanup()


### PR DESCRIPTION
Addresses feedback from PR #7774 review.

**Fix 1 (Codex P1 — RideShotgunSession.swift):**
`cancel()` now sends `ride_shotgun_stop` to the daemon before transitioning to the cancelled state. This ensures the server-side screen capture session terminates immediately rather than running until timeout after the user presses Cancel on iOS. If `watch_started` has not yet arrived (no watchId), the IPC is skipped and the daemon times out on its own.

**Fix 2 (Devin Red — AmbientAgentManager.swift):**
Setting `activeSession = nil` and `completedSummary = ...` in the same synchronous block caused the summary sheet to be silently dropped because SwiftUI cannot present a new sheet while another is being dismissed. The fix delays setting `completedSummary` by 0.6 s (via `Task.sleep`) so the progress-sheet dismissal animation finishes before the summary sheet is requested.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
