### PR TITLE
fix: address review feedback on iOS debug panel

### DIFF
--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -9,14 +9,29 @@ import VellumAssistantShared
 /// the version label 7 times.
 struct DeveloperSettingsSection: View {
     @EnvironmentObject var clientProvider: ClientProvider
+
+    var body: some View {
+        // Forward clientProvider.traceStore into a child view that holds it as
+        // @ObservedObject so SwiftUI re-renders when trace events arrive
+        // (keeps counts and the Clear button's enabled state live).
+        DeveloperSettingsSectionContent(
+            clientProvider: clientProvider,
+            traceStore: clientProvider.traceStore
+        )
+    }
+}
+
+private struct DeveloperSettingsSectionContent: View {
+    let clientProvider: ClientProvider
+    @ObservedObject var traceStore: TraceStore
     @State private var showDebugPanel = false
 
     private var sessionCount: Int {
-        clientProvider.traceStore.eventsBySession.count
+        traceStore.eventsBySession.count
     }
 
     private var totalEventCount: Int {
-        clientProvider.traceStore.eventsBySession.values.reduce(0) { $0 + $1.count }
+        traceStore.eventsBySession.values.reduce(0) { $0 + $1.count }
     }
 
     var body: some View {
@@ -26,7 +41,7 @@ struct DeveloperSettingsSection: View {
                 LabeledContent("Total events", value: "\(totalEventCount)")
 
                 Button("Clear All Trace Events", role: .destructive) {
-                    clientProvider.traceStore.resetAll()
+                    traceStore.resetAll()
                 }
                 .disabled(totalEventCount == 0)
             }
@@ -46,10 +61,10 @@ struct DeveloperSettingsSection: View {
         .navigationTitle("Developer")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showDebugPanel) {
-            // Show most recent session's traces, or nil if none.
-            let sessionId = clientProvider.traceStore.eventsBySession.keys.first
+            // Use the most recently active session rather than an arbitrary dict key.
+            let sessionId = traceStore.mostRecentSessionId
             DebugPanelView(
-                traceStore: clientProvider.traceStore,
+                traceStore: traceStore,
                 sessionId: sessionId,
                 onClose: { showDebugPanel = false }
             )

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -92,7 +92,7 @@ struct SettingsView: View {
                         .onTapGesture {
                             versionTapCount += 1
                             if versionTapCount >= 7 {
-                                developerModeEnabled.toggle()
+                                developerModeEnabled = true
                                 versionTapCount = 0
                             }
                         }

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -185,6 +185,21 @@ public final class TraceStore: ObservableObject {
         return events.filter { $0.kind == "tool_failed" }.count
     }
 
+    // MARK: - Session Selection
+
+    /// Returns the session ID whose last event has the highest `timestampMs`,
+    /// i.e. the most recently active session. Returns `nil` if no events exist.
+    ///
+    /// Used by developer tooling to auto-select a relevant session when no
+    /// explicit selection context is available (e.g. when opening the debug panel
+    /// from the Settings screen rather than from an active chat thread).
+    public var mostRecentSessionId: String? {
+        eventsBySession
+            .compactMapValues { $0.last?.timestampMs }
+            .max(by: { $0.value < $1.value })
+            .map(\.key)
+    }
+
     // MARK: - Reset
 
     /// Remove all events for a given session.


### PR DESCRIPTION
Addresses feedback from PR #7779 review:

- **Fix arbitrary session selection** (Devin bug 1): Replace `eventsBySession.keys.first` (unordered dict) with a new `TraceStore.mostRecentSessionId` computed property that picks the session whose last event has the highest `timestampMs`. This ensures the debug panel opened from Settings shows the most recently active session, not an arbitrary one.

- **Fix 7-tap gesture toggle semantics** (Devin bug 2): Change `developerModeEnabled.toggle()` to `developerModeEnabled = true`. The gesture is documented as an "unlock" — it should only enable developer mode. Disabling is handled by the explicit toggle in the Developer section.

- **Fix stale TraceStore observation** (Codex P2): Refactor `DeveloperSettingsSection` into an outer shell + private `DeveloperSettingsSectionContent` child view that holds `@ObservedObject var traceStore: TraceStore`. This ensures SwiftUI re-renders when trace events arrive while the screen is open, keeping session/event counts and the Clear button's enabled state live.

Closes feedback on #7779.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
