### PR TITLE
fix(ios): prevent offline queue data loss and fix cold-start flush

### DIFF
--- a/clients/ios/App/OfflineMessageQueue.swift
+++ b/clients/ios/App/OfflineMessageQueue.swift
@@ -62,6 +62,8 @@ final class OfflineMessageQueue {
 
     var isEmpty: Bool { queue.isEmpty }
     var count: Int { queue.count }
+    /// Read-only snapshot of all queued messages in FIFO order.
+    var allMessages: [OfflineQueuedMessage] { queue }
 
     private init() {
         queue = Self.load()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -188,8 +188,24 @@ public final class ChatViewModel: ObservableObject {
 
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol
-    public var sessionId: String?
+    public var sessionId: String? {
+        didSet {
+            #if os(iOS)
+            // If the daemon reconnected before this VM had a session ID, a deferred
+            // flush was requested. Now that we have a session, run it.
+            if sessionId != nil && needsOfflineFlush {
+                needsOfflineFlush = false
+                flushOfflineQueue()
+            }
+            #endif
+        }
+    }
     private var reconnectObserver: NSObjectProtocol?
+    #if os(iOS)
+    /// Set to true when daemonDidReconnect fires before sessionId is populated.
+    /// Cleared and actioned in the sessionId didSet observer.
+    private var needsOfflineFlush: Bool = false
+    #endif
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -415,7 +431,14 @@ public final class ChatViewModel: ObservableObject {
                 self?.isMemoryDegraded = false
                 self?.memoryDegradedReason = nil
                 #if os(iOS)
-                self?.flushOfflineQueue()
+                // If we already have a session ID, flush immediately. Otherwise
+                // defer: sessionId's didSet will trigger flushOfflineQueue() once
+                // the session is restored from history (cold-start reconnect case).
+                if self?.sessionId != nil {
+                    self?.flushOfflineQueue()
+                } else {
+                    self?.needsOfflineFlush = true
+                }
                 #endif
             }
         }
@@ -723,27 +746,24 @@ public final class ChatViewModel: ObservableObject {
     ///
     /// Called automatically when the daemon reconnects. Only flushes messages whose
     /// sessionId matches this view model's current session, so concurrent view models
-    /// on different threads don't steal each other's queued messages.
+    /// on different sessions don't interfere with each other's queued messages.
+    ///
+    /// Messages are removed from persistent storage one at a time, immediately before
+    /// each send, so a crash mid-flush leaves unprocessed messages intact rather than
+    /// silently dropping them.
     func flushOfflineQueue() {
         let queue = OfflineMessageQueue.shared
         guard !queue.isEmpty else { return }
 
         guard let currentSessionId = sessionId else {
-            // No session yet — nothing to flush for this view model.
+            // No session yet — defer until sessionId is populated.
+            needsOfflineFlush = true
             return
         }
 
-        // Dequeue only the messages that belong to this session.
-        // Messages for other sessions are left in place for their respective VMs to flush.
-        let allQueued = queue.dequeueAll()
-        let mine = allQueued.filter { $0.sessionId == currentSessionId }
-        let others = allQueued.filter { $0.sessionId != currentSessionId }
-
-        // Re-enqueue messages belonging to other sessions.
-        for msg in others {
-            queue.enqueue(sessionId: msg.sessionId, text: msg.text, attachments: msg.ipcAttachments)
-        }
-
+        // Read the queue contents without clearing. Filter for this session only;
+        // other sessions' messages stay in the persistent store for their own VMs.
+        let mine = queue.allMessages.filter { $0.sessionId == currentSessionId }
         guard !mine.isEmpty else { return }
 
         log.info("Flushing \(mine.count) offline-queued message(s) for session \(currentSessionId)")
@@ -759,9 +779,11 @@ public final class ChatViewModel: ObservableObject {
             }
         }
 
-        // Send messages sequentially. Each send is async in the HTTP transport but
-        // the daemon processes messages in order, so fire them all immediately.
+        // Remove each message from persistent storage and send it. Removal happens
+        // before the send attempt so a successful removal + failed send is recoverable
+        // via the normal error retry path, rather than duplicating on the next flush.
         for queued in mine {
+            queue.remove(id: queued.id)
             sendUserMessage(queued.text, attachments: queued.ipcAttachments)
         }
     }


### PR DESCRIPTION
Addresses feedback on #7778.

## Changes

- **Durable flush (P1)**: Replace the dequeueAll-then-re-enqueue pattern in flushOfflineQueue() with per-message remove(id:) calls. Each message is removed from persistent storage immediately before being sent. This eliminates the window where other sessions' messages were absent from UserDefaults and prevents silent data loss if the app is killed mid-flush.

- **Cold-start reconnect (P2)**: Add a needsOfflineFlush flag and a didSet observer on sessionId. When daemonDidReconnect fires before the session ID is restored from history, the flag is set instead of bailing out immediately. Once sessionId is populated, the observer triggers flushOfflineQueue() automatically.

- **Add allMessages accessor**: Added a read-only allMessages property to OfflineMessageQueue so callers can inspect the queue without destructively clearing it.

## Files modified
- clients/ios/App/OfflineMessageQueue.swift
- clients/shared/Features/Chat/ChatViewModel.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
