### PR TITLE
fix(ios-avatar): address review feedback on avatar customization iOS port

### DIFF
--- a/clients/ios/Views/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/ios/Views/Avatar/AvatarCustomizationPanel.swift
@@ -379,11 +379,18 @@ struct AvatarCustomizationPanel: View {
 
     /// Toggle lock on a field. Unlocking removes the override so the resolver
     /// falls back to trait-based values and auto-evolution can control the field.
+    /// Locking captures the current resolved value as an override so the displayed
+    /// appearance is preserved — without this, locked fields would fall back to defaults.
     private func toggleLock(field: AvatarEvolutionState.AppearanceField) {
         if evolutionState.lockedFields.contains(field) {
             evolutionState.lockedFields.remove(field)
             evolutionState.userOverrides.removeValue(forKey: field)
         } else {
+            // Resolve without the lock so we can snapshot the current effective value
+            let currentResolved = AvatarEvolutionResolver.resolve(state: evolutionState)
+            if let currentValue = currentResolved.value(for: field) {
+                evolutionState.userOverrides[field] = currentValue
+            }
             evolutionState.lockedFields.insert(field)
         }
         resolveAndApply()

--- a/clients/ios/Views/Avatar/EvolvingAvatarView.swift
+++ b/clients/ios/Views/Avatar/EvolvingAvatarView.swift
@@ -36,7 +36,6 @@ struct EvolvingAvatarView: View {
             avatarImageView
                 .scaleEffect(x: breatheScaleX, y: breatheScaleY, anchor: .bottom)
                 .scaleEffect(appeared ? 1.0 : 0.0, anchor: .bottom)
-                .opacity(evolutionState.unlockedFeatures.contains(.blob) ? 1.0 : 0.0)
         }
         .onChange(of: evolutionState.unlockedFeatures.count) { oldCount, newCount in
             if newCount > oldCount {
@@ -77,15 +76,17 @@ struct EvolvingAvatarView: View {
         return .violet
     }
 
-    /// Progressive opacity based on unlock level
+    /// Progressive opacity based on unlock level.
+    /// Falls back to a visible baseline so the avatar preview renders even before onboarding
+    /// milestones have been recorded (e.g. when opened directly from Settings on iOS).
     private var avatarOpacity: Double {
         let features = evolutionState.unlockedFeatures
         if features.contains(.fullExpression) { return 1.0 }
         if features.contains(.baseBody) { return 0.95 }
         if features.contains(.coreFace) { return 0.85 }
         if features.contains(.eyes) { return 0.75 }
-        if features.contains(.blob) { return 0.6 }
-        return 0.0
+        // Baseline: show at blob-level opacity so the customization panel is never blank
+        return 0.6
     }
 
     private func startBreathing() {
@@ -108,7 +109,8 @@ struct EvolvingAvatarView: View {
 // MARK: - Blob Avatar Shape
 
 /// Draws the blob avatar using SwiftUI Canvas — works cross-platform without AppKit.
-/// Renders the same warm-tan organic blob with eyes as the macOS NSImage-based version.
+/// Colors are driven entirely by the supplied DinoPalette so body/cheek customization
+/// is reflected in the live preview.
 private struct BlobAvatarShape: View {
     let palette: DinoPalette
 
@@ -143,13 +145,13 @@ private struct BlobAvatarShape: View {
         }
         path.closeSubpath()
 
-        // Fill: warm tan (#E3DCB6) — the fixed neutral that reads in both light and dark
-        context.fill(path, with: .color(Color(red: 0xE3/255.0, green: 0xDC/255.0, blue: 0xB6/255.0)))
+        // Fill with palette mid shade — mirrors PixelSpriteBuilder.buildBlobNSImage on macOS
+        context.fill(path, with: .color(Color(hex: UInt(palette.mid))))
 
-        // Outline stroke: dark (#1C1917)
+        // Outline stroke using palette outline (darkest body shade)
         context.stroke(
             path,
-            with: .color(Color(red: 0x1C/255.0, green: 0x19/255.0, blue: 0x17/255.0)),
+            with: .color(Color(hex: UInt(palette.outline))),
             lineWidth: max(1.5, nominalRadius * 0.06)
         )
 
@@ -163,7 +165,7 @@ private struct BlobAvatarShape: View {
         for sign: CGFloat in [-1.0, 1.0] {
             let ex = centerX + sign * eyeSpacing
 
-            // White sclera
+            // White sclera (eyeWhite is always 0xFFFFFF per DinoPalette)
             let scleraRect = CGRect(
                 x: ex - eyeOuterRadius,
                 y: eyeY - eyeOuterRadius,
@@ -173,18 +175,18 @@ private struct BlobAvatarShape: View {
             context.fill(Path(ellipseIn: scleraRect), with: .color(.white))
             context.stroke(
                 Path(ellipseIn: scleraRect),
-                with: .color(Color(red: 0x1C/255.0, green: 0x19/255.0, blue: 0x17/255.0)),
+                with: .color(Color(hex: UInt(palette.pupil))),
                 lineWidth: max(0.8, nominalRadius * 0.03)
             )
 
-            // Dark pupil
+            // Pupil using palette pupil color
             let pupilRect = CGRect(
                 x: ex - pupilRadius,
                 y: eyeY - pupilRadius,
                 width: pupilRadius * 2,
                 height: pupilRadius * 2
             )
-            context.fill(Path(ellipseIn: pupilRect), with: .color(Color(red: 0x1C/255.0, green: 0x19/255.0, blue: 0x17/255.0)))
+            context.fill(Path(ellipseIn: pupilRect), with: .color(Color(hex: UInt(palette.pupil))))
         }
     }
 }

--- a/clients/shared/Features/Avatar/LooksConfig.swift
+++ b/clients/shared/Features/Avatar/LooksConfig.swift
@@ -140,4 +140,20 @@ public struct LooksConfig: Equatable {
             heldItem: heldItem
         )
     }
+
+    /// Look up the resolved String value for a given AppearanceField.
+    /// Returns nil for optional color fields that are not set.
+    public func value(for field: AvatarEvolutionState.AppearanceField) -> String? {
+        switch field {
+        case .bodyColor:      return bodyColor
+        case .cheekColor:     return cheekColor
+        case .hat:            return hat
+        case .hatColor:       return hatColor
+        case .shirt:          return shirt
+        case .shirtColor:     return shirtColor
+        case .accessory:      return accessory
+        case .accessoryColor: return accessoryColor
+        case .heldItem:       return heldItem
+        }
+    }
 }


### PR DESCRIPTION
Addresses review feedback on #7785.

- **BlobAvatarShape now uses DinoPalette colors** instead of hardcoded tan/dark hex values. The blob fill uses `palette.mid`, the outline uses `palette.outline`, and the eye outline/pupils use `palette.pupil`. This makes body color and cheek color selections actually visible in the live preview.

- **Avatar preview is no longer blank on first launch**: Removed the hard opacity gate that required the `.blob` feature to be unlocked. `avatarOpacity` now falls back to 0.6 (the former blob level) instead of 0.0, so the customization panel always shows a baseline avatar even when no onboarding milestones have been recorded on iOS.

- **Lock-on captures current value as override**: When a user taps the lock icon to lock a field, the current resolved value is persisted as a `userOverride` before inserting the lock. This prevents locking from unexpectedly resetting appearance to defaults. Added `LooksConfig.value(for:)` helper to look up field values by `AppearanceField`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
