### PR TITLE
fix: share IOSThreadStore to prevent dual-store data loss for private threads

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -101,28 +101,6 @@ class IOSThreadStore: ObservableObject {
         }
     }
 
-    /// Initializer for secondary stores (e.g. the Private Threads settings panel)
-    /// that need access to the daemon client for sending messages but should not
-    /// register global session-list callbacks that would clobber the main store's
-    /// handlers. In standalone mode, loads persisted threads from UserDefaults.
-    init(daemonClient: any DaemonClientProtocol, registerDaemonCallbacks: Bool) {
-        self.daemonClient = daemonClient
-
-        if daemonClient is DaemonClient {
-            isConnectedMode = true
-            // No default thread — secondary stores start empty and show only
-            // what has been created within the current session.
-            threads = []
-        } else {
-            let loaded = Self.load()
-            threads = loaded
-        }
-
-        if registerDaemonCallbacks, let daemon = daemonClient as? DaemonClient {
-            setupDaemonCallbacks(daemon)
-        }
-    }
-
     // MARK: - Daemon Thread Sync
 
     private func setupDaemonCallbacks(_ daemon: DaemonClient) {

--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -22,7 +22,8 @@ struct VellumAssistantApp: App {
                 if onboardingCompleted {
                     ContentView(
                         authManager: appDelegate.authManager,
-                        ambientAgent: appDelegate.ambientAgentManager
+                        ambientAgent: appDelegate.ambientAgentManager,
+                        daemonClient: appDelegate.clientProvider.client
                     )
                     .environmentObject(appDelegate.clientProvider)
                 } else {

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -9,6 +9,17 @@ struct ContentView: View {
     @State private var connectPhase: ConnectPhase = .initial
     @State private var selectedTab: Tab = .home
     @State private var navigateToConnect = false
+    /// Single thread store shared between the Chats tab (ThreadListView) and the
+    /// Private Threads settings panel (PrivateThreadsSection). Keeping one store
+    /// prevents the dual-store data-loss race where two independent stores each
+    /// overwrite the other's UserDefaults writes in standalone mode.
+    @StateObject private var threadStore: IOSThreadStore
+
+    init(authManager: AuthManager, ambientAgent: AmbientAgentManager, daemonClient: any DaemonClientProtocol) {
+        self.authManager = authManager
+        self.ambientAgent = ambientAgent
+        _threadStore = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient))
+    }
 
     private enum Tab { case home, chats, tasks, identity, settings }
 
@@ -218,7 +229,7 @@ struct ContentView: View {
                     Label("Home", systemImage: "house")
                 }
 
-            ThreadListView(daemonClient: clientProvider.client)
+            ThreadListView(store: threadStore)
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
                 .tag(Tab.chats)
                 .tabItem {
@@ -241,7 +252,7 @@ struct ContentView: View {
                     Label("Identity", systemImage: "person.text.rectangle")
                 }
 
-            SettingsView(authManager: authManager, navigateToConnect: $navigateToConnect)
+            SettingsView(authManager: authManager, navigateToConnect: $navigateToConnect, threadStore: threadStore)
                 .environmentObject(clientProvider)
                 .tag(Tab.settings)
                 .tabItem {
@@ -252,7 +263,8 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(authManager: AuthManager(), ambientAgent: AmbientAgentManager())
-        .environmentObject(ClientProvider(client: DaemonClient(config: .default)))
+    let client = DaemonClient(config: .default)
+    ContentView(authManager: AuthManager(), ambientAgent: AmbientAgentManager(), daemonClient: client)
+        .environmentObject(ClientProvider(client: client))
 }
 #endif

--- a/clients/ios/Views/Settings/PrivateThreadsSection.swift
+++ b/clients/ios/Views/Settings/PrivateThreadsSection.swift
@@ -6,19 +6,16 @@ import VellumAssistantShared
 /// workflow. Private threads are backed by daemon sessions with threadType "private"
 /// so they are excluded from normal session restoration and the main thread list.
 struct PrivateThreadsSection: View {
-    @StateObject private var store: IOSThreadStore
+    /// Shared with the main ThreadListView so both views read from and write to the
+    /// same in-memory thread list. This prevents the dual-store data-loss bug where
+    /// two independent stores each overwrite the other's UserDefaults changes.
+    @ObservedObject var store: IOSThreadStore
     @State private var showingCreateSheet = false
     @State private var newThreadName = ""
     @State private var renamingThread: IOSThread?
     @State private var renameText = ""
     @State private var threadToDelete: IOSThread?
     @State private var showingDeleteConfirmation = false
-
-    init(daemonClient: any DaemonClientProtocol) {
-        // Use the secondary initializer so this store does not register global
-        // session-list callbacks that would overwrite the main thread store's handlers.
-        _store = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient, registerDaemonCallbacks: false))
-    }
 
     var body: some View {
         Form {
@@ -176,7 +173,7 @@ struct PrivateThreadsSection: View {
 #if DEBUG
 #Preview {
     NavigationStack {
-        PrivateThreadsSection(daemonClient: MockDaemonClient())
+        PrivateThreadsSection(store: IOSThreadStore(daemonClient: MockDaemonClient()))
     }
 }
 #endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -8,6 +8,9 @@ struct SettingsView: View {
     @AppStorage(UserDefaultsKeys.developerModeEnabled) private var developerModeEnabled: Bool = false
     @Binding var navigateToConnect: Bool
     @State private var versionTapCount: Int = 0
+    /// Shared thread store — passed through so PrivateThreadsSection can show and
+    /// manage private threads without creating a second store that races on UserDefaults.
+    var threadStore: IOSThreadStore
 
     var body: some View {
         NavigationStack {
@@ -56,7 +59,7 @@ struct SettingsView: View {
                         Label("Parental Controls", systemImage: "lock.shield")
                     }
                     NavigationLink {
-                        PrivateThreadsSection(daemonClient: clientProvider.client)
+                        PrivateThreadsSection(store: threadStore)
                     } label: {
                         Label("Private Threads", systemImage: "lock.shield.fill")
                     }
@@ -173,7 +176,8 @@ extension Bundle {
 }
 
 #Preview {
-    SettingsView(authManager: AuthManager(), navigateToConnect: .constant(false))
-        .environmentObject(ClientProvider(client: DaemonClient(config: .fromUserDefaults())))
+    let client = DaemonClient(config: .fromUserDefaults())
+    SettingsView(authManager: AuthManager(), navigateToConnect: .constant(false), threadStore: IOSThreadStore(daemonClient: client))
+        .environmentObject(ClientProvider(client: client))
 }
 #endif

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -7,7 +7,7 @@ import VellumAssistantShared
 
 struct ThreadListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @StateObject private var store: IOSThreadStore
+    @ObservedObject var store: IOSThreadStore
     @State private var navigationPath: [UUID] = []
     @State private var selectedThreadId: UUID?
     @State private var searchText: String = ""
@@ -15,16 +15,14 @@ struct ThreadListView: View {
     @State private var renameText: String = ""
     @State private var showArchived: Bool = false
 
-    init(daemonClient: any DaemonClientProtocol) {
-        _store = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient))
-    }
-
     private var activeThreads: [IOSThread] {
-        store.threads.filter { !$0.isArchived }
+        // Exclude private threads — they are managed separately via the Private Threads
+        // settings panel and must not appear in the main chat list.
+        store.threads.filter { !$0.isArchived && !$0.isPrivate }
     }
 
     private var archivedThreads: [IOSThread] {
-        store.threads.filter { $0.isArchived }
+        store.threads.filter { $0.isArchived && !$0.isPrivate }
     }
 
     private var filteredActiveThreads: [IOSThread] {


### PR DESCRIPTION
## Summary
- Addresses Devin review feedback on PR #7771 (private threads on iOS)

### Issues Fixed

**1. Private threads leaked into main thread list (Devin BUG_0001)**
`ThreadListView.activeThreads` and `archivedThreads` now filter out `isPrivate` threads, matching the macOS behaviour in `ThreadManager.swift`.

**2. Dual-store data loss in standalone mode (Devin BUG_0002)**
`PrivateThreadsSection` was creating its own `IOSThreadStore` that shared the same `UserDefaults` key (`ios_threads_v1`) as the main store. Two independent stores writing to the same key would overwrite each other's changes, silently losing threads.

**Fix:** Lift the single `IOSThreadStore` instance up to `ContentView`, pass it to both `ThreadListView` (via `@ObservedObject`) and `SettingsView` → `PrivateThreadsSection`. The secondary initializer on `IOSThreadStore` (added by PR #7771) is removed since it is no longer needed.

**3. Phantom regular thread created on private-thread deletion (Codex P2)**
With the shared store, the `deleteThread` guard that ensures at least one non-archived regular thread is no longer triggered when deleting private threads (because the main store always has regular threads), eliminating the spurious regular-thread creation.

## Test plan
- [ ] Open Chats tab in standalone mode — private threads do not appear in the list
- [ ] Open Settings → Private Threads — private threads appear correctly
- [ ] Create a private thread, then create a regular thread; verify both stores see the same state (no thread loss)
- [ ] Delete the last private thread; verify no phantom regular thread appears in the Chats list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
