### PR TITLE
fix: resolve iOS/macOS build errors and lint failure

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { getAnthropicProvider, extractText, userMessageWithImage, userMessageWithImages } from '../../../../providers/anthropic-send-message.js';
+import { getAnthropicProvider, extractText, userMessageWithImages } from '../../../../providers/anthropic-send-message.js';
 import { initializeProviders } from '../../../../providers/registry.js';
 import { loadConfig, invalidateConfigCache } from '../../../../config/loader.js';
 import {
@@ -349,60 +349,4 @@ export async function run(
     }
     return { content: `Vision analysis failed: ${(err as Error).message}`, isError: true };
   }
-}
-
-async function analyzeKeyframe(
-  provider: import('../../../../providers/types.js').Provider,
-  keyframe: MediaKeyframe,
-): Promise<{ output: Record<string, unknown>; confidence: number }> {
-  // Read the image file and encode as base64
-  const imageData = await readFile(keyframe.filePath);
-  const base64 = imageData.toString('base64');
-
-  // Determine media type from file extension
-  const ext = keyframe.filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
-  const mediaTypeMap: Record<string, string> = {
-    jpg: 'image/jpeg',
-    jpeg: 'image/jpeg',
-    png: 'image/png',
-    gif: 'image/gif',
-    webp: 'image/webp',
-  };
-  const mediaType = mediaTypeMap[ext] ?? 'image/jpeg';
-
-  const response = await provider.sendMessage(
-    [userMessageWithImage(base64, mediaType, VLM_PROMPT)],
-    undefined,
-    undefined,
-    {
-      config: {
-        model: 'claude-sonnet-4-6',
-        max_tokens: 1024,
-      },
-    },
-  );
-
-  // Extract text from response
-  const responseText = extractText(response);
-
-  // Parse JSON from response
-  let output: Record<string, unknown>;
-  try {
-    // Try to extract JSON from the response (handle markdown code fences)
-    const jsonMatch = responseText.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, responseText];
-    output = JSON.parse(jsonMatch[1]!.trim()) as Record<string, unknown>;
-  } catch {
-    // If JSON parsing fails, wrap raw text as output
-    output = {
-      sceneDescription: responseText,
-      subjects: [],
-      actions: [],
-      context: '',
-    };
-  }
-
-  // Add timestamp context to the output
-  output.timestamp = keyframe.timestamp;
-
-  return { output, confidence: 0.8 };
 }

--- a/clients/shared/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/shared/Features/Avatar/AvatarAppearanceManager.swift
@@ -22,7 +22,7 @@ public final class AvatarAppearanceManager {
     }
 
     private var homeDirectory: String {
-        FileManager.default.homeDirectoryForCurrentUser.path
+        NSHomeDirectory()
     }
 
     public func start() {

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -1,7 +1,6 @@
-#if canImport(UIKit)
+#if os(iOS)
 import Foundation
 import os
-import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "OfflineMessageQueue")
 


### PR DESCRIPTION
## Summary
- **AvatarAppearanceManager**: replaced `homeDirectoryForCurrentUser` (macOS-only) with `NSHomeDirectory()` (cross-platform)
- **ChatAttachmentManager**: added `nonisolated` to `generateThumbnail` and `compressImageIfNeeded` — pure static functions that don't access actor-isolated state but inherited `@MainActor` from the class, causing async/await errors when called from `Task.detached`
- **OfflineMessageQueue**: moved from `clients/ios/App/` to `clients/shared/Features/Chat/` so `ChatViewModel` (in the shared library) can reference it; removed `import VellumAssistantShared` (now part of the module)
- **analyze-keyframes.ts**: removed dead `analyzeKeyframe` function (replaced by chunked analysis) that caused lint unused-vars error

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22353167698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
