### PR TITLE
fix(swift): add nonisolated to static members in ChatAttachmentManager

### DIFF
--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -32,12 +32,12 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Limits
 
     /// Maximum file size per attachment (20 MB).
-    static let maxFileSize = 20 * 1024 * 1024
+    nonisolated static let maxFileSize = 20 * 1024 * 1024
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5 MB limit per image; base64 encoding adds ~33% overhead.
-    static let maxImageSize = 4 * 1024 * 1024
+    nonisolated static let maxImageSize = 4 * 1024 * 1024
     /// Maximum number of attachments per message.
-    public static let maxAttachments = 5
+    nonisolated public static let maxAttachments = 5
 
     // MARK: - Error callback
 
@@ -321,7 +321,7 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Static helpers (shared with ChatViewModel+Attachments and mapIPCAttachments)
 
     /// Resize image data to fit within `maxDimension` and return PNG data.
-    public static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
+    nonisolated public static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
         #if os(macOS)
         guard let image = NSImage(data: data) else { return nil }
         let size = image.size
@@ -362,7 +362,7 @@ public final class ChatAttachmentManager: ObservableObject {
 
     /// Compress image data if it exceeds the size limit.
     /// Returns (compressedData, wasCompressed) tuple.
-    public static func compressImageIfNeeded(data: Data, maxSize: Int) -> (Data, Bool) {
+    nonisolated public static func compressImageIfNeeded(data: Data, maxSize: Int) -> (Data, Bool) {
         // Check if compression is needed
         guard data.count > maxSize else {
             return (data, false)


### PR DESCRIPTION
## Summary
- Add `nonisolated` to static `let` constants (`maxFileSize`, `maxImageSize`, `maxAttachments`) and static methods (`compressImageIfNeeded`, `generateThumbnail`) on `@MainActor` class `ChatAttachmentManager`
- These members are called from `Task.detached` closures which run outside the main actor, causing "expression is 'async' but is not marked with 'await'" build errors
- Since these are pure computations with no mutable actor state, `nonisolated` is the correct fix

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22354136361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
