### PR TITLE
fix(db): qualify second DROP TABLE with temp schema in migrateMemoryEntityRelationDedup

### DIFF
--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -317,7 +317,7 @@ export function migrateMemoryEntityRelationDedup(database: Db): void {
       FROM memory_entity_relation_merge
     `);
 
-    raw.exec(/*sql*/ `DROP TABLE memory_entity_relation_merge`);
+    raw.exec(/*sql*/ `DROP TABLE temp.memory_entity_relation_merge`);
 
     raw.query(
       `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,


### PR DESCRIPTION
Addresses review feedback on #7792: the second DROP TABLE inside the transaction at line 320 was still using an unqualified name. Apply the same temp. prefix for consistency and to prevent accidentally targeting a permanent table in an attached schema.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
